### PR TITLE
Backport DDA 72658 - Fix some uses of part_at() to use precalc positions

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13406,7 +13406,7 @@ ret_val<void> item::link_to( vehicle &veh, const point &mount, link_state link_t
         } else if( !veh.is_external_part( veh.mount_to_tripoint( mount ) ) ) {
             return ret_val<void>::make_failure( _( "You can't attach a tow-line to an internal part." ) );
         } else {
-            const int part_at = veh.part_at( mount );
+            const int part_at = veh.part_at( veh.coord_translate( mount ) );
             if( part_at != -1 && !veh.part( part_at ).carried_stack.empty() ) {
                 return ret_val<void>::make_failure( _( "You can't attach a tow-line to a racked part." ) );
             }

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -463,9 +463,17 @@ void veh_app_interact::rename()
 
 void veh_app_interact::remove()
 {
-    int const part = veh->part_at( a_point );
-    vehicle_part &vp = veh->part( part >= 0 ? part : 0 );
-    const vpart_info &vpinfo = vp.info();
+    map &here = get_map();
+    const tripoint a_point_bub( veh->mount_to_tripoint( a_point ) );
+
+    vehicle_part *vp;
+    if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
+        vp = &sel_part->part();
+    } else {
+        int const part = veh->part_at( veh->coord_translate( a_point ) );
+        vp = &veh->part( part >= 0 ? part : 0 );
+    }
+    const vpart_info &vpinfo = vp->info();
     const requirement_data reqs = vpinfo.removal_requirements();
     Character &you = get_player_character();
     const inventory &inv = you.crafting_inventory();
@@ -505,7 +513,7 @@ void veh_app_interact::remove()
 
 void veh_app_interact::plug()
 {
-    const int part = veh->part_at( a_point );
+    const int part = veh->part_at( veh->coord_translate( a_point ) );
     const tripoint pos = veh->global_part_pos3( part );
     item cord( "power_cord" );
     cord.link_to( *veh, a_point, link_state::automatic );
@@ -551,9 +559,15 @@ void veh_app_interact::merge()
 
 void veh_app_interact::populate_app_actions()
 {
-
-    int const part = veh->part_at( a_point );
-    const vehicle_part &vp = veh->part( part >= 0 ? part : 0 );
+    map &here = get_map();
+    vehicle_part *vp;
+    const tripoint a_point_bub( veh->mount_to_tripoint( a_point ) );
+    if( auto sel_part = here.veh_at( a_point_bub ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
+        vp = &sel_part->part();
+    } else {
+        const int part = veh->part_at( veh->coord_translate( a_point ) );
+        vp = &veh->part( part >= 0 ? part : 0 );
+    }
 
     const std::string ctxt_letters = ctxt.get_available_single_char_hotkeys();
     imenu.entries.clear();


### PR DESCRIPTION
#### Summary
Backport DDA 72658 - Fix some uses of part_at() to use precalc positions

#### Purpose of change

> part_at() refers to parts by precalc, unlike most other vehicle functions that go by mount, so part_at was always returning -1 in some places

#### Testing
Compiled and ran. Drove a car. No problems.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
