### PR TITLE
Backport Unhardcode dead vegetation extras (#73022)

### DIFF
--- a/data/json/itemgroups/trash_and_debris.json
+++ b/data/json/itemgroups/trash_and_debris.json
@@ -168,6 +168,11 @@
   },
   {
     "type": "item_group",
+    "id": "dead_vegetation",
+    "items": [ { "item": "twig", "prob": 15, "count": [ 5, 20 ] }, [ "withered", 60 ], [ "stick_long", 15 ], [ "stick", 30 ] ]
+  },
+  {
+    "type": "item_group",
     "id": "trash",
     "ammo": 20,
     "magazine": 50,

--- a/data/json/mapgen/map_extras/dead_vegetation.json
+++ b/data/json/mapgen/map_extras/dead_vegetation.json
@@ -1,0 +1,96 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_dead_vegetation",
+    "object": {
+      "place_nested": [
+        { "chunks": [ "15x15_dead_vegetation" ], "x": [ 4, 5 ], "y": [ 4, 5 ] },
+        { "chunks": [ "15x15_dead_vegetation" ], "x": [ 0, 4 ], "y": [ 0, 9 ] },
+        { "chunks": [ "15x15_dead_vegetation" ], "x": [ 5, 9 ], "y": [ 0, 9 ] },
+        { "chunks": [ "15x15_dead_vegetation" ], "x": [ 0, 9 ], "y": [ 0, 4 ] },
+        { "chunks": [ "15x15_dead_vegetation" ], "x": [ 0, 9 ], "y": [ 5, 9 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_point_dead_vegetation",
+    "object": { "place_nested": [ { "chunks": [ "15x15_dead_vegetation" ], "x": [ 0, 9 ], "y": [ 0, 9 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "15x15_dead_vegetation",
+    "object": {
+      "mapgensize": [ 15, 15 ],
+      "place_nested": [
+        { "chunks": [ "7x7_dead_vegetation" ], "x": [ 0, 8 ], "y": [ 0, 8 ] },
+        { "chunks": [ "7x7_dead_vegetation" ], "x": [ 0, 8 ], "y": [ 0, 8 ] },
+        { "chunks": [ "7x7_dead_vegetation" ], "x": [ 0, 8 ], "y": [ 0, 8 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "7x7_dead_vegetation",
+    "object": {
+      "mapgensize": [ 7, 7 ],
+      "rows": [
+        "  xxx  ",
+        " xXXXx ",
+        "xXXXXXx",
+        "xXXXXXx",
+        "xXXXXXx",
+        " xXXXx ",
+        "  xxx  "
+      ],
+      "nested": { "X": { "chunks": [ "1x1_dead_vegetation" ] }, "x": { "chunks": [ "1x1_dead_vegetation", "null" ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "1x1_dead_vegetation",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "ter_furn_transforms": { " ": { "transform": "dead_vegetation" } },
+      "place_items": [ { "item": "dead_vegetation", "x": 0, "y": 0, "chance": 1 } ]
+    }
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "dead_vegetation",
+    "//": "Ideally place withered plant item somehow",
+    "furniture": [
+      {
+        "result": "f_null",
+        "valid_flags": [ "PLANT", "FLOWER", "ORGANIC" ],
+        "//": "Ideally place a withered plant, for now we just place items randomly"
+      }
+    ],
+    "terrain": [
+      {
+        "result": "t_grass_dead",
+        "valid_terrain": [ "t_grass", "t_grass_long", "t_grass_tall", "t_grass_golf", "t_grass_white", "t_moss", "t_forestfloor" ]
+      },
+      { "result": "t_tree_deadpine", "valid_terrain": [ "t_tree_pine" ] },
+      { "result": "t_tree_birch_harvested", "valid_terrain": [ "t_tree_birch" ] },
+      { "result": "t_tree_dead", "valid_terrain": [ "t_tree_willow" ] },
+      { "result": "t_tree_hickory_dead", "valid_terrain": [ "t_tree_hickory", "t_tree_hickory_harvested" ] },
+      {
+        "result": "t_dirt",
+        "valid_flags": [ "SHRUB" ],
+        "//": "Ideally place sticks half the time, for now we just place items randomly"
+      },
+      {
+        "result": "t_dirt",
+        "valid_flags": [ "YOUNG" ],
+        "//": "Ideally place a long stick half the time, for now we just place items randomly"
+      },
+      { "result": [ [ "t_tree_dead", 9 ], [ "t_trunk", 4 ], [ "t_stump", 3 ] ], "valid_flags": [ "TREE" ] }
+    ]
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -380,7 +380,7 @@
     "type": "map_extra",
     "name": { "str": "Dead Vegetation" },
     "description": "Dead vegetation is here.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_dead_vegetation" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_dead_vegetation" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown"
@@ -390,7 +390,7 @@
     "type": "map_extra",
     "name": { "str": "Dead Vegetation (Point)" },
     "description": "Dead vegetation is here.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_point_dead_vegetation" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_point_dead_vegetation" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown"

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -121,7 +121,6 @@ static const map_extra_id map_extra_mx_casings( "mx_casings" );
 static const map_extra_id map_extra_mx_city_trap( "mx_city_trap" );
 static const map_extra_id map_extra_mx_clay_deposit( "mx_clay_deposit" );
 static const map_extra_id map_extra_mx_corpses( "mx_corpses" );
-static const map_extra_id map_extra_mx_dead_vegetation( "mx_dead_vegetation" );
 static const map_extra_id map_extra_mx_fungal_zone( "mx_fungal_zone" );
 static const map_extra_id map_extra_mx_grove( "mx_grove" );
 static const map_extra_id map_extra_mx_helicopter( "mx_helicopter" );
@@ -130,7 +129,6 @@ static const map_extra_id map_extra_mx_looters( "mx_looters" );
 static const map_extra_id map_extra_mx_minefield( "mx_minefield" );
 static const map_extra_id map_extra_mx_null( "mx_null" );
 static const map_extra_id map_extra_mx_point_burned_ground( "mx_point_burned_ground" );
-static const map_extra_id map_extra_mx_point_dead_vegetation( "mx_point_dead_vegetation" );
 static const map_extra_id map_extra_mx_pond( "mx_pond" );
 static const map_extra_id map_extra_mx_portal_in( "mx_portal_in" );
 static const map_extra_id map_extra_mx_reed( "mx_reed" );
@@ -1319,47 +1317,6 @@ static bool mx_clay_deposit( map &m, const tripoint &abs_sub )
     return false;
 }
 
-static bool mx_dead_vegetation( map &m, const tripoint &abs_sub )
-{
-    // This map extra kills all plant life, creating area of desolation.
-    // Possible result of acid rain / radiation / etc.,
-    // but reason is not exposed (no rads, acid pools, etc.)
-
-    for( int i = 0; i < SEEX * 2; i++ ) {
-        for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint loc( i, j, abs_sub.z );
-
-            dead_vegetation_parser( m, loc );
-        }
-    }
-
-    return true;
-}
-
-static bool mx_point_dead_vegetation( map &m, const tripoint &abs_sub )
-{
-    // This map extra creates patch of dead vegetation using a simple cellular automaton.
-    // Lesser version of mx_dead_vegetation
-
-    constexpr int width = SEEX * 2;
-    constexpr int height = SEEY * 2;
-
-    // Generate the cells for dead vegetation.
-    std::vector<std::vector<int>> current = CellularAutomata::generate_cellular_automaton( width,
-                                            height, 55, 5, 4, 3 );
-
-    for( int i = 0; i < width; i++ ) {
-        for( int j = 0; j < height; j++ ) {
-            if( current[i][j] == 1 ) {
-                const tripoint loc( i, j, abs_sub.z );
-                dead_vegetation_parser( m, loc );
-            }
-        }
-    }
-
-    return true;
-}
-
 static void burned_ground_parser( map &m, const tripoint &loc )
 {
     const furn_t &fid = m.furn( loc ).obj();
@@ -2231,8 +2188,6 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_shrubbery, mx_shrubbery },
     { map_extra_mx_pond, mx_pond },
     { map_extra_mx_clay_deposit, mx_clay_deposit },
-    { map_extra_mx_dead_vegetation, mx_dead_vegetation },
-    { map_extra_mx_point_dead_vegetation, mx_point_dead_vegetation },
     { map_extra_mx_burned_ground, mx_burned_ground },
     { map_extra_mx_point_burned_ground, mx_point_burned_ground },
     { map_extra_mx_casings, mx_casings },


### PR DESCRIPTION
#### Summary

Absolute bane of my existence.

#### Purpose of change

So this apparently needed CleverRaven/Cataclysm-DDA#72699?! How? This does not even touch the transforms.

- Backports CleverRaven/Cataclysm-DDA#73022

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

This… works. Compiled without issues, too and applied cleanly. I can not believe it.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
