### PR TITLE
Gas Station Improvements

### DIFF
--- a/data/json/mapgen/gas_stations/s_gas.json
+++ b/data/json/mapgen/gas_stations/s_gas.json
@@ -46,8 +46,8 @@
       "signs": { "P": { "signage": "Danger!  Do not smoke!  Risk of explosion!" } },
       "vendingmachines": { "1": { "item_group": "vending_drink", "lootable": true }, "2": { "item_group": "vending_food", "lootable": true } },
       "place_liquids": [
-        { "liquid": "gasoline", "x": 2, "y": 3, "repeat": [ 200, 1075 ] },
-        { "liquid": "diesel", "x": 4, "y": 3, "repeat": [ 200, 1075 ] }
+        { "liquid": "gasoline", "x": 2, "y": 3, "repeat": [ 0, 800 ] },
+        { "liquid": "diesel", "x": 4, "y": 3, "repeat": [ 0, 800 ] }
       ],
       "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
     }
@@ -60,18 +60,18 @@
     "object": {
       "fill_ter": "t_thconc_floor",
       "rows": [
-        "____]]]____:____]]]____]",
-        "____]]]____:____]]]____]",
-        "____!#!____:____!#!____]",
-        "____]]]____:____]]]____]",
-        "____]]]____:____]]]____]",
-        "____]]]____:____]]]____]",
-        "____!#!____:____!#!____]",
-        "____]]]____:____]]]____]",
-        "____]]]____:____]]]____]",
+        "____b]]____:____]]b____]",
+        "_____]]____:____]]_____]",
+        "_____gÁ____:____Ád_____]",
+        "_____]]____:____]]_____]",
+        "_____]]____:____]]_____]",
+        "_____]]____:____]]_____]",
+        "_____gÁ____:____Ád_____]",
+        "_____]]____:____]]_____]",
+        "____b]]____:____]]b____]",
         "]]]]]]]]]]]]]]]]]]]]]]]]",
-        "]]]]]]]]]]]]]]Á]]]]]]]]]",
-        "#xxxxxxxxx///xxxxxxxxx#]",
+        "]]]]]]]]]]]]]]]]]]]]]]]]",
+        "####xxxxxx///xxxxxx####]",
         "#1.......&...&.......1#]",
         "#r...................{#]",
         "#r..rrrrr.....rrrrr..{#]",
@@ -100,7 +100,8 @@
         "Á": "t_concrete",
         "]": "t_concrete",
         ".": "t_thconc_floor",
-        "4": "t_gutter_downspout"
+        "4": "t_gutter_downspout",
+        "b": "t_little_column"
       },
       "furniture": {
         "&": "f_trashcan",
@@ -117,12 +118,16 @@
         "o": "f_oven",
         "S": "f_sink",
         "T": "f_toilet",
-        "Á": "f_rack"
+        "Á": "f_aut_gas_console"
       },
+      "place_liquids": [
+        { "liquid": "gasoline", "x": 2, "y": 10, "repeat": [ 0, 800 ] },
+        { "liquid": "diesel", "x": 20, "y": 10, "repeat": [ 0, 800 ] }
+      ],
       "toilets": { "T": {  } },
-      "gaspumps": { "!": {  } },
+      "gaspumps": { "g": { "fuel": "gasoline" }, "d": { "fuel": "diesel" } },
+      "place_furniture": [ { "furn": "f_gas_tank", "x": 5, "y": 10 }, { "furn": "f_diesel_tank", "x": 18, "y": 10 } ],
       "vendingmachines": { "D": { "item_group": "vending_drink" }, "F": { "item_group": "vending_food" } },
-      "place_signs": [ { "signage": "Wide selection of storage batteries!  Discounts!", "x": 13, "y": 10 } ],
       "items": { "l": { "item": "SUS_janitors_closet", "chance": 70 }, "&": { "item": "trash_cart", "chance": 50 } },
       "place_loot": [
         { "group": "cash_register_random", "x": [ 9, 13 ], "y": 18, "chance": 100 },
@@ -133,12 +138,10 @@
         { "group": "softdrugs", "x": 1, "y": [ 13, 17 ], "chance": 80, "repeat": [ 1, 4 ] },
         { "group": "behindcounter", "x": [ 9, 13 ], "y": 21, "chance": 80, "repeat": [ 1, 4 ] },
         { "group": "road", "x": [ 7, 15 ], "y": [ 0, 8 ], "chance": 50, "repeat": [ 1, 4 ] },
-        { "group": "gas_charging_rack", "x": [ 15, 20 ], "y": 18, "chance": 50, "repeat": [ 1, 2 ] },
-        { "group": "gas_charging_rack", "x": 14, "y": 10, "chance": 50 },
         { "group": "dining", "x": 17, "y": 21, "chance": 45 },
         { "group": "bed", "x": [ 15, 16 ], "y": 21, "chance": 70 },
         { "item": "microwave", "x": 19, "y": 21, "chance": 80 },
-        { "item": "laptop", "x": 11, "y": 18, "chance": 70 }
+        { "item": "laptop", "x": 11, "y": 18, "chance": 20 }
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE_GASSTATION", "x": [ 2, 20 ], "y": [ 16, 17 ], "chance": 2 } ]
     }
@@ -190,7 +193,7 @@
           "y": [ 15, 16 ]
         }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
+      "place_monster": [ { "group": "GROUP_ROOF_ANIMAL", "x": [ 4, 12 ], "y": [ 7, 20 ], "repeat": [ 1, 2 ], "chance": 8 } ]
     }
   },
   {
@@ -207,7 +210,7 @@
         "________________________",
         "________________________",
         "________________________",
-        "_______G________D_______",
+        "______rG________Dr______",
         "________________________",
         "________________________",
         "________________________",
@@ -239,7 +242,8 @@
         "=": "t_rock_floor",
         "~": "t_railing",
         "_": "t_pavement",
-        "4": "t_gutter_downspout"
+        "4": "t_gutter_downspout",
+        "r": "t_pavement"
       },
       "furniture": {
         "6": "f_table",
@@ -260,8 +264,14 @@
         "H": "f_armchair",
         "S": "f_stool",
         "s": "f_camp_chair",
-        "R": "f_shower"
+        "R": "f_shower",
+        "r": "f_aut_gas_console"
       },
+      "place_furniture": [ { "furn": "f_gas_tank", "x": 0, "y": 8 }, { "furn": "f_diesel_tank", "x": 23, "y": 8 } ],
+      "place_liquids": [
+        { "liquid": "gasoline", "x": 0, "y": 8, "repeat": [ 0, 800 ] },
+        { "liquid": "diesel", "x": 23, "y": 8, "repeat": [ 0, 800 ] }
+      ],
       "toilets": { ";": {  } },
       "gaspumps": { "G": { "fuel": "gasoline" }, "D": { "fuel": "diesel" } },
       "items": {
@@ -340,7 +350,7 @@
           "y": [ 12, 17 ]
         }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
+      "place_monster": [ { "group": "GROUP_ROOF_ANIMAL", "x": [ 4, 11 ], "y": [ 7, 15 ], "repeat": [ 1, 2 ], "chance": 15 } ]
     }
   }
 ]

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -169,15 +169,19 @@
       { "group": "GROUP_FERAL", "weight": 13 },
       { "monster": "mon_feral_soldier", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zombie_brainless", "weight": 65 },
-      { "monster": "mon_gas_zombie", "weight": 1, "cost_multiplier": 2, "starts": "7 days" }
+      { "monster": "mon_zombie_brainless", "weight": 65 }
     ]
   },
   {
     "type": "monstergroup",
     "default": "mon_null",
     "name": "GROUP_ZOMBIE_GAS",
-    "monsters": [ { "monster": "mon_gas_zombie", "weight": 250, "cost_multiplier": 2, "starts": "7 days" } ]
+    "monsters": [
+      { "monster": "mon_zombie", "weight": 472, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_technician", "weight": 1, "cost_multiplier": 12 },
+      { "group": "GROUP_FERAL", "weight": 13 },
+      { "monster": "mon_zombie_fireman", "weight": 10, "cost_multiplier": 2 }
+    ]
   },
   {
     "type": "monstergroup",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2079,9 +2079,6 @@ class jmapgen_gaspump : public jmapgen_piece
             const point r( x.get(), y.get() );
             int charges = amount.get();
             dat.m.furn_set( r, f_null );
-            if( charges == 0 ) {
-                charges = rng( 10000, 50000 );
-            }
             itype_id chosen_fuel = fuel.get( dat );
             if( chosen_fuel.is_null() ) {
                 dat.m.place_gas_pump( r, charges );
@@ -6365,7 +6362,9 @@ void map::place_gas_pump( const point &p, int charges, const itype_id &fuel_type
 {
     item fuel( fuel_type, calendar::start_of_cataclysm );
     fuel.charges = charges;
-    add_item( p, fuel );
+    if( fuel.charges > 0 ) {
+        add_item( p, fuel );
+    }
     ter_set( p, ter_id( fuel.fuel_pump_terrain() ) );
 }
 


### PR DESCRIPTION
#### Summary
Improve gas stations and remove random spillage when using pumps

#### Purpose of change
It always bothered me that you had a random chance to spill a shitload of gasoline at the pump. The pumps have safety triggers specifically to prevent this, and I've never seen anyone Mr. Bean gasoline all over the place.

Gas station maps were weird. The pumps all had X amount of free gas in them (????) and several did not have consoles to let you buy more gas.

Gasoline zombies were still spawning. I don't totally hate the idea of something like this, but currently fire is way too deadly (both to the player and to zombies), gasoline on the ground burns way too long, and there are some exploits with gasoline zombies that need fixing.

Zombies were also spawning in midair above/around the stations. ??? why

#### Describe the solution
- Remove gasoline zombies from gas station spawns. They'll come back once I've fixed fire, or if not them, something else that fills that role.
- Gas pumps no longer have free gasoline in them. You need to buy it at the terminal.
- Added terminals to stations that didn't have them.
- Reduced the amount of fuel in the stations' tanks by ~20%.
- Made roof_animals spawn on the actual roofs instead of a bunch of zombies in midair.
- Removed the storage batteries sitting out in the open in front of one of the stations. These did not make any sense and would have been immediately stolen long before the Cataclysm even started. They should be replaced by an EV charging station, but that's low priority as it wouldn't work anyway since the grid is down.
- Updated the logic on gas pumps to work properly when they don't start with gas. Also updated their message - they no longer say "out of order" when you simply need to buy more gas.
- Changed the pump spill chance to only go off if you have the Clumsy trait or are below 66% manipulation. 

#### Testing
Spawned in, checked all the stations, pumped gas a bunch of times with mittens and a bite suit on, spilled. Pumped gas a bunch of times without that stuff, did not spill, pumped gas a bunch of times with clumsy, spilled.

#### Additional context
https://www.youtube.com/watch?v=Ao-GDQ488DY

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
