### PR TITLE
Backport DDA 73505 - recipe flags for contemplation

### DIFF
--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -1323,6 +1323,10 @@ See [Character](#character)
 - ```NEED_FULL_MAGAZINE``` If this recipe requires magazines, it needs one that is full.
 - ```NO_RESIZE``` This clothes you crafted spawn unfitted 
 - ```SECRET``` Not automatically learned at character creation time based on high skill levels.
+- ```AFFECTED_BY_PAIN``` 1 unit of pain decreases the speed of craft for 1%. Recommended to not use in vanilla recipes
+- ```NO_MANIP``` Manipulation score do not affect crafting this recipe
+- ```NO_BENCH``` Workbench bonus or penalty do not apply to this recipe
+- ```NO_ENCHANTMENT``` Enchantment (used in mutations, CBM, effects etc) bonus or penalty do not apply to this recipe
 
 
 ### Crafting recipes

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -64,8 +64,10 @@
 
 static const limb_score_id limb_score_manip( "manip" );
 
+static const std::string flag_AFFECTED_BY_PAIN( "AFFECTED_BY_PAIN" );
 static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
+static const std::string flag_NO_MANIP( "NO_MANIP" );
 
 enum TAB_MODE {
     NORMAL,
@@ -2278,7 +2280,10 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
     } else if( crafter.crafting_speed_multiplier( rec ) < 1.0f ) {
         int morale_modifier = crafter.morale_crafting_speed_multiplier( rec ) * 100;
         int lighting_modifier = crafter.lighting_craft_speed_multiplier( rec ) * 100;
-        int limb_modifier = crafter.get_limb_score( limb_score_manip ) * 100;
+        int limb_modifier = rec.has_flag( flag_NO_MANIP ) ? 100 : crafter.get_limb_score(
+                                limb_score_manip ) * 100;
+        int pain_multi = rec.has_flag( flag_AFFECTED_BY_PAIN ) ? 100 * std::max( 0.0f,
+                         1.0f - ( crafter.get_perceived_pain() / 100.0f ) ) : 100;
 
         std::stringstream modifiers_list;
         if( morale_modifier < 100 ) {
@@ -2295,6 +2300,12 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
                 modifiers_list << ", ";
             }
             modifiers_list << _( "hands encumbrance/wounds" ) << " " << limb_modifier << "%";
+        }
+        if( pain_multi < 100 ) {
+            if( !modifiers_list.str().empty() ) {
+                modifiers_list << ", ";
+            }
+            modifiers_list << _( "pain" ) << " " << pain_multi << "%";
         }
 
         right_print( w, 0, 1, i_yellow,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2877,6 +2877,11 @@ void avatar::disarm( npc &target )
 
     item_location it = target.get_wielded_item();
     const item_location weapon = get_wielded_item();
+
+    if( it->has_flag( flag_INTEGRATED ) ) {
+        return;
+    };
+
     // roll your melee and target's dodge skills to check if grab/smash attack succeeds
     int hitspread = target.deal_melee_attack( this, hit_roll() );
     if( hitspread < 0 ) {


### PR DESCRIPTION
#### Summary
Partially backport flags for hands-free recipes.

#### Purpose of change
We don't use MoM, but these are potentially useful flags for future use.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
