### PR TITLE
Port #77347 from DDA (Stop melatonin spawning in huge amounts)

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2431,7 +2431,7 @@
       [ "con_milk", 20 ],
       [ "milk_evap", 15 ],
       [ "milk_UHT", 10 ],
-      { "count": 20, "prob": 20, "group": "melatonin_tablet_bottle_plastic_pill_supplement_10" },
+      { "prob": 20, "group": "melatonin_tablet_bottle_plastic_pill_supplement_1_10" },
       [ "can_spam", 30 ],
       [ "can_tuna", 35 ],
       [ "can_salmon", 25 ],
@@ -2861,6 +2861,13 @@
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": 6 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "melatonin_tablet_bottle_plastic_pill_supplement_1_10",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_supplement",
+    "entries": [ { "item": "melatonin_tablet", "container-item": "null", "count": [ 1, 10 ] } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
See: https://github.com/CleverRaven/Cataclysm-DDA/pull/77347

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
