### PR TITLE
Snap target moves camera

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2956,6 +2956,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     } else if( new_pos == valid_pos ) {
         // We can reuse new_traj
         dst = valid_pos;
+        set_view_offset( dst - src );
         traj = new_traj;
     } else {
         dst = valid_pos;


### PR DESCRIPTION
#### Summary
Snap targeting ranged attacks moves the camera.


#### Purpose of change
Closes #46

Snap targeting wasn't moving the camera. This was fine when aiming at nearby monsters on the same Z level, but caused problems when aiming across Z levels or at very distant monsters - you could get the shot off OK, but you couldn't see what you were aiming at. This appears to be an unintentional bug and was present in DDA.

#### Describe the solution
Offset the view in all cases when snap targeting. There's no real reason I can think of to ever not do this, so I didn't see a need to special-case anything.

#### Testing
![image](https://github.com/user-attachments/assets/872b3a0f-4398-4e65-b812-ac30f63ce61b)
Loaded in, stood on a roof, aimed at a monster down below. Teleported to the ground, tried manually and snap targeting different monsters. Also tried peek-throwing a grenade down to the lower level, saw that this all worked very well.

#### Note
The TILES version of the game sometimes draws a fake cursor (usually) adjacent to the player when it doesn't think they can see to the actual target. In some cases, this can happen even when the player totally can see the target - I'm guessing this is an artifact of the pre-3d system. This is a known issue and only seems to apply when aiming across Z levels. It is also extremely minor, so I don't see it as a blocker here.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
