### PR TITLE
Fix refugee's teamster dialogue which doesn't roll directions anymore (#72437)

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -53,7 +53,12 @@
       {
         "text": "So, have your caravans seen anything interesting out there in the wasteland?",
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS",
-        "condition": { "math": [ "time_since(n_timer_teamster_directions_recycler)", ">=", "time('2 d')" ] },
+        "condition": {
+          "or": [
+            { "math": [ "!has_var(n_timer_teamster_directions_recycler)" ] },
+            { "math": [ "time_since(n_timer_teamster_directions_recycler)", ">=", "time('2 d')" ] }
+          ]
+        },
         "effect": [
           { "math": [ "npc_randomize_dialogue_direction", "=", "rand(2)" ] },
           { "math": [ "n_timer_teamster_directions_recycler", "=", "time('now')" ] }


### PR DESCRIPTION
#### Summary
Content "Backport 72437"


#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72437


#### Describe the solution


#### Describe alternatives you've considered

#### Testing

Did not apply cleanly but resolved the conflict.

The thing worm girl changed to remove the exodii was limiting the rand() to 2, which I kept.

Before the change: the teamster would persistently just keep on saying "sorry, there is nothing to tell you about".
After the change: Got directions successfully after two ingame days.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
