### PR TITLE
Cloaks have proper coverage and POCKETS to warm your hands.

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -3,7 +3,7 @@
     "id": "american_flag",
     "type": "ARMOR",
     "name": { "str": "American flag" },
-    "description": "A large American flag, made to fly in even the worst conditions.",
+    "description": "A large banner decorated with red and white striped representing the thirteen colonies, and fifty white stars representing the states over a field of blue.",
     "weight": "3200 g",
     "volume": "2 L",
     "price": 5000,
@@ -13,15 +13,18 @@
     "symbol": "[",
     "looks_like": "towel",
     "color": "light_red",
-    "warmth": 20,
-    "material_thickness": 0.3,
+    "warmth": 8,
+    "material_thickness": 0.1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "POCKETS", "COLLAR" ],
     "armor": [
+      { "encumbrance": 15, "coverage": 60, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
-        "encumbrance": 50,
+        "covers": [ "leg_l", "leg_r" ],
         "coverage": 60,
-        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "encumbrance": 15,
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
       }
     ]
   },
@@ -164,7 +167,7 @@
       {
         "id": "albanian_flag",
         "name": { "str": "Albanian flag" },
-        "description": "It's a solid red, overlaid with the crest of Albania.",
+        "description": "It's solid red overlaid with a black two-headed eagle, the crest of Albania.",
         "weight": 10,
         "append": true
       },
@@ -1572,7 +1575,7 @@
     "color": "pink",
     "warmth": 10,
     "material_thickness": 0.3,
-    "flags": [ "OVERSIZE", "BELTED", "POWERARMOR_COMPATIBLE" ],
+    "flags": [ "OVERSIZE", "BELTED", "POWERARMOR_COMPATIBLE", "POCKETS", "COLLAR" ],
     "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {
@@ -1621,7 +1624,7 @@
     "color": "red",
     "warmth": 15,
     "material_thickness": 0.5,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l" ] },
       {
@@ -1636,8 +1639,8 @@
   {
     "id": "grass_cloak",
     "type": "ARMOR",
-    "name": { "str": "grass cloak" },
-    "description": "A primitive cloak.  Ötzi wore one, too.",
+    "name": { "str": "grass poncho" },
+    "description": "A simple primitive cape made of woven grass.",
     "weight": "710 g",
     "volume": "1600 ml",
     "price": 2000,
@@ -1649,7 +1652,7 @@
     "color": "yellow",
     "warmth": 10,
     "material_thickness": 0.4,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 4, "coverage": 65, "covers": [ "torso" ] },
       {
@@ -1665,7 +1668,7 @@
     "id": "cloak",
     "type": "ARMOR",
     "name": { "str": "cloak" },
-    "description": "A heavy cloak meant to be thrown over your body.",
+    "description": "A long hooded cape that covers much of the body.",
     "weight": "1175 g",
     "volume": "3 L",
     "price": 10700,
@@ -1685,16 +1688,16 @@
         "layers": [ "BELTED" ]
       }
     ],
-    "warmth": 30,
+    "warmth": 18,
     "material_thickness": 0.4,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ]
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "POCKETS", "COLLAR" ]
   },
   {
     "id": "cloak_denim",
     "type": "ARMOR",
     "name": { "str": "denim cloak" },
-    "description": "A heavy denim cloak worn over your body.  Warmer, sturdier and heavier than a cotton cloak.",
+    "description": "A heavy denim cape worn over the body.  It is warm, sturdy, and comes with a hood.",
     "//": "16.5 oz.",
     "weight": "1800 g",
     "volume": "4 L",
@@ -1705,7 +1708,7 @@
     "looks_like": "coat_rain",
     "symbol": "[",
     "color": "light_blue",
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY", "POCKETS" ],
     "armor": [
       { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
@@ -1716,7 +1719,7 @@
         "layers": [ "BELTED" ]
       }
     ],
-    "warmth": 50,
+    "warmth": 25,
     "material_thickness": 1.1
   },
   {
@@ -1729,14 +1732,14 @@
     "price": 10800,
     "price_postapoc": 500,
     "to_hit": -1,
-    "material": [ "cotton" ],
+    "material": [ "lycra" ],
     "symbol": "[",
     "looks_like": "cloak",
     "color": "dark_gray",
-    "warmth": 10,
-    "material_thickness": 0.2,
+    "warmth": 6,
+    "material_thickness": 0.1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
@@ -1772,19 +1775,19 @@
     "id": "cloak_black",
     "type": "ARMOR",
     "name": { "str": "dark cloak" },
-    "description": "A black cloak meant to be thrown over your body.  Commonly used by witches and other creatures of the night.",
+    "description": "A long black cape with no hood, a common costume piece for witches and other creatures of the night.",
     "weight": "100 g",
     "volume": "2000 ml",
     "price": 9000,
     "price_postapoc": 50,
     "to_hit": -1,
-    "material": [ "cotton" ],
+    "material": [ "lycra" ],
     "symbol": "[",
     "looks_like": "cloak",
     "color": "dark_gray",
-    "warmth": 8,
+    "warmth": 6,
     "material_thickness": 0.1,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
@@ -1800,7 +1803,7 @@
     "id": "cloak_fur",
     "type": "ARMOR",
     "name": { "str": "fur cloak" },
-    "description": "A heavy fur cloak meant to be thrown over your body.",
+    "description": "A long and heavy fur cape with a hood.",
     "weight": "1735 g",
     "volume": "4 L",
     "price": 24500,
@@ -1811,15 +1814,15 @@
     "looks_like": "cloak_leather",
     "color": "brown",
     "warmth": 60,
-    "material_thickness": 0.6,
+    "material_thickness": 2.0,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "POCKETS" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 9, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 6,
+        "encumbrance": 9,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1829,7 +1832,7 @@
     "id": "cloak_leather",
     "type": "ARMOR",
     "name": { "str": "leather cloak" },
-    "description": "A heavy leather cloak meant to be thrown over your body.",
+    "description": "A heavy leather cape that offers a degree of protection as well as warmth.",
     "weight": "2060 g",
     "volume": "3500 ml",
     "price": 24500,
@@ -1842,13 +1845,13 @@
     "warmth": 40,
     "material_thickness": 1.5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "POCKETS" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 6,
+        "encumbrance": 8,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1858,7 +1861,7 @@
     "id": "cloak_wool",
     "type": "ARMOR",
     "name": { "str": "wool cloak" },
-    "description": "A heavy woolen cloak meant to be thrown over your body.",
+    "description": "A heavy woolen cape for inclement weather.",
     "weight": "900 g",
     "volume": "3750 ml",
     "price": 24500,
@@ -1871,7 +1874,7 @@
     "warmth": 50,
     "material_thickness": 0.5,
     "environmental_protection": 3,
-    "flags": [ "OVERSIZE", "HOOD", "BELTED" ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
@@ -1887,7 +1890,7 @@
     "id": "jedi_cloak",
     "type": "ARMOR",
     "name": { "str": "Jedi cloak" },
-    "description": "A long, flowing robe.  Be sure to tear it off dramatically before fighting any foes!",
+    "description": "A long, flowing cape modeled after those worn in a popular film franchise.",
     "weight": "1587 g",
     "volume": "2500 ml",
     "price": 22500,
@@ -1900,7 +1903,7 @@
     "warmth": 5,
     "material_thickness": 0.3,
     "environmental_protection": 5,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
       { "encumbrance": 3, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "head", "hand_l", "hand_r" ] },
       {
@@ -1917,7 +1920,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  You must be carrying a unified power supply, or UPS, to use it.  Activate to toggle visibility.",
-    "weight": "1552 g",
+    "weight": "2552 g",
     "volume": "3500 ml",
     "price": 5500000,
     "price_postapoc": 25000,
@@ -1938,13 +1941,13 @@
       "need_charges": 20,
       "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
     },
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF" ],
+    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF", "POCKETS", "COLLAR" ],
     "armor": [
-      { "encumbrance": 50, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 25, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 50,
+        "encumbrance": 25,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1957,7 +1960,19 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "FB51 optical cloak (on)", "str_pl": "FB51 optical cloaks (on)" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  It is turned on, and continually draining power from a UPS.  Use it to turn it off.",
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "ACTIVE_CLOAKING", "TRADER_AVOID", "SOFT", "NO_REPAIR", "RAINPROOF" ],
+    "flags": [
+      "USE_UPS",
+      "OVERSIZE",
+      "HOOD",
+      "BELTED",
+      "ACTIVE_CLOAKING",
+      "TRADER_AVOID",
+      "SOFT",
+      "NO_REPAIR",
+      "RAINPROOF",
+      "POCKETS",
+      "COLLAR"
+    ],
     "power_draw": "20 kW",
     "revert_to": "optical_cloak",
     "use_action": {
@@ -1985,7 +2000,7 @@
     "warmth": 35,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "BELTED", "OVERSIZE" ],
+    "flags": [ "BELTED", "OVERSIZE", "POCKETS" ],
     "armor": [
       { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] },
       {
@@ -2030,13 +2045,13 @@
     "symbol": "[",
     "color": "white",
     "name": { "str": "rain poncho" },
-    "description": "A lightweight transparent plastic rain poncho with a hood.  It folds into a very compact form when not in use.",
+    "description": "A lightweight transparent PVC rain poncho with a hood.  It folds into a very compact form when not in use.",
     "price": 5000,
     "price_postapoc": 50,
     "material": [ "vinyl" ],
     "weight": "280 g",
     "volume": "250 ml",
-    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT" ],
+    "flags": [ "RAINPROOF", "HOOD", "OVERSIZE", "BELTED", "TRANSPARENT", "POCKETS" ],
     "environmental_protection": 1,
     "material_thickness": 0.4,
     "variant_type": "generic",
@@ -2053,8 +2068,8 @@
   {
     "id": "coat_straw",
     "type": "ARMOR",
-    "name": { "str": "straw cape" },
-    "description": "Layers of dry grass draped over each other, used since ancient times to keep the rain off.",
+    "name": { "str": "straw cloak" },
+    "description": "A long, mantled cape made of layers of dry grass strung together and carefully draped over each other.  It looks like something out of a samurai film.",
     "weight": "907 g",
     "volume": "4 L",
     "price": 9000,
@@ -2064,25 +2079,25 @@
     "looks_like": "coat_winter",
     "color": "yellow",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80, "encumbrance": 12 },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 80, "encumbrance": 8 },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100 },
       {
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l", "leg_hip_r", "leg_hip_l" ],
-        "coverage": 100
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "coverage": 100,
+        "encumbrance": 8
       },
-      { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ], "coverage": 10 },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 2 }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 8 }
     ],
     "warmth": 15,
     "material_thickness": 2,
-    "flags": [ "OVERSIZE", "RAINPROOF", "BELTED" ]
+    "flags": [ "OVERSIZE", "RAINPROOF", "BELTED", "POCKETS" ]
   },
   {
     "id": "snuggie",
     "type": "ARMOR",
     "name": { "str": "snuggie" },
-    "description": "Perfect for reading all those books you scavenged.",
+    "description": "A fuzzy housecoat, halfway between a blanket and a bathrobe.  It's quite warm.",
     "weight": "625 g",
     "volume": "3 L",
     "price": 3600,
@@ -2095,7 +2110,7 @@
     "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "UNRESTRICTED", "OUTER" ],
+    "flags": [ "UNRESTRICTED", "OUTER", "POCKETS", "HOOD" ],
     "armor": [ { "encumbrance": 20, "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Touch up cloaks, give them the POCKETS flag.

#### Purpose of change
Cloaks had some weirdness going on. Flags weren't using the leg_draped parts, and none of the cloaks or ponchos had the POCKETS flags. This flag allows you to keep your hands warm inside the garment if you're not holding anything too big.

#### Describe the solution
- Halloween cloaks are now very thin lycra
- Adjusted warmth of a few cloaks, made denim cloak a lot less hot
- Fur cloak is now 2mm thick instead of 0.5mm (????)
- Gave all cloaks and ponchos the POCKETS flag. Updated descriptions on a lot of them
- Adjusted coverage of the straw cape, it was a bit odd.

#### Testing
Loaded in and tried out the cloaks in-game. They look good.

#### Additional context
Inspired by #79 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
