### PR TITLE
Fix infinite stam from dodge, add stam check to block

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1966,7 +1966,7 @@ void Character::on_try_dodge()
     const int base_burn_rate = get_option<int>( STATIC( "PLAYER_BASE_STAMINA_BURN_RATE" ) );
     const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
     burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
-                                  dodge_skill_modifier ) );
+                                    dodge_skill_modifier ) );
     set_activity_level( EXPLOSIVE_EXERCISE );
 }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2078,7 +2078,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     // Skill of 10 and no relevant encumbrance almost guarantees a block attempt regardless of stamina.
     // The + 0.01 is a safety margin to prevent floating point precision errors in x_in_y.
     float melee_skill = has_active_bionic( bio_cqb ) ? 5 : get_skill_level( skill_melee );
-    if( !x_in_y( melee_skill * 40.0 * get_limb_score( limb_score_reaction ) - 100 * get_stamina_dodge_modifier(), 200 ) ) {
+    if( !x_in_y( melee_skill * 40.0 * get_limb_score( limb_score_reaction ) - 100 *
+                 get_stamina_dodge_modifier(), 200 ) ) {
         add_msg_debug( debugmode::DF_MELEE, "Block roll failed" );
         return false;
     }


### PR DESCRIPTION
#### Summary
Dodging no longer restores stamina, blocking is harder when you're tired.

#### Purpose of change
- Dodging was incorrectly restoring stamina instead of decreasing it.
- Blocking was too much of a sure thing, firing 100% of the time after 5 ranks.

Fixes #155 

#### Describe the solution
- Dodging decrements stamina instead of incrementing it.
- Blocking now adds a stamina check. At 100% stamina and 5 skill (assuming reaction score of 100), you block 100% of the time. At 0% stamina, that scales down to a 50% chance. Blocking is still impossible while you're winded.
- This raises the skill ceiling, allowing higher-skill characters to perform better when tired, but basically nobody has 100% block chance anymore.

#### Describe alternatives you've considered
- I looked at adding stamina costs to blocking and at reducing stamina regain while doing high-impact activities, but these were both too punishing. You need to be able to press . and restore stamina to survive.
- I think if players are still too tanky (and I'm not convinced they will be) the trick will be to make them easier to damage, looking at armor, encumbrance, and dodge/block chance, not easier to tire out. A winded character is basically dead in a lot of circumstances.
- The intent is that you are getting hit and taking at least some chip damage pretty much all the time if you are in melee. Blocking and dodging and armor are intended to stretch out your character's operational life before they have to hunker down and heal up. They're also intended to show a progression of power as you become less concerned (but never unconcerned!) with low-level enemies.
- Temporary boosts such as the planned power armor overhaul should be the exception.

#### Testing
- Loaded and ran, saw dodging cost stamina as intended. Saw blocking became harder.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
