### PR TITLE
Fix several issues of NPC movement. (#72072)

### DIFF
--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -58,7 +58,8 @@ static bool can_move( const npc &source )
 
 static bool can_move_melee( const npc &source )
 {
-    return can_move( source ) && source.rules.engagement != combat_engagement::FREE_FIRE;
+    return can_move( source ) && source.rules.engagement != combat_engagement::FREE_FIRE &&
+           source.rules.engagement != combat_engagement::NO_MOVE;
 }
 
 bool npc_attack_rating::operator>( const npc_attack_rating &rhs ) const
@@ -285,9 +286,14 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                     //add_msg_debug( debugmode::DF_NPC_MOVEAI,
                     //               "<color_light_gray>%s is at least %i away from allies, enemy within %i of ally.  Going for attack.</color>",
                     //               source.name, source.mem_combat.formation_distance, source.closest_enemy_to_friendly_distance() );
+                } else if( source.mem_combat.formation_distance <= source.mem_combat.engagement_distance ) {
+                    add_msg_debug( debugmode::DF_NPC_MOVEAI,
+                                   "<color_light_gray>%s can't path to melee target, and is staying close to ranged allies.  Stay in place.</color>",
+                                   source.name );
+                    source.move_pause();
                 } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                                   "<color_light_gray>%s can't path to melee target, or is staying close to ranged allies.</color>",
+                                   "<color_light_gray>%s can't path to melee target, and is not staying close to ranged allies.  Get close to player.</color>",
                                    source.name );
                     source.look_for_player( get_player_character() );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1445,10 +1445,12 @@ void npc::move()
     if( action == npc_undecided && is_walking_with() && player_character.in_vehicle &&
         !in_vehicle ) {
         action = npc_follow_embarked;
+        path.clear();
     }
 
     if( action == npc_undecided && is_walking_with() && rules.has_flag( ally_rule::follow_close ) &&
-        rl_dist( pos(), player_character.pos() ) > follow_distance() ) {
+        rl_dist( pos(), player_character.pos() ) > follow_distance() && !( player_character.in_vehicle &&
+                in_vehicle ) ) {
         action = npc_follow_player;
     }
 
@@ -1524,6 +1526,7 @@ void npc::move()
         // check if in vehicle before rushing off to fetch things
         if( is_walking_with() && player_character.in_vehicle ) {
             action = npc_follow_embarked;
+            path.clear();
         } else if( fetching_item ) {
             // Set to true if find_item() found something
             action = npc_pickup;


### PR DESCRIPTION
#### Summary
Content "Backport 72072"

#### Purpose of change

- Backports CleverRaven/Cataclysm-DDA#72072

#### Describe the solution

Verbatim backport. Patch applied cleanly, no manual changes done by me.

#### Describe alternatives you've considered

#### Testing

This patch applies cleanly, so there is not much potential for breakage I'd say. ~~Still needs compilation and for good measure minor testing to make sure the game loads and doesnt crash when npcs follow you.~~

No crashes, compiles cleanly, NPC follows me normally.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
