### PR TITLE
Remove leftover NRE EOC calls from LIXA

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json
+++ b/data/json/effects_on_condition/nether_eocs/LIXA_EOCs_spells_traps.json
@@ -498,54 +498,54 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_1",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "1" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "1" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_2",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "2" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "2" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_3",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "3" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "3" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_4",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "4" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "4" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_5",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "5" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "5" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_6",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "6" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "6" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_7",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "7" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "7" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_8",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "8" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "8" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_9",
-    "effect": [ { "math": [ "u_LIXA_entry", "=", "9" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] } ]
+    "effect": [ { "math": [ "u_LIXA_entry", "=", "9" ] }, { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_10",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "10" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -553,7 +553,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_11",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "11" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -561,7 +561,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_12",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "12" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -569,7 +569,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_13",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "13" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -577,7 +577,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_14",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "14" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -585,7 +585,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_15",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "15" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {
@@ -593,7 +593,7 @@
     "id": "EOC_LIXA_UNFOLD_ENTRY_SETUP_16",
     "effect": [
       { "math": [ "u_LIXA_entry", "=", "16" ] },
-      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY", "capture_generic_nre_anomaly" ] }
+      { "run_eocs": [ "EOC_LIXA_UNFOLD_ENTRY" ] }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Remove leftover NRE EOC calls from LIXA

#### Purpose of change
- Funny alphabet soup PR title
- LIXA had some leftover calls to a removed EOC, where in the infinite hallway it would try to check if you had an NRE and give you anomaly data if so. We don't have the NRE or the EOC it was trying to call so this was causing an error.

#### Describe the solution
- Remove the call

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
