### PR TITLE
Partially backport but fix 74004

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -469,8 +469,8 @@ static butcher_type get_butcher_type( player_activity *act )
         action = butcher_type::BLEED;
     } else if( act->id() == ACT_SKIN ) {
         action = butcher_type::SKIN;
-    // } else if( act->id() == ACT_DISMEMBER ) {
-    //    action = butcher_type::DISMEMBER;
+        // } else if( act->id() == ACT_DISMEMBER ) {
+        //    action = butcher_type::DISMEMBER;
     }
     return action;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8154,65 +8154,6 @@ std::string Character::weapname_ammo() const
     }
 }
 
-// Tests to see if a character has room to enter a vehicle tile.
-bool Character::move_in_vehicle( Creature *c, const tripoint &dest_loc ) const
-{
-    map &m = get_map();
-    const optional_vpart_position vp_there = m.veh_at( dest_loc );
-    if( vp_there ) {
-        vehicle &veh = vp_there->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            const optional_vpart_position vp = m.veh_at( dest_loc );
-            // Check for obstacles and appliances to prevent squishing when the part is
-            // not a vehicle or when the player is not actually entering the tile IE grabbing.
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
-                !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += contents.max_volume();
-                free_cargo += contents.free_volume();
-            }
-        }
-        if( capacity > 0_ml ) {
-            // First, we'll try to squeeze in. Open-topped vehicle parts have more room for us.
-            if( !veh.enclosed_at( dest_loc ) ) {
-                free_cargo *= 1.2;
-            }
-            const creature_size size = get_size();
-            // TODO: A large human should be 145,000ml+, a huge one should be at least 300k
-            // The other sizes look fine though.
-            if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                if( ( size == creature_size::tiny && free_cargo < 11719_ml ) ||
-                    ( size == creature_size::small && free_cargo < 23438_ml ) ||
-                    ( size == creature_size::medium && free_cargo < 46875_ml ) ||
-                    ( size == creature_size::large && free_cargo < 93750_ml ) ||
-                    ( size == creature_size::huge && free_cargo < 187500_ml ) ) {
-                    add_msg_if_player( m_warning, _( "There's not enough room for you to fit there." ) );
-                    return false; // Even if we squeeze, there's no room.
-                }
-                c->add_effect( effect_cramped_space, 2_turns, true );
-                return true;
-            }
-        }
-        const optional_vpart_position vp = m.veh_at( dest_loc );
-        // Sufficiently gigantic characters aren't comfortable in stock seats, roof or no.
-        if( in_vehicle && get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-            !vp.part_with_feature( "HUGE_OK", false ) && !has_effect( effect_cramped_space ) ) {
-            add_msg_if_player( m_warning, _( "You barely fit in this tiny human vehicle." ) );
-            add_msg_if_npc( m_warning, _( "%s has to really cram their huge body to fit." ), c->disp_name() );
-            c->add_effect( effect_cramped_space, 2_turns, true );
-            return true;
-        }
-    }
-    return true;
-}
-
 void Character::on_hit( Creature *source, bodypart_id bp_hit,
                         float /*difficulty*/, dealt_projectile_attack const *const proj )
 {
@@ -11271,50 +11212,13 @@ void Character::process_effects()
     }
 
     // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
-    if( has_effect( effect_cramped_space ) ) {
-        map &here = get_map();
-        const tripoint your_pos = pos();
-        const optional_vpart_position vp_there = here.veh_at( your_pos );
-        if( !vp_there ) {
-            remove_effect( effect_cramped_space );
-        }
-        if( is_npc() && !has_effect( effect_narcosis ) && has_effect( effect_cramped_space ) ) {
+    bool cramped = has_effect( effect_cramped_space );
+    // return is intentionally discarded, sets cramped if appropriate
+    can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
+    if( cramped ) {
+        if( is_npc() && !has_effect( effect_narcosis ) ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );
-        }
-        bool is_cramped_space = false;
-        vehicle &veh = vp_there->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( your_pos, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            const optional_vpart_position vp = here.veh_at( your_pos );
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) ) {
-                capacity += contents.max_volume();
-                free_cargo += contents.free_volume();
-            }
-            const creature_size size = get_size();
-            if( capacity > 0_ml ) {
-                // Open-topped vehicle parts have more room.
-                if( !veh.enclosed_at( your_pos ) ) {
-                    free_cargo *= 1.2;
-                }
-                if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                    ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                    ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                    ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                    ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                    is_cramped_space = true;
-                }
-            }
-            if( get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-                !vp.part_with_feature( "HUGE_OK", false ) ) {
-                is_cramped_space = true;
-            }
-        }
-        if( !is_cramped_space ) {
-            remove_effect( effect_cramped_space );
         }
     }
 
@@ -11387,6 +11291,14 @@ void Character::process_effects()
             add_effect( effect_downed, rng( 1_turns, 2_turns ) );
         }
     }
+    if( has_effect( effect_cramped_space ) ) {
+        // return is intentionally discarded, sets cramped if appropriate
+        can_move_to_vehicle_tile( get_map().getglobal( pos() ), cramped );
+        if( !cramped ) {
+            remove_effect( effect_cramped_space );
+        }
+    }
+
     Creature::process_effects();
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -1469,9 +1469,6 @@ class Character : public Creature, public visitable
         void dismount();
         void forced_dismount();
 
-        /** Attempt to enter a tile in a vehicle */
-        bool move_in_vehicle( Creature *c, const tripoint &dest_loc ) const;
-
         bool is_deaf() const;
         bool is_mute() const;
         // Get the specified limb score. If bp is defined, only the scores from that body part type are summed.

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -194,6 +194,100 @@ void Creature::setpos( const tripoint &p )
     on_move( old_loc );
 }
 
+static units::volume size_to_volume( creature_size size_class )
+{
+    // returns midpoint of size from volume_to_size, minus 1_ml
+    // e.g. max tiny size is 7500, max small size is 46250, we return
+    // 46250+7500 / 2 - 1_ml = 26875_ml - 1ml
+    // TODO: size_to_volume and volume_to_size of these functions should be merged into one single source of truth.
+    // TODO: This calculation is underestimating the size of a medium creature. They should be around 10500 ml.
+    // Large and Huge creatures should probably be bigger too. This would necessitate increasing vpart capacity.
+    if( size_class == creature_size::tiny ) {
+        return 3749_ml;
+    } else if( size_class == creature_size::small ) {
+        return 26874_ml;
+    } else if( size_class == creature_size::medium ) {
+        return 77124_ml;
+    } else if( size_class == creature_size::large ) {
+        return 295874_ml;
+    }
+    return 741874_ml;
+}
+
+bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
+{
+    map &here = get_map();
+    const optional_vpart_position vp_there = here.veh_at( loc );
+    if( !vp_there ) {
+        cramped = false;
+        return true;
+    }
+
+    const monster *mon = as_monster();
+
+    vehicle &veh = vp_there->vehicle();
+
+    std::vector<vehicle_part *> cargo_parts;
+    cargo_parts = veh.get_parts_at( here.bub_from_abs( loc ), "CARGO", part_status_flag::any );
+
+    units::volume capacity = 0_ml;
+    units::volume free_cargo = 0_ml;
+    for( vehicle_part *part : cargo_parts ) {
+        vehicle_stack contents = veh.get_items( *part );
+        if( !vp_there.part_with_feature( "CARGO_PASSABLE", false ) &&
+            !vp_there.part_with_feature( "APPLIANCE", false ) &&
+            !vp_there.part_with_feature( "OBSTACLE", false ) ) {
+            capacity += contents.max_volume();
+            free_cargo += contents.free_volume();
+        }
+    }
+    if( capacity > 0_ml ) {
+        // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
+        if( !veh.enclosed_at( here.getlocal( loc ) ) ) {
+            free_cargo *= 1.2;
+        }
+        const creature_size size = get_size();
+        units::volume critter_volume;
+        if( mon ) {
+            critter_volume = mon->get_volume();
+        } else {
+            critter_volume = size_to_volume( size );
+        }
+
+        if( critter_volume > free_cargo * 1.33 ) {
+            return false;
+        }
+
+        if( critter_volume >= size_to_volume( creature_size::huge ) &&
+            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
+            return false;
+        }
+
+        if( critter_volume > free_cargo ) {
+            if( !mon || !( mon->type->bodytype == "snake" || mon->type->bodytype == "blob" ||
+                           mon->type->bodytype == "fish" ||
+                           has_flag( mon_flag_PLASTIC ) ) ) {
+                cramped = true;
+                return true;
+            }
+        }
+
+        if( size == creature_size::huge && !vp_there.part_with_feature( "AISLE", false ) &&
+            !vp_there.part_with_feature( "HUGE_OK", false ) ) {
+            cramped = true;
+            return true;
+        }
+    }
+    cramped = false;
+    return true;
+}
+
+bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const
+{
+    bool dummy = false;
+    return can_move_to_vehicle_tile( loc, dummy );
+}
+
 void Creature::move_to( const tripoint_abs_ms &loc )
 {
     const tripoint_abs_ms old_loc = get_location();

--- a/src/creature.h
+++ b/src/creature.h
@@ -318,6 +318,10 @@ class Creature : public viewer
             return get_location().z();
         }
         void setpos( const tripoint &p );
+        /** Checks if the creature fits into a given tile. Set the boolean argument to true if the creature would barely fit. */
+        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const;
+        /** Helper overload for when the boolean is discardable */
+        bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9054,7 +9054,7 @@ item::armor_status item::damage_armor_durability( damage_unit &du, const bodypar
     if( post_mitigated_dmg > armors_own_resist ) {
         // Figure out chance of damage relative to the damage we took.
         float damaged_chance = ( 0.11 * ( post_mitigated_dmg / ( armors_own_resist + 2 ) ) + 0.1 ) *
-                                 enchant_multiplier;
+                               enchant_multiplier;
         // Soft items are protected from bash damage in much the same way the PLASTIC flag protects monsters.
         if( du.type == damage_bash && is_soft() ) {
             damaged_chance *= 0.66;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -133,64 +133,6 @@ static bool z_is_valid( int z )
     return z >= -OVERMAP_DEPTH && z <= OVERMAP_HEIGHT;
 }
 
-bool monster::monster_move_in_vehicle( const tripoint &p ) const
-{
-    map &m = get_map();
-    monster critter = *this;
-    const optional_vpart_position vp = m.veh_at( p );
-    if( vp.has_value() ) {
-        vehicle &veh = vp->vehicle();
-        units::volume capacity = 0_ml;
-        units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::any );
-        for( vehicle_part *&part : cargo_parts ) {
-            vehicle_stack contents = veh.get_items( *part );
-            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
-                !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += contents.max_volume();
-                free_cargo += contents.free_volume();
-            }
-        }
-        if( capacity > 0_ml ) {
-            // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-            if( !veh.enclosed_at( p ) ) {
-                free_cargo *= 1.2;
-            }
-            if( !veh.enclosed_at( p ) && flies() ) {
-                return true; // No amount of cargo will block a flying monster if there's no roof.
-            }
-            const creature_size size = get_size();
-            if( ( size == creature_size::tiny && free_cargo < 15625_ml ) ||
-                ( size == creature_size::small && free_cargo < 31250_ml ) ||
-                ( size == creature_size::medium && free_cargo < 62500_ml ) ||
-                ( size == creature_size::large && free_cargo < 125000_ml ) ||
-                ( size == creature_size::huge && free_cargo < 250000_ml ) ) {
-                if( ( size == creature_size::tiny && free_cargo < 11719_ml ) ||
-                    ( size == creature_size::small && free_cargo < 23438_ml ) ||
-                    ( size == creature_size::medium && free_cargo < 46875_ml ) ||
-                    ( size == creature_size::large && free_cargo < 93750_ml ) ||
-                    ( size == creature_size::huge && free_cargo < 187500_ml ) ||
-                    ( get_volume() > 850000_ml && !vp.part_with_feature( "HUGE_OK", false ) ) ) {
-                    return false; // Return false if there's just no room whatsoever. Anything over 850 liters will simply never fit in a vehicle part that isn't specifically made for it.
-                    // I'm sorry but you can't let a kaiju ride shotgun.
-                }
-                if( type->bodytype == "snake" || type->bodytype == "blob" || type->bodytype == "fish" ||
-                    has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) {
-                    return true; // Return true if we're wiggly enough to be fine with cramped space.
-                }
-                critter.add_effect( effect_cramped_space, 2_turns, true );
-                return true; // Otherwise we add the effect and return true.
-            }
-            if( size == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
-                !vp.part_with_feature( "HUGE_OK", false ) ) {
-                critter.add_effect( effect_cramped_space, 2_turns, true );
-                return true; // Sufficiently gigantic creatures have trouble in stock seats, roof or no.
-            }
-        }
-    }
-    return true;
-}
-
 bool monster::will_move_to( const tripoint &p ) const
 {
     map &here = get_map();
@@ -1692,7 +1634,8 @@ bool monster::bash_at( const tripoint &p )
         return false;
     }
 
-    bool try_bash = !can_move_to( p ) || one_in( 3 );
+    const bool too_cramped = !can_move_to_vehicle_tile( get_map().getglobal( p ) );
+    bool try_bash = !can_move_to( p ) || one_in( 3 ) || too_cramped;
     if( !try_bash ) {
         return false;
     }
@@ -1702,7 +1645,7 @@ bool monster::bash_at( const tripoint &p )
     }
 
     map &here = get_map();
-    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() ) ) {
+    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || too_cramped ) ) {
         // if the only thing here is road or flat, rarely bash it
         bool flat_ground = here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ||
                            here.has_flag( ter_furn_flag::TFLAG_FLAT, p );
@@ -1876,7 +1819,8 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         }
     }
 
-    if( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) && !monster_move_in_vehicle( p ) ) {
+    bool cramped = false; // applies an effect if monster does end up moving there
+    if( !can_move_to_vehicle_tile( here.getglobal( p ), cramped ) ) {
         return false;
     }
 
@@ -1974,6 +1918,9 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     optional_vpart_position vp_dest = here.veh_at( destination );
     if( vp_dest ) {
         vp_dest->vehicle().invalidate_mass();
+        if( cramped ) {
+            add_effect( effect_cramped_space, 2_turns, true );
+        }
     }
     if( is_hallucination() ) {
         //Hallucinations don't do any of the stuff after this point

--- a/src/monster.h
+++ b/src/monster.h
@@ -214,8 +214,6 @@ class monster : public Creature
         bool will_move_to( const tripoint &p ) const;
         bool know_danger_at( const tripoint &p ) const;
 
-        bool monster_move_in_vehicle( const tripoint &p ) const;
-
         bool will_reach( const point &p ); // Do we have plans to get to (x, y)?
         int  turns_to_reach( const point &p ); // How long will it take?
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3361,8 +3361,14 @@ std::unordered_set<tripoint> npc::get_path_avoid() const
     }
 
     for( const tripoint &p : here.points_in_radius( pos(), 6 ) ) {
-        if( sees_dangerous_field( p ) || ( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) &&
-                                           !move_in_vehicle( const_cast<npc *>( this ), p ) ) ) {
+        if( sees_dangerous_field( p ) ) {
+            ret.insert( p );
+        }
+    }
+
+    // Why is this in path avoid if they can't move there at all?
+    for( const tripoint &p : here.points_in_radius( pos(), 6 ) ) {
+        if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
             ret.insert( p );
         }
     }


### PR DESCRIPTION
#### Summary
Partially backport and fix DDA 74004 - sane-ify vehicle movement checks

#### Purpose of change
DDA 74004 aimed to typify tripoints and replace the duplicated cramped space checks with a single one that Character:: and monster:: could both point to. This is a good idea, however the PR introduced a number of coding mistakes that basically broke vehicles entirely and needed to be fixed by hand.

#### Describe the solution
- Backport the PR
- Fix creature size calculations so that large creatures aren't treated as huge creatures
- Add cramped space checks to Character::process_effects() so that cramped space doesn't stick on Characters forever
- Fix bad logic in can_move_to_vehicle_tile() which was making all spaces which could be entered count as cramped
- Fix bad logic in can_move_to_vehicle_tile() which was counting any tile that wasn't inside a vehicle as cramped

#### Describe alternatives you've considered
- Not backporting and leaving my original work in place, as it worked to begin with and all the above issues were introduced by 74004

#### Testing
- Enter a vehicle as a normal and a large character. Fit in some tiles easily, get cramped in others
- See cramped space fall off when in a tile where I fit easily, and when outside of a vehicle

#### Additional context
- The creature:: volume calculations are different than the ones I'd used before, and I think seat volume may need an audit now, that or there's a seat volume backport which was missed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
