### PR TITLE
Port #77250 from CDDA - no starting fires in water

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1909,7 +1909,15 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
     if( !here.is_flammable( where ) ) {
         try_fuel_fire( *act, *you, true );
         if( !here.is_flammable( where ) ) {
-            you->add_msg_if_player( m_info, _( "There's nothing to light there." ) );
+            if( here.has_flag_ter( ter_furn_flag::TFLAG_USABLE_FIRE, where ) ) {
+                you->add_msg_if_player( m_info, _( "It's already burning hot there." ) );
+            } else if( here.has_flag_ter( ter_furn_flag::TFLAG_LIQUID, where ) ||
+                       here.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, where ) ||
+                       here.has_flag_ter( ter_furn_flag::TFLAG_LIQUIDCONT, where ) ) {
+                you->add_msg_if_player( m_info, _( "You need dry ground to light a fire." ) );
+            } else {
+                you->add_msg_if_player( m_info, _( "There's nothing to light there." ) );
+            }
             you->cancel_activity();
             return;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3379,6 +3379,13 @@ bool map::flammable_items_at( const tripoint_bub_ms &p, int threshold )
 
 bool map::is_flammable( const tripoint &p )
 {
+    // No fires on liquid tiles regardless of other factors
+    // TODO: Burning fuel on water, fires on boats?
+    if( has_flag_ter( ter_furn_flag::TFLAG_LIQUID, p ) ||
+        has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, p ) ||
+        has_flag_ter( ter_furn_flag::TFLAG_LIQUIDCONT, p ) ) {
+        return false;
+    }
 
     if( has_flag( ter_furn_flag::TFLAG_FLAMMABLE, p ) ) {
         return true;


### PR DESCRIPTION
Port https://github.com/CleverRaven/Cataclysm-DDA/pull/77250/ from Cataclysm:DDA, making it impossible to start fires on or in water using a fire-starting tool.

Make the flammability checks slightly more granular to make sure we exclude things like sewage and puddles.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
