### PR TITLE
Port #73801 from CDDA

### DIFF
--- a/data/json/monsters/cyborgs.json
+++ b/data/json/monsters/cyborgs.json
@@ -19,7 +19,7 @@
     "melee_skill": 3,
     "melee_dice": 2,
     "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "cut", "amount": 12 } ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "bleed_rate": 25,
     "vision_night": 3,
     "//grab": "Bulkier than a base zombie but awkward because of the metal bits",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11842,8 +11842,8 @@ bool Character::unload( item_location &loc, bool bypass_activity,
             add_msg( m_info, _( "The %s is already empty!" ), it.tname() );
             return false;
         }
-        if( !it.can_unload_liquid() ) {
-            add_msg( m_info, _( "The liquid can't be unloaded in its current state!" ) );
+        if( !it.can_unload() ) {
+            add_msg( m_info, _( "The item can't be unloaded in its current state!" ) );
             return false;
         }
 

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -196,7 +196,7 @@ hint_rating Character::rate_action_reload( const item &it ) const
 hint_rating Character::rate_action_unload( const item &it ) const
 {
     if( it.is_container() && !it.empty() &&
-        it.can_unload_liquid() ) {
+        it.can_unload() ) {
         return hint_rating::good;
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3710,7 +3710,7 @@ void iexamine::keg( Character &you, const tripoint &examp )
     const units::volume keg_cap = get_keg_capacity( examp );
 
     const bool has_container_with_liquid = map_cursor( examp ).has_item_with( []( const item & it ) {
-        return !it.is_container_empty() && it.can_unload_liquid();
+        return !it.is_container_empty() && it.can_unload();
     } );
     const bool liquid_present = map_cursor( examp ).has_item_with( []( const item & it ) {
         return it.made_of_from_type( phase_id::LIQUID );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9860,7 +9860,7 @@ bool item::is_magazine_full() const
     return contents.is_magazine_full();
 }
 
-bool item::can_unload_liquid() const
+bool item::can_unload() const
 {
     if( has_flag( flag_NO_UNLOAD ) ) {
         return false;

--- a/src/item.h
+++ b/src/item.h
@@ -1736,9 +1736,10 @@ class item : public visitable
         bool can_reload_with( const item &ammo, bool now ) const;
 
         /**
-          * Returns true if any of the contents are not frozen or not empty if it's liquid
+          * Returns true if it doesn't have flag NO_UNLOAD,
+          * and any of the contents are not frozen or not empty if it's liquid
           */
-        bool can_unload_liquid() const;
+        bool can_unload() const;
 
         /**
          * Returns true if none of the contents are solid


### PR DESCRIPTION
Port #73801 from CDDA
See: https://github.com/CleverRaven/Cataclysm-DDA/pull/73801

Just a minor bugfix that makes room for non-liquid ammo types in the affected functions.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
