### PR TITLE
Backport DDA 72106: Port some mutation/cbm specific fields to enchantments, part 2

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1786,7 +1786,7 @@
     "name": { "str": "Titanium Skeletal Bracing" },
     "description": "Titanium bracing has been installed onto your elbows, knees, and spine, making them far better at handling strain.  Your carrying capacity is increased by 20 kilograms, or about 44 pounds, and you receive slightly less bashing damage to your arms, legs and torso.",
     "occupied_bodyparts": [ [ "torso", 8 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 3 ], [ "leg_r", 3 ] ],
-    "weight_capacity_bonus": "20 kg",
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "add": 20000 } ] } ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
     "protec": [
       [ "torso", { "bash": 2 } ],

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -850,11 +850,6 @@
     "info": "This clothing is restrictive and <bad>slows your movement speed</bad>."
   },
   {
-    "id": "SLOWS_THIRST",
-    "type": "json_flag",
-    "info": "This clothing <good>slows your thirst</good> by reducing moisture loss."
-  },
-  {
     "id": "STURDY",
     "type": "json_flag",
     "info": "This clothing will <good>protect</good> you from harm and withstand <info>a lot of abuse</info>.",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -1514,7 +1514,8 @@
     "color": "dark_gray",
     "warmth": 15,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "HOOD", "RAINPROOF", "SLOWS_THIRST", "SLOWS_MOVEMENT" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "HOOD", "WATERPROOF", "SLOWS_MOVEMENT", "MUNDANE" ],
+    "relic_data": { "passive_effects": [ { "has": "WORN", "values": [ { "value": "THIRST", "multiply": -0.3 } ] } ] },
     "armor": [ { "encumbrance": 18, "coverage": 95, "covers": [ "foot_l", "foot_r", "leg_l", "leg_r", "torso", "arm_l", "arm_r" ] } ]
   },
   {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -3819,7 +3819,9 @@
     "charges_per_use": 1,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "utility_exoskeleton_on", "active": true },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "SLOWS_MOVEMENT", "ELECTRONIC" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_exo_strength" } ] },
+    "relic_data": {
+      "passive_effects": [ { "id": "ench_exo_strength" }, { "condition": "ACTIVE", "values": [ { "value": "CARRY_WEIGHT", "add": 215000 } ] } ]
+    },
     "armor": [
       {
         "encumbrance": 20,
@@ -3841,7 +3843,6 @@
     "power_draw": "972216 mW",
     "//": "Battery should last two hours (02:00:07). Weight capacity bonus should include weight of item AND battery, plus 90kg.",
     "revert_to": "utility_exoskeleton_off",
-    "weight_capacity_bonus": "215 kg",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s disengages.", "target": "utility_exoskeleton_off" }
   },
   {
@@ -3867,7 +3868,9 @@
     "charges_per_use": 1,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "ice_utility_exoskeleton_on", "active": true },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "SLOWS_MOVEMENT", "ELECTRONIC" ],
-    "relic_data": { "passive_effects": [ { "id": "ench_exo_strength" } ] },
+    "relic_data": {
+      "passive_effects": [ { "id": "ench_exo_strength" }, { "condition": "ACTIVE", "values": [ { "value": "CARRY_WEIGHT", "add": 190000 } ] } ]
+    },
     "armor": [
       {
         "encumbrance": 20,
@@ -3888,7 +3891,6 @@
     "turns_per_charge": 1,
     "//": "Full tank lasts a bit under three hours (166.66 minutes). Has less carry bonus than the battery one since the weight of the fuel will drop over time.",
     "revert_to": "ice_utility_exoskeleton_off",
-    "weight_capacity_bonus": "190 kg",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s disengages.", "target": "ice_utility_exoskeleton_off" }
   }
 ]

--- a/data/json/mutations/mutation_item_traits.json
+++ b/data/json/mutations/mutation_item_traits.json
@@ -12,6 +12,6 @@
     "valid": false,
     "purifiable": false,
     "types": [ "Equipment" ],
-    "weight_capacity_modifier": 1.1
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.1 } ] } ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -591,7 +591,7 @@
     "types": [ "CARDIO" ],
     "changes_to": [ "GOODCARDIO2" ],
     "category": [ "FISH", "LUPINE", "MOUSE", "INSECT", "RABBIT", "CHIROPTERAN" ],
-    "cardio_multiplier": 1.3
+    "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": 0.3 } ] } ]
   },
   {
     "type": "mutation",
@@ -603,7 +603,7 @@
     "prereqs": [ "GOODCARDIO" ],
     "threshreq": [ "THRESH_MOUSE", "THRESH_RABBIT" ],
     "category": [ "MOUSE", "RABBIT" ],
-    "cardio_multiplier": 1.6
+    "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": 0.6 } ] } ]
   },
   {
     "type": "mutation",
@@ -679,7 +679,7 @@
     "types": [ "METABOLISM" ],
     "changes_to": [ "GIZZARD" ],
     "category": [ "FISH", "BIRD", "TROGLOBITE", "CHIROPTERAN", "GASTROPOD", "CEPHALOPOD", "RAPTOR" ],
-    "metabolism_modifier": -0.333
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.333 } ] } ]
   },
   {
     "type": "mutation",
@@ -900,7 +900,7 @@
     "name": { "str": "Packmule" },
     "points": 1,
     "description": "You pack things very efficiently!  You can retrieve things from containers 10% faster.",
-    "obtain_cost_multiplier": 0.9,
+    "enchantments": [ { "values": [ { "value": "OBTAIN_COST_MULTIPLIER", "multiply": -0.1 } ] } ],
     "starting_trait": true,
     "valid": false,
     "cancels": [ "DISORGANIZED" ]
@@ -914,7 +914,7 @@
     "starting_trait": true,
     "valid": false,
     "cancels": [ "BADBACK" ],
-    "weight_capacity_modifier": 1.35
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.35 } ] } ]
   },
   {
     "type": "mutation",
@@ -1002,7 +1002,7 @@
     "category": [ "MOUSE", "LUPINE" ],
     "starting_trait": true,
     "active": true,
-    "stomach_size_multiplier": 2.0
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 } ] } ]
   },
   {
     "type": "mutation",
@@ -1379,7 +1379,7 @@
     "starting_trait": true,
     "valid": false,
     "types": [ "CARDIO" ],
-    "cardio_multiplier": 0.7
+    "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": -0.3 } ] } ]
   },
   {
     "type": "mutation",
@@ -1502,7 +1502,7 @@
     "starting_trait": true,
     "category": [ "BIRD", "ELFA" ],
     "cancels": [ "STRONGBACK" ],
-    "weight_capacity_modifier": 0.65
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.35 } ] } ]
   },
   {
     "type": "mutation",
@@ -1520,7 +1520,7 @@
     "name": { "str": "Disorganized" },
     "points": -1,
     "description": "You are terrible at organizing and storing your possessions.  You retrieve things from containers 10% slower.",
-    "obtain_cost_multiplier": 1.1,
+    "enchantments": [ { "values": [ { "value": "OBTAIN_COST_MULTIPLIER", "multiply": 0.1 } ] } ],
     "valid": false,
     "cancels": [ "PACKMULE" ]
   },
@@ -2654,12 +2654,15 @@
     "types": [ "BONES" ],
     "category": [ "MOUSE", "RABBIT", "BIRD", "SLIME", "ELFA", "SPIDER", "CHIROPTERAN" ],
     "changes_to": [ "HOLLOW_BONES" ],
-    "attackcost_modifier": 0.9,
-    "weight_capacity_modifier": 0.8,
     "enchantments": [
       {
         "condition": "ALWAYS",
-        "values": [ { "value": "EXTRA_BASH", "multiply": 0.4 }, { "value": "MOVE_COST", "multiply": -0.1 } ]
+        "values": [
+          { "value": "EXTRA_BASH", "multiply": 0.4 },
+          { "value": "MOVE_COST", "multiply": -0.1 },
+          { "value": "ATTACK_SPEED", "multiply": -0.1 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+        ]
       }
     ]
   },
@@ -3238,7 +3241,7 @@
     "prereqs": [ "JAUNDICE" ],
     "leads_to": [ "BARK", "THORNS", "LEAVES" ],
     "category": [ "PLANT", "ELFA" ],
-    "thirst_modifier": -0.2,
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": -0.2 } ] } ],
     "integrated_armor": [ "integrated_plantskin" ]
   },
   {
@@ -3809,7 +3812,7 @@
     "visibility": 4,
     "ugliness": 3,
     "description": "You develop a reservoir of fluids that bulges out of your abdomen.  Your body has adapted to containing extra liquids in event of shortfalls.",
-    "thirst_modifier": -0.25,
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": -0.25 } ] } ],
     "types": [ "THIRST" ],
     "leads_to": [ "BOMBADIER_BLAST" ],
     "category": [ "INSECT" ]
@@ -4311,9 +4314,9 @@
         "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" }, { "u_has_flag": "QUADRUPED_CROUCH" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
-      { "values": [ { "value": "MOVE_COST", "multiply": 0.38 } ] }
-    ],
-    "weight_capacity_modifier": 0.8
+      { "values": [ { "value": "MOVE_COST", "multiply": 0.35 } ] },
+      { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] }
+    ]
   },
   {
     "type": "mutation",
@@ -4505,9 +4508,8 @@
     "points": -5,
     "description": "You seem to get full faster now, and food goes through you more rapidly as well.",
     "purifiable": false,
-    "stomach_size_multiplier": 0.9,
-    "enchantments": [ { "values": [ { "value": "KCAL", "multiply": -0.4 } ] } ],
     "prereqs": [ "BEAK", "DRILL_BEAK", "BEAK_HUM" ],
+    "enchantments": [ { "values": [ { "value": "KCAL", "multiply": -0.4 }, { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.1 } ] } ],
     "prereqs2": [ "LIGHTEATER" ],
     "threshreq": [ "THRESH_BIRD" ],
     "cancels": [ "GOURMAND" ],
@@ -4974,7 +4976,7 @@
     "category": [ "URSINE" ],
     "active": true,
     "cost": 0,
-    "stomach_size_multiplier": 3.0
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -5679,9 +5681,15 @@
     "prereqs2": [ "DENSE_BONES" ],
     "changes_to": [ "LARGE_OK", "HUGE" ],
     "category": [ "URSINE", "CATTLE", "LIZARD", "CHIMERA", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ],
-    "stomach_size_multiplier": 1.5,
-    "weight_capacity_modifier": 1.05
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.05 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -5697,9 +5705,15 @@
     "threshreq": [ "THRESH_URSINE", "THRESH_CATTLE", "THRESH_LIZARD", "THRESH_CHIMERA", "THRESH_CRUSTACEAN" ],
     "changes_to": [ "HUGE" ],
     "category": [ "URSINE", "CATTLE", "LIZARD", "CHIMERA", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ],
-    "stomach_size_multiplier": 1.5,
-    "weight_capacity_modifier": 1.05
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.05 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -5716,12 +5730,19 @@
     "prereqs2": [ "STR_UP_3", "STR_UP_4" ],
     "changes_to": [ "HUGE_OK" ],
     "category": [ "URSINE", "CATTLE", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "MAX_HP", "add": -6 }, { "value": "STRENGTH", "add": 4 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MAX_HP", "add": -6 },
+          { "value": "STRENGTH", "add": 4 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.1 }
+        ]
+      }
+    ],
     "fatigue_modifier": 0.15,
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
-    "stomach_size_multiplier": 2.0,
-    "weight_capacity_modifier": 1.1
+    "destroys_gear": true
   },
   {
     "type": "mutation",
@@ -5738,11 +5759,17 @@
     "prereqs2": [ "STR_UP_3", "STR_UP_4" ],
     "threshreq": [ "THRESH_URSINE", "THRESH_CATTLE", "THRESH_CRUSTACEAN" ],
     "category": [ "URSINE", "CATTLE", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 4 } ] } ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 4 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.1 }
+        ]
+      }
+    ],
     "restricts_gear": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r" ],
-    "destroys_gear": true,
-    "stomach_size_multiplier": 2.0,
-    "weight_capacity_modifier": 1.1
+    "destroys_gear": true
   },
   {
     "type": "mutation",
@@ -6128,13 +6155,19 @@
     "visibility": 4,
     "mixed_effect": true,
     "starting_trait": true,
-    "description": "You are very short!  Either you haven't fully grown up yet, or you've got some form of dwarfism.  You can't carry as much, your feet can't reach the pedals to drive a car, and you're not as durable as the average adult.",
+    "description": "You are very short.  Either you haven't fully grown up yet, or you've got some form of dwarfism.  You can't carry as much, your feet can't reach the pedals to drive a car, and you're not as durable as the average adult.",
     "types": [ "SIZE" ],
     "changes_to": [ "SMALL" ],
     "category": [ "MOUSE", "RABBIT" ],
-    "stomach_size_multiplier": 0.5,
-    "enchantments": [ { "values": [ { "value": "MAX_HP", "multiply": -0.2 } ] } ],
-    "weight_capacity_modifier": 0.7
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MAX_HP", "multiply": -0.05 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6144,13 +6177,20 @@
     "points": 0,
     "visibility": 5,
     "mixed_effect": true,
-    "description": "You've noticeably shrunk in size.  You're able to move with increased litheness, but your smaller stature prevents you from carrying as much.",
+    "description": "You've noticeably shrunk in size.  You're able to move with increased litheness, but your smaller stature prevents you from driving a car or carrying as much.",
     "types": [ "SIZE" ],
     "changes_to": [ "SMALL2" ],
     "category": [ "MOUSE", "RABBIT" ],
-    "stomach_size_multiplier": 0.6,
-    "enchantments": [ { "values": [ { "value": "BONUS_DODGE", "add": 1 }, { "value": "MAX_HP", "multiply": -0.05 } ] } ],
-    "weight_capacity_modifier": 0.8
+    "enchantments": [
+      {
+        "values": [
+          { "value": "BONUS_DODGE", "add": 1 },
+          { "value": "MAX_HP", "multiply": -0.05 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.6 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6165,9 +6205,16 @@
     "prereqs": [ "SMALL" ],
     "changes_to": [ "SMALL_OK" ],
     "category": [ "MOUSE" ],
-    "stomach_size_multiplier": 0.5,
-    "enchantments": [ { "values": [ { "value": "BONUS_DODGE", "add": 2 }, { "value": "MAX_HP", "multiply": -0.3 } ] } ],
-    "weight_capacity_modifier": 0.5,
+    "enchantments": [
+      {
+        "values": [
+          { "value": "BONUS_DODGE", "add": 2 },
+          { "value": "MAX_HP", "multiply": -0.3 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.5 }
+        ]
+      }
+    ],
     "noise_modifier": 0.0
   },
   {
@@ -6184,9 +6231,16 @@
     "threshreq": [ "THRESH_MOUSE" ],
     "leads_to": [ "CRAFTY" ],
     "category": [ "MOUSE" ],
-    "stomach_size_multiplier": 0.5,
-    "enchantments": [ { "values": [ { "value": "BONUS_DODGE", "add": 2 }, { "value": "MAX_HP", "multiply": -0.25 } ] } ],
-    "weight_capacity_modifier": 0.7,
+    "enchantments": [
+      {
+        "values": [
+          { "value": "BONUS_DODGE", "add": 2 },
+          { "value": "MAX_HP", "multiply": -0.25 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.3 }
+        ]
+      }
+    ],
     "noise_modifier": 0.0
   },
   {
@@ -6199,11 +6253,14 @@
     "prereqs": [ "SMALL_OK" ],
     "threshreq": [ "THRESH_MOUSE" ],
     "category": [ "MOUSE" ],
-    "stealth_modifier": 40,
     "enchantments": [
       {
         "condition": "ALWAYS",
-        "values": [ { "value": "SPEED", "multiply": 0.15 }, { "value": "MOVE_COST", "multiply": -0.25 } ]
+        "values": [
+          { "value": "SPEED", "multiply": 0.15 },
+          { "value": "MOVE_COST", "multiply": -0.25 },
+          { "value": "STEALTH_MODIFIER", "add": 40 }
+        ]
       }
     ]
   },
@@ -6691,9 +6748,16 @@
     "types": [ "BONES" ],
     "prereqs": [ "LIGHT_BONES" ],
     "category": [ "BIRD", "SLIME", "ELFA" ],
-    "attackcost_modifier": 0.8,
-    "weight_capacity_modifier": 0.6,
-    "enchantments": [ { "values": [ { "value": "EXTRA_BASH", "multiply": 0.8 }, { "value": "MOVE_COST", "multiply": -0.2 } ] } ]
+    "enchantments": [
+      {
+        "values": [
+          { "value": "EXTRA_BASH", "multiply": 0.8 },
+          { "value": "MOVE_COST", "multiply": -0.2 },
+          { "value": "ATTACK_SPEED", "multiply": -0.2 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.4 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6708,14 +6772,14 @@
       {
         "values": [
           { "value": "MOVE_COST", "multiply": 0.05 },
+          { "value": "ATTACK_SPEED", "multiply": 0.05 },
           { "value": "MAX_HP", "add": 4 },
           { "value": "MOVECOST_SWIM_MOD", "multiply": 0.2 },
-          { "value": "BONUS_DODGE", "add": -1 }
+          { "value": "BONUS_DODGE", "add": -1 },
+          { "value": "CARRY_WEIGHT", "multiply": 0.15 }
         ]
       }
     ],
-    "attackcost_modifier": 1.05,
-    "weight_capacity_modifier": 1.15,
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "bash": 2 } ]
   },
   {
@@ -6804,7 +6868,7 @@
     "types": [ "METABOLISM" ],
     "changes_to": [ "HUNGER2", "MET_RAT" ],
     "category": [ "RAT", "ALPHA", "MEDICAL", "ELFA", "BEAST", "SLIME", "RAPTOR", "CHIMERA", "MOUSE", "RABBIT" ],
-    "metabolism_modifier": 0.5,
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": 0.5 } ] } ],
     "stamina_regen_modifier": 0.1
   },
   {
@@ -6821,7 +6885,7 @@
     "healing_multiplier": 1.5,
     "fatigue_modifier": 0.5,
     "fatigue_regen_modifier": 0.333,
-    "metabolism_modifier": 0.333
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": 0.333 } ] } ]
   },
   {
     "type": "mutation",
@@ -6833,7 +6897,7 @@
     "changes_to": [ "HUNGER3" ],
     "types": [ "METABOLISM" ],
     "category": [ "BEAST", "SLIME", "RAPTOR", "CHIMERA" ],
-    "metabolism_modifier": 1.0,
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": 1 } ] } ],
     "stamina_regen_modifier": 0.3
   },
   {
@@ -6846,7 +6910,7 @@
     "leads_to": [ "EATHEALTH" ],
     "types": [ "METABOLISM" ],
     "category": [ "CHIMERA" ],
-    "metabolism_modifier": 2.0,
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": 2 } ] } ],
     "stamina_regen_modifier": 0.5
   },
   {
@@ -6859,7 +6923,7 @@
     "types": [ "THIRST" ],
     "changes_to": [ "THIRST2" ],
     "category": [ "SLIME", "CEPHALOPOD", "CHIMERA", "ELFA", "GASTROPOD", "FISH", "BATRACHIAN", "CRUSTACEAN" ],
-    "thirst_modifier": 0.5
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": 0.5 } ] } ]
   },
   {
     "type": "mutation",
@@ -6871,7 +6935,7 @@
     "prereqs": [ "THIRST" ],
     "changes_to": [ "THIRST3" ],
     "category": [ "FISH", "SLIME", "CEPHALOPOD", "BATRACHIAN", "CRUSTACEAN" ],
-    "thirst_modifier": 1.0
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": 1 } ] } ]
   },
   {
     "type": "mutation",
@@ -6883,7 +6947,7 @@
     "prereqs": [ "THIRST2" ],
     "category": [ "BATRACHIAN", "CRUSTACEAN" ],
     "threshreq": [ "THRESH_BATRACHIAN", "THRESH_CRUSTACEAN" ],
-    "thirst_modifier": 2.0
+    "enchantments": [ { "values": [ { "value": "THIRST", "multiply": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -7308,7 +7372,7 @@
     "ugliness": 10,
     "description": "Your body is more or less one consistent whole: a single, giant, omni-cell that alters itself as needed.",
     "purifiable": false,
-    "stomach_size_multiplier": 3,
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 2 } ] } ],
     "prereqs": [ "INT_SLIME" ],
     "prereqs2": [ "PER_SLIME_OK" ],
     "threshreq": [ "THRESH_SLIME" ],
@@ -7595,7 +7659,7 @@
     "changes_to": [ "COLDBLOOD2" ],
     "category": [ "FISH", "CEPHALOPOD", "SPIDER", "GASTROPOD", "INSECT", "LIZARD", "BATRACHIAN", "PLANT", "CRUSTACEAN" ],
     "temperature_speed_modifier": 0.2,
-    "metabolism_modifier": -0.333
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.333 } ] } ]
   },
   {
     "type": "mutation",
@@ -7610,7 +7674,7 @@
     "changes_to": [ "COLDBLOOD3" ],
     "category": [ "INSECT", "LIZARD", "BATRACHIAN", "PLANT", "CRUSTACEAN" ],
     "temperature_speed_modifier": 0.333,
-    "metabolism_modifier": -0.5
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.5 } ] } ]
   },
   {
     "type": "mutation",
@@ -7625,7 +7689,7 @@
     "changes_to": [ "COLDBLOOD4" ],
     "category": [ "INSECT", "LIZARD", "BATRACHIAN", "PLANT" ],
     "temperature_speed_modifier": 0.5,
-    "metabolism_modifier": -0.5
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.5 } ] } ]
   },
   {
     "type": "mutation",
@@ -7641,7 +7705,7 @@
     "purifiable": false,
     "category": [ "LIZARD", "PLANT", "BATRACHIAN" ],
     "temperature_speed_modifier": 0.5,
-    "metabolism_modifier": -0.5
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.5 } ] } ]
   },
   {
     "type": "mutation",
@@ -8853,7 +8917,7 @@
     "name": { "str": "Debug Cardio" },
     "points": 99,
     "valid": false,
-    "cardio_multiplier": 10000,
+    "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": 10000 } ] } ],
     "description": "You can run, but you'll never run out of breath.",
     "debug": true
   },
@@ -9174,8 +9238,7 @@
       "chance": 15,
       "strength_damage": { "damage_type": "bash", "amount": 1.5 }
     },
-    "enchantments": [ "ench_quadruped_movement_full" ],
-    "weight_capacity_modifier": 0.8
+    "enchantments": [ "ench_quadruped_movement_full", { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] } ]
   },
   {
     "type": "mutation",
@@ -9399,7 +9462,7 @@
     "types": [ "SKIN" ],
     "changes_to": [ "CAMO2" ],
     "category": [ "CEPHALOPOD" ],
-    "stealth_modifier": -20
+    "enchantments": [ { "values": [ { "value": "STEALTH_MODIFIER", "add": 20 } ] } ]
   },
   {
     "type": "mutation",
@@ -9414,7 +9477,7 @@
     "category": [ "CEPHALOPOD" ],
     "prereqs": [ "CAMO1" ],
     "threshreq": [ "THRESH_CEPHALOPOD" ],
-    "stealth_modifier": 20
+    "enchantments": [ { "values": [ { "value": "STEALTH_MODIFIER", "add": 20 } ] } ]
   },
   {
     "type": "mutation",

--- a/doc/ARMOR_BALANCE_AND_DESIGN.md
+++ b/doc/ARMOR_BALANCE_AND_DESIGN.md
@@ -541,7 +541,7 @@ Some armor with custom abilities can be handled as enchantments. This is a new w
   "valid": false,
   "purifiable": false,
   "types": [ "Equipment" ],
-  "weight_capacity_modifier": 1.1
+  "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.1 } ] } ]
 }
 ```
 

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -233,7 +233,6 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```SEMITANGIBLE``` Prevents the item from participating in the encumbrance system when worn.
 - ```SKINTIGHT``` Undergarment layer.
 - ```SLOWS_MOVEMENT``` This piece of clothing multiplies move cost by 1.1.
-- ```SLOWS_THIRST``` This piece of clothing multiplies the rate at which the player grows thirsty by 0.70.
 - ```STAR_PLATE``` Item can be worn with ryūsei battle kit armor; specifically can be put in pocket for armor with this flag restriction.
 - ```STAR_SHOULDER``` Item can be worn with ryūsei battle kit armor ; specifically can be put in pocket for armor with this flag restriction.
 - ```STAR_SKIRT``` Item can be worn with ryūsei battle kit armor; specifically can be put in pocket for armor with this flag restriction.

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1298,8 +1298,6 @@ mod = min( max, ( limb_score / denominator ) - subtract );
 | `available_upgrades`         | (_optional_) Upgrades available for this bionic, i.e. the list of bionics having this one referenced by `upgraded_bionic`.
 | `encumbrance`                | (_optional_) A list of body parts and how much this bionic encumber them.
 | `known_ma_styles`            | (_optional_) A list of martial art styles that are known to the wearer when the bionic is activated
-| `weight_capacity_bonus`      | (_optional_) Bonus to weight carrying capacity in grams, can be negative.  Strings can be used - "5000 g" or "5 kg" (default: `0`)
-| `weight_capacity_modifier`   | (_optional_) Factor modifying base weight carrying capacity. (default: `1`)
 | `canceled_mutations`         | (_optional_) A list of mutations/traits that are removed when this bionic is installed (e.g. because it replaces the fault biological part).
 | `mutation_conflicts`         | (_optional_) A list of mutations that prevent this bionic from being installed.
 | `included_bionics`           | (_optional_) Additional bionics that are installed automatically when this bionic is installed. This can be used to install several bionics from one CBM item, which is useful as each of those can be activated independently.
@@ -3616,8 +3614,6 @@ Armor can be defined like this:
 "environmental_protection" : 0,     //  (Optional, default = 0) How much environmental protection it affords
 "encumbrance" : 0,                  // Base encumbrance (unfitted value)
 "max_encumbrance" : 0,              // When a character is completely full of volume, the encumbrance of a non-rigid storage container will be set to this. Otherwise it'll be between the encumbrance and max_encumbrance following the equation: encumbrance + (max_encumbrance - encumbrance) * non-rigid volume / non-rigid capacity.  By default, max_encumbrance is encumbrance + (non-rigid volume / 250ml).
-"weight_capacity_bonus": "20 kg",   // (Optional, default = 0) Bonus to weight carrying capacity, can be negative. Strings must be used - "5000 g" or "5 kg"
-"weight_capacity_modifier": 1.5,    // (Optional, default = 1) Factor modifying base weight carrying capacity.
 "sided": true,                      // (Optional, default false) If true, this is a sided armor. Sided armor is armor that even though it describes covering, both legs, both arms, both hands, etc. actually only covers one "side" at a time but can be moved back and forth between sides at will by the player.
 "coverage": 80,                     // What percentage of body part is covered (in general)
 "cover_melee": 60,                  // What percentage of body part is covered (against melee)

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -799,7 +799,7 @@ Character status value  | Description
 `ARMOR_HEAT`            | 
 `ARMOR_STAB`            | 
 `ATTACK_NOISE`          | Affects the amount of noise you make while melee attacking.
-`ATTACK_SPEED`          | Affects attack speed of item even if it's not the one you're wielding.
+`ATTACK_SPEED`          | Affects attack speed of item, even if it's not the one you're wielding, and throwing cost (capped at 25 moves). `"add": 10` adds 10 moves to each attack (makes it longer), `"add": -10` makes each attack faster for 10 moves; `"multiply": 1` doubles the speed of each attack
 `AVOID_FRIENDRY_FIRE`   | Flat chance for your character to avoid friendry fire if there is a friend in the line of fire. From 0.0 (no chance) to 1.0 (never frindly fire).
 `BANDAGE_BONUS`         | Affects the `bandages_power` you have when applying medicine.
 `BIONIC_MANA_PENALTY`       | same as mutation `bionic_mana_penalty` field, changes how big the mana penalty for having bionic energy is (default ratio is 1 kj removes 1 mana point). better to use with `multiply`, using `add` just adds or removes flat amount of mana no matter of energy level. `"multiply": 1` double the ratio (1 kj removes 2 mana points), `"multiply": -0.5` halves it
@@ -807,6 +807,7 @@ Character status value  | Description
 `BLEED_STOP_BONUS`      | Affects the `bleed` level when applying medicine.
 `BONUS_BLOCK`           | Affects the number of blocks you can perform.
 `BONUS_DODGE`           | Affects the number of dodges you can perform.
+`CARDIO_MULTIPLIER`     | Affects total cardio fitness by this amount.  Since it's a percent, using `multiply` is recommended.
 `CARRY_WEIGHT`          | Affect the summary weight player can carry. `"add": 1000` adds 1 kg of weight to carry.
 `CASTING_TIME_MULTIPLIER`   | Same as mutation `casting_time_multiplier` field, changes your casting speed. Since it's a percent, using `multiply` is recommended. `"multiply": 2"` triples the casting speed 
 `COMBAT_CATCHUP`        | Affects the rate at which you relearn combat skills (multiplier).
@@ -845,7 +846,7 @@ Character status value  | Description
 `MELEE_DAMAGE`          | Adds damage to melee attacks
 `MELEE_STAMINA_CONSUMPTION` | Changes amount of stamina used when swing in melee; stamina consumption is a negative value, so `"add": 100` decreases amount of stamina consumed, when `"add": -100` increases it; `"multiply": 1` increases, `"multiply": -0.5` decreases it. Can't be bigger than -50.
 `MENDING_MODIFIER`      | Changes the speed of your limb mend. Since it's a percent, using `multiply` is recommended.
-`METABOLISM`            | 
+`METABOLISM`            | Multiplier for `metabolic_rate_base`, which respond for default bmi rate; Formula for basic bmi is `metabolic_rate_base * ( (weight_in_kg / 10 ) + (6.25 * height) - (5 * age) + 5 )`; Since it's a percent, using `multiply` is recommended.
 `MOD_HEALTH`            | If this is anything other than zero (which it defaults to) you will to mod your health to a max/min of `MOD_HEALTH_CAP` every half hour.
 `MOD_HEALTH_CAP`        | If this is anything other than zero (which it defaults to) you will cap your `MOD_HEALTH` gain/loss at this every half hour.
 `MOTION_VISION_RANGE `  | Reveals all monsters as a red `?` within the specified radius.
@@ -854,7 +855,7 @@ Character status value  | Description
 `MOVECOST_OBSTACLE_MOD` | How many moves you spend to move 1 tile, if this tile has a movecost more than 105 moves; not shown in UI
 `MOVECOST_SWIM_MOD`     | How many moves you spend to move 1 tile in water; not shown in UI
 `NIGHT_VIS`             | How well you can see in darkness.  `ADD` adds tiles, so `"ADD": 3` increases night vision distance by 3 tiles.
-`OBTAIN_COST_MULTIPLIER`| Same as `obtain_cost_multiplier`, modifier for pulling an item from a container and storing it back, as a handling penalty. `"add": 100` add 100 additional moves to item wield (1 second)
+`OBTAIN_COST_MULTIPLIER`| Modifier for pulling an item from a container, as a handling penalty or bonus. `"add": 100` add 100 additional moves to item wield (1 second)
 `OVERKILL_DAMAGE`       | multiplies or contributes to the damage to an enemy corpse after death. The lower the number, the more damage caused.
 `OVERMAP_SIGHT`         | Increases the amount of overmap tiles you can see around.
 `PAIN`                  | When gaining pain the amount gained will be modified by this much.  You will still always gain at least 1 pain.
@@ -881,8 +882,8 @@ Character status value  | Description
 `SOCIAL_LIE`            | Affects your ability to lie.
 `SOCIAL_PERSUADE`       | Affects your ability to persuade.
 `SPEED`                 | Affects your base speed.
-`STEALTH_MODIFIER`      | Same as mutation `stealth_modifier` value, amount to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
-`STOMACH_SIZE_MULTIPLIER`   | Same as mutation `stomach_size_multiplier` field, changes how much food you can consume at once. `"add": 1000` adds 1 L to stomach size
+`STEALTH_MODIFIER`      | Amount to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
+`STOMACH_SIZE_MULTIPLIER`   | Changes how much food you can consume at once. `"add": 1000` adds 1 L to stomach size
 `STRENGTH`              | Affects the strength stat.
 `THIRST`                | 
 `UGLINESS`              | Affects your `ugliness` stat, which affects NPCs' initial opinion of you.

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -176,7 +176,6 @@ Note that **all new traits that can be obtained through mutation must be purifia
       "cut": 2
     }
   ],
-  "stealth_modifier": 0,                      // Percentage to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
   "active": true,                             // When set the mutation is an active mutation that the player needs to activate (default: false).
   "starts_active": true,                      // When true, this 'active' mutation starts active (default: false, requires 'active').
   "cost": 8,                                  // Cost to activate this mutation.  Needs one of the hunger, thirst, or fatigue values set to true (default: 0).
@@ -192,7 +191,6 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "hearing_modifier": 1.8,                    // changes how good you can hear different sounds
   "integrated_armor": [ "integrated_fur" ],   // this item is worn on your character forever, until you get rid of this mutation
   "noise_modifier": 0.4,                      // changes how much noise you produce while walking, `0.5` halves it, `2` doubles it
-  "obtain_cost_multiplier": 1.1,              // modifier for pulling an item from a container and storing it back, as a handling penalty
   "overmap_sight": -10,                       // adjusts sight range on the overmap. Positives make it farther, negatives make it closer. This will allow the character to see futher on the overmap at night if the mutation is active at all times
   "ranged_mutation": {                        // activation of the mutation allow you to shoot a fake gun
     "type": "pseudo_shotgun",                 // fake gun that is used to shoot
@@ -204,7 +202,6 @@ Note that **all new traits that can be obtained through mutation must be purifia
     "type": "water_clean",                    // item to spawn
     "message": "You spawn a bottle of water." // message, that would be shown upon activation
   },
-  "stomach_size_multiplier": 2.0,             // modifier for the stomach size, increases how much food you can consume at once
   "scent_modifier": 0.0,                      // float affecting the intensity of your smell (default: 1.0).
   "scent_intensity": 800,                     // int affecting the target scent toward which you current smell gravitates (default: 500).
   "scent_mask": -200,                         // int added to your target scent value (default: 0).
@@ -221,19 +218,14 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "allowed_category": [ "ALPHA" ],            // List of categories you can mutate into (default: empty).
   "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l" ],  // List of body parts that can't receive CBMs (default: empty).
   "lumination": [ [ "head", 20 ], [ "arm_l", 10 ] ],              // List of glowing bodypart and the intensity of the glow as a float (default: empty).
-  "metabolism_modifier": 0.333,               // Extra metabolism rate multiplier (1.0 doubles, -0.5 halves).
-  "thirst_modifier": 0.1,                     // Extra thirst modifier (1.0 doubles, -0.5 halves).
   "fatigue_modifier": 0.5,                    // Extra fatigue rate multiplier (1.0 doubles usage, -0.5 halves).
   "fatigue_regen_modifier": 0.333,            // Modifier for the rate at which fatigue and sleep deprivation drops when resting.
   "stamina_regen_modifier": 0.1,              // Increase stamina regen by this proportion (1.0 being 100% of normal regen).
-  "cardio_multiplier": 1.5,                   // Multiplies total cardio fitness by this amount.
   "crafting_speed_multiplier": 0.5,           // Multiplies your total crafting speed. 0.5 is 50% of normal speed, 1.2 is 20% faster than normal speed.
   "healing_multiplier": 0.5,                  // Multiplier to PLAYER/NPC_HEALING_RATE.
   "healing_awake": 1.0,                       // Healing rate per turn while awake. Positives will increase healing while negatives will decrease healing.
   "healing_resting": 0.5,                     // Healing rate per turn while resting. Positives will increase healing while negatives will decrease healing.
   "mending_modifier": 1.2,                    // Multiplier on how fast your limbs mend (1.2 is 20% faster).
-  "attackcost_modifier": 0.9,                 // Attack cost modifier (0.9 is 10% faster, 1.1 is 10% slower).
-  "weight_capacity_modifier": 0.9,            // Carrying capacity modifier (0.9 is 10% less, 1.1 is 10% more).
   "social_modifiers": { "persuade": -10 },    // Social modifiers.  Can be: intimidate, lie, persuade.
   "spells_learned": [ [ "spell_slime_spray", 1 ] ], // Spells learned and the level they're at after gaining the trait/mutation.
   "transform": {
@@ -269,7 +261,6 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "deactivated_eocs": [ "eoc_id_1" ],         // List of effect_on_conditions that attempt to activate when this mutation is successfully deactivated.
   "enchantments": [ "ench_id_1" ],            // List of enchantments granted by this mutation.  Can be either IDs or an inline definition of the enchantment (see MAGIC.md)
   "temperature_speed_modifier": 0.5,          // If nonzero, become slower when cold, and faster when hot (1.0 gives +/-1% speed for each degree above or below 65 F).
-  "pain_modifier": 5,                         // Flat increase (for positive numbers)\ reduction (for negative) to the amount of pain recived. Reduction can go all the way to 0. Applies after pain enchantment. (so if you have Pain Resistant trait along with 5 flat pain reduction and recive 20 pain, you would gain 20*(1-0.25)-5=10 pain)
   "mana_modifier": 100,                       // Positive or negative change to total mana pool.
   "mana_regen_multiplier": 1.5,               // Multiplier on your mana regeneration.  0.5 is 50% of normal, 1.5 is 150% of normal.
   "mana_multiplier": 1.25,                    // Multiplier on your total mana amount, after mana_modifier and any other bonuses. 0.75 is 75% of normal, 1.5 is 150% of normal. 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -331,7 +331,6 @@ void bionic_data::load( const JsonObject &jsobj, const std::string &src )
     // uses assign because optional doesn't handle loading units as strings
     assign( jsobj, "react_cost", power_over_time, false, 0_kJ );
     assign( jsobj, "capacity", capacity, false );
-    assign( jsobj, "weight_capacity_bonus", weight_capacity_bonus, false );
     assign( jsobj, "act_cost", power_activate, false, 0_kJ );
     assign( jsobj, "deact_cost", power_deactivate, false, 0_kJ );
     assign( jsobj, "trigger_cost", power_trigger, false, 0_kJ );
@@ -353,7 +352,6 @@ void bionic_data::load( const JsonObject &jsobj, const std::string &src )
 
     optional( jsobj, was_loaded, "spell_on_activation", spell_on_activate );
 
-    optional( jsobj, was_loaded, "weight_capacity_modifier", weight_capacity_modifier, 1.0f );
     optional( jsobj, was_loaded, "exothermic_power_gen", exothermic_power_gen );
     optional( jsobj, was_loaded, "power_gen_emission", power_gen_emission );
     optional( jsobj, was_loaded, "coverage_power_gen_penalty", coverage_power_gen_penalty );

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -30,13 +30,6 @@ enum class character_stat : char;
 struct bionic_data {
     bionic_data();
 
-    bionic_id id;
-    std::vector<std::pair<bionic_id, mod_id>> src;
-
-    translation name;
-    translation description;
-
-    std::optional<translation> cant_remove_reason;
     /** Power cost on activation */
     units::energy power_activate = 0_kJ;
     /** Power cost on deactivation */
@@ -47,54 +40,31 @@ struct bionic_data {
     units::energy power_trigger = 0_kJ;
     /** Amount of free energy the bionic generates each turn regardless of activation state*/
     units::energy power_trickle = 0_kJ;
-    /** How often a bionic draws or produces power while active in turns */
-    time_duration charge_time = 0_turns;
     /** Power bank size **/
     units::energy capacity = 0_kJ;
-    /** If true multiples of this can be installed */
-    bool dupes_allowed = false;
-    /** Is true if a bionic is an active instead of a passive bionic */
-    bool activated = false;
-    /** Is true if a bionic is activated automatically on install */
-    bool activated_on_install = false;
-    /**
-    * If true, this bionic is included with another.
-    */
-    bool included = false;
-    /**Factor modifying weight capacity*/
-    float weight_capacity_modifier = 1.0f;
-    /**Bonus to weight capacity*/
-    units::mass weight_capacity_bonus = 0_gram;
-    /**Map of stats and their corresponding bonuses passively granted by a bionic*/
-    std::map<character_stat, int> stat_bonus;
-    /**This bionic draws power through a cable*/
-    bool is_remote_fueled = false;
-    /**Fuel types that can be used by this bionic*/
-    std::vector<material_id> fuel_opts;
-    /**Fraction of fuel energy converted to bionic power*/
-    float fuel_efficiency = 0.0f;
-    /**Fraction of fuel energy passively converted to bionic power*/
-    float passive_fuel_efficiency = 0.0f;
-    /**Fraction of coverage diminishing fuel_efficiency*/
-    std::optional<float> coverage_power_gen_penalty;
-    /**If true this bionic emits heat when producing power*/
-    bool exothermic_power_gen = false;
+
+    cata::value_ptr<fake_spell> spell_on_activate;
+
+    bionic_id id;
+
     /**Type of field emitted by this bionic when it produces energy*/
     emit_id power_gen_emission = emit_id::NULL_ID();
-    /**Amount of environmental protection offered by this bionic*/
-    std::map<bodypart_str_id, size_t> env_protec;
+    itype_id fake_weapon;
+    /**
+     * Id of another bionic which this bionic can upgrade.
+     */
+    bionic_id upgraded_bionic;
+    /**
+     * Id of another bionic which this bionic needs to have installed to be installed.
+     * Also prevents that bionic from being removed while this bionic is installed.
+     */
+    bionic_id required_bionic;
 
-    /**Amount of damage protection offered by this bionic*/
-    std::map<bodypart_str_id, resistances> protec;
-
-    float vitamin_absorb_mod = 1.0f;
-
-    // Bonus or penalty to social checks (additive).  50 adds 50% to success, -25 subtracts 25%
-    social_modifiers social_mods;
-    /** whether to immediately close ui when activating - used for targeted bionics */
-    bool activated_close_ui;
-    /** whether to immediately close ui when deactivating - used for targeted bionics */
-    bool deactivated_close_ui;
+    /**Requirement to bionic installation - this is a crafting requirement such as soldering_standard or surface_heat*/
+    requirement_id installation_requirement;
+    std::vector<std::pair<bionic_id, mod_id>> src;
+    /**Fuel types that can be used by this bionic*/
+    std::vector<material_id> fuel_opts;
     /** effect_on_conditions triggered when this bionic is activated */
     std::vector<effect_on_condition_id> activated_eocs;
     /** effect_on_conditions triggered while this bionic is active */
@@ -105,13 +75,41 @@ struct bionic_data {
     std::vector<enchantment_id> enchantments;
     /** kown martial arts styles */
     std::vector<matype_id> ma_styles;
-
-    cata::value_ptr<fake_spell> spell_on_activate;
-
     /**
      * Proficiencies given on install (and removed on uninstall) of this bionic
      */
     std::vector<proficiency_id> proficiencies;
+    /**
+    * Pseudo items and weapons this CBM spawns
+    */
+    std::vector<itype_id> passive_pseudo_items;
+    std::vector<itype_id> toggled_pseudo_items;
+    /**
+     * Mutations/trait that are removed upon installing this CBM.
+     * E.g. enhanced optic bionic may cancel HYPEROPIC trait.
+     */
+    std::vector<trait_id> canceled_mutations;
+    /**
+     * Additional bionics that are installed automatically when this
+     * bionic is installed. This can be used to install several bionics
+     * from one CBM item, which is useful as each of those can be
+     * activated independently.
+     */
+    std::vector<bionic_id> included_bionics;
+    /**
+     * Bionics that are incompatible with this bionic and will be
+     * deactivated automatically when this bionic is activated.
+     */
+    std::vector<bionic_id> autodeactivated_bionics;
+    cata::flat_set<json_character_flag> flags;
+    cata::flat_set<json_character_flag> active_flags;
+    cata::flat_set<json_character_flag> inactive_flags;
+    /**Map of stats and their corresponding bonuses passively granted by a bionic*/
+    std::map<character_stat, int> stat_bonus;
+    /**Amount of environmental protection offered by this bionic*/
+    std::map<bodypart_str_id, size_t> env_protec;
+    /**Amount of damage protection offered by this bionic*/
+    std::map<bodypart_str_id, resistances> protec;
     /**
      * Body part slots used to install this bionic, mapped to the amount of space required.
      */
@@ -120,20 +118,8 @@ struct bionic_data {
      * Body part encumbered by this bionic, mapped to the amount of encumbrance caused.
      */
     std::map<bodypart_str_id, int> encumbrance;
-
-    /**
-    * Pseudo items and weapons this CBM spawns
-    */
-    std::vector<itype_id> passive_pseudo_items;
-    std::vector<itype_id> toggled_pseudo_items;
-    itype_id fake_weapon;
     std::set<json_character_flag> installable_weapon_flags;
 
-    /**
-     * Mutations/trait that are removed upon installing this CBM.
-     * E.g. enhanced optic bionic may cancel HYPEROPIC trait.
-     */
-    std::vector<trait_id> canceled_mutations;
     /**
      * Mutations/traits that prevent installing this CBM
      */
@@ -147,48 +133,59 @@ struct bionic_data {
      */
     std::map<spell_id, int> learned_spells;
 
-    /**
-     * Additional bionics that are installed automatically when this
-     * bionic is installed. This can be used to install several bionics
-     * from one CBM item, which is useful as each of those can be
-     * activated independently.
-     */
-    std::vector<bionic_id> included_bionics;
 
-    /**
-     * Bionics that are incompatible with this bionic and will be
-     * deactivated automatically when this bionic is activated.
-     */
-    std::vector<bionic_id> autodeactivated_bionics;
 
-    /**
-     * Id of another bionic which this bionic can upgrade.
-     */
-    bionic_id upgraded_bionic;
     /**
      * Upgrades available for this bionic (opposite to @ref upgraded_bionic).
      */
     std::set<bionic_id> available_upgrades;
+    translation name;
+    translation description;
 
+    std::optional<translation> cant_remove_reason;
+    /** How often a bionic draws or produces power while active in turns */
+    time_duration charge_time = 0_turns;
+
+    /**Fraction of fuel energy converted to bionic power*/
+    float fuel_efficiency = 0.0f;
+    /**Fraction of fuel energy passively converted to bionic power*/
+    float passive_fuel_efficiency = 0.0f;
+    float vitamin_absorb_mod = 1.0f;
+    /**Fraction of coverage diminishing fuel_efficiency*/
+    std::optional<float> coverage_power_gen_penalty;
+    // Bonus or penalty to social checks (additive).  50 adds 50% to success, -25 subtracts 25%
+    social_modifiers social_mods;
+
+    /** If true multiples of this can be installed */
+    bool dupes_allowed = false;
+    /** Is true if a bionic is an active instead of a passive bionic */
+    bool activated = false;
+    /** Is true if a bionic is activated automatically on install */
+    bool activated_on_install = false;
     /**
-     * Id of another bionic which this bionic needs to have installed to be installed.
-     * Also prevents that bionic from being removed while this bionic is installed.
-     */
-    bionic_id required_bionic;
+    * If true, this bionic is included with another.
+    */
+    bool included = false;
+    /**This bionic draws power through a cable*/
+    bool is_remote_fueled = false;
+    /**If true this bionic emits heat when producing power*/
+    bool exothermic_power_gen = false;
+    /** whether to immediately close ui when activating - used for targeted bionics */
+    bool activated_close_ui;
+    /** whether to immediately close ui when deactivating - used for targeted bionics */
+    bool deactivated_close_ui;
 
-    /**Requirement to bionic installation - this is a crafting requirement such as soldering_standard or surface_heat*/
-    requirement_id installation_requirement;
+    bool was_loaded = false;
 
-    cata::flat_set<json_character_flag> flags;
-    cata::flat_set<json_character_flag> active_flags;
-    cata::flat_set<json_character_flag> inactive_flags;
+
+
+
     bool has_flag( const json_character_flag &flag ) const;
     bool has_active_flag( const json_character_flag &flag ) const;
     bool has_inactive_flag( const json_character_flag &flag ) const;
 
     itype_id itype() const;
 
-    bool was_loaded = false;
     void load( const JsonObject &obj, const std::string &src );
     void finalize();
     static void load_bionic( const JsonObject &jo, const std::string &src );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3297,23 +3297,10 @@ units::volume Character::volume_carried_with_tweaks( const item_tweaks &tweaks )
 units::mass Character::weight_capacity() const
 {
     // Get base capacity from creature,
-    // then apply player-only mutation and trait effects.
+    // then apply enchantment.
     units::mass ret = Creature::weight_capacity();
     /** @EFFECT_STR increases carrying capacity */
     ret += get_str() * 4_kilogram;
-    ret *= mutation_value( "weight_capacity_modifier" );
-
-    units::mass worn_weight_bonus = 0_gram;
-    ret *= worn.weight_capacity_modifier();
-    worn_weight_bonus += worn.weight_capacity_bonus();
-
-    units::mass bio_weight_bonus = 0_gram;
-    for( const bionic_id &bid : get_bionics() ) {
-        ret *= bid->weight_capacity_modifier;
-        bio_weight_bonus +=  bid->weight_capacity_bonus;
-    }
-
-    ret += bio_weight_bonus + worn_weight_bonus;
 
     ret = enchantment_cache->modify_value( enchant_vals::mod::CARRY_WEIGHT, ret );
 
@@ -5228,11 +5215,6 @@ needs_rates Character::calc_needs_rates() const
 
     static const std::string player_thirst_rate( "PLAYER_THIRST_RATE" );
     rates.thirst = get_option< float >( player_thirst_rate );
-    static const std::string thirst_modifier( "thirst_modifier" );
-    rates.thirst *= 1.0f + mutation_value( thirst_modifier );
-    if( worn_with_flag( flag_SLOWS_THIRST ) ) {
-        rates.thirst *= 0.7f;
-    }
 
     static const std::string player_fatigue_rate( "PLAYER_FATIGUE_RATE" );
     rates.fatigue = get_option< float >( player_fatigue_rate );
@@ -6111,9 +6093,8 @@ int Character::visibility( bool, int ) const
     }
     // TODO:
     // if ( dark_clothing() && light check ...
-    int stealth_modifier = std::floor( mutation_value( "stealth_modifier" ) );
-    stealth_modifier = enchantment_cache->modify_value( enchant_vals::mod::STEALTH_MODIFIER,
-                       stealth_modifier );
+    // or add STEALTH_MODIFIER enchantment to dark clothes
+    int stealth_modifier = enchantment_cache->modify_value( enchant_vals::mod::STEALTH_MODIFIER, 1 );
     return clamp( 100 - stealth_modifier, 40, 160 );
 }
 
@@ -6421,31 +6402,22 @@ float calc_mutation_value_multiplicative( const std::vector<const mutation_branc
 static const std::map<std::string, std::function <float( std::vector<const mutation_branch *> )>>
 mutation_value_map = {
     { "healing_awake", calc_mutation_value<&mutation_branch::healing_awake> },
-    { "pain_modifier", calc_mutation_value<&mutation_branch::pain_modifier> },
     { "healing_multiplier", calc_mutation_value_multiplicative<&mutation_branch::healing_multiplier> },
     { "mending_modifier", calc_mutation_value_multiplicative<&mutation_branch::mending_modifier> },
     { "temperature_speed_modifier", calc_mutation_value<&mutation_branch::temperature_speed_modifier> },
-    { "metabolism_modifier", calc_mutation_value<&mutation_branch::metabolism_modifier> },
-    { "thirst_modifier", calc_mutation_value<&mutation_branch::thirst_modifier> },
     { "fatigue_regen_modifier", calc_mutation_value<&mutation_branch::fatigue_regen_modifier> },
     { "fatigue_modifier", calc_mutation_value<&mutation_branch::fatigue_modifier> },
     { "stamina_regen_modifier", calc_mutation_value<&mutation_branch::stamina_regen_modifier> },
-    { "stealth_modifier", calc_mutation_value<&mutation_branch::stealth_modifier> },
     { "mana_modifier", calc_mutation_value_additive<&mutation_branch::mana_modifier> },
     { "mana_multiplier", calc_mutation_value_multiplicative<&mutation_branch::mana_multiplier> },
     { "mana_regen_multiplier", calc_mutation_value_multiplicative<&mutation_branch::mana_regen_multiplier> },
     { "bionic_mana_penalty", calc_mutation_value_multiplicative<&mutation_branch::bionic_mana_penalty> },
     { "casting_time_multiplier", calc_mutation_value_multiplicative<&mutation_branch::casting_time_multiplier> },
-    { "attackcost_modifier", calc_mutation_value_multiplicative<&mutation_branch::attackcost_modifier> },
-    { "cardio_multiplier", calc_mutation_value_multiplicative<&mutation_branch::cardio_multiplier> },
-    { "weight_capacity_modifier", calc_mutation_value_multiplicative<&mutation_branch::weight_capacity_modifier> },
     { "noise_modifier", calc_mutation_value_multiplicative<&mutation_branch::noise_modifier> },
     { "overmap_sight", calc_mutation_value_additive<&mutation_branch::overmap_sight> },
     { "overmap_multiplier", calc_mutation_value_multiplicative<&mutation_branch::overmap_multiplier> },
     { "reading_speed_multiplier", calc_mutation_value_multiplicative<&mutation_branch::reading_speed_multiplier> },
     { "crafting_speed_multiplier", calc_mutation_value_multiplicative<&mutation_branch::crafting_speed_multiplier> },
-    { "obtain_cost_multiplier", calc_mutation_value_multiplicative<&mutation_branch::obtain_cost_multiplier> },
-    { "stomach_size_multiplier", calc_mutation_value_multiplicative<&mutation_branch::stomach_size_multiplier> },
     { "vomit_multiplier", calc_mutation_value_multiplicative<&mutation_branch::vomit_multiplier> },
     { "consume_time_modifier", calc_mutation_value_multiplicative<&mutation_branch::consume_time_modifier> },
     { "sweat_multiplier", calc_mutation_value_multiplicative<&mutation_branch::sweat_multiplier> },
@@ -6717,11 +6689,10 @@ int Character::base_bmr() const
 
 int Character::get_bmr() const
 {
-    int base_bmr_calc = base_bmr();
-    base_bmr_calc *= clamp( activity_history.average_activity(), NO_EXERCISE,
-                            maximum_exertion_level() );
-    return std::ceil( enchantment_cache->modify_value( enchant_vals::mod::METABOLISM, base_bmr_calc ) );
+    return base_bmr() * std::ceil( clamp( activity_history.average_activity(), NO_EXERCISE,
+                                          maximum_exertion_level() ) );
 }
+
 
 void Character::set_activity_level( float new_level )
 {
@@ -7280,7 +7251,7 @@ int Character::get_cardiofit() const
     const int cardio_base = get_cardio_acc();
 
     // Mut mod contains the base 1.0f for all modifiers
-    const float mut_mod = mutation_value( "cardio_multiplier" );
+    const float mut_mod = enchantment_cache->modify_value( enchant_vals::mod::CARDIO_MULTIPLIER, 1 );
     // 1 point of athletics skill = 1% more cardio, up to 10% cardio
     const float athletics_mod = get_skill_level( skill_swimming ) / 100.0f;
     // At some point we might have proficiencies that affect this.
@@ -7295,7 +7266,6 @@ int Character::get_cardiofit() const
 
     // Add up all of our cardio mods.
     float cardio_modifier = mut_mod + athletics_mod + prof_mod + health_mod;
-
     // Modify cardio accumulator by our cardio mods.
     const int cardio_fitness = static_cast<int>( cardio_base * cardio_modifier );
 
@@ -12740,12 +12710,6 @@ void Character::mod_pain( int npain )
         }
         if( mult < 0 ) {
             npain = roll_remainder( npain * ( 1 + mult ) );
-        }
-        if( mutation_value( "pain_modifier" ) != 0 ) {
-            npain = roll_remainder( npain + mutation_value( "pain_modifier" ) );
-            if( npain < 0 ) {
-                return;
-            }
         }
         npain += enchantment_cache->get_value_add( enchant_vals::mod::PAIN );
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1168,23 +1168,6 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     return result;
 }
 
-units::mass outfit::weight_capacity_bonus() const
-{
-    units::mass ret = 0_gram;
-    for( const item &clothing : worn ) {
-        ret += clothing.get_weight_capacity_bonus();
-    }
-    return ret;
-}
-
-float outfit::weight_capacity_modifier() const
-{
-    float ret = 1.0f;
-    for( const item &clothing : worn ) {
-        ret *= clothing.get_weight_capacity_modifier();
-    }
-    return ret;
-}
 
 units::mass outfit::weight() const
 {

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -106,8 +106,6 @@ class outfit
         bool natural_attack_restricted_on( const sub_bodypart_id &bp ) const;
         units::mass weight_carried_with_tweaks( const std::map<const item *, int> &without ) const;
         units::mass weight() const;
-        float weight_capacity_modifier() const;
-        units::mass weight_capacity_bonus() const;
         units::volume holster_volume() const;
         int used_holsters() const;
         int total_holsters() const;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -706,8 +706,7 @@ float Character::metabolic_rate_base() const
 {
     static const std::string hunger_rate_string( "PLAYER_HUNGER_RATE" );
     float hunger_rate = get_option< float >( hunger_rate_string );
-    static const std::string metabolism_modifier( "metabolism_modifier" );
-    return hunger_rate * ( 1.0f + mutation_value( metabolism_modifier ) );
+    return enchantment_cache->modify_value( enchant_vals::mod::METABOLISM, hunger_rate );
 }
 
 // TODO: Make this less chaotic to let NPC retroactive catch up work here

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -305,7 +305,6 @@ const flag_id flag_SLEEP_AID( "SLEEP_AID" );
 const flag_id flag_SLEEP_AID_CONTAINER( "SLEEP_AID_CONTAINER" );
 const flag_id flag_SLEEP_IGNORE( "SLEEP_IGNORE" );
 const flag_id flag_SLOWS_MOVEMENT( "SLOWS_MOVEMENT" );
-const flag_id flag_SLOWS_THIRST( "SLOWS_THIRST" );
 const flag_id flag_SLOW_WIELD( "SLOW_WIELD" );
 const flag_id flag_SMOKABLE( "SMOKABLE" );
 const flag_id flag_SMOKED( "SMOKED" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -310,7 +310,6 @@ extern const flag_id flag_SLEEP_AID;
 extern const flag_id flag_SLEEP_AID_CONTAINER;
 extern const flag_id flag_SLEEP_IGNORE;
 extern const flag_id flag_SLOWS_MOVEMENT;
-extern const flag_id flag_SLOWS_THIRST;
 extern const flag_id flag_SLOW_WIELD;
 extern const flag_id flag_SMOKABLE;
 extern const flag_id flag_SMOKED;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4298,31 +4298,6 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     // Whatever the last entry was, we want a newline at this point
     info.back().bNewLine = true;
 
-    const units::mass weight_bonus = get_weight_capacity_bonus();
-    const float weight_modif = get_weight_capacity_modifier();
-    if( weight_modif != 1 ) {
-        std::string modifier;
-        if( weight_modif < 1 ) {
-            modifier = "<num><bad>x</bad>";
-        } else {
-            modifier = "<num><color_light_green>x</color>";
-        }
-        info.emplace_back( "ARMOR",
-                           _( "<bold>Weight capacity modifier</bold>: " ), modifier,
-                           iteminfo::no_newline | iteminfo::is_decimal, weight_modif );
-    }
-    if( weight_bonus != 0_gram ) {
-        std::string bonus;
-        if( weight_bonus < 0_gram ) {
-            bonus = string_format( "<num> <bad>%s</bad>", weight_units() );
-        } else {
-            bonus = string_format( "<num> <color_light_green> %s</color>", weight_units() );
-        }
-        info.emplace_back( "ARMOR", _( "<bold>Weight capacity bonus</bold>: " ), bonus,
-                           iteminfo::no_newline | iteminfo::is_decimal,
-                           convert_weight( weight_bonus ) );
-    }
-
     if( show_bodygraph ) {
         insert_separation_line( info );
 
@@ -5437,31 +5412,6 @@ void item::bionic_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         }
     }
 
-    const units::mass weight_bonus = bid->weight_capacity_bonus;
-    const float weight_modif = bid->weight_capacity_modifier;
-    if( weight_modif != 1 ) {
-        std::string modifier;
-        if( weight_modif < 1 ) {
-            modifier = "<num><bad>x</bad>";
-        } else {
-            modifier = "<num><color_light_green>x</color>";
-        }
-        info.emplace_back( "CBM",
-                           _( "<bold>Weight capacity modifier</bold>: " ), modifier,
-                           iteminfo::no_newline | iteminfo::is_decimal,
-                           weight_modif );
-    }
-    if( weight_bonus != 0_gram ) {
-        std::string bonus;
-        if( weight_bonus < 0_gram ) {
-            bonus = string_format( "<num> <bad>%s</bad>", weight_units() );
-        } else {
-            bonus = string_format( "<num> <color_light_green>%s</color>", weight_units() );
-        }
-        info.emplace_back( "CBM", _( "<bold>Weight capacity bonus</bold>: " ), bonus,
-                           iteminfo::no_newline | iteminfo::is_decimal,
-                           convert_weight( weight_bonus ) );
-    }
 }
 
 void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
@@ -7999,24 +7949,6 @@ void item::calc_rot_while_processing( time_duration processing_duration )
 
     // Apply no rot or temperature while smoking
     last_temp_check += processing_duration;
-}
-
-float item::get_weight_capacity_modifier() const
-{
-    const islot_armor *t = find_armor_data();
-    if( t == nullptr ) {
-        return 1;
-    }
-    return t->weight_capacity_modifier;
-}
-
-units::mass item::get_weight_capacity_bonus() const
-{
-    const islot_armor *t = find_armor_data();
-    if( t == nullptr ) {
-        return 0_gram;
-    }
-    return t->weight_capacity_bonus;
 }
 
 int item::get_env_resist( int override_base_resist ) const

--- a/src/item.h
+++ b/src/item.h
@@ -2261,16 +2261,6 @@ class item : public visitable
                           encumber_flags = encumber_flags::none ) const;
 
         /**
-         * Returns the weight capacity modifier (@ref islot_armor::weight_capacity_modifier) that this item provides when worn.
-         * For non-armor it returns 1. The modifier is multiplied with the weight capacity of the character that wears the item.
-         */
-        float get_weight_capacity_modifier() const;
-        /**
-         * Returns the weight capacity bonus (@ref islot_armor::weight_capacity_modifier) that this item provides when worn.
-         * For non-armor it returns 0. The bonus is added to the total weight capacity of the character that wears the item.
-         */
-        units::mass get_weight_capacity_bonus() const;
-        /**
          * Returns the resistance to environmental effects (@ref islot_armor::env_resist) that this
          * item provides when worn. See @ref player::get_env_resist. Higher values are better.
          * For non-armor it returns 0.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3061,8 +3061,6 @@ void islot_armor::load( const JsonObject &jo )
     optional( jo, was_loaded, "warmth", warmth, 0 );
     optional( jo, was_loaded, "non_functional", non_functional, itype_id() );
     optional( jo, was_loaded, "damage_verb", damage_verb );
-    optional( jo, was_loaded, "weight_capacity_modifier", weight_capacity_modifier, 1.0 );
-    optional( jo, was_loaded, "weight_capacity_bonus", weight_capacity_bonus, mass_reader{}, 0_gram );
     optional( jo, was_loaded, "power_armor", power_armor, false );
     optional( jo, was_loaded, "valid_mods", valid_mods );
 }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -717,8 +717,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 return 0;
             }
 
-            int primary_cost = ch.mutation_value( "obtain_cost_multiplier" ) * ch.item_handling_cost( *target(),
-                               true, container_mv );
+            int primary_cost = ch.item_handling_cost( *target(), true, container_mv );
             primary_cost = ch.enchantment_cache->modify_value( enchant_vals::mod::OBTAIN_COST_MULTIPLIER,
                            primary_cost );
             int parent_obtain_cost = container.obtain_cost( ch, qty );

--- a/src/itype.h
+++ b/src/itype.h
@@ -386,14 +386,6 @@ struct islot_armor {
          */
         int warmth = 0;
         /**
-        * Factor modifying weight capacity
-        */
-        float weight_capacity_modifier = 1.0f;
-        /**
-        * Bonus to weight capacity
-        */
-        units::mass weight_capacity_bonus = 0_gram;
-        /**
          * Whether this is a power armor item.
          */
         bool power_armor = false;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -68,6 +68,7 @@ namespace io
             case enchant_vals::mod::BIONIC_POWER: return "BIONIC_POWER";
             case enchant_vals::mod::MAX_STAMINA: return "MAX_STAMINA";
             case enchant_vals::mod::REGEN_STAMINA: return "REGEN_STAMINA";
+            case enchant_vals::mod::CARDIO_MULTIPLIER: return "CARDIO_MULTIPLIER";
             case enchant_vals::mod::MAX_HP: return "MAX_HP";
             case enchant_vals::mod::REGEN_HP: return "REGEN_HP";
             case enchant_vals::mod::HUNGER: return "HUNGER";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -45,6 +45,7 @@ enum class mod : int {
     BIONIC_POWER,
     MAX_STAMINA,
     REGEN_STAMINA,
+    CARDIO_MULTIPLIER,
     MAX_HP,        // for all limbs! use with caution
     REGEN_HP,
     HUNGER,        // hunger rate

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2761,7 +2761,6 @@ int Character::attack_speed( const item &weap ) const
     move_cost *= ma_mult;
     move_cost += ma_move_cost;
 
-    move_cost *= mutation_value( "attackcost_modifier" );
     if( is_on_ground() ) {
         if( has_flag( json_flag_PSEUDOPOD_GRASP ) ) {
             move_cost *= 1.5;

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -221,11 +221,7 @@ struct mutation_branch {
         std::optional<float> healing_multiplier = std::nullopt;
         // Limb mending bonus
         std::optional<float> mending_modifier = std::nullopt;
-        std::optional<float> pain_modifier = std::nullopt;
         // Additional bonuses
-        std::optional<float> attackcost_modifier = std::nullopt;
-        std::optional<float> cardio_multiplier = std::nullopt;
-        std::optional<float> weight_capacity_modifier = std::nullopt;
         std::optional<float> noise_modifier = std::nullopt;
         float scent_modifier = 1.0f;
         std::optional<int> scent_intensity;
@@ -261,13 +257,8 @@ struct mutation_branch {
 
         std::optional<float> crafting_speed_multiplier = std::nullopt;
 
-        // Subtracted from the range at which monsters see player, corresponding to percentage of change. Clamped to +/- 60 for effectiveness
-        std::optional<float> stealth_modifier = std::nullopt;
-
         // Speed lowers--or raises--for every X F (X C) degrees below or above 65 F (18.3 C)
         std::optional<float> temperature_speed_modifier = std::nullopt;
-        // Extra metabolism rate multiplier. 1.0 doubles usage, -0.5 halves.
-        std::optional<float> metabolism_modifier = std::nullopt;
         // As above but for thirst.
         std::optional<float> thirst_modifier = std::nullopt;
         // As above but for fatigue.
@@ -276,10 +267,6 @@ struct mutation_branch {
         std::optional<float> fatigue_regen_modifier = std::nullopt;
         // Modifier for the rate at which stamina regenerates.
         std::optional<float> stamina_regen_modifier = std::nullopt;
-        // the modifier for obtaining an item from a container as a handling penalty
-        std::optional<float> obtain_cost_multiplier = std::nullopt;
-        // the modifier for the stomach size
-        std::optional<float> stomach_size_multiplier = std::nullopt;
         // the modifier for the vomit chance
         std::optional<float> vomit_multiplier = std::nullopt;
         // the modifier for sweat amount

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -392,22 +392,14 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     }
 
     optional( jo, was_loaded, "healing_awake", healing_awake, std::nullopt );
-    optional( jo, was_loaded, "pain_modifier", pain_modifier, std::nullopt );
     optional( jo, was_loaded, "healing_multiplier", healing_multiplier, std::nullopt );
     optional( jo, was_loaded, "mending_modifier", mending_modifier, std::nullopt );
-    optional( jo, was_loaded, "stealth_modifier", stealth_modifier, std::nullopt );
-    optional( jo, was_loaded, "attackcost_modifier", attackcost_modifier, std::nullopt );
-    optional( jo, was_loaded, "cardio_multiplier", cardio_multiplier, std::nullopt );
-    optional( jo, was_loaded, "weight_capacity_modifier", weight_capacity_modifier, std::nullopt );
     optional( jo, was_loaded, "noise_modifier", noise_modifier, std::nullopt );
     optional( jo, was_loaded, "temperature_speed_modifier", temperature_speed_modifier, std::nullopt );
-    optional( jo, was_loaded, "metabolism_modifier", metabolism_modifier, std::nullopt );
     optional( jo, was_loaded, "thirst_modifier", thirst_modifier, std::nullopt );
     optional( jo, was_loaded, "fatigue_modifier", fatigue_modifier, std::nullopt );
     optional( jo, was_loaded, "fatigue_regen_modifier", fatigue_regen_modifier, std::nullopt );
     optional( jo, was_loaded, "stamina_regen_modifier", stamina_regen_modifier, std::nullopt );
-    optional( jo, was_loaded, "obtain_cost_multiplier", obtain_cost_multiplier, std::nullopt );
-    optional( jo, was_loaded, "stomach_size_multiplier", stomach_size_multiplier, std::nullopt );
     optional( jo, was_loaded, "vomit_multiplier", vomit_multiplier, std::nullopt );
     optional( jo, was_loaded, "sweat_multiplier", sweat_multiplier, std::nullopt );
     optional( jo, was_loaded, "overmap_sight", overmap_sight, std::nullopt );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1160,7 +1160,7 @@ int throw_cost( const Character &c, const item &to_throw )
     move_cost *= stamina_penalty;
     move_cost += skill_cost;
     move_cost -= dexbonus;
-    move_cost *= c.mutation_value( "attackcost_modifier" );
+    move_cost = c.enchantment_cache->modify_value( enchant_vals::mod::ATTACK_SPEED, move_cost );
 
     return std::max( 25, move_cost );
 }

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -305,7 +305,7 @@ void stomach_contents::deserialize( const JsonObject &jo )
 units::volume stomach_contents::capacity( const Character &owner ) const
 {
     return owner.enchantment_cache->modify_value( enchant_vals::mod::STOMACH_SIZE_MULTIPLIER,
-            max_volume * owner.mutation_value( "stomach_size_multiplier" ) );
+            max_volume );
 }
 
 units::volume stomach_contents::stomach_remaining( const Character &owner ) const

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -584,7 +584,8 @@ void widget::set_default_var_range( const avatar &ava )
         case widget_var::cardio_fit:
             _var_min = 0;
             // Same maximum used by get_cardiofit - 3 x BMR, adjusted for mutations
-            _var_max = 3 * ava.base_bmr() * ava.mutation_value( "cardio_multiplier" );
+            _var_max = 3 * ava.base_bmr() * ava.enchantment_cache->modify_value(
+                           enchant_vals::mod::CARDIO_MULTIPLIER, 1 );
             break;
         case widget_var::carry_weight:
             _var_min = 0;

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -172,7 +172,7 @@ TEST_CASE( "base_cardio", "[cardio][base]" )
 //
 // Some traits affect cardio fitness directly:
 //
-// - cardio_multiplier: Multiplies maximum cardio
+// - CARDIO_MULTIPLIER: Multiplies maximum cardio
 //   - Languorous: Bad cardio, less total stamina
 //   - Indefatigable, Hyperactive: Good cardio, more total stamina
 //
@@ -213,7 +213,7 @@ TEST_CASE( "cardio_is_and_is_not_affected_by_certain_traits", "[cardio][traits]"
         check_trait_cardio_stamina_run( they, "HUGE", base_cardio, base_stamina, 81 );
     }
 
-    SECTION( "Traits with cardio_multiplier" ) {
+    SECTION( "Traits with CARDIO_MULTIPLIER" ) {
         // These traits were formerly implemented by max_stamina_modifier, which multiplied
         // maximum stamina. Now that cardio fitness is actually implemented, these traits
         // directly affect total cardio fitness, and thus maximum stamina (and running distance).

--- a/tests/char_biometrics_test.cpp
+++ b/tests/char_biometrics_test.cpp
@@ -473,8 +473,8 @@ TEST_CASE( "activity_levels_and_calories_in_daily_diary", "[avatar][biometrics][
         test_activity_duration( dummy, NO_EXERCISE, 1_minutes );
 
         int expect_gained_kcal = 1283;
-        int expect_net_kcal = 553;
-        int expect_spent_kcal = 730;
+        int expect_net_kcal = 527;
+        int expect_spent_kcal = 756;
 
         CHECK( condensed_spaces( dummy.total_daily_calories_string() ) == string_format(
                    "<color_c_white> Minutes at each exercise level Calories per day</color>\n"
@@ -499,7 +499,7 @@ TEST_CASE( "mutations_may_affect_character_metabolic_rate", "[biometrics][metabo
     // game balance JSON, the below tests are likely to fail and need adjustment.
     REQUIRE( normal_metabolic_rate == 1.0f );
 
-    // Mutations with a "metabolism_modifier" in mutations.json add/subtract to the base rate.
+    // Mutations with "METABOLISM" enchantment in mutations.json add/subtract to the base rate.
     // For example the rapid / fast / very fast / extreme metabolisms:
     //
     //     MET_RAT (+0.333), HUNGER (+0.5), HUNGER2 (+1.0), HUNGER3 (+2.0)

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -26,7 +26,6 @@ static void wield_check_from_inv( avatar &guy, const itype_id &item_name, const 
     item backpack( "backpack" );
     REQUIRE( backpack.can_contain( spawned_item ).success() );
     auto item_iter = guy.worn.wear_item( guy, backpack, false, false );
-    REQUIRE( guy.mutation_value( "obtain_cost_multiplier" ) == 1.0 );
 
     item_location backpack_loc( guy, & **item_iter );
     backpack_loc->put_in( spawned_item, pocket_type::CONTAINER );
@@ -71,7 +70,6 @@ TEST_CASE( "Wield_time_test", "[wield]" )
         item_location backpack_loc( guy, & **item_iter );
         backpack_loc->put_in( plastic_bag, pocket_type::CONTAINER );
         REQUIRE( backpack_loc->num_item_stacks() == 1 );
-        REQUIRE( guy.mutation_value( "obtain_cost_multiplier" ) == 1.0 );
 
         item_location plastic_bag_loc( backpack_loc, &backpack_loc->only_item() );
         plastic_bag_loc->put_in( cargo_pants, pocket_type::CONTAINER );
@@ -97,7 +95,6 @@ TEST_CASE( "Wield_time_test", "[wield]" )
     SECTION( "Wielding without hand encumbrance" ) {
         avatar guy;
         clear_character( guy );
-        REQUIRE( guy.mutation_value( "obtain_cost_multiplier" ) == 1.0 );
 
         wield_check_from_inv( guy, itype_aspirin, 300 );
         clear_character( guy );


### PR DESCRIPTION
#### Summary
Move traits, mutations, and the stillsuit over to use enchantment fields instead of hardcoded stuff or bespoke json objects.

#### Purpose of change
I was on the fence about doing this because I don't think we need to prioritize jsonization as much. C++ is faster and I have no problem working with it. We aren't relying on community contributions as much, buuuuut on the other hand it makes it easier to port other stuff that we do want.

#### Testing
Loaded in, tried mutating. All looks good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
