### PR TITLE
Sane-ify grenades

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -431,7 +431,7 @@
     "symbol": "*",
     "color": "green",
     "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
-    "countdown_action": { "type": "explosion", "explosion": { "power": 260, "shrapnel": { "casing_mass": 100, "fragment_mass": 0.02 } } },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.02 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
     "melee_damage": { "bash": 6 }
   },
@@ -1192,7 +1192,7 @@
     "symbol": "*",
     "color": "light_gray",
     "explode_in_fire": true,
-    "explosion": { "power": 300, "shrapnel": { "casing_mass": 310, "fragment_mass": 0.5 } },
+    "explosion": { "power": 300, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } },
     "use_action": {
       "need_wielding": true,
       "target": "pipebomb_act",
@@ -1222,8 +1222,8 @@
     "color": "light_gray",
     "use_action": { "type": "message", "message": "You've already lit the %s, try throwing it instead.", "name": "Pull pin" },
     "explode_in_fire": true,
-    "explosion": { "power": 300, "shrapnel": { "casing_mass": 310, "fragment_mass": 0.5 } },
-    "countdown_action": { "type": "explosion", "explosion": { "power": 300, "shrapnel": { "casing_mass": 310, "fragment_mass": 0.5 } } },
+    "explosion": { "power": 300, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 300, "shrapnel": { "casing_mass": 410, "fragment_mass": 0.5 } } },
     "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
     "melee_damage": { "bash": 5 }
   },

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -324,7 +324,8 @@ static void do_blast( const Creature *source, const tripoint &p, const float pow
         if( pl == nullptr ) {
             const double dmg = std::max( force - critter->get_armor_type( damage_bash,
                                          bodypart_id( "torso" ) ) / 2.0, 0.0 );
-            const int actual_dmg = rng_float( dmg * 2, dmg * 3 );
+            const int actual_dmg = std::max( 0.0, rng_float( ( -dmg * 0.5 ) / critter->ranged_target_size(),
+                                             dmg * 3 ) );
             critter->apply_damage( mutable_source, bodypart_id( "torso" ), actual_dmg );
             critter->check_dead_state();
             add_msg_debug( debugmode::DF_EXPLOSION, "Blast hits %s for %d damage", critter->disp_name(),
@@ -432,6 +433,8 @@ static std::vector<tripoint> shrapnel( const Creature *source, const tripoint &s
         if( damage > 0 && critter && !critter->is_dead_state() ) {
             std::poisson_distribution<> d( cloud.density );
             int hits = d( rng_get_engine() );
+            hits = std::max( 0, rng( ( -hits / 2.5 ) / critter->ranged_target_size(),
+                                     hits * critter->ranged_target_size() ) );
             dealt_projectile_attack frag;
             frag.proj = proj;
             frag.proj.speed = cloud.velocity;
@@ -444,7 +447,7 @@ static std::vector<tripoint> shrapnel( const Creature *source, const tripoint &s
             int damaging_hits = 0;
             int non_damaging_hits = 0;
             for( int i = 0; i < hits; ++i ) {
-                frag.missed_by = rng_float( 0.05, 7.0 / critter->ranged_target_size() );
+                frag.missed_by = rng_float( 0.05, 1.0 / critter->ranged_target_size() );
                 critter->deal_projectile_attack( mutable_source, frag, false );
                 if( frag.dealt_dam.total_damage() > 0 ) {
                     damaging_hits++;


### PR DESCRIPTION
#### Summary
Sane-ify Grenades

#### Purpose of change
DDA grenades were running through some very detailed and interesting models that attempted to properly depict the effects of a shrapnel bomb going off, but they suffered from a fatal flaw - pretty much every single piece of shrapnel would hit someone if they were standing in the area of effect.

IRL grenades are expected have a >50% casualty rate within 15 meters of the blast. DDA's grenades were easily killing 30+ zombies in a single blast, when realistically you should see some killed, some maimed, some scratched, and some unharmed. This issue was bad enough with zombies, but it got really odd when you looked at how they interacted with huge creatures (who were treated as completely blocking tiles, even though logically standing behind a cow would not necessarily save you from a frag grenade) and with tiny creatures, whose itty bitty bodies were absorbing thousands of pieces of metal across cubic meters of space.

#### Describe the solution
Added a randomizer for how much damage the pressure wave does and how many frags actually hit a creature in the blast radius. This is layered overtop of everything else as a new check, and is based partially off of creature size.

The pressure wave:
            const int actual_dmg = std::max( 0.0, rng_float( ( -dmg * 0.5 ) / critter->ranged_target_size(),
                                             dmg * 3 ) );

A better model might be to have the pressure wave lean toward one side or something, but the distances we're dealing with across the 1 or 2 tiles where it really counts are so fudgy that a lot of distance-based solutions don't work, which is one of the reasons they would always just kill everything within a tile or two. So we go with some good ol' RNG, keeping it top-heavy so that it's at least very likely that most stuff in proximity to the bomb has a bad time.

Shrapnel:
            hits = std::max( 0, rng( ( -hits / 2.5 ) / critter->ranged_target_size(),

The shrapnel calc is a lot swingier, with more weight toward the bottom.

#### Testing
Frag grenades can kill upwards of 20 birds, but will not perfectly kill 50+ of them in the shape of the blast radius if they happen to be stacked up that way.

Frag grenades thrown into dense crowds of normal zombies killed between 3 and 9 of them. Usually anything immediately adjacent to the grenade was killed, but once in a blue moon I saw a miraculous survival. Grenades remain deadly several tiles out, but it becomes much more random as you get farther from the epicenter.

Pipebombs have fewer, larger fragments. These remain deadly when detonated close to armored enemies, and are still somewhat effective against crowds, but being jury-rigged bombs, they are not going to be as precisely deadly to large crowds as factory-made grenades.

The other homemade bombs should all work as intended. Grenade launchers seem OK too for the moment.

Grenades remain a handy tool for thinning crowds, especially in tight confines, but are no longer going to delete screenfuls of zombies. This also makes them slightly safer to use, but you should still be using cover, going prone, wearing armor, etc.

#### Additional context

Kevin admitted to fudging the json values to get his desired results in the last DDA grenade PR before the fork. That's fine, but the values may need further adjusting if we decide that the changes here make them not work as desired. From testing I think we're good, but it's something to keep in mind.

This also makes going prone more effective than it was before, as it reduces your effective size. That's probably also fine, but if it turns out people are heedlessly lobbing grenades everywhere and taking micronaps to avoid blowing themselves up we'll want to poke at it.

I'd also like to make shrapnel and explosions more dangerous indoors, but let's not get ahead of ourselves just yet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
