### PR TITLE
Revert "Revert "Backport DDA 76818 - Spells can damage other limbs""

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -229,7 +229,7 @@ Field group | Description | Example
 `min_range`, `max_range`, `range_increment` | Distance from the caster to the target.  Can be omitted if the target is the caster (giving an buff/debuff, spawning an item).  <br>Note: the reality bubble diameter is ~60 tiles. | "min_range": 2, <br>"max_range": 10, <br>"range_increment": 0.5,
 `min_aoe`, `max_aoe`, `aoe_increment` | Short for "area of effect", area/zone of tiles that the spell will affect. | "min_aoe": 0, <br>"max_aoe": 5, <br>"aoe_increment": 0.1, 
 `min_accuracy`, `max_accuracy`, `accuracy_increment` | Accuracy of the spell.  -20 accuracy will cause it to always miss, 20 will cause it always hit.  Currently doesn't work. | "min_accuracy" -20, <br>"max_accuracy": 20, <br>"accuracy_increment": 1.5
-`min_dot`, `max_dot`, `dot_increment` | Short for "damage over time".  Similar to damage, positive values hurt while negative values heal.  <br>Note: dot values are rounded up, so 1.1 will be 2. | "min_dot": 0, <br>"max_dot": 2, <br>"dot_increment": 0.1,
+`min_dot`, `max_dot`, `dot_increment` | Short for "damage over time".  Similar to damage, positive values hurt while negative values heal.  <br>Note: decimal values use roll_remainder(); having 0.5 would result in dot dealing 1 damage randomly every 2 seconds on average. Affected by `affected_body_parts` field | "min_dot": 0, <br>"max_dot": 2, <br>"dot_increment": 0.1,
 `min_pierce`, `max_pierce`, `pierce_increment` | Armor "piercing", how much armor of the same `damage_type` the spell will ignore. | "min_pierce": 0, <br>"max_pierce": 1, <br>"pierce_increment": 0.1,
 `min_liquid_volume`, `max_liquid_volume`, `liquid_increment` | The amount of fluid in ml that each creature targeted by the spell is splashed with. More liquid makes it harder to resist with armor ( or with environmental resist for monsters ),
 `base_casting_time`, `final_casting_time`, `casting_time_increment` | Time the caster spends when casting the spell.  Similar to duration, it's writed in moves, which allows spells to be casted in fractions of a second.  Ignored for monsters and items that cast spells.  If several spells are chained, only the first one will apply the cost.  <br>Note: The casting time is not shown to the player (e.g. a cast of 300 will behave as if the player waits for 3 turns). | "base_casting_time": 1000, <br>"final_casting_time": 100, <br>"casting_time_increment": -50,
@@ -238,7 +238,8 @@ Field group | Description | Example
 `effect_str` | The "effect" the spell has (see [EFFECTS_JSON](EFFECTS_JSON.md)).  Varies according to the spell `effect` field. | "effect_str": "zapped", "effect_str": "mon_zombie",
 `max_level` | How much you can train the spell.  Default is 0.  Ignored for monsters and items that cast spells. | "max_level": 10,
 `difficulty` | How hard is to cast the spell.  A high difficulty spell is easier to fail, failing grants spell XP at no resource cost.  It also limits the maximum spellcasting skill that can be gained by casting it (e.g. difficulty 10 will train up to spellcasting lvl 10). | "difficulty": 7,
-`affected_body_parts` | `body_part` where the `effect_str` will occur.  Set at `torso` by default.  Currently doesn't work. | "affected_body_parts": [ "head" ] 
+`multiple_projectiles` | If value is bigger than one, instead of shooting single spell with damage X, you will shoot `multiple_projectiles` amount of projectiles with damage `damage/multiple_projectiles`, which may damage different body parts (each projectile has 75% chance to hit torso still). Doesn't interact with affected_body_parts | "multiple_projectiles": 2,
+`affected_body_parts` | `body_part` where the `attack`, `dot` or `effect_str` will occur.  For effects, set at `torso` by default. For attack and dot, picks a random bodypart, weighted by it's hit_size | "affected_body_parts": [ "head" ] 
 `extra_effects` | Allows to cast a secondary spell `id` immediately after the primary spell.  Allows for multiple `id`s. | "extra_effects": [ <br> { <br> "id": "fireball", <br> "hit_self": false, <br> "max_level": 3 <br> }, <br> { "id": "storm_chain_1" } <br>]
 `learn_spells` | Allow user to learn the spell `id` when they reach that spell level  (e.g. `"create_atomic_light": 5` means user will learn create_atomic_light when they reach level 5 of the primary spell).  Allows for multiple `id`s. | "learn_spells": { "create_atomic_light": 5, "megablast": 10 }
 `teachable` | Whether it's possible to teach this spell between characters.  Default is true. | `"teachable": true`
@@ -283,7 +284,7 @@ Flag                       | Description
 `NO_PROJECTILE`            | The "projectile" portion of the spell phases through walls, the epicenter of the spell effect is exactly where you target it, with no regards to obstacles.
 `NON_MAGICAL`              | Ignores spell resistance when calculating damage mitigation.
 `PAIN_NORESIST`            | Pain altering spells can't be resisted (like with the deadened trait).
-`PERCENTAGE_DAMAGE`        | The spell deals damage based on the target's current hp.  This means that the spell can't directly kill the target.
+`PERCENTAGE_DAMAGE`        | The spell deals damage based on the target's current hp.  This means that the spell can't directly kill the target. For characters (NPC or Avatar) damage applies to all body parts (damage 10 would deal 10% damage for each limb). If affected_body_parts is specified, deal percentage damage only to this body parts. Works with both attacks and DOTs
 `PERMANENT`                | Items or creatures spawned with this spell do not disappear and die as normal.  Items can only be permanent at maximum spell level; creatures can be permanent at any spell level.
 `PERMANENT_ALL_LEVELS`     | Items spawned with this spell do not disappear even if the spell is not max level.
 `POLYMORPH_GROUP`          | A `targeted_polymorph` spell will transform the target into a random monster from the `monstergroup` in `effect_str`.
@@ -298,6 +299,7 @@ Flag                       | Description
 `SOMATIC`                  | Arm encumbrance affects fail % and casting time (slightly).
 `SPAWN_GROUP`              | Spawn or summon from an `item_group` or `monstergroup`, instead of the specific IDs.
 `SPAWN_WITH_DEATH_DROPS`   | Allows summoned monsters to retain their usual death drops, otherwise they drop nothing.
+`SPLIT_DAMAGE`             | If used, instead of dealing damage to a random body part, damage would be spread evenly across entire body, unless affected_body_parts is specificed. Works only on characters (NPC or Avatar), for monsters do not have limbs. Works with both attacks and DOTs
 `SWAP_POS`                 | A projectile spell swaps the positions of the caster and target.
 `TARGET_TELEPORT`          | Teleport spell changes to maximum range target with aoe as variation around target.
 `UNSAFE_TELEPORT`          | Teleport spell risks killing the caster or others.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6301,7 +6301,6 @@ std::string Character::extended_description() const
         nc_color name_color = state_col;
         std::pair<std::string, nc_color> hp_bar = get_hp_bar( get_part_hp_cur( bp ), get_part_hp_max( bp ),
                 false );
-
         ss += colorize( left_justify( bp_heading, longest ), name_color );
         ss += colorize( hp_bar.first, hp_bar.second );
         // Trailing bars. UGLY!

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -984,8 +984,9 @@ projectile_attack_results Creature::select_body_part_projectile_attack(
     const bool magic = proj.proj_effects.count( "MAGIC" ) > 0;
     double hit_value = missed_by + rng_float( -0.5, 0.5 );
     if( magic ) {
-        // Best possible hit
-        hit_value = -0.5;
+        // We want spells to hit all bodyparts randomly, not only torso
+        // It still gonna be torso mainly
+        hit_value = rng_float( -0.5, 1.5 );
     }
     // Range is -0.5 to 1.5 -> missed_by will be [1, 0], so the rng addition to it
     // will push it to at most 1.5 and at least -0.5
@@ -3108,12 +3109,12 @@ void Creature::process_damage_over_time()
 {
     for( auto DoT = damage_over_time_map.begin(); DoT != damage_over_time_map.end(); ) {
         if( DoT->duration > 0_turns ) {
-            for( const bodypart_str_id &bp : DoT->bps ) {
-                const int dmg_amount = DoT->amount;
-                if( dmg_amount < 0 ) {
-                    heal_bp( bp.id(), -dmg_amount );
-                } else if( dmg_amount > 0 ) {
-                    deal_damage( nullptr, bp.id(), damage_instance( DoT->type, dmg_amount ) );
+            for( const bodypart_id &bp : DoT->bps ) {
+                const double dmg_amount = DoT->amount;
+                if( dmg_amount < 0.0 ) {
+                    heal_bp( bp.id(), roll_remainder( -dmg_amount ) );
+                } else if( dmg_amount > 0.0 ) {
+                    deal_damage( nullptr, bp.id(), damage_instance( DoT->type, roll_remainder( dmg_amount ) ) );
                 }
             }
             DoT->duration -= 1_turns;

--- a/src/damage.h
+++ b/src/damage.h
@@ -178,8 +178,8 @@ class damage_over_time_data
     public:
         damage_type_id type;
         time_duration duration;
-        std::vector<bodypart_str_id> bps;
-        int amount = 0;
+        std::vector<bodypart_id> bps;
+        double amount = 0.0;
 
         bool was_loaded = false;
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -121,6 +121,7 @@ std::string enum_to_string<spell_flag>( spell_flag data )
         case spell_flag::PERMANENT: return "PERMANENT";
         case spell_flag::PERMANENT_ALL_LEVELS: return "PERMANENT_ALL_LEVELS";
         case spell_flag::PERCENTAGE_DAMAGE: return "PERCENTAGE_DAMAGE";
+        case spell_flag::SPLIT_DAMAGE: return "SPLIT_DAMAGE";
         case spell_flag::IGNORE_WALLS: return "IGNORE_WALLS";
         case spell_flag::NO_PROJECTILE: return "NO_PROJECTILE";
         case spell_flag::HOSTILE_SUMMON: return "HOSTILE_SUMMON";
@@ -243,6 +244,7 @@ const float spell_type::energy_increment_default = 0.0f;
 const trait_id spell_type::spell_class_default = trait_NONE;
 const magic_energy_type spell_type::energy_source_default = magic_energy_type::none;
 const damage_type_id spell_type::dmg_type_default = damage_type_id::NULL_ID();
+const int spell_type::multiple_projectiles_default = 0;
 const int spell_type::difficulty_default = 0;
 const int spell_type::max_level_default = 0;
 const int spell_type::base_casting_time_default = 0;
@@ -510,6 +512,10 @@ void spell_type::load( const JsonObject &jo, const std::string_view src )
     if( !was_loaded || jo.has_member( "difficulty" ) ) {
         difficulty = get_dbl_or_var( jo, "difficulty", false, difficulty_default );
     }
+    if( !was_loaded || jo.has_member( "multiple_projectiles" ) ) {
+        multiple_projectiles = get_dbl_or_var( jo, "multiple_projectiles", false,
+                                               multiple_projectiles_default );
+    }
     if( !was_loaded || jo.has_member( "max_level" ) ) {
         max_level = get_dbl_or_var( jo, "max_level", false, max_level_default );
     }
@@ -650,6 +656,8 @@ void spell_type::serialize( JsonOut &json ) const
                  io::enum_to_string( energy_source_default ) );
     json.member( "damage_type", dmg_type, dmg_type_default );
     json.member( "difficulty", static_cast<int>( difficulty.min.dbl_val.value() ), difficulty_default );
+    json.member( "multiple_projectiles", static_cast<int>( multiple_projectiles.min.dbl_val.value() ),
+                 multiple_projectiles_default );
     json.member( "max_level", static_cast<int>( max_level.min.dbl_val.value() ), max_level_default );
     json.member( "base_casting_time", static_cast<int>( base_casting_time.min.dbl_val.value() ),
                  base_casting_time_default );
@@ -820,7 +828,7 @@ int spell::accuracy( Creature &caster ) const
     }
 }
 
-int spell::min_leveled_dodge_training( const Creature &caster ) const
+double spell::min_leveled_dodge_training( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     return type->min_dodge_training.evaluate( d ) + std::round( get_effective_level() *
@@ -860,26 +868,26 @@ int spell::liquid_volume( Creature &caster ) const
     }
 }
 
-int spell::min_leveled_dot( const Creature &caster ) const
+double spell::min_leveled_dot( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     return type->min_dot.evaluate( d ) + std::round( get_effective_level() *
             type->dot_increment.evaluate( d ) );
 }
 
-int spell::damage_dot( const Creature &caster ) const
+double spell::damage_dot( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
-    const int leveled_dot = min_leveled_dot( caster );
-    if( type->min_dot.evaluate( d ) >= 0 ||
+    const double leveled_dot = min_leveled_dot( caster );
+    if( type->min_dot.evaluate( d ) >= 0.0 ||
         type->max_dot.evaluate( d ) >= type->min_dot.evaluate( d ) ) {
-        return std::min( leveled_dot, static_cast<int>( type->max_dot.evaluate( d ) ) );
+        return std::min( leveled_dot, type->max_dot.evaluate( d ) );
     } else { // if it's negative, min and max work differently
-        return std::max( leveled_dot, static_cast<int>( type->max_dot.evaluate( d ) ) );
+        return std::max( leveled_dot, type->max_dot.evaluate( d ) );
     }
 }
 
-damage_over_time_data spell::damage_over_time( const std::vector<bodypart_str_id> &bps,
+damage_over_time_data spell::damage_over_time( const std::vector<bodypart_id> &bps,
         const Creature &caster ) const
 {
     damage_over_time_data temp;
@@ -1155,6 +1163,12 @@ bool spell::can_learn( const Character &guy ) const
         return true;
     }
     return guy.has_trait( type->spell_class );
+}
+
+int spell::get_amount_of_projectiles( const Character &guy ) const
+{
+    dialogue d( get_talker_for( guy ), nullptr );
+    return type->multiple_projectiles.evaluate( d );
 }
 
 int spell::energy_cost( const Character &guy ) const
@@ -1522,9 +1536,14 @@ bool spell::is_valid() const
     return type.is_valid();
 }
 
-bool spell::bp_is_affected( const bodypart_str_id &bp ) const
+int spell::bps_affected( ) const
 {
-    return type->affected_bps.test( bp );
+    return type->affected_bps.count();
+}
+
+bool spell::bp_is_affected( const bodypart_id &bp ) const
+{
+    return type->affected_bps.test( bp.id() );
 }
 
 void spell::create_field( const tripoint &at, Creature &caster ) const

--- a/src/magic.h
+++ b/src/magic.h
@@ -47,51 +47,52 @@ class event;
 template <typename E> struct enum_traits;
 
 enum class spell_flag : int {
-    PERMANENT, // Items or creatures spawned with this spell do not disappear and die as normal.
-    PERMANENT_ALL_LEVELS, // Items spawned with this spell do not disappear even if the spell is not max level.
-    PERCENTAGE_DAMAGE, // The spell deals damage based on the target's current HP.
-    IGNORE_WALLS, // Spell's aoe goes through walls.
-    NO_PROJECTILE, // Spell's original targeting area can be targeted through walls.
-    SWAP_POS, // A projectile spell swaps the positions of the caster and target.
+    CONCENTRATE, // Focus affects spell fail %.
+    DODGEABLE, // The target can dodge this attack completely if they succeed on a dodge roll against its spell level. Implies NO_DODGE_MITIGATION.
+    EXTRA_EFFECTS_FIRST, // The extra effects are cast before the main spell.
+    FRIENDLY_POLY, // Polymorph spell makes the monster friendly.
     HOSTILE_SUMMON, // Summon spell always spawns a hostile monster.
     HOSTILE_50, // Summoned monster spawns friendly 50% of the time.
-    POLYMORPH_GROUP, // Polymorph spell chooses a monster from a group.
-    FRIENDLY_POLY, // Polymorph spell makes the monster friendly.
-    SILENT, // Spell makes no noise at target.
-    NO_EXPLOSION_SFX, // Spell has no visual explosion.
+    IGNITE_FLAMMABLE, // If spell effect area has any thing flammable, a fire will be produced. LIQUID spells can ignite target characters' equipment.
+    IGNORE_WALLS, // Spell's aoe goes through walls.
     LIQUID, // This spell is a splash of liquid, the amount proportional to its damage. Characters can block the effects with clothing and armor.
     LIQUID_DAMAGE_ARMOR, // Requires LIQUID. The liquid splashed by this spell can damage items worn by characters according to its liquid_volume amount, damage amount, and type.
     LIQUID_DAMAGE_TARGET, // Requires LIQUID. Will damage target characters according to the liquid_volume amount that isn't blocked by their armor. Monsters are damaged normally.
-    MAKE_FILTHY, // Requires LIQUID. The liquid splashed by this spell can add the FILTHY flag to items worn by characters, according to its liquid_volume.
     LOUD, // Spell makes extra noise at target.
-    VERBAL, // Spell makes noise at caster location, mouth encumbrance affects fail %.
-    SOMATIC, // Arm encumbrance affects fail % and casting time (slightly).
+    MAKE_FILTHY, // Requires LIQUID. The liquid splashed by this spell can add the FILTHY flag to items worn by characters, according to its liquid_volume.
+    MUST_HAVE_CLASS_TO_LEARN, // You can't learn the spell unless you already have the class.
+    MUTATE_TRAIT, // Overrides the mutate spell_effect to use a specific trait_id instead of a category.
+    NO_BLOCK_MITIGATION, // This attack does not allow for the usual 1/3 damage mitigation via a block roll.
+    NO_CORPSE_QUIET, // Allow summoned monsters to vanish/leave without leaving a corpse.
+    NO_DODGE_MITIGATION, // This attack does not allow for the usual 1/3 damage mitigation via a dodge roll.
+    NO_EXPLOSION_SFX, // Spell has no visual explosion.
+    NO_FAIL, // This spell cannot fail when you cast it.
     NO_HANDS, // Hands do not affect spell energy cost.
-    UNSAFE_TELEPORT, // Teleport spell risks killing the caster or others.
-    TARGET_TELEPORT, // Aoe is teleport variance from target.
     NO_LEGS, // Legs do not affect casting time.
-    CONCENTRATE, // Focus affects spell fail %.
+    NO_PROJECTILE, // Spell's original targeting area can be targeted through walls.
+    NON_MAGICAL, // Ignores spell resistance, which disallows the usual 1/3 damage mitigation available there.
+    PAIN_NORESIST, // Pain altering spells can't be resisted (like with the deadened trait).
+    PERMANENT, // Items or creatures spawned with this spell do not disappear and die as normal.
+    PERMANENT_ALL_LEVELS, // Items spawned with this spell do not disappear even if the spell is not max level.
+    PERCENTAGE_DAMAGE, // The spell deals damage based on the target's current HP.
+    POLYMORPH_GROUP, // Polymorph spell chooses a monster from a group.
+    PSIONIC, // Psychic powers instead of traditional magic.
     RANDOM_AOE, // Picks random number between min+increment*level and max instead of normal behavior.
     RANDOM_DAMAGE, // Picks random number between min+increment*level and max instead of normal behavior.
     RANDOM_DURATION, // Picks random number between min+increment*level and max instead of normal behavior.
     RANDOM_TARGET, // Picks a random valid target within your range instead of normal behavior.
     RANDOM_CRITTER, // Same as RANDOM_TARGET but ignores ground.
-    MUTATE_TRAIT, // Overrides the mutate spell_effect to use a specific trait_id instead of a category.
-    WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells )).
-    EXTRA_EFFECTS_FIRST, // The extra effects are cast before the main spell.
-    PAIN_NORESIST, // Pain altering spells can't be resisted (like with the deadened trait).
-    NO_FAIL, // This spell cannot fail when you cast it.
-    SPAWN_GROUP, // Spawn or summon from an item or monster group, instead of individual item/monster ID.
-    IGNITE_FLAMMABLE, // If spell effect area has any thing flammable, a fire will be produced. LIQUID spells can ignite target characters' equipment.
-    MUST_HAVE_CLASS_TO_LEARN, // You can't learn the spell unless you already have the class.
-    SPAWN_WITH_DEATH_DROPS, // Allow summoned monsters to drop their usual death drops.
-    NO_CORPSE_QUIET, // Allow summoned monsters to vanish/leave without leaving a corpse.
-    NON_MAGICAL, // Ignores spell resistance, which disallows the usual 1/3 damage mitigation available there.
-    PSIONIC, // Psychic powers instead of traditional magic.
     RECHARM, // Charm_monster spell adds to duration of existing charm_monster effect.
-    DODGEABLE, // The target can dodge this attack completely if they succeed on a dodge roll against its spell level. Implies NO_DODGE_MITIGATION.
-    NO_DODGE_MITIGATION, // This attack does not allow for the usual 1/3 damage mitigation via a dodge roll.
-    NO_BLOCK_MITIGATION, // This attack does not allow for the usual 1/3 damage mitigation via a block roll.
+    SILENT, // Spell makes no noise at target.
+    SOMATIC, // Arm encumbrance affects fail % and casting time (slightly).
+    SPAWN_GROUP, // Spawn or summon from an item or monster group, instead of individual item/monster ID.
+    SPAWN_WITH_DEATH_DROPS, // Allow summoned monsters to drop their usual death drops.
+    SPLIT_DAMAGE, // spell apply damage across all limbs. Works only with characters, for monsters do not have limbs
+    SWAP_POS, // A projectile spell swaps the positions of the caster and target.
+    TARGET_TELEPORT, // Aoe is teleport variance from target.
+    UNSAFE_TELEPORT, // Teleport spell risks killing the caster or others.
+    VERBAL, // Spell makes noise at caster location, mouth encumbrance affects fail %.
+    WONDER, // instead of casting each of the extra_spells, it picks N of them and casts them (where N is std::min( damage(), number_of_spells )).
     LAST
 };
 
@@ -351,6 +352,9 @@ class spell_type
         // the difficulty of casting a spell
         dbl_or_var difficulty;
 
+        // if projectile should shot more than one projectile
+        dbl_or_var multiple_projectiles;
+
         // max level this spell can achieve
         dbl_or_var max_level;
 
@@ -451,6 +455,7 @@ class spell_type
         static const magic_energy_type energy_source_default;
         static const damage_type_id dmg_type_default;
         static const int difficulty_default;
+        static const int multiple_projectiles_default;
         static const int max_level_default;
         static const int base_casting_time_default;
         static const float casting_time_increment_default;
@@ -486,14 +491,14 @@ class spell
 
         // minimum damage including levels
         int min_leveled_damage( const Creature &caster ) const;
-        int min_leveled_dot( const Creature &caster ) const;
+        double min_leveled_dot( const Creature &caster ) const;
         // minimum aoe including levels
         int min_leveled_aoe( const Creature &caster ) const;
         // minimum duration including levels (moves)
         int min_leveled_duration( const Creature &caster ) const;
         int min_leveled_accuracy( const Creature &caster ) const;
         int min_leveled_effect_intensity( const Creature &caster ) const;
-        int min_leveled_dodge_training( const Creature &caster ) const;
+        double min_leveled_dodge_training( const Creature &caster ) const;
         int min_leveled_liquid_volume( const Creature &caster ) const;
 
     public:
@@ -540,8 +545,8 @@ class spell
         int effect_intensity( Creature &caster ) const;
         float dodge_training( Creature &caster ) const;
         int liquid_volume( Creature &caster ) const;
-        int damage_dot( const Creature &caster ) const;
-        damage_over_time_data damage_over_time( const std::vector<bodypart_str_id> &bps,
+        double damage_dot( const Creature &caster ) const;
+        damage_over_time_data damage_over_time( const std::vector<bodypart_id> &bps,
                                                 const Creature &caster ) const;
         dealt_damage_instance get_dealt_damage_instance( Creature &caster ) const;
         dealt_projectile_attack get_projectile_attack( const tripoint &target,
@@ -583,10 +588,12 @@ class spell
         bool can_cast( const Character &guy ) const;
         // can the Character learn this spell?
         bool can_learn( const Character &guy ) const;
+        int get_amount_of_projectiles( const Character &guy ) const;
         // is this spell valid
         bool is_valid() const;
+        int bps_affected() const;
         // is the bodypart affected by the effect
-        bool bp_is_affected( const bodypart_str_id &bp ) const;
+        bool bp_is_affected( const bodypart_id &bp ) const;
         // check if the spell has a particular flag
         bool has_flag( const spell_flag &flag ) const;
         bool has_flag( const std::string &flag ) const;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -622,14 +622,55 @@ static void damage_targets( const spell &sp, Creature &caster,
             }
 
             for( damage_unit &val : atk.proj.impact.damage_units ) {
-                if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) && ( liquid_damage_target || !liquid ) ) {
-                    // TODO: Change once spells don't always target get_max_hitsize_bodypart(). Should target each bodypart with it's respective %
-                    val.amount = cr->get_hp( cr->get_max_hitsize_bodypart() ) * sp.damage( caster ) / 100.0;
-                }
                 val.amount *= damage_mitigation_multiplier;
             }
-            // Ensure we don't accidentally try to damage a monster with a splash attack that isn't supposed to hurt
-            if( liquid_damage_target || !liquid ) {
+            if( cr->as_character() != nullptr && ( liquid_damage_target || !liquid ) ) {
+                int multishot = sp.get_amount_of_projectiles( *caster.as_character() );
+                std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
+
+                if( sp.bps_affected() > 0 ) {
+                    for( auto it = target_bdpts.begin(); it != target_bdpts.end(); ) {
+                        if( !sp.bp_is_affected( it->id() ) ) {
+                            it = target_bdpts.erase( it );
+                        } else {
+                            ++it;
+                        }
+                    }
+                }
+
+                if( multishot > 1 ) {
+                    for( damage_unit &val : atk.proj.impact.damage_units ) {
+                        val.amount = roll_remainder( val.amount / multishot );
+                    }
+                    for( int i = 0; i < multishot; ++i ) {
+                        cr->deal_projectile_attack( cr, atk, true );
+                    }
+                } else if( sp.has_flag( spell_flag::SPLIT_DAMAGE ) ) {
+                    int amount_of_bp = target_bdpts.size();
+                    for( damage_unit &val : atk.proj.impact.damage_units ) {
+                        val.amount = roll_remainder( val.amount / amount_of_bp );
+                    }
+                    for( bodypart_id bp_id : target_bdpts ) {
+                        cr->deal_damage( cr, bp_id, atk.proj.impact );
+                    }
+                } else if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
+                    for( bodypart_id bp_id : target_bdpts ) {
+                        for( damage_unit &val : atk.proj.impact.damage_units ) {
+                            val.amount = roll_remainder( cr->get_hp( bp_id ) * sp.damage( caster ) / 100.0 );
+                            cr->deal_damage( cr, bp_id, atk.proj.impact );
+                        }
+                    }
+                } else {
+                    cr->deal_projectile_attack( &caster, atk, true );
+                }
+            }
+
+            if( cr->as_monster() != nullptr ) {
+                for( damage_unit &val : atk.proj.impact.damage_units ) {
+                    if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
+                        val.amount = cr->get_hp() * sp.damage( caster ) / 100.0;
+                    }
+                }
                 cr->deal_projectile_attack( &caster, atk, true );
             }
         } else if( sp.damage( caster ) < 0 ) {
@@ -637,8 +678,41 @@ static void damage_targets( const spell &sp, Creature &caster,
             add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );
         }
-        // TODO: randomize hit location
-        cr->add_damage_over_time( sp.damage_over_time( { body_part_torso }, caster ) );
+
+        // handling DOTs here
+        if( sp.damage_dot( caster ) > 0 ) {
+            if( cr->as_character() != nullptr ) {
+                std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
+
+                if( sp.bps_affected() > 0 ) {
+                    for( auto it = target_bdpts.begin(); it != target_bdpts.end(); ) {
+                        if( !sp.bp_is_affected( it->id() ) ) {
+                            it = target_bdpts.erase( it );
+                        } else {
+                            ++it;
+                        }
+                    }
+                }
+
+                if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
+                    for( bodypart_id bpid : target_bdpts ) {
+                        damage_over_time_data foo = sp.damage_over_time( { bpid }, caster );
+                        foo.amount = cr->get_hp( bpid ) * foo.amount / 100.0;
+                        cr->add_damage_over_time( foo );
+                    }
+                } else if( sp.has_flag( spell_flag::SPLIT_DAMAGE ) ) {
+                    damage_over_time_data dot_data = sp.damage_over_time( target_bdpts, caster );
+                    dot_data.amount /= target_bdpts.size();
+                    cr->add_damage_over_time( dot_data );
+                } else if( !target_bdpts.empty() ) {
+                    cr->add_damage_over_time( sp.damage_over_time( target_bdpts, caster ) );
+                } else {
+                    cr->add_damage_over_time( sp.damage_over_time( { cr->get_random_body_part() }, caster ) );
+                }
+            } else {
+                cr->add_damage_over_time( sp.damage_over_time( { body_part_bp_null }, caster ) );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I tracked down the weird issue that was happening and it was an unfortunate moment of PEBCAK. So this can go back in.