### PR TITLE
Backport - Bionic multimeter (73992)

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1675,6 +1675,38 @@
     "flags": [ "BIONIC_SHOCKPROOF", "BIONIC_NPC_USABLE" ]
   },
   {
+    "id": "bio_multimeter",
+    "type": "bionic",
+    "name": { "str": "Integrated Multimeter" },
+    "description": "Your fingers and arms have been implanted with retractable electrical probes connected to a multimeter embedded in your arm, allowing you to measure electrical voltage, resistance, and current by touch.  This also provides your hands and arms with a modicum of protection against electric shocks.",
+    "occupied_bodyparts": [ [ "hand_l", 1 ], [ "hand_r", 1 ] ],
+    "passive_pseudo_items": [ "integrated_multimeter" ],
+    "flags": [ "BIONIC_SHOCKPROOF", "BIONIC_NPC_USABLE" ],
+    "protec": [
+      [ "hand_l", { "electric": 3 } ],
+      [ "hand_r", { "electric": 3 } ],
+      [ "arm_l", { "electric": 3 } ],
+      [ "arm_r", { "electric": 3 } ]
+    ],
+    "available_upgrades": [ "bio_electrokit" ]
+  },
+  {
+    "id": "bio_electrokit",
+    "type": "bionic",
+    "name": { "str": "Integrated Circuitry Toolset" },
+    "description": "Your fingers and arms have been implanted a soldering iron, a multimeter, and a set of small screwdrivers, providing all the tools required for working with bench-scale electrical circuits.  This also provides your hands and arms with a modicum of protection against electric shocks.",
+    "occupied_bodyparts": [ [ "hand_l", 2 ], [ "hand_r", 2 ] ],
+    "passive_pseudo_items": [ "integrated_electrokit", "integrated_multimeter" ],
+    "flags": [ "BIONIC_SHOCKPROOF", "BIONIC_NPC_USABLE" ],
+    "protec": [
+      [ "hand_l", { "electric": 3 } ],
+      [ "hand_r", { "electric": 3 } ],
+      [ "arm_l", { "electric": 3 } ],
+      [ "arm_r", { "electric": 3 } ]
+    ],
+    "upgraded_bionic": "bio_multimeter"
+  },
+  {
     "id": "bio_torsionratchet",
     "type": "bionic",
     "name": { "str": "Joint Torsion Ratchet" },

--- a/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
@@ -82,6 +82,7 @@
       {
         "distribution": [
           { "item": "bio_tools", "prob": 15 },
+          { "item": "bio_electrokit", "prob": 15 },
           { "item": "bio_magnet", "prob": 15 },
           { "item": "bio_soporific", "prob": 20 },
           { "item": "bio_sunglasses", "prob": 25 },
@@ -160,6 +161,7 @@
       [ "bio_radscrubber", 20 ],
       [ "bio_recycler", 20 ],
       [ "bio_tools", 30 ],
+      [ "bio_electrokit", 20 ],
       [ "bio_ar", 30 ],
       [ "bio_taste_blocker", 50 ],
       [ "bio_water_extractor", 40 ]

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -10,6 +10,8 @@
       [ "bio_fuel_cell_gasoline", 10 ],
       [ "bio_lampoil", 10 ],
       [ "bio_tools", 10 ],
+      [ "bio_multimeter", 10 ],
+      [ "bio_electrokit", 10 ],
       [ "bio_ups", 10 ],
       [ "bio_flashlight", 10 ],
       [ "bio_tattoo_led", 10 ],
@@ -105,6 +107,8 @@
     "items": [
       [ "bio_power_storage", 10 ],
       [ "bio_tools", 10 ],
+      [ "bio_multimeter", 10 ],
+      [ "bio_electrokit", 10 ],
       [ "bio_flashlight", 10 ],
       [ "bio_fuel_cell_gasoline", 10 ],
       [ "bio_lampoil", 10 ],

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -1018,6 +1018,28 @@
     "difficulty": 6
   },
   {
+    "id": "bio_multimeter",
+    "copy-from": "bionic_general_npc_usable",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Integrated Multimeter CBM" },
+    "looks_like": "bio_tools",
+    "description": "A set of electrical leads to be embedded in the user's fingers, connected to a multimeter unit in their hand.  Allows the user to measure voltage, resistance, and current using their fingertips, and provides slight protection against electric shocks.",
+    "price": "2 kUSD",
+    "price_postapoc": "20 USD",
+    "difficulty": 3
+  },
+  {
+    "id": "bio_electrokit",
+    "copy-from": "bionic_general_npc_usable",
+    "type": "BIONIC_ITEM",
+    "name": { "str": "Integrated Circuitry Toolset CBM" },
+    "looks_like": "bio_tools",
+    "description": "A soldering iron, multimeter, and set of fine screwdrivers implanted in the user's hands.  Contains all the tools required for manipulating bench-scale electrical circuits, and provides slight protection against electric shocks.",
+    "price": "4 kUSD",
+    "price_postapoc": "35 USD",
+    "difficulty": 5
+  },
+  {
     "id": "bio_torsionratchet",
     "copy-from": "bionic_general_npc_usable",
     "type": "BIONIC_ITEM",

--- a/data/json/items/tool/integrated.json
+++ b/data/json/items/tool/integrated.json
@@ -211,5 +211,77 @@
     "charges_per_use": 20,
     "charged_qualities": [ [ "WELD", 2 ] ],
     "melee_damage": { "bash": 2, "cut": -1 }
+  },
+  {
+    "id": "integrated_multimeter",
+    "type": "TOOL_ARMOR",
+    "category": "armor",
+    "weight": "50 g",
+    "volume": "25 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "symbol": ",",
+    "color": "brown",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "material_thickness": 0.5,
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "PERSONAL",
+      "WATER_FRIENDLY",
+      "SOFT",
+      "NO_REPAIR",
+      "ALLOWS_NATURAL_ATTACKS",
+      "TRADER_AVOID",
+      "USES_BIONIC_POWER"
+    ],
+    "material": [ "superalloy", "copper" ],
+    "name": { "str_sp": "integrated multimeter" },
+    "description": "Integrated bionic multimeter implanted in your fingers.",
+    "to_hit": -1,
+    "use_action": [ { "type": "VOLTMETER" } ]
+  },
+  {
+    "id": "integrated_electrokit",
+    "type": "TOOL_ARMOR",
+    "category": "armor",
+    "weight": "50 g",
+    "volume": "25 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "symbol": ",",
+    "color": "brown",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "material_thickness": 0.5,
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "PERSONAL",
+      "WATER_FRIENDLY",
+      "SOFT",
+      "NO_REPAIR",
+      "ALLOWS_NATURAL_ATTACKS",
+      "TRADER_AVOID",
+      "USES_BIONIC_POWER"
+    ],
+    "material": [ "superalloy", "copper" ],
+    "name": { "str_sp": "integrated soldering iron" },
+    "description": "Integrated soldering iron and screwdriver set.",
+    "to_hit": -1,
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [ "plastic", "lead", "tin", "zinc" ],
+        "skill": "fabrication",
+        "cost_scaling": 0.1,
+        "move_cost": 1500
+      }
+    ],
+    "ammo": [ "battery" ],
+    "charges_per_use": 1,
+    "qualities": [ [ "SCREW", 1 ], [ "SCREW_FINE", 1 ] ]
   }
 ]

--- a/data/json/recipes/appliances/oven.json
+++ b/data/json/recipes/appliances/oven.json
@@ -136,7 +136,14 @@
       { "proficiency": "prof_elec_circuits", "skill_penalty": 0 }
     ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "tools": [ [ [ "soldering_iron", -1 ], [ "soldering_iron_portable", -1 ], [ "integrated_welder", -1 ] ] ],
+    "tools": [
+      [
+        [ "soldering_iron", -1 ],
+        [ "soldering_iron_portable", -1 ],
+        [ "integrated_electrokit", -1 ],
+        [ "integrated_welder", -1 ]
+      ]
+    ],
     "components": [
       [ [ "plastic_chunk", 4 ] ],
       [ [ "sheet_metal_small", 1 ] ],

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1731,6 +1731,7 @@
         [ "welder_crude", 84 ],
         [ "soldering_iron", 84 ],
         [ "soldering_iron_portable", 84 ],
+        [ "integrated_electrokit", 84 ],
         [ "integrated_welder", 84 ]
       ]
     ],
@@ -1764,6 +1765,7 @@
         [ "welder_crude", 84 ],
         [ "soldering_iron", 84 ],
         [ "soldering_iron_portable", 84 ],
+        [ "integrated_electrokit", 84 ],
         [ "integrated_welder", 84 ]
       ]
     ],
@@ -1798,6 +1800,7 @@
         [ "welder_crude", 84 ],
         [ "soldering_iron", 84 ],
         [ "soldering_iron_portable", 84 ],
+        [ "integrated_electrokit", 84 ],
         [ "integrated_welder", 84 ]
       ]
     ],
@@ -1828,6 +1831,7 @@
         [ "welder_crude", 84 ],
         [ "soldering_iron", 84 ],
         [ "soldering_iron_portable", 84 ],
+        [ "integrated_electrokit", 84 ],
         [ "integrated_welder", 84 ]
       ]
     ],
@@ -1863,6 +1867,7 @@
         [ "welder_crude", 84 ],
         [ "soldering_iron", 84 ],
         [ "soldering_iron_portable", 84 ],
+        [ "integrated_electrokit", 84 ],
         [ "integrated_welder", 84 ]
       ]
     ],

--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_cross.json
@@ -138,7 +138,11 @@
       "time": "1 d",
       "skills": [ [ "electronics", 8 ] ],
       "inline": {
-        "tools": [ [ [ "hazmat_suit", -1 ] ], [ [ "mask_gas", 50 ] ], [ [ "soldering_iron", 50 ], [ "soldering_iron_portable", 50 ] ] ],
+        "tools": [
+          [ [ "hazmat_suit", -1 ] ],
+          [ [ "mask_gas", 50 ] ],
+          [ [ "soldering_iron", 50 ], [ "soldering_iron_portable", 50 ], [ "integrated_electrokit", 50 ] ]
+        ],
         "qualities": [ [ { "id": "SCREW" } ], [ { "id": "SCREW_FINE" } ], [ { "id": "WRENCH" } ], [ { "id": "WRENCH_FINE" } ] ],
         "components": [
           [ [ "solder_wire", 50 ] ],

--- a/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_normal.json
+++ b/data/json/recipes/basecamps/base/fbmc_outpost/recipe_modular_outpost_normal.json
@@ -123,7 +123,11 @@
       "time": "1 d",
       "skills": [ [ "electronics", 8 ] ],
       "inline": {
-        "tools": [ [ [ "hazmat_suit", -1 ] ], [ [ "mask_gas", 50 ] ], [ [ "soldering_iron", 50 ], [ "soldering_iron_portable", 50 ] ] ],
+        "tools": [
+          [ [ "hazmat_suit", -1 ] ],
+          [ [ "mask_gas", 50 ] ],
+          [ [ "soldering_iron", 50 ], [ "soldering_iron_portable", 50 ], [ "integrated_electrokit", 50 ] ]
+        ],
         "qualities": [ [ { "id": "SCREW" } ], [ { "id": "SCREW_FINE" } ], [ { "id": "WRENCH" } ], [ { "id": "WRENCH_FINE" } ] ],
         "components": [
           [ [ "solder_wire", 50 ] ],

--- a/data/json/recipes/practice/electronics.json
+++ b/data/json/recipes/practice/electronics.json
@@ -31,7 +31,7 @@
     "book_learn": [ [ "mag_electronics", 1 ], [ "manual_electronics", 1 ], [ "advanced_electronics", 2 ], [ "textbook_electronics", 3 ] ],
     "//": "Some parts are listed as tools so they are not destroyed during crafting, while the components are consumed.",
     "tools": [
-      [ [ "voltmeter", 5 ], [ "multimeter", 5 ] ],
+      [ [ "voltmeter", 5 ], [ "multimeter", 5 ], [ "integrated_multimeter", 5 ] ],
       [ [ "antenna", -1 ], [ "circuit", -1 ], [ "element", -1 ], [ "light_bulb", -1 ], [ "motor_micro", -1 ] ]
     ],
     "components": [ [ [ "cable", 10 ] ], [ [ "e_scrap", 5 ] ] ],
@@ -55,7 +55,7 @@
     ],
     "book_learn": [ [ "manual_electronics", 1 ], [ "advanced_electronics", 2 ], [ "textbook_electronics", 3 ] ],
     "tools": [
-      [ [ "multimeter", 50 ] ],
+      [ [ "multimeter", 50 ], [ "integrated_multimeter", 50 ] ],
       [ [ "breadboard", -1 ] ],
       [ [ "power_supply", -1 ] ],
       [ [ "amplifier", -1 ], [ "element", -1 ], [ "receiver", -1 ], [ "transponder", -1 ] ]
@@ -82,7 +82,7 @@
     ],
     "book_learn": [ [ "advanced_electronics", 4 ], [ "textbook_electronics", 4 ], [ "ic_reference_electronics", 3 ] ],
     "tools": [
-      [ [ "multimeter", 100 ] ],
+      [ [ "multimeter", 100 ], [ "integrated_multimeter", 100 ] ],
       [ [ "breadboard", -1 ] ],
       [ [ "power_supply", -1 ] ],
       [ [ "processor", -1 ] ],

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1006,6 +1006,7 @@
         [ "integrated_welder", 300 ],
         [ "soldering_iron", 300 ],
         [ "soldering_iron_portable", 300 ],
+        [ "integrated_electrokit", 300 ],
         [ "oxy_torch", 40 ]
       ]
     ],
@@ -1182,6 +1183,7 @@
         [ "integrated_welder", 150 ],
         [ "soldering_iron", 150 ],
         [ "soldering_iron_portable", 150 ],
+        [ "integrated_electrokit", 150 ],
         [ "oxy_torch", 20 ]
       ]
     ],
@@ -1221,6 +1223,7 @@
         [ "integrated_welder", 75 ],
         [ "soldering_iron", 75 ],
         [ "soldering_iron_portable", 75 ],
+        [ "integrated_electrokit", 75 ],
         [ "oxy_torch", 10 ]
       ]
     ],
@@ -1385,6 +1388,7 @@
         [ "integrated_welder", 225 ],
         [ "soldering_iron", 225 ],
         [ "soldering_iron_portable", 225 ],
+        [ "integrated_electrokit", 225 ],
         [ "oxy_torch", 30 ]
       ]
     ],
@@ -1555,7 +1559,8 @@
         [ "welder_crude", 150 ],
         [ "integrated_welder", 150 ],
         [ "soldering_iron", 150 ],
-        [ "soldering_iron_portable", 150 ]
+        [ "soldering_iron_portable", 150 ],
+        [ "integrated_electrokit", 150 ]
       ]
     ],
     "components": [ [ [ "steel_chunk", 6 ], [ "scrap", 18 ] ], [ [ "pipe", 2 ] ] ]

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -226,7 +226,8 @@
         [ "welder_crude", 30 ],
         [ "integrated_welder", 30 ],
         [ "soldering_iron", 30 ],
-        [ "soldering_iron_portable", 30 ]
+        [ "soldering_iron_portable", 30 ],
+        [ "integrated_electrokit", 30 ]
       ]
     ],
     "components": [

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -249,6 +249,7 @@
     "tools": [
       [
         [ "soldering_iron", 1 ],
+        [ "integrated_electrokit", 1 ],
         [ "soldering_iron_portable", 1 ],
         [ "integrated_welder", 1 ],
         [ "small_repairkit", 1 ],

--- a/data/json/uncraft/vehicle/alternator.json
+++ b/data/json/uncraft/vehicle/alternator.json
@@ -40,7 +40,15 @@
     "difficulty": 4,
     "time": "40 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "tools": [ [ [ "soldering_iron", 80 ], [ "soldering_iron_portable", 80 ], [ "toolset", 80 ], [ "oxy_torch", 40 ] ] ],
+    "tools": [
+      [
+        [ "soldering_iron", 80 ],
+        [ "soldering_iron_portable", 80 ],
+        [ "integrated_electrokit", 80 ],
+        [ "toolset", 80 ],
+        [ "oxy_torch", 40 ]
+      ]
+    ],
     "components": [
       [ [ "power_supply", 4 ] ],
       [ [ "cable", 400 ] ],

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2494,7 +2494,7 @@ TEST_CASE( "repairable_and_with_what_tools", "[iteminfo][repair]" )
     // FIXME: Use an item that can only be repaired by test tools
     CHECK( item_info_str( hazmat, repaired ) ==
            "--\n"
-           "<color_c_white>Repair</color> using integrated welder, gunsmith repair kit, firearm repair kit, soldering iron, portable soldering iron, or TEST soldering iron.\n"
+           "<color_c_white>Repair</color> using integrated soldering iron, integrated welder, gunsmith repair kit, firearm repair kit, soldering iron, portable soldering iron, or TEST soldering iron.\n"
            "<color_c_white>With</color> <color_c_cyan>Plastic</color>.\n" );
 
     CHECK( item_info_str( rock, repaired ) ==


### PR DESCRIPTION
#### Summary
Backport DDA 73992 - Bionic Multimeter

#### Purpose of change
Add a bionic electronics tool

#### Describe the solution
Straightforward backport, minus Exodii stuff.

#### Testing
Runs fine

#### Additional context
It looks like our recipes are a bit different? Our armor recipes in suits.json mostly just rely on the requirements in USING, this PR had a bunch of manually typed out ones. I don't know why that came about. Our method seems better, maybe we backported something about that, or it's from when I revamped armor? Anyway they both do the same thing afaik so it's fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
