### PR TITLE
rename debug nightvision trait for clarity and improve some other debug trait descriptions

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8803,10 +8803,10 @@
   {
     "type": "mutation",
     "id": "DEBUG_NIGHTVISION",
-    "name": { "str": "Debug Night Vision" },
+    "name": { "str": "Debug Night and Map Vision" },
     "points": 99,
     "valid": false,
-    "description": "You can clearly see that this is for dev purposes only.",
+    "description": "Grants flawless night vision and the ability to see all of the overmaps without having to reveal them manually.  As such, you can clearly see that this is for dev purposes only.",
     "debug": true
   },
   {
@@ -8815,7 +8815,7 @@
     "name": { "str": "Debug Clairvoyance" },
     "points": 99,
     "valid": false,
-    "description": "You can clearly see that this is for dev purposes only.",
+    "description": "Being able to see through walls and the floor is clearly for dev purposes only.",
     "flags": [ "CLAIRVOYANCE_PLUS" ],
     "debug": true
   },
@@ -8825,7 +8825,7 @@
     "name": { "str": "Debug Clairvoyance Super" },
     "points": 99,
     "valid": false,
-    "description": "You can see all the bugs with this one.",
+    "description": "Much bigger range than the other Debug Clairvoyance trait.  Unsure which one to use?  Use them both!  You can see all the bugs with this one.",
     "flags": [ "SUPER_CLAIRVOYANCE" ],
     "debug": true
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Backports CleverRaven/Cataclysm-DDA/pull/77367
As the original change is mine, there is no attribution trouble.

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

One of the very few things that does not need testing in the world.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
