### PR TITLE
Port #77347 and #77349 plus minor fixes

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -256,8 +256,7 @@
     "entries": [
       { "group": "bfipowder_bottle_plastic_5_60", "prob": 100 },
       { "item": "dayquil", "count-min": 1, "count-max": 30, "container-item": "bottle_plastic", "prob": 50 },
-      { "item": "nyquil", "count-min": 1, "count-max": 30, "container-item": "bottle_plastic", "prob": 50 },
-      { "item": "flu_shot", "count-min": 1, "count-max": 10, "container-item": "null", "prob": 50 }
+      { "item": "nyquil", "count-min": 1, "count-max": 30, "container-item": "bottle_plastic", "prob": 50 }
     ]
   },
   {
@@ -283,7 +282,6 @@
       { "group": "antifungal_dr_group", "prob": 10 },
       { "group": "antiparasitic_dr_group", "prob": 10 },
       { "group": "diazepam_dr_group", "prob": 10 },
-      { "group": "calcium_dr_group", "prob": 10 },
       { "group": "iron_dr_group", "prob": 10 },
       { "group": "prozac_dr_group", "prob": 10 },
       { "group": "thorazine_dr_group", "prob": 10 },
@@ -374,9 +372,7 @@
       { "prob": 5, "group": "strong_antibiotic_bottle_plastic_pill_prescription_1_5" },
       { "prob": 2, "group": "antifungal_bottle_plastic_pill_prescription_1_5" },
       { "prob": 3, "group": "antiparasitic_bottle_plastic_pill_prescription_1_10" },
-      [ "survnote", 1 ],
       { "prob": 4, "group": "diazepam_bottle_plastic_pill_prescription_1_10" },
-      [ "flu_shot", 5 ],
       [ "syringe", 8 ]
     ]
   },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -26,8 +26,7 @@
       { "item": "gasbomb", "prob": 1 },
       { "group": "guns_swat", "prob": 20 },
       { "group": "mags_swat", "prob": 20 },
-      { "group": "gear_eod", "prob": 20 },
-      { "item": "survnote", "prob": 1 }
+      { "group": "gear_eod", "prob": 20 }
     ]
   },
   {
@@ -140,8 +139,7 @@
       { "group": "stand_flyer", "prob": 100 },
       [ "recipe_augs", 20 ],
       [ "decoy_anarch", 50 ],
-      { "group": "newspaper_recent", "prob": 200 },
-      [ "survnote", 1 ]
+      { "group": "newspaper_recent", "prob": 200 }
     ]
   },
   {
@@ -184,7 +182,6 @@
       { "item": "smoxygen_tank", "prob": 10, "charges": [ 0, 12 ] },
       [ "antifungal", 5 ],
       [ "antiparasitic", 10 ],
-      [ "survnote", 1 ],
       [ "diazepam", 10 ],
       [ "stethoscope", 35 ],
       [ "jar_3l_glass_sealed", 15 ],
@@ -226,7 +223,6 @@
       [ "gloves_medical", 50 ],
       { "item": "disinfectant", "prob": 35, "charges": [ 1, 10 ] },
       { "prob": 40, "group": "bottle_otc_painkiller_1_20" },
-      [ "flu_shot", 2 ],
       [ "blanket", 50 ],
       [ "down_blanket", 10 ],
       [ "pillow", 50 ],
@@ -1544,7 +1540,6 @@
       { "item": "knife_trench", "prob": 14 },
       { "item": "switchblade", "prob": 15 },
       { "item": "bondage_mask", "prob": 1 },
-      { "item": "survnote", "prob": 5 },
       { "item": "thermos", "prob": 25 }
     ]
   },
@@ -1570,7 +1565,6 @@
       { "item": "kevlar", "prob": 15 },
       { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster", "prob": 4 },
       { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "nylon_holster", "prob": 6 },
-      { "item": "survnote", "prob": 10 },
       { "item": "family_photo", "prob": 10 },
       { "item": "tazer", "prob": 5 }
     ]
@@ -1680,7 +1674,6 @@
       { "item": "soap", "prob": 5, "charges": [ 1, 10 ] },
       { "item": "detergent", "prob": 5, "charges": [ 1, 20 ] },
       { "item": "knitting_needles", "prob": 1 },
-      { "item": "survnote", "prob": 2 },
       { "item": "ankle_wallet_pouch", "prob": 5 }
     ]
   },
@@ -2431,7 +2424,7 @@
       [ "con_milk", 20 ],
       [ "milk_evap", 15 ],
       [ "milk_UHT", 10 ],
-      { "count": 20, "prob": 20, "group": "melatonin_tablet_bottle_plastic_pill_supplement_10" },
+      { "prob": 20, "group": "melatonin_tablet_bottle_plastic_pill_supplement_1_10" },
       [ "can_spam", 30 ],
       [ "can_tuna", 35 ],
       [ "can_salmon", 25 ],
@@ -2554,7 +2547,6 @@
       { "item": "oil_lamp", "prob": 5, "charges": [ 0, 750 ] },
       [ "lamp_oil", 5 ],
       [ "flotation_vest", 1 ],
-      [ "flu_shot", 1 ],
       [ "coat_rain", 5 ],
       [ "hood_rain", 5 ],
       [ "umbrella", 7 ],
@@ -2861,6 +2853,13 @@
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": 6 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "melatonin_tablet_bottle_plastic_pill_supplement_1_10",
+    "subtype": "collection",
+    "container-item": "bottle_plastic_pill_supplement",
+    "entries": [ { "item": "melatonin_tablet", "container-item": "null", "count": [ 1, 10 ] } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
Ports https://github.com/CleverRaven/Cataclysm-DDA/pull/77347 
and https://github.com/CleverRaven/Cataclysm-DDA/pull/77349

#### Summary

Fixes a few issues with melatonin and calcium tablet spawning. Removes flu shots from a couple of locations that didn't make sense.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
