### PR TITLE
Backport 72234 - Refactor camp hunting function 

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -286,7 +286,7 @@ class basecamp
          * if skill is higher, an item or corpse is spawned
          */
         void hunting_results( int skill, const mission_id &miss_id, int attempts, int difficulty );
-        void make_corpse_from_group( std::vector<MonsterGroupResult> group );
+        void make_corpse_from_group( const std::vector<MonsterGroupResult> &group );
         inline const tripoint_abs_ms &get_dumping_spot() const {
             return dumping_spot;
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4733,9 +4733,9 @@ void basecamp::hunting_results( int skill, const mission_id &miss_id, int attemp
                             &results_from_mission_group ) );
 }
 
-void basecamp::make_corpse_from_group( std::vector<MonsterGroupResult> group )
+void basecamp::make_corpse_from_group( const std::vector<MonsterGroupResult> &group )
 {
-    for( MonsterGroupResult monster : group ) {
+    for( const MonsterGroupResult &monster : group ) {
         const mtype_id target = monster.name;
         item result = item::make_corpse( target, calendar::turn, "" );
         if( !result.is_null() ) {


### PR DESCRIPTION
#### Summary
Content "Backport 72234"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72234


#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Patch applies cleanly. Look over it before merging.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
