### PR TITLE
Backport Update the standard building palette (#72164)

### DIFF
--- a/data/json/mapgen/library.json
+++ b/data/json/mapgen/library.json
@@ -32,7 +32,7 @@
         ".....4..................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
     }
   },
@@ -70,9 +70,8 @@
         ".....4..................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette_vandalized", "vandalized_library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
-      "nested": { "|": { "chunks": [ [ "bile_field", 10 ], [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] } },
       "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
     }
   },
@@ -164,7 +163,7 @@
         ".5.....5..#[[[y| | [#...",
         "..........######o####..."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 3, 22 ], "y": [ 10, 14 ] } ],
       "place_monsters": [ { "monster": "GROUP_MAYBE_ZOMBIE", "x": [ 16, 21 ], "y": [ 5, 7 ], "density": 1 } ]
     }
@@ -203,9 +202,8 @@
         ".5.....5..#[[[y| | [#...",
         "..........######o####..."
       ],
-      "palettes": [ "standard_building_palette_vandalized", "vandalized_library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
-      "nested": { "|": { "chunks": [ [ "bile_field", 10 ], [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] } },
       "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 3, 22 ], "y": [ 10, 14 ] } ],
       "place_monsters": [ { "monster": "GROUP_MAYBE_ZOMBIE", "x": [ 16, 21 ], "y": [ 5, 7 ], "density": 1 } ]
     }
@@ -301,7 +299,7 @@
         "...........#y CC  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 5, 9 ], "y": [ 4, 16 ] } ],
       "terrain": { "G": "t_grass" },
@@ -342,12 +340,9 @@
         "...........#y CC  + t#..",
         "...........###########.."
       ],
-      "palettes": [ "standard_building_palette_vandalized", "vandalized_library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
-      "nested": {
-        "G": { "chunks": [ "roof_6x6_garden_1" ] },
-        "|": { "chunks": [ [ "bile_field", 10 ], [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] }
-      },
+      "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
       "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 5, 9 ], "y": [ 4, 16 ] } ],
       "terrain": { "G": "t_grass" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ]
@@ -444,7 +439,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "library_palette" ],
+      "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
     }
   },
@@ -482,8 +477,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette_vandalized", "vandalized_library_palette" ],
-      "nested": { "|": { "chunks": [ [ "bile_field", 10 ], [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] } },
+      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
     }
   },

--- a/data/json/mapgen/s_clothing.json
+++ b/data/json/mapgen/s_clothing.json
@@ -33,7 +33,7 @@
         "..####################..",
         "....................4..."
       ],
-      "palettes": [ "standard_building_palette", "clothes_store_palette" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "clothes_store_palette" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ],
       "vehicles": { " ": { "vehicle": "shopping_cart", "chance": 1, "status": 0 } },
@@ -125,7 +125,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "tailor_palette" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "tailor_palette" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white" },
       "place_loot": [ { "group": "cash_register_random", "x": 18, "y": [ 6, 9 ] } ]
     }
@@ -213,7 +213,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "furs_palette" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "furs_palette" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white" },
       "place_loot": [ { "group": "cash_register_random", "x": 7, "y": 7 } ]
     }
@@ -442,7 +442,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "tailor_palette" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "tailor_palette" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white" },
       "place_loot": [ { "group": "cash_register_random", "repeat": 2, "x": [ 10, 13 ], "y": 7 } ]
     }
@@ -728,7 +728,7 @@
         "...........-............",
         "...........-............"
       ],
-      "palettes": [ "standard_building_palette", "clothes_store_palette" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "clothes_store_palette" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white", "D": "t_linoleum_white" },
       "place_loot": [ { "group": "cash_register_random", "x": [ 10, 13 ], "y": 7 } ]
     }

--- a/data/json/mapgen/s_fabricstore.json
+++ b/data/json/mapgen/s_fabricstore.json
@@ -32,7 +32,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_palette", "fabric_store_pallete" ],
+      "palettes": [ "standard_building_general_and_variant_palette", "fabric_store_pallete" ],
       "terrain": { "t": "t_linoleum_white", "S": "t_linoleum_white", "_": "t_linoleum_white" },
       "place_loot": [ { "group": "cash_register_random", "x": 7, "y": 7 } ]
     }

--- a/data/json/mapgen_palettes/building.json
+++ b/data/json/mapgen_palettes/building.json
@@ -1,41 +1,98 @@
 [
   {
     "type": "palette",
-    "id": "standard_building_palette",
+    "id": "standard_building_general_and_variant_palette",
+    "//": "Palette used to randomize the state of the building",
+    "parameters": {
+      "building_variant_palette": {
+        "type": "palette_id",
+        "scope": "overmap_special",
+        "//": "null_palette represents normal building here",
+        "default": { "distribution": [ [ "null_palette", 400 ], [ "standard_building_vandalized_palette", 600 ] ] }
+      }
+    },
+    "palettes": [ "standard_building_shared_palette", { "param": "building_variant_palette" } ]
+  },
+  {
+    "type": "palette",
+    "id": "standard_building_shared_palette",
+    "parameters": {
+      "interior_wall_type": {
+        "type": "ter_str_id",
+        "default": {
+          "distribution": [
+            [ "t_wall_b", 1 ],
+            [ "t_wall_g", 1 ],
+            [ "t_wall_p", 1 ],
+            [ "t_wall_P", 1 ],
+            [ "t_wall_r", 1 ],
+            [ "t_wall_w", 6 ],
+            [ "t_wall_y", 1 ],
+            [ "t_wall_gray", 1 ],
+            [ "t_wall_brown", 1 ],
+            [ "t_wall_cyan", 1 ],
+            [ "t_wall_black", 1 ],
+            [ "t_wall_orange", 1 ]
+          ]
+        }
+      },
+      "exterior_wall_type": {
+        "type": "ter_str_id",
+        "default": {
+          "distribution": [
+            [ "t_brick_wall", 6 ],
+            [ "t_rock_wall", 3 ],
+            [ "t_wall_wood", 3 ],
+            [ "t_concrete_wall", 4 ],
+            [ "t_adobe_brick_wall", 1 ]
+          ]
+        }
+      }
+    },
     "furniture": { "S": "f_sink" },
     "terrain": {
       ".": [ [ "t_region_groundcover_urban", 20 ], "t_region_shrub_decorative" ],
-      " ": "t_floor",
-      "+": "t_door_c",
-      "*": "t_door_glass_c",
       "4": "t_gutter_downspout",
-      "|": "t_wall",
-      "#": "t_brick_wall",
-      ":": "t_wall_glass",
+      "|": { "param": "interior_wall_type", "fallback": "t_wall_w" },
+      "#": { "param": "exterior_wall_type", "fallback": "t_brick_wall" },
       "-": "t_sidewalk",
-      "o": "t_window",
       "<": "t_stairs_up",
-      ">": "t_stairs_down"
+      ">": "t_stairs_down",
+      "+": [ [ "t_door_c", 5 ], [ "t_door_o", 5 ], [ "t_door_locked_interior", 1 ] ],
+      "*": [
+        [ "t_door_locked_peep", 2 ],
+        "t_door_locked_alarm",
+        [ "t_door_locked", 10 ],
+        [ "t_door_elocked_peep", 4 ],
+        "t_door_elocked_alarm",
+        [ "t_door_elocked", 15 ],
+        "t_door_c",
+        [ "t_door_o", 2 ]
+      ],
+      ":": "t_wall_glass",
+      "o": "t_window"
     },
     "toilets": { "t": {  } }
   },
   {
     "type": "palette",
-    "id": "standard_building_palette_vandalized",
-    "furniture": { "S": "f_sink" },
-    "terrain": {
-      ".": [ [ "t_region_groundcover_urban", 20 ], "t_region_shrub_decorative" ],
-      " ": "t_floor",
-      "+": "t_door_c",
-      "*": "t_door_glass_c",
-      "4": "t_gutter_downspout",
-      "|": "t_wall",
-      "#": "t_brick_wall",
-      ":": "t_wall_glass",
-      "-": "t_sidewalk",
-      "o": [ "t_window", "t_window_frame" ],
-      "<": "t_stairs_up",
-      ">": "t_stairs_down"
+    "id": "standard_building_vandalized_palette",
+    "nested": {
+      "+": { "chunks": [ [ "damaged_door_nested", 1 ], [ "destroyed_door_nested", 3 ], [ "null", 4 ] ] },
+      "*": { "chunks": [ [ "damaged_door_nested", 1 ], [ "destroyed_door_nested", 3 ], [ "null", 4 ] ] },
+      "o": { "chunks": [ [ "damaged_window_nested", 1 ], [ "destroyed_window_nested", 1 ], [ "null", 2 ] ] },
+      ":": { "chunks": [ [ "destroyed_glass_door_wall", 1 ], [ "null", 2 ] ] },
+      "|": { "chunks": [ [ "bile_field", 1 ], [ "shelter_graffiti", 2 ], [ "general_graffiti", 2 ], [ "null", 245 ] ] },
+      "#": { "chunks": [ [ "shelter_graffiti", 1 ], [ "general_graffiti", 1 ], [ "null", 248 ] ] },
+      " ": {
+        "chunks": [
+          [ "corpse_blood_1x1", 3 ],
+          [ "corpse_blood_casings_1x1", 1 ],
+          [ "blood_field", 8 ],
+          [ "bile_field", 1 ],
+          [ "null", 387 ]
+        ]
+      }
     },
     "toilets": { "t": {  } }
   }


### PR DESCRIPTION
#### Summary
Content "Backport 72164"

#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72164

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Patch applied cleanly, spawned some buildings affected and they indeed had a parameterized wall and some vandalism, the latter of which is excellent for the setting.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
