### PR TITLE
Title screens, keybinds, and linting

### DIFF
--- a/data/json/monstergroups/mutant_upgrades.json
+++ b/data/json/monstergroups/mutant_upgrades.json
@@ -2,10 +2,7 @@
   {
     "type": "monstergroup",
     "name": "GROUP_CROW_MUTANT",
-    "monsters": [
-      { "monster": "mon_crow_mutant_small", "weight": 650 },
-      { "monster": "mon_crow_mutant", "weight": 350 }
-    ]
+    "monsters": [ { "monster": "mon_crow_mutant_small", "weight": 650 }, { "monster": "mon_crow_mutant", "weight": 350 } ]
   },
   {
     "name": "GROUP_CENTIPEDE_ADULT",
@@ -49,9 +46,6 @@
     "name": "GROUP_RATKIN_EVOLVED",
     "type": "monstergroup",
     "default": "mon_big_rat",
-    "monsters": [
-      { "monster": "mon_big_rat", "weight": 320 },
-      { "monster": "mon_tunnel_rat", "weight": 180 }
-    ]
+    "monsters": [ { "monster": "mon_big_rat", "weight": 320 }, { "monster": "mon_tunnel_rat", "weight": 180 } ]
   }
 ]

--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -553,9 +553,7 @@
     "aggro_character": true,
     "aggression": 100,
     "morale": 100,
-    "scents_tracked": [
-      "sc_human"
-    ],
+    "scents_tracked": [ "sc_human" ],
     "melee_dice": 1,
     "melee_dice_sides": 3,
     "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
@@ -571,7 +569,19 @@
     "special_attacks": [ [ "SHRIEK", 100 ], [ "EAT_CARRION", 40 ], [ "EAT_FOOD", 120 ] ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
     "upgrades": { "half_life": 21, "into_group": "GROUP_CROW_MUTANT" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "EATS", "SMALL_HIDER", "SWARMS", "HIT_AND_RUN", "CORNERED_FIGHTER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "FLIES",
+      "EATS",
+      "SMALL_HIDER",
+      "SWARMS",
+      "HIT_AND_RUN",
+      "CORNERED_FIGHTER"
+    ]
   },
   {
     "id": "mon_crow_mutant",
@@ -591,9 +601,7 @@
     "color": "dark_gray",
     "aggression": 100,
     "morale": 105,
-    "scents_tracked": [
-      "sc_human"
-    ],
+    "scents_tracked": [ "sc_human" ],
     "melee_skill": 4,
     "melee_dice": 2,
     "melee_dice_sides": 8,

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -328,7 +328,19 @@
     "harvest": "cat_medium_with_skull",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_feline_sample_single",
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN", "SMALL_HIDER", "CORNERED_FIGHTER", "CLIMBS" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "HIT_AND_RUN",
+      "SMALL_HIDER",
+      "CORNERED_FIGHTER",
+      "CLIMBS"
+    ]
   },
   {
     "id": "mon_cat",

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -322,10 +322,7 @@
     "vision_night": 30,
     "fear_triggers": [ "PLAYER_CLOSE", "FIRE", "HURT", "FRIEND_ATTACKED", "SOUND" ],
     "flags": [ "FISHABLE", "SEES", "SMELLS", "HEARS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ],
-  "upgrades": {
-    "age_grow": 8,
-    "into": "mon_big_bullfrog"
-  }
+    "upgrades": { "age_grow": 8, "into": "mon_big_bullfrog" }
   },
   {
     "id": "mon_bullfrog",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2361,10 +2361,7 @@
     "points": 2,
     "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "survival" }, { "level": 3, "name": "cooking" } ],
     "proficiencies": [ "prof_knitting", "prof_knitting_speed" ],
-    "pets": [
-      { "name": "mon_cat", "amount": 18 },
-      { "name": "mon_cat_kitten", "amount": 10 }
-    ],
+    "pets": [ { "name": "mon_cat", "amount": 18 }, { "name": "mon_cat_kitten", "amount": 10 } ],
     "items": {
       "both": {
         "entries": [

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -118,12 +118,7 @@
     "id": "eggs_frog",
     "type": "requirement",
     "//": "All of the different frog eggs",
-    "components": [
-      [
-        [ "egg_bullfrog", 4 ],
-        [ "egg_mutant_frog", 1 ]
-      ]
-    ]
+    "components": [ [ [ "egg_bullfrog", 4 ], [ "egg_mutant_frog", 1 ] ] ]
   },
   {
     "id": "eggs_invert",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2324,15 +2324,14 @@
     "type": "keybinding",
     "name": "Examine nearby terrain or furniture",
     "category": "DEFAULTMODE",
-    "id": "examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "id": "examine"
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_2" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_2" } ]
   },
   {
     "type": "keybinding",

--- a/data/title/en.alt1
+++ b/data/title/en.alt1
@@ -1,28 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
 # Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_light_cyan>   _________            __                   .__                                </color>
-<color_light_cyan>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
-<color_light_cyan>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \     </color>
-<color_light_cyan>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
-<color_light_cyan>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    </color>
-<color_light_cyan>           \/      \/             \/      \/        \/          \/       \/     </color>
-<color_light_blue>    ________                   .__      ________                                </color>
-<color_light_blue>    \______ \  _____   _______ |  | __  \______ \  _____    ___.__   ______     </color>
-<color_light_blue>     |    |  \ \__  \  \_  __ \|  |/ /   |    |  \ \__  \  <   |  | /  ___/     </color>
-<color_light_blue>     |    `   \ / __ \_ |  | \/|    <    |    `   \ / __ \_ \___  | \___ \      </color>
-<color_light_blue>    /_______  /(____  / |__|   |__|_ \  /_______  /(____  / / ____|/____  >     </color>
-<color_light_blue>            \/      \/              \/          \/      \/  \/          \/      </color>
-<color_light_blue>                     _____   .__                         .___                   </color>
-<color_light_blue>                    /  _  \  |  |__    ____  _____     __| _/                   </color>
-<color_light_blue>                   /  /_\  \ |  |  \ _/ __ \ \__  \   / __ |                    </color>
-<color_light_blue>                  /    |    \|   Y  \\  ___/  / __ \_/ /_/ |              </color><color_light_green>.-.   </color>
-<color_light_blue>                  \____|__  /|___|  / \___  >(____  /\____ |          </color><color_light_green>_  |   `  </color>
-<color_light_blue>                          \/      \/      \/      \/      \/           </color><color_light_green>',|    \ </color>
-<color_white>     ***                                                  </color><color_light_green>_..        -.,,'-., / </color>
-<color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
-<color_white>     *** =========='      </color><color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>
-<color_white>     ||'''/ |                                        </color><color_light_green>`````'-    /```''-    | |  </color>
-<color_white>     ,\.    |                                                </color><color_light_green>'.-_`,,,,,,,,,\.\--</color>
-<color_white>    /  |    ^          ___,,,,,,,,,,...-------''''''``````````                  </color>
-<color_brown>*------'''''*``````````                                                         </color>
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.christmas
+++ b/data/title/en.christmas
@@ -1,21 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_light_cyan>   _________            __                   .__                                
-<color_light_cyan>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      
-<color_light_cyan>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \     
-<color_light_cyan>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    
-<color_light_cyan>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    
-<color_light_cyan>           \/      \/             \/      \/        \/          \/       \/     
-<color_white>     _________              __           _________ .__                          
-<color_white>    /   _____/____    _____/  |______    \_   ___ \|  | _____   __ __  ______   
-<color_red>    \_____  \\__  \  /    \   __\__  \   /    \  \/|  | \__  \ |  |  \/  ___/   
-<color_red>    /        \/ __ \|   |  \  |  / __ \_ \     \___|  |__/ __ \|  |  /\___ \    
-<color_red>   /_______  (____  /___|  /__| (____  /  \______  /____(____  /____//____  >   
-<color_red>           \/     \/     \/          \/          \/          \/           \/    
-<color_light_blue>                     _____   .__                         .___                   
-<color_light_blue>                    /  _  \  |  |__    ____  _____     __| _/                   
-<color_light_blue>                   /  /_\  \ |  |  \ _/ __ \ \__  \   / __ |                    
-<color_light_blue>                  /    |    \|   Y  \\  ___/  / __ \_/ /_/ |                    
-<color_light_blue>                  \____|__  /|___|  / \___  >(____  /\____ |                    
-<color_light_blue>                          \/      \/      \/      \/      \/                    
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.easter
+++ b/data/title/en.easter
@@ -1,24 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_light_green>   _________            __                   .__                                
-<color_light_green>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      
-<color_light_green>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \     
-<color_light_green>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    
-<color_light_green>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    
-<color_light_green>           \/      \/             \/      \/        \/          \/       \/     
-<color_white>    _______     ___    _ ,---.   .--.,---.   .--.<color_light_cyan>.-./`)<color_white>     .-''-.     .-'''-.  
-<color_white>   \  ____  \ .'   |  | ||    \  |  ||    \  |  |<color_light_cyan> \<color_light_red>.-.<color_light_cyan>')<color_white>  .'<color_blue>_ _<color_white>   \   / <color_red>_<color_white>     \ 
-<color_white>   | |    \ | |   .'  | ||  ,  \ |  ||  ,  \ |  |<color_light_cyan>/ <color_light_red>`-'<color_light_cyan> \<color_white> / <color_blue>( ` )<color_white>   ' <color_red>(`' )<color_white>/`--' 
-<color_white>   | |____/ / .'  '<color_green>_<color_white>  | ||  |\<color_light_blue>_<color_white> \|  ||  |\<color_magenta>_<color_white> \|  | <color_light_cyan>`-'`"`<color_white>. <color_blue>(_ <color_yellow>o<color_blue> _)<color_white>  |<color_red>(_ <color_yellow>o<color_red> _)<color_white>.    
-<color_white>   |   <color_yellow>_ _<color_white> '. '   <color_green>( \.-.<color_white>||  <color_light_blue>_( )_<color_white>\  ||  <color_magenta>_( )_<color_white>\  | .---. |  <color_blue>(_,_)<color_white>___| <color_red>(_,_)<color_white>. '.  
-<color_white>   |  <color_yellow>( ' )<color_white>  \' <color_green>(`. <color_yellow>_<color_green>` /<color_white>|| <color_light_blue>(_ <color_yellow>o<color_light_blue> _)<color_white>  || <color_magenta>(_ <color_light_green>o<color_magenta> _)<color_white>  | |   | '  \   .---..---.  \  : 
-<color_white>   | <color_yellow>(_<color_red>{;}<color_yellow>_)<color_white> || <color_green>(_ <color_yellow>(_)<color_green> _)<color_white>|  <color_light_blue>(_,_)<color_white>\  ||  <color_magenta>(_,_)<color_white>\  | |   |  \  `-'    /\    `-'  | 
-<color_white>   |  <color_yellow>(_,_)<color_white>  / \ <color_green>/  . \<color_white> /|  |    |  ||  |    |  | |   |   \       /  \       /  
-<color_white>   /_______.'   `<color_green>`-'`-'<color_white>' '--'    '--''--'    '--' '---'    `'-..-'    `-...-'   
-<color_green>                     _____   .__                         .___                   
-<color_green>                    /  _  \  |  |__    ____  _____     __| _/                   
-<color_green>                   /  /_\  \ |  |  \ _/ __ \ \__  \   / __ |                    
-<color_green>                  /    |    \|   Y  \\  ___/  / __ \_/ /_/ |                    
-<color_green>                  \____|__  /|___|  / \___  >(____  /\____ |                    
-<color_green>                          \/      \/      \/      \/      \/                    
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.halloween
+++ b/data/title/en.halloween
@@ -1,29 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_red> ▄<color_light_cyan>▓▓▓▓</color>▄   ▄▄▄     ▄<color_light_cyan>▓▓▓▓▓▓▓▓</color>▓ ▄<color_light_cyan>▓</color>▄      ▄<color_light_cyan>▓▓▓▓</color>▄  <color_light_cyan>▓▓</color>▓   ▓<color_light_cyan>▓▓</color>   <color_light_cyan>▓▓</color>▓  <color_light_cyan>▓▓▓▓</color>▄▄ <color_light_cyan>▓▓▓</color>▄▄<color_light_cyan>▓▓▓</color>▄
-<color_red>▒<color_light_cyan>▓▓</color>▀ ▀<color_light_cyan>▓</color>  ▒<color_light_cyan>▓▓▓▓</color>▄   ▓  <color_light_cyan>▓▓</color>▒ ▓▒▒<color_light_cyan>▓▓▓▓</color>▄   ▒<color_light_cyan>▓▓</color>▀ ▀<color_light_cyan>▓</color> ▓<color_light_cyan>▓▓</color>▒    ▒<color_light_cyan>▓▓</color>  <color_light_cyan>▓▓</color>▒▒<color_light_cyan>▓▓</color>    ▒▓<color_light_cyan>▓▓</color>▒▀<color_light_cyan>▓▓</color> <color_light_cyan>▓▓</color>▒
-<color_red>▒▓<color_light_cyan>▓</color>    ▄ ▒<color_light_cyan>▓▓</color>  ▀<color_light_cyan>▓</color>▄ ▒ ▓<color_light_cyan>▓▓</color>░ ▒░▒<color_light_cyan>▓▓</color>  ▀<color_light_cyan>▓</color>▄ ▒▓<color_light_cyan>▓</color>    ▄▒<color_light_cyan>▓▓</color>░     ▒<color_light_cyan>▓▓</color> <color_light_cyan>▓▓</color>░░ ▓<color_light_cyan>▓▓</color>▄  ▓<color_light_cyan>▓▓</color>    ▓<color_light_cyan>▓▓</color>░▒
-<color_red>▒▓▓▄ ▄<color_light_cyan>▓▓</color>▒░<color_light_cyan>▓▓</color>▄▄▄▄<color_light_cyan>▓▓</color>░ ▓<color_light_cyan>▓▓</color>▓ ░ ░<color_light_cyan>▓▓</color>▄▄▄▄<color_light_cyan>▓▓</color>▒▓▓▄ ▄<color_light_cyan>▓▓</color>▒<color_light_cyan>▓▓</color>░     ░ ▐<color_light_cyan>▓▓</color>▓░  ▒   <color_light_cyan>▓▓</color>▒<color_light_cyan>▓▓</color>    ▒<color_light_cyan>▓▓</color> ▓
-<color_red>▒ ▓<color_light_cyan>▓▓▓</color>▀ ░ ▓<color_light_cyan>▓</color>   ▓<color_light_cyan>▓▓</color>▒ ▒<color_light_cyan>▓▓</color>▒ ░  ▓<color_light_cyan>▓</color>   ▓<color_light_cyan>▓▓</color>▒ ▓<color_light_cyan>▓▓▓</color>▀ ░<color_light_cyan>▓▓▓▓▓▓</color>▒ ░ <color_light_cyan>▓▓</color>▒▓░▒<color_light_cyan>▓▓▓▓▓▓</color>▒▒<color_light_cyan>▓▓</color>▒   ░<color_light_cyan>▓▓</color>▒░
-<color_red>░ ░▒ ▒  ░ ▒▒   ▓▒<color_light_cyan>▓</color>░ ▒ ░░    ▒▒   ▓▒<color_light_cyan>▓</color>░ ░▒ ▒  ░ ▒░▓  ░  <color_light_cyan>▓▓</color>▒▒▒ ▒ ▒▓▒ ▒ ░ ▒░   ░  ░
-<color_red>  ░  ▒     ▒   ▒▒ ░   ░      ▒   ▒▒ ░ ░  ▒  ░ ░ ▒  ░▓<color_light_cyan>▓▓</color> ░▒░ ░ ░▒  ░ ░  ░      ░
-<color_red>░          ░   ▒    ░        ░   ▒  ░         ░ ░   ▒ ▒ ░░  ░  ░  ░ ░      ░
-<color_red>░ ░            ░  ░              ░  ░ ░         ░  ░░ ░           ░        ░
-<color_red>░   ▓<color_light_blue>▓▓▓▓▓</color>▄  ▄▄▄       <color_light_blue>▓▓</color>▀<color_light_blue>▓▓▓</color>   <color_light_blue>▓▓</color> ▄<color_light_blue>▓</color>▀   ▓<color_light_blue>▓▓▓▓▓</color>▄  ▄▄▄░    ▓<color_light_blue>▓▓</color>   <color_light_blue>▓▓</color>▓  <color_light_blue>▓▓▓▓▓</color>▄
-<color_red>    ▒<color_light_blue>▓▓</color>▀ <color_light_blue>▓▓</color>▌▒<color_light_blue>▓▓▓▓</color>▄    ▓<color_light_blue>▓▓</color> ▒ <color_light_blue>▓▓</color>▒ <color_light_blue>▓▓</color>▄<color_light_blue>▓</color>▒    ▒<color_light_blue>▓▓</color>▀ <color_light_blue>▓▓</color>▌▒<color_light_blue>▓▓▓▓</color>▄    ▒<color_light_blue>▓▓</color>  <color_light_blue>▓▓</color>▒▒<color_light_blue>▓▓</color>    ▒
-<color_red>    ░<color_light_blue>▓▓</color>   <color_light_blue>▓</color>▌▒<color_light_blue>▓▓</color>  ▀<color_light_blue>▓</color>▄  ▓<color_light_blue>▓▓</color> ░▄<color_light_blue>▓</color> ▒▓<color_light_blue>▓▓▓</color>▄░    ░<color_light_blue>▓▓</color>   <color_light_blue>▓</color>▌▒<color_light_blue>▓▓</color>  ▀<color_light_blue>▓</color>▄   ▒<color_light_blue>▓▓</color> <color_light_blue>▓▓</color>░░ ▓<color_light_blue>▓▓</color>▄
-<color_red>    ░▓<color_light_blue>▓</color>▄   ▌░<color_light_blue>▓▓</color>▄▄▄▄<color_light_blue>▓▓</color> ▒<color_light_blue>▓▓</color>▀▀<color_light_blue>▓</color>▄  ▓<color_light_blue>▓▓</color> <color_light_blue>▓</color>▄    ░▓<color_light_blue>▓</color>▄   ▌░<color_light_blue>▓▓</color>▄▄▄▄<color_light_blue>▓▓</color>  ░ ▐<color_light_blue>▓▓</color>▓░  ▒   <color_light_blue>▓▓</color>▒
-<color_red>    ░▒<color_light_blue>▓▓▓▓</color>▓  ▓<color_light_blue>▓</color>   ▓<color_light_blue>▓▓</color>▒░<color_light_blue>▓▓</color>▓ ▒<color_light_blue>▓▓</color>▒▒<color_light_blue>▓▓</color>▒ <color_light_blue>▓</color>▄   ░▒<color_light_blue>▓▓▓▓</color>▓  ▓<color_light_blue>▓</color>   ▓<color_light_blue>▓▓</color>▒ ░ <color_light_blue>▓▓</color>▒▓░▒<color_light_blue>▓▓▓▓▓▓</color>▒▒
-<color_red>     ▒▒▓  ▒  ▒▒   ▓▒<color_light_blue>▓</color>░░ ▒▓ ░▒▓░▒ ▒▒ ▓▒    ▒▒▓  ▒  ▒▒   ▓▒<color_light_blue>▓</color>░  <color_light_blue>▓▓</color>▒▒▒ ▒ ▒▓▒ ▒ ░
-<color_red>     ░ ▒  ▒   ▒   ▒▒ ░  ░▒ ░ ▒░░ ░▒ ▒░    ░ ▒  ▒   ▒   ▒▒ ░▓<color_light_blue>▓▓</color> ░▒░ ░ ░▒  ░ ░
-<color_red>     ░ ░  ░   ░   ▒     ░░   ░ ░ ░░ ░     ░ ░  ░   ░   ▒   ▒ ▒ ░░  ░  ░  ░
-<color_red>       ░          ░▄▄▄   ░   <color_light_blue>▓▓</color>░ <color_light_blue>▓▓</color> ▓<color_light_blue>▓▓▓▓▓</color> ▄▄▄      ▓<color_light_blue>▓▓▓▓▓</color>▄░ ░           ░
-<color_red>     ░            ▒<color_light_blue>▓▓▓▓</color>▄    ▓<color_light_blue>▓▓</color>░ <color_light_blue>▓▓</color>▒▓<color_light_blue>▓</color>   ▀▒<color_light_blue>▓▓▓▓</color>▄    ▒<color_light_blue>▓▓</color>▀ <color_light_blue>▓▓</color>▌ ░
-<color_red>                  ▒<color_light_blue>▓▓</color>  ▀<color_light_blue>▓</color>▄  ▒<color_light_blue>▓▓</color>▀▀<color_light_blue>▓▓</color>░▒<color_light_blue>▓▓▓</color>  ▒<color_light_blue>▓▓</color>  ▀<color_light_blue>▓</color>▄  ░<color_light_blue>▓▓</color>   <color_light_blue>▓</color>▌
-<color_red>                  ░<color_light_blue>▓▓</color>▄▄▄▄<color_light_blue>▓▓</color> ░▓<color_light_blue>▓</color> ░<color_light_blue>▓▓</color> ▒▓<color_light_blue>▓</color>  ▄░<color_light_blue>▓▓</color>▄▄▄▄<color_light_blue>▓▓</color> ░▓<color_light_blue>▓</color>▄   ▌
-<color_red>                   ▓<color_light_blue>▓</color>   ▓<color_light_blue>▓▓</color>▒░▓<color_light_blue>▓</color>▒░<color_light_blue>▓▓</color>▓░▒<color_light_blue>▓▓▓▓</color>▒▓<color_light_blue>▓</color>   ▓<color_light_blue>▓▓</color>▒░▒<color_light_blue>▓▓▓▓</color>▓
-<color_red>                   ▒▒   ▓▒<color_light_blue>▓</color>░ ▒ ░░▒░▒░░ ▒░ ░▒▒   ▓▒<color_light_blue>▓</color>░ ▒▒▓  ▒
-<color_red>                    ▒   ▒▒ ░ ▒ ░▒░ ░ ░ ░  ░ ▒   ▒▒ ░ ░ ▒  ▒
-<color_red>                    ░   ▒    ░  ░░ ░   ░    ░   ▒    ░ ░  ░
-<color_red>                        ░  ░ ░  ░  ░   ░  ░     ░  ░   ░
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.independence_day
+++ b/data/title/en.independence_day
@@ -1,21 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_blue>  _________                         __  .__  __          __  .__                
-<color_blue>  \_   ___ \  ____   ____   _______/  |_|__|/  |_ __ ___/  |_|__| ____   ____   
-<color_blue>  /    \  \/ /  _ \ /    \ /  ___/\   __\  \   __\  |  \   __\  |/  _ \ /    \  
-<color_blue>  \     \___(  <_> )   |  \\___ \  |  | |  ||  | |  |  /|  | |  (  <_> )   |  \ 
-<color_blue>   \______  /\____/|___|  /____  > |__| |__||__| |____/ |__| |__|\____/|___|  / 
-<color_blue>          \/            \/     \/                                           \/  
-<color_red>          ___________             __________                __                  
-<color_red>          \__    ___/___ _____    \______   \_____ ________/  |_ ___.__.        
-<color_red>            |    |_/ __ \\__  \    |     ___/\__  \\_  __ \   __<   |  |        
-<color_red>            |    |\  ___/ / __ \_  |    |     / __ \|  | \/|  |  \___  |        
-<color_red>            |____| \___  >____  /  |____|    (____  /__|   |__|  / ____|        
-<color_red>                       \/     \/                  \/             \/             
-<color_white>                       _____  .__                       .___                    
-<color_light_gray>   ________ <color_white>          /  _  \ |  |__   ____ _____     __| _/                    
-<color_light_gray>  |<color_blue>:<color_white>:<color_blue>:<color_white>:<color_red>====<color_light_gray>|<color_white>         /  /_\  \|  |  \_/ __ \\__  \   / __ |                     
-<color_light_gray>  |<color_white>:<color_blue>:<color_white>:<color_blue>:<color_white>====<color_light_gray>|<color_white>        /    |    \   Y  \  ___/ / __ \_/ /_/ |                     
-<color_light_gray>  |<color_red>========<color_light_gray>|<color_white>        \____|__  /___|  /\___  >____  /\____ |                     
-<color_light_gray>            <color_white>                \/     \/     \/     \/      \/                     
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.new_year
+++ b/data/title/en.new_year
@@ -1,22 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_white>   _________            __                   .__                                
-<color_white>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      
-<color_red>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \     
-<color_red>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    
-<color_red>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    
-<color_red>           \/      \/             \/      \/        \/          \/       \/     
-<color_green>            ___________.__         ___________                                  
-<color_green>            \_   _____/|__|______  \__    ___/______   ____   ____              
-<color_green>             |    __)  |  \_  __ \   |    |  \_  __ \_/ __ \_/ __ \             
-<color_green>      /\<color_green>     |     \   |  ||  | \/   |    |   |  | \/\  ___/\  ___/             
-<color_green>     /\<color_red>*<color_green>\<color_brown>    \___  /   |__||__|      |____|   |__|    \___  >\___  >            
-<color_green>    /\<color_yellow>O<color_green>\<color_blue>*<color_green>\<color_brown>       \/                                       \/     \/             
-<color_green>   /<color_red>*<color_green>/\/\/\<color_white>            _____   .__                         .___                 
-<color_green>  /\<color_white>O<color_green><color_green>\/\<color_pink>*<color_green>\/\<color_white>          /  _  \  |  |__    ____  _____     __| _/                 
-<color_green> /\<color_blue>*<color_green>\/\<color_light_green>*<color_green>\/\/\<color_red>        /  /_\  \ |  |  \ _/ __ \ \__  \   / __ |                  
-<color_green>/\<color_light_cyan>O<color_green><color_green>\/\/<color_red>*<color_green>/\/<color_yellow>O<color_green>/\<color_red>      /    |    \|   Y  \\  ___/  / __ \_/ /_/ |                  
-<color_brown>      ||<color_red>            \____|__  /|___|  / \___  >(____  /\____ |                  
-<color_brown>      ||<color_red>                    \/      \/      \/      \/      \/                  
-<color_brown>      ||                                                                        
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/en.thanksgiving
+++ b/data/title/en.thanksgiving
@@ -1,29 +1,21 @@
 # The ASCII art must be 18 lines in height (6 lines per ascii art text line).
-# Max length of a line is 80 characters; the following line is for reference.
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
 ################################################################################
-<color_light_cyan>   _________            __                   .__                                
-<color_light_cyan>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      
-<color_light_cyan>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \     
-<color_light_cyan>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    
-<color_light_cyan>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  /    
-<color_light_cyan>           \/      \/             \/      \/        \/          \/       \/     
-<color_light_blue>      ___________            __                   ________                      
-<color_light_blue>      \__    ___/_ _________|  | __ ____ ___.__.  \______ \ _____  ___.__.      
-<color_light_blue>        |    | |  |  \_  __ \  |/ // __ <   |  |   |    |  \\__  \<   |  |      
-<color_light_blue>        |    | |  |  /|  | \/    <\  ___/\___  |   |    `   \/ __ \\___  |      
-<color_light_blue>        |____| |____/ |__|  |__|_ \\___  > ____|  /_______  (____  / ____|      
-<color_light_blue>                                 \/    \/\/               \/     \/\/           
-<color_light_blue>                                   _____   .__                         .___     
-<color_white>                    .--.          <color_light_blue>/  _  \  |  |__    ____  _____     __| _/     
-<color_white>    {\<color_brown>             / <color_yellow>q<color_red> {\        <color_light_blue>/  /_\  \ |  |  \ _/ __ \ \__  \   / __ |      
-<color_white>    { `\<color_brown>           \ (-<color_red>(~`      <color_light_blue>/    |    \|   Y  \\  ___/  / __ \_/ /_/ |      
-<color_white>   { '.{`\<color_brown>          \ \ <color_red>)       <color_light_blue>\____|__  /|___|  / \___  >(____  /\____ |      
-<color_white>   {'-{ ' \<color_brown>  .-""'-. \ \                <color_light_blue>\/      \/      \/      \/      \/      
-<color_white>   {._{'.' \<color_brown>/       '.) \                                                       
-<color_white>   {_.{.   <color_brown>{`            |                                                      
-<color_white>   {._{ ' <color_brown>{   <color_white>;'-=-.<color_brown>     |                                                      
-<color_white>    {-.{.' <color_brown>{  <color_white>';-=-.`<color_brown>    /                                                      
-<color_white>     {._.{.<color_brown>;    <color_white>'-=-<color_brown>   .'                                                       
-<color_white>      {_.-' <color_brown>`'.__  _,-'                                                         
-<color_white>               <color_red>|||`                                                             
-<color_white>              <color_red>.='==,                                                            
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/ru.alt1
+++ b/data/title/ru.alt1
@@ -4,22 +4,15 @@
 <color_light_cyan>    |    |  \  / __ \_ |  |   / __ \_|    <  /  Y  \|  /  | _(__  <|  Y Y  \    </color>
 <color_light_cyan>    |____|__ \(____  / |__|  (____  /|__|_ \|___|  /\__/  //____  /|__|_|  /    </color>
 <color_light_cyan>            \/     \/             \/      \/     \/     \/      \/       \/     </color>
-<color_light_blue>  ___________ ..                                       ______                   </color>
-<color_light_blue>  \__    ___/____    __ __  ___ __  __   __   ____     \___  \  ___ __  __ __   </color>
-<color_light_blue>    |    | _/ __ \  /  V  \ \  |  ||  |_|  |_/ __ \    /  /|  \ \  |  ||  |  |  </color>
-<color_light_blue>    |    | \  ___/ |  Y Y  \|     ||  _ \  |\  ___/  _/  /_|   \|     ||  /  |  </color>
-<color_light_blue>    |____|  \___  >|__|_|  /|__|  ||____/__| \___  > \  _____  /|__|  |\__/  /  </color>
-<color_light_blue>                \/       \/     \/               \/   \/     \/     \/     \/   </color>
-<color_light_blue>           __________                                                           </color>
-<color_light_blue>           \______   \ ______   ____ _______    ____     __    __ __            </color>
-<color_light_blue>            |    |  _/ \     |_/ __ \\____  \ _/ __ \   /  \  |  |  |           </color>
-<color_light_blue>            |    |)  \ |  Y  |\  ___/ |  |)  >\  ___/ _/ /\ \_|  /  |     </color><color_light_green>.-.   </color>
-<color_light_blue>            |______  / |__|  / \___  >|   __/  \___  >\  __  /\__/  / </color><color_light_green>_  </color><color_light_green>|   `  </color>
-<color_light_blue>                   \/      \/      \/ |__|         \/  \/  \/     \/   </color><color_light_green>',|    \ </color>
-<color_white>     ***                                                  </color><color_light_green>_..        -.,,'-., / </color>
-<color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
-<color_white>     *** =========='      </color><color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>
-<color_white>     ||'''/ |                                        </color><color_light_green>`````'-    /```''-    | |  </color>
-<color_white>     ,\.    |                                                </color><color_light_green>'.-_`,,,,,,,,,\.\--</color>
-<color_white>    /  |    ^          ___,,,,,,,,,,...-------''''''``````````                  </color>
-<color_brown>*------'''''*``````````                                                         </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/ru.title
+++ b/data/title/ru.title
@@ -4,15 +4,15 @@
 <color_light_cyan>    |    |  \  / __ \_ |  |   / __ \_|    <  /  Y  \|  /  | _(__  <|  Y Y  \    </color>
 <color_light_cyan>    |____|__ \(____  / |__|  (____  /|__|_ \|___|  /\__/  //____  /|__|_|  /    </color>
 <color_light_cyan>            \/     \/             \/      \/     \/     \/      \/       \/     </color>
-<color_light_blue>  ___________ ..                                       ______                   </color>
-<color_light_blue>  \__    ___/____    __ __  ___ __  __   __   ____     \___  \  ___ __  __ __   </color>
-<color_light_blue>    |    | _/ __ \  /  V  \ \  |  ||  |_|  |_/ __ \    /  /|  \ \  |  ||  |  |  </color>
-<color_light_blue>    |    | \  ___/ |  Y Y  \|     ||  _ \  |\  ___/  _/  /_|   \|     ||  /  |  </color>
-<color_light_blue>    |____|  \___  >|__|_|  /|__|  ||____/__| \___  > \  _____  /|__|  |\__/  /  </color>
-<color_light_blue>                \/       \/     \/               \/   \/     \/     \/     \/   </color>
-<color_light_blue>           __________                                                           </color>
-<color_light_blue>           \______   \ ______   ____ _______    ____     __    __ __            </color>
-<color_light_blue>            |    |  _/ \     |_/ __ \\____  \ _/ __ \   /  \  |  |  |           </color>
-<color_light_blue>            |    |)  \ |  Y  |\  ___/ |  |)  >\  ___/ _/ /\ \_|  /  |           </color>
-<color_light_blue>            |______  / |__|  / \___  >|   __/  \___  >\  __  /\__/  /           </color>
-<color_light_blue>                   \/      \/      \/ |__|         \/  \/  \/     \/            </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>

--- a/data/title/zh_CN.title
+++ b/data/title/zh_CN.title
@@ -1,18 +1,21 @@
-<color_light_cyan>                  **                  **                  **                    </color>
-<color_light_cyan>                  **                  **             *************              </color>
-<color_light_cyan>                  **             **************     **   * **                   </color>
-<color_light_cyan>             *************       *    *      **        ***  * *                 </color>
-<color_light_cyan>             **   **             * *  **  *  *       *** *  * ***               </color>
-<color_light_cyan>                  * *            * ** ** **  *      *  ******** **              </color>
-<color_light_blue>                 ** **             ** **                *    **                 </color>
-<color_light_blue>                 **  ***             ** **               ** **                  </color>
-<color_light_blue>               ***    ****          ***  ***              ****            </color><color_light_green>.-.   </color>
-<color_light_blue>           ******      *****      ****    *****       *****  ******   </color><color_light_green>_  </color><color_light_green>|   `  </color>
-<color_light_blue>            ***         ****   *****       *****   *****       *****   </color><color_light_green>',|    \ </color>
-<color_white>     ***                 </color><color_light_blue>*                  ***           </color><color_light_green>_..    </color><color_light_blue>**  </color><color_light_green>-.,,'-., / </color>
-<color_white>    *   *  /-\                                       </color><color_light_green>,,,,/   |           |    \ </color>
-<color_white>     *** =========='      <color_red>----               ----        </color><color_light_green>`  _/`'.,       \ _--  </color>
-<color_white>     ||'''/ |                                        </color><color_light_green>`````'-    /```''-    | |  </color>
-<color_white>     ,\.    |                                                </color><color_light_green>'.-_`,,,,,,,,,\.\--</color>
-<color_white>    /  |    ^          ___,,,,,,,,,,...-------''''''``````````                  </color>
-<color_brown>*------'''''*``````````                                                         </color>
+# The ASCII art must be 18 lines in height (6 lines per ascii art text line).
+# Max length of a line (excluding color tags) is 80 characters; the following line is for reference.
+################################################################################
+<color_light_gray>   _________            __                   .__                                </color>
+<color_light_gray>   \_   ___ \ _____   _/  |_ _____     ____  |  |   ___.__   ______  _____      </color>
+<color_light_gray>   /    \  \/ \__  \  \   __\\__  \  _/ ___\ |  |  <   |  | /  ___/ /     \  '  </color>
+<color_light_gray>   \     \____ / __ \_ |  |   / __ \_\  \___ |  |__ \___  | \___ \ |  Y Y  \    </color>
+<color_light_gray>    \______  /(____  / |__|  (____  / \___  >|____/ / ____|/____  >|__|_|  / '  </color>
+<color_light_gray>           \/      \/             \/      \/        \/          \/       \/     </color>
+<color_red>            ________ .               .__                     __                 </color>
+<color_red>            \______ \|\       ____   |  |  _____    ______ _/  |_               </color>
+<color_red>               |  |  | \__  _/ __ \  |  |  \__  \  /  ___/ \   __\              </color>
+<color_red>               |  |  |  _ \ \  ___/  |  |__ / __ \ \___ \   |  |                </color>
+<color_red>               |__|  |_| \_\ \___  > |____/(____  /_____  > |__|                </color>
+<color_red>                                 \/             \/      \/                      </color>
+<color_light_gray>  _________                                           __                        </color>
+<color_light_gray>  \_   ____\   ____   ______     ___   ____ _____   _/  |_ ._    ___   ______   </color>
+<color_light_gray>  /   / ______/ __ \ |      \ _/ __ \ |   _|\__  \  \   __\| \  /   \ |      \  </color>
+<color_light_gray>  \   \/__  /\  ___/ |  |\   \\  ___/ |  /   / __ \  |  |  |  |<  |  >|  |\   \ </color>
+<color_light_gray>   \_____  /  \____ >|__| \  / \___  >|__|  (____  / |__|  |__| \___/ |__| \  / </color>
+<color_light_gray>         \/       \/       \/      \/            \/                         \/  </color>


### PR DESCRIPTION
#### Summary

Fix the variant title screens so they don't say DDA anymore, fix the default e keybind so that it's examine and pick up, not just examine, lint some stuff to prep for a new build.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
