### PR TITLE
Backport DDA 72142: Faults can modify the price of an item

### DIFF
--- a/data/json/faults/faults_bionics.json
+++ b/data/json/faults/faults_bionics.json
@@ -4,6 +4,7 @@
     "type": "fault",
     "name": { "str": "Already deployed" },
     "description": "This bionic needs to be reset to its factory state.",
+    "price_modifier": 0.8,
     "item_prefix": "salvaged"
   }
 ]

--- a/data/json/faults/faults_vehicles.json
+++ b/data/json/faults/faults_vehicles.json
@@ -5,6 +5,7 @@
     "name": { "str": "Worn drive belt" },
     "description": "Required for operation of an attached alternator.",
     "item_prefix": "faulty",
+    "price_modifier": 0.7,
     "flags": [ "NO_ALTERNATOR_CHARGE" ]
   },
   {
@@ -13,6 +14,7 @@
     "name": { "str": "Faulty glow plugs" },
     "description": "Help when starting an engine in low ambient temperatures.",
     "item_prefix": "faulty",
+    "price_modifier": 0.7,
     "flags": [ "BAD_COLD_START" ]
   },
   {
@@ -21,14 +23,16 @@
     "name": { "str": "Active immobiliser" },
     "description": "An immobiliser device prevents starting of the vehicle without the appropriate key.",
     "item_prefix": "faulty",
+    "price_modifier": 0.25,
     "flags": [ "IMMOBILIZER" ]
   },
   {
     "id": "fault_engine_pump_diesel",
     "type": "fault",
     "name": { "str": "Faulty diesel pump" },
-    "description": "Required to pump and pressurize diesel from a vehicles tank.",
+    "description": "Required to pump and pressurize diesel from a vehicle's tank.",
     "item_prefix": "faulty",
+    "price_modifier": 0.7,
     "flags": [ "BAD_FUEL_PUMP" ]
   },
   {
@@ -37,6 +41,7 @@
     "name": { "str": "Expired air filter" },
     "description": "An expired filter reduces fuel efficiency and increases smoke production.",
     "item_prefix": "faulty",
+    "price_modifier": 0.9,
     "flags": [ "DOUBLE_FUEL_CONSUMPTION", "EXTRA_EXHAUST" ]
   },
   {
@@ -45,14 +50,16 @@
     "name": { "str": "Expired fuel filter" },
     "description": "An expired filter reduces performance and increases the chance of backfires.",
     "item_prefix": "faulty",
+    "price_modifier": 0.7,
     "flags": [ "REDUCE_ENG_POWER", "ENG_BACKFIRE" ]
   },
   {
     "id": "fault_engine_pump_fuel",
     "type": "fault",
     "name": { "str": "Faulty fuel pump" },
-    "description": "Required to pump gasoline from a vehicles tank.",
+    "description": "Required to pump gasoline from a vehicle's tank.",
     "item_prefix": "faulty",
+    "price_modifier": 0.7,
     "flags": [ "BAD_FUEL_PUMP" ]
   },
   {
@@ -61,6 +68,7 @@
     "name": { "str": "Faulty starter motor" },
     "description": "Required to initially start the engine.",
     "item_prefix": "faulty",
+    "price_modifier": 0.5,
     "flags": [ "BAD_STARTER" ]
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1646,6 +1646,7 @@ Faults can be defined for more specialized damage of an item.
   "name": { "str": "Spent casing in chamber" }, // fault name for display
   "description": "This gun currently...", // fault description
   "item_prefix": "jammed", // optional string, items with this fault will be prefixed with this
+  "price_modifier": 0.4, // (Optional, double) Defaults to 1 if not specified. A multiplier on the price of an item when this fault is present. Values above 1.0 will increase the item's value.
   "flags": [ "JAMMED_GUN" ] // optional flags, see below
 }
 ```

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -72,6 +72,12 @@ std::string fault::item_prefix() const
     return item_prefix_.translated();
 }
 
+
+double fault::price_mod() const
+{
+    return price_modifier;
+}
+
 std::string fault::type() const
 {
     return type_;
@@ -97,6 +103,7 @@ void fault::load( const JsonObject &jo )
     optional( jo, false, "item_prefix", f.item_prefix_ );
     optional( jo, false, "fault_type", f.type_ );
     optional( jo, false, "flags", f.flags );
+    optional( jo, false, "price_modifier", f.price_modifier );
 
     if( !faults_all.emplace( f.id_, f ).second ) {
         jo.throw_error_at( "id", "parsed fault overwrites existing definition" );

--- a/src/fault.h
+++ b/src/fault.h
@@ -56,6 +56,7 @@ class fault
         std::string type() const; // use a set of types?
         std::string description() const;
         std::string item_prefix() const;
+        double price_mod() const;
         bool has_flag( const std::string &flag ) const;
 
         const std::set<fault_fix_id> &get_fixes() const;
@@ -75,6 +76,7 @@ class fault
         translation item_prefix_; // prefix added to affected item's name
         std::set<fault_fix_id> fixes;
         std::set<std::string> flags;
+        double price_modifier = 1.0;
 };
 
 #endif // CATA_SRC_FAULT_H

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7066,6 +7066,10 @@ int item::price_no_contents( bool practical, std::optional<int> price_override )
         price = std::max( price - PRICE_FILTHY_MALUS, 0 );
     }
 
+    for( fault_id fault : faults ) {
+        price *= fault->price_mod();
+    }
+
     return price;
 }
 


### PR DESCRIPTION
#### Summary
Backport 72142 from DDA: Faults can modify the price of an item

#### Testing
Spawned in, got a smartphone wet and saw that its price dropped to $0

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
