### PR TITLE
Fix limb string extractor (#72090)

### DIFF
--- a/lang/string_extractor/parsers/body_part.py
+++ b/lang/string_extractor/parsers/body_part.py
@@ -5,15 +5,20 @@ from ..write_text import write_text
 def parse_body_part(json, origin):
     # See comments in `body_part_struct::load` of bodypart.cpp about why xxx
     # and xxx_multiple are not inside a single translation object.
-    name = get_singular_name(json["name"])
 
-    write_text(json["name"], origin, comment="Name of body part")
+    name = ""
+    if "name" in json:
+        name = get_singular_name(json["name"])
+        write_text(json["name"], origin, comment="Name of body part")
+    elif "id" in json:
+        name = json["id"]
 
     if "name_multiple" in json:
         write_text(json["name_multiple"], origin, comment="Name of body part")
 
-    write_text(json["accusative"], origin,
-               comment="Accusative name of body part")
+    if "accusative" in json:
+        write_text(json["accusative"], origin,
+                   comment="Accusative name of body part")
 
     if "accusative_multiple" in json:
         write_text(json["accusative_multiple"], origin,
@@ -23,11 +28,13 @@ def parse_body_part(json, origin):
         write_text(json["encumbrance_text"], origin,
                    comment="Encumbrance text of body part \"{}\"".format(name))
 
-    write_text(json["heading"], origin,
-               comment="Heading of body part \"{}\"".format(name))
+    if "heading" in json:
+        write_text(json["heading"], origin,
+                   comment="Heading of body part \"{}\"".format(name))
 
-    write_text(json["heading_multiple"], origin,
-               comment="Heading of body part \"{}\"".format(name))
+    if "heading_multiple" in json:
+        write_text(json["heading_multiple"], origin,
+                   comment="Heading of body part \"{}\"".format(name))
 
     if "smash_message" in json:
         write_text(json["smash_message"], origin,


### PR DESCRIPTION
#### Summary
Content "Backport 72090"

#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72090

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Patch applied cleanly, no further need for testing.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
