### PR TITLE
Finish removing backer name stuff

### DIFF
--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -97,7 +97,6 @@ void snippet_library::reload_names( const cata_path &path )
         };
 
         const std::unordered_map<std::string, usage_info> usages = {
-            { "backer", { true, nullptr, &snippets_by_category["<male_backer_name>"], &snippets_by_category["<female_backer_name>"] } },
             { "given", { true, nullptr, &snippets_by_category["<male_given_name>"], &snippets_by_category["<female_given_name>"] } },
             { "family", { false, &snippets_by_category["<family_name>"], nullptr, nullptr } },
             { "nick", { false, &snippets_by_category["<nick_name>"], nullptr, nullptr } },

--- a/tests/data/name.json
+++ b/tests/data/name.json
@@ -1,20 +1,5 @@
 [
   {
-    "usage": "backer",
-    "gender": "male",
-    "name": "Male Backer"
-  },
-  {
-    "usage": "backer",
-    "gender": "female",
-    "name": "Female Backer"
-  },
-  {
-    "usage": "backer",
-    "gender": "unisex",
-    "name": "Unisex Backer"
-  },
-  {
     "usage": "family",
     "name": "Family"
   },

--- a/tests/name_test.cpp
+++ b/tests/name_test.cpp
@@ -56,28 +56,16 @@ TEST_CASE( "name_generation", "[name]" )
             std::string name = SNIPPET.expand( "<family_name>" );
             CHECK( name == "Family" );
         }
-        WHEN( "Getting a male backer name" ) {
-            for( int i = 0; i < 8; ++i ) {
-                std::string name = SNIPPET.expand( "<male_backer_name>" );
-                CHECK_THAT( name, IsOneOf( {"Male Backer", "Unisex Backer"} ) );
-            }
-        }
-        WHEN( "Getting a female backer name" ) {
-            for( int i = 0; i < 8; ++i ) {
-                std::string name = SNIPPET.expand( "<female_backer_name>" );
-                CHECK_THAT( name, IsOneOf( {"Female Backer", "Unisex Backer"} ) );
-            }
-        }
         WHEN( "Generating a male name" ) {
             for( int i = 0; i < 16; ++i ) {
                 std::string name = SNIPPET.expand( "<male_full_name>" );
-                CHECK_THAT( name, IsOneOf( {"Male Backer", "Unisex Backer", "Male Family", "Unisex Family", "Male 'Nick' Family", "Unisex 'Nick' Family"} ) );
+                CHECK_THAT( name, IsOneOf( {"Male Family", "Unisex Family", "Male 'Nick' Family", "Unisex 'Nick' Family"} ) );
             }
         }
         WHEN( "Generating a female name" ) {
             for( int i = 0; i < 16; ++i ) {
                 std::string name = SNIPPET.expand( "<female_full_name>" );
-                CHECK_THAT( name, IsOneOf( {"Female Backer", "Unisex Backer", "Female Family", "Unisex Family", "Female 'Nick' Family", "Unisex 'Nick' Family"} ) );
+                CHECK_THAT( name, IsOneOf( {"Female Family", "Unisex Family", "Female 'Nick' Family", "Unisex 'Nick' Family"} ) );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Remove dead code related to backer names

#### Purpose of change
#324 removed backer names, but some dead code was left in the game referring to them.

#### Describe the solution
Remove the code, remove backer name checks from tests.

#### Testing
Compiles and runs

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
