### PR TITLE
revert backport of 72835 because it breaks the build

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -167,10 +167,8 @@ static const ter_str_id ter_t_grass_long( "t_grass_long" );
 static const ter_str_id ter_t_grass_tall( "t_grass_tall" );
 static const ter_str_id ter_t_improvised_shelter( "t_improvised_shelter" );
 static const ter_str_id ter_t_moss( "t_moss" );
-static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_sand( "t_sand" );
 static const ter_str_id ter_t_tree_young( "t_tree_young" );
-static const ter_str_id ter_t_treetop( "t_treetop" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
@@ -4821,7 +4819,7 @@ int om_cutdown_trees_trunks( const tripoint_abs_omt &omt_tgt, int chance )
 int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate,
                       bool force_cut_trunk )
 {
-    smallmap target_bay;
+    tinymap target_bay;
     target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
@@ -4842,14 +4840,6 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
                 target_bay.ter_set( elem, ter_t_trunk );
             }
             target_bay.ter_set( p, ter_t_dirt );
-            for( int z = p.z + 1; z <= OVERMAP_HEIGHT; z++ ) {
-                const tripoint up_tree = tripoint{ p.xy(), z};
-                if( target_bay.ter( up_tree ) == ter_t_treetop ) {
-                    target_bay.ter_set( up_tree, ter_t_open_air );
-                } else {
-                    break;
-                }
-            }
             harvested++;
         }
     }


### PR DESCRIPTION
#### Summary

I messed up lol

#### Purpose of change

#### Describe the solution

It would have needed CleverRaven/Cataclysm-DDA#72724 as a dependency.

#### Describe alternatives you've considered

#### Testing

Compiles.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
