### PR TITLE
More armor rigidity updates

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -26,7 +26,8 @@
         "cover_melee": 80,
         "cover_ranged": 80,
         "cover_vitals": 0,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -121,7 +122,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 4,
         "coverage": 90,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -171,7 +173,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "pair of cloth-padded sleeves", "str_pl": "pairs of cloth-padded sleeves" },
-    "description": "The sleeves of a thick cotton shirt, with a bunch of cloth sewn in to act as extra padding.  They're quite lonely, no longer being attached to each other by the rest of the shirt.",
+    "description": "The sleeves of a thick cotton shirt, with a bunch of cloth sewn in to act as extra padding.",
     "weight": "400 g",
     "volume": "1500 ml",
     "price_postapoc": 100,
@@ -189,7 +191,7 @@
         ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": 8
+        "encumbrance": 16
       }
     ],
     "warmth": 35,
@@ -225,7 +227,8 @@
           { "type": "plastic", "covered_by_mat": 90, "thickness": 1.5 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 100
+        "coverage": 100,
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -234,7 +237,8 @@
           { "type": "plastic", "covered_by_mat": 50, "thickness": 1.5 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 100
+        "coverage": 100,
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -243,7 +247,8 @@
           { "type": "plastic", "covered_by_mat": 90, "thickness": 1.5 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 80
+        "coverage": 80,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -281,7 +286,6 @@
     "color": "brown",
     "warmth": 25,
     "material_thickness": 4,
-    "valid_mods": [ "steel_padded" ],
     "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -331,7 +335,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 4,
         "coverage": 80,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -358,7 +363,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 4,
         "coverage": 80,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -404,7 +410,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 6,
         "coverage": 75,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 1, "cut": 1 }
@@ -448,7 +455,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 14,
         "coverage": 80,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -531,7 +539,6 @@
     "color": "light_gray",
     "warmth": 50,
     "material_thickness": 5,
-    "valid_mods": [ "steel_padded" ],
     "flags": [ "VARSIZE", "STURDY" ],
     "armor": [ { "encumbrance": 20, "coverage": 100, "covers": [ "arm_l", "arm_r" ] } ]
   },
@@ -729,7 +736,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_elbow_r" ],
         "coverage": 100,
-        "encumbrance": 3
+        "encumbrance": 3,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -756,7 +764,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 5,
         "coverage": 95,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -859,7 +868,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l", "arm_upper_r", "arm_upper_l" ],
         "coverage": 85,
-        "encumbrance": 10
+        "encumbrance": 10,
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 4 }
@@ -906,7 +916,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "encumbrance": 10
+        "encumbrance": 10,
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 4 }
@@ -953,7 +964,8 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "encumbrance": 6
+        "encumbrance": 6,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -1000,7 +1012,8 @@
           { "type": "thermo_resin", "covered_by_mat": 90, "thickness": 1.75 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 5 }
         ],
-        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_elbow_l", "arm_elbow_r" ]
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_elbow_l", "arm_elbow_r" ],
+        "rigid_layer_only": true
       }
     ]
   }

--- a/data/json/items/armor/brigandine.json
+++ b/data/json/items/armor/brigandine.json
@@ -25,7 +25,8 @@
         ],
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 12
+        "encumbrance": 12,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -75,7 +76,8 @@
         "cover_melee": 100,
         "cover_ranged": 100,
         "cover_vitals": 90,
-        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ]
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -124,7 +126,8 @@
         "cover_melee": 100,
         "cover_ranged": 100,
         "cover_vitals": 90,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_upper_r", "leg_upper_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_upper_r", "leg_upper_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -169,7 +172,8 @@
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r" ],
         "coverage": 100,
-        "encumbrance": 12
+        "encumbrance": 12,
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -179,7 +183,8 @@
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r", "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 100,
-        "encumbrance": 0
+        "encumbrance": 0,
+        "rigid_layer_only": true
       }
     ]
   },

--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -35,7 +35,7 @@
     "color": "light_gray",
     "material_thickness": 1,
     "flags": [ "WATER_FRIENDLY", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 30, "coverage": 50, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 30, "coverage": 50, "covers": [ "eyes" ] } ]
   },
   {
     "id": "fancy_sunglasses",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -133,13 +133,15 @@
         "encumbrance": 7,
         "coverage": 95,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r" ]
+        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r" ],
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 7,
         "coverage": 70,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_palm_l", "hand_palm_r" ]
+        "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 2 }
@@ -147,18 +149,18 @@
   {
     "id": "platemail_gauntlets_xl",
     "type": "ARMOR",
-    "name": { "str": "pair of XL plate gauntlets", "str_pl": "pairs of XL plate gauntlets" },
+    "name": { "str": "pair of plate gauntlets", "str_pl": "pairs of plate gauntlets" },
     "copy-from": "platemail_gauntlets",
     "proportional": { "weight": 1.5, "volume": 1.5 },
-    "extend": { "flags": [ "OVERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "platemail_gauntlets_xs",
     "type": "ARMOR",
     "copy-from": "platemail_gauntlets",
-    "name": { "str": "pair of XS plate gauntlets", "str_pl": "pairs of XS plate gauntlets" },
+    "name": { "str": "pair of plate gauntlets", "str_pl": "pairs of plate gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "gauntlets_chitin",
@@ -183,12 +185,14 @@
         "encumbrance": 12,
         "coverage": 95,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r", "hand_palm_l", "hand_palm_r" ]
+        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r", "hand_palm_l", "hand_palm_r" ],
+        "rigid_layer_only": true
       },
       {
         "coverage": 50,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 2 }
@@ -316,19 +320,22 @@
         "encumbrance": 8,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_palm_l", "hand_palm_r", "hand_back_l", "hand_back_r" ]
+        "specifically_covers": [ "hand_palm_l", "hand_palm_r", "hand_back_l", "hand_back_r" ],
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 0,
         "coverage": 98,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
+        "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ],
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 0,
         "coverage": 50,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 1 }
@@ -424,7 +431,8 @@
         "material": [
           { "type": "steel", "covered_by_mat": 100, "thickness": 0.4 },
           { "type": "leather", "covered_by_mat": 80, "thickness": 0.5 }
-        ]
+        ],
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 3,

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -22,7 +22,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 8,
         "coverage": 60,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -117,7 +118,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 2,
         "coverage": 90,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -257,13 +259,6 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
         "coverage": 100,
-        "encumbrance": 2
-      },
-      {
-        "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_ankle_l", "foot_ankle_r" ],
-        "coverage": 60,
         "encumbrance": 2
       }
     ]
@@ -535,7 +530,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],
         "coverage": 100,
-        "encumbrance": 3
+        "encumbrance": 3,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -562,7 +558,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 5,
         "coverage": 90,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -610,7 +607,8 @@
           { "type": "plastic", "covered_by_mat": 90, "thickness": 1.5 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 100
+        "coverage": 100,
+        "rigid_layer_only": true
       },
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -619,7 +617,8 @@
           { "type": "plastic", "covered_by_mat": 60, "thickness": 1.5 },
           { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 100
+        "coverage": 100,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -653,14 +652,16 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 80,
-        "encumbrance": 4
+        "encumbrance": 4,
+        "rigid_layer_only": true
       },
       {
         "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 60,
-        "encumbrance": 5
+        "encumbrance": 5,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -766,14 +767,16 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 90,
-        "encumbrance": 2
+        "encumbrance": 2,
+        "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 70,
-        "encumbrance": 3
+        "encumbrance": 3,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -781,7 +784,7 @@
     "id": "platemail_tasset_xs",
     "type": "ARMOR",
     "copy-from": "platemail_tasset",
-    "name": { "str": "XS plate tasset" },
+    "name": { "str": "plate tasset" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "use_action": {
       "type": "transform",
@@ -789,13 +792,13 @@
       "target": "platemail_tasset_loose_xs",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "platemail_tasset_xl",
     "type": "ARMOR",
     "copy-from": "platemail_tasset",
-    "name": { "str": "XL plate tasset" },
+    "name": { "str": "plate tasset" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "use_action": {
       "type": "transform",
@@ -803,7 +806,7 @@
       "target": "platemail_tasset_loose_xl",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "platemail_tasset_loose",
@@ -825,7 +828,7 @@
     "id": "platemail_tasset_loose_xs",
     "type": "ARMOR",
     "copy-from": "platemail_tasset_loose",
-    "name": { "str": "XS plate tasset (loose)" },
+    "name": { "str": "plate tasset (loose)" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "use_action": {
       "type": "transform",
@@ -833,13 +836,13 @@
       "target": "platemail_tasset_xs",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "platemail_tasset_loose_xl",
     "type": "ARMOR",
     "copy-from": "platemail_tasset_loose",
-    "name": { "str": "XL plate tasset (loose)" },
+    "name": { "str": "plate tasset (loose)" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "use_action": {
       "type": "transform",
@@ -847,7 +850,7 @@
       "target": "platemail_tasset_xl",
       "menu_text": "Loosen"
     },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "platemail_leg_guards",
@@ -919,7 +922,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 4,
         "coverage": 80,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -946,7 +950,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 6,
         "coverage": 80,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -1200,14 +1205,17 @@
           { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.75 },
           { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 5 }
         ],
-        "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_lower_l", "leg_lower_r" ]
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r", "leg_lower_l", "leg_lower_r" ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "encumbrance": 2,
         "coverage": 75,
         "material": [ { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.5 } ],
-        "specifically_covers": [ "foot_arch_l", "foot_arch_r", "foot_ankle_r", "foot_ankle_l" ]
+        "specifically_covers": [ "foot_arch_l", "foot_arch_r", "foot_ankle_r", "foot_ankle_l" ],
+        "layers": [ "BELTED" ],
+        "rigid_layer_only": true
       }
     ]
   },

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -224,7 +224,8 @@
     "material_thickness": 2,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes", "mouth" ] } ]
+    "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes", "mouth" ],
+    "rigid_layer_only": true } ]
   },
   {
     "id": "mask_rioter",
@@ -385,14 +386,14 @@
       {
         "id": "zombie_mask",
         "name": { "str": "zombie mask" },
-        "description": "A flimsy leather zombie mask.  When zombies were still works of fiction.",
+        "description": "A flimsy rubber zombie mask.  It can't compare to the real thing.",
         "weight": 100
       },
       {
         "id": "chicken_mask",
         "name": { "str": "chicken mask" },
         "color": "light_gray",
-        "description": "A chicken mask that looks like a killer in Miami would wear.",
+        "description": "A rubber chicken mask that looks like a killer in Miami would wear.",
         "weight": 30
       },
       {
@@ -417,14 +418,14 @@
       },
       {
         "id": "scream_mask",
-        "name": { "str": "Scream mask" },
+        "name": { "str": "screaming mask" },
         "color": "dark_gray",
-        "description": "A white mask with a screaming face on it, much like the mask Ghostface wore in Scream, black hood included.",
+        "description": "A black hood with a white facemask molded to look like a screaming phantom.",
         "weight": 41
       },
       {
         "id": "president_mask",
-        "name": { "str": "President mask" },
+        "name": { "str": "president mask" },
         "description": "A full-head mask that looks like one of the former leaders of the USA, back when that was a thing.",
         "weight": 41
       },

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -20,10 +20,13 @@
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 22,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 6.5 } ]
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 6.5 } ],
+        "rigid_layer_only": true
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 18 },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 18 }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 18,
+      "rigid_layer_only": true },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 18,
+      "rigid_layer_only": true }
     ],
     "warmth": 20,
     "material_thickness": 6,
@@ -55,7 +58,8 @@
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 90,
         "encumbrance": [ 5, 5 ],
-        "specifically_covers": [ "leg_upper_r", "leg_upper_l", "leg_hip_r", "leg_hip_l" ]
+        "specifically_covers": [ "leg_upper_r", "leg_upper_l", "leg_hip_r", "leg_hip_l" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 2 }
@@ -291,7 +295,8 @@
     "longest_side": "60 cm",
     "material_thickness": 1.6,
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
-    "armor": [ { "encumbrance": 35, "coverage": 95, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ] } ],
+    "armor": [ { "encumbrance": 35, "coverage": 95, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+    "rigid_layer_only": true } ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -318,31 +323,36 @@
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 20
+        "encumbrance": 20,
+        "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
-        "encumbrance": 10
+        "encumbrance": 10,
+        "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
-        "encumbrance": 10
+        "encumbrance": 10,
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 7,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r" ]
+        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r" ],
+        "rigid_layer_only": true
       },
       {
         "encumbrance": 7,
         "coverage": 70,
         "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_palm_l", "hand_palm_r" ]
+        "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -480,7 +490,8 @@
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 6 } ],
         "coverage": 100,
-        "layers": [ "OUTER", "NORMAL" ]
+        "layers": [ "OUTER", "NORMAL" ],
+        "rigid_layer_only": true
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -512,7 +523,7 @@
     "price": 110000,
     "price_postapoc": 3000,
     "to_hit": -5,
-    "material": [ "leather", "steel" ],
+    "material": [ "steel", "leather" ],
     "symbol": "[",
     "color": "brown",
     "longest_side": "60 cm",
@@ -523,19 +534,21 @@
         "coverage": 95,
         "encumbrance": 22,
         "material": [
-          { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 0.9 }
-        ]
+          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 0.9 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 4 }
+        ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 90,
         "encumbrance": 22,
         "material": [
-          { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 0.9 }
+          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 0.9 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 4 }
         ],
-        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_upper_r", "arm_upper_l" ]
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_upper_r", "arm_upper_l" ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -611,7 +624,8 @@
         "material": [
           { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 2 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 7 }
-        ]
+        ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
@@ -631,7 +645,8 @@
           "arm_shoulder_r",
           "leg_hip_l",
           "leg_hip_r"
-        ]
+        ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
@@ -642,7 +657,8 @@
           { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.75 },
           { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 5 }
         ],
-        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "leg_lower_l", "leg_lower_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "arm_lower_l", "arm_lower_r", "leg_lower_l", "leg_lower_r", "leg_knee_l", "leg_knee_r" ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "foot_l", "foot_r" ],
@@ -650,7 +666,8 @@
         "encumbrance": 5,
         "coverage": 75,
         "material": [ { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.5 } ],
-        "specifically_covers": [ "foot_arch_l", "foot_arch_r", "foot_ankle_r", "foot_ankle_l" ]
+        "specifically_covers": [ "foot_arch_l", "foot_arch_r", "foot_ankle_r", "foot_ankle_l" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -672,7 +689,8 @@
     "longest_side": "60 cm",
     "material_thickness": 4,
     "flags": [ "VARSIZE", "STURDY", "OUTER" ],
-    "armor": [ { "encumbrance": 15, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
+    "armor": [ { "encumbrance": 15, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
+    "rigid_layer_only": true } ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -694,7 +712,8 @@
     "longest_side": "40 cm",
     "material_thickness": 4,
     "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 18, "coverage": 80, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ] } ]
+    "armor": [ { "encumbrance": 18, "coverage": 80, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+    "rigid_layer_only": true } ]
   },
   {
     "id": "beekeeping_suit",
@@ -984,14 +1003,6 @@
         "coverage": 98,
         "encumbrance": 9,
         "rigid_layer_only": true
-      },
-      {
-        "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_ankle_l", "foot_ankle_r" ],
-        "coverage": 60,
-        "encumbrance": 2,
-        "rigid_layer_only": true
       }
     ]
   },
@@ -1115,7 +1126,6 @@
       },
       {
         "material": [
-          { "type": "steel_chain", "covered_by_mat": 60, "thickness": 1.2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "foot_l", "foot_r" ],

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -881,8 +881,7 @@
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 17,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 } ],
-        "rigid_layer_only": true
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 } ]
       }
     ],
     "warmth": 25,


### PR DESCRIPTION
#### Summary
Continue enforcing rigidity for hard armor

#### Purpose of change
Continuing #259 which only touched on torso and head armor.

#### Describe the solution
- Finish going through and enforcing rigidity for most of the hard armor in the game. 
- Fix a few remaining encumbrance bugs.
- Remove ankle protection from chainmail chausses - chausses often cover parts of the feet IRL, but even without them being rigid, it winds up being impossible to match them properly with most shoes. The foot protection was not really important anyway.

#### Testing
Loaded in and put stuff on. Looked good.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->