### PR TITLE
Backport - Add scrapple as a comestible (74143)

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1891,5 +1891,26 @@
     "volume": "240 ml",
     "flags": [ "EATEN_HOT", "FREEZERBURN" ],
     "fun": 4
+  },
+  {
+    "id": "scrapple",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "scrapple" },
+    "symbol": "%",
+    "looks_like": "offal_cooked",
+    "description": "Meat scraps and grain pressed into a loaf, sliced, and pan-fried.  It was a popular dish in the Mid-Atlantic United States.",
+    "price_postapoc": "40 cent",
+    "material": [ "flesh", "wheat" ],
+    "primary_material": "flesh",
+    "color": "brown",
+    "weight": "58 g",
+    "volume": "56 ml",
+    "spoils_in": "5 days",
+    "calories": 127,
+    "fun": 1,
+    "quench": -8,
+    "flags": [ "EATEN_HOT" ],
+    "vitamins": [ [ "vitC", 0 ], [ "calcium", 3 ], [ "iron", 8 ] ]
   }
 ]

--- a/data/json/recipes/food/meat_dishes.json
+++ b/data/json/recipes/food/meat_dishes.json
@@ -153,5 +153,35 @@
       [ [ "eggs_bird", 1, "LIST" ] ]
     ],
     "charges": 4
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "scrapple",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_MEAT",
+    "skill_used": "cooking",
+    "difficulty": 3,
+    "time": "60 m",
+    "book_learn": [ [ "cookbook", 2 ], [ "family_cookbook", 2 ] ],
+    "batch_time_factors": [ 83, 4 ],
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
+    "tools": [ [ [ "surface_heat", 32, "LIST" ] ] ],
+    "//": "grain = 12u, meat = 20u",
+    "charges": 8,
+    "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_knife_skills" }, { "proficiency": "prof_frying" } ],
+    "components": [
+      [ [ "meat_offal", 2, "LIST" ], [ "meat_nofish", 1, "LIST" ] ],
+      [
+        [ "salt", 2 ],
+        [ "syrup", 1 ],
+        [ "seasoning_italian", 2 ],
+        [ "wild_herbs", 2 ],
+        [ "seasoning_salt", 2 ],
+        [ "pepper", 2 ],
+        [ "hot_sauce", 1 ]
+      ],
+      [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Backport DDA 74143 - add scrapple

#### Purpose of change
Scrapple

#### Describe the solution
Scrapple

#### Describe alternatives you've considered
Scrapple

#### Testing
Scrapple

#### Additional context
Not Fried Chicken

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
