### PR TITLE
add rocky soil and mx_rock_formation

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -14,6 +14,18 @@
   },
   {
     "type": "terrain",
+    "id": "t_dirt_rocky",
+    "name": "rocky soil",
+    "description": "Many stones are protruding from beneath the ground.  This will not be good farmland.",
+    "symbol": ".",
+    "color": "light_gray",
+    "looks_like": "t_railroad_rubble",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+  },
+  {
+    "type": "terrain",
     "id": "t_forestfloor",
     "name": "forest floor",
     "description": "Covered in twigs and lots of brown, decaying leaves.",

--- a/data/json/mapgen/map_extras/rock_formation.json
+++ b/data/json/mapgen/map_extras/rock_formation.json
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_rock_formation",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "         --             ",
+        "        -#-             ",
+        "       --#-    ----     ",
+        "      --##-------#---   ",
+        "     --############--   ",
+        "    ----#--- --####--   ",
+        "       ---  --##-----   ",
+        "             ----       ",
+        "              - -       ",
+        "                -       ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "-": [ [ "t_dirt_rocky", 5 ], "t_moss" ], "#": [ [ "t_dirt_rocky", 5 ], "t_moss" ] },
+      "furniture": {
+        "-": [ [ "f_rubble_rock", 5 ], "f_boulder_small", [ "f_null", 10 ] ],
+        "#": [ "f_boulder_small", "f_boulder_medium", "f_boulder_large", "f_rubble_rock" ]
+      }
+    }
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -557,6 +557,15 @@
     "flags": [ "MAN_MADE" ]
   },
   {
+    "id": "mx_rock_formation",
+    "type": "map_extra",
+    "name": { "str": "Rock formation" },
+    "description": "Rocky ground and some boulders.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_rock_formation" },
+    "sym": ".",
+    "color": "light_gray"
+  },
+  {
     "id": "mx_toxic_waste",
     "type": "map_extra",
     "name": { "str": "Toxic waste" },

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -29,13 +29,13 @@
     "//": "Weights are set high in order to allow mods to add rare terrains.",
     "region_terrain_and_furniture": {
       "terrain": {
-        "t_region_groundcover": { "t_grass": 12000, "t_grass_dead": 4000, "t_grass_long": 200, "t_dirt": 2000 },
-        "t_region_groundcover_urban": { "t_grass": 20, "t_grass_dead": 6, "t_grass_long": 3, "t_dirt": 1 },
-        "t_region_groundcover_forest": { "t_forestfloor": 20, "t_grass": 1, "t_grass_long": 1, "t_moss": 1, "t_grass_dead": 4 },
-        "t_region_groundcover_swamp": { "t_grass_long": 300, "t_moss": 200, "t_dirt": 200, "t_grass_dead": 110 },
-        "t_region_groundcover_barren": { "t_dirt": 30, "t_grass_dead": 2, "t_railroad_rubble": 1 },
+        "t_region_groundcover": { "t_grass": 12000, "t_grass_dead": 4000, "t_grass_long": 200, "t_dirt": 2000, "t_dirt_rocky": 150 },
+        "t_region_groundcover_urban": { "t_grass": 20, "t_grass_dead": 6, "t_grass_long": 3, "t_dirt": 1, "t_dirt_rocky": 5 },
+        "t_region_groundcover_forest": { "t_forestfloor": 20, "t_grass": 1, "t_grass_long": 1, "t_moss": 1, "t_grass_dead": 4, "t_dirt_rocky": 1 },
+        "t_region_groundcover_swamp": { "t_grass_long": 300, "t_moss": 200, "t_dirt": 200, "t_grass_dead": 110, "t_dirt_rocky": 5 },
+        "t_region_groundcover_barren": { "t_dirt": 30, "t_grass_dead": 2, "t_railroad_rubble": 1, "t_dirt_rocky": 20 },
         "t_region_grass": { "t_grass": 18, "t_grass_dead": 10, "t_grass_long": 3, "t_dirt": 2 },
-        "t_region_soil": { "t_dirt": 1 },
+        "t_region_soil": { "t_dirt": 7, "t_dirt_rocky": 3 },
         "t_region_shrub_forest_dense": {
           "t_underbrush": 30,
           "t_shrub": 30,
@@ -551,6 +551,7 @@
           "mx_point_burned_ground": 500,
           "mx_poison_ivy_patch": 2000,
           "mx_grove": 500,
+          "mx_rock_formation": 500,
           "mx_shrubbery": 500,
           "mx_spider": 200,
           "mx_clearcut": 125,
@@ -579,11 +580,12 @@
         }
       },
       "forest_thick": {
-        "chance": 30,
+        "chance": 40,
         "extras": {
           "mx_blackberry_patch": 800,
           "mx_grove": 500,
           "mx_shrubbery": 500,
+          "mx_rock_formation": 500,
           "mx_point_dead_vegetation": 800,
           "mx_poison_ivy_patch": 2000,
           "mx_point_burned_ground": 500,
@@ -625,6 +627,7 @@
           "mx_knotweed_patch": 140,
           "mx_nest_dermatik": 75,
           "mx_point_dead_vegetation": 60,
+          "mx_rock_formation": 50,
           "mx_science": 15,
           "mx_military": 25,
           "mx_crater": 20,
@@ -647,6 +650,7 @@
           "mx_grass": 3500,
           "mx_grass2": 3500,
           "mx_trees2": 800,
+          "mx_rock_formation": 500,
           "mx_point_burned_ground": 500,
           "mx_point_dead_vegetation": 1000,
           "mx_poison_ivy_patch": 100,


### PR DESCRIPTION
#### Summary

![image](https://github.com/user-attachments/assets/56c2e955-acbb-4b62-a9ae-6de35e41ee7b)

![image](https://github.com/user-attachments/assets/0ae2456e-25c3-45d8-ae9d-3e7137e4b357)

#### Purpose of change

Variation in terrain.

#### Describe the solution

- Add rock formation map extra
- Add rocky soil to go with it, which spawns everywhere now (see below) and needs to be dug out and filled with dirt to be farmable.
- Slightly up map extra chance for thick forest because the weighted list is overloaded. Some of this badly needs to be overmap terrain instead.

All of these gray tiles are rocky ground.

![image](https://github.com/user-attachments/assets/8c94104e-50ef-4cf5-8b68-d378c102002d)

#### Describe alternatives you've considered

#### Testing

Applied locally.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
