### PR TITLE
Remove bad logic

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2721,7 +2721,7 @@ target_handler::trajectory target_ui::run()
             break;
         }
         case ExitCode::Fire: {
-            if( mode != TargetMode::SelectOnly || mode != TargetMode::ThrowCreature ) {
+            if( mode != TargetMode::SelectOnly ) {
                 bool harmful = !( mode == TargetMode::Spell && casting->damage( player_character ) <= 0 );
                 on_target_accepted( harmful );
             }


### PR DESCRIPTION
#### Summary
Silence clang error in throw targeting check

#### Purpose of change
An if statement was always evaluating as true.

#### Describe the solution
Remove the unused part of the check.

#### Testing
Game runs and you can still throw things and creatures.

#### Additional context
Credit to @phi-bee for finding it originally and @NetSysFire for finding out that I forgot to fix it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
