### PR TITLE
Point Buy is Default

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2805,9 +2805,9 @@ void options_manager::add_options_world_default()
     add_empty_line();
 
     add( "CHARACTER_POINT_POOLS", "world_default", to_translation( "Character point pools" ),
-         to_translation( "Allowed point pools for character generation." ),
-    { { "any", to_translation( "Any" ) }, { "multi_pool", to_translation( "Legacy Multipool" ) }, { "story_teller", to_translation( "Survivor" ) } },
-    "story_teller"
+         to_translation( "Methods allowed for character creation." ),
+    { { "any", to_translation( "Any" ) }, { "multi_pool", to_translation( "Multipool" ) }, { "one_pool", to_translation( "Single Pool" ) } },
+    "any"
        );
 
     add_empty_line();
@@ -2820,7 +2820,7 @@ void options_manager::add_options_world_default()
              "uninitiated, and some professions skip portions of the game's content.  If "
              "new to the game, meta progression will help you be introduced to mechanics at "
              "a reasonable pace." ),
-         true
+         false
        );
 }
 

--- a/src/player_difficulty.h
+++ b/src/player_difficulty.h
@@ -8,9 +8,9 @@
 constexpr int HIGH_STAT = 12;
 
 enum class pool_type {
-    FREEFORM = 0,
-    ONE_POOL,
+    ONE_POOL = 0,
     MULTI_POOL,
+    FREEFORM,
     TRANSFER,
 };
 


### PR DESCRIPTION
#### Summary

Enable point buy by default. Remove player_difficulty estimations.

#### Purpose of change

Freeform is fine as an option, but game balance is important and giving the player some structure will inspire them to be creative with their builds. Furthermore, the difficulty estimations introduced with "Suvivor mode" were very arbitrary and had a lot of strange problems, such as musician counting as having armor because the character started with a guitar strapped to their back.

The oft-cited issue of players picking a lot of trivial penalties to get "free points" is only an issue because those negative traits are not hindering enough. They should either have their point values adjusted, or they should be reworked to provide more of an interesting challenge.

#### Describe the solution

Re-enable point buy by default. Rename survivor mode to freeform. Remove difficulty estimations. Make point buy the default choice, and clarify some of the UI text.

#### Additional context

- The multi-point UI is a lot cleaner than it used to be, but it could still use some work.
- The code for the difficulty estimations still exists, it may be worth fixing up later but I don't think it's a priority at this time.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
