### PR TITLE
Reduce some healing bonuses

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -67,14 +67,14 @@
     "name": "PLAYER_HEALING_RATE",
     "info": "Set base player healing rate per turn.  Default: 0.0001",
     "stype": "float",
-    "value": 0.0001
+    "value": 0.00009
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "NPC_HEALING_RATE",
     "info": "Set base NPC healing rate per turn.  Default: 0.0001",
     "stype": "float",
-    "value": 0.0001
+    "value": 0.00009
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2327,7 +2327,7 @@
     "part_descs": true,
     "max_duration": "4 d",
     "base_mods": { "healing_rate": [ 2 ], "healing_head": [ 50 ], "healing_torso": [ 150 ] },
-    "scaling_mods": { "healing_rate": [ 2 ] }
+    "scaling_mods": { "healing_rate": [ 1 ] }
   },
   {
     "type": "effect_type",
@@ -2342,7 +2342,7 @@
     "part_descs": true,
     "max_duration": "4 d",
     "base_mods": { "healing_rate": [ 2 ], "healing_head": [ 50 ], "healing_torso": [ 150 ] },
-    "scaling_mods": { "healing_rate": [ 2 ] }
+    "scaling_mods": { "healing_rate": [ 1 ] }
   },
   {
     "type": "effect_type",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -668,8 +668,8 @@
       {
         "values": [
           { "value": "MENDING_MODIFIER", "multiply": 1 },
-          { "value": "REGEN_HP", "multiply": 0.5 },
-          { "value": "REGEN_HP_AWAKE", "multiply": 0.133 }
+          { "value": "REGEN_HP", "multiply": 0.45 },
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.12 }
         ]
       }
     ]
@@ -2310,7 +2310,7 @@
         "values": [
           { "value": "MENDING_MODIFIER", "multiply": 3 },
           { "value": "REGEN_HP", "multiply": 0.5 },
-          { "value": "REGEN_HP_AWAKE", "multiply": 0.44 }
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.4 }
         ]
       }
     ]
@@ -2329,7 +2329,7 @@
       {
         "values": [
           { "value": "MENDING_MODIFIER", "multiply": 15 },
-          { "value": "REGEN_HP", "multiply": 1.5 },
+          { "value": "REGEN_HP", "multiply": 1.25 },
           { "value": "REGEN_HP_AWAKE", "multiply": 0.8 }
         ]
       }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6468,7 +6468,7 @@ float Character::healing_rate_medicine( float at_rest_quality, const bodypart_id
     }
 
     if( get_lifestyle() > 0.0f ) {
-        rate_medicine *= 1.0f + get_lifestyle() / 200.0f;
+        rate_medicine *= 1.0f + get_lifestyle() / 220.0f;
     } else {
         rate_medicine *= 1.0f + get_lifestyle() / 400.0f;
     }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -309,7 +309,8 @@ void Character::update_body( const time_point &from, const time_point &to )
             const int &vit_quantity = get_daily_vitamin( v.first, true );
             const int RDA = vitamin_RDA( v.first, vit_quantity );
             // With three vitamins tracked, this essentially gives us three chances for a bonus.
-            if( RDA >= 90 && one_in( 2 ) ) {
+            // We average at about 2.6 points of lifestyle/day max.
+            if( ( RDA > 50 ) && ( rng( 1, 115 ) <= std::min( RDA, 100 ) ) ) {
                 mod_daily_health( 1, 200 );
             }
 


### PR DESCRIPTION
#### Summary
Reduce the effect of healing bonuses

#### Purpose of change
The base healing rate is OK, maybe a little fast, but it quickly gets waaay too fast once characters have a few ranks and proficiencies. This is because the current system was not designed with proficiencies in mind, and because a bunch of things were added that make it fairly trivial to have a really amazing lifestyle score.

#### Describe the solution
- Reduce base healing rate for the player character by 10%.
- Set NPC healing rate to the same as the player's - this may need review. Hostile/neutral NPCs can't really take care of themselves so maybe they need to heal faster.
- Bandages and disinfectant have had their effectiveness reduced from 2-16 to 2-9.
- Fast healing mutations have had their effectiveness reduced by about 10%.
- Slow healing mutations remain unchanged.
- Reduced the heal rate bonus provided by lifestyle by 10%.
- Lifestyle penalty remains unchanged.
- Vitamins: These are a stopgap solution - vitamins are not healthy in and of themselves, IRL they confer no benefit except to prevent deficiency, but for the time being they're standing in for a balanced diet. Previously they gave a guaranteed lifestyle point at 60% and another at 90% for each of the three vitamins. There is now a single chance to get a lifestyle point per day per vitamin, provided the character hits over 50% of their RDA. This chance scales with RDA, capping at a 90% when the character hits 100% RDA or above. That works out to about 2.6 lifestyle points per day rather than 6 - a significant decrease, but it was far too high before.

#### Describe alternatives you've considered
- Seats should have their comfort displayed when using e(x)amine. Can this be done for webs for spiders? Do they get that kind of comfort when sitting, or only when sleeping?

#### Testing
Basic testing shows that a low-skill character can still use rudimentary tools to heal a couple pips of health in a single night's sleep. This nerf is mostly a game feel thing and may need to be revisited later once I've had a chance to play with it for a longer period of time.

#### Additional context
It may be worth looking into converting the scaling bandage/disinfectant buff to a float, like 1.5, if it winds up feeling too crummy.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
