### PR TITLE
Port #76352 and Nerf Crowd Crush

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -333,21 +333,32 @@ void suffer::while_grabbed( Character &you )
     creature_tracker &creatures = get_creature_tracker();
     int crowd = 0;
     int impassable_ter = 0;
+    // Medium size characters == 3.
+    int your_size = static_cast<std::underlying_type_t<creature_size>>( you.get_size() );
+    int crush_grabs_req = your_size - 1;
+    // Minimum of 1 grabber required.
+    crush_grabs_req = std::max( 1, crush_grabs_req );
+
     int crush_resist = 0;
     for( auto&& dest : here.points_in_radius( you.pos(), 1, 0 ) ) { // *NOPAD*
         const monster *const mon = creatures.creature_at<monster>( dest );
-        if( mon && mon->has_flag( mon_flag_GROUP_BASH ) && !mon->is_hallucination() ) {
-            crowd++;
-            add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
-                           mon->name(), crowd );
-        }
-        if( here.impassable( dest ) ) {
-            impassable_ter++;
+        if( mon ) {
+            int mon_size = static_cast<std::underlying_type_t<creature_size>>( mon->get_size() );
+            // Small monsters can't crush huge characters. Tiny monsters can't crush anyone.
+            if( mon->has_flag( mon_flag_GROUP_BASH ) && !mon->is_hallucination() && your_size <= mon_size + 2 && mon_size != 1 ) {
+                crowd++;
+                add_msg_debug( debugmode::DF_CHARACTER, "Crowd pressure check: monster %s found, crowd size %d",
+                               mon->name(), crowd );
+            }
+        } else if( here.impassable( dest ) ) {
+        impassable_ter++;
         }
     }
 
-    // If we aren't near two monsters with GROUP_BASH we won't suffocate.
-    if( crowd < 2 ) {
+    add_msg_debug( debugmode::DF_CHARACTER,
+                   "Crowd pressure sum: character size requires %d grabbers, found %d ", crush_grabs_req, crowd );
+    // if we aren't near enough monsters with GROUP_BASH we won't suffocate
+    if( crowd < crush_grabs_req ) {
         return;
     }
 
@@ -369,18 +380,16 @@ void suffer::while_grabbed( Character &you )
     if( you.has_trait( trait_SLIMESPAWNER ) || you.has_trait( trait_TRANSPIRATION ) ) {
         crush_resist += 1;
     }
-    if( crush_resist <= rng( 0, 19 ) ) {
-        if( crowd == 3 ) {
-            // Only a chance to lose breath at low grab chance, none with only a single zombie
+    if( crowd == crush_grabs_req ) {
+        // only a chance to lose breath at minimum grabs
             you.oxygen -= rng( 0, 1 );
-        } else if( crowd == 4 ) {
+        } else if( crowd <= crush_grabs_req * 2 ) {
             you.oxygen -= 1;
-        } else if( crowd <= 6 ) {
+        } else if( crowd <= crush_grabs_req * 3 ) {
             you.oxygen -= rng( 1, 2 );
-        } else if( crowd <= 8 ) {
+        } else if( crowd <= crush_grabs_req * 4 ) {
             you.oxygen -= 2;
         }
-    }
 
     // a few warnings before starting to take damage
     if( you.oxygen <= 5 ) {


### PR DESCRIPTION
#### Summary

Ports https://github.com/CleverRaven/Cataclysm-DDA/pull/76352 which makes a character's size affect the number of grabbers needed for them to suffer crowd crush. Goes a step further and adds some sanity checks to adjacent walls and relative size.

#### Purpose of change

Crowd crush was another mechanic added to deal with overpowered armor. While it's perfectly logical that a mob of zombies could crush you, and standing in an intersection holding tab while hundreds of zombies swarm you is not a style of gameplay we want to support except maybe for chimera mutants, it was always overtuned, and you'd be dealing with the mechanic any time you happened to be next to a wall and two or three zombies.

As mentioned in #20 , I believe the way to deal with armor being too strong is not to introduce mechanics which simply bypass it. These merely create new concerns for the player, and while that's not a bad thing in and of itself, they don't address the underlying issue. Ultimately, this is a survival RPG about building up and equipping your character, and the game world should respect the work the player has put in.

#### Describe the solution

The linked PR partially addressed this by adjusting the number of zombies required to crush characters based on character size, but here we go a step further by making it impossible for tiny monsters to crush anyone, and impossible for small monsters to crush huge characters.

Also implements a check for the wall crush mechanic. Now, walls are not counted unless the number of adjacent crushers plus the number of adjacent walls is higher than six, as two empty spaces should logically still leave a character some wiggle room. This means you're still penalized for standing in a closet while three zombies crush you, but you probably won't get suffocated because you were fighting three zombies next to a chain link fence in an open field. This has the knock-on effect of reducing the warning spam from the wall crush mechanic, which was probably a large part of what bothered people about crowd crush.

#### Testing

Spawned in, fought variably sized groups of zombies in a corner. Changed my size. Saw that everything worked as intended.

#### Additional context

Grabbing GROUP_BASH enemies (IE Zombies) required to crush a character, by character size. Note that walls do not count as grabbing enemies to proc crowd crush, they only bonus it if it's procced:
Tiny: 1
Small: 2
Medium: 3
Large: 4
Huge: 5

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
