### PR TITLE
Backport: Changed neoprene patch price from 100 to 5 (#72174)

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3366,7 +3366,7 @@
     "name": { "str": "neoprene patch", "str_pl": "neoprene patches" },
     "description": "A small neoprene patch.  Can be used to repair neoprene clothing.",
     "price": 1000,
-    "price_postapoc": 100,
+    "price_postapoc": 5,
     "material": [ "neoprene" ],
     "flags": [ "NO_SALVAGE" ],
     "weight": "3 g",


### PR DESCRIPTION
#### Summary
Content "Backport 72174"

#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72174

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

None, there is literally none needed for this trivial change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
