### PR TITLE
Backport 78371 from DDA

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2313,7 +2313,8 @@ bool npc::is_minion() const
 
 bool npc::guaranteed_hostile() const
 {
-    return is_enemy() || ( my_fac && my_fac->likes_u < -10 );
+    return attitude_to( get_player_character() ) == Attitude::HOSTILE || is_enemy() ||
+           ( my_fac && my_fac->likes_u < -10 );
 }
 
 bool npc::is_walking_with() const


### PR DESCRIPTION
#### Summary
Backport DDA 78371 - Improve NPC hostility checks for guilt

#### Purpose of change
In some circumstances, bandits were still triggering guilt when attacked before they'd gone hostile. This should never happen as their faction is always hostile to the player, but somehow certain bandits (and not others!) were causing this.

It is always OK to kill bandits unless you are a pacifist. Self-defense, even pre-emptive self-defense, is not a crime in TLG.

#### Describe the solution
Improves the check to npc::guaranteed_hostile()

#### Testing
Compiled and ran.

#### Additional context
I suspect this isn't over, but we'll need someone to spot the issue again and give us a save before we can track it down properly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
