### PR TITLE
Backport - typified animation.cpp (73609)

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -100,44 +100,45 @@ class bullet_animation : public basic_animation
         }
 };
 
-bool is_point_visible( const tripoint &p, int margin = 0 )
+bool is_point_visible( const tripoint_bub_ms &p, int margin = 0 )
 {
     return g->is_in_viewport( p, margin ) && get_player_view().sees( p );
 }
 
-bool is_radius_visible( const tripoint &center, int radius )
+bool is_radius_visible( const tripoint_bub_ms &center, int radius )
 {
     return is_point_visible( center, -radius );
 }
 
-bool is_layer_visible( const std::map<tripoint, explosion_tile> &layer )
+bool is_layer_visible( const std::map<tripoint_bub_ms, explosion_tile> &layer )
 {
     return std::any_of( layer.begin(), layer.end(),
-    []( const std::pair<tripoint, explosion_tile> &element ) {
+    []( const std::pair<tripoint_bub_ms, explosion_tile> &element ) {
         return is_point_visible( element.first );
     } );
 }
 
 //! Get p relative to u's current position and view
-tripoint relative_view_pos( const avatar &u, const tripoint &p ) noexcept
+tripoint_rel_ms relative_view_pos( const avatar &u, const tripoint_bub_ms &p ) noexcept
 {
-    return p - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(), -u.posz() );
+    return tripoint_rel_ms( p.raw() - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(),
+                            -u.posz() ) );
 }
 
 // Convert p to screen position relative to the current terrain view
-tripoint relative_view_pos( const game &g, const tripoint &p ) noexcept
+tripoint_rel_ms relative_view_pos( const game &g, const tripoint_bub_ms &p ) noexcept
 {
-    return p - g.ter_view_p + point( POSX, POSY );
+    return tripoint_rel_ms( p.raw() - g.ter_view_p + point( POSX, POSY ) );
 }
 
-void draw_explosion_curses( game &g, const tripoint &center, const int r,
+void draw_explosion_curses( game &g, const tripoint_bub_ms &center, const int r,
                             const nc_color &col )
 {
     if( !is_radius_visible( center, r ) ) {
         return;
     }
     // TODO: Make it look different from above/below
-    const tripoint p = relative_view_pos( get_avatar(), center );
+    const tripoint_rel_ms p = relative_view_pos( get_avatar(), center );
 
     explosion_animation anim;
 
@@ -145,27 +146,27 @@ void draw_explosion_curses( game &g, const tripoint &center, const int r,
     shared_ptr_fast<game::draw_callback_t> explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
         if( r == 0 ) {
-            mvwputch( g.w_terrain, point( p.y, p.x ), col, '*' );
+            mvwputch( g.w_terrain, point( p.y(), p.x() ), col, '*' );
         }
 
         for( int i = 1; i <= frame; ++i ) {
             // corner: top left
-            mvwputch( g.w_terrain, p.xy() + point( -i, -i ), col, '/' );
+            mvwputch( g.w_terrain, p.xy().raw() + point( -i, -i ), col, '/' );
             // corner: top right
-            mvwputch( g.w_terrain, p.xy() + point( i, -i ), col, '\\' );
+            mvwputch( g.w_terrain, p.xy().raw() + point( i, -i ), col, '\\' );
             // corner: bottom left
-            mvwputch( g.w_terrain, p.xy() + point( -i, i ), col, '\\' );
+            mvwputch( g.w_terrain, p.xy().raw() + point( -i, i ), col, '\\' );
             // corner: bottom right
-            mvwputch( g.w_terrain, p.xy() + point( i, i ), col, '/' );
+            mvwputch( g.w_terrain, p.xy().raw() + point( i, i ), col, '/' );
             for( int j = 1 - i; j < 0 + i; j++ ) {
                 // edge: top
-                mvwputch( g.w_terrain, p.xy() + point( j, -i ), col, '-' );
+                mvwputch( g.w_terrain, p.xy().raw() + point( j, -i ), col, '-' );
                 // edge: bottom
-                mvwputch( g.w_terrain, p.xy() + point( j, i ), col, '-' );
+                mvwputch( g.w_terrain, p.xy().raw() + point( j, i ), col, '-' );
                 // edge: left
-                mvwputch( g.w_terrain, p.xy() + point( -i, j ), col, '|' );
+                mvwputch( g.w_terrain, p.xy().raw() + point( -i, j ), col, '|' );
                 // edge: right
-                mvwputch( g.w_terrain, p.xy() + point( i, j ), col, '|' );
+                mvwputch( g.w_terrain, p.xy().raw() + point( i, j ), col, '|' );
             }
         }
     } );
@@ -187,13 +188,13 @@ constexpr explosion_neighbors operator ^ ( explosion_neighbors lhs, explosion_ne
 }
 
 void draw_custom_explosion_curses( game &g,
-                                   const std::list< std::map<tripoint, explosion_tile> > &layers )
+                                   const std::list< std::map<tripoint_bub_ms, explosion_tile> > &layers )
 {
     avatar &player_character = get_avatar();
     // calculate screen offset relative to player + view offset position
-    const tripoint center = player_character.pos() + player_character.view_offset;
-    const tripoint topleft( center.x - getmaxx( g.w_terrain ) / 2,
-                            center.y - getmaxy( g.w_terrain ) / 2, 0 );
+    const tripoint_bub_ms center = player_character.pos_bub() + player_character.view_offset;
+    const tripoint topleft( center.x() - getmaxx( g.w_terrain ) / 2,
+                            center.y() - getmaxy( g.w_terrain ) / 2, 0 );
 
     explosion_animation anim;
 
@@ -204,7 +205,7 @@ void draw_custom_explosion_curses( game &g,
             for( const auto &pr : *it ) {
                 // update tripoint in relation to top left corner of curses window
                 // mvwputch already filters out of bounds coordinates
-                const tripoint p = pr.first - topleft;
+                const tripoint p = pr.first.raw() - topleft;
                 const explosion_neighbors ngh = pr.second.neighborhood;
                 const nc_color col = pr.second.color;
 
@@ -262,7 +263,7 @@ void draw_custom_explosion_curses( game &g,
 } // namespace
 
 #if defined(TILES)
-void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc_color &col )
+void explosion_handler::draw_explosion( const tripoint_bub_ms &p, const int r, const nc_color &col )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -299,15 +300,35 @@ void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc
         tilecontext->void_explosion();
     }
 }
-#else
+
 void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc_color &col )
 {
+    explosion_handler::draw_explosion( tripoint_bub_ms( p ), r, col );
+}
+#else
+void explosion_handler::draw_explosion( const tripoint_bub_ms &p, const int r, const nc_color &col )
+{
     draw_explosion_curses( *g, p, r, col );
+}
+
+void explosion_handler::draw_explosion( const tripoint &p, const int r, const nc_color &col )
+{
+    draw_explosion_curses( *g, tripoint_bub_ms( p ), r, col );
 }
 #endif
 
 void explosion_handler::draw_custom_explosion( const tripoint &,
         const std::map<tripoint, nc_color> &all_area, const std::optional<std::string> &tile_id )
+{
+    std::map<tripoint_bub_ms, nc_color> temp;
+    for( const auto &it : all_area ) {
+        temp.insert( std::pair<tripoint_bub_ms, nc_color>( tripoint_bub_ms( it.first ), it.second ) );
+    }
+    explosion_handler::draw_custom_explosion( temp, tile_id );
+}
+
+void explosion_handler::draw_custom_explosion(
+    const std::map<tripoint_bub_ms, nc_color> &all_area, const std::optional<std::string> &tile_id )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -321,38 +342,39 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
     // Layers will first be generated, then drawn in inverse order
 
     // Start by getting rid of everything except current z-level
-    std::map<tripoint, explosion_tile> neighbors;
+    std::map<tripoint_bub_ms, explosion_tile> neighbors;
     avatar &player_character = get_avatar();
 #if defined(TILES)
     if( !use_tiles ) {
         for( const auto &pr : all_area ) {
-            const tripoint relative_point = relative_view_pos( player_character, pr.first );
-            if( relative_point.z == 0 ) {
+            const tripoint_rel_ms relative_point = relative_view_pos( player_character, pr.first );
+            if( relative_point.z() == 0 ) {
                 neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second, tile_id };
             }
         }
     } else {
         // In tiles mode, the coordinates have to be absolute
-        const tripoint view_center = relative_view_pos( player_character, player_character.pos() );
+        const tripoint_rel_ms view_center = relative_view_pos( player_character,
+                                            player_character.pos_bub() );
         for( const auto &pr : all_area ) {
             // Relative point is only used for z level check
-            const tripoint relative_point = relative_view_pos( player_character, pr.first );
-            if( relative_point.z == view_center.z ) {
+            const tripoint_rel_ms relative_point = relative_view_pos( player_character, pr.first );
+            if( relative_point.z() == view_center.z() ) {
                 neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second, tile_id };
             }
         }
     }
 #else
     for( const auto &pr : all_area ) {
-        const tripoint relative_point = relative_view_pos( player_character, pr.first );
-        if( relative_point.z == 0 ) {
+        const tripoint_rel_ms relative_point = relative_view_pos( player_character, pr.first );
+        if( relative_point.z( ) == 0 ) {
             neighbors[pr.first] = explosion_tile{ N_NO_NEIGHBORS, pr.second, tile_id };
         }
     }
 #endif
 
     // Searches for a neighbor, sets the neighborhood flag on current point and on the neighbor
-    const auto set_neighbors = [&]( const tripoint & pos,
+    const auto set_neighbors = [&]( const tripoint_bub_ms & pos,
                                     explosion_neighbors & ngh,
                                     explosion_neighbors here,
     explosion_neighbors there ) {
@@ -367,7 +389,7 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
 
     // If the point we are about to remove has a neighbor in a given direction
     // unset that neighbor's flag that our current point is its neighbor
-    const auto unset_neighbor = [&]( const tripoint & pos,
+    const auto unset_neighbor = [&]( const tripoint_bub_ms & pos,
                                      const explosion_neighbors ngh,
                                      explosion_neighbors here,
     explosion_neighbors there ) {
@@ -381,7 +403,7 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
 
     // Find all neighborhoods
     for( auto &pr : neighbors ) {
-        const tripoint &pt = pr.first;
+        const tripoint_bub_ms &pt = pr.first;
         explosion_neighbors &ngh = pr.second.neighborhood;
 
         set_neighbors( pt + point_west, ngh, N_WEST, N_EAST );
@@ -391,9 +413,9 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
     }
 
     // We need to save the layers because we will draw them in reverse order
-    std::list< std::map<tripoint, explosion_tile> > layers;
+    std::list< std::map<tripoint_bub_ms, explosion_tile> > layers;
     while( !neighbors.empty() ) {
-        std::map<tripoint, explosion_tile> layer;
+        std::map<tripoint_bub_ms, explosion_tile> layer;
         bool changed = false;
         // Find a layer that can be drawn
         for( const auto &pr : neighbors ) {
@@ -408,7 +430,7 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
         }
         // Remove the layer from the area to process
         for( const auto &pr : layer ) {
-            const tripoint &pt = pr.first;
+            const tripoint_bub_ms &pt = pr.first;
             const explosion_neighbors ngh = pr.second.neighborhood;
 
             unset_neighbor( pt + point_west, ngh, N_WEST, N_EAST );
@@ -429,7 +451,7 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
 
     explosion_animation anim;
     // We need to draw all explosions up to now
-    std::map<tripoint, explosion_tile> combined_layer;
+    std::map<tripoint_bub_ms, explosion_tile> combined_layer;
 
     shared_ptr_fast<game::draw_callback_t> explosion_cb =
     make_shared_fast<game::draw_callback_t>( [&]() {
@@ -453,24 +475,25 @@ void explosion_handler::draw_custom_explosion( const tripoint &,
 namespace
 {
 
-void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tripoint *const p )
+void draw_bullet_curses( map &m, const tripoint_bub_ms &t, const char bullet,
+                         const tripoint_bub_ms *const p )
 {
     if( !is_point_visible( t ) ) {
         return;
     }
 
     avatar &player_character = get_avatar();
-    const tripoint vp = player_character.pos() + player_character.view_offset;
+    const tripoint_bub_ms vp = player_character.pos_bub() + player_character.view_offset;
 
-    if( vp.z != t.z ) {
+    if( vp.z() != t.z() ) {
         return;
     }
 
     shared_ptr_fast<game::draw_callback_t> bullet_cb = make_shared_fast<game::draw_callback_t>( [&]() {
-        if( p != nullptr && p->z == vp.z ) {
-            m.drawsq( g->w_terrain, *p, drawsq_params().center( vp ) );
+        if( p != nullptr && p->z() == vp.z() ) {
+            m.drawsq( g->w_terrain, *p, drawsq_params().center( vp.raw() ) );
         }
-        mvwputch( g->w_terrain, t.xy() - vp.xy() + point( POSX, POSY ), c_red, bullet );
+        mvwputch( g->w_terrain, t.xy().raw() - vp.xy().raw() + point( POSX, POSY ), c_red, bullet );
     } );
     g->add_draw_callback( bullet_cb );
     bullet_animation().progress();
@@ -481,8 +504,8 @@ void draw_bullet_curses( map &m, const tripoint &t, const char bullet, const tri
 #if defined(TILES)
 /* Bullet Animation -- Maybe change this to animate the ammo itself flying through the air?*/
 // need to have a version where there is no player defined, possibly. That way shrapnel works as intended
-void game::draw_bullet( const tripoint &t, const int /*i*/,
-                        const std::vector<tripoint> &/*trajectory*/, const char bullet )
+void game::draw_bullet( const tripoint_bub_ms &t, const int /*i*/,
+                        const std::vector<tripoint_bub_ms> &/*trajectory*/, const char bullet )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -516,11 +539,30 @@ void game::draw_bullet( const tripoint &t, const int /*i*/,
     bullet_animation().progress();
     tilecontext->void_bullet();
 }
+
+void game::draw_bullet( const tripoint &t, const int i,
+                        const std::vector<tripoint> &trajectory, const char bullet )
+{
+    std::vector<tripoint_bub_ms> temp;
+    temp.resize( trajectory.size() );
+    for( const tripoint &it : trajectory ) {
+        const tripoint_bub_ms tmp = tripoint_bub_ms( it );
+        temp.emplace_back( tmp );
+    }
+    game::draw_bullet( tripoint_bub_ms( t ), i, temp, bullet );
+}
 #else
-void game::draw_bullet( const tripoint &t, const int i, const std::vector<tripoint> &trajectory,
+void game::draw_bullet( const tripoint_bub_ms &t, const int i,
+                        const std::vector<tripoint_bub_ms> &trajectory,
                         const char bullet )
 {
     draw_bullet_curses( m, t, bullet, &trajectory[i] );
+}
+void game::draw_bullet( const tripoint &t, const int i, const std::vector<tripoint> &trajectory,
+                        const char bullet )
+{
+    const tripoint_bub_ms temp = tripoint_bub_ms( trajectory[i] );
+    draw_bullet_curses( m, tripoint_bub_ms( t ), bullet, &temp );
 }
 #endif
 
@@ -528,17 +570,17 @@ namespace
 {
 // short visual animation (player, monster, ...) (hit, dodge, ...)
 // cTile is a UTF-8 strings, and must be a single cell wide!
-void hit_animation( const avatar &u, const tripoint &center, nc_color cColor,
+void hit_animation( const avatar &u, const tripoint_bub_ms &center, nc_color cColor,
                     const std::string &cTile )
 {
-    const tripoint init_pos = relative_view_pos( u, center );
+    const tripoint_rel_ms init_pos = relative_view_pos( u, center );
     // Only show animation if initially visible
-    if( init_pos.z == 0 && is_valid_in_w_terrain( init_pos.xy() ) ) {
+    if( init_pos.z() == 0 && is_valid_in_w_terrain( init_pos.xy().raw() ) ) {
         shared_ptr_fast<game::draw_callback_t> hit_cb = make_shared_fast<game::draw_callback_t>( [&]() {
             // In case the window is resized during waiting, we always re-calculate the animation position
-            const tripoint pos = relative_view_pos( u, center );
-            if( pos.z == 0 && is_valid_in_w_terrain( pos.xy() ) ) {
-                mvwprintz( g->w_terrain, pos.xy(), cColor, cTile );
+            const tripoint_rel_ms pos = relative_view_pos( u, center );
+            if( pos.z() == 0 && is_valid_in_w_terrain( pos.xy().raw() ) ) {
+                mvwprintz( g->w_terrain, pos.xy().raw(), cColor, cTile );
             }
         } );
         g->add_draw_callback( hit_cb );
@@ -551,7 +593,7 @@ void hit_animation( const avatar &u, const tripoint &center, nc_color cColor,
     }
 }
 
-void draw_hit_mon_curses( const tripoint &center, const monster &m, const avatar &u,
+void draw_hit_mon_curses( const tripoint_bub_ms &center, const monster &m, const avatar &u,
                           const bool dead )
 {
     hit_animation( u, center, red_background( m.type->color ), dead ? "%" : m.symbol() );
@@ -560,7 +602,7 @@ void draw_hit_mon_curses( const tripoint &center, const monster &m, const avatar
 } // namespace
 
 #if defined(TILES)
-void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
+void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead )
 {
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
@@ -579,10 +621,20 @@ void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
 
     bullet_animation().progress();
 }
-#else
+
 void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
 {
+    game::draw_hit_mon( tripoint_bub_ms( p ), m, dead );
+}
+#else
+void game::draw_hit_mon( const tripoint_bub_ms &p, const monster &m, const bool dead )
+{
     draw_hit_mon_curses( p, m, u, dead );
+}
+
+void game::draw_hit_mon( const tripoint &p, const monster &m, const bool dead )
+{
+    draw_hit_mon_curses( tripoint_bub_ms( p ), m, u, dead );
 }
 #endif
 
@@ -592,7 +644,7 @@ void draw_hit_player_curses( const game &/* g */, const Character &p, const int 
 {
     nc_color const col = !dam ? yellow_background( p.symbol_color() ) : red_background(
                              p.symbol_color() );
-    hit_animation( get_avatar(), p.pos(), col, p.symbol() );
+    hit_animation( get_avatar(), p.pos_bub(), col, p.symbol() );
 }
 } //namespace
 
@@ -618,7 +670,7 @@ void game::draw_hit_player( const Character &p, const int dam )
                               : p.male ? npc_male : npc_female;
 
     shared_ptr_fast<draw_callback_t> hit_cb = make_shared_fast<draw_callback_t>( [&]() {
-        tilecontext->init_draw_hit( p.pos(), type );
+        tilecontext->init_draw_hit( p.pos_bub(), type );
     } );
     add_draw_callback( hit_cb );
 
@@ -634,15 +686,16 @@ void game::draw_hit_player( const Character &p, const int dam )
 /* Line drawing code, not really an animation but should be separated anyway */
 namespace
 {
-void draw_line_curses( game &g, const tripoint &center, const std::vector<tripoint> &ret,
+void draw_line_curses( game &g, const tripoint_bub_ms &center,
+                       const std::vector<tripoint_bub_ms> &ret,
                        bool noreveal )
 {
 
     avatar &player_character = get_avatar();
     map &here = get_map();
-    drawsq_params params = drawsq_params().highlight( true ).center( center );
+    drawsq_params params = drawsq_params().highlight( true ).center( center.raw() );
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &p : ret ) {
+    for( const tripoint_bub_ms &p : ret ) {
         const Creature *critter = creatures.creature_at( p, true );
 
         // NPCs and monsters get drawn with inverted colors
@@ -653,8 +706,8 @@ void draw_line_curses( game &g, const tripoint &center, const std::vector<tripoi
             const char sym = '?';
             const nc_color col = c_dark_gray;
             const catacurses::window &w = g.w_terrain;
-            const int k = p.x + getmaxx( w ) / 2 - center.x;
-            const int j = p.y + getmaxy( w ) / 2 - center.y;
+            const int k = p.x() + getmaxx( w ) / 2 - center.x();
+            const int j = p.y() + getmaxy( w ) / 2 - center.y();
             mvwputch( w, point( k, j ), col, sym );
         } else {
             // This function reveals tile at p and writes it to the player's memory
@@ -672,24 +725,20 @@ void game::draw_line( const tripoint &p, const tripoint &center,
         return;
     }
 
+    std::vector<tripoint_bub_ms> temp;
+    temp.resize( points.size() );
+    for( const tripoint &it : points ) {
+        const tripoint_bub_ms tmp = tripoint_bub_ms( it );
+        temp.emplace_back( tmp );
+    }
+
     if( !use_tiles ) {
-        draw_line_curses( *this, center, points, noreveal );
+        draw_line_curses( *this, tripoint_bub_ms( center ), temp, noreveal );
         return;
     }
 
-    tilecontext->init_draw_line( p, points, "line_target", true );
+    tilecontext->init_draw_line( tripoint_bub_ms( p ), temp, "line_target", true );
 }
-#else
-void game::draw_line( const tripoint &p, const tripoint &center,
-                      const std::vector<tripoint> &points, bool noreveal )
-{
-    if( !u.sees( p ) ) {
-        return;
-    }
-
-    draw_line_curses( *this, center, points, noreveal );
-}
-#endif
 
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
@@ -702,56 +751,114 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
     draw_line( p.raw(), center.raw(), raw_points, noreveal );
 }
 
+#else
+void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
+                      const std::vector<tripoint_bub_ms> &points, bool noreveal )
+{
+    if( !u.sees( p ) ) {
+        return;
+    }
+
+    draw_line_curses( *this, center, points, noreveal );
+}
+
+void game::draw_line( const tripoint &p, const tripoint &center,
+                      const std::vector<tripoint> &points, bool noreveal )
+{
+    if( !u.sees( p ) ) {
+        return;
+    }
+
+    std::vector<tripoint_bub_ms> temp;
+    for( const tripoint &it : points ) {
+        const tripoint_bub_ms tmp = tripoint_bub_ms( it );
+        temp.push_back( tmp );
+    }
+    draw_line_curses( *this, tripoint_bub_ms( center ), temp, noreveal );
+}
+#endif
+
 namespace
 {
-void draw_line_curses( game &g, const std::vector<tripoint> &points )
+void draw_line_curses( game &g, const std::vector<tripoint_bub_ms> &points )
 {
     avatar &player_character = get_avatar();
     map &here = get_map();
-    for( const tripoint &p : points ) {
+    for( const tripoint_bub_ms &p : points ) {
         here.drawsq( g.w_terrain, p, drawsq_params().highlight( true ) );
     }
 
-    const tripoint p = points.empty() ? tripoint {POSX, POSY, 0} :
-                       relative_view_pos( player_character, points.back() );
-    mvwputch( g.w_terrain, p.xy(), c_white, 'X' );
+    const tripoint_rel_ms p = points.empty() ? tripoint_rel_ms {POSX, POSY, 0} :
+                              relative_view_pos( player_character, points.back() );
+    mvwputch( g.w_terrain, p.xy().raw(), c_white, 'X' );
 }
 } //namespace
 
 #if defined(TILES)
 void game::draw_line( const tripoint &p, const std::vector<tripoint> &points )
 {
-    draw_line_curses( *this, points );
-    tilecontext->init_draw_line( p, points, "line_trail", false );
+    std::vector<tripoint_bub_ms> temp;
+    temp.resize( points.size() );
+    for( const tripoint &it : points ) {
+        const tripoint_bub_ms tmp = tripoint_bub_ms( it );
+        temp.emplace_back( tmp );
+    }
+    draw_line_curses( *this, temp );
+    tilecontext->init_draw_line( tripoint_bub_ms( p ), temp, "line_trail", false );
 }
 #else
 void game::draw_line( const tripoint &/*p*/, const std::vector<tripoint> &points )
 {
-    draw_line_curses( *this, points );
+    std::vector<tripoint_bub_ms> temp;
+    temp.resize( points.size() );
+    for( const tripoint &it : points ) {
+        const tripoint_bub_ms tmp = tripoint_bub_ms( it );
+        temp.emplace_back( tmp );
+    }
+    draw_line_curses( *this, temp );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_cursor( const tripoint &p ) const
+void game::draw_cursor( const tripoint_bub_ms &p ) const
 {
-    const tripoint rp = relative_view_pos( *this, p );
-    mvwputch_inv( w_terrain, rp.xy(), c_light_green, 'X' );
+    const tripoint_rel_ms rp = relative_view_pos( *this, p );
+    mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
     tilecontext->init_draw_cursor( p );
 }
-#else
+
 void game::draw_cursor( const tripoint &p ) const
 {
-    const tripoint rp = relative_view_pos( *this, p );
-    mvwputch_inv( w_terrain, rp.xy(), c_light_green, 'X' );
+    game::draw_cursor( tripoint_bub_ms( p ) );
+}
+#else
+void game::draw_cursor( const tripoint_bub_ms &p ) const
+{
+    const tripoint_rel_ms rp = relative_view_pos( *this, p );
+    mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
+}
+void game::draw_cursor( const tripoint &p ) const
+{
+    game::draw_cursor( tripoint_bub_ms( p ) );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_highlight( const tripoint &p )
+void game::draw_highlight( const tripoint_bub_ms &p )
 {
     tilecontext->init_draw_highlight( p );
 }
+
+void game::draw_highlight( const tripoint &p )
+{
+    game::draw_highlight( tripoint_bub_ms( p ) );
+}
 #else
+void game::draw_highlight( const tripoint_bub_ms & )
+{
+    // Do nothing
+}
+
 void game::draw_highlight( const tripoint & )
 {
     // Do nothing
@@ -790,11 +897,11 @@ namespace
 void draw_sct_curses( const game &g )
 {
     avatar &player_character = get_avatar();
-    const tripoint off = relative_view_pos( player_character, tripoint_zero );
+    const tripoint_rel_ms off = relative_view_pos( player_character, tripoint_bub_ms( tripoint_zero ) );
 
     for( const scrollingcombattext::cSCT &text : SCT.vSCT ) {
-        const int dy = off.y + text.getPosY();
-        const int dx = off.x + text.getPosX();
+        const int dy = off.y() + text.getPosY();
+        const int dx = off.x() + text.getPosX();
 
         if( !is_valid_in_w_terrain( point( dx, dy ) ) ) {
             continue;
@@ -829,25 +936,27 @@ void game::draw_sct() const
 
 namespace
 {
-void draw_zones_curses( const catacurses::window &w, const tripoint &start, const tripoint &end,
+void draw_zones_curses( const catacurses::window &w, const tripoint_bub_ms &start,
+                        const tripoint_bub_ms &end,
                         const tripoint &offset )
 {
-    if( end.x < start.x || end.y < start.y || end.z < start.z ) {
+    if( end.x() < start.x() || end.y() < start.y() || end.z() < start.z() ) {
         return;
     }
 
     nc_color    const col = invert_color( c_light_green );
-    const std::string line( end.x - start.x + 1, '~' );
-    int         const x = start.x - offset.x;
+    const std::string line( end.x() - start.x() + 1, '~' );
+    int         const x = start.x() - offset.x;
 
-    for( int y = start.y; y <= end.y; ++y ) {
+    for( int y = start.y(); y <= end.y(); ++y ) {
         mvwprintz( w, point( x, y - offset.y ), col, line );
     }
 }
 } //namespace
 
 #if defined(TILES)
-void game::draw_zones( const tripoint &start, const tripoint &end, const tripoint &offset ) const
+void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                       const tripoint &offset ) const
 {
     if( use_tiles ) {
         tilecontext->init_draw_zones( start, end, offset );
@@ -856,14 +965,16 @@ void game::draw_zones( const tripoint &start, const tripoint &end, const tripoin
     }
 }
 #else
-void game::draw_zones( const tripoint &start, const tripoint &end, const tripoint &offset ) const
+void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                       const tripoint &offset ) const
 {
     draw_zones_curses( w_terrain, start, end, offset );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr,
+void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
+                            const std::string &ncstr,
                             const nc_color &nccol )
 {
     if( test_mode ) {
@@ -889,103 +1000,161 @@ void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const
     tilecontext->init_draw_async_anim( p, tile_id );
     g->invalidate_main_ui_adaptor();
 }
+
+void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr,
+                            const nc_color &nccol )
+{
+    game::draw_async_anim( tripoint_bub_ms( p ), tile_id, ncstr, nccol );
+}
 #else
-void game::draw_async_anim( const tripoint &p, const std::string &, const std::string &ncstr,
+void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &, const std::string &ncstr,
                             const nc_color &nccol )
 {
     if( !ncstr.empty() ) {
         g->init_draw_async_anim_curses( p, ncstr, nccol );
     }
 }
+
+void game::draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr,
+                            const nc_color &nccol )
+{
+    game::draw_async_anim( tripoint_bub_ms( p ), tile_id, ncstr, nccol );
+}
 #endif
 
 #if defined(TILES)
-void game::draw_radiation_override( const tripoint &p, const int rad )
+void game::draw_radiation_override( const tripoint_bub_ms &p, const int rad )
 {
     if( use_tiles ) {
         tilecontext->init_draw_radiation_override( p, rad );
     }
 }
 #else
-void game::draw_radiation_override( const tripoint &, const int )
+void game::draw_radiation_override( const tripoint_bub_ms &, const int )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_terrain_override( const tripoint &p, const ter_id &id )
+void game::draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_terrain_override( p, id );
     }
 }
+
+void game::draw_terrain_override( const tripoint &p, const ter_id &id )
+{
+    game::draw_terrain_override( tripoint_bub_ms( p ), id );
+}
 #else
+void game::draw_terrain_override( const tripoint_bub_ms &, const ter_id & )
+{
+}
 void game::draw_terrain_override( const tripoint &, const ter_id & )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_furniture_override( const tripoint &p, const furn_id &id )
+void game::draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_furniture_override( p, id );
     }
 }
+
+void game::draw_furniture_override( const tripoint &p, const furn_id &id )
+{
+    game::draw_furniture_override( tripoint_bub_ms( p ), id );
+}
 #else
+void game::draw_furniture_override( const tripoint_bub_ms &, const furn_id & )
+{
+}
+
 void game::draw_furniture_override( const tripoint &, const furn_id & )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_graffiti_override( const tripoint &p, const bool has )
+void game::draw_graffiti_override( const tripoint_bub_ms &p, const bool has )
 {
     if( use_tiles ) {
         tilecontext->init_draw_graffiti_override( p, has );
     }
 }
 #else
-void game::draw_graffiti_override( const tripoint &, const bool )
+void game::draw_graffiti_override( const tripoint_bub_ms &, const bool )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_trap_override( const tripoint &p, const trap_id &id )
+void game::draw_trap_override( const tripoint_bub_ms &p, const trap_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_trap_override( p, id );
     }
 }
+
+void game::draw_trap_override( const tripoint &p, const trap_id &id )
+{
+    game::draw_trap_override( tripoint_bub_ms( p ), id );
+}
 #else
+void game::draw_trap_override( const tripoint_bub_ms &, const trap_id & )
+{
+}
+
 void game::draw_trap_override( const tripoint &, const trap_id & )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_field_override( const tripoint &p, const field_type_id &id )
+void game::draw_field_override( const tripoint_bub_ms &p, const field_type_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_field_override( p, id );
     }
 }
+
+void game::draw_field_override( const tripoint &p, const field_type_id &id )
+{
+    game::draw_field_override( tripoint_bub_ms( p ), id );
+}
 #else
+void game::draw_field_override( const tripoint_bub_ms &, const field_type_id & )
+{
+}
+
 void game::draw_field_override( const tripoint &, const field_type_id & )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
+void game::draw_item_override( const tripoint_bub_ms &p, const itype_id &id, const mtype_id &mid,
                                const bool hilite )
 {
     if( use_tiles ) {
         tilecontext->init_draw_item_override( p, id, mid, hilite );
     }
 }
+
+void game::draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
+                               const bool hilite )
+{
+    game::draw_item_override( tripoint_bub_ms( p ), id, mid, hilite );
+}
 #else
+void game::draw_item_override( const tripoint_bub_ms &, const itype_id &, const mtype_id &,
+                               const bool )
+{
+}
+
 void game::draw_item_override( const tripoint &, const itype_id &, const mtype_id &,
                                const bool )
 {
@@ -994,14 +1163,26 @@ void game::draw_item_override( const tripoint &, const itype_id &, const mtype_i
 
 #if defined(TILES)
 void game::draw_vpart_override(
-    const tripoint &p, const vpart_id &id, const int part_mod, const units::angle &veh_dir,
+    const tripoint_bub_ms &p, const vpart_id &id, const int part_mod, const units::angle &veh_dir,
     const bool hilite, const point &mount )
 {
     if( use_tiles ) {
         tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
     }
 }
+
+void game::draw_vpart_override(
+    const tripoint &p, const vpart_id &id, const int part_mod, const units::angle &veh_dir,
+    const bool hilite, const point &mount )
+{
+    game::draw_vpart_override( tripoint_bub_ms( p ), id, part_mod, veh_dir, hilite, mount );
+}
 #else
+void game::draw_vpart_override( const tripoint_bub_ms &, const vpart_id &, const int,
+                                const units::angle &, const bool, const point & )
+{
+}
+
 void game::draw_vpart_override( const tripoint &, const vpart_id &, const int,
                                 const units::angle &, const bool, const point & )
 {
@@ -1009,20 +1190,29 @@ void game::draw_vpart_override( const tripoint &, const vpart_id &, const int,
 #endif
 
 #if defined(TILES)
-void game::draw_below_override( const tripoint &p, const bool draw )
+void game::draw_below_override( const tripoint_bub_ms &p, const bool draw )
 {
     if( use_tiles ) {
         tilecontext->init_draw_below_override( p, draw );
     }
 }
+
+void game::draw_below_override( const tripoint &p, const bool draw )
+{
+    game::draw_below_override( tripoint_bub_ms( p ), draw );
+}
 #else
+void game::draw_below_override( const tripoint_bub_ms &, const bool )
+{
+}
+
 void game::draw_below_override( const tripoint &, const bool )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_monster_override( const tripoint &p, const mtype_id &id, const int count,
+void game::draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id, const int count,
                                   const bool more, const Creature::Attitude att )
 {
     if( use_tiles ) {
@@ -1030,7 +1220,7 @@ void game::draw_monster_override( const tripoint &p, const mtype_id &id, const i
     }
 }
 #else
-void game::draw_monster_override( const tripoint &, const mtype_id &, const int,
+void game::draw_monster_override( const tripoint_bub_ms &, const mtype_id &, const int,
                                   const bool, const Creature::Attitude )
 {
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1500,7 +1500,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
 
                         if( g->display_overlay_state( ACTION_DISPLAY_RADIATION ) ) {
-                            const auto rad_override = radiation_override.find( pos );
+                            const auto rad_override = radiation_override.find( tripoint_bub_ms( pos ) );
                             const bool rad_overridden = rad_override != radiation_override.end();
                             if( rad_overridden || !invisible[0] ) {
                                 const int rad_value = rad_overridden ? rad_override->second :
@@ -1771,7 +1771,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             if( !var ) {
                 continue;
             }
-            const auto mon_override = monster_override.find( p.com.pos );
+            const auto mon_override = monster_override.find( tripoint_bub_ms( p.com.pos ) );
             if( mon_override != monster_override.end() ) {
                 const int count = std::get<1>( mon_override->second );
                 const bool more = std::get<2>( mon_override->second );
@@ -2664,7 +2664,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             // TODO: also use some vehicle id, for less predictability
         {
             // new scope for variable declarations
-            const auto vp_override = vpart_override.find( pos );
+            const auto vp_override = vpart_override.find( tripoint_bub_ms( pos ) );
             const bool vp_overridden = vp_override != vpart_override.end();
             if( vp_overridden ) {
                 const vpart_id &vp_id = std::get<0>( vp_override->second );
@@ -2715,7 +2715,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             break;
         case TILE_CATEGORY::MONSTER:
             // FIXME: add persistent id to Creature type, instead of using monster pointer address
-            if( monster_override.find( pos ) == monster_override.end() ) {
+            if( monster_override.find( tripoint_bub_ms( pos ) ) == monster_override.end() ) {
                 seed = reinterpret_cast<uintptr_t>( creatures.creature_at<monster>( pos ) );
             }
             break;
@@ -3098,7 +3098,7 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
     }
 
     map &here = get_map();
-    const auto low_override = draw_below_override.find( p );
+    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second :
         ( invisible[0] || here.dont_draw_lower_floor( p ) ) ) {
@@ -3138,12 +3138,12 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
                                const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     map &here = get_map();
-    const auto override = terrain_override.find( p );
+    const auto override = terrain_override.find( tripoint_bub_ms( p ) );
     const bool overridden = override != terrain_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( terrain_override.find( p + dir ) != terrain_override.end() ) {
+            if( terrain_override.find( tripoint_bub_ms( p + dir ) ) != terrain_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3163,11 +3163,11 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         const std::bitset<NUM_TERCONN> &rotate_group = t.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+            get_connect_values( tripoint_bub_ms( p ), subtile, rotation, connect_group, rotate_group, {} );
             // re-memorize previously seen terrain in case new connections have been seen
             here.memory_cache_ter_set_dirty( p, true );
         } else {
-            get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
+            get_terrain_orientation( tripoint_bub_ms( p ), rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
         if( here.memory_cache_ter_is_dirty( p ) ) {
@@ -3193,9 +3193,11 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             const std::bitset<NUM_TERCONN> &rotate_group = t2.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_connect_values( p, subtile, rotation, connect_group, rotate_group, terrain_override );
+                get_connect_values( tripoint_bub_ms( p ), subtile, rotation, connect_group, rotate_group,
+                                    terrain_override );
             } else {
-                get_terrain_orientation( p, rotation, subtile, terrain_override, invisible, rotate_group );
+                get_terrain_orientation( tripoint_bub_ms( p ), rotation, subtile, terrain_override, invisible,
+                                         rotate_group );
             }
             const std::string &tname = t2.id().str();
             // tile overrides are never memorized
@@ -3225,12 +3227,12 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
                                  const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     avatar &you = get_avatar();
-    const auto override = furniture_override.find( p );
+    const auto override = furniture_override.find( tripoint_bub_ms( p ) );
     const bool overridden = override != furniture_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( furniture_override.find( p + dir ) != furniture_override.end() ) {
+            if( furniture_override.find( tripoint_bub_ms( p + dir ) ) != furniture_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3277,7 +3279,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             // both the current and neighboring overrides may change the appearance
             // of the tile, so always re-calculate it.
             const auto furn = [&]( const tripoint & q, const bool invis ) -> furn_id {
-                const auto it = furniture_override.find( q );
+                const auto it = furniture_override.find( tripoint_bub_ms( q ) );
                 return it != furniture_override.end() ? it->second :
                 ( !overridden || !invis ) ? here.furn( q ) : furn_str_id::NULL_ID().id();
             };
@@ -3325,12 +3327,12 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
 bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, const bool memorize_only )
 {
-    const auto override = trap_override.find( p );
+    const auto override = trap_override.find( tripoint_bub_ms( p ) );
     const bool overridden = override != trap_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( trap_override.find( p + dir ) != trap_override.end() ) {
+            if( trap_override.find( tripoint_bub_ms( p + dir ) ) != trap_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3371,7 +3373,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             // both the current and neighboring overrides may change the appearance
             // of the tile, so always re-calculate it.
             const auto tr_at = [&]( const tripoint & q, const bool invis ) -> trap_id {
-                const auto it = trap_override.find( q );
+                const auto it = trap_override.find( tripoint_bub_ms( q ) );
                 return it != trap_override.end() ? it->second :
                 ( !overridden || !invis ) ? here.tr_at( q ).loadid : tr_null;
             };
@@ -3435,7 +3437,7 @@ bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &heig
     }
 
     map &here = get_map();
-    const auto override = graffiti_override.find( p );
+    const auto override = graffiti_override.find( tripoint_bub_ms( p ) );
     const bool overridden = override != graffiti_override.end();
     if( overridden ? !override->second : ( invisible[0] || !here.has_graffiti_at( p ) ) ) {
         return false;
@@ -3456,7 +3458,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
         return false;
     }
 
-    const auto fld_override = field_override.find( p );
+    const auto fld_override = field_override.find( tripoint_bub_ms( p ) );
     const bool fld_overridden = fld_override != field_override.end();
     map &here = get_map();
     const field_type_id &fld = fld_overridden ?
@@ -3482,7 +3484,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                             found = fld;
                         }
                     }
-                    const auto it = field_override.find( q );
+                    const auto it = field_override.find( tripoint_bub_ms( q ) );
                     return it != field_override.end() ? it->second :
                            ( !fld_overridden || !invis ) ?  found : fd_null;
                 };
@@ -3580,7 +3582,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             const bool nv = false;
 
             auto field_at = [&]( const tripoint & q, const bool invis ) -> field_type_id {
-                const auto it = field_override.find( q );
+                const auto it = field_override.find( tripoint_bub_ms( q ) );
                 return it != field_override.end() ? it->second :
                 ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
             };
@@ -3604,7 +3606,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
     }
 
     if( fld.obj().display_items ) {
-        const auto it_override = item_override.find( p );
+        const auto it_override = item_override.find( tripoint_bub_ms( p ) );
         const bool it_overridden = it_override != item_override.end();
 
         itype_id it_id;
@@ -3760,7 +3762,7 @@ bool cata_tiles::draw_vpart_below( const tripoint &p, const lit_level /*ll*/, in
         return false;
     }
 
-    const auto low_override = draw_below_override.find( p );
+    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
             get_map().dont_draw_lower_floor( p ) ) ) {
@@ -3789,7 +3791,7 @@ bool cata_tiles::draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3
 bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool roof, const bool memorize_only )
 {
-    const auto override = vpart_override.find( p );
+    const auto override = vpart_override.find( tripoint_bub_ms( p ) );
     const bool overridden = override != vpart_override.end();
     map &here = get_map();
     // first memorize the actual vpart
@@ -3880,7 +3882,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int 
     }
 
     // Check if we even need to draw below. If not, bail.
-    const auto low_override = draw_below_override.find( p );
+    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
             get_map().dont_draw_lower_floor( p ) ) ) {
@@ -3924,7 +3926,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
     Character &you = get_player_character();
     const Creature *pcritter = get_creature_tracker().creature_at( p, true );
     const bool always_visible = pcritter && pcritter->has_flag( mon_flag_ALWAYS_VISIBLE );
-    const auto override = monster_override.find( p );
+    const auto override = monster_override.find( tripoint_bub_ms( p ) );
     if( override != monster_override.end() ) {
         const mtype_id id = std::get<0>( override->second );
         if( !id ) {
@@ -4142,7 +4144,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
 
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
-        item_override.find( pos ) == item_override.end() &&
+        item_override.find( tripoint_bub_ms( pos ) ) == item_override.end() &&
         here.could_see_items( pos, get_player_character() ) ) {
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
@@ -4317,7 +4319,7 @@ void tileset_cache::loader::ensure_default_item_highlight()
 
 /* Animation Functions */
 /* -- Inits */
-void cata_tiles::init_explosion( const tripoint &p, int radius )
+void cata_tiles::init_explosion( const tripoint_bub_ms &p, int radius )
 {
     do_draw_explosion = true;
     exp_pos = p;
@@ -4326,21 +4328,31 @@ void cata_tiles::init_explosion( const tripoint &p, int radius )
 void cata_tiles::init_custom_explosion_layer( const std::map<tripoint, explosion_tile> &layer )
 {
     do_draw_custom_explosion = true;
+    std::map<tripoint_bub_ms, explosion_tile> temp;
+    for( const auto &it : layer ) {
+        temp.insert( std::pair<tripoint_bub_ms, explosion_tile>( tripoint_bub_ms( it.first ), it.second ) );
+    }
+    custom_explosion_layer = temp;
+}
+void cata_tiles::init_custom_explosion_layer( const std::map<tripoint_bub_ms, explosion_tile>
+        &layer )
+{
+    do_draw_custom_explosion = true;
     custom_explosion_layer = layer;
 }
-void cata_tiles::init_draw_bullet( const tripoint &p, std::string name )
+void cata_tiles::init_draw_bullet( const tripoint_bub_ms &p, std::string name )
 {
     do_draw_bullet = true;
     bul_pos = p;
     bul_id = std::move( name );
 }
-void cata_tiles::init_draw_hit( const tripoint &p, std::string name )
+void cata_tiles::init_draw_hit( const tripoint_bub_ms &p, std::string name )
 {
     do_draw_hit = true;
     hit_pos = p;
     hit_entity_id = std::move( name );
 }
-void cata_tiles::init_draw_line( const tripoint &p, std::vector<tripoint> trajectory,
+void cata_tiles::init_draw_line( const tripoint_bub_ms &p, std::vector<tripoint_bub_ms> trajectory,
                                  std::string name, bool target_line )
 {
     do_draw_line = true;
@@ -4349,12 +4361,16 @@ void cata_tiles::init_draw_line( const tripoint &p, std::vector<tripoint> trajec
     line_endpoint_id = std::move( name );
     line_trajectory = std::move( trajectory );
 }
-void cata_tiles::init_draw_cursor( const tripoint &p )
+void cata_tiles::init_draw_cursor( const tripoint_bub_ms &p )
 {
     do_draw_cursor = true;
     cursors.emplace_back( p );
 }
 void cata_tiles::init_draw_highlight( const tripoint &p )
+{
+    cata_tiles::init_draw_highlight( tripoint_bub_ms( p ) );
+}
+void cata_tiles::init_draw_highlight( const tripoint_bub_ms &p )
 {
     do_draw_highlight = true;
     highlights.emplace_back( p );
@@ -4369,7 +4385,7 @@ void cata_tiles::init_draw_sct()
 {
     do_draw_sct = true;
 }
-void cata_tiles::init_draw_zones( const tripoint &_start, const tripoint &_end,
+void cata_tiles::init_draw_zones( const tripoint_bub_ms &_start, const tripoint_bub_ms &_end,
                                   const tripoint &_offset )
 {
     do_draw_zones = true;
@@ -4377,50 +4393,51 @@ void cata_tiles::init_draw_zones( const tripoint &_start, const tripoint &_end,
     zone_end = _end;
     zone_offset = _offset;
 }
-void cata_tiles::init_draw_async_anim( const tripoint &p, const std::string &tile_id )
+void cata_tiles::init_draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id )
 {
     do_draw_async_anim = true;
     async_anim_layer[ p ] = tile_id;
 }
-void cata_tiles::init_draw_radiation_override( const tripoint &p, const int rad )
+void cata_tiles::init_draw_radiation_override( const tripoint_bub_ms &p, const int rad )
 {
     radiation_override.emplace( p, rad );
 }
-void cata_tiles::init_draw_terrain_override( const tripoint &p, const ter_id &id )
+void cata_tiles::init_draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id )
 {
     terrain_override.emplace( p, id );
 }
-void cata_tiles::init_draw_furniture_override( const tripoint &p, const furn_id &id )
+void cata_tiles::init_draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id )
 {
     furniture_override.emplace( p, id );
 }
-void cata_tiles::init_draw_graffiti_override( const tripoint &p, const bool has )
+void cata_tiles::init_draw_graffiti_override( const tripoint_bub_ms &p, const bool has )
 {
     graffiti_override.emplace( p, has );
 }
-void cata_tiles::init_draw_trap_override( const tripoint &p, const trap_id &id )
+void cata_tiles::init_draw_trap_override( const tripoint_bub_ms &p, const trap_id &id )
 {
     trap_override.emplace( p, id );
 }
-void cata_tiles::init_draw_field_override( const tripoint &p, const field_type_id &id )
+void cata_tiles::init_draw_field_override( const tripoint_bub_ms &p, const field_type_id &id )
 {
     field_override.emplace( p, id );
 }
-void cata_tiles::init_draw_item_override( const tripoint &p, const itype_id &id,
+void cata_tiles::init_draw_item_override( const tripoint_bub_ms &p, const itype_id &id,
         const mtype_id &mid, const bool hilite )
 {
     item_override.emplace( p, std::make_tuple( id, mid, hilite ) );
 }
-void cata_tiles::init_draw_vpart_override( const tripoint &p, const vpart_id &id,
+void cata_tiles::init_draw_vpart_override( const tripoint_bub_ms &p, const vpart_id &id,
         const int part_mod, const units::angle &veh_dir, const bool hilite, const point &mount )
 {
     vpart_override.emplace( p, std::make_tuple( id, part_mod, veh_dir, hilite, mount ) );
 }
-void cata_tiles::init_draw_below_override( const tripoint &p, const bool draw )
+void cata_tiles::init_draw_below_override( const tripoint_bub_ms &p, const bool draw )
 {
     draw_below_override.emplace( p, draw );
 }
-void cata_tiles::init_draw_monster_override( const tripoint &p, const mtype_id &id, const int count,
+void cata_tiles::init_draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id,
+        const int count,
         const bool more, const Creature::Attitude att )
 {
     monster_override.emplace( p, std::make_tuple( id, count, more, att ) );
@@ -4530,16 +4547,16 @@ void cata_tiles::void_monster_override()
 
 bool cata_tiles::has_draw_override( const tripoint &p ) const
 {
-    return radiation_override.find( p ) != radiation_override.end() ||
-           terrain_override.find( p ) != terrain_override.end() ||
-           furniture_override.find( p ) != furniture_override.end() ||
-           graffiti_override.find( p ) != graffiti_override.end() ||
-           trap_override.find( p ) != trap_override.end() ||
-           field_override.find( p ) != field_override.end() ||
-           item_override.find( p ) != item_override.end() ||
-           vpart_override.find( p ) != vpart_override.end() ||
-           draw_below_override.find( p ) != draw_below_override.end() ||
-           monster_override.find( p ) != monster_override.end();
+    return radiation_override.find( tripoint_bub_ms( p ) ) != radiation_override.end() ||
+           terrain_override.find( tripoint_bub_ms( p ) ) != terrain_override.end() ||
+           furniture_override.find( tripoint_bub_ms( p ) ) != furniture_override.end() ||
+           graffiti_override.find( tripoint_bub_ms( p ) ) != graffiti_override.end() ||
+           trap_override.find( tripoint_bub_ms( p ) ) != trap_override.end() ||
+           field_override.find( tripoint_bub_ms( p ) ) != field_override.end() ||
+           item_override.find( tripoint_bub_ms( p ) ) != item_override.end() ||
+           vpart_override.find( tripoint_bub_ms( p ) ) != vpart_override.end() ||
+           draw_below_override.find( tripoint_bub_ms( p ) ) != draw_below_override.end() ||
+           monster_override.find( tripoint_bub_ms( p ) ) != monster_override.end();
 }
 
 /* -- Animation Renders */
@@ -4553,27 +4570,27 @@ void cata_tiles::draw_explosion_frame()
         subtile = corner;
         rotation = 0;
 
-        draw_from_id_string( exp_name, exp_pos + point( -i, -i ),
+        draw_from_id_string( exp_name, exp_pos.raw() + point( -i, -i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos + point( -i, i ),
+        draw_from_id_string( exp_name, exp_pos.raw() + point( -i, i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos + point( i, i ),
+        draw_from_id_string( exp_name, exp_pos.raw() + point( i, i ),
                              subtile, rotation++, lit_level::LIT, nv_goggles_activated );
-        draw_from_id_string( exp_name, exp_pos + point( i, -i ),
+        draw_from_id_string( exp_name, exp_pos.raw() + point( i, -i ),
                              subtile, rotation, lit_level::LIT, nv_goggles_activated );
 
         subtile = edge;
         for( int j = 1 - i; j < 0 + i; j++ ) {
             rotation = 0;
-            draw_from_id_string( exp_name, exp_pos + point( j, -i ),
+            draw_from_id_string( exp_name, exp_pos.raw() + point( j, -i ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
-            draw_from_id_string( exp_name, exp_pos + point( j, i ),
+            draw_from_id_string( exp_name, exp_pos.raw() + point( j, i ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
 
             rotation = 1;
-            draw_from_id_string( exp_name, exp_pos + point( -i, j ),
+            draw_from_id_string( exp_name, exp_pos.raw() + point( -i, j ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
-            draw_from_id_string( exp_name, exp_pos + point( i, j ),
+            draw_from_id_string( exp_name, exp_pos.raw() + point( i, j ),
                                  subtile, rotation, lit_level::LIT, nv_goggles_activated );
         }
     }
@@ -4639,7 +4656,7 @@ void cata_tiles::draw_custom_explosion_frame()
                 break;
         }
 
-        const tripoint &p = pr.first;
+        const tripoint_bub_ms &p = pr.first;
         std::string explosion_tile_id;
         // Use target sprite if exist, otherwise col will determine fallback sprite
         if( pr.second.tile_name &&
@@ -4656,22 +4673,22 @@ void cata_tiles::draw_custom_explosion_frame()
             explosion_tile_id = exp_weak;
         }
 
-        draw_from_id_string( explosion_tile_id, p, subtile, rotation, lit_level::LIT,
+        draw_from_id_string( explosion_tile_id, p.raw(), subtile, rotation, lit_level::LIT,
                              nv_goggles_activated );
     }
 }
 void cata_tiles::draw_bullet_frame()
 {
-    draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos, 0, 0,
+    draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos.raw(), 0, 0,
                          lit_level::LIT, false );
 }
 void cata_tiles::draw_hit_frame()
 {
     std::string hit_overlay = "animation_hit";
 
-    draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos, 0, 0,
+    draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos.raw(), 0, 0,
                          lit_level::LIT, false );
-    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false );
+    draw_from_id_string( hit_overlay, hit_pos.raw(), 0, 0, lit_level::LIT, false );
 }
 void cata_tiles::draw_line()
 {
@@ -4681,22 +4698,22 @@ void cata_tiles::draw_line()
     static std::string line_overlay = "animation_line";
     if( !is_target_line || get_player_view().sees( line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( line_overlay, it->raw(), 0, 0, lit_level::LIT, false );
         }
     }
 
-    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, false );
+    draw_from_id_string( line_endpoint_id, line_trajectory.back().raw(), 0, 0, lit_level::LIT, false );
 }
 void cata_tiles::draw_cursor()
 {
-    for( const tripoint &p : cursors ) {
-        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, false );
+    for( const tripoint_bub_ms &p : cursors ) {
+        draw_from_id_string( "cursor", p.raw(), 0, 0, lit_level::LIT, false );
     }
 }
 void cata_tiles::draw_highlight()
 {
-    for( const tripoint &p : highlights ) {
-        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, false );
+    for( const tripoint_bub_ms &p : highlights ) {
+        draw_from_id_string( "highlight", p.raw(), 0, 0, lit_level::LIT, false );
     }
 }
 void cata_tiles::draw_weather_frame()
@@ -4768,8 +4785,8 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 void cata_tiles::draw_zones_frame()
 {
     tripoint player_pos = get_player_character().pos();
-    for( int iY = zone_start.y; iY <= zone_end.y; ++ iY ) {
-        for( int iX = zone_start.x; iX <= zone_end.x; ++iX ) {
+    for( int iY = zone_start.y(); iY <= zone_end.y(); ++ iY ) {
+        for( int iX = zone_start.x(); iX <= zone_end.x(); ++iX ) {
             draw_from_id_string( "highlight", TILE_CATEGORY::NONE, empty_string,
                                  zone_offset.xy() + tripoint( iX, iY, player_pos.z ),
                                  0, 0, lit_level::LIT, false );
@@ -4783,11 +4800,11 @@ void cata_tiles::draw_async_anim()
     // game::draw_async_anim can be called multiple times, storing each animation to be played in async_anim_layer
     // Iterate through every tripoint-tileid pair in async_anim_layer
     for( const auto &anim : async_anim_layer ) {
-        const tripoint p = anim.first;
+        const tripoint_bub_ms p = anim.first;
         const std::string tile_id = anim.second;
         // Only draw if sprite found
         if( find_tile_looks_like( tile_id, TILE_CATEGORY::NONE, "" ) ) {
-            draw_from_id_string( tile_id, p, 0, 0, lit_level::LIT, nv_goggles_activated );
+            draw_from_id_string( tile_id, p.raw(), 0, 0, lit_level::LIT, nv_goggles_activated );
         }
     }
 }
@@ -4835,13 +4852,13 @@ void cata_tiles::init_light()
     g->reset_light_level();
 }
 
-void cata_tiles::get_terrain_orientation( const tripoint &p, int &rota, int &subtile,
-        const std::map<tripoint, ter_id> &ter_override, const std::array<bool, 5> &invisible,
+void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
+        const std::map<tripoint_bub_ms, ter_id> &ter_override, const std::array<bool, 5> &invisible,
         const std::bitset<NUM_TERCONN> &rotate_group )
 {
     map &here = get_map();
     const bool overridden = ter_override.find( p ) != ter_override.end();
-    const auto ter = [&]( const tripoint & q, const bool invis ) -> ter_str_id {
+    const auto ter = [&]( const tripoint_bub_ms & q, const bool invis ) -> ter_str_id {
         const auto override_it = ter_override.find( q );
         return override_it != ter_override.end() ? override_it->second.id() :
         ( !overridden || !invis ) ? here.ter( q ).id() : ter_str_id::NULL_ID();
@@ -5112,10 +5129,10 @@ int cata_tiles::get_rotation_unconnected( const char rot_to )
     return rotation;
 }
 
-void cata_tiles::get_connect_values( const tripoint &p, int &subtile, int &rotation,
+void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
                                      const std::bitset<NUM_TERCONN> &connect_group,
                                      const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                     const std::map<tripoint, ter_id> &ter_override )
+                                     const std::map<tripoint_bub_ms, ter_id> &ter_override )
 {
     uint8_t connections = get_map().get_known_connections( p, connect_group, ter_override );
     uint8_t rotation_targets = get_map().get_known_rotates_to( p, rotate_to_group, ter_override );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -512,16 +512,16 @@ class cata_tiles
         void get_tile_values_with_ter( const tripoint &p, int t, const std::array<int, 4> &tn,
                                        int &subtile, int &rotation,
                                        const std::bitset<NUM_TERCONN> &rotate_to_group );
-        static void get_connect_values( const tripoint &p, int &subtile, int &rotation,
+        static void get_connect_values( const tripoint_bub_ms &p, int &subtile, int &rotation,
                                         const std::bitset<NUM_TERCONN> &connect_group,
                                         const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                        const std::map<tripoint, ter_id> &ter_override );
+                                        const std::map<tripoint_bub_ms, ter_id> &ter_override );
         static void get_furn_connect_values( const tripoint &p, int &subtile, int &rotation,
                                              const std::bitset<NUM_TERCONN> &connect_group,
                                              const std::bitset<NUM_TERCONN> &rotate_to_group,
                                              const std::map<tripoint, furn_id> &furn_override );
-        void get_terrain_orientation( const tripoint &p, int &rota, int &subtile,
-                                      const std::map<tripoint, ter_id> &ter_override,
+        void get_terrain_orientation( const tripoint_bub_ms &p, int &rota, int &subtile,
+                                      const std::map<tripoint_bub_ms, ter_id> &ter_override,
                                       const std::array<bool, 5> &invisible,
                                       const std::bitset<NUM_TERCONN> &rotate_group );
 
@@ -581,35 +581,39 @@ class cata_tiles
 
     public:
         // Animation layers
-        void init_explosion( const tripoint &p, int radius );
+        void init_explosion( const tripoint_bub_ms &p, int radius );
         void draw_explosion_frame();
         void void_explosion();
 
+        // TODO: Get rid of untyped overload
         void init_custom_explosion_layer( const std::map<tripoint, explosion_tile> &layer );
+        void init_custom_explosion_layer( const std::map<tripoint_bub_ms, explosion_tile> &layer );
         void draw_custom_explosion_frame();
         void void_custom_explosion();
 
-        void init_draw_bullet( const tripoint &p, std::string name );
+        void init_draw_bullet( const tripoint_bub_ms &p, std::string name );
         void draw_bullet_frame();
         void void_bullet();
 
-        void init_draw_hit( const tripoint &p, std::string name );
+        void init_draw_hit( const tripoint_bub_ms &p, std::string name );
         void draw_hit_frame();
         void void_hit();
 
         void draw_footsteps_frame( const tripoint &center );
 
         // pseudo-animated layer, not really though.
-        void init_draw_line( const tripoint &p, std::vector<tripoint> trajectory,
+        void init_draw_line( const tripoint_bub_ms &p, std::vector<tripoint_bub_ms> trajectory,
                              std::string line_end_name, bool target_line );
         void draw_line();
         void void_line();
 
-        void init_draw_cursor( const tripoint &p );
+        void init_draw_cursor( const tripoint_bub_ms &p );
         void draw_cursor();
         void void_cursor();
 
+        // TODO: Get rid of untyped overload
         void init_draw_highlight( const tripoint &p );
+        void init_draw_highlight( const tripoint_bub_ms &p );
         void draw_highlight();
         void void_highlight();
 
@@ -621,44 +625,45 @@ class cata_tiles
         void draw_sct_frame( std::multimap<point, formatted_text> &overlay_strings );
         void void_sct();
 
-        void init_draw_zones( const tripoint &start, const tripoint &end, const tripoint &offset );
+        void init_draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                              const tripoint &offset );
         void draw_zones_frame();
         void void_zones();
 
-        void init_draw_async_anim( const tripoint &p, const std::string &tile_id );
+        void init_draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id );
         void draw_async_anim();
         void void_async_anim();
 
-        void init_draw_radiation_override( const tripoint &p, int rad );
+        void init_draw_radiation_override( const tripoint_bub_ms &p, int rad );
         void void_radiation_override();
 
-        void init_draw_terrain_override( const tripoint &p, const ter_id &id );
+        void init_draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id );
         void void_terrain_override();
 
-        void init_draw_furniture_override( const tripoint &p, const furn_id &id );
+        void init_draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id );
         void void_furniture_override();
 
-        void init_draw_graffiti_override( const tripoint &p, bool has );
+        void init_draw_graffiti_override( const tripoint_bub_ms &p, bool has );
         void void_graffiti_override();
 
-        void init_draw_trap_override( const tripoint &p, const trap_id &id );
+        void init_draw_trap_override( const tripoint_bub_ms &p, const trap_id &id );
         void void_trap_override();
 
-        void init_draw_field_override( const tripoint &p, const field_type_id &id );
+        void init_draw_field_override( const tripoint_bub_ms &p, const field_type_id &id );
         void void_field_override();
 
-        void init_draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
+        void init_draw_item_override( const tripoint_bub_ms &p, const itype_id &id, const mtype_id &mid,
                                       bool hilite );
         void void_item_override();
 
-        void init_draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
+        void init_draw_vpart_override( const tripoint_bub_ms &p, const vpart_id &id, int part_mod,
                                        const units::angle &veh_dir, bool hilite, const point &mount );
         void void_vpart_override();
 
-        void init_draw_below_override( const tripoint &p, bool draw );
+        void init_draw_below_override( const tripoint_bub_ms &p, bool draw );
         void void_draw_below_override();
 
-        void init_draw_monster_override( const tripoint &p, const mtype_id &id, int count,
+        void init_draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id, int count,
                                          bool more, Creature::Attitude att );
         void void_monster_override();
 
@@ -766,31 +771,31 @@ class cata_tiles
         bool do_draw_zones = false;
         bool do_draw_async_anim = false;
 
-        tripoint exp_pos;
+        tripoint_bub_ms exp_pos;
         int exp_rad = 0;
 
-        std::map<tripoint, explosion_tile> custom_explosion_layer;
-        std::map<tripoint, std::string> async_anim_layer;
+        std::map<tripoint_bub_ms, explosion_tile> custom_explosion_layer;
+        std::map<tripoint_bub_ms, std::string> async_anim_layer;
 
-        tripoint bul_pos;
+        tripoint_bub_ms bul_pos;
         std::string bul_id;
 
-        tripoint hit_pos;
+        tripoint_bub_ms hit_pos;
         std::string hit_entity_id;
 
-        tripoint line_pos;
+        tripoint_bub_ms line_pos;
         bool is_target_line = false;
-        std::vector<tripoint> line_trajectory;
+        std::vector<tripoint_bub_ms> line_trajectory;
         std::string line_endpoint_id;
 
-        std::vector<tripoint> cursors;
-        std::vector<tripoint> highlights;
+        std::vector<tripoint_bub_ms> cursors;
+        std::vector<tripoint_bub_ms> highlights;
 
         weather_printable anim_weather;
         std::string weather_name;
 
-        tripoint zone_start;
-        tripoint zone_end;
+        tripoint_bub_ms zone_start;
+        tripoint_bub_ms zone_end;
         tripoint zone_offset;
 
         // offset values, in tile coordinates, not pixels
@@ -798,20 +803,20 @@ class cata_tiles
         // offset for drawing, in pixels.
         point op;
 
-        std::map<tripoint, int> radiation_override;
-        std::map<tripoint, ter_id> terrain_override;
-        std::map<tripoint, furn_id> furniture_override;
-        std::map<tripoint, bool> graffiti_override;
-        std::map<tripoint, trap_id> trap_override;
-        std::map<tripoint, field_type_id> field_override;
+        std::map<tripoint_bub_ms, int> radiation_override;
+        std::map<tripoint_bub_ms, ter_id> terrain_override;
+        std::map<tripoint_bub_ms, furn_id> furniture_override;
+        std::map<tripoint_bub_ms, bool> graffiti_override;
+        std::map<tripoint_bub_ms, trap_id> trap_override;
+        std::map<tripoint_bub_ms, field_type_id> field_override;
         // bool represents item highlight
-        std::map<tripoint, std::tuple<itype_id, mtype_id, bool>> item_override;
+        std::map<tripoint_bub_ms, std::tuple<itype_id, mtype_id, bool>> item_override;
         // int, angle, bool represents part_mod, veh_dir, and highlight respectively
         // point represents the mount direction
-        std::map<tripoint, std::tuple<vpart_id, int, units::angle, bool, point>> vpart_override;
-        std::map<tripoint, bool> draw_below_override;
+        std::map<tripoint_bub_ms, std::tuple<vpart_id, int, units::angle, bool, point>> vpart_override;
+        std::map<tripoint_bub_ms, bool> draw_below_override;
         // int represents spawn count
-        std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;
+        std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Creature::Attitude>> monster_override;
 
     private:
         /**

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3056,6 +3056,12 @@ void Creature::draw( const catacurses::window &w, const tripoint &origin, bool i
     }
 }
 
+void Creature::draw( const catacurses::window &w, const tripoint_bub_ms &origin,
+                     bool inverted ) const
+{
+    Creature::draw( w, origin.raw(), inverted );
+}
+
 bool Creature::is_symbol_highlighted() const
 {
     return false;

--- a/src/creature.h
+++ b/src/creature.h
@@ -953,7 +953,9 @@ class Creature : public viewer
 
         bool underwater;
         void draw( const catacurses::window &w, const point &origin, bool inverted ) const;
+        // TODO: Get rid of the untyped overload
         void draw( const catacurses::window &w, const tripoint &origin, bool inverted ) const;
+        void draw( const catacurses::window &w, const tripoint_bub_ms &origin, bool inverted ) const;
         /**
          * Write information about this creature.
          * @param w the window to print the text into.

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -626,14 +626,14 @@ void editmap::draw_main_ui_overlay()
                 for( int y = 0; y < SEEY * 2; y++ ) {
                     const tripoint tmp_p( x, y, target.z );
                     const tripoint map_p = origin_p + tmp_p;
-                    g->draw_radiation_override( map_p, tmpmap.get_radiation( tmp_p ) );
+                    g->draw_radiation_override( tripoint_bub_ms( map_p ), tmpmap.get_radiation( tmp_p ) );
                     // scent is managed in `game` instead of `map`, so there's no override for it
                     // temperature is managed in `game` instead of `map`, so there's no override for it
                     // TODO: visibility could be affected by both the actual map and the preview map,
                     // which complicates calculation, so there's no override for it (yet)
                     g->draw_terrain_override( map_p, tmpmap.ter( tmp_p ) );
                     g->draw_furniture_override( map_p, tmpmap.furn( tmp_p ) );
-                    g->draw_graffiti_override( map_p, tmpmap.has_graffiti_at( tmp_p ) );
+                    g->draw_graffiti_override( tripoint_bub_ms( map_p ), tmpmap.has_graffiti_at( tmp_p ) );
                     g->draw_trap_override( map_p, tmpmap.tr_at( tmp_p ).loadid );
                     g->draw_field_override( map_p, tmpmap.field_at( tmp_p ).displayed_field_type() );
                     const maptile &tile = tmpmap.maptile_at( tmp_p );
@@ -659,7 +659,7 @@ void editmap::draw_main_ui_overlay()
                     } else {
                         g->draw_vpart_override( map_p, vpart_id::NULL_ID(), 0, 0_degrees, false, point_zero );
                     }
-                    g->draw_below_override( map_p,
+                    g->draw_below_override( tripoint_bub_ms( map_p ),
                                             tmpmap.ter( tmp_p ).obj().has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) );
                 }
             }
@@ -684,7 +684,8 @@ void editmap::draw_main_ui_overlay()
                 }
             }
             for( const auto &it : spawns ) {
-                g->draw_monster_override( it.first, std::get<0>( it.second ), std::get<1>( it.second ),
+                g->draw_monster_override( tripoint_bub_ms( it.first ), std::get<0>( it.second ),
+                                          std::get<1>( it.second ),
                                           std::get<2>( it.second ), std::get<3>( it.second ) );
             }
         } else {

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -97,8 +97,13 @@ void nuke( const tripoint_abs_omt &p );
 void shockwave( const tripoint &p, int radius, int force, int stun, int dam_mult,
                 bool ignore_player );
 
+// TODO: Get rid of untyped overload
 void draw_explosion( const tripoint &p, int radius, const nc_color &col );
+void draw_explosion( const tripoint_bub_ms &p, int radius, const nc_color &col );
+// TODO: Get rid of untyped overload
 void draw_custom_explosion( const tripoint &p, const std::map<tripoint, nc_color> &area,
+                            const std::optional<std::string> &tile_id = std::nullopt );
+void draw_custom_explosion( const std::map<tripoint_bub_ms, nc_color> &area,
                             const std::optional<std::string> &tile_id = std::nullopt );
 
 int ballistic_damage( float velocity, float mass );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3886,12 +3886,12 @@ static shared_ptr_fast<game::draw_callback_t> create_zone_callback(
             }
 #endif
 
-            const tripoint start( std::min( zone_start->x, zone_end->x ),
-                                  std::min( zone_start->y, zone_end->y ),
-                                  zone_end->z );
-            const tripoint end( std::max( zone_start->x, zone_end->x ),
-                                std::max( zone_start->y, zone_end->y ),
-                                zone_end->z );
+            const tripoint_bub_ms start( std::min( zone_start->x, zone_end->x ),
+                                         std::min( zone_start->y, zone_end->y ),
+                                         zone_end->z );
+            const tripoint_bub_ms end( std::max( zone_start->x, zone_end->x ),
+                                       std::max( zone_start->y, zone_end->y ),
+                                       zone_end->z );
             g->draw_zones( start, end, offset );
         }
     } );
@@ -3911,7 +3911,7 @@ static shared_ptr_fast<game::draw_callback_t> create_trail_callback(
     } );
 }
 
-void game::init_draw_async_anim_curses( const tripoint &p, const std::string &ncstr,
+void game::init_draw_async_anim_curses( const tripoint_bub_ms &p, const std::string &ncstr,
                                         const nc_color &nccol )
 {
     std::pair <std::string, nc_color> anim( ncstr, nccol );
@@ -3923,12 +3923,12 @@ void game::draw_async_anim_curses()
     // game::draw_async_anim_curses can be called multiple times, storing each animation to be played in async_anim_layer_curses
     // Iterate through every animation in async_anim_layer
     for( const auto &anim : async_anim_layer_curses ) {
-        const tripoint p = anim.first - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(),
-                           -u.posz() );
+        const tripoint_bub_ms p = anim.first - u.view_offset + tripoint( POSX - u.posx(), POSY - u.posy(),
+                                  -u.posz() );
         const std::string ncstr = anim.second.first;
         const nc_color nccol = anim.second.second;
 
-        mvwprintz( w_terrain, p.xy(), nccol, ncstr );
+        mvwprintz( w_terrain, p.xy().raw(), nccol, ncstr );
     }
 }
 
@@ -4121,12 +4121,12 @@ void game::draw_critter( const Creature &critter, const tripoint &center )
     }
 }
 
-bool game::is_in_viewport( const tripoint &p, int margin ) const
+bool game::is_in_viewport( const tripoint_bub_ms &p, int margin ) const
 {
-    const tripoint diff( u.pos() + u.view_offset - p );
+    const tripoint_rel_ms diff( u.pos_bub() + u.view_offset - p );
 
-    return ( std::abs( diff.x ) <= getmaxx( w_terrain ) / 2 - margin ) &&
-           ( std::abs( diff.y ) <= getmaxy( w_terrain ) / 2 - margin );
+    return ( std::abs( diff.x() ) <= getmaxx( w_terrain ) / 2 - margin ) &&
+           ( std::abs( diff.y() ) <= getmaxy( w_terrain ) / 2 - margin );
 }
 
 void game::draw_ter( const bool draw_sounds )

--- a/src/game.h
+++ b/src/game.h
@@ -248,12 +248,12 @@ class game
 
     public:
         // Curses counterpart of the async_anim functions in cata_tiles
-        void init_draw_async_anim_curses( const tripoint &p, const std::string &ncstr,
+        void init_draw_async_anim_curses( const tripoint_bub_ms &p, const std::string &ncstr,
                                           const nc_color &nccol );
         void draw_async_anim_curses();
         void void_async_anim_curses();
     protected:
-        std::map<tripoint, std::pair <std::string, nc_color>>
+        std::map<tripoint_bub_ms, std::pair <std::string, nc_color>>
                 async_anim_layer_curses; // NOLINT(cata-serialize)
 
     public:
@@ -756,44 +756,75 @@ class game
         void knockback( std::vector<tripoint> &traj, int stun, int dam_mult );
 
         // Animation related functions
+        // TODO: Get rid of untyped overload
         void draw_bullet( const tripoint &t, int i, const std::vector<tripoint> &trajectory,
                           char bullet );
+        void draw_bullet( const tripoint_bub_ms &t, int i, const std::vector<tripoint_bub_ms> &trajectory,
+                          char bullet );
+        // TODO: Get rid of untyped overload
         void draw_hit_mon( const tripoint &p, const monster &m, bool dead = false );
+        void draw_hit_mon( const tripoint_bub_ms &p, const monster &m, bool dead = false );
         void draw_hit_player( const Character &p, int dam );
         // TODO: fix point types (remove the first overload)
         void draw_line( const tripoint &p, const tripoint &center_point,
                         const std::vector<tripoint> &points, bool noreveal = false );
         void draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center_point,
                         const std::vector<tripoint_bub_ms> &points, bool noreveal = false );
+        // TODO: Change to typed when single user is updated.
         void draw_line( const tripoint &p, const std::vector<tripoint> &points );
         void draw_weather( const weather_printable &wPrint ) const;
         void draw_sct() const;
-        void draw_zones( const tripoint &start, const tripoint &end, const tripoint &offset ) const;
+        void draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                         const tripoint &offset ) const;
         // Draw critter (if visible!) on its current position into w_terrain.
         // @param center the center of view, same as when calling map::draw
         void draw_critter( const Creature &critter, const tripoint &center );
+        // TODO: Get rid of untyped overload
         void draw_cursor( const tripoint &p ) const;
+        void draw_cursor( const tripoint_bub_ms &p ) const;
         // Draw a highlight graphic at p, for example when examining something.
         // TILES only, in curses this does nothing
+        // TODO: Get rid of untyped overload
         void draw_highlight( const tripoint &p );
+        void draw_highlight( const tripoint_bub_ms &p );
         // Draws an asynchronous animation at p with tile_id as its sprite. If ncstr is specified, it will also be displayed in curses.
+        // TODO: Get rid of untyped overload
         void draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr = "",
                               const nc_color &nccol = c_black );
-        void draw_radiation_override( const tripoint &p, int rad );
+        void draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
+                              const std::string &ncstr = "",
+                              const nc_color &nccol = c_black );
+        void draw_radiation_override( const tripoint_bub_ms &p, int rad );
+        // TODO: Get rid of untyped overload
         void draw_terrain_override( const tripoint &p, const ter_id &id );
+        void draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id );
+        // TODO: Get rid of untyped overload
         void draw_furniture_override( const tripoint &p, const furn_id &id );
-        void draw_graffiti_override( const tripoint &p, bool has );
+        void draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id );
+        void draw_graffiti_override( const tripoint_bub_ms &p, bool has );
+        // TODO: Get rid of untyped overload
         void draw_trap_override( const tripoint &p, const trap_id &id );
+        void draw_trap_override( const tripoint_bub_ms &p, const trap_id &id );
+        // TODO: Get rid of untyped overload
         void draw_field_override( const tripoint &p, const field_type_id &id );
+        void draw_field_override( const tripoint_bub_ms &p, const field_type_id &id );
+        // TODO: Get rid of untyped overload
         void draw_item_override( const tripoint &p, const itype_id &id, const mtype_id &mid,
                                  bool hilite );
+        void draw_item_override( const tripoint_bub_ms &p, const itype_id &id, const mtype_id &mid,
+                                 bool hilite );
+        // TODO: Get rid of untyped overload
         void draw_vpart_override( const tripoint &p, const vpart_id &id, int part_mod,
                                   const units::angle &veh_dir, bool hilite, const point &mount );
+        void draw_vpart_override( const tripoint_bub_ms &p, const vpart_id &id, int part_mod,
+                                  const units::angle &veh_dir, bool hilite, const point &mount );
+        // TODO: Get rid of untyped overload
         void draw_below_override( const tripoint &p, bool draw );
-        void draw_monster_override( const tripoint &p, const mtype_id &id, int count,
+        void draw_below_override( const tripoint_bub_ms &p, bool draw );
+        void draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id, int count,
                                     bool more, Creature::Attitude att );
 
-        bool is_in_viewport( const tripoint &p, int margin = 0 ) const;
+        bool is_in_viewport( const tripoint_bub_ms &p, int margin = 0 ) const;
         /**
          * Check whether movement is allowed according to safe mode settings.
          * @return true if the movement is allowed, otherwise false.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1977,15 +1977,15 @@ void map::set_map_damage( const tripoint_bub_ms &p, int dmg )
     return current_submap->set_map_damage( l, dmg );
 }
 
-uint8_t map::get_known_connections( const tripoint &p,
+uint8_t map::get_known_connections( const tripoint_bub_ms &p,
                                     const std::bitset<NUM_TERCONN> &connect_group,
-                                    const std::map<tripoint, ter_id> &override ) const
+                                    const std::map<tripoint_bub_ms, ter_id> &override ) const
 {
     if( connect_group.none() ) {
         return 0;
     }
 
-    const level_cache &ch = access_cache( p.z );
+    const level_cache &ch = access_cache( p.z() );
     uint8_t val = 0;
     std::function<bool( const tripoint & )> is_memorized;
     avatar &player_character = get_avatar();
@@ -2006,11 +2006,11 @@ uint8_t map::get_known_connections( const tripoint &p,
 #endif
 
     const bool overridden = override.find( p ) != override.end();
-    const bool is_transparent = ch.transparency_cache[p.x][p.y] > LIGHT_TRANSPARENCY_SOLID;
+    const bool is_transparent = ch.transparency_cache[p.x()][p.y()] > LIGHT_TRANSPARENCY_SOLID;
 
     // populate connection information
     for( int i = 0; i < 4; ++i ) {
-        tripoint neighbour = p + offsets[i];
+        tripoint_bub_ms neighbour = p + offsets[i];
         if( !inbounds( neighbour ) ) {
             continue;
         }
@@ -2018,10 +2018,10 @@ uint8_t map::get_known_connections( const tripoint &p,
         const bool neighbour_overridden = neighbour_override != override.end();
         // if there's some non-memory terrain to show at the neighboring tile
         const bool may_connect = neighbour_overridden ||
-                                 get_visibility( ch.visibility_cache[neighbour.x][neighbour.y],
+                                 get_visibility( ch.visibility_cache[neighbour.x()][neighbour.y()],
                                          get_visibility_variables_cache() ) == visibility_type::CLEAR ||
                                  // or if an actual center tile is transparent or next to a memorized tile
-                                 ( !overridden && ( is_transparent || is_memorized( neighbour ) ) );
+                                 ( !overridden && ( is_transparent || is_memorized( neighbour.raw() ) ) );
         if( may_connect ) {
             const ter_t &neighbour_terrain = neighbour_overridden ?
                                              neighbour_override->second.obj() : ter( neighbour ).obj();
@@ -2034,9 +2034,9 @@ uint8_t map::get_known_connections( const tripoint &p,
     return val;
 }
 
-uint8_t map::get_known_rotates_to( const tripoint &p,
+uint8_t map::get_known_rotates_to( const tripoint_bub_ms &p,
                                    const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                   const std::map<tripoint, ter_id> &override ) const
+                                   const std::map<tripoint_bub_ms, ter_id> &override ) const
 {
     if( rotate_to_group.none() ) {
         return CHAR_MAX;
@@ -2046,7 +2046,7 @@ uint8_t map::get_known_rotates_to( const tripoint &p,
 
     // populate connection information
     for( int i = 0; i < 4; ++i ) {
-        tripoint neighbour = p + offsets[i];
+        tripoint_bub_ms neighbour = p + offsets[i];
         if( !inbounds( neighbour ) ) {
             continue;
         }
@@ -9378,7 +9378,7 @@ bool map::has_graffiti_at( const tripoint &p ) const
 int map::determine_wall_corner( const tripoint &p ) const
 {
     const std::bitset<NUM_TERCONN> &test_connect_group = ter( p ).obj().connect_to_groups;
-    uint8_t connections = get_known_connections( p, test_connect_group );
+    uint8_t connections = get_known_connections( tripoint_bub_ms( p ), test_connect_group );
     // The bits in connections are SEWN, whereas the characters in LINE_
     // constants are NESW, so we want values in 8 | 2 | 1 | 4 order.
     switch( connections ) {

--- a/src/map.h
+++ b/src/map.h
@@ -867,8 +867,9 @@ class map
         // terrain. Additional overrides can be passed in to override terrain
         // at specific positions. This is used to display terrain overview in
         // the map editor.
-        uint8_t get_known_connections( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
-                                       const std::map<tripoint, ter_id> &override = {} ) const;
+        uint8_t get_known_connections( const tripoint_bub_ms &p,
+                                       const std::bitset<NUM_TERCONN> &connect_group,
+                                       const std::map<tripoint_bub_ms, ter_id> &override = {} ) const;
         // as above, but for furniture
         uint8_t get_known_connections_f( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
                                          const std::map<tripoint, furn_id> &override = {} ) const;
@@ -880,8 +881,9 @@ class map
         // Based on the true terrain.
         // Additional overrides can be passed in to override terrain
         // at specific positions.
-        uint8_t get_known_rotates_to( const tripoint &p, const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                      const std::map<tripoint, ter_id> &override = {} ) const;
+        uint8_t get_known_rotates_to( const tripoint_bub_ms &p,
+                                      const std::bitset<NUM_TERCONN> &rotate_to_group,
+                                      const std::map<tripoint_bub_ms, ter_id> &override = {} ) const;
         // as above, but for furniture (considers neighbouring terrain and furniture)
         uint8_t get_known_rotates_to_f( const tripoint &p, const std::bitset<NUM_TERCONN> &rotate_to_group,
                                         const std::map<tripoint, ter_id> &override = {},

--- a/tests/connect_rotate_test.cpp
+++ b/tests/connect_rotate_test.cpp
@@ -20,7 +20,8 @@ class cata_tiles_test_helper
         static void get_connect_values( const tripoint &p, int &subtile, int &rotation,
                                         const std::bitset<NUM_TERCONN> &connect_group,
                                         const std::bitset<NUM_TERCONN> &rotate_to_group ) {
-            cata_tiles::get_connect_values( p, subtile, rotation, connect_group, rotate_to_group, {} );
+            cata_tiles::get_connect_values( tripoint_bub_ms( p ), subtile, rotation, connect_group,
+                                            rotate_to_group, {} );
         }
 };
 


### PR DESCRIPTION
#### Summary
Backport 73609 - Typify animation

#### Purpose of change
More typification stuff. Necessary infrastructure for getting monsters to display effect icons.

#### Testing
Compiles and runs

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
