### PR TITLE
Backport DDA 77295

### DIFF
--- a/src/iteminfo_query.h
+++ b/src/iteminfo_query.h
@@ -85,6 +85,7 @@ enum class iteminfo_parts : size_t {
     AMMO_UPSCOST,
     AMMO_TO_FIRE,
 
+    GUN_DEFAULT_BORE,
     GUN_DEFAULT_AMMO,
     GUN_MAX_RANGE,
     GUN_AIMING_STATS,

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1615,7 +1615,6 @@ TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
         std::vector<iteminfo_parts> aim_stats = { iteminfo_parts::GUN_AIMING_STATS };
         CHECK( item_info_str( glock, aim_stats ) ==
                "--\n"
-               "<color_c_white>Base aim speed</color>: <color_c_yellow>29</color>\n"
                "<color_c_cyan>Regular</color>\n"
                "Even chance of good hit at range: <color_c_yellow>2</color>\n"
                "Time to reach aim level: <color_c_yellow>233</color> moves\n"


### PR DESCRIPTION
#### Summary
Backport DDA 77295 - fix several issues of gun_info

#### Additional Context
I am not totally sure about DDA's automation of all the gun stat stuff, but it's halfway done already and does beat the old system, so we may as well go along with it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
