### PR TITLE
Add stat descriptors and raise chargen max

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -224,8 +224,7 @@
     "material_thickness": 2,
     "environmental_protection": 1,
     "flags": [ "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes", "mouth" ],
-    "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes", "mouth" ], "rigid_layer_only": true } ]
   },
   {
     "id": "mask_rioter",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -23,10 +23,8 @@
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 6.5 } ],
         "rigid_layer_only": true
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 18,
-      "rigid_layer_only": true },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 18,
-      "rigid_layer_only": true }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 18, "rigid_layer_only": true },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 18, "rigid_layer_only": true }
     ],
     "warmth": 20,
     "material_thickness": 6,
@@ -295,8 +293,14 @@
     "longest_side": "60 cm",
     "material_thickness": 1.6,
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
-    "armor": [ { "encumbrance": 35, "coverage": 95, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "rigid_layer_only": true } ],
+    "armor": [
+      {
+        "encumbrance": 35,
+        "coverage": 95,
+        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "rigid_layer_only": true
+      }
+    ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -689,8 +693,14 @@
     "longest_side": "60 cm",
     "material_thickness": 4,
     "flags": [ "VARSIZE", "STURDY", "OUTER" ],
-    "armor": [ { "encumbrance": 15, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
-    "rigid_layer_only": true } ],
+    "armor": [
+      {
+        "encumbrance": 15,
+        "coverage": 85,
+        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
+        "rigid_layer_only": true
+      }
+    ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -712,8 +722,14 @@
     "longest_side": "40 cm",
     "material_thickness": 4,
     "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 18, "coverage": 80, "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
-    "rigid_layer_only": true } ]
+    "armor": [
+      {
+        "encumbrance": 18,
+        "coverage": 80,
+        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "rigid_layer_only": true
+      }
+    ]
   },
   {
     "id": "beekeeping_suit",
@@ -1125,9 +1141,7 @@
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
-        "material": [
-          { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 3 }
-        ],
+        "material": [ { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_ankle_l", "foot_ankle_r" ],
         "coverage": 100,

--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -1,36 +1,36 @@
 # Game Balance
 # Stat system scaling:
-Ranges below will be using strength as the example since it's the easiest to itemize, but what the numbers mean is equivalent between all stats.
+0 - Helpless:  Totally incapacitated.  (0 STR or DEX - cannot move. 0 INT or PER - unconscious and cannot wake. Not currently implemented so for now 1 is the minimum.)
+1-2 - Feeble:  Can barely function.  (Should only happen as the result of injury or other effects. Permanent 1-2s would likely require assisted living.)
+3-4 - Disabled:  Severely impaired.  (Lowest chargen stat. Could represent a permanent disability or transitory effects of e.g. extreme pain or drunkenness.)
+5-6 - Weak:  Barely adequate.  (Noticably worse off than most people, the lowest limit of what would be "typical" in the pre-Cataclysm workplace.)
+7-8 - Below Average:  A little worse than most.  (Not noticably worse off. A nominally healthy but inactive adult, or a teen who skips class too often)
+9-10  Average:  Typical for an adult human.  (You are neither good nor bad at this. A person who goes for a run two or three times a month.)
+11-12 Above Average:  A little better than most.  (Good but not especially great, like someone who reads regularly or goes to the gym 1 to 2 times weekly.)
+13-14 Great:  Head and shoulders above the rest.  (Someone who is obviously quite talented. The smartest guy in a small town. A minor league athlete.)
+15-16 World-Class:  Exceptional, with few peers.  (15 = chargen max. Good enough to compete in the major leagues or Olympics.)
+17-18 Peak:  The absolute limit of human potential.  (Would have been one of the best in the world, if not THE best.)
+19-20 Superhuman:  Better than anyone ever was.  (No human ever reached this level before bionics and mutagens.)
+21-22 Freakish:  Beyond what is natural.  (Obviously capable of incredible feats.)
+23-24 Monstrous:  Frightening to behold.  (Capabilities that even the most gullible person could not mistake for human.)
+25-26 Impossible:  Tremendously capable.  (At this point you are flipping over small cars and doing calculus without scratch paper.)
+27-28 Unbelievable:  Out of this world.  (You get the idea.)
+29-30 Transcendant:  Phenomenal.
+31+ Post-human:  Beyond what was.
 
-Minimal stat: 0 (Should only happen due to penalties, instant failure in most scenarios.  Basically actively dying, almost unable to even carry themselves.)
 
-Very low stat: 4 (Lowest in chargen.  Either an average person who's injured or someone who's naturally very dainty and sedentary.)
-
-Moderately low stat: 6 (Below average.  Sedentary job, not very active.)
-
-Nominal stat: 8 ("Average" human.  Mostly sedentary job, somewhat active but not particularly a gym-goer, etc.)
-
-Moderately high stat: 10 (Has a decent bit of strength.  Active job and/or works out consistently.)
-
-Very high stat: 14 (Very strong.  Job is either based around fitness or they're dedicated to building a lot of muscle.  Should require a lot of effort to maintain.)
-
-Maximal human stat: 20 (Extremely strong.  People who spend their whole lives dedicated to being as strong as possible, and with good genetics too.  Olympic powerlifters, record-setting strongmen, etc.)
-
-Superhuman: >20 (Anything beyond this should require bionics or mutations.)
-
-
-# Skill system scaling:
-Minimum skill: 0 (You have no idea where to even start.  Even following clearly written directions is a challenge because you don't know basic terms and procedures.)
-
-Beginning hobbyist level: 1-2 (You've done this enough that you understand how to do basic things, know the tools that are used, and follow the language.)
-
-Proficient hobbyist level: 3-4 (You've used the tools for a while and they don't feel unfamiliar to you.  Given enough directions you can do most things.)
-
-Early professional level: 5-6 (You've been using these tools a while and know not just how to use them, but how to do some impressive stuff, and some of the more efficient shortcuts and common pitfalls.)
-
-Expert professional level: 7-8 (There's not much you don't know about this stuff and you'd be genuinely impressed if someone knew tricks you don't.)
-
-Master level: 9-10 (While there may be very specific tricks you don't know yet, overall you pretty much have no room for major improvement in this skill.  Sure, you'll continue to get better, but only in subtle ways noticeable to you, not anything major.)
+# Skill System Scaling:
+0 - Never Practiced.  (You've never done any cooking that didn't involve a microwave, and even then only rarely.)
+1 - Basic Understanding.  (You drove around the block a few times while your dad reminded you to check your rear view mirror.)
+2 - Elementary Familiarity.  (You spent a year on the swim team back in high school.)
+3 - Employable.  (You can design a website, but you're not writing browser extensions by hand.)
+4 - Skilled.  (You learned how to clean, maintain, and operate a rifle during Army basic training, and have had your share of experience since the world ended.)
+5 - Journeyman.  (You're a journeyman electrician with years of education and experience.)
+6 - Esteemed Professional.  (You were a backup dancer for a famous pop star.)
+7 - Major Talent.  (You represented your country in archery during the last Olympics and placed fourth.)
+8 - Top of the Field.  (Your scientific abilities were so renowned that the government kidnapped you and forced you to work in an underground lab.)
+9 - Phenom.  (If the world hadn't ended, your contributions to the field of medicine could have been considered invaluable for decades to come.)
+10 - Legendary.  (If you are not literaly Miyamoto Musashi, then you are pretty sure you could take him in a duel.)
 
 
 # Monster melee skill scaling:

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -671,6 +671,47 @@ void Character::randomize_height()
     init_height = clamp( x, Character::min_height(), Character::max_height() );
 }
 
+std::string Character::get_stat_descriptor( int stat_value )
+{
+    std::string stat_descriptor;
+    if( stat_value <= 0 ) {
+        stat_descriptor = _( "Helpless" );
+    } else if( stat_value <= 2 ) {
+        stat_descriptor = _( "Feeble" );
+    } else if( stat_value <= 4 ) {
+        stat_descriptor = _( "Disabled" );
+    } else if( stat_value <= 6 ) {
+        stat_descriptor = _( "Weak" );
+    } else if( stat_value <= 8 ) {
+        stat_descriptor = _( "Below Average" );
+    } else if( stat_value <= 10 ) {
+        stat_descriptor = _( "Average" );
+    } else if( stat_value <= 12 ) {
+        stat_descriptor = _( "Above Average" );
+    } else if( stat_value <= 14 ) {
+        stat_descriptor = _( "Great" );
+    } else if( stat_value <= 16 ) {
+        stat_descriptor = _( "World-Class" );
+    } else if( stat_value <= 18 ) {
+        stat_descriptor = _( "Peak" );
+    } else if( stat_value <= 20 ) {
+        stat_descriptor = _( "Superhuman" );
+    } else if( stat_value <= 22 ) {
+        stat_descriptor = _( "Freakish" );
+    } else if( stat_value <= 24 ) {
+        stat_descriptor = _( "Monstrous" );
+    } else if( stat_value <= 26 ) {
+        stat_descriptor = _( "Impossible" );
+    } else if( stat_value <= 28 ) {
+        stat_descriptor = _( "Unbelievable" );
+    } else if( stat_value <= 30 ) {
+        stat_descriptor = _( "Transcendant" );
+    } else {
+        stat_descriptor = _( "Post-Human" );
+    }
+    return stat_descriptor;
+}
+
 item_location Character::get_wielded_item() const
 {
     return const_cast<Character *>( this )->get_wielded_item();

--- a/src/character.h
+++ b/src/character.h
@@ -3289,6 +3289,7 @@ class Character : public Creature, public visitable
         int get_mutation_visibility_cap( const Character *observed ) const;
         /** Returns an enumeration of visible mutations with colors */
         std::string visible_mutations( int visibility_cap ) const;
+        std::string get_stat_descriptor( int stat_value );
         std::string get_throw_descriptor( int throwforce );
 
         player_activity get_destination_activity() const;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -120,7 +120,8 @@ constexpr int MAX_AIM_COST = 10;
 constexpr int MAX_SKILL = 10;
 
 // Maximum (effective) level for a stat.
-constexpr int MAX_STAT = 14;
+// While 18 is the theoretical human maximum, the player is simply not that guy - yet.
+constexpr int MAX_STAT = 15;
 
 // Maximum range at which ranged attacks can be executed.
 constexpr int RANGE_HARD_CAP = 60;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1192,7 +1192,9 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
             u.recalc_hp();
             u.set_stored_kcal( u.get_healthy_kcal() );
             description_str =
-                string_format( _( "Base HP: %d" ), u.get_part_hp_max( bodypart_id( "head" ) ) )
+                colorize( string_format( _( "%s\n" ), u.as_character()->get_stat_descriptor( u.get_str() ) ),
+                          c_light_blue )
+                + string_format( _( "\nBase HP: %d" ), u.get_part_hp_max( bodypart_id( "head" ) ) )
                 + string_format( _( "\nCarry weight: %.1f %s" ), convert_weight( u.weight_capacity() ),
                                  weight_units() )
                 + string_format( _( "\nResistance to knock down effect when hit: %.1f" ), u.stability_roll() )
@@ -1210,14 +1212,13 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                        "\n- Reload speed for weapons using muscle power to reload"
                        "\n- Pull strength of some mutations"
                        "\n- Resistance for being pulled or grabbed by some monsters"
-                       "\n- Speed of corpses pulping"
+                       "\n- Speed and effectiveness of smashing corpses and terrain"
                        "\n- Speed and effectiveness of prying things open, chopping wood, and mining"
                        "\n- Chance of escaping grabs and traps"
                        "\n- Power produced by muscle-powered vehicles"
                        "\n- Most aspects of melee combat"
-                       "\n- Effectiveness of smashing furniture or terrain"
                        "\n- Resistance to many diseases and poisons"
-                       "\n- Ability to drag heavy objects and grants bonus to speed when dragging them"
+                       "\n- Ability to drag heavy objects"
                        "\n- Ability to wield heavy weapons with one hand"
                        "\n- Ability to manage gun recoil"
                        "\n- Duration of action of various drugs and alcohol" ),
@@ -1228,7 +1229,9 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
         case 1: {
             description_str =
                 colorize(
-                    string_format( _( "Melee to-hit bonus: +%.2f" ), u.get_melee_hit_base() )
+                    colorize( string_format( _( "%s\n" ), u.as_character()->get_stat_descriptor( u.get_dex() ) ),
+                              c_light_blue )
+                    + string_format( _( "\nMelee to-hit bonus: +%.2f" ), u.get_melee_hit_base() )
                     + string_format( _( "\nThrowing penalty per target's dodge: +%d" ),
                                      u.throw_dispersion_per_dodge( false ) ),
                     COL_STAT_BONUS );
@@ -1244,8 +1247,7 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                 + _( "\n\nAffects:" )
                 + colorize(
                     _( "\n- Effectiveness of lockpicking"
-                       "\n- Resistance for being grabbed by some monsters"
-                       "\n- Chance of escaping grabs and traps"
+                       "\n- Chance of avoiding or escaping grabs and traps"
                        "\n- Effectiveness of disarming traps"
                        "\n- Chance of success when manipulating with gun modifications"
                        "\n- Effectiveness of repairing and modifying clothes and armor"
@@ -1254,9 +1256,7 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                        "\n- Throwing speed"
                        "\n- Aiming speed"
                        "\n- Speed and effectiveness of chopping wood with powered tools"
-                       "\n- Chance to avoid traps"
                        "\n- Chance to get better results when butchering corpses or cutting items"
-                       "\n- Chance of avoiding cuts on sharp terrain"
                        "\n- Chance of losing control of vehicle when driving"
                        "\n- Chance of damaging melee weapon on attack"
                        "\n- Damage from falling" ),
@@ -1267,9 +1267,11 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
         case 2: {
             const int read_spd = u.read_speed();
             description_str =
-                colorize( string_format( _( "Read times: %d%%" ), read_spd ),
-                          ( read_spd == 100 ? COL_STAT_NEUTRAL :
-                            ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
+                colorize( string_format( _( "%s\n" ), u.as_character()->get_stat_descriptor( u.get_int() ) ),
+                          c_light_blue )
+                + colorize( string_format( _( "\nRead times: %d%%" ), read_spd ),
+                            ( read_spd == 100 ? COL_STAT_NEUTRAL :
+                              ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
                 + string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
                 + colorize( string_format( _( "\nCrafting bonus: %2d%%" ), u.get_int() ),
                             COL_STAT_BONUS )
@@ -1280,7 +1282,6 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                        "\n- Chance of success when installing bionics"
                        "\n- Chance of success when manipulating with gun modifications"
                        "\n- Chance to learn a recipe when crafting from a book"
-                       "\n- Chance to learn martial arts techniques when using CQB bionic"
                        "\n- Chance of hacking computers and card readers"
                        "\n- Chance of successful robot reprogramming"
                        "\n- Chance of successful decrypting memory cards"
@@ -1294,22 +1295,23 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
         case 3: {
             if( u.ranged_per_mod() > 0 ) {
                 description_str =
-                    colorize( string_format( _( "Aiming penalty: -%d" ), u.ranged_per_mod() ),
-                              COL_STAT_PENALTY );
+                    colorize( string_format( _( "%s\n" ), u.as_character()->get_stat_descriptor( u.get_per() ) ),
+                              c_light_blue )
+                    + colorize( string_format( _( "\nAiming penalty: -%d" ), u.ranged_per_mod() ),
+                                COL_STAT_PENALTY );
             }
             description_str +=
                 string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
                 + _( "\n\nAffects:" )
                 + colorize(
                     _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
-                       "\n- Time needed for safe cracking"
                        "\n- Sight distance on game map and overmap"
                        "\n- Effectiveness of stealing"
                        "\n- Throwing accuracy"
                        "\n- Chance of losing control of vehicle when driving"
-                       "\n- Chance of spotting camouflaged creatures"
-                       "\n- Effectiveness of lockpicking"
-                       "\n- Effectiveness of foraging"
+                       "\n- Chance of spotting hidden creatures"
+                       "\n- Speed and effectiveness of lockpicking"
+                       "\n- Speed and effectiveness of foraging"
                        "\n- Precision when examining wounds and using first aid skill"
                        "\n- Detection and disarming traps"
                        "\n- Morale bonus when playing a musical instrument"


### PR DESCRIPTION
#### Summary
Add stat descritpors in chargen and raise max to 15

#### Purpose of change
Our stats are set up a little bit differently from DDA's. We needed to update documentation and to go with this, I wanted to make it clear to players what their stats actually mean.

#### Describe the solution
- Update game_balance.json to explain new stat and skill values
- Update chargen stat menu to display a descriptor for every stat value
- Raise the stat maximum in chargen from 14 to 15, the lower end of world-class. While 18 is the theoretical human maximum, a value that high would require a special profession or something to go with it.

#### Describe alternatives you've considered
- I may reduce the cap back to 14 once I've added in some professions which represent people who have dedicated their lives and careers to training one stat, and have good genes for it to boot.
- I want to add the descriptors to the @ screen, but there's precious little real estate there, I need to think about how to do that.

#### Testing
- Load the game, open chargen, raise a stat to 15, see the descriptors all display appropriately

#### Additional context
![image](https://github.com/user-attachments/assets/0b0bdd11-ed2a-4082-9a2e-2ea14f9d6ba0)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
