### PR TITLE
Backport use item/tname instead of its raw name (nname) in recipe menu (#72202)

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14616,6 +14616,13 @@ std::string item::nname( const itype_id &id, unsigned int quantity )
     return t->nname( quantity );
 }
 
+std::string item::tname( const itype_id &id, unsigned int quantity,
+                         const tname::segment_bitset &segments )
+{
+    item item_temp( id );
+    return item_temp.tname( quantity, segments );
+}
+
 bool item::count_by_charges( const itype_id &id )
 {
     const itype *t = find_type( id );

--- a/src/item.h
+++ b/src/item.h
@@ -418,6 +418,8 @@ class item : public visitable
         std::string tname( unsigned int quantity = 1,
                            tname::segment_bitset const &segments = tname::default_tname ) const;
         std::string tname( unsigned int quantity, bool with_prefix ) const;
+        static std::string tname( const itype_id &id, unsigned int quantity = 1,
+                                  tname::segment_bitset const &segments = tname::default_tname );
         std::string display_money( unsigned int quantity, unsigned int total,
                                    const std::optional<unsigned int> &selected = std::nullopt ) const;
         /**

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -108,11 +108,16 @@ constexpr uint64_t tname_conditional_bits =    // TODO: fine grain?
     1ULL << static_cast<size_t>( tname::segments::COMPONENTS ) |
     1ULL << static_cast<size_t>( tname::segments::TAGS ) |
     1ULL << static_cast<size_t>( tname::segments::VARS );
+constexpr uint64_t item_name_bits =    // item prefix + item name + item suffix
+    1ULL << static_cast<size_t>( tname::segments::CUSTOM_ITEM_PREFIX ) |
+    1ULL << static_cast<size_t>( tname::segments::TYPE ) |
+    1ULL << static_cast<size_t>( tname::segments::CUSTOM_ITEM_SUFFIX );
 constexpr segment_bitset default_tname( default_tname_bits );
 constexpr segment_bitset unprefixed_tname( default_tname_bits & ~tname_prefix_bits );
 constexpr segment_bitset tname_sort_key( default_tname_bits & ~tname_unsortable_bits );
 constexpr segment_bitset tname_contents( tname_contents_bits );
 constexpr segment_bitset tname_conditional( tname_conditional_bits );
+constexpr segment_bitset item_name( item_name_bits );
 
 } // namespace tname
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1226,7 +1226,7 @@ std::string recipe::result_name( const bool decorated ) const
             name = iter_var->alt_name.translated();
         }
     } else {
-        name = item::nname( result_ );
+        name = item::tname( result_, 1, tname::item_name );
     }
     if( decorated &&
         uistate.favorite_recipes.find( this->ident() ) != uistate.favorite_recipes.end() ) {

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -158,17 +158,17 @@ std::string tool_comp::to_string( const int batch, const int ) const
         //~ %1$s: tool name, %2$d: charge requirement
         return string_format( npgettext( "requirement", "%1$s (%2$d charge)", "%1$s (%2$d charges)",
                                          charge_total ),
-                              item::nname( type ), charge_total );
+                              item::tname( type, 1, tname::item_name ), charge_total );
     } else {
-        return item::nname( type, std::abs( count ) );
+        return item::tname( type, std::abs( count ), tname::item_name );
     }
 }
 
 std::string item_comp::to_string( const int batch, const int avail ) const
 {
     const int c = std::abs( count ) * batch;
-    const itype *type_ptr = item::find_type( type );
-    if( type_ptr->count_by_charges() ) {
+    const item item_temp = item( type );
+    if( item_temp.count_by_charges() ) {
         // Count-by-charge
 
         if( avail == item::INFINITE_CHARGES ) {
@@ -176,16 +176,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  type_ptr->nname( 1 ), c );
+                                  item_temp.tname( 1, tname::item_name ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: charge requirement, %3%d: available charges
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  type_ptr->nname( 1 ), c, avail );
+                                  item_temp.tname( 1, tname::item_name ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: charge requirement
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  type_ptr->nname( 1 ), c );
+                                  item_temp.tname( 1, tname::item_name ), c );
         }
     } else {
         if( avail == item::INFINITE_CHARGES ) {
@@ -193,16 +193,16 @@ std::string item_comp::to_string( const int batch, const int avail ) const
             return string_format( npgettext( "requirement", "%2$d %1$s (have infinite)",
                                              "%2$d %1$s (have infinite)",
                                              c ),
-                                  type_ptr->nname( c ), c );
+                                  item_temp.tname( c, tname::item_name ), c );
         } else if( avail > 0 ) {
             //~ %1$s: item name, %2$d: required count, %3%d: available count
             return string_format( npgettext( "requirement", "%2$d %1$s (have %3$d)",
                                              "%2$d %1$s (have %3$d)", c ),
-                                  type_ptr->nname( c ), c, avail );
+                                  item_temp.tname( c, tname::item_name ), c, avail );
         } else {
             //~ %1$s: item name, %2$d: required count
             return string_format( npgettext( "requirement", "%2$d %1$s", "%2$d %1$s", c ),
-                                  type_ptr->nname( c ), c );
+                                  item_temp.tname( c, tname::item_name ), c );
         }
     }
 }


### PR DESCRIPTION
#### Summary
Content "Backport 72202"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72202


#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Patch applied cleanly, this one seems less likely to break something due to its low complexity.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
