### PR TITLE
Backport: Move ruined books from abstract.json

### DIFF
--- a/data/json/items/book/abstract.json
+++ b/data/json/items/book/abstract.json
@@ -367,35 +367,5 @@
     "use_action": [ "MA_MANUAL" ],
     "intelligence": 9,
     "time": "10 m"
-  },
-  {
-    "type": "GENERIC",
-    "id": "book_ruined",
-    "category": "books",
-    "symbol": ",",
-    "color": "white",
-    "name": { "str": "ruined book" },
-    "description": "A ruined book.  Someone has thoroughly ruined this book by ripping pages out and covering the remainder in… is that paint?",
-    "price": 0,
-    "price_postapoc": 0,
-    "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID", "TINDER" ],
-    "weight": "1587 g",
-    "volume": "1500 ml"
-  },
-  {
-    "type": "GENERIC",
-    "id": "book_pieces",
-    "category": "books",
-    "symbol": ",",
-    "color": "white",
-    "name": { "str_sp": "pieces of books" },
-    "description": "Scraps of paper that used to be part of a book.  It might make good tinder, but not much else.",
-    "price": 0,
-    "price_postapoc": 0,
-    "material": [ "paper" ],
-    "flags": [ "TRADER_AVOID", "TINDER" ],
-    "weight": "120 g",
-    "volume": "200 ml"
   }
 ]

--- a/data/json/items/book/misc.json
+++ b/data/json/items/book/misc.json
@@ -1452,5 +1452,35 @@
         "description": "A history of the development of Rabbinic Judaism, from the Jewish Revolt in the first century to the writing of the Mishnah, and how Judaism and Christianity fully separated."
       }
     ]
+  },
+  {
+    "type": "GENERIC",
+    "id": "book_ruined",
+    "category": "books",
+    "symbol": ",",
+    "color": "white",
+    "name": { "str": "ruined book" },
+    "description": "A ruined book.  Someone has thoroughly ruined this book by ripping pages out and covering the remainder in… is that paint?",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "paper" ],
+    "flags": [ "TRADER_AVOID" ],
+    "weight": "1587 g",
+    "volume": "1500 ml"
+  },
+  {
+    "type": "GENERIC",
+    "id": "book_pieces",
+    "category": "books",
+    "symbol": ",",
+    "color": "white",
+    "name": { "str_sp": "pieces of books" },
+    "description": "Scraps of paper that used to be part of a book.  Completely useless now.",
+    "price": 0,
+    "price_postapoc": 0,
+    "material": [ "paper" ],
+    "flags": [ "TRADER_AVOID" ],
+    "weight": "120 g",
+    "volume": "200 ml"
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Backport 72665"

#### Purpose of change

- Backport CleverRaven/Cataclysm-DDA#72665

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Loads and displays correctly.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
