### PR TITLE
Trap Fixes (spiders and rollmats)

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -737,7 +737,7 @@
     "color": "white",
     "symbol": "^",
     "visibility": 17,
-    "avoidance": 99,
+    "avoidance": 15,
     "difficulty": 99,
     "trap_radius": 4,
     "action": "spell",


### PR DESCRIPTION
#### Summary
Make trapdoor spider dens detectable, nerf rollmat comfort.

#### Purpose of change

Trapdoor spider dens were totally unfindable, even with ground-penetrating sonar. Additionally, rollmats (which are implemented as traps) were set to comfort 4, which is the same as an actual mattress.

#### Describe the solution

Spider dens are now difficult to detect, usually requiring high perception and devices or the associated proficiencies. Ground-penetrating sonar spots them instantly, as that's exactly the kind of thing it would be made for.

Both types of rollmats are now comfort 3, the same as a straw bed or an armchair.

#### Testing

Verified sonar was working. Tried several test survivors. At 12 perception and 4 devices with no proficiencies in full daylight with no eye encumbrance, I could reliably spot them within a minute or two. It didn't seem possible if I went much lower than that. This is intentionally a very hard check as the spider dens are almost always hinted at with environmental clues (bones, bug chunks) and the consequence for stepping on one is not huge.

Also renamed them to web-covered burrow and made them avoidable, though this is very difficult as trapdoor spiders are extremely sensitive to vibrations. Don't step on the damn thing.

#### Additional comments

Traps are very old and in dire need of modernization.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
