### PR TITLE
Backport Paper wrapper should have tinder flag (#72177)

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3216,7 +3216,7 @@
     "symbol": ",",
     "color": "light_gray",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
-    "flags": [ "COLLAPSE_CONTENTS" ]
+    "flags": [ "COLLAPSE_CONTENTS", "TINDER" ]
   },
   {
     "id": "wrapper_foil",


### PR DESCRIPTION
#### Summary
Content "Backport 72177"

#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72177

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

None needed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
