### PR TITLE
poison ivy tweaks

### DIFF
--- a/data/json/mapgen/map_extras/wild_foliage.json
+++ b/data/json/mapgen/map_extras/wild_foliage.json
@@ -5,7 +5,7 @@
       "nested_mapgen_id": "nested_poison_ivy",
       "object": {
         "mapgensize": [ 1, 1 ],
-        "place_terrain": [ { "ter": "t_grass", "x": 0, "y": 0 } ],
+        "place_terrain": [ { "ter": "t_region_groundcover", "x": 0, "y": 0 } ],
         "place_traps": [ { "trap": "tr_poison_ivy", "x": 0, "y": 0 } ],
         "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
       }
@@ -15,32 +15,6 @@
       "method": "json",
       "update_mapgen_id": "mx_poison_ivy_patch",
       "object": {
-        "rows": [
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        "
-        ],
         "place_nested": [ { "chunks": [ [ "nested_poison_ivy", 100 ] ], "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 0, 8 ] } ],
         "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
       }

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -649,7 +649,7 @@
           "mx_trees2": 800,
           "mx_point_burned_ground": 500,
           "mx_point_dead_vegetation": 1000,
-          "mx_poison_ivy_patch": 400,
+          "mx_poison_ivy_patch": 100,
           "mx_trees": 500,
           "mx_knotweed_patch": 250,
           "mx_fallen_shed": 200,


### PR DESCRIPTION
#### Summary

#### Purpose of change

#### Describe the solution

- remove empty rows object since a recent backports allows omitting those
- use `t_region_groundcover` instead of grass
- make poison ivy a little less common in fields as go botany indicates these grow primarily in forests (<https://gobotany.nativeplanttrust.org/species/toxicodendron/radicans/> and <https://gobotany.nativeplanttrust.org/species/toxicodendron/rydbergii/>), it can benefit from an anthropogenic habitat palette or terrain/furniture group in the future that places it more commonly in certain man made areas.

#### Describe alternatives you've considered

#### Testing

Loads without errors, results are what I want.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
