### PR TITLE
Update cattail quest

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -810,12 +810,12 @@
     "id": "MISSION_LEARN_ABOUT_CATTAIL_JELLY",
     "type": "mission_definition",
     "name": { "str": "Gather cattail stalks to create cattail jelly" },
-    "description": "Gather <color_light_blue>80 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks.  <color_light_blue>Bring back the provided bag</color> as well.",
+    "description": "Gather <color_light_blue>20 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks.  <color_light_blue>Bring back the provided bag</color> as well.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "and": [
         { "u_has_item": "duffelbag" },
-        { "u_has_items": { "item": "cattail_stalk", "count": 80 } },
+        { "u_has_items": { "item": "cattail_stalk", "count": 20 } },
         { "math": [ "u_skill('survival')", ">=", "1" ] }
       ]
     },
@@ -829,12 +829,12 @@
     },
     "end": {
       "effect": [
-        { "u_sell_item": "cattail_stalk", "count": 80 },
+        { "u_sell_item": "cattail_stalk", "count": 20 },
         { "u_sell_item": "duffelbag" },
-        { "npc_consume_item": "cattail_stalk", "count": 80 },
+        { "npc_consume_item": "cattail_stalk", "count": 20 },
         { "u_learn_recipe": "cattail_jelly" },
         { "u_message": "You learn how to craft cattail jelly.", "popup": true },
-        { "u_spawn_item": "cattail_jelly", "container": "bag_zipper", "count": 7 }
+        { "u_spawn_item": "cattail_jelly", "container": "bag_zipper", "count": 5 }
       ]
     },
     "dialogue": {


### PR DESCRIPTION
#### Summary
Reduce requirements for cattail NPC quest

#### Purpose of change
#172 made foraging harder, so 50 cattail stalks became a huge burden for a presumably 0 skill character. 20 is still a lot now, but it's much more manageable and the reward is quite good.

Closes #236 

#### Describe the solution
50 -> 20

https://www.youtube.com/watch?v=KpbGv6THEQ8

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
