### PR TITLE
Rename small traits and adjust HP

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6163,8 +6163,8 @@
       {
         "values": [
           { "value": "MAX_HP", "multiply": -0.15 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.25 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.25 }
         ]
       }
     ]
@@ -6181,13 +6181,14 @@
     "types": [ "SIZE" ],
     "changes_to": [ "SMALL2" ],
     "category": [ "MOUSE", "RABBIT" ],
+    "//": "Small is slightly less punishing than Little by design, as it's a mutation and not a starting trait.",
     "enchantments": [
       {
         "values": [
           { "value": "BONUS_DODGE", "add": 1 },
           { "value": "MAX_HP", "multiply": -0.15 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.6 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.2 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.25 }
         ]
       }
     ]


### PR DESCRIPTION
#### Summary
Swap Small and Little trait names, adjust HP

#### Purpose of change
Small (chargen trait) is for kids or characters with dwarfism. Little (mutation) is for people turning into mice and rabbits. In America, the polite term for someone with dwarfism is generally "little person", so it made sense to swap these two names.

Small/little characters were previously only losing 5% of their max HP. Given that these people are 3 to 4 feet tall, that was really undershooting it, especially since being Tiny shaves off 30% of your max HP.

There was additionally a bug with stomach size. Small characters had tiny stomachs. This was carried over from DDA and needed fixing.

#### Describe the solution
- Swap the names.
- Move both traits to a 15% HP reduction. Tiny stays the same.
- Little reduces your stomach size by 25%. Small reduces it by 20%. Compare to Tiny which cuts it by 50%.
- Carry weight penalty for Little and Small increased from -20% to -25%. Compare to Tiny which cuts it by 50%.

#### Testing
Base 84 HP at Medium size becomes 71 HP at Small, and 58 at Tiny. Both Little and Small mutations have the same effect HP-wise.

Walked around eating grass and bushes, was able to pretty quickly get a decent amount of kcal without any stomach size issues.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
