### PR TITLE
Nerf preplanted crops

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -324,14 +324,14 @@
     "comfort": 1,
     "floor_bedding_warmth": 50,
     "required_str": -1,
-    "deconstruct": { "items": [ { "item": "withered", "count": 50 } ] },
+    "deconstruct": { "items": [ { "item": "leaves", "count": 125 } ] },
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "bash": {
       "str_min": 2,
       "str_max": 6,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "withered", "count": [ 45, 50 ] } ]
+      "sound": "whish.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "leaves", "count": 125 } ]
     }
   },
   {

--- a/data/json/items/biosignatures.json
+++ b/data/json/items/biosignatures.json
@@ -48,7 +48,7 @@
   {
     "type": "COMESTIBLE",
     "id": "feces_roach",
-    "name": { "str_sp": "roach dirt" },
+    "name": { "str_sp": "insect droppings" },
     "copy-from": "feces_bird",
     "description": "Large black pellets of rotting material."
   },

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -802,7 +802,7 @@
     "id": "box_snack",
     "type": "GENERIC",
     "category": "container",
-    "name": { "str": "snack cardboard box", "str_pl": "snack cardboard boxes" },
+    "name": { "str": "cardboard snack box", "str_pl": "cardboard snack boxes" },
     "description": "A small cardboard box for housing snacks.  Sized so you can take it on the go.",
     "ascii_picture": "box_snack",
     "weight": "12 g",

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -533,15 +533,15 @@
         "%": "t_dirtfloor"
       },
       "sealed_item": {
-        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_planter_harvest", "chance": 100 },
-        "%": { "item": { "item": "seed_oats" }, "furniture": "f_planter_harvest", "chance": 100 }
+        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 30 },
+        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_planter_seedling", "chance": 30 },
+        "%": { "item": { "item": "seed_oats" }, "furniture": "f_planter_seedling", "chance": 30 }
       },
       "palettes": [ "farm" ]
     }

--- a/data/json/mapgen/farm_2side.json
+++ b/data/json/mapgen/farm_2side.json
@@ -78,15 +78,15 @@
       },
       "furniture": { "l": "f_locker", "y": "f_hay" },
       "sealed_item": {
-        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 80 },
-        "%": { "item": { "item": "seed_oats" }, "furniture": "f_plant_seedling", "chance": 80 }
+        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "%": { "item": { "item": "seed_oats" }, "furniture": "f_plant_seedling", "chance": 20 }
       },
       "items": {
         "l": [

--- a/data/json/mapgen/farm_tiles.json
+++ b/data/json/mapgen/farm_tiles.json
@@ -1,5 +1,11 @@
 [
   {
+    "type": "monstergroup",
+    "name": "GROUP_CROWS",
+    "is_safe": true,
+    "monsters": [ { "monster": "mon_crow", "weight": 2, "pack_size": [ 2, 5 ] }, { "monster": "mon_crow_mutant_small", "weight": 1, "pack_size": [ 1, 3 ] } ]
+  },
+  {
     "type": "mapgen",
     "method": "json",
     "om_terrain": [ "farm_lot_wire_straight_h" ],
@@ -32,7 +38,8 @@
         "                        ",
         "########################"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -68,7 +75,8 @@
         "                        ",
         "%%%%%%%%%%%%%%%%%%%%%%%%"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -104,7 +112,8 @@
         "        ////////        ",
         "%%%%%%%%////////%%%%%%%%"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -140,7 +149,8 @@
         "%       ////////        ",
         "%%%%%%%%////////%%%%%%%%"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -176,7 +186,8 @@
         "########################",
         "                        "
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -212,7 +223,8 @@
         "%                       ",
         "%%%%%%%%%%%%%%%%%%%%%%%%"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -248,7 +260,8 @@
         "%                       ",
         "%%%%%%%%%%%%%%%%%%%%%%%%"
       ],
-      "palettes": [ "farm_lots" ]
+      "palettes": [ "farm_lots" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -285,7 +298,8 @@
         " ##  ##  ##  ##  ##  ##  ##  ##  ##  ##  ##  ### ##  ##  ##  ##  ##  ##  ##  ##  ##  ##  ##  ###"
       ],
       "palettes": [ "farm_lots" ],
-      "place_vehicles": [ { "vehicle": "farm_vehicles", "x": [ 4, 18 ], "y": [ 4, 18 ], "chance": 3, "rotation": [ 90, 270 ] } ]
+      "place_vehicles": [ { "vehicle": "farm_vehicles", "x": [ 4, 18 ], "y": [ 4, 18 ], "chance": 3, "rotation": [ 90, 270 ] } ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -1032,7 +1046,7 @@
         "........................"
       ],
       "palettes": [ "farm_lots" ],
-      "place_monster": [ { "monster": "mon_chicken", "x": [ 2, 21 ], "y": [ 1, 14 ], "repeat": [ 4, 10 ] } ],
+      "place_monster": [ { "monster": "mon_chicken", "x": [ 2, 21 ], "y": [ 1, 14 ], "repeat": [ 4, 10 ], "chance": 3 } ],
       "terrain": { "_": [ "t_region_groundcover", [ "t_region_soil", 3 ] ] },
       "item": { "_": { "item": "birdfood", "chance": 1, "repeat": [ 1, 3 ] } }
     }
@@ -1074,7 +1088,7 @@
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
       "palettes": [ "farm_lots" ],
       "remove_all": { "c": {  }, "C": {  }, "|": {  } },
-      "place_monster": [ { "monster": "mon_chicken", "x": [ 2, 21 ], "y": [ 1, 14 ], "repeat": [ 4, 10 ] } ],
+      "place_monster": [ { "monster": "mon_chicken", "x": [ 2, 21 ], "y": [ 1, 14 ], "repeat": [ 4, 10 ], "chance": 3 } ],
       "terrain": { "_": [ "t_region_groundcover", [ "t_region_soil", 3 ] ] },
       "item": { "_": { "item": "birdfood", "chance": 1, "repeat": [ 1, 3 ] } }
     }
@@ -1125,11 +1139,11 @@
         "_": "t_region_soil"
       },
       "sealed_item": {
-        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 70 }
+        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 20 }
       }
     }
   },
@@ -1182,11 +1196,11 @@
         "_": "t_region_soil"
       },
       "sealed_item": {
-        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 70 },
-        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 70 }
+        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_plant_seedling", "chance": 20 },
+        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_plant_seedling", "chance": 20 }
       }
     }
   },
@@ -1487,7 +1501,8 @@
         "                        "
       ],
       "palettes": [ "roof_palette" ],
-      "terrain": { "_": "t_shingle_flat_roof" }
+      "terrain": { "_": "t_shingle_flat_roof" },
+      "place_monsters": [ { "monster": "GROUP_CROWS", "x": [ 5, 19 ], "y": [ 4, 16 ], "chance": 3 } ]
     }
   }
 ]

--- a/data/json/mapgen/gardening_store.json
+++ b/data/json/mapgen/gardening_store.json
@@ -78,10 +78,10 @@
         "Z": "f_planter"
       },
       "sealed_item": {
-        "1": { "item": { "item": "seed_chamomile" }, "furniture": "f_planter_harvest" },
-        "2": { "item": { "item": "seed_thyme" }, "furniture": "f_planter_harvest" },
-        "3": { "item": { "item": "seed_bee_balm" }, "furniture": "f_planter_harvest" },
-        "5": { "item": { "item": "seed_mugwort" }, "furniture": "f_planter_harvest" }
+        "1": { "item": { "item": "seed_chamomile" }, "furniture": "f_planter_mature" },
+        "2": { "item": { "item": "seed_thyme" }, "furniture": "f_planter_mature" },
+        "3": { "item": { "item": "seed_bee_balm" }, "furniture": "f_planter_mature" },
+        "5": { "item": { "item": "seed_mugwort" }, "furniture": "f_planter_mature" }
       },
       "items": {
         "I": { "item": "office", "chance": 30 },

--- a/data/json/mapgen/isherwood_farms/cabin_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/cabin_isherwood.json
@@ -93,12 +93,12 @@
       "place_vehicles": [ { "vehicle": "uncovered_wagon", "x": 2, "y": 2, "rotation": 180, "chance": 100, "status": 0 } ],
       "place_monster": [ { "monster": "mon_horse", "x": 17, "y": 3, "chance": 100 } ],
       "sealed_item": {
-        "Q": { "item": { "item": "seed_lentils" }, "furniture": "f_planter_harvest" },
-        "e": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_harvest" },
-        "I": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_harvest" },
-        "j": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_harvest" },
-        "z": { "item": { "item": "soybean_seed" }, "furniture": "f_planter_harvest" },
-        "u": { "item": { "item": "seed_beans" }, "furniture": "f_planter_harvest" }
+        "Q": { "item": { "item": "seed_lentils" }, "furniture": "f_planter_seedling" },
+        "e": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling" },
+        "I": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling" },
+        "j": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_seedling" },
+        "z": { "item": { "item": "soybean_seed" }, "furniture": "f_planter_seedling" },
+        "u": { "item": { "item": "seed_beans" }, "furniture": "f_planter_seedling" }
       },
       "terrain": {
         " ": "t_floor",

--- a/data/json/mapgen/mall/mall_ground.json
+++ b/data/json/mapgen/mall/mall_ground.json
@@ -275,10 +275,10 @@
         "}": "t_linoleum_gray",
         "F": "t_sidewalk"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "*": "f_trashcan",
+        "1": "f_hedge_short",
         "3": "f_table",
         "4": "f_chair",
         "!": "f_counter",
@@ -398,13 +398,11 @@
         "}": "t_linoleum_white_no_roof",
         "1": "t_linoleum_white"
       },
-      "sealed_item": {
-        "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" },
-        "{": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" }
-      },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "*": "f_trashcan",
+        "1": "f_hedge_short",
+        "{": "f_hedge_short",
         "3": "f_table",
         "&": "f_table",
         "4": "f_chair",
@@ -560,12 +558,10 @@
         { "item_group": "vending_drink", "x": 74, "y": 17, "lootable": true },
         { "item_group": "vending_food", "x": 74, "y": 18, "lootable": true }
       ],
-      "sealed_item": {
-        "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" },
-        "{": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" }
-      },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
+        "{": "f_hedge_short",
         "*": "f_trashcan",
         "!": "f_counter",
         "0": "f_counter",
@@ -770,9 +766,9 @@
         "A": "t_linoleum_white",
         "!": "t_linoleum_white"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
         "*": "f_trashcan",
         "3": "f_table",
         "!": "f_counter",
@@ -924,9 +920,9 @@
         "1": "t_linoleum_white_no_roof",
         "!": "t_linoleum_white"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
         "*": "f_trashcan",
         "!": "f_counter",
         "0": "f_counter",
@@ -1127,10 +1123,10 @@
         "A": "t_linoleum_white",
         "!": "t_linoleum_white"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "*": "f_trashcan",
+        "1": "f_hedge_short",
         "$": "f_counter",
         "±": "f_counter",
         "4": "f_wardrobe",
@@ -1272,9 +1268,9 @@
         "!": "t_linoleum_white",
         "]": "t_linoleum_white"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
         "*": "f_trashcan",
         "!": "f_counter",
         "0": "f_counter",
@@ -1408,12 +1404,10 @@
         "Ʉ": "t_carpet_concrete_green",
         ":": "t_carpet_concrete_green"
       },
-      "sealed_item": {
-        "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" },
-        "°": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" }
-      },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
+        "°": "f_hedge_short",
         "*": "f_trashcan",
         "!": "f_counter",
         "0": "f_counter",
@@ -1562,9 +1556,9 @@
         "4": "t_carpet_red",
         "Á": "t_carpet_red"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
+        "1": "f_hedge_short",
         "*": "f_trashcan",
         "!": "f_counter",
         "0": "f_counter",
@@ -1722,13 +1716,11 @@
         "Ʉ": "t_carpet_concrete_green",
         ":": "t_carpet_concrete_green"
       },
-      "sealed_item": {
-        "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" },
-        "{": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" }
-      },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "*": "f_trashcan",
+        "1": "f_hedge_short",
+        "{": "f_hedge_short",
         ":": "f_rack_wood",
         "Ʌ": "f_table",
         "$": "f_counter",
@@ -1888,10 +1880,10 @@
         "Δ": "t_atm",
         "1": "t_linoleum_white_no_roof"
       },
-      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "furniture": {
         "%": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "*": "f_trashcan",
+        "1": "f_hedge_short",
         "!": "f_counter",
         "0": "f_counter",
         "$": "f_counter",

--- a/data/json/mapgen/nested/farm_nested.json
+++ b/data/json/mapgen/nested/farm_nested.json
@@ -40,7 +40,8 @@
         "%/////////////////////%/",
         "%%%%%%%%%%%%%%%%%%%%%%%/"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -75,7 +76,8 @@
         "%/////////////////////%/",
         "%%%%%%%%%%%%%%%%%%%%%%%/"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -110,7 +112,8 @@
         "P//////////////////////P",
         "PPPPPPPPPPPPPPPPPPPPPPPP"
       ],
-      "palettes": [ "farm_house" ]
+       "palettes": [ "farm_house" ],
+       "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -145,7 +148,8 @@
         "P//////////////////////P",
         "PPPP%%%%PPPPPPPP%%%%PPPP"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 0, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -180,7 +184,8 @@
         "P//////////////////////P",
         "PPPPPPPPPPPPPPPPPPPPPPPP"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -221,7 +226,8 @@
         "%//////////////////////%",
         "%%%%%%%%%%%//%%%%%%%%%%%"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 2 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 }, { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 4 } ]
     }
   },
   {
@@ -910,7 +916,8 @@
         "                        "
       ],
       "palettes": [ "paddock" ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 } ]
     }
   },
   {
@@ -947,7 +954,8 @@
         "___..................___"
       ],
       "palettes": [ "paddock" ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_monsters": [ { "monster": "GROUP_FARM_PESTS", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 3 } ]
     }
   },
   {

--- a/data/json/mapgen/police_department.json
+++ b/data/json/mapgen/police_department.json
@@ -57,7 +57,6 @@
         "    s     ||||||||||||||||s                     "
       ],
       "palettes": [ "police_dept" ],
-      "sealed_item": { "*": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
       "items": {
         "1": [ { "item": "SUS_dishes", "chance": 100 }, { "item": "SUS_silverware", "chance": 100 } ],
         "2": { "item": "SUS_cookware", "chance": 100, "repeat": [ 1, 3 ] },
@@ -66,7 +65,7 @@
         "5": { "item": "SUS_kitchen_sink", "chance": 100 }
       },
       "terrain": { " ": "t_region_groundcover_urban" },
-      "furniture": { "1": "f_cupboard", "2": "f_cupboard", "3": "f_cupboard", "4": "f_cupboard", "5": "f_sink" },
+      "furniture": { "*": "f_hedge_short", "1": "f_cupboard", "2": "f_cupboard", "3": "f_cupboard", "4": "f_cupboard", "5": "f_sink" },
       "place_vehicles": [
         { "vehicle": "police_pileup", "x": 44, "y": 43, "chance": 20, "rotation": 90 },
         { "vehicle": "police_pileup", "x": 39, "y": 43, "chance": 20, "rotation": 90 },

--- a/data/json/mapgen/s_hardware.json
+++ b/data/json/mapgen/s_hardware.json
@@ -184,10 +184,10 @@
         "4": "t_gutter_downspout"
       },
       "sealed_item": {
-        "1": { "item": { "item": "seed_cabbage" }, "furniture": "f_planter_harvest" },
-        "2": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_harvest" },
-        "3": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_harvest" },
-        "M": { "item": { "item": "seed_flower" }, "furniture": "f_planter_harvest" }
+        "1": { "item": { "item": "seed_cabbage" }, "furniture": "f_planter_seedling" },
+        "2": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling" },
+        "3": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling" },
+        "M": { "item": { "item": "seed_flower" }, "furniture": "f_planter_seedling" }
       },
       "furniture": {
         "r": "f_counter",

--- a/data/json/mapgen/smoke_lounge.json
+++ b/data/json/mapgen/smoke_lounge.json
@@ -88,7 +88,7 @@
         "Y": "f_trashcan"
       },
       "vendingmachines": { "M": { "item_group": "vending_drink", "lootable": true }, "F": { "item_group": "vending_food", "lootable": true } },
-      "sealed_item": { "1": { "item": { "item": "seed_tobacco" }, "furniture": "f_planter_harvest" } },
+      "sealed_item": { "1": { "item": { "item": "seed_tobacco" }, "furniture": "f_planter_seedling" } },
       "toilets": { "&": {  } }
     },
     "om_terrain": "smoke_lounge",
@@ -234,7 +234,7 @@
         "Y": "f_trashcan"
       },
       "vendingmachines": { "M": { "item_group": "vending_drink", "lootable": true }, "F": { "item_group": "vending_food", "lootable": true } },
-      "sealed_item": { "1": { "item": { "item": "seed_tobacco" }, "furniture": "f_planter_harvest" } },
+      "sealed_item": { "1": { "item": { "item": "seed_tobacco" }, "furniture": "f_planter_seedling" } },
       "toilets": { "&": {  } }
     },
     "om_terrain": "smoke_lounge_1",

--- a/data/json/mapgen_palettes/farm_lots.json
+++ b/data/json/mapgen_palettes/farm_lots.json
@@ -6,7 +6,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "rows": [ "#" ],
-      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 } }
+      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 15 } }
     }
   },
   {
@@ -16,7 +16,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "rows": [ "#" ],
-      "sealed_item": { "#": { "item": { "item": "seed_wheat" }, "furniture": "f_plant_seedling", "chance": 70 } }
+      "sealed_item": { "#": { "item": { "item": "seed_wheat" }, "furniture": "f_plant_seedling", "chance": 15 } }
     }
   },
   {
@@ -29,14 +29,14 @@
     "terrain": {
       ",": "t_dirtfloor",
       ":": "t_metal_floor",
-      "#": [ [ "t_dirtmound", 98 ], [ "t_region_soil", 2 ] ],
+      "#": [ [ "t_dirtmound", 2000 ], [ "t_region_grass", 310 ], [ "t_region_soil", 280 ], [ "t_puddle", 1 ], [ "t_shrub", 2 ], [ "t_pit_shallow", 1 ] ],
       "%": "t_fence_wire",
       "+": "t_door_c",
       "|": [ [ "t_wall_wood", 500 ], [ "t_wall_wood_chipped", 4 ], [ "t_wall_wood_broken", 1 ] ],
-      " ": [ [ "t_region_soil", 25 ], [ "t_region_groundcover", 3 ], [ "t_dirtmound", 2 ] ],
+      " ": [ [ "t_region_soil", 2500 ], [ "t_region_groundcover", 300 ], [ "t_region_grass", 300 ], [ "t_dirtmound", 200 ], [ "t_puddle", 1 ], [ "t_pit_shallow", 2 ] ],
       "i": "t_region_groundcover",
       ".": "t_null",
-      "/": [ [ "t_region_soil", 200 ], [ "t_region_groundcover", 5 ] ],
+      "/": [ [ "t_region_soil", 195 ], [ "t_region_groundcover", 5 ], [ "t_region_grass", 5 ] ],
       "5": "t_barndoor",
       "6": "t_palisade_pulley",
       "T": [ [ "t_region_groundcover_barren", 20 ], [ "t_region_tree_shade", 30 ] ],

--- a/data/json/mapgen_palettes/house_w_palette.json
+++ b/data/json/mapgen_palettes/house_w_palette.json
@@ -258,14 +258,14 @@
     },
     "sealed_item": {
       "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_seedling" },
-      "2": { "item": { "item": "seed_chamomile" }, "furniture": "f_planter_harvest" },
-      "3": { "item": { "item": "seed_thyme" }, "furniture": "f_planter_harvest" },
-      "4": { "item": { "item": "seed_bee_balm" }, "furniture": "f_planter_harvest" },
-      "5": { "item": { "item": "seed_mugwort" }, "furniture": "f_planter_harvest" },
-      "6": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_harvest" },
-      "7": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_harvest" },
-      "8": { "item": { "item": "soybean_seed" }, "furniture": "f_planter_harvest" },
-      "9": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_harvest" }
+      "2": { "item": { "item": "seed_chamomile" }, "furniture": "f_planter_mature" },
+      "3": { "item": { "item": "seed_thyme" }, "furniture": "f_planter_mature" },
+      "4": { "item": { "item": "seed_bee_balm" }, "furniture": "f_planter_mature" },
+      "5": { "item": { "item": "seed_mugwort" }, "furniture": "f_planter_mature" },
+      "6": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling" },
+      "7": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_seedling" },
+      "8": { "item": { "item": "soybean_seed" }, "furniture": "f_planter_seedling" },
+      "9": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling" }
     }
   }
 ]

--- a/data/json/mapgen_palettes/lab/lab_modular_palette.json
+++ b/data/json/mapgen_palettes/lab/lab_modular_palette.json
@@ -155,10 +155,10 @@
       "≠": "f_chest",
       "Ø": "f_pinball_machine",
       "Æ": "f_arcade_machine",
-      "ʭ": "f_ladder"
+      "ʭ": "f_ladder",
+      "ե": "f_hedge_short"
     },
     "terrain": { "a": "t_strconc_floor", ":": "t_wall_glass" },
-    "sealed_item": { "ե": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
     "items": {
       "a": { "item": "fireplace_fill", "chance": 30, "repeat": [ 2, 5 ] },
       "d": [
@@ -282,15 +282,15 @@
       "6": "f_machinery_heavy",
       "Ö": "f_machinery_light",
       "3": "f_vending_c",
-      "4": "f_vending_c"
+      "4": "f_vending_c",
+      "]": "f_hedge_short"
     },
     "items": {
       "3": { "item": "vending_food", "chance": 90 },
       "4": { "item": "vending_drink", "chance": 90 },
       "Q": { "item": "gas_charging_rack", "chance": 30 },
       "J": [ { "item": "mechanics", "chance": 30 } ]
-    },
-    "sealed_item": { "]": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } }
+    }
   },
   {
     "type": "palette",
@@ -357,9 +357,9 @@
       "7": "f_anesthetic",
       "8": "f_GC",
       "9": "f_MS",
-      "0": "f_NMR"
+      "0": "f_NMR",
+      "л": "f_hedge_short"
     },
-    "sealed_item": { "л": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
     "items": {
       "a": [
         { "item": "mutagen_kits", "chance": 4 },
@@ -482,9 +482,9 @@
       "4": "f_dialysis",
       "5": "f_ventilator",
       "7": "f_anesthetic",
-      "8": [ [ "f_MRI", 5 ], [ "f_CTscan", 5 ] ]
+      "8": [ [ "f_MRI", 5 ], [ "f_CTscan", 5 ] ],
+      "л": "f_hedge_short"
     },
-    "sealed_item": { "л": { "item": { "item": "seed_rose" }, "furniture": "f_planter_harvest" } },
     "items": {
       "a": [
         { "item": "virology_lab_fridge", "chance": 30 },

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -6,6 +6,11 @@
     "monsters": [ { "monster": "mon_null" } ]
   },
   {
+    "name": "GROUP_FARM_PESTS",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_null", "weight": 50000 }, { "monster": "mon_worm", "weight": 90 }, { "monster": "mon_aphid", "weight": 600, "pack_size": [ 3, 6 ] }, { "monster": "mon_rabbit", "weight": 100, "pack_size": [ 1, 3 ] }, { "monster": "mon_crow", "weight": 700, "pack_size": [ 1, 6 ] }, { "monster": "mon_locust_small", "weight": 200, "pack_size": [ 2, 5 ] }, { "monster": "mon_deer", "weight": 200, "pack_size": [ 1, 2 ] }, { "monster": "mon_mantis_small", "weight": 10 }, { "monster": "mon_lady_bug", "weight": 60, "pack_size": [ 1, 2 ] }, { "monster": "mon_rat", "weight": 40, "pack_size": [ 1, 3 ] }, { "monster": "mon_slug_forest", "weight": 60, "pack_size": [ 1, 3 ] }, { "monster": "mon_dog", "weight": 2, "pack_size": [ 1, 2 ] }, { "monster": "mon_worm_small", "weight": 400, "pack_size": [ 1, 2 ] }, { "monster": "mon_snail_forest", "weight": 60, "pack_size": [ 1, 2 ] }, { "monster": "mon_coyote", "weight": 10, "pack_size": [ 1, 4 ] }, { "monster": "mon_snail_forest", "weight": 60, "pack_size": [ 1, 2 ] } ]
+  },
+  {
     "type": "monstergroup",
     "name": "GROUP_BLACK_ROAD",
     "monsters": [

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -29,12 +29,12 @@
     "//": "Weights are set high in order to allow mods to add rare terrains.",
     "region_terrain_and_furniture": {
       "terrain": {
-        "t_region_groundcover": { "t_grass": 12000, "t_grass_dead": 4000, "t_dirt": 2000 },
-        "t_region_groundcover_urban": { "t_grass": 20, "t_grass_dead": 6, "t_dirt": 1 },
+        "t_region_groundcover": { "t_grass": 12000, "t_grass_dead": 4000, "t_grass_long": 200, "t_dirt": 2000 },
+        "t_region_groundcover_urban": { "t_grass": 20, "t_grass_dead": 6, "t_grass_long": 3, "t_dirt": 1 },
         "t_region_groundcover_forest": { "t_forestfloor": 20, "t_grass": 1, "t_grass_long": 1, "t_moss": 1, "t_grass_dead": 4 },
-        "t_region_groundcover_swamp": { "t_grass_long": 300, "t_grass_tall": 100, "t_moss": 200, "t_dirt": 200, "t_grass_dead": 110 },
+        "t_region_groundcover_swamp": { "t_grass_long": 300, "t_moss": 200, "t_dirt": 200, "t_grass_dead": 110 },
         "t_region_groundcover_barren": { "t_dirt": 30, "t_grass_dead": 2, "t_railroad_rubble": 1 },
-        "t_region_grass": { "t_grass": 20, "t_grass_dead": 10, "t_dirt": 2 },
+        "t_region_grass": { "t_grass": 18, "t_grass_dead": 10, "t_grass_long": 3, "t_dirt": 2 },
         "t_region_soil": { "t_dirt": 1 },
         "t_region_shrub_forest_dense": {
           "t_underbrush": 30,


### PR DESCRIPTION
#### Summary
Nerf farms and other preplanted crops

#### Purpose of change
Our lore states that the world had been slipping into dissaray for a long time. People were dying, bugs were getting bigger and more aggressive, work wasn't getting done, supply lines were in tatters, and worst of all, something in the soil was killing off a lot of the plant life. It's April, the world ended back in March. Exactly how much farming do you think got done?

Farmlands in general were really boring locations. I suppose they're not tremendously exciting IRL, but they didn't really have anything going on besides infinite free food.

This PR does not change anything about the farming system itself. Planting and harvesting crops works as it always has.

#### Describe the solution
- Remove 70% of the pre-planted crops from just about everywhere. This includes farms, people's yards, and anything else I could find. I'm sure I missed some.
- Exceptions are made for places that were being more actively tended or had some degree of shelter from the Cataclysm.
- Decrease spawns of a few farm chickens while we're here. They were spawning 100% of the time which was no good.
- Adjust farmlands to look more Cataclysmic. They're now a little overgrown and patchy looking.
- Infest the farms with all manner of pests, including aphids, worms, rats, crows, locusts, deer, rabbits, snails, and slugs, as well as some predators creeping around to feed off of them. Nature is...healing?
- Change the mall planters to be filled with short hedges instead of thousands of fully grown rosebushes full of rose hips.
- Change most or all pre-grown crops to be seedlings or (in the case of herbs, mostly) mature.
- Fix the pile of leaves furniture item, which was previously a free withered plant (which can be spun into cordage) generator.

#### Describe alternatives you've considered
Farming needs to be redone completely from the ground up. That may allow me to do things that seem reasonable, like adjusting the growth phase of the crops if the player decides to move the Cataclysm start date to Autumn instead of Spring.

Farms need more varied tiles - oddly healthy cornfields full of feral kids, rarer types of farms (we currently only really have corn and wheat), farm plots that have been totally burned down, ways for triffids to actually affect crops by turning them into super versions, farms that were totally fallow, farms that got worked on quite a bit more, farms where the rows were only half dug, farms that have already been completely stripped by the bugs who have since moved on, etc.

We also need more weedy plants that just take up space and contribute nothing especially useful to indicate a lack of care. All the ones I tried to add were pretty flowers or herbs that would aid in survival.

I didn't do much to the Isherwood farm. They're taking care of it and it's in a sheltered area so it's supposed to be a lot nicer. I may need to go back and kill some of their plants though.

#### Testing
![image](https://github.com/user-attachments/assets/c4f53343-2513-4232-b980-d8d64eca23f6)
These zombies showed up from a nearby mass grave.

![image](https://github.com/user-attachments/assets/2f9493fe-c779-4c1b-9a87-9c52e1b63d3e)
Here we see how bad the fields can sometimes look.

![image](https://github.com/user-attachments/assets/6b9a848f-a4c8-4630-b8ae-e356207e59c2)
They're not edible, but you can hide behind them.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
