### PR TITLE
Fix VARSIZE bug(?)

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1068,7 +1068,7 @@ void Item_factory::finalize_post_armor( itype &obj )
 
             // need to account for varsize stuff here and double encumbrance if so
             if( obj.has_flag( flag_VARSIZE ) ) {
-                data.encumber = std::min( data.encumber * 2, data.encumber + 10 );
+                data.encumber = std::max( data.encumber * 2, data.encumber + 10 );
             }
 
             // Recalc max encumber as well


### PR DESCRIPTION
#### Summary
Fixed an error where VARSIZE was resulting in incorrect values for items that fit.

#### Purpose of change
The code was setting the value as the smaller of 1/2 the listed encumbrance or the listed encumbrance - 10 in one place, but in another it was trying to reverse that by setting the value to the larger of 2x the new value or the new value +10. So it was converting the arithmetic correctly, but then incorrectly swapping the std::min for std::max. This seems to be a longstanding DDA bug, but the way this is put together kind of hurts my brain and I'm not sure what was even intended to begin with.

fixes #69 

#### Describe the solution
Now they're both std::min. I don't know if max or min was the original intent, but min makes it waaay easier to stat items.

#### Describe alternatives you've considered
VARSIZE as it is will eventually go away and be replaced by a better system, but for now I just need it to work.

Now that this is done I can start the encumbrance audit for real.

#### Testing
Spawned some fitting and non-fitting items and saw that they now had the expected values, including both high encumbrance items like heels and low encumbrance items like a longcoat. Refitted a poor fit longcoat and saw that its new encumbrance was also correct.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
