### PR TITLE
Add RNG and time to foraging

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -318,7 +318,7 @@
   {
     "id": "ACT_FORAGE",
     "type": "activity_type",
-    "activity_level": "LIGHT_EXERCISE",
+    "activity_level": "MODERATE_EXERCISE",
     "verb": "foraging",
     "based_on": "speed"
   },

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -203,6 +203,7 @@ static const proficiency_id proficiency_prof_traps( "prof_traps" );
 static const proficiency_id proficiency_prof_trapsetting( "prof_trapsetting" );
 
 static const quality_id qual_ANESTHESIA( "ANESTHESIA" );
+static const quality_id qual_AXE( "AXE" );
 static const quality_id qual_DIG( "DIG" );
 static const quality_id qual_DRILL( "DRILL" );
 static const quality_id qual_GRASS_CUT( "GRASS_CUT" );
@@ -4169,11 +4170,14 @@ void iexamine::shrub_wildveggies( Character &you, const tripoint &examp )
         return;
     }
 
-    add_msg( _( "You forage through the %s." ), here.tername( examp ) );
     ///\EFFECT_SURVIVAL speeds up foraging
-    int move_cost = 100000 / ( 2 * you.get_skill_level( skill_survival ) + 5 );
+    int move_cost = 3000000 / ( 2 * you.get_skill_level( skill_survival ) + 5 );
     ///\EFFECT_PER randomly speeds up foraging
     move_cost /= rng( std::max( 4, you.per_cur ), 4 + you.per_cur * 2 );
+    if( you.has_quality( qual_GRASS_CUT ) || you.has_quality( qual_AXE ) ) {
+        add_msg( _( "You quickly hack through the dense undergrowth." ) );
+        move_cost *= 0.9;
+    }
     you.assign_activity( forage_activity_actor( move_cost ) );
     you.activity.placement = here.getglobal( examp );
     you.activity.auto_resume = true;


### PR DESCRIPTION
#### Summary
Wild plants (both individual and underbrush) take time to forage and don't always yield.

#### Purpose of change
Foraging was way too easy. A zero skill nobody could comfortably live off of plants they shouldn't even be able to identify or find, let alone know the practical applications of. To a degree, there's no accounting for player IRL knowledge, but even so, survival ranks should feel meaningful and the rewards should feel earned.

This is a part of the de-free-foodening and helps us with our general roadmap for 1.0

#### Describe the solution
- Foraging now takes a lot of time. The base is five minutes per attempt, but this is reduced by perception and survival skill.
- With underbrush, having a grass or tree cutting tool on hand will reduce this time by 10%. You get a message about this if you've got such a tool on you.
- Foraging, both in underbrush and picking wild plants (including things like fruit trees) now relies on a die roll against your survival skill and perception. With 0 skill and 8 perception, you have about an 8% chance to find something. This ramps up rapidly as you get any skill at all, and caps at about 85%. Perception helps more with underbrush foraging.
- Failing a forage check on either kind of plant sets the plant to its harvested state, so you can fail to pick a dandelion and lose it. Where did it go? That's left a little vague - it was probably just not suitable for consumption - rotten or dead or too young. The message states that you didn't find anything worthwhile, not that the plant vanished.
- Because foraging now takes a few minutes, you get fewer attempts per day and it actually matters for weariness. Don't spend your time and energy foraging things you don't want!
- Foraging underbrush is harder than foraging individual plants.
- This doesn't affect farming or raiding preplanted farms. Purposefully cultivated food crops are generally assumed to be much more accessible, and in any event they'll have their own systems.
- This does point to a bit of incongruity re: harvesting a peach tree in someone's yard (uses the wild plant system) or harvesting a rose bush from a planter in the same yard (uses the farming system), but that incongruity already existed and will be addressed by making some plants easier to harvest and by eventually making farming much less of a sure thing.

#### Describe alternatives you've considered
This is a very early version of this system, with just the bare bones in place. We'd like to have:
- Loot pools that improve with your skill and perception.
- A check when foraging for plants (not underbrush) that conditionally allows for tools to speed up the process, defined in the furniture's json.
- Variable difficulty levels for non-underbrush plants, or even their products. Burdock is harder to ID and find than dandelion, for example. It would be harder and less likely to get a cattail rhizome than it would to get a stalk or a leaf.
- Bonuses from mutations. Rabbits and elves should be excellent at this stuff. Lupines, rats, mice, plants, and ursines too, but less so.

These would all be pretty simple to implement, but let's try doing one thing at a time.

#### Testing
Went outside, foraged. Changed my skills and stats. Saw my chances go up and the time it took to go down. Saw I was accumulating weariness at the desired rate. Used a sickle. Saw the message about cutting through underbrush. Dropped the sickle, got a hatchet, moved away, did it again, saw the message. Everything looks good.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
