### PR TITLE
Fix recipe errors

### DIFF
--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -385,7 +385,7 @@
     "using": [ [ "tailoring_leather", 1 ] ]
   },
   {
-    "result": "leather_vambraces_xs",
+    "result": "leather_vambraces_xl",
     "type": "recipe",
     "copy-from": "leather_vambraces",
     "time": "180 m",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -536,29 +536,6 @@
     ]
   },
   {
-    "result": "boots_survivor_xl",
-    "type": "recipe",
-    "copy-from": "boots_survivor",
-    "difficulty": 7,
-    "skills_required": [ "fabrication", 5 ],
-    "time": "45 h",
-    "using": [ [ "tailoring_kevlar_fabric", 27 ], [ "fastener_small", 10 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
-      { "proficiency": "prof_leatherworking" },
-      { "proficiency": "prof_cobbling" },
-      { "proficiency": "prof_closures" },
-      { "proficiency": "prof_closures_waterproofing" },
-      { "proficiency": "prof_polymerworking" }
-    ],
-    "components": [
-      [ [ "filament_durable", 100, "LIST" ] ],
-      [ [ "thread_kevlar", 18 ] ],
-      [ [ "sheet_metal_small", 4 ] ],
-      [ [ "xl_boots", 1 ] ]
-    ]
-  },
-  {
     "result": "clogs",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -767,47 +767,6 @@
     ]
   },
   {
-    "result": "helmet_nasal",
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_HEAD",
-    "skill_used": "fabrication",
-    "difficulty": 5,
-    "time": "7 h 12 m",
-    "book_learn": [ [ "textbook_armwest", 4 ] ],
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 4 ], [ "leather", 4 ] ] ],
-    "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_leatherworking_basic" },
-      { "proficiency": "prof_armorsmithing" }
-    ]
-  },
-  {
-    "result": "xs_helmet_nasal",
-    "type": "recipe",
-    "copy-from": "helmet_nasal",
-    "time": "7 h 12 m",
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "components": [ [ [ "fur", 3 ], [ "leather", 3 ] ] ]
-  },
-  {
-    "result": "xl_helmet_nasal",
-    "type": "recipe",
-    "copy-from": "helmet_nasal",
-    "time": "8 h 5 m",
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 6 ], [ "leather", 6 ] ] ]
-  },
-  {
     "result": "platemail_great_helm",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
@@ -2198,7 +2157,7 @@
     "components": [ [ [ "link_sheet", 3 ] ], [ [ "chain_link", 75 ] ], [ [ "wire", 2 ] ] ]
   },
   {
-    "result": "chainmail_coif_xl",
+    "result": "chainmail_coif_xs",
     "type": "recipe",
     "copy-from": "chainmail_coif",
     "components": [ [ [ "link_sheet", 2 ] ], [ [ "chain_link", 50 ] ], [ [ "wire", 2 ] ] ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -493,24 +493,6 @@
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
-    "result": "platemail_leg_guards_xs",
-    "type": "recipe",
-    "copy-from": "platemail_leg_guards",
-    "time": "190 m",
-    "using": [ [ "blacksmithing_standard", 20 ], [ "lc_steel_standard", 3 ], [ "strap_small", 6 ], [ "clasps", 2 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "swage", -1 ] ] ]
-  },
-  {
-    "result": "platemail_leg_guards_xl",
-    "type": "recipe",
-    "copy-from": "platemail_leg_guards",
-    "time": "3 h 30 m",
-    "using": [ [ "blacksmithing_standard", 30 ], [ "lc_steel_standard", 6 ], [ "strap_small", 12 ], [ "clasps", 2 ] ],
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "swage", -1 ] ] ]
-  },
-  {
     "result": "carpet_legguards",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2127,7 +2127,7 @@
     "using": [ [ "tailoring_faux_fur_patchwork", 8 ], [ "fastener_large", 1 ] ]
   },
   {
-    "result": "coat_fur_xl",
+    "result": "coat_faux_fur_xl",
     "type": "recipe",
     "copy-from": "coat_faux_fur",
     "time": "9 h 30 m",

--- a/data/json/uncraft/armor/torso.json
+++ b/data/json/uncraft/armor/torso.json
@@ -149,15 +149,6 @@
     "components": [ [ [ "sheet_lycra_patchwork", 6 ] ] ]
   },
   {
-    "result": "coat_faux_fur",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "skill_used": "tailor",
-    "difficulty": 1,
-    "time": "20 m",
-    "components": [ [ [ "sheet_faux_fur_patchwork", 10 ] ], [ [ "zipper_long_plastic", 1 ] ] ]
-  },
-  {
     "result": "sleeveless_longcoat_faux_fur",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
@@ -165,6 +156,24 @@
     "difficulty": 1,
     "time": "20 m",
     "components": [ [ [ "sheet_faux_fur_patchwork", 6 ] ], [ [ "zipper_long_plastic", 1 ] ] ]
+  },
+  {
+    "result": "sleeveless_longcoat_faux_fur_xs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "20 m",
+    "components": [ [ [ "sheet_faux_fur_patchwork", 3 ] ], [ [ "zipper_long_plastic", 1 ] ] ]
+  },
+  {
+    "result": "sleeveless_longcoat_faux_fur_xl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "20 m",
+    "components": [ [ [ "sheet_faux_fur_patchwork", 8 ] ], [ [ "zipper_long_plastic", 1 ] ] ]
   },
   {
     "result": "under_armor",


### PR DESCRIPTION
#### Summary
Fix some recipe ID errors

#### Purpose of change
A couple or recipes from #30 #35 and #78 had incorrect IDs or were accidentally duplicated. They weren't throwing errors at the time, but a recent backport from DDA gave the game the ability to catch those errors.

#### Describe the solution
Deleted the redundant recipes, renamed the ones that needed it. Added xl and xs deconstruction recipes for the faux fur coat while I was at it.

#### Testing
Made a world, spawned in, set skills to 10, unlocked all crafts, browsed all the recipes I fixed, saw no errors.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
