### PR TITLE
Minor Helmet Encumbrance Fixes

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -334,10 +334,10 @@
     "looks_like": "helmet_motor",
     "color": "dark_gray",
     "armor": [
-      { "covers": [ "head" ], "coverage": 100, "encumbrance": 28,
+      { "covers": [ "head" ], "coverage": 100, "encumbrance": 42,
       "rigid_layer_only": true },
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 12 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 6 }
+      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 36 },
+      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 12 }
     ],
     "warmth": 25,
     "material_thickness": 8,
@@ -685,7 +685,7 @@
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_forehead", "head_ear_l", "head_ear_r" ],
         "coverage": 95,
-        "encumbrance": 24,
+        "encumbrance": 32,
         "rigid_layer_only": true
       },
       {
@@ -700,11 +700,11 @@
         "rigid_layer_only": true,
         "specifically_covers": [ "mouth_cheeks", "mouth_chin" ],
         "coverage": 95,
-        "encumbrance": 3
+        "encumbrance": 10
       },
       { "covers": [ "head" ], "specifically_covers": [ "head_nape", "head_throat" ], "coverage": 60,
       "rigid_layer_only": true },
-      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 60, "encumbrance": 8 }
+      { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 60, "encumbrance": 12 }
     ],
     "warmth": 5,
     "material_thickness": 4,
@@ -749,7 +749,7 @@
     "flags": [ "VARSIZE", "STURDY", "OUTER", "NORMAL", "PADDED" ],
     "armor": [
       {
-        "encumbrance": 52,
+        "encumbrance": 48,
         "coverage": 100,
         "covers": [ "head" ],
         "specifically_covers": [ "head_forehead", "head_crown", "head_ear_l", "head_ear_r" ],
@@ -1008,7 +1008,7 @@
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "STURDY", "OUTER" ],
     "armor": [
       {
-        "encumbrance": 44,
+        "encumbrance": 32,
         "coverage": 100,
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r" ],
@@ -1050,7 +1050,7 @@
     "flags": [ "WATER_FRIENDLY", "OUTER", "BELTED" ],
     "armor": [
       {
-        "encumbrance": 18,
+        "encumbrance": 26,
         "coverage": 100,
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown" ],
@@ -1277,7 +1277,7 @@
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 }
         ],
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 18,
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown" ],
         "coverage": 100,
@@ -1289,7 +1289,7 @@
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 14 }
         ],
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 0,
         "covers": [ "head" ],
         "specifically_covers": [ "head_forehead" ],
         "coverage": 90,
@@ -1329,21 +1329,21 @@
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_forehead" ],
         "coverage": 100,
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 24,
         "rigid_layer_only": true
       },
       {
         "covers": [ "head" ],
         "specifically_covers": [ "head_ear_l", "head_ear_r" ],
         "coverage": 20,
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 24,
         "rigid_layer_only": true
       },
       {
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_nose" ],
         "coverage": 90,
-        "encumbrance": 0,
+        "encumbrance": 15,
         "rigid_layer_only": true
       }
     ],
@@ -1811,7 +1811,7 @@
   {
     "id": "platemail_visored_helm_xl_raised",
     "type": "ARMOR",
-    "name": { "str": "XL visored plate helm (raised)", "str_pl": "XL visored plate helm (raised)" },
+    "name": { "str": "visored plate helm (raised)", "str_pl": "visored plate helm (raised)" },
     "copy-from": "platemail_visored_helm_raised",
     "use_action": {
       "type": "transform",
@@ -1846,7 +1846,7 @@
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.5 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 6 }
         ],
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 9,
         "coverage": 100,
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_forehead" ],
@@ -1857,7 +1857,7 @@
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.5 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 6 }
         ],
-        "encumbrance_modifiers": [ "NONE" ],
+        "encumbrance": 9,
         "coverage": 50,
         "covers": [ "head" ],
         "specifically_covers": [ "head_ear_l", "head_ear_r" ],


### PR DESCRIPTION
#### Summary
Minor fixes to helmet encumbrance

#### Purpose of change
Following #259 , a few helmets had really wonky encumbrance values. These still need a full audit, but for now these temporary fixes put things in line with more or less what they were.

#### Describe the solution
Manually adjust some enc values.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
