### PR TITLE
Remove Skill Rust

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1218,14 +1218,7 @@
     "trigger_cost": "25 J",
     "time": "1 s",
     "enchantments": [
-      {
-        "condition": "ACTIVE",
-        "values": [
-          { "value": "READING_EXP", "add": 2 },
-          { "value": "SKILL_RUST_RESIST", "add": 20 },
-          { "value": "LEARNING_FOCUS", "add": 10 }
-        ]
-      }
+      { "condition": "ACTIVE", "values": [ { "value": "READING_EXP", "add": 2 }, { "value": "LEARNING_FOCUS", "add": 10 } ] }
     ]
   },
   {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -336,7 +336,7 @@
     "volume": "500 ml",
     "price": 25000,
     "price_postapoc": 50,
-    "flags": [ "UNDERSIZE", "PREFIX_XS","WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
+    "flags": [ "UNDERSIZE", "PREFIX_XS", "WATER_FRIENDLY", "OUTER", "SPLINT", "ALLOWS_TAIL" ]
   },
   {
     "id": "miner_hat",
@@ -2644,7 +2644,17 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes regardless of your state of mutation.  Provides excellent protection from harm as well providing breathing gas while underwater.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID", "UNRESTRICTED" ],
+    "flags": [
+      "VARSIZE",
+      "STURDY",
+      "WATER_FRIENDLY",
+      "REBREATHER",
+      "SWIM_GOGGLES",
+      "OVERSIZE",
+      "PREFIX_XL",
+      "TRADER_AVOID",
+      "UNRESTRICTED"
+    ],
     "turns_per_charge": 60,
     "revert_to": "mask_h2osurvivor_xl",
     "use_action": {
@@ -2664,7 +2674,17 @@
     "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  Use it to turn it on.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID", "UNRESTRICTED" ],
+    "flags": [
+      "VARSIZE",
+      "STURDY",
+      "WATER_FRIENDLY",
+      "REBREATHER",
+      "SWIM_GOGGLES",
+      "UNDERSIZE",
+      "PREFIX_XS",
+      "TRADER_AVOID",
+      "UNRESTRICTED"
+    ],
     "turns_per_charge": 60,
     "revert_to": "mask_h2osurvivor_xs",
     "use_action": {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3764,40 +3764,6 @@ int Character::smash_ability() const
     return ret;
 }
 
-void Character::do_skill_rust()
-{
-    for( std::pair<const skill_id, SkillLevel> &pair : *_skills ) {
-        const Skill &aSkill = *pair.first;
-        SkillLevel &skill_level_obj = pair.second;
-
-        if( aSkill.is_combat_skill() &&
-            ( ( has_flag( json_flag_PRED2 ) && calendar::once_every( 8_hours ) ) ||
-              ( has_flag( json_flag_PRED3 ) && calendar::once_every( 4_hours ) ) ||
-              ( has_flag( json_flag_PRED4 ) && calendar::once_every( 3_hours ) ) ) ) {
-            // Their brain is optimized to remember this
-            if( one_in( 13 ) ) {
-                // They've already passed the roll to avoid rust at
-                // this point, but print a message about it now and
-                // then.
-                //
-                // 13 combat skills.
-                // This means PRED2/PRED3/PRED4 think of hunting on
-                // average every 8/4/3 hours, enough for immersion
-                // without becoming an annoyance.
-                //
-                add_msg_if_player( _( "Your heart races as you recall your most recent hunt." ) );
-                mod_stim( 1 );
-            }
-            continue;
-        }
-
-        const int rust_resist = enchantment_cache->modify_value( enchant_vals::mod::SKILL_RUST_RESIST, 0 );
-        if( skill_level_obj.rust( rust_resist, mutation_value( "skill_rust_multiplier" ) ) ) {
-            mod_power_level( -bio_memory->power_trigger );
-        }
-    }
-}
-
 int Character::focus_equilibrium_fatigue_cap( int equilibrium ) const
 {
     if( get_fatigue() >= fatigue_levels::MASSIVE_FATIGUE && equilibrium > 20 ) {
@@ -6477,7 +6443,6 @@ mutation_value_map = {
     { "overmap_sight", calc_mutation_value_additive<&mutation_branch::overmap_sight> },
     { "overmap_multiplier", calc_mutation_value_multiplicative<&mutation_branch::overmap_multiplier> },
     { "reading_speed_multiplier", calc_mutation_value_multiplicative<&mutation_branch::reading_speed_multiplier> },
-    { "skill_rust_multiplier", calc_mutation_value_multiplicative<&mutation_branch::skill_rust_multiplier> },
     { "crafting_speed_multiplier", calc_mutation_value_multiplicative<&mutation_branch::crafting_speed_multiplier> },
     { "obtain_cost_multiplier", calc_mutation_value_multiplicative<&mutation_branch::obtain_cost_multiplier> },
     { "stomach_size_multiplier", calc_mutation_value_multiplicative<&mutation_branch::stomach_size_multiplier> },

--- a/src/character.h
+++ b/src/character.h
@@ -1555,7 +1555,6 @@ class Character : public Creature, public visitable
     protected:
 
         void on_move( const tripoint_abs_ms &old_pos ) override;
-        void do_skill_rust();
         /** Applies stat mods to character. */
         void apply_mods( const trait_id &mut, bool add_remove );
 

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -341,9 +341,6 @@ void Character::update_body( const time_point &from, const time_point &to )
         as_avatar()->advance_daily_calories();
     }
 
-    if( calendar::once_every( 24_hours ) ) {
-        do_skill_rust();
-    }
 }
 
 void Character::update_enchantment_mutations()

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -98,7 +98,6 @@ namespace io
             case enchant_vals::mod::MOD_HEALTH: return "MOD_HEALTH";
             case enchant_vals::mod::MOD_HEALTH_CAP: return "MOD_HEALTH_CAP";
             case enchant_vals::mod::READING_EXP: return "READING_EXP";
-            case enchant_vals::mod::SKILL_RUST_RESIST: return "SKILL_RUST_RESIST";
             case enchant_vals::mod::OVERMAP_SIGHT: return "OVERMAP_SIGHT";
             case enchant_vals::mod::READING_SPEED_MULTIPLIER: return "READING_SPEED_MULTIPLIER";
             case enchant_vals::mod::KCAL: return "KCAL";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -75,7 +75,6 @@ enum class mod : int {
     MOD_HEALTH,
     MOD_HEALTH_CAP,
     READING_EXP,
-    SKILL_RUST_RESIST,
     READING_SPEED_MULTIPLIER,
     OVERMAP_SIGHT,
     KCAL,

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -419,7 +419,8 @@ void main_menu::init_windows()
 void main_menu::init_strings()
 {
     // ASCII Art
-    mmenu_title = load_file( PATH_INFO::title( current_holiday ), _( "Cataclysm: The Last Generation" ) );
+    mmenu_title = load_file( PATH_INFO::title( current_holiday ),
+                             _( "Cataclysm: The Last Generation" ) );
     // MOTD
     auto motd = load_file( PATH_INFO::motd(), _( "No message today." ) );
 

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -294,9 +294,6 @@ struct mutation_branch {
         // Multiplier for reading speed, defaulting to 1.
         std::optional<float> reading_speed_multiplier = std::nullopt;
 
-        // Multiplier for skill rust delay, defaulting to 1.
-        std::optional<float> skill_rust_multiplier = std::nullopt;
-
         // Multiplier for consume time, defaulting to 1.
         std::optional<float> consume_time_modifier = std::nullopt;
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -413,7 +413,6 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "overmap_sight", overmap_sight, std::nullopt );
     optional( jo, was_loaded, "overmap_multiplier", overmap_multiplier, std::nullopt );
     optional( jo, was_loaded, "reading_speed_multiplier", reading_speed_multiplier, std::nullopt );
-    optional( jo, was_loaded, "skill_rust_multiplier", skill_rust_multiplier, std::nullopt );
     optional( jo, was_loaded, "consume_time_modifier", consume_time_modifier, std::nullopt );
     optional( jo, was_loaded, "scent_modifier", scent_modifier, 1.0f );
     optional( jo, was_loaded, "scent_intensity", scent_intensity, std::nullopt );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -914,7 +914,7 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
         }
         float learning_bonus = 100.0f * std::max( ( 1.0f + you.get_int() / 40.0f ) - 0.1f *
                                level.exercise() / level.knowledgeExperience(), 1.0f );
-        if( level.isRusty() ) {
+        if( level.knowledgeLevel() > level.level() ) {
             info_text = string_format( _( "%s\n\nPractical level: %d (%d%%) " ), info_text,
                                        level.level(), level.exercise() );
             if( level.knowledgeLevel() > level.level() ) {

--- a/src/skill.h
+++ b/src/skill.h
@@ -178,8 +178,7 @@ class SkillLevel
         void train( int amount, float catchup_modifier, float knowledge_modifier,
                     bool allow_multilevel = false );
         void knowledge_train( int amount, int npc_knowledge = 0 );
-        bool isRusty() const;
-        bool rust( int rust_resist, float rust_multiplier = 1 );
+        //bool rust( int rust_resist, float rust_multiplier = 1 );
         void practice();
         bool can_train() const;
         void set_exercise( int value, bool raw = false );


### PR DESCRIPTION
#### Summary
Remove skill rust and everything to do with it.

#### Purpose of change
I'm not going to beat around the bush: Skill rust sucks - not just in Cataclysm, I mean like, conceptually. It is an awful mechanic in almost every game where it features, with the odd exception of games like Dwarf Fortress where very long periods of time pass quickly and it's used to keep your dwarves differentiated by preventing everyone from becoming a polymath.

It served no practical purpose in Cataclysm. The periods of time depicted in the game are not actually long enough to believably cause any major backsliding in skill. When first (re) implemented in DDA, it was extremely overtuned. People complained, and it got nerfed to the point where all it did was turn all your skills red as you accumulated a couple percentage points of rust per week.

A "fix" was added that was supposed to make everyone happy by adding a bonus to retraining rusted skills that would give you a small boost to learning once caught up, but due to the nerfed rate of rust, this was almost always inconsequential. It amounted to a lot of faff and a lot of grief on both player and dev side for basically no benefit. The only real effect of it was a slight sense of annoyance when you noticed some of your skills had turned red.

#### Describe the solution
It's gone forever and it's never coming back.

#### Describe alternatives you've considered
A trait, injury, effect, or faulty bionic that caused skills to deteriorate over time might be interesting, but it should never be something forced on every character.

An enemy that ate skills (something nether-associated, not a common thing) would also be cool. If we ever get around to implementing psionics, maybe you could trade skill ranks for power upgrades or something.

Some mutations could also eat some of your skills when you acquire them as a one-time cost to simulate your character losing a bit of their human brain. You'd be able to get them back and they'd stay, though.

It may eventually make sense to implement a system where players have to keep their skills sharp only if they're at rank 8, 9, or 10 - this would be both to simulate the fact that mastery is something you need to stay on top of, and to give max-level players something to do. I'm not sure a straight time = rust system is the way to go in that case though.

#### Testing
Spawned in, set my skills to 3, read a coding book to get coding up to 5. Sat around for a couple of days. Everything still looked the same afterwards, so I think we're good.

#### Additional context
I am a firm believer in throwing roadblocks and speedbumps to keep players from progressing too quickly or too easily. This change is not being done to make the game easier, it's being done because I don't think this was a good way to accomplish that, and neither did it feel like a realistic representation of the idea.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
