### PR TITLE
Backport Pickaxe_list and rope_natural relevant Fix (#72175)

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2115,7 +2115,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
     "pre_terrain": "t_brick_wall",
     "post_terrain": "t_embrasure_brick"
   },
@@ -2144,7 +2144,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "30 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ],
     "pre_terrain": "t_adobe_brick_wall",
     "post_terrain": "t_embrasure_adobe_brick"
   },
@@ -4986,8 +4986,8 @@
       [ { "id": "DIG", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
-      [ [ "rope_natural", 1, "LIST" ] ]
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
+      [ [ "tool_rope_long", 1, "LIST" ] ]
     ],
     "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
     "byproducts": [ { "group": "digging_soil_loam_50L", "count": 40 } ],
@@ -5010,8 +5010,8 @@
       [ { "id": "DIG", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
-      [ [ "rope_natural", 1, "LIST" ] ]
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
+      [ [ "tool_rope_long", 1, "LIST" ] ]
     ],
     "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
     "byproducts": [ { "group": "mining_rock" } ],
@@ -5027,7 +5027,7 @@
     "category": "DIG",
     "required_skills": [ [ "fabrication", 0 ] ],
     "time": "70 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ] ] ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_terrain": "t_wall_resin_cage",
     "post_terrain": "t_floor_resin",
@@ -5102,7 +5102,8 @@
       [ { "id": "DIG", "level": 2 } ]
     ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 160 ], [ "elec_jackhammer", 2112 ] ],
+      [ [ "tool_rope_long", 1, "LIST" ] ],
       [
         "miner_hat",
         "hat_hard",
@@ -5112,8 +5113,7 @@
         "helmet_riot",
         "tac_helmet",
         "miner_hat_on"
-      ],
-      [ [ "rope_natural", 1, "LIST" ] ]
+      ]
     ],
     "//": "Helmets are essential because you're digging up and things may fall on you.",
     "components": [ [ [ "2x4", 18 ] ], [ [ "wood_beam", 2 ] ], [ [ "nails", 90, "LIST" ], [ "nuts_bolts", 90 ] ] ],
@@ -7152,7 +7152,7 @@
     "qualities": [ [ { "id": "DIG", "level": 2 } ] ],
     "required_skills": [ [ "survival", 3 ] ],
     "time": "300 m",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ] ],
     "byproducts": [ { "group": "mining_rock" } ],
     "pre_terrain": "t_rock_floor",
     "post_terrain": "t_pit",
@@ -7493,7 +7493,7 @@
     "components": [ [ [ "2x4", 4 ] ], [ [ "nails", 16, "LIST" ] ] ],
     "pre_terrain": "t_rock_roof",
     "post_terrain": "t_skylight_frame",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ]
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 50 ], [ "elec_jackhammer", 660 ] ] ]
   },
   {
     "type": "construction",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -124,7 +124,7 @@
     "id": "pickaxe_list",
     "type": "requirement",
     "//": "Pickaxe tools",
-    "tools": [ [ [ "pickaxe", -1 ] ], [ [ "bronze_pickaxe", -1 ] ] ]
+    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ] ] ]
   },
   {
     "id": "serum_production_standard",
@@ -301,7 +301,7 @@
     "id": "mining_standard",
     "type": "requirement",
     "//": "mining",
-    "tools": [ [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 300 ], [ "elec_jackhammer", 3960 ] ] ]
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 300 ], [ "elec_jackhammer", 3960 ] ] ]
   },
   {
     "id": "bronzesmithing_tools",
@@ -341,8 +341,7 @@
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CHISEL", "level": 2 }, { "id": "PRY", "level": 3 } ],
     "tools": [
       [
-        [ "pickaxe", -1 ],
-        [ "bronze_pickaxe", -1 ],
+        [ "pickaxe_list", 1, "LIST" ],
         [ "jackhammer", 140 ],
         [ "elec_jackhammer", 1848 ],
         [ "hammer_sledge", -1 ],
@@ -376,7 +375,7 @@
     "//": "Tools for removing road / sidewalk",
     "qualities": [ { "id": "PRY", "level": 3 } ],
     "tools": [
-      [ [ "pickaxe", -1 ], [ "bronze_pickaxe", -1 ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
+      [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ],
       [ [ "masonrysaw_off", 100 ], [ "electric_masonrysaw_off", 1320 ] ]
     ]
   },
@@ -514,5 +513,20 @@
     "//2": "The comment called for adequate protection. When a way to check for that without writing down and keeping updated a list of anything that can protect the arms in the requirements, add arm protection requirement",
     "//3": "Can instead add arm damage risk, mitigated by skill and reduced by armor, when such a thing becomes possible",
     "qualities": [ { "id": "CUT_FINE", "level": 2 } ]
+  },
+  {
+    "id": "tool_rope_long",
+    "type": "requirement",
+    "//": "Long rope used as a tool, in constuction process and so on",
+    "tools": [
+      [
+        [ "rope_30", -1 ],
+        [ "rope_makeshift_30", -1 ],
+        [ "vine_30", -1 ],
+        [ "grapnel", -1 ],
+        [ "chain", -1 ],
+        [ "hd_tow_cable", -1 ]
+      ]
+    ]
   }
 ]

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -29,7 +29,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "fabrication",
     "time": "5 m",
-    "tools": [ [ [ "pickaxe_list", -1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
     "components": [ [ [ "rock", 24 ] ] ]
   },
   {

--- a/data/mods/innawood/recipes/recipe_deconstruction.json
+++ b/data/mods/innawood/recipes/recipe_deconstruction.json
@@ -13,7 +13,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "fabrication",
     "time": "5 m",
-    "tools": [ [ [ "pickaxe_list", -1, "LIST" ], [ "jackhammer", 1 ], [ "elec_jackhammer", 50 ] ] ],
+    "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 1 ], [ "elec_jackhammer", 50 ] ] ],
     "components": [ [ [ "rock", 24 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Backport 72175"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72175


#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Loads and looks correctly. Patch applied cleanly minus for the fact that I had to stop it trying to apply stuff to the non-existent magiclysm mod.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
