### PR TITLE
Backport: [Security] Don't search forks for build artifacts

### DIFF
--- a/.github/workflows/post-spell-check-result.yml
+++ b/.github/workflows/post-spell-check-result.yml
@@ -16,30 +16,33 @@ jobs:
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download pr id artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
           name: pull_request_id
+          allow_forks: false
       - name: Download spell check retcode artifact
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
           name: spell_check_retcode
+          allow_forks: false
       - name: set-spell-check-retcode
         id: set-spell-check-retcode
         run: echo "spell-check-retcode=$( cat spell_check_retcode )" >> $GITHUB_OUTPUT
       - name: Download spell check output artifact
         if: steps.set-spell-check-retcode.outputs.spell-check-retcode >= 1
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
           name: spell_check_output
+          allow_forks: false
       - name: 'Comment on PR'
         if: steps.set-spell-check-retcode.outputs.spell-check-retcode >= 1
-        uses: actions/github-script@v6.3.3
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -29,6 +29,7 @@ jobs:
         workflow: ${{ github.event.workflow_run.name }}
         run_id: ${{ github.event.workflow_run.id }}
         name: basic-build
+        allow_forks: false
     - name: set-basic-build-success
       id: set-basic-build-success
       run: echo "basic-build-success=$( cat basic-build )" >> $GITHUB_OUTPUT
@@ -38,6 +39,7 @@ jobs:
         workflow: ${{ github.event.workflow_run.name }}
         run_id: ${{ github.event.workflow_run.id }}
         name: pull_request_id
+        allow_forks: false
     - name: set-pr-id
       id: set-pr-id
       run: echo "pr-id=$( cat pull_request_id )" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Backports CleverRaven/Cataclysm-DDA/pull/78170.

Yes, we are not vulnerable right now as the repo can not be forked. Still fixes those two dependabot alerts in the Security tab. Better safe than sorry as the backport is basically nothing.

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
