### PR TITLE
ui_adaptor: don't invalidate uis below when exiting game

### DIFF
--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -205,6 +205,7 @@ void catacurses::erase()
 
 void catacurses::endwin()
 {
+    ui_manager::reset();
     return curses_check_result( ::endwin(), OK, "endwin" );
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3727,6 +3727,7 @@ void catacurses::endwin()
     font.reset();
     map_font.reset();
     overmap_font.reset();
+    ui_manager::reset();
     WinDestroy();
 }
 

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -77,6 +77,9 @@ ui_adaptor::ui_adaptor( ui_adaptor::debug_message_ui ) : is_imgui( false ),
 
 ui_adaptor::~ui_adaptor()
 {
+    if( is_shutting_down ) {
+        return;
+    }
     if( is_debug_message_ui ) {
         cata_assert( showing_debug_message );
         showing_debug_message = false;
@@ -299,6 +302,11 @@ void ui_adaptor::reset()
     position( point_zero, point_zero );
 }
 
+void ui_adaptor::shutdown()
+{
+    is_shutting_down = true;
+}
+
 void ui_adaptor::invalidate( const rectangle<point> &rect, const bool reenable_uis_below )
 {
     if( rect.p_min.x >= rect.p_max.x || rect.p_min.y >= rect.p_max.y ) {
@@ -510,6 +518,13 @@ void invalidate_all_ui_adaptors()
 {
     for( ui_adaptor &adaptor : ui_stack ) {
         adaptor.invalidate_ui();
+    }
+}
+
+void reset()
+{
+    for( ui_adaptor &adaptor : ui_stack ) {
+        adaptor.shutdown();
     }
 }
 } // namespace ui_manager

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -219,6 +219,8 @@ class ui_adaptor
          **/
         void reset();
 
+        void shutdown();
+
         /* See the `ui_manager` namespace */
         static void invalidate( const rectangle<point> &rect, bool reenable_uis_below );
         static bool has_imgui();
@@ -245,6 +247,7 @@ class ui_adaptor
 
         bool disabling_uis_below;
         bool is_debug_message_ui;
+        bool is_shutting_down = false;
 
         mutable bool invalidated;
         mutable bool deferred_resize;
@@ -289,6 +292,7 @@ void redraw_invalidated();
  **/
 void screen_resized();
 void invalidate_all_ui_adaptors();
+void reset();
 } // namespace ui_manager
 
 #endif // CATA_SRC_UI_MANAGER_H

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -761,6 +761,7 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
 // Ends the terminal, destroy everything
 void catacurses::endwin()
 {
+    ui_manager::reset();
     DeleteObject( font );
     WinDestroy();
     // Unload it


### PR DESCRIPTION
#### Summary
Port 76000 from DDA

Closes #134 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
