### PR TITLE
Port DDA 72237: Assign default value of 1.0 for fault price modifiers

### DIFF
--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -103,7 +103,7 @@ void fault::load( const JsonObject &jo )
     optional( jo, false, "item_prefix", f.item_prefix_ );
     optional( jo, false, "fault_type", f.type_ );
     optional( jo, false, "flags", f.flags );
-    optional( jo, false, "price_modifier", f.price_modifier );
+    optional( jo, false, "price_modifier", f.price_modifier, 1.0 );
 
     if( !faults_all.emplace( f.id_, f ).second ) {
         jo.throw_error_at( "id", "parsed fault overwrites existing definition" );


### PR DESCRIPTION
#### Summary
Port DDA 72237: Assign default value of 1.0 for fault price modifiers

#### Testing
Compiled and ran with no issues. Item costs for regular and shorted smartphone are now identical, I'm guessing the cost I saw in #147 was the bug that this fixes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
