### PR TITLE
Backport 72734 - Enforce mon_ prefix for monster id

### DIFF
--- a/data/json/mapgen/LIXA_mapgen.json
+++ b/data/json/mapgen/LIXA_mapgen.json
@@ -1090,7 +1090,7 @@
         { "point": "trap", "id": "tr_LIXA_back_16", "x": 21, "y": 0 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
-      "place_monster": [ { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "repeat": 2 } ]
+      "place_monster": [ { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "repeat": 2 } ]
     }
   },
   {
@@ -1160,7 +1160,7 @@
         { "point": "trap", "id": "tr_LIXA_forward_16", "x": 21, "y": 23 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
-      "place_monster": [ { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 } ]
+      "place_monster": [ { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 } ]
     }
   },
   {
@@ -1231,7 +1231,7 @@
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "terrain": { "2": [ "t_LIXA_unfolded_tube", "t_LIXA_unfolded_tube_broken" ] },
-      "place_monster": [ { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 } ]
+      "place_monster": [ { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 } ]
     }
   },
   {
@@ -1301,8 +1301,8 @@
         { "point": "trap", "id": "tr_LIXA_forward_16", "x": 21, "y": 23 }
       ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "terrain": { "2": [ "t_LIXA_unfolded_tube", "t_LIXA_unfolded_tube_broken" ] }
@@ -1375,8 +1375,8 @@
         { "point": "trap", "id": "tr_LIXA_back_16", "x": 21, "y": 0 }
       ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "terrain": {
@@ -1453,8 +1453,8 @@
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_3", "x": [ 8, 21 ], "y": [ 7, 18 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 7, 18 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_3", "x": [ 8, 21 ], "y": [ 7, 18 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 7, 18 ], "pack_size": 1 }
       ],
       "terrain": {
         "2": [ "t_LIXA_unfolded_tube", "t_LIXA_unfolded_tube_broken" ],
@@ -1529,8 +1529,8 @@
         { "point": "trap", "id": "tr_LIXA_back_16", "x": 21, "y": 0 }
       ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_3", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_1", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_3", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "terrain": {
@@ -1606,8 +1606,8 @@
         { "point": "trap", "id": "tr_LIXA_forward_16", "x": 21, "y": 23 }
       ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_4", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_2", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_4", "x": [ 8, 21 ], "y": [ 2, 21 ], "pack_size": 1 }
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "terrain": {
@@ -1757,10 +1757,10 @@
       ],
       "palettes": [ "LIXA_unfolded_palette" ],
       "place_monster": [
-        { "monster": "LIXA_eigenspectre_2", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 },
-        { "monster": "LIXA_eigenspectre_3", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_eigenspectre_4", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 },
-        { "monster": "LIXA_living_vector", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 }
+        { "monster": "mon_eigenspectre_2", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1, "repeat": 1 },
+        { "monster": "mon_eigenspectre_3", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_eigenspectre_4", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 },
+        { "monster": "mon_living_vector", "x": [ 7, 18 ], "y": [ 2, 21 ], "pack_size": 1 }
       ],
       "terrain": {
         "2": [ "t_LIXA_unfolded_tube", "t_LIXA_unfolded_tube_broken" ],

--- a/data/json/mapgen/debug_ramps.json
+++ b/data/json/mapgen/debug_ramps.json
@@ -33,9 +33,9 @@
       "terrain": { "#": "t_rock", ".": "t_grass", "<": "t_low_stairs_begin", "E": "t_low_stairs_end", "H": "t_grass", "~": "t_water_dp" },
       "furniture": { "H": "f_ladder" },
       "place_monster": [
-        { "monster": "debug_mon", "x": 1, "y": 1 },
-        { "monster": "debug_mon", "x": 3, "y": 1 },
-        { "monster": "debug_mon", "x": 5, "y": 1 }
+        { "monster": "pseudo_debug_mon", "x": 1, "y": 1 },
+        { "monster": "pseudo_debug_mon", "x": 3, "y": 1 },
+        { "monster": "pseudo_debug_mon", "x": 5, "y": 1 }
       ]
     }
   }

--- a/data/json/monsters/LIXA_monsters.json
+++ b/data/json/monsters/LIXA_monsters.json
@@ -65,7 +65,7 @@
     "base_casting_time": 100,
     "shape": "blast",
     "effect": "summon",
-    "effect_str": "LIXA_eigenspectre_3_echo"
+    "effect_str": "mon_eigenspectre_3_echo"
   },
   {
     "id": "LIXA_vector_volley",
@@ -129,7 +129,7 @@
     "effect_str": "EOC_LIXA_unfold_return"
   },
   {
-    "id": "LIXA_eigenspectre_1",
+    "id": "mon_eigenspectre_1",
     "type": "MONSTER",
     "name": { "str": "eigenspectre" },
     "description": "This is the opposite of a human silhouette; every facet of every detail on display, with no shape to make sense of them.  You can see both sides of an ID badge on a white labcoat.  You can see every muscle and nerve in eyes blown wide with horror.",
@@ -159,7 +159,7 @@
     "armor": { "electric": 1 }
   },
   {
-    "id": "LIXA_eigenspectre_2",
+    "id": "mon_eigenspectre_2",
     "type": "MONSTER",
     "name": { "str": "photonic eigenspectre" },
     "description": "The endless details of this figure are mercifully obscured by the viscous light coursing 'through' it.  It cannot contain anything, but the smears of light follow the shapes of stomach and intestines, and are splattered across what must be the lips and chin.",
@@ -214,7 +214,7 @@
     "armor": { "electric": 1 }
   },
   {
-    "id": "LIXA_eigenspectre_3",
+    "id": "mon_eigenspectre_3",
     "type": "MONSTER",
     "name": { "str": "shifting eigenspectre" },
     "description": "This distorted figure is a kaliadescope of borders.  Every part of a human, flattened into place, warps wildly from second to second.  The word your mind conjures to describe it is 'rotating', though you're not sure why.",
@@ -252,7 +252,7 @@
     "armor": { "electric": 1 }
   },
   {
-    "id": "LIXA_eigenspectre_3_echo",
+    "id": "mon_eigenspectre_3_echo",
     "type": "MONSTER",
     "name": { "str": "shifting eigenspectre" },
     "description": "This distorted figure is a kaliadescope of borders.  Every part of a human, flattened into place, warps wildly from second to second.  The word your mind conjures to describe it is 'rotating', though you're not sure why.",
@@ -291,7 +291,7 @@
     "armor": { "electric": 1 }
   },
   {
-    "id": "LIXA_eigenspectre_4",
+    "id": "mon_eigenspectre_4",
     "type": "MONSTER",
     "name": { "str": "titanic eigenspectre" },
     "description": "There is somehow more of this figure than the others.  Every side of every surface is on display, but each of those seems like the thin edge of a larger shape.  There is an eternity here, where a scientist used to be.",
@@ -326,7 +326,7 @@
     "armor": { "electric": 1 }
   },
   {
-    "id": "LIXA_living_vector",
+    "id": "mon_living_vector",
     "type": "MONSTER",
     "name": { "str": "unfolded impossibility", "str_pl": "unfolded impossibilities" },
     "description": "This is the entirety of the infinite chamber you are in, which perfectly contains itself.  If you look very closely, you might see yourself looking back.  You are sure that at any other time, seeing this would crack your brain like an eggshell.  But you understand it just fine right now.  And you can see it breathing.",

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "debug_mon",
+    "id": "pseudo_debug_mon",
     "type": "MONSTER",
     "name": { "str": "debug monster" },
     "description": "This monster exists only for testing purposes.",
@@ -136,7 +136,7 @@
     ]
   },
   {
-    "id": "weakpoint_mon",
+    "id": "pseudo_weakpoint_mon",
     "type": "MONSTER",
     "name": { "str": "weakpoint monster" },
     "description": "This monster exists only for weakpoint testing purposes.",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -191,11 +191,11 @@ static const material_id material_wool( "wool" );
 
 static const morale_type morale_null( "morale_null" );
 
-static const mtype_id debug_mon( "debug_mon" );
 static const mtype_id mon_human( "mon_human" );
 static const mtype_id mon_zombie_smoker( "mon_zombie_smoker" );
 static const mtype_id mon_zombie_soldier( "mon_zombie_soldier" );
 static const mtype_id mon_zombie_survivor( "mon_zombie_survivor" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static const quality_id qual_BOIL( "BOIL" );
 static const quality_id qual_JACK( "JACK" );
@@ -2341,7 +2341,7 @@ struct dps_comp_data {
 };
 
 static const std::vector<std::pair<translation, dps_comp_data>> dps_comp_monsters = {
-    { to_translation( "Best" ), { debug_mon, true, false } },
+    { to_translation( "Best" ), { pseudo_debug_mon, true, false } },
     { to_translation( "Vs. Agile" ), { mon_zombie_smoker, true, true } },
     { to_translation( "Vs. Armored" ), { mon_zombie_soldier, true, true } },
     { to_translation( "Vs. Mixed" ), { mon_zombie_survivor, false, true } },

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1601,6 +1601,13 @@ void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::stri
 void MonsterGenerator::check_monster_definitions() const
 {
     for( const mtype &mon : mon_templates->get_all() ) {
+        if( !mon.src.empty() && mon.src.back().second.str() == "dda" ) {
+            std::string mon_id = mon.id.str();
+            std::string suffix_id = mon_id.substr( 0, mon_id.find( '_' ) );
+            if( suffix_id != "mon" && suffix_id != "pseudo" ) {
+                debugmsg( "monster %s is missing mon_ (or pseudo_) prefix from id", mon.id.c_str() );
+            }
+        }
         if( mon.harvest.is_null() && !mon.has_flag( mon_flag_ELECTRONIC ) && !mon.id.is_null() ) {
             debugmsg( "monster %s has no harvest entry", mon.id.c_str(), mon.harvest.c_str() );
         }

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -34,7 +34,7 @@ static const efftype_id effect_test_fatalism( "test_fatalism" );
 static const efftype_id effect_test_int_remove( "test_int_remove" );
 static const efftype_id effect_test_vitamineff( "test_vitamineff" );
 
-static const mtype_id debug_mon( "debug_mon" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static const vitamin_id vitamin_test_vitv( "test_vitv" );
 static const vitamin_id vitamin_test_vitx( "test_vitx" );
@@ -736,7 +736,7 @@ static void test_deadliness( const effect &applied, const int expected_dead, con
         for( int j = 0; j < 10; ++j ) {
             tripoint cursor( i + 20, j + 20, 0 );
 
-            mons.push_back( g->place_critter_at( debug_mon, cursor ) );
+            mons.push_back( g->place_critter_at( pseudo_debug_mon, cursor ) );
             // make sure they're there!
             CHECK( creatures.creature_at<Creature>( cursor ) != nullptr );
         }

--- a/tests/effective_dps_test.cpp
+++ b/tests/effective_dps_test.cpp
@@ -13,10 +13,10 @@
 #include "test_data.h"
 #include "type_id.h"
 
-static const mtype_id debug_mon( "debug_mon" );
 static const mtype_id mon_zombie_smoker( "mon_zombie_smoker" );
 static const mtype_id mon_zombie_soldier_no_weakpoints( "mon_zombie_soldier_no_weakpoints" );
 static const mtype_id mon_zombie_survivor_no_weakpoints( "mon_zombie_survivor_no_weakpoints" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_cutting( "cutting" );
@@ -121,7 +121,7 @@ TEST_CASE( "effective_damage_per_second", "[effective][dps]" )
     item good_sword( "test_balanced_sword" );
 
     SECTION( "against a debug monster with no armor or dodge" ) {
-        monster mummy( debug_mon );
+        monster mummy( pseudo_debug_mon );
 
         CHECK( clumsy_sword.effective_dps( dummy, mummy ) == Approx( 25.0f ).epsilon( 0.15f ) );
         CHECK( good_sword.effective_dps( dummy, mummy ) == Approx( 38.0f ).epsilon( 0.15f ) );
@@ -143,7 +143,7 @@ TEST_CASE( "effective_damage_per_second", "[effective][dps]" )
     }
 
     SECTION( "effect of STR and DEX on damage per second" ) {
-        monster mummy( debug_mon );
+        monster mummy( pseudo_debug_mon );
 
         SECTION( "STR 6, DEX 6" ) {
             dummy.str_max = 6;

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -22,10 +22,10 @@ static const efftype_id effect_sleep( "sleep" );
 
 static const move_mode_id move_mode_prone( "prone" );
 
-static const mtype_id debug_mon( "debug_mon" );
 static const mtype_id mon_manhack( "mon_manhack" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id mon_zombie_hulk( "mon_zombie_hulk" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static const skill_id skill_melee( "melee" );
 
@@ -290,7 +290,7 @@ TEST_CASE( "Incapacited_character_can_not_dodge" )
 TEST_CASE( "Melee_skill_training_caps", "[melee], [melee_training_cap], [skill]" )
 {
     standard_npc dude( "TestCharacter", dude_pos, {} );
-    monster dummy_1( debug_mon );
+    monster dummy_1( pseudo_debug_mon );
     monster zed( mon_zombie );
     SkillLevel &level = dude.get_skill_level_object( skill_melee );
     REQUIRE( level.knowledgeLevel() == 4 );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -302,6 +302,19 @@ static void monster_check()
     CHECK( can_catch_player( "mon_zombie_dog", tripoint_south_east ) > 0 );
 }
 
+TEST_CASE( "check_mon_id" )
+{
+    for( const mtype &mon : MonsterGenerator::generator().get_all_mtypes() ) {
+        if( !mon.src.empty() && mon.src.back().second.str() != "dda" ) {
+            continue;
+        }
+        std::string mon_id = mon.id.str();
+        std::string suffix_id = mon_id.substr( 0, mon_id.find( '_' ) );
+        INFO( "Now checking the id of " << mon.id.str() );
+        CHECK( ( suffix_id == "mon"  || suffix_id == "pseudo" ) );
+    }
+}
+
 // Write out a map of slope at which monster is moving to time required to reach their destination.
 TEST_CASE( "write_slope_to_speed_map_trig", "[.]" )
 {

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -25,7 +25,7 @@
 #include "vpart_position.h"
 #include "vpart_range.h"
 
-static const mtype_id debug_mon( "debug_mon" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up )
 {
@@ -292,7 +292,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
         CAPTURE( existing_creature->is_monster() );
         REQUIRE( !existing_creature );
     }
-    monster *dmon_p = g->place_critter_at( debug_mon, map_starting_point );
+    monster *dmon_p = g->place_critter_at( pseudo_debug_mon, map_starting_point );
     REQUIRE( dmon_p );
     monster &dmon = *dmon_p;
 

--- a/tests/weakpoint_test.cpp
+++ b/tests/weakpoint_test.cpp
@@ -15,10 +15,10 @@ static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
 static const damage_type_id damage_cut( "cut" );
 
-static const mtype_id debug_mon( "debug_mon" );
 static const mtype_id mon_test_weakpoint_mon( "mon_test_weakpoint_mon" );
 static const mtype_id mon_test_zombie_cop( "mon_test_zombie_cop" );
 static const mtype_id mon_zombie( "mon_zombie" );
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 
 struct weakpoint_report_item {
     std::string weakpoint;
@@ -88,7 +88,7 @@ TEST_CASE( "weakpoint_basic", "[monster][weakpoint]" )
 {
     constexpr float epsilon = 0.225f;
     // Debug Monster has two weakpoints at 25% each, one leaves 0 armor the other 25 bullet armor, down from 100 bullet armor
-    weakpoint_report wr1 = damage_monster( debug_mon, damage_instance( damage_bullet, 100.0f,
+    weakpoint_report wr1 = damage_monster( pseudo_debug_mon, damage_instance( damage_bullet, 100.0f,
                                            0.0f ), 1000 );
     CHECK( wr1.PercHits( "the knee" ) == Approx( 0.25f ).epsilon( epsilon ) );
     CHECK( wr1.AveDam( "the knee" ) == Approx( 75.0f ).epsilon( epsilon ) ); // 25 armor
@@ -98,7 +98,7 @@ TEST_CASE( "weakpoint_basic", "[monster][weakpoint]" )
     CHECK( wr1.AveDam( "" ) == Approx( 0.0f ).epsilon( epsilon ) ); // Full 100 armor
 
     // With 25 ap, adjust no weakpoint and the knee damage
-    weakpoint_report wr2 = damage_monster( debug_mon, damage_instance( damage_bullet, 100.0f,
+    weakpoint_report wr2 = damage_monster( pseudo_debug_mon, damage_instance( damage_bullet, 100.0f,
                                            25.0f ), 1000 );
     CHECK( wr2.PercHits( "the knee" ) == Approx( 0.25f ).epsilon( epsilon ) );
     CHECK( wr2.AveDam( "the knee" ) == Approx( 100.0f ).epsilon( epsilon ) ); // 25 armor with 25 ap
@@ -108,7 +108,7 @@ TEST_CASE( "weakpoint_basic", "[monster][weakpoint]" )
     CHECK( wr2.AveDam( "" ) == Approx( 25.0f ).epsilon( epsilon ) ); // Full 100 armor with 25 ap
 
     // No cut armordebug_mon
-    weakpoint_report wr3 = damage_monster( debug_mon, damage_instance( damage_cut, 100.0f,
+    weakpoint_report wr3 = damage_monster( pseudo_debug_mon, damage_instance( damage_cut, 100.0f,
                                            0.0f ), 1000 );
     CHECK( wr3.PercHits( "the knee" ) == Approx( 0.25f ).epsilon( epsilon ) );
     CHECK( wr3.AveDam( "the knee" ) == Approx( 100.0f ).epsilon( epsilon ) );
@@ -121,7 +121,7 @@ TEST_CASE( "weakpoint_basic", "[monster][weakpoint]" )
 TEST_CASE( "weakpoint_practice", "[monster][weakpoint]" )
 {
     avatar &dummy = get_avatar();
-    mtype_id wp_mon( "weakpoint_mon" );
+    mtype_id wp_mon( "pseudo_weakpoint_mon" );
     proficiency_id prof( "prof_debug_weakpoint" );
     clear_character( dummy );
 


### PR DESCRIPTION
#### Summary
All monsters must have mon_ or pseudo_ before their ID. This is not actually important for code reasons, it's just useful for organization.

Two files were not backported: One for magiclysm, and one for portal storm EOCs, since we have neither.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
