### PR TITLE
add TRADER_AVOID and TINDER to cottonwood tree bolls

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -37,6 +37,7 @@
     "price": 1,
     "price_postapoc": 1,
     "material": [ "wood" ],
+    "flags": [ "TRADER_AVOID", "TINDER" ],
     "volume": "250 ml"
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Cottonwood tree bolls can be used as tinder"

#### Purpose of change

Not a backport for once. An original change.

Cottonwood tree bolls burn very easily.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
