### PR TITLE
Backport: higher "parasites" actually means lower chance of parasites (#72178)

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -727,7 +727,7 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "raw offal" },
     "description": "A selection of uncooked internal organs and entrails.  Filled with essential vitamins, but most people consider it a bit gross unless it's very carefully prepared.",
-    "proportional": { "parasites": 2.0 },
+    "proportional": { "parasites": 0.5 },
     "price_postapoc": 25,
     "delete": { "flags": [ "SMOKABLE" ] },
     "relative": { "vitamins": [ [ "iron", 4 ] ], "fun": -5 }

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1454,7 +1454,7 @@
     "fun": -10,
     "//0": "DW 0.2g protein 0.04 fat 0.04 carb... 0.2*4+0.04*4+0.04*9 = 1.326kcal",
     "calories": 1.3,
-    "parasites": 10,
+    "parasites": 20,
     "flags": [ "FREEZERBURN", "RAW", "NO_AUTO_CONSUME", "BIRD", "NUTRIENT_OVERRIDE" ],
     "//1": "1 earthworm has such a small amount of vitamins, i'm not sure it's possible to model them.",
     "vitamins": [ [ "calcium", 0.3 ], [ "iron", 0.8 ] ]
@@ -1470,7 +1470,7 @@
     "quench": 10,
     "fun": -20,
     "calories": 13.2,
-    "parasites": 20,
+    "parasites": 10,
     "vitamins": [ [ "calcium", 3 ], [ "iron", 8 ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Backport 72178"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72178


#### Describe the solution


#### Describe alternatives you've considered

#### Testing

None

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
