### PR TITLE
Backport Fix item group birthdays (#72194)

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3116,7 +3116,7 @@ void receive_item( itype_id &item_name, int count, std::string_view container_na
 {
     if( use_item_group ) {
         item_group::ItemList new_items;
-        new_items = item_group::items_from( item_group_id( item_name.c_str() ) );
+        new_items = item_group::items_from( item_group_id( item_name.c_str() ), calendar::turn );
         std::string popup_message;
         for( item &new_item : new_items ) {
             for( const std::string &flag : flags ) {


### PR DESCRIPTION
#### Summary
Content "Backport 72194"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72194

#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Patch applied cleanly, this is a one line fix, I strongly assume this will work as is but I can compile tomorrow or something.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
