### PR TITLE
Fix aim variance bug

### DIFF
--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -355,10 +355,7 @@
     "description": "A set of small wheels, mounted on pivots, like the ones on a rolling office chair.",
     "damage_modifier": 50,
     "folded_volume": "1250 ml",
-    "breaks_into": [
-      { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
-    ],
+    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 2 ] } ],
     "rolling_resistance": 29.0,
     "wheel_offroad_rating": 0.1,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 6 ], "ROAD": [ 0, 3 ] },
@@ -383,10 +380,7 @@
     "durability": 70,
     "damage_modifier": 50,
     "folded_volume": "3150 ml",
-    "breaks_into": [
-      { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] }
-    ],
+    "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 2 ] } ],
     "rolling_resistance": 14.0,
     "wheel_offroad_rating": 0.4,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 6 ], "ROAD": [ 0, 3 ] },

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -975,6 +975,12 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         dispersion_sources dispersion = get_weapon_dispersion( gun );
         dispersion.add_range( recoil_total() );
         dispersion.add_spread( proj.shot_spread );
+        // Shooting is never completely deterministic.
+        // Peak Human (18+) perception can get a bit better than - 200 variance, but it caps at -100.
+        double variance_min = 900.0 - ( std::min( 800.0,
+                                        ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
+                                                limb_score_vision ) ) / 2.0 ) ) ) ) );
+        dispersion.add_range( rng( variance_min, -200 ) );
 
         bool first = true;
         bool headshot = false;
@@ -2313,13 +2319,6 @@ dispersion_sources Character::get_weapon_dispersion( const item &obj ) const
     dispersion.add_range( ranged_dex_mod() );
 
     dispersion.add_range( get_modifier( character_modifier_ranged_dispersion_manip_mod ) );
-
-    // Shooting is never completely deterministic.
-    // Peak Human (18+) perception can get a bit better than - 200 variance, but it caps at -100.
-    double variance_min = 900.0 - ( std::min( 800.0,
-                                    ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
-                                            limb_score_vision ) ) / 2.0 ) ) ) ) );
-    dispersion.add_range( rng( variance_min, -200 ) );
 
     if( is_driving() ) {
         // get volume of gun (or for auxiliary gunmods the parent gun)


### PR DESCRIPTION
#### Summary

Fixes a bug introduced in #29 

#### Purpose of change

The new aim variance system was running too early in the process, resulting in a fluctuating readout on the player's aim UI. This probably was also causing bugs with NPC code such as their firearm evaluation.

#### Describe the solution

Moved the code to run in fire_gun() immediately before the gun actually goes off.

#### Testing

Spawned a character and shot at some stuff. The HUD looks like it should again. Adjusted my perception lower and higher and saw my precision decrease and increase as expected.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
