### PR TITLE
Backport DDA 72327 - Itemgroups can define crafted components for an item

### DIFF
--- a/doc/ITEM_SPAWN.md
+++ b/doc/ITEM_SPAWN.md
@@ -89,6 +89,7 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 "charges": <number>|<array>,
 "charges-min": <number>,
 "charges-max": <number>,
+"components": "<array>",
 "contents-item": "<item-id>" (can be a string or an array of strings),
 "contents-group": "<group-id>" (can be a string or an array of strings),
 "ammo-item": "<ammo-item-id>",
@@ -114,6 +115,8 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 `custom-flags`: An array of flags that will be applied to this item.
 
 `variant`: A valid itype variant id for this item.
+
+`components`: Valid itype ids which are put into the item as its components, as may be done with in-game crafting. Note that there is no requirement for a matching recipe to exist, the components may be any existent item. You could define a spawned `hamburger` to have components of `[ "rock", "rock" ]` but it won't be good food... rocks contain no calories or nutrients!
 
 `event`: A reference to a holiday in the `holiday` enum. If specified, the entry only spawns during the specified real holiday. This works the same way as the seasonal title screens, where the holiday is checked against the current system's time. If the holiday matches, the item's spawn probability is taken from the `prob` field. Otherwise, the spawn probability becomes 0.
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4952,6 +4952,15 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
     } else {
         use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
     }
+    if( obj.has_array( "components" ) ) {
+        JsonArray ja = obj.get_array( "components" );
+        std::vector<itype_id> made_of;
+        for( auto sub : ja ) {
+            itype_id component = itype_id( sub );
+            made_of.emplace_back( component );
+        }
+        sptr->components_items = made_of;
+    }
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
     use_modifier |= load_str_arr( modifier.snippets, obj, "snippets" );
     if( obj.has_member( "sealed" ) ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -230,6 +230,17 @@ item Single_item_creator::create_single_without_container( const time_point &bir
     if( one_in( 3 ) && tmp.has_flag( flag_VARSIZE ) ) {
         tmp.set_flag( flag_FIT );
     }
+    if( components_items ) {
+        for( itype_id component_id : *components_items ) {
+            if( !component_id.is_valid() ) {
+                debugmsg( "Invalid components item %s in %s (could not find matching itype id)",
+                          component_id.c_str(), context() );
+                continue;
+            }
+            item component = item( component_id, calendar::turn );
+            tmp.components.add( component );
+        }
+    }
     if( modifier ) {
         modifier->modify( tmp, "modifier for " + context() );
     } else {

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -195,6 +195,10 @@ class Item_spawn_data
         std::optional<itype_id> container_item;
         std::optional<std::string> container_item_variant;
         overflow_behaviour on_overflow = overflow_behaviour::none;
+        /**
+         * These item(s) are spawned as components
+         */
+        std::optional<std::vector<itype_id>> components_items;
         bool sealed = true;
 
         struct relic_generator {
@@ -262,7 +266,6 @@ class Item_modifier
          */
         std::unique_ptr<Item_spawn_data> contents;
         bool sealed = true;
-
         /**
          * Custom flags to be added to the item.
          */


### PR DESCRIPTION
#### Summary
Part one of three backports needed for this change. It lets us say, for instance, what kind of meat should be in a can of meat soup that is placed via mapgen, poplates a trader's list, etc.

#### Testing
Compiles and runs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
