### PR TITLE
Nerf Gourmand, more stomach size fixes

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1002,7 +1002,7 @@
     "category": [ "MOUSE", "LUPINE" ],
     "starting_trait": true,
     "active": true,
-    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.1 } ] } ]
   },
   {
     "type": "mutation",
@@ -6163,7 +6163,7 @@
       {
         "values": [
           { "value": "MAX_HP", "multiply": -0.15 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.25 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
           { "value": "CARRY_WEIGHT", "multiply": -0.25 }
         ]
       }
@@ -6187,7 +6187,7 @@
         "values": [
           { "value": "BONUS_DODGE", "add": 1 },
           { "value": "MAX_HP", "multiply": -0.15 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.2 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
           { "value": "CARRY_WEIGHT", "multiply": -0.25 }
         ]
       }
@@ -6211,7 +6211,7 @@
         "values": [
           { "value": "BONUS_DODGE", "add": 2 },
           { "value": "MAX_HP", "multiply": -0.3 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.75 },
           { "value": "CARRY_WEIGHT", "multiply": -0.5 }
         ]
       }
@@ -6225,7 +6225,7 @@
     "name": { "str": "Unassuming" },
     "points": 3,
     "mixed_effect": true,
-    "description": "You've mastered your tiny form!  Item encumbrance and carry weight penalties are reduced, and you've learned to use your increased nimbleness to offset your reduced capacity to absorb damage.",
+    "description": "You're still tiny, but your anatomy has adjusted to make more efficient use of your size.  You feel a little tougher, and you can eat and carry more than before.",
     "types": [ "SIZE" ],
     "prereqs": [ "SMALL2" ],
     "purifiable": false,
@@ -6237,7 +6237,7 @@
         "values": [
           { "value": "BONUS_DODGE", "add": 2 },
           { "value": "MAX_HP", "multiply": -0.25 },
-          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.5 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.7 },
           { "value": "CARRY_WEIGHT", "multiply": -0.3 }
         ]
       }


### PR DESCRIPTION
#### Summary
Nerf gourmand and small/tiny stomach sizes

#### Purpose of change
Enchantments don't use the same scaling as the old json objects did for some things, so stomach sizes were off.

#### Describe the solution
- Gourmand now adds 10% stomach size, not 100%
- Little and Small now add a -50% stomach size penalty

#### Testing
Spawned in and ate stuff, saw that it all behaved appropriately.

#### Additional context
This isn't actually all that punishing. You normally get full around 1.4 liters, and .7 liters is still plenty of food for small characters. Tiny characters have it a bit worse, but it's offset by mouse (the only tiny mutant) also getting +10% stomach capacity from gourmand and unassuming reducing their base penalty to -70%, to say nothing of their anti-thirst mutation. Playing as a mouse I was able to run around and eat protein bars and not have any issues. Yes they have to eat often, but that's a real mouse problem.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
