### PR TITLE
Backport 74116 and adjust pain intelligence penalty

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1017,10 +1017,15 @@ void avatar::reset_stats()
     // Pain
     if( get_perceived_pain() > 0 ) {
         const stat_mod ppen = get_pain_penalty();
-        mod_str_bonus( -ppen.strength );
-        mod_dex_bonus( -ppen.dexterity );
-        mod_int_bonus( -ppen.intelligence );
-        mod_per_bonus( -ppen.perception );
+        ppen_str = ppen.strength;
+        ppen_dex = ppen.dexterity;
+        ppen_int = ppen.intelligence;
+        ppen_per = ppen.perception;
+        ppen_spd = ppen.speed;
+        mod_str_bonus( -ppen_str );
+        mod_dex_bonus( -ppen_dex );
+        mod_int_bonus( -ppen_int );
+        mod_per_bonus( -ppen_per );
         if( ppen.dexterity > 0 ) {
             add_miss_reason( _( "Your pain distracts you!" ), static_cast<unsigned>( ppen.dexterity ) );
         }

--- a/src/character.h
+++ b/src/character.h
@@ -579,6 +579,13 @@ class Character : public Creature, public visitable
         int int_cur;
         int per_cur;
 
+        // Used to display pain penalties
+        int ppen_str;
+        int ppen_dex;
+        int ppen_int;
+        int ppen_per;
+        int ppen_spd;
+
         int kill_xp = 0;
         // Level-up points spent on Stats through Kills
         int spent_upgrade_points = 0;
@@ -945,6 +952,7 @@ class Character : public Creature, public visitable
         static int thirst_speed_penalty( int thirst );
         /** Returns the effect of pain on stats */
         stat_mod get_pain_penalty() const;
+        stat_mod read_pain_penalty() const;
         /** returns players strength adjusted by any traits that affect strength during lifting jobs */
         int get_lift_str() const;
         /** Takes off an item, returning false on fail. The taken off item is processed in the interact */

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -613,7 +613,7 @@ static medical_column draw_stats_summary( const int column_count, avatar *player
         speed_detail_str += colorize( string_format( _( "%s    -%2d%%\n" ), pge_str, pen ), c_red );
     }
 
-    pen = player->get_pain_penalty().speed;
+    pen = player->ppen_spd;
     if( pen >= 1 ) {
         pge_str = pgettext( "speed penalty", "Pain " );
         speed_detail_str += colorize( string_format( _( "%s    -%2d%%\n" ), pge_str, pen ), c_red );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1544,7 +1544,7 @@ void Character::disp_info( bool customize_character )
         }
     }
     if( get_perceived_pain() > 0 ) {
-        const stat_mod ppen = get_pain_penalty();
+        const stat_mod ppen = read_pain_penalty();
         std::pair<std::string, nc_color> pain_desc = display::pain_text_color( *this );
         std::string pain_text;
         pain_desc.first = string_format( _( "You are in %s\n" ), pain_desc.first );

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -369,22 +369,32 @@ TEST_CASE( "Enchantment_PAIN_PENALTY_MOD_test", "[magic][enchantments]" )
     INFO( "Character has 50 pain, not affected by enchantments" );
     guy.set_pain( 50 );
     advance_turn( guy );
-    INFO( "Stats are: 6 str, 6 dex, 3 int, 3 per, 85 speed" );
+    INFO( "Stats are: 6 str, 6 dex, 6 int, 6 per, 85 speed" );
     REQUIRE( guy.get_str() == 6 );
     REQUIRE( guy.get_dex() == 6 );
-    REQUIRE( guy.get_int() == 4 );
-    REQUIRE( guy.get_per() == 4 );
+    REQUIRE( guy.get_int() == 6 );
+    REQUIRE( guy.get_per() == 6 );
     REQUIRE( guy.get_speed() == 85 );
 
+    INFO( "Character has 100 pain, not affected by enchantments" );
+    guy.set_pain( 100 );
+    advance_turn( guy );
+    INFO( "Stats are: 3 str, 3 dex, 2 int, 4 per, 85 speed" );
+    REQUIRE( guy.get_str() == 3 );
+    REQUIRE( guy.get_dex() == 3 );
+    REQUIRE( guy.get_int() == 2 );
+    REQUIRE( guy.get_per() == 4 );
+    REQUIRE( guy.get_speed() == 67 );
 
     INFO( "Character has 50 pain, obtain enchantment" );
     guy.i_add( item( "test_PAIN_PENALTY_MOD_ench_item_1" ) );
     guy.recalculate_enchantment_cache();
+    guy.set_pain( 50 );
     advance_turn( guy );
-    INFO( "Stats are: 4 str, 8 dex, 7 int, 0 per, 89 speed" );
+    INFO( "Stats are: 4 str, 7 dex, 7 int, 1 per, 90 speed" );
     REQUIRE( guy.get_str() == 4 );
-    REQUIRE( guy.get_dex() == 8 );
-    REQUIRE( guy.get_int() == 7 );
-    REQUIRE( guy.get_per() == 0 );
-    REQUIRE( guy.get_speed() == 89 );
+    REQUIRE( guy.get_dex() == 3 );
+    REQUIRE( guy.get_int() == 3 );
+    REQUIRE( guy.get_per() == 6 );
+    REQUIRE( guy.get_speed() == 90 );
 }


### PR DESCRIPTION
#### Summary
Backport 74116 - Correctly display pain penalties

#### Purpose of change
Pain was changed over to use the enchantment system, but it wasn't displaying penalties properly in the effects panel.

#### Describe the solution
- Backport, but make adjustments. DDA 72687 changed the pain penalty values. We made the decision to keep them mostly as they were.
- This PR adds 33% to the intelligence penalty caused by pain. DDA similarly raised their int penalty - intelligence-based tasks require concentration and the ability to solve complex problems, which is kinda hard when you're in agony.
- Alters the method of applying pain penalties to use std::bound so that stats are never brought below 1 and penalties cannot go negative and grant bonuses.

#### Testing
Compiles, runs. Pain displays correctly. Pain penalties are within expected parameters.

#### Additional context
See #339 for more discussion.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
