### PR TITLE
Mostly port 72099

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -273,15 +273,9 @@ activity_handlers::do_turn_functions = {
     { ACT_ATM, atm_do_turn },
     { ACT_FISH, fish_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },
-    { ACT_BLEED, butcher_do_turn },
-    { ACT_BUTCHER, butcher_do_turn },
-    { ACT_BUTCHER_FULL, butcher_do_turn },
     { ACT_TRAVELLING, travel_do_turn },
-    { ACT_FIELD_DRESS, butcher_do_turn },
-    { ACT_SKIN, butcher_do_turn },
-    { ACT_QUARTER, butcher_do_turn },
+    // DISMEMBER is disabled until we tie it to a proficiency where the character knows how to stop a zombie reviving with less work.
     // { ACT_DISMEMBER, butcher_do_turn },
-    { ACT_DISSECT, butcher_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_JACKHAMMER, jackhammer_do_turn },
@@ -3041,10 +3035,10 @@ void activity_handlers::repair_item_do_turn( player_activity *act, Character *yo
     }
 }
 
-void activity_handlers::butcher_do_turn( player_activity * /*act*/, Character *you )
-{
-    you->burn_energy_arms( -20 );
-}
+// void activity_handlers::dismember_do_turn( player_activity * /*act*/, Character *you )
+// {
+//     you->burn_energy_arms( -20 );
+// }
 
 void activity_handlers::wait_finish( player_activity *act, Character *you )
 {

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -162,7 +162,8 @@ void adv_inventory_do_turn( player_activity *act, Character *you );
 void armor_layers_do_turn( player_activity *act, Character *you );
 void atm_do_turn( player_activity *act, Character *you );
 void build_do_turn( player_activity *act, Character *you );
-void butcher_do_turn( player_activity *act, Character *you );
+// DISMEMBER is disabled until we tie it to a proficiency where the character knows how to stop a zombie reviving with less work.
+// void dismember_do_turn( player_activity *act, Character *you );
 void chop_trees_do_turn( player_activity *act, Character *you );
 void consume_drink_menu_do_turn( player_activity *act, Character *you );
 void consume_food_menu_do_turn( player_activity *act, Character *you );


### PR DESCRIPTION
 Ported from: https://github.com/CleverRaven/Cataclysm-DDA/pull/72099

#### Summary
Port DDA 72099 - no stamina cost for butchery

#### Purpose of change
There's no reason for butchery to cost stamina as it's a long-term activity.

#### Describe the solution
Implemented the solution in DDA #72099, but left out dismemberment. We will have dismemberment once we attach it to a proficiency or something where the character knows how to efficiently disable zombie revival.

#### Testing
Compiled, loaded, butchered, no problem.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
