### PR TITLE
Port #74229 from DDA

### DIFF
--- a/src/third-party/flatbuffers/stl_emulation.h
+++ b/src/third-party/flatbuffers/stl_emulation.h
@@ -626,7 +626,7 @@ class span FLATBUFFERS_FINAL_CLASS {
  private:
   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
   pointer const data_;
-  const size_type count_;
+  size_type count_;
 };
 
  #if !defined(FLATBUFFERS_SPAN_MINIMAL)


### PR DESCRIPTION
#### Summary
Port the fix to stl_emulation span::count_ from https://github.com/CleverRaven/Cataclysm-DDA/pull/74229


#### Purpose of change
A back-end build fix. Thanks to @NetSysFire for chasing this one down and of course to the original PR folks for doing the legwork.

#### Describe the solution
const size_type count_;  ->  size_type count_;


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
