### PR TITLE
Backport 73001 again: Remove city_center, simplify mx_fungal_zone

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -53,7 +53,6 @@
       "radius": 135,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "fema_entrance",
         { "om_terrain": "bunker", "om_terrain_match_type": "TYPE" },
@@ -80,7 +79,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "s_pharm",
         "s_gun",
@@ -104,7 +102,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "s_gas", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "s_gas_rural", "om_terrain_match_type": "TYPE" },
         "roadstop",
@@ -199,7 +196,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "hotel_tower",
         "s_restaurant",
@@ -224,7 +220,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "s_restaurant_coffee",
         "s_restaurant",
@@ -248,7 +243,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
@@ -272,7 +266,6 @@
       "radius": 90,
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "desolatebarn",
         "shoppingplaza",
@@ -301,7 +294,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_restaurant_coffee",
         "s_restaurant_fast",
         "s_restaurant",
@@ -322,14 +314,7 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
-      "terrain": [
-        "bridge",
-        { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
-        "s_grocery",
-        "trailer_commercial",
-        "bakery"
-      ],
+      "terrain": [ "bridge", { "om_terrain": "road", "om_terrain_match_type": "PREFIX" }, "s_grocery", "trailer_commercial", "bakery" ],
       "message": "You add roads, local grocery and convenience stores as well as bakeries to your map."
     }
   },
@@ -346,7 +331,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bakery",
         "s_butcher",
         "craft_shop",
@@ -368,7 +352,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_bike_shop",
         "gym_fitness",
         "gym",
@@ -394,7 +377,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "park", "om_terrain_match_type": "PREFIX" },
         "veterinarian",
         "NatureTrail",
@@ -419,7 +401,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "bar", "om_terrain_match_type": "PREFIX" },
         "music_venue",
         "movietheater",
@@ -442,7 +423,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_gun",
         "s_hunting",
         "s_camping",
@@ -465,7 +445,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "museum", "om_terrain_match_type": "TYPE" },
         "s_antique",
         "s_library",
@@ -487,7 +466,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "mall_a_1",
         "mall_a_2",
         "mall_a_3",
@@ -524,7 +502,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "furniture",
         "home_improvement",
         "hdwr_large_1_2_0",
@@ -551,7 +528,6 @@
       "terrain": [
         "bridge",
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "s_electronicstore",
         "s_electronics",
         "s_hardware",

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -1073,20 +1073,6 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": "city_center",
-    "//": "Need to fix magical teleportation with actual aligned manhole placement",
-    "object": {
-      "fill_ter": "t_region_grass",
-      "place_nested": [
-        { "chunks": [ "24x24_road_four_way_crossroad" ], "x": 0, "y": 0 },
-        { "chunks": [ "1x1_manhole" ], "x": [ 5, 18 ], "y": [ 5, 18 ] }
-      ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "method": "json",
     "nested_mapgen_id": "24x24_road_four_way_rotary",
     "object": {
       "mapgensize": [ 24, 24 ],

--- a/data/json/obsoletion_and_migration/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration/obsolete_overmap_terrain.json
@@ -55,6 +55,11 @@
   },
   {
     "type": "oter_id_migration",
+    "//": "migrated in 0.I",
+    "oter_ids": { "city_center": "road_nesw_manhole" }
+  },
+  {
+    "type": "oter_id_migration",
     "//": "obsoleted in 0.G, but no migration in 0.G so to be removed after 0.I stable",
     "oter_ids": {
       "apartments_con_tower_001_east": "omt_obsolete",

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -537,7 +537,11 @@
     "name": { "str": "Fungal infestation" },
     "description": "Fungal-infested location.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
-    "min_max_zlevel": [ 0, 0 ]
+    "sym": "F",
+    "color": "yellow",
+    "autonote": true,
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "FUNGAL" ]
   },
   {
     "id": "mx_reed",

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -8,7 +8,6 @@
       { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
-      { "terrain": "city_center", "locations": [ "field", "road" ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
       { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }
     ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -1,40 +1,54 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "park", "park_roof", "park_2", "park_3", "park_4", "park_5", "park_5_roof", "park_6", "park_7", "park_7_roof" ],
+    "abstract": "generic_park",
     "copy-from": "generic_city_building",
     "name": "park",
     "sym": "O",
-    "color": "green"
+    "color": "green",
+    "extras": "park"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "park", "park_roof", "park_2", "park_3", "park_4", "park_5", "park_5_roof", "park_6", "park_7", "park_7_roof" ],
+    "copy-from": "generic_park"
   },
   {
     "type": "overmap_terrain",
     "id": [ "playground", "playground_roof", "playground_1" ],
-    "copy-from": "park",
+    "copy-from": "generic_park",
     "name": "playground"
   },
   {
     "type": "overmap_terrain",
     "id": [ "dog_park" ],
-    "copy-from": "park",
+    "copy-from": "generic_park",
     "name": "dog park"
   },
   {
     "type": "overmap_terrain",
+    "abstract": "sports_court",
+    "copy-from": "generic_city_building",
+    "sym": "O",
+    "color": "dark_gray"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "volleyball_court" ],
-    "copy-from": "park",
-    "name": "volleyball court"
+    "copy-from": "sports_court",
+    "name": "volleyball court",
+    "color": "yellow"
   },
   {
     "type": "overmap_terrain",
     "id": [ "tennis_court" ],
-    "copy-from": "park",
+    "copy-from": "sports_court",
     "name": "tennis court"
   },
   {
     "type": "overmap_terrain",
     "id": [ "baskeball_court" ],
-    "copy-from": "park",
+    "copy-from": "sports_court",
     "name": "basketball court"
   },
   {
@@ -90,7 +104,8 @@
     "copy-from": "generic_city_building",
     "name": "fishing pond",
     "sym": "S",
-    "color": "i_blue"
+    "color": "i_blue",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -106,7 +121,8 @@
     "copy-from": "generic_city_building",
     "name": "small wooded trail",
     "sym": "S",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -147,7 +163,8 @@
     "copy-from": "generic_city_building",
     "name": "nature trail",
     "sym": "S",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -155,7 +172,8 @@
     "copy-from": "generic_city_building",
     "name": "public pond",
     "sym": "P",
-    "color": "i_green"
+    "color": "i_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -165,7 +183,8 @@
     "color": "yellow",
     "see_cost": 5,
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING" ]
+    "flags": [ "SIDEWALK", "SOURCE_FARMING" ],
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -174,7 +193,8 @@
     "name": "public garden",
     "looks_like": "publicgarden",
     "sym": "g",
-    "color": "light_green"
+    "color": "light_green",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",
@@ -965,7 +985,8 @@
     "copy-from": "generic_city_building",
     "name": "private park roof",
     "sym": "p",
-    "color": "light_green_red"
+    "color": "light_green_red",
+    "extras": "park"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -24,18 +24,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "city_center",
-    "copy-from": "generic_transportation",
-    "name": "road",
-    "sym": "┼",
-    "color": "dark_gray",
-    "see_cost": 2,
-    "travel_cost_type": "road",
-    "extras": "city_center",
-    "flags": [ "NO_ROTATE" ]
-  },
-  {
-    "type": "overmap_terrain",
     "abstract": "generic_bridge",
     "copy-from": "generic_transportation",
     "name": "bridge",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -700,7 +700,7 @@
         }
       },
       "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
-      "city_center": { "chance": 20, "extras": { "mx_fungal_zone": 100 } },
+      "park": { "chance": 60, "extras": { "mx_fungal_zone": 100 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 1, "mx_laststand": 1 } },
       "build": {
         "chance": 90,

--- a/doc/REGION_SETTINGS.md
+++ b/doc/REGION_SETTINGS.md
@@ -395,14 +395,14 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 
 ### Fields
 
-|          Identifier          |                                                    Description                                                  |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road, city_center and road_nesw_manhole. |
-| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.                |
-| `trail_connection`           | overmap_connection id used for forest trails.                                                                   |
-| `sewer_connection`           | overmap_connection id used for sewer connections.                                                               |
-| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                                         |
-| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                                |
+|          Identifier          |                                                    Description                                     |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `intra_city_road_connection` | overmap_connection id used within cities. Should include locations for road and road_nesw_manhole. |
+| `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.   |
+| `trail_connection`           | overmap_connection id used for forest trails.                                                      |
+| `sewer_connection`           | overmap_connection id used for sewer connections.                                                  |
+| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                            |
+| `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                   |
 
 ### Example
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -71,7 +71,6 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 static const oter_str_id oter_central_lab( "central_lab" );
 static const oter_str_id oter_central_lab_core( "central_lab_core" );
 static const oter_str_id oter_central_lab_train_depot( "central_lab_train_depot" );
-static const oter_str_id oter_city_center( "city_center" );
 static const oter_str_id oter_empty_rock( "empty_rock" );
 static const oter_str_id oter_field( "field" );
 static const oter_str_id oter_forest( "forest" );
@@ -974,7 +973,7 @@ bool oter_t::type_is( const oter_type_t &type ) const
 bool oter_t::has_connection( om_direction::type dir ) const
 {
     // TODO: It's a DAMN UGLY hack. Remove it as soon as possible.
-    if( id == oter_road_nesw_manhole || id == oter_city_center ) {
+    if( id == oter_road_nesw_manhole ) {
         return true;
     }
     return om_lines::has_segment( line, dir );
@@ -5551,10 +5550,6 @@ void overmap::place_cities()
             do {
                 build_city_street( local_road, tmp.pos, tmp.size, cur_dir, tmp );
             } while( ( cur_dir = om_direction::turn_right( cur_dir ) ) != start_dir );
-
-            // Replace city's original intersection OMT with a dedicated 'city_center' OMT
-            // This allows setting map extras specifically to cities (or their centers)
-            ter_set( tripoint_om_omt( tmp.pos, 0 ), oter_city_center );
         }
     }
 }


### PR DESCRIPTION
#### Summary
This time with attribution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
