### PR TITLE
Revert "More logical pocket/hood/collar flags"

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9364,41 +9364,17 @@ std::string Character::is_snuggling() const
     return "nothing";
 }
 
-// If the player is not on all fours or wielding anything big, check if hands can be put in pockets
+// If the player is not wielding anything big, check if hands can be put in pockets
 bool Character::can_use_pockets() const
 {
     // TODO Check that the pocket actually has enough space for the wielded item?
-    if( !has_effect( effect_quadruped_full ) ) {
-        return weapon.volume() < 500_ml;
-    } else {
-        return false;
-    }
+    return weapon.volume() < 500_ml;
 }
 
 // If the player's head is not encumbered, check if hood can be put up
-bool Character::can_use_hood( item armor ) const
+bool Character::can_use_hood() const
 {
-    // Check for a conflicting item on the same layer that covers the head.
-    //for( auto it = worn.begin(); it != worn.end(); ++it ) {
-    // const item &worn_armor = *it;
-    //        for( const item &worn_armor : worn ) {
-    for( const item &worn_armor : worn.get_worn() ) {
-        if( worn_armor.covers( body_part_head ) && worn_armor.get_layer() == armor.get_layer() ) {
-            return false;
-        }
-    }
-    // Check encumbrance after verifying no conflicts
     return encumb( body_part_head ) < 10;
-}
-
-item Character::get_usable_hood( Character &you ) const
-{
-    for( const item &armor : you.worn.get_worn() ) {
-        if( armor.has_flag( flag_HOOD ) && can_use_hood( armor ) ) {
-            return armor;  // Return a copy of the found item
-        }
-    }
-    return null_item_reference();  // Return a copy of the "null" item
 }
 
 // If the player's mouth is not encumbered, check if collar can be put up
@@ -9410,9 +9386,7 @@ bool Character::can_use_collar() const
 std::map<bodypart_id, int> Character::bonus_item_warmth() const
 {
     const int pocket_warmth = worn.pocket_warmth();
-    std::pair<int, item> hood_info = worn.hood_warmth();
-    int hood_warmth_int = hood_info.first;
-    item hood = hood_info.second;
+    const int hood_warmth = worn.hood_warmth();
     const int collar_warmth = worn.collar_warmth();
 
     std::map<bodypart_id, int> ret;
@@ -9423,8 +9397,8 @@ std::map<bodypart_id, int> Character::bonus_item_warmth() const
             ret[bp] += pocket_warmth;
         }
 
-        if( bp == body_part_head && can_use_hood( hood ) ) {
-            ret[bp] += hood_warmth_int;
+        if( bp == body_part_head && can_use_hood() ) {
+            ret[bp] += hood_warmth;
         }
 
         if( bp == body_part_mouth && can_use_collar() ) {

--- a/src/character.h
+++ b/src/character.h
@@ -3304,8 +3304,7 @@ class Character : public Creature, public visitable
         void clear_destination_activity();
 
         bool can_use_pockets() const;
-        bool can_use_hood( item armor ) const;
-        item get_usable_hood( Character &you ) const;
+        bool can_use_hood() const;
         bool can_use_collar() const;
         /** Returns warmth provided by an armor's bonus, like hoods, pockets, etc. */
         std::map<bodypart_id, int> bonus_item_warmth() const;

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1746,14 +1746,15 @@ int outfit::pocket_warmth() const
     return warmth;
 }
 
-std::pair<int, item> outfit::hood_warmth() const
+int outfit::hood_warmth() const
 {
+    int warmth = 0;
     for( const item &w : worn ) {
         if( w.has_flag( flag_HOOD ) ) {
-            return { w.get_warmth(), w };
+            warmth = std::max( warmth, w.get_warmth() );
         }
     }
-    return { 0, null_item_reference() };
+    return warmth;
 }
 
 int outfit::collar_warmth() const
@@ -2467,7 +2468,7 @@ void outfit::prepare_bodymap_info( bodygraph_info &info, const bodypart_id &bp,
                 //~ name of a clothing/armor item, indicating it has pockets providing hand warmth
                 info.worn_names.push_back( string_format( _( "%s (pockets)" ), armor.tname() ) );
             }
-            if( bp == body_part_head && armor.has_flag( flag_HOOD ) && person.can_use_hood( armor ) ) {
+            if( bp == body_part_head && armor.has_flag( flag_HOOD ) && person.can_use_hood() ) {
                 //~ name of a clothing/armor item, indicating it has a hood providing head warmth
                 info.worn_names.push_back( string_format( _( "%s (hood)" ), armor.tname() ) );
             }

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -67,9 +67,6 @@ class outfit
     public:
         outfit() = default;
         explicit outfit( const std::list<item> &items ) : worn( items ) {}
-        const std::list<item> &get_worn() const {
-            return worn;
-        }
         bool is_worn( const item &clothing ) const;
         bool is_worn( const itype_id &clothing ) const;
         bool is_worn_module( const item &thing ) const;
@@ -127,7 +124,7 @@ class outfit
         units::volume small_pocket_volume( const units::volume &threshold )  const;
         int empty_holsters() const;
         int pocket_warmth() const;
-        std::pair<int, item> hood_warmth() const;
+        int hood_warmth() const;
         int collar_warmth() const;
         /** Returns warmth provided by armor, etc. */
         std::map<bodypart_id, int> warmth( const Character &guy ) const;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -20,7 +20,6 @@
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
-#include "character_attire.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -996,7 +995,7 @@ void suffer::from_sunburn( Character &you, bool severe )
                         && you.can_use_pockets() )
                    || ( bp == body_part_head
                         && you.worn_with_flag( flag_HOOD )
-                        && you.can_use_hood( you.get_usable_hood( you ) ) )
+                        && you.can_use_hood() )
                    || ( ( ( bp == body_part_arm_l ) || ( bp == body_part_hand_l ) ) &&
                         you.has_trait( trait_NO_LEFT_ARM ) )
                    || ( ( ( bp == body_part_arm_r ) || ( bp == body_part_hand_r ) ) &&


### PR DESCRIPTION
There was a version issue, this needs to be reverted to fix that.