### PR TITLE
Fix armor damage messaging bug

### DIFF
--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -389,7 +389,7 @@ void Character::describe_damage( damage_unit &du, item &armor ) const
     // Fire has its own method, but heat damage exists outside of fire IE lasers
     if( du.type == STATIC( damage_type_id( "bash" ) ) ) {
         damage_verb = material.bash_dmg_verb();
-    } else if( du.type == STATIC( damage_type_id( "heat" ) ) || STATIC( damage_type_id( "acid" ) ) ) {
+    } if( du.type == STATIC( damage_type_id( "heat" ) ) || du.type == STATIC( damage_type_id( "acid" ) ) ) {
         damage_verb = material.acid_dmg_verb();
     } else {
         damage_verb = material.cut_dmg_verb();


### PR DESCRIPTION
#### Summary
Fixes a bug with damaged items giving the wrong messaging.


#### Purpose of change

Closes #50 

#### Describe the solution

There was a malformed conditional statement which is now boniformed.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
