### PR TITLE
Backport 71961: Replace ITEM_BROKEN flag on emp and watter affected items with faults

### DIFF
--- a/data/json/faults/faults_electronic.json
+++ b/data/json/faults/faults_electronic.json
@@ -1,0 +1,71 @@
+[
+  {
+    "type": "fault",
+    "id": "fault_electronic_blown_fuse",
+    "fault_type": "shorted",
+    "name": { "str": "Blown fuse" },
+    "description": "Required for closing a protected electronic circuit.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_blown_fuse",
+    "name": "Replace blown fuse",
+    "success_msg": "You replace the blown fuse of the %s.",
+    "time": "5 m",
+    "faults_removed": [ "fault_electronic_blown_fuse" ],
+    "skills": { "electronics": 3 },
+    "requirements": [ { "qualities": [ { "id": "SCREW", "level": 1 } ], "components": [ [ [ "e_scrap", 1 ], [ "copper_wire", 1 ] ] ] } ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_electronic_blown_capacitor",
+    "fault_type": "shorted",
+    "name": { "str": "Blown capacitor" },
+    "description": "Required for storing charge in an electronic circuit.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_blown_capacitor",
+    "name": "Replace blown fuse",
+    "success_msg": "You replace the blow capacitor of the %s.",
+    "time": "10 m",
+    "faults_removed": [ "fault_electronic_blown_capacitor" ],
+    "skills": { "electronics": 4 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "SCREW", "level": 1 } ],
+        "tools": [ [ "soldering_iron" ], [ "soldering_iron_portable" ] ],
+        "components": [ [ [ "e_scrap", 1 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_electronic_shorted_circuit",
+    "fault_type": "shorted",
+    "name": { "str": "Shorted electronic circuit" },
+    "description": "An electronic circuit has been destroyed by overvoltage.",
+    "item_prefix": "shorted",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_electronic_shorted_circuit",
+    "name": "Replace shorted circuit",
+    "success_msg": "You replace the shorted circuit of the %s.",
+    "time": "70 m",
+    "faults_removed": [ "fault_electronic_shorted_circuit" ],
+    "skills": { "electronics": 5 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "SCREW", "level": 1 } ],
+        "tools": [ [ "soldering_iron" ], [ "soldering_iron_portable" ] ],
+        "components": [ [ [ "circuit", 1 ] ] ]
+      }
+    ]
+  }
+]

--- a/data/json/faults/faults_water.json
+++ b/data/json/faults/faults_water.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "fault_wet",
+    "type": "fault",
+    "fault_type": "wet",
+    "name": { "str": "Wet" },
+    "description": "Item is too wet to use and has to be dried.",
+    "item_prefix": "waterlogged",
+    "flags": [ "ITEM_BROKEN" ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet",
+    "name": "Passively dry",
+    "success_msg": "You dry the %s.",
+    "time": "120 m",
+    "faults_removed": [ "fault_wet" ],
+    "skills": { "fabrication": 2 },
+    "requirements": [
+      {
+        "qualities": [ { "id": "CONTAIN", "level": 1 } ],
+        "components": [ [ [ "flour", 10 ], [ "dry_rice", 10 ], [ "dry_beans", 10 ], [ "dry_lentils", 10 ] ] ]
+      }
+    ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet_oven",
+    "name": "Dry with hot air in an oven.  Requires good temperature control.",
+    "success_msg": "You heat up and dry the %s.",
+    "time": "60 m",
+    "faults_removed": [ "fault_wet" ],
+    "skills": { "cooking": 4 },
+    "requirements": [ { "qualities": [ { "id": "OVEN", "level": 3 } ] } ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_fault_wet_hot_air",
+    "name": "Dry with hot air.",
+    "success_msg": "You dry the %s with hot air.",
+    "time": "10 m",
+    "faults_removed": [ "fault_wet" ],
+    "requirements": [ { "qualities": [ { "id": "BLOW_HOT_AIR", "level": 1 } ] } ]
+  }
+]

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -23,6 +23,7 @@
 #include "creature_tracker.h"
 #include "debug.h"
 #include "enums.h"
+#include "fault.h"
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"
@@ -1252,7 +1253,11 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     if( loc->wetness && loc->has_flag( flag_WATER_BREAK_ACTIVE ) ) {
         if( query_yn( _( "This item is still wet and it will break if you turn it on. Proceed?" ) ) ) {
             loc->deactivate();
-            loc->set_flag( flag_ITEM_BROKEN );
+            loc.get_item()->set_fault( random_entry( fault::get_by_type( std::string( "wet" ) ) ) );
+            // An electronic item in water is also shorted.
+            if( loc->has_flag( flag_ELECTRONIC ) ) {
+                loc.get_item()->set_fault( random_entry( fault::get_by_type( std::string( "shorted" ) ) ) );
+            }
         } else {
             return;
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -28,6 +28,7 @@
 #include "damage.h"
 #include "debug.h"
 #include "enums.h"
+#include "fault.h"
 #include "field_type.h"
 #include "flag.h"
 #include "game.h"
@@ -775,7 +776,7 @@ void emp_blast( const tripoint &p )
                 !player_character.has_flag( json_flag_EMP_IMMUNE ) ) {
                 add_msg( m_bad, _( "The EMP blast fries your %s!" ), it->tname() );
                 it->deactivate();
-                it->set_flag( flag_ITEM_BROKEN );
+                it->faults.insert( random_entry( fault::get_by_type( "shorted" ) ) );
             }
         }
     }
@@ -788,7 +789,7 @@ void emp_blast( const tripoint &p )
                 add_msg( _( "The EMP blast fries the %s!" ), it.tname() );
             }
             it.deactivate();
-            it.set_flag( flag_ITEM_BROKEN );
+            it.set_fault( random_entry( fault::get_by_type( "shorted" ) ) );
         }
     }
     // TODO: Drain NPC energy reserves

--- a/src/fault.h
+++ b/src/fault.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_FAULT_H
 
 #include <iosfwd>
+#include <list>
 #include <map>
 #include <new>
 #include <optional>
@@ -52,6 +53,7 @@ class fault
     public:
         const fault_id &id() const;
         std::string name() const;
+        std::string type() const; // use a set of types?
         std::string description() const;
         std::string item_prefix() const;
         bool has_flag( const std::string &flag ) const;
@@ -59,6 +61,7 @@ class fault
         const std::set<fault_fix_id> &get_fixes() const;
 
         static const std::map<fault_id, fault> &all();
+        static const std::list<fault_id> &get_by_type( const std::string &type );
         static void load( const JsonObject &jo );
         static void reset();
         static void check_consistency();
@@ -66,6 +69,7 @@ class fault
     private:
         friend class fault_fix;
         fault_id id_ = fault_id::NULL_ID();
+        std::string type_;
         translation name_;
         translation description_;
         translation item_prefix_; // prefix added to affected item's name

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -81,6 +81,7 @@
 #include "event.h"
 #include "event_bus.h"
 #include "faction.h"
+#include "fault.h"
 #include "field.h"
 #include "field_type.h"
 #include "filesystem.h"
@@ -11582,46 +11583,33 @@ void game::on_options_changed()
 
 void game::water_affect_items( Character &ch ) const
 {
-    std::vector<item_location> dissolved;
-    std::vector<item_location> destroyed;
-    std::vector<item_location> wet;
-
     for( item_location &loc : ch.all_items_loc() ) {
         // check flag first because its cheaper
         if( loc->has_flag( flag_WATER_DISSOLVE ) && !loc.protected_from_liquids() ) {
-            dissolved.emplace_back( loc );
+            add_msg_if_player_sees( ch.pos(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
+                                    ch.disp_name( true, true ), loc->display_name() );
+            loc.remove_item();
         } else if( loc->has_flag( flag_WATER_BREAK ) && !loc->is_broken()
                    && !loc.protected_from_liquids() ) {
-            destroyed.emplace_back( loc );
+
+            add_msg_if_player_sees( ch.pos(), m_bad, _( "The water destroyed %1$s %2$s!" ),
+                                    ch.disp_name( true ), loc->display_name() );
+            loc->deactivate();
+            // TODO: Maybe different types of wet faults? But I can't think of any.
+            // This just means it's still too wet to use.
+            loc->set_fault( random_entry( fault::get_by_type( std::string( "wet" ) ) ) );
+            // An electronic item in water is also shorted.
+            if( loc->has_flag( flag_ELECTRONIC ) ) {
+                loc->set_fault( random_entry( fault::get_by_type( std::string( "shorted" ) ) ) );
+            }
         } else if( loc->has_flag( flag_WATER_BREAK_ACTIVE ) && !loc->is_broken()
                    && !loc.protected_from_liquids() ) {
-            wet.emplace_back( loc );
+            const int wetness_add = 5100 * std::log10( units::to_milliliter( loc->volume() ) );
+            loc->wetness += wetness_add;
+            loc->wetness = std::min( loc->wetness, 5 * wetness_add );
         } else if( loc->typeId() == itype_towel && !loc.protected_from_liquids() ) {
             loc->convert( itype_towel_wet, &ch ).active = true;
         }
-    }
-
-    if( dissolved.empty() && destroyed.empty() && wet.empty() ) {
-        return;
-    }
-
-    for( item_location &it : dissolved ) {
-        add_msg_if_player_sees( ch.pos(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
-                                ch.disp_name( true, true ), it->display_name() );
-        it.remove_item();
-    }
-
-    for( item_location &it : destroyed ) {
-        add_msg_if_player_sees( ch.pos(), m_bad, _( "The water destroyed %1$s %2$s!" ),
-                                ch.disp_name( true ), it->display_name() );
-        it->deactivate();
-        it->set_flag( flag_ITEM_BROKEN );
-    }
-
-    for( item_location &it : wet ) {
-        const int wetness_add = 5100 * std::log10( units::to_milliliter( it->volume() ) );
-        it->wetness += wetness_add;
-        it->wetness = std::min( it->wetness, 5 * wetness_add );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7603,6 +7603,12 @@ item &item::set_flag( const flag_id &flag )
     return *this;
 }
 
+item &item::set_fault( const fault_id &fault_id )
+{
+    faults.insert( fault_id );
+    return *this;
+}
+
 item &item::unset_flag( const flag_id &flag )
 {
     item_tags.erase( flag );
@@ -9809,12 +9815,14 @@ bool item::is_irremovable() const
 
 bool item::is_broken() const
 {
-    return has_flag( flag_ITEM_BROKEN );
+    return has_flag( flag_ITEM_BROKEN ) || has_fault_flag( std::string( "ITEM_BROKEN" ) );
 }
 
 bool item::is_broken_on_active() const
 {
-    return has_flag( flag_ITEM_BROKEN ) || ( wetness && has_flag( flag_WATER_BREAK_ACTIVE ) );
+    return has_flag( flag_ITEM_BROKEN ) ||
+           has_fault_flag( std::string( "ITEM_BROKEN" ) ) ||
+           ( wetness && has_flag( flag_WATER_BREAK_ACTIVE ) );
 }
 
 int item::wind_resist() const
@@ -14117,7 +14125,10 @@ bool item::process_internal( map &here, Character *carrier, const tripoint &pos,
 
         if( wetness && has_flag( flag_WATER_BREAK ) ) {
             deactivate();
-            set_flag( flag_ITEM_BROKEN );
+            set_fault( random_entry( fault::get_by_type( std::string( "wet" ) ) ) );
+            if( has_flag( flag_ELECTRONIC ) ) {
+                set_fault( random_entry( fault::get_by_type( std::string( "shorted" ) ) ) );
+            }
         }
 
         if( !is_food() && item_counter > 0 ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1973,6 +1973,9 @@ class item : public visitable
         /** Idempotent filter setting an item specific flag. */
         item &set_flag( const flag_id &flag );
 
+        /** Idempotent filter setting an item specific fault. */
+        item &set_fault( const fault_id &fault_id );
+
         /** Idempotent filter removing an item specific flag */
         item &unset_flag( const flag_id &flag );
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -434,10 +434,13 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item smart_phone( itype_test_smart_phone );
 
             REQUIRE( guy.wield( smart_phone ) );
+            item *test_item = guy.get_wielded_item().get_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -451,10 +454,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             backpack.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( backpack ) );
+            item *test_item = &guy.get_wielded_item()->only_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -468,10 +473,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             body_bag.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
+            item *test_item = &guy.get_wielded_item()->only_item();
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( test_item->faults.empty() );
+                CHECK_FALSE( test_item->is_broken() );
             }
         }
 
@@ -487,10 +494,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             duffelbag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( duffelbag ) );
+            item *test_item = &guy.get_wielded_item()->only_item().only_item();
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( test_item->faults.empty() );
+                CHECK( test_item->is_broken() );
             }
         }
 
@@ -506,10 +515,12 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             body_bag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
+            item *test_item = &guy.get_wielded_item()->only_item().only_item();
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( test_item->faults.empty() );
+                CHECK_FALSE( test_item->is_broken() );
             }
         }
     }

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2189,6 +2189,7 @@ overbore
 overbuilt
 overclock
 overclocks
+overcurrent
 overdosage
 overdrinking
 overengineered
@@ -2197,6 +2198,7 @@ overgloves
 overgrowth
 overhood
 overhoods
+overload
 overmap
 overmaps
 overpenetration


### PR DESCRIPTION
#### Summary
Backport DDA 71961: Replace ITEM_BROKEN flag on emp and watter affected items with faults

#### Purpose of change
Update EMP and water damage to electronics and other items to use the faults system instead of the old hardcoded one. Also a necessary step to backport the rest of DDA's fault system.

#### Testing

Spawned in, walked into deep water, saw it destroy my matches and smartphone.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
