### PR TITLE
Backport 73372 - NPC faction camps

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1832,16 +1832,7 @@
     "roof": "t_rock_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
-    "flags": [
-      "NOITEM",
-      "SUPPORTS_ROOF",
-      "WALL",
-      "NO_SCENT",
-      "AUTO_WALL_SYMBOL",
-      "MINEABLE",
-      "BLOCK_WIND",
-      "UNCLINGABLE"
-    ],
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "UNCLINGABLE" ],
     "bash": {
       "str_min": 120,
       "str_max": 400,

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -12,16 +12,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "BARRICADABLE_WINDOW",
-      "BLOCK_WIND",
-      "REDUCE_SCENT",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "BARRICADABLE_WINDOW", "BLOCK_WIND", "REDUCE_SCENT", "WINDOW", "SUPPORTS_ROOF" ],
     "deconstruct": { "ter_set": "t_window_empty", "items": [ { "item": "glass_sheet", "count": 1 } ] },
     "bash": {
       "str_min": 3,
@@ -347,15 +338,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "BLOCK_WIND",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "FLAMMABLE", "NOITEM", "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS", "BLOCK_WIND", "WINDOW", "SUPPORTS_ROOF" ],
     "curtain_transform": "t_window_no_curtains",
     "open": "t_window_domestic",
     "examine_action": "curtains",
@@ -410,16 +393,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "ALARMED",
-      "NOITEM",
-      "BARRICADABLE_WINDOW",
-      "BLOCK_WIND",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "ALARMED", "NOITEM", "BARRICADABLE_WINDOW", "BLOCK_WIND", "WINDOW", "SUPPORTS_ROOF" ],
     "bash": {
       "str_min": 3,
       "str_max": 6,
@@ -511,15 +485,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "NOITEM",
-      "FLAMMABLE",
-      "SUPPORTS_ROOF",
-      "MOUNTABLE",
-      "PERMEABLE",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "NOITEM", "FLAMMABLE", "SUPPORTS_ROOF", "MOUNTABLE", "PERMEABLE", "SUPPORTS_ROOF" ],
     "curtain_transform": "t_window_empty",
     "examine_action": "curtains",
     "close": "t_window_empty_curtains_closed",
@@ -596,17 +562,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "SHARP",
-      "FLAMMABLE",
-      "NOITEM",
-      "MOUNTABLE",
-      "SMALL_PASSAGE",
-      "PERMEABLE",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ]
+    "flags": [ "TRANSPARENT", "SHARP", "FLAMMABLE", "NOITEM", "MOUNTABLE", "SMALL_PASSAGE", "PERMEABLE", "WINDOW", "SUPPORTS_ROOF" ]
   },
   {
     "type": "terrain",
@@ -1222,14 +1178,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "BLOCK_WIND",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "NOITEM", "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS", "BLOCK_WIND", "WINDOW", "SUPPORTS_ROOF" ],
     "curtain_transform": "t_window_bars",
     "examine_action": "curtains",
     "open": "t_window_bars_domestic",
@@ -1270,15 +1219,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "BLOCK_WIND",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "NOITEM", "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS", "BLOCK_WIND", "WINDOW", "SUPPORTS_ROOF" ],
     "curtain_transform": "t_window_bars",
     "examine_action": "curtains",
     "close": "t_window_bars_curtains",
@@ -1533,15 +1474,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "OPENCLOSE_INSIDE",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "BLOCK_WIND",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "FLAMMABLE", "NOITEM", "OPENCLOSE_INSIDE", "BARRICADABLE_WINDOW_CURTAINS", "BLOCK_WIND", "WINDOW", "SUPPORTS_ROOF" ],
     "curtain_transform": "t_plastic_window",
     "examine_action": "curtains",
     "open": "t_plastic_window_with_curtain_open_window_closed",
@@ -1642,15 +1575,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "FLAMMABLE",
-      "NOITEM",
-      "BARRICADABLE_WINDOW_CURTAINS",
-      "BLOCK_WIND",
-      "REDUCE_SCENT",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "FLAMMABLE", "NOITEM", "BARRICADABLE_WINDOW_CURTAINS", "BLOCK_WIND", "REDUCE_SCENT", "WINDOW", "SUPPORTS_ROOF" ],
     "deconstruct": {
       "ter_set": "t_window_empty",
       "items": [
@@ -1779,15 +1704,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "rotates_to": "INDOORFLOOR",
-    "flags": [
-      "TRANSPARENT",
-      "NOITEM",
-      "THIN_OBSTACLE",
-      "BLOCK_WIND",
-      "REDUCE_SCENT",
-      "WINDOW",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "BLOCK_WIND", "REDUCE_SCENT", "WINDOW", "SUPPORTS_ROOF" ],
     "bash": {
       "str_min": 50,
       "str_max": 75,

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -9,6 +9,7 @@
     "size": 1,
     "power": 100,
     "fac_food_supply": { "calories": 0, "vitamins": {  } },
+    "consumes_food": true,
     "wealth": 0,
     "relations": {
       "your_followers": {
@@ -60,7 +61,9 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 115200, "vitamins": { "iron": 800, "calcium": 800, "vitC": 600 } },
+    "//": "90 days worth of food for 10 people, at 3000kcal/day and full RDA of iron/calcium/vitC",
+    "//2": "Expect to see these values a lot.",
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 100000000,
     "currency": "RobofacCoin",
     "price_rules": [ { "group": "NC_ROBOFAC_gear", "markup": 2 } ],
@@ -74,6 +77,7 @@
         "defends your space": true,
         "knows your voice": true
       },
+      "robofac_auxiliaries": { "share my stuff": true },
       "marloss": { "kill on sight": true }
     },
     "epilogues": [
@@ -91,7 +95,8 @@
     "known_by_u": false,
     "size": 70,
     "power": 100,
-    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
+    "//": "No food supply, they eat off of robofac's",
+    "fac_food_supply": { "calories": 0, "vitamins": {  } },
     "wealth": 75000,
     "currency": "RobofacCoin",
     "relations": {
@@ -117,7 +122,8 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 201600, "vitamins": {  } },
+    "//": "FIXME: No camp! One character spawns at the refugee center but can't eat out of their stores",
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 100000000,
     "relations": {
       "old_guard": {
@@ -155,7 +161,9 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
+    "//": "(only) 30 days worth of food for 100 people, at 3000kcal/day and full RDA of iron/calcium/vitC",
+    "//2": "Their canonical starvation is not yet implemented.",
+    "fac_food_supply": { "calories": 9000000000, "vitamins": { "iron": 288000, "calcium": 288000, "vitC": 288000 } },
     "wealth": 75000000,
     "currency": "FMCNote",
     "price_rules": [
@@ -201,6 +209,7 @@
         "kill on sight": false,
         "watch your back": true,
         "share my stuff": false,
+        "share public goods": true,
         "guard your stuff": true,
         "lets you in": false,
         "defends your space": false,
@@ -241,7 +250,8 @@
     "known_by_u": false,
     "size": 5,
     "power": 0,
-    "fac_food_supply": { "calories": 1152, "vitamins": {  } },
+    "//": "No camp, on purpose! These guys will literally starve.",
+    "fac_food_supply": { "calories": 0, "vitamins": {  } },
     "wealth": 100,
     "relations": {
       "lobby_beggars": {
@@ -301,7 +311,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 10000000,
     "currency": "FMCNote",
     "price_rules": [ { "item": "money_strap_FMCNote", "fixed_adj": 0 }, { "item": "money_bundle_FMCNote", "fixed_adj": 0 } ],
@@ -331,7 +341,8 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 172800, "vitamins": {  } },
+    "//": "No camp, on purpose! The pilgrim group should probably be full marloss, and not need to eat?",
+    "fac_food_supply": { "calories": 0, "vitamins": {  } },
     "wealth": 25000,
     "relations": {
       "marloss": {
@@ -376,7 +387,8 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 172800, "vitamins": {  } },
+    "//": "90 days worth of food for 10 people, at 3000kcal/day and full RDA of iron/calcium/vitC",
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 2500000,
     "relations": {
       "lobby_beggars": { "knows your voice": true },
@@ -394,13 +406,13 @@
   {
     "type": "faction",
     "id": "hells_raiders",
-    "name": "Hell's Raiders",
+    "name": "Bandits",
     "likes_u": -25,
     "respects_u": -25,
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 230400, "vitamins": {  } },
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 45000000,
     "relations": {
       "hells_raiders": {
@@ -476,7 +488,8 @@
     "known_by_u": false,
     "size": 1,
     "power": 10,
-    "fac_food_supply": { "calories": 2304, "vitamins": {  } },
+    "//": "90 days worth of food for 1 person, at 3000kcal/day and full RDA of iron/calcium/vitC",
+    "fac_food_supply": { "calories": 270000000, "vitamins": { "iron": 8640, "calcium": 8640, "vitC": 8640 } },
     "wealth": 0,
     "relations": {
       "apis_hive": {
@@ -504,7 +517,8 @@
     "size": 7,
     "power": 10,
     "currency": "signed_chit",
-    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
+    "//": "FOUR camps.",
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 75000,
     "relations": {
       "free_merchants": {
@@ -577,7 +591,7 @@
     "size": 25,
     "power": 20,
     "currency": "icon",
-    "fac_food_supply": { "calories": 87500, "vitamins": {  } },
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 82500,
     "relations": {
       "gods_community": {
@@ -669,7 +683,8 @@
     "size": 1,
     "power": 1,
     "currency": "fur",
-    "fac_food_supply": { "calories": 87500, "vitamins": {  } },
+    "//": "90 days worth of food for 1 person, at 3000kcal/day and full RDA of iron/calcium/vitC",
+    "fac_food_supply": { "calories": 270000000, "vitamins": { "iron": 8640, "calcium": 8640, "vitC": 8640 } },
     "wealth": 82500,
     "relations": {
       "free_merchants": {
@@ -751,7 +766,8 @@
     "known_by_u": false,
     "size": 3,
     "power": 3,
-    "fac_food_supply": { "calories": 100, "vitamins": {  } },
+    "//": "FIXME: Currently no camps! Spawns via % chance in a bit of nested mapgen, then moves to an existing lighthouse (with no way to know which lighthouse during mapgen!). Will probably need some dynamic camp placement to support.",
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 20000,
     "relations": {
       "free_merchants": { "knows your voice": true },
@@ -770,7 +786,8 @@
     "known_by_u": true,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 230400, "vitamins": {  } },
+    "//": "7 days worth of food for 10 people, at 3000kcal/day and *half* RDA of iron/calcium/vitC",
+    "fac_food_supply": { "calories": 210000000, "vitamins": { "iron": 3360, "calcium": 3360, "vitC": 3360 } },
     "wealth": 45000000,
     "relations": {
       "hells_raiders": {
@@ -801,7 +818,7 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "fac_food_supply": { "calories": 115200, "vitamins": {  } },
+    "fac_food_supply": { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } },
     "wealth": 25000000,
     "currency": "FlatCoin",
     "price_rules": [

--- a/data/json/obsoletion_and_migration_0.I/camp_placement.json
+++ b/data/json/obsoletion_and_migration_0.I/camp_placement.json
@@ -1,0 +1,62 @@
+[
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Refugee Center", "overmap_terrain": "evac_center_13", "faction": "free_merchants" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Exodii", "overmap_terrain": "exodii_base_x1y2z1", "faction": "exodii" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "???", "overmap_terrain": "hive", "faction": "apis_hive" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Lapin", "overmap_terrain": "cabin_lapin", "faction": "lapin" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Holdouts", "overmap_terrain": "prison_island_1_6", "faction": "prisoners" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "New England Church Retreat", "overmap_terrain": "godco_5", "faction": "gods_community" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Tacoma", "overmap_terrain": "ranch_camp_67", "faction": "tacoma_commune" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Hub 01", "overmap_terrain": "robofachq_surface_entrance", "faction": "robofac" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Cody & Jay", "overmap_terrain": "isolated_house_farm_gunsmith", "faction": "isolated_artisans" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Cabin", "overmap_terrain": "cabin_isherwood", "faction": "isherwood_family" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Isherwood Stables", "overmap_terrain": "horse_farm_isherwood_6", "faction": "isherwood_family" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Isherwood Outcropping", "overmap_terrain": "farm_isherwood_2", "faction": "isherwood_family" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Isherwood Farms", "overmap_terrain": "dairy_farm_isherwood_SW", "faction": "isherwood_family" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Merchant", "overmap_terrain": "bunker_shop_b", "faction": "wasteland_scavengers" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "The Great Library", "overmap_terrain": "campus_media_0_0_0", "faction": "the_great_library" }
+  }
+]

--- a/data/json/overmap/overmap_special/campus.json
+++ b/data/json/overmap/overmap_special/campus.json
@@ -63,7 +63,12 @@
       { "point": [ 10, 6, 3 ], "overmap": "campus_commons_1_2_3_north" },
       { "point": [ 9, 7, 3 ], "overmap": "campus_commons_0_3_3_north" },
       { "point": [ 10, 7, 3 ], "overmap": "campus_commons_1_3_3_north" },
-      { "point": [ 12, 10, 0 ], "overmap": "campus_media_0_0_0_north" },
+      {
+        "point": [ 12, 10, 0 ],
+        "overmap": "campus_media_0_0_0_north",
+        "camp": "the_great_library",
+        "camp_name": "The Great Library"
+      },
       { "point": [ 12, 11, 0 ], "overmap": "campus_media_0_1_0_north" },
       { "point": [ 13, 10, 0 ], "overmap": "campus_media_1_0_0_north" },
       { "point": [ 13, 11, 0 ], "overmap": "campus_media_1_1_0_north" },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -443,7 +443,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "hive_edge_01_north" },
       { "point": [ 0, 2, 0 ], "overmap": "hive_edge_02_north" },
       { "point": [ 1, 0, 0 ], "overmap": "hive_edge_10_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "hive_north" },
+      { "point": [ 1, 1, 0 ], "overmap": "hive_north", "camp": "apis_hive", "camp_name": "???" },
       { "point": [ 1, 2, 0 ], "overmap": "hive_edge_12_north" },
       { "point": [ 2, 0, 0 ], "overmap": "hive_edge_20_north" },
       { "point": [ 2, 1, 0 ], "overmap": "hive_edge_21_north" },
@@ -1302,7 +1302,7 @@
       { "point": [ 2, 0, 0 ], "overmap": "prison_island_1_3_north" },
       { "point": [ 3, 0, 0 ], "overmap": "prison_island_1_4_north" },
       { "point": [ 4, 0, 0 ], "overmap": "prison_island_1_5_north" },
-      { "point": [ 0, 1, 0 ], "overmap": "prison_island_1_6_north" },
+      { "point": [ 0, 1, 0 ], "overmap": "prison_island_1_6_north", "camp": "prisoners", "camp_name": "Holdouts" },
       { "point": [ 1, 1, 0 ], "overmap": "prison_island_1_7_north" },
       { "point": [ 2, 1, 0 ], "overmap": "prison_island_1_8_north" },
       { "point": [ 3, 1, 0 ], "overmap": "prison_island_1_9_north" },
@@ -2043,7 +2043,12 @@
       { "point": [ 9, 6, 0 ], "overmap": "evac_center_10_north" },
       { "point": [ 5, 7, 0 ], "overmap": "evac_center_11_north" },
       { "point": [ 6, 7, 0 ], "overmap": "evac_center_12_north" },
-      { "point": [ 7, 7, 0 ], "overmap": "evac_center_13_north" },
+      {
+        "point": [ 7, 7, 0 ],
+        "overmap": "evac_center_13_north",
+        "camp": "free_merchants",
+        "camp_name": "Refugee Center"
+      },
       { "point": [ 8, 7, 0 ], "overmap": "evac_center_14_north" },
       { "point": [ 9, 7, 0 ], "overmap": "evac_center_15_north" },
       { "point": [ 5, 8, 0 ], "overmap": "evac_center_16_north" },
@@ -2399,7 +2404,12 @@
       { "point": [ -2, 4, 0 ], "overmap": "godco_6_north" },
       { "point": [ -3, 4, 0 ], "overmap": "forest_thick" },
       { "point": [ -4, 4, 0 ], "overmap": "forest_thick" },
-      { "point": [ -1, 4, 0 ], "overmap": "godco_5_north" },
+      {
+        "point": [ -1, 4, 0 ],
+        "overmap": "godco_5_north",
+        "camp": "gods_community",
+        "camp_name": "New England Church Retreat"
+      },
       { "point": [ 0, 4, 0 ], "overmap": "godco_4_north" },
       { "point": [ 1, 4, 0 ], "overmap": "forest_thick" },
       { "point": [ 2, 4, 0 ], "overmap": "forest_thick" },
@@ -2643,7 +2653,7 @@
       { "point": [ 1, 7, 1 ], "overmap": "ranch_camp_65_roof_north" },
       { "point": [ 2, 7, 0 ], "overmap": "ranch_camp_66_north" },
       { "point": [ 2, 7, 1 ], "overmap": "ranch_camp_66_roof_north" },
-      { "point": [ 3, 7, 0 ], "overmap": "ranch_camp_67_north" },
+      { "point": [ 3, 7, 0 ], "overmap": "ranch_camp_67_north", "camp": "tacoma_commune", "camp_name": "Tacoma" },
       { "point": [ 3, 7, 1 ], "overmap": "ranch_camp_67_roof_north" },
       { "point": [ 4, 7, 0 ], "overmap": "ranch_camp_68_north" },
       { "point": [ 4, 7, 1 ], "overmap": "ranch_camp_68_roof_north" },
@@ -3546,7 +3556,12 @@
       { "point": [ 2, -1, 0 ], "overmap": "robofachq_surface_road2_north" },
       { "point": [ 3, -1, 0 ], "overmap": "robofachq_surface_road3_north" },
       { "point": [ 0, 0, 0 ], "overmap": "robofachq_surface_parking_north" },
-      { "point": [ 1, 0, 0 ], "overmap": "robofachq_surface_entrance_north" },
+      {
+        "point": [ 1, 0, 0 ],
+        "overmap": "robofachq_surface_entrance_north",
+        "camp": "robofac",
+        "camp_name": "Hub 01"
+      },
       { "point": [ 2, 0, 0 ], "overmap": "robofachq_surface_car_entrance_north" },
       { "point": [ 3, 0, 0 ], "overmap": "robofachq_surface_a3_north" },
       { "point": [ 0, 1, 0 ], "overmap": "robofachq_surface_b0_north" },
@@ -5394,7 +5409,7 @@
       { "point": [ 1, 4, 0 ], "overmap": "special_forest" },
       { "point": [ 2, 4, 0 ], "overmap": "special_forest_thick" },
       { "point": [ 3, 4, 0 ], "overmap": "special_forest" },
-      { "point": [ 4, 4, 0 ], "overmap": "cabin_isherwood_north" },
+      { "point": [ 4, 4, 0 ], "overmap": "cabin_isherwood_north", "camp": "isherwood_family", "camp_name": "Cabin" },
       { "point": [ 4, 4, 1 ], "overmap": "cabin_lake_roof_north" },
       { "point": [ 5, 4, 0 ], "overmap": "special_forest" },
       { "point": [ 6, 4, 0 ], "overmap": "special_forest" },
@@ -5529,7 +5544,12 @@
       { "point": [ 14, 8, 0 ], "overmap": "special_field" },
       { "point": [ 15, 8, 0 ], "overmap": "special_field" },
       { "point": [ 16, 8, 0 ], "overmap": "horse_farm_isherwood_5_north" },
-      { "point": [ 17, 8, 0 ], "overmap": "horse_farm_isherwood_6_north" },
+      {
+        "point": [ 17, 8, 0 ],
+        "overmap": "horse_farm_isherwood_6_north",
+        "camp": "isherwood_family",
+        "camp_name": "Isherwood Stables"
+      },
       { "point": [ 18, 8, 0 ], "overmap": "horse_farm_isherwood_7_north" },
       { "point": [ 18, 8, 1 ], "overmap": "horse_farm_isherwood_7_hayloft_north" },
       { "point": [ 18, 8, 2 ], "overmap": "horse_farm_isherwood_7_roof_north" },
@@ -5831,7 +5851,12 @@
       { "point": [ 10, 18, 0 ], "overmap": "farm_isherwood_3_north" },
       { "point": [ 10, 18, 2 ], "overmap": "farm_isherwood_3_roof_north" },
       { "point": [ 10, 18, 1 ], "overmap": "farm_isherwood_3_hayloft_north" },
-      { "point": [ 11, 18, 0 ], "overmap": "farm_isherwood_2_north" },
+      {
+        "point": [ 11, 18, 0 ],
+        "overmap": "farm_isherwood_2_north",
+        "camp": "isherwood_family",
+        "camp_name": "Isherwood Outcropping"
+      },
       { "point": [ 11, 18, -1 ], "overmap": "farm_isherwood_2_cellar_north" },
       { "point": [ 11, 18, 1 ], "overmap": "farm_isherwood_2_roof_north" },
       { "point": [ 12, 18, 0 ], "overmap": "farm_isherwood_1_north" },
@@ -5971,7 +5996,12 @@
       { "point": [ 23, 22, 0 ], "overmap": "rural_road_ns" },
       { "point": [ 24, 22, 0 ], "overmap": "smokehouse_north" },
       { "point": [ 24, 22, 1 ], "overmap": "smokehouse_roof_north" },
-      { "point": [ 25, 22, 0 ], "overmap": "dairy_farm_isherwood_SW_north" },
+      {
+        "point": [ 25, 22, 0 ],
+        "overmap": "dairy_farm_isherwood_SW_north",
+        "camp": "isherwood_family",
+        "camp_name": "Isherwood Farms"
+      },
       { "point": [ 25, 22, 1 ], "overmap": "dairy_farm_isherwood_SW_roof_north" },
       { "point": [ 26, 22, 0 ], "overmap": "dairy_farm_isherwood_SE_north" },
       { "point": [ 26, 22, 1 ], "overmap": "dairy_farm_isherwood_SE_roof_north" },
@@ -6853,7 +6883,7 @@
     "type": "overmap_special",
     "id": "Occupied Chem Lab",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "chemical_lab_ocu_north" },
+      { "point": [ 0, 0, 0 ], "overmap": "chemical_lab_ocu_north", "camp": "wasteland_scavengers", "camp_name": "Chemist" },
       { "point": [ 0, 0, 1 ], "overmap": "chemical_lab_roof_ocu_north" },
       { "point": [ -1, -1, 0 ], "locations": [ "land", "road" ] },
       { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
@@ -6872,7 +6902,7 @@
     "type": "overmap_special",
     "id": "Occupied Scrap Yard",
     "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_ocu_north" },
+      { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_ocu_north", "camp": "wasteland_scavengers", "camp_name": "Scrapper" },
       { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
@@ -6889,7 +6919,12 @@
       { "point": [ 0, 0, 0 ], "overmap": "lumbermill_0_0_ocu_north" },
       { "point": [ 1, 0, 0 ], "overmap": "lumbermill_1_0_ocu_north" },
       { "point": [ 0, 1, 0 ], "overmap": "lumbermill_0_1_ocu_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "lumbermill_1_1_ocu_north" },
+      {
+        "point": [ 1, 1, 0 ],
+        "overmap": "lumbermill_1_1_ocu_north",
+        "camp": "wasteland_scavengers",
+        "camp_name": "Lumbermill (survivor base)"
+      },
       { "point": [ 0, 0, 1 ], "overmap": "lumbermill_0_0_roof_north" },
       { "point": [ 1, 0, 1 ], "overmap": "lumbermill_1_0_roof_north" },
       { "point": [ 0, 1, 1 ], "overmap": "lumbermill_0_1_roof_north" },
@@ -6968,7 +7003,12 @@
     "id": "bunker shop",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "bunker_shop_g_south" },
-      { "point": [ 0, 0, -1 ], "overmap": "bunker_shop_b_south" }
+      {
+        "point": [ 0, 0, -1 ],
+        "overmap": "bunker_shop_b_south",
+        "camp": "wasteland_scavengers",
+        "camp_name": "Merchant"
+      }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "existing": true, "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],

--- a/data/json/recipes/basecamps/special_hardcoded.json
+++ b/data/json/recipes/basecamps/special_hardcoded.json
@@ -1,0 +1,41 @@
+[
+  {
+    "//": "This file contains a special NPC-only basecamp which doesn't place anything, equivalent to the barebones camp. It is placed during mapgen, and should not show up as a valid player option in regular gameplay. The entire purpose is to provide 'water_well' so NPCs don't dehydrate to death.",
+    "//2": "Has hardcoded references in place (overmap.cpp) and overmap::migrate_camps.",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "faction_base_bare_bones_NPC_camp_0",
+    "description": "NPC-only.  If you see this it's a bug",
+    "category": "CC_BUILDING",
+    "subcategory": "CSC_BUILDING_BASES",
+    "skill_used": "fabrication",
+    "autolearn": false,
+    "never_learn": true,
+    "time": "1 h",
+    "construction_blueprint": "fbbb",
+    "blueprint_provides": [
+      { "id": "gathering" },
+      { "id": "fbbb_crafting_recipes_basic" },
+      { "id": "fbbb_crafting_recipes_cooking" },
+      { "id": "fbbb_crafting_recipes_crafting" },
+      { "id": "fbbb_crafting_recipes_custom" },
+      { "id": "fbbb" },
+      { "id": "firewood" },
+      { "id": "foraging" },
+      { "id": "sorting" },
+      { "id": "logging" },
+      { "id": "trapping" },
+      { "id": "hunting" },
+      { "id": "kitchen" },
+      { "id": "relaying" },
+      { "id": "walls" },
+      { "id": "recruiting" },
+      { "id": "scouting" },
+      { "id": "water_well" },
+      { "id": "patrolling" }
+    ],
+    "blueprint_requires": [ { "id": "not_an_upgrade" } ],
+    "blueprint_name": "NPC-only.  If you see this it's a bug",
+    "check_blueprint_needs": false
+  }
+]

--- a/data/mods/Aftershock/migration/camp_placement.json
+++ b/data/mods/Aftershock/migration/camp_placement.json
@@ -1,0 +1,11 @@
+[
+  {
+    "//": "Remove all entries after 0.I",
+    "type": "camp_migration",
+    "camp_migrations": { "name": "PrepNet", "overmap_terrain": "prepnet_orchard", "faction": "Prepnet_Phyle" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Port Augustmoon", "overmap_terrain": "augustmoon_main_concourse1", "faction": "UICA" }
+  }
+]

--- a/data/mods/Magiclysm/obsolete/camp_placement.json
+++ b/data/mods/Magiclysm/obsolete/camp_placement.json
@@ -1,0 +1,15 @@
+[
+  {
+    "//": "Remove all entries after 0.I",
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Forge of Wonders", "overmap_terrain": "forge_3A", "faction": "forge_lords" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Healer's respite", "overmap_terrain": "magic_shop", "faction": "healers_grey" }
+  },
+  {
+    "type": "camp_migration",
+    "camp_migrations": { "name": "Old Wizard", "overmap_terrain": "lake_retreat_z3", "faction": "wizards_ancient" }
+  }
+]

--- a/doc/FACTIONS.md
+++ b/doc/FACTIONS.md
@@ -14,6 +14,7 @@ An NPC faction looks like this:
     "size": 100,
     "power": 100,
     "fac_food_supply": { "calories": 115200, "vitamins": { "iron": 800, "calcium": 800, "vitC": 600 } },
+    "consumes_food": true,
     "lone_wolf_faction": true,
     "wealth": 75000000,
     "currency": "FMCNote",
@@ -66,8 +67,10 @@ Field                 | Meaning
 `"known_by_u"`        | boolean, whether the player has met members of the faction.  Can be changed in play.  Unknown factions will not be displayed in the faction menu.
 `"size"`              | integer, an approximate count of the members of the faction.  Has no effect in play currently.
 `"power"`             | integer, an approximation of the faction's power.  Has no effect in play currently.
-`"fac_food_supply"`   | integer, the number of calories (not kilocalories!) available to the faction. Has no effect in play currently.
-`"vitamins"`          | array, *units* of vitamins available to this faction. This is not the same as RDA, see [the vitamins doc](VITAMIN.md) for more details. Has no effect in play currently.
+`"fac_food_supply"`   | object, mandatory. The overall food supply of the faction, including the `calories` and `vitamins`.
+`"calories"`          | integer, the number of calories (not kilocalories!) available to the faction. 
+`"vitamins"`          | array, *units* of vitamins available to this faction. This is not the same as RDA, see [the vitamins doc](VITAMIN.md) for more details.
+`"consumes_food"`     | bool, optional, defaults to false. Controls whether characters eating from the fac_food_supply actually removes food from it. Note that eating is controlled by the external optional "NO_NPC_FOOD". consumes_food only controls whether the eaten food is removed from storage (whether the amount of food available goes down!)
 `"wealth"`            | integer, number of post-apocalyptic currency in cents that that faction has to purchase stuff. Serves as an upper limit on the amount of items restocked by a NPC of this faction with a defined shopkeeper_item_group (see NPCs.md)
 `"currency"`          | string, the item `"id"` of the faction's preferred currency.  Faction shopkeeps will trade faction current at 100% value, for both selling and buying.
 `"price_rules"`       | array, allows defining `premium`, `markup`, `price` and/or `fixed_adj` for an `item`/`category`/`group`.<br/><br/>`premium` is a price multiplier that applies to both sides.<br/> `markup` is only used when an NPC is selling to the avatar and defaults to `1`.<br/>`price` replaces the item's `price_postapoc`.<br/>`fixed_adj` is used instead of adjustment based on social skill and intelligence stat and can be used to define secondary currencies.<br/><br/>Lower entries override higher ones. For conditionals, the avatar is used as alpha and the evaluating npc as beta
@@ -101,10 +104,9 @@ Flag                   | Meaning
 ---------------------- | --
 `"kill on sight"`      | Members of the acting faction are always hostile to members of the object faction.
 `"watch your back"`    | Members of the acting faction will treat attacks on members of the object faction as attacks on themselves.
-`"share my stuff"`     | Members of the acting faction will not object if members of the object faction take items owned by the acting faction.
+`"share my stuff"`     | Members of the acting faction will not object if members of the object faction take items owned by the acting faction. Camps of the acting faction will allow members of the object faction to eat from their food stores (including water access).
+`"share public goods"` | Camps of the acting faction will allow members of the object faction to drink from camp water wells. Irrelevant if the relationship already allows "share my stuff".
 `"guard your stuff"`   | Members of the acting faction will object if someone takes items owned by the object faction.
-`"lets you in"`        | Members of the acting faction will not object if a member of the object faction enters territory controlled by the acting faction.
-`"defends your space"` | Members of the acting faction will become hostile if someone enters territory controlled by the object faction.
+`"lets you in"`        | Members of the acting faction will not object if a member of the object faction enters territory controlled by the acting faction. No current gameplay effect.
+`"defends your space"` | Members of the acting faction will become hostile if someone enters territory controlled by the object faction. No current gameplay effect.
 `"knows your voice"`   | Members of the acting faction will not comment on speech by members of the object faction.
-
-So far, only `"kill on sight"`, `"knows your voice"`, and `"watch your back"` have been implemented.

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -423,7 +423,7 @@ Depending on the subtype, there are further relevant fields:
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "campground_1a_north", "locations": [ "forest_edge" ] },
       { "point": [ 1, 0, 0 ], "overmap": "campground_1b_north" },
-      { "point": [ 0, 1, 0 ], "overmap": "campground_2a_north" },
+      { "point": [ 0, 1, 0 ], "overmap": "campground_2a_north", "camp": "isherwood_family", "camp_name": "Campground camp" },
       { "point": [ 1, 1, 0 ], "overmap": "campground_2b_north" }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
@@ -444,6 +444,8 @@ Depending on the subtype, there are further relevant fields:
 | `point`     | `[ x, y, z]` of the overmap terrain within the special.                                                                                                                                    |
 | `overmap`   | Id of the `overmap_terrain` to place at the location. If ommited no overmap_terrain is placed but the point will still be checked for valid locations when deciding if placement is valid. |
 | `locations` | List of `overmap_location` ids that this overmap terrain may be placed on. Overrides the specials overall `locations` field.                                                               |
+| `camp`      | Will make a NPC-owned camp spawn here when given a value. The entered value is the ID of the faction that owns this camp.                                                                  |
+| `camp_name` | Name that will be displayed on the overmap for the camp.                                                                                                                                   |
 
 ### Connections
 

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -61,6 +61,7 @@ from .parsers.morale_type import parse_morale_type
 from .parsers.movement_mode import parse_movement_mode
 from .parsers.mutation_category import parse_mutation_category
 from .parsers.overmap_land_use_code import parse_overmap_land_use_code
+from .parsers.overmap_special import parse_overmap_special
 from .parsers.practice import parse_practice
 from .parsers.scenario import parse_scenario
 from .parsers.shop_blacklist import parse_shopkeeper_blacklist
@@ -113,6 +114,7 @@ parsers = {
     "body_part": parse_body_part,
     "book": parse_generic,
     "butchery_requirement": dummy_parser,
+    "camp_migration": dummy_parser,
     "character_mod": parse_character_mod,
     "charge_removal_blacklist": dummy_parser,
     "city": parse_city,
@@ -192,7 +194,7 @@ parsers = {
     "overmap_connection": dummy_parser,
     "overmap_land_use_code": parse_overmap_land_use_code,
     "overmap_location": dummy_parser,
-    "overmap_special": dummy_parser,
+    "overmap_special": parse_overmap_special,
     "overmap_special_migration": dummy_parser,
     "overmap_terrain": parse_overmap_terrain,
     "palette": parse_palette,

--- a/lang/string_extractor/parsers/overmap_special.py
+++ b/lang/string_extractor/parsers/overmap_special.py
@@ -1,0 +1,8 @@
+from ..write_text import write_text
+
+
+def parse_overmap_special(json, origin):
+    for overmap in json["overmaps"]:
+        if "camp_name" in overmap:
+            write_text(overmap["camp_name"], origin,
+                       comment="Name of NPC faction camp")

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -187,9 +187,12 @@ void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &n
     update_resources( bldg );
 }
 
-void basecamp::define_camp( const tripoint_abs_omt &p, const std::string_view camp_type )
+void basecamp::define_camp( const tripoint_abs_omt &p, const std::string_view camp_type,
+                            bool player_founded )
 {
-    query_new_name( true );
+    if( player_founded ) {
+        query_new_name( true );
+    }
     omt_pos = p;
     const oter_id &omt_ref = overmap_buffer.ter( omt_pos );
     // purging the regions guarantees all entries will start with faction_base_
@@ -205,9 +208,11 @@ void basecamp::define_camp( const tripoint_abs_omt &p, const std::string_view ca
         e.pos = omt_pos;
         expansions[base_camps::base_dir] = e;
         const std::string direction = oter_get_rotation_string( omt_ref );
-        const oter_id bcid( direction.empty() ? "faction_base_camp_0" : "faction_base_camp_new_0" +
-                            direction );
-        overmap_buffer.ter_set( omt_pos, bcid );
+        if( player_founded ) {
+            const oter_id bcid( direction.empty() ? "faction_base_camp_0" : "faction_base_camp_new_0" +
+                                direction );
+            overmap_buffer.ter_set( omt_pos, bcid );
+        }
         update_provides( base_camps::faction_encode_abs( e, 0 ),
                          expansions[base_camps::base_dir] );
     } else {
@@ -317,6 +322,24 @@ bool basecamp::has_water() const
 {
     // special case required for fbmh_well_north constructed between b9162 (Jun 16, 2019) and b9644 (Sep 20, 2019)
     return has_provides( "water_well" ) || has_provides( "fbmh_well_north" );
+}
+
+bool basecamp::allowed_access_by( Character &guy, bool water_request ) const
+{
+    // The owner can always access their own camp.
+    if( fac() == guy.get_faction() ) {
+        return true;
+    }
+    // Sharing stuff also means sharing access.
+    if( fac()->has_relationship( guy.get_faction()->id, npc_factions::share_my_stuff ) ) {
+        return true;
+    }
+    // Some factions will share access to infinite water sources, but not food
+    if( water_request &&
+        fac()->has_relationship( guy.get_faction()->id, npc_factions::share_public_goods ) ) {
+        return true;
+    }
+    return false;
 }
 
 std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
@@ -429,6 +452,7 @@ void basecamp::update_resources( const std::string &bldg )
 void basecamp::update_provides( const std::string &bldg, expansion_data &e_data )
 {
     if( !recipe_id( bldg ).is_valid() ) {
+        debugmsg( "Invalid basecamp recipe %s", bldg );
         return;
     }
 
@@ -808,14 +832,8 @@ void basecamp::unload_camp_map()
 
 void basecamp::set_owner( faction_id new_owner )
 {
-    for( const std::pair<faction_id, faction> fac : g->faction_manager_ptr->all() ) {
-        if( fac.first == new_owner ) {
-            owner = new_owner;
-            return;
-        }
-    }
-    //Fallthrough, id must be invalid
-    debugmsg( "Could not find matching faction for new owner's faction_id!" );
+    // Absolutely no safety checks, factions don't exist until you've encountered them but we sometimes set the owner before that
+    owner = new_owner;
 }
 
 faction_id basecamp::get_owner()

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -210,7 +210,8 @@ class basecamp
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );
         void add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
                             const point &dir );
-        void define_camp( const tripoint_abs_omt &p, std::string_view camp_type );
+        void define_camp( const tripoint_abs_omt &p, std::string_view camp_type,
+                          bool player_founded = true );
 
         std::string expansion_tab( const point &dir ) const;
         // check whether the point is the part of camp
@@ -272,6 +273,7 @@ class basecamp
         /// Changes the faction opinion for you by @ref change, returns opinion
         int camp_morale( int change = 0 ) const;
 
+        bool allowed_access_by( Character &guy, bool water_request = false ) const;
         // recipes, gathering, and craft support functions
         // from a direction
         std::map<recipe_id, translation> recipe_deck( const point &dir ) const;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1784,7 +1784,17 @@ conditional_t::func f_math( const JsonObject &jo, const std::string_view member 
 conditional_t::func f_u_has_camp()
 {
     return []( dialogue const & ) {
-        return !get_player_character().camps.empty();
+        for( const tripoint_abs_omt &camp_tripoint : get_player_character().camps ) {
+            std::optional<basecamp *> camp = overmap_buffer.find_camp( camp_tripoint.xy() );
+            if( !camp ) {
+                continue;
+            }
+            basecamp *bcp = *camp;
+            if( bcp->get_owner() == get_player_character().get_faction()->id ) {
+                return true;
+            }
+        }
+        return false;
     };
 }
 

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -132,6 +132,7 @@ faction_template::faction_template( const JsonObject &jsobj )
     , wealth( jsobj.get_int( "wealth" ) )
 {
     jsobj.get_member( "description" ).read( desc );
+    optional( jsobj, false, "consumes_food", consumes_food, false );
     optional( jsobj, false, "price_rules", price_rules, faction_price_rules_reader {} );
     jsobj.read( "fac_food_supply", food_supply, true );
     if( jsobj.has_string( "currency" ) ) {
@@ -1052,6 +1053,10 @@ void faction_manager::display() const
                 continue;
             }
             basecamp *temp_camp = *p;
+            if( temp_camp->get_owner() != player_character.get_faction()->id ) {
+                // Don't display NPC camps as ours
+                continue;
+            }
             camps.push_back( temp_camp );
         }
         lore.clear();

--- a/src/faction.h
+++ b/src/faction.h
@@ -50,6 +50,7 @@ enum relationship : int {
     kill_on_sight,
     watch_your_back,
     share_my_stuff,
+    share_public_goods,
     guard_your_stuff,
     lets_you_in,
     defend_your_space,
@@ -62,6 +63,7 @@ const std::unordered_map<std::string, relationship> relation_strs = { {
         { "kill on sight", kill_on_sight },
         { "watch your back", watch_your_back },
         { "share my stuff", share_my_stuff },
+        { "share public goods", share_public_goods },
         { "guard your stuff", guard_your_stuff },
         { "lets you in", lets_you_in },
         { "defends your space", defend_your_space },
@@ -114,6 +116,7 @@ class faction_template
         int size; // How big is our sphere of influence?
         int power; // General measure of our power
         nutrients food_supply; //Total nutritional value held
+        bool consumes_food; //Whether this faction actually draws down the food_supply when eating from it
         int wealth;  //Total trade currency
         bool lone_wolf_faction; // is this a faction for just one person?
         itype_id currency; // id of the faction currency

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2168,6 +2168,10 @@ void basecamp::abandon_camp()
     for( npc_ptr &guy : get_npcs_assigned() ) {
         talk_function::stop_guard( *guy );
     }
+    // We must send this message early, before the name is erased.
+    add_msg( m_info, _( "You abandon %s." ), name );
+    std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
+    known_camps.erase( omt_pos );
     overmap_buffer.remove_camp( *this );
     map &here = get_map();
     const tripoint sm_pos = omt_to_sm_copy( omt_pos.raw() );
@@ -2175,7 +2179,6 @@ void basecamp::abandon_camp()
     // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
     // here.remove_submap_camp( here.getlocal( bb_pos ) );
     here.remove_submap_camp( here.bub_from_abs( ms_pos ) );
-    add_msg( m_info, _( "You abandon %s." ), name );
 }
 
 void basecamp::scan_pseudo_items()
@@ -5530,7 +5533,7 @@ nutrients basecamp::camp_food_supply( nutrients &change )
         double percent_consumed = std::abs( static_cast<double>( change.calories ) ) /
                                   fac()->food_supply.calories;
         consumed = fac()->food_supply;
-        if( std::abs( change.calories ) > fac()->food_supply.calories ) {
+        if( std::abs( change.calories ) > fac()->food_supply.calories && fac()->consumes_food ) {
             //Whoops, we don't have enough food. Empty the larder! No crumb shall go un-eaten!
             fac()->food_supply += change;
             faction *yours = get_player_character().get_faction();
@@ -5543,8 +5546,10 @@ nutrients basecamp::camp_food_supply( nutrients &change )
             return consumed;
         }
         consumed *= percent_consumed;
-        // Subtraction since we use the absolute value of change's calories to get the percent
-        fac()->food_supply -= consumed;
+        if( fac()->consumes_food ) {
+            // Subtraction since we use the absolute value of change's calories to get the percent
+            fac()->food_supply -= consumed;
+        }
         return consumed;
     }
     fac()->food_supply += change;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1982,6 +1982,11 @@ void iexamine::bulletin_board( Character &you, const tripoint &examp )
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt );
     if( bcp ) {
         basecamp *temp_camp = *bcp;
+        if( !temp_camp->allowed_access_by( you ) ) {
+            you.add_msg_if_player( _( "You don't run this camp, the board is useless to you." ) );
+            return;
+        }
+
         temp_camp->validate_bb_pos( here.getglobal( examp ) );
         temp_camp->validate_assignees();
         temp_camp->validate_sort_points();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -410,6 +410,7 @@ void DynamicDataLoader::initialize()
     add( "attack_vector", &attack_vector::load_attack_vectors );
     add( "effect_type", &load_effect_type );
     add( "oter_id_migration", &overmap::load_oter_id_migration );
+    add( "camp_migration", &overmap::load_oter_id_camp_migration );
     add( "overmap_terrain", &overmap_terrains::load );
     add( "construction_category", &construction_categories::load );
     add( "construction_group", &construction_groups::load );
@@ -613,6 +614,7 @@ void DynamicDataLoader::unload_data()
     overmap_special_migration::reset();
     overmap_terrains::reset();
     overmap::reset_oter_id_migrations();
+    overmap::reset_oter_id_camp_migrations();
     profession::reset();
     profession_blacklist::reset();
     proficiency::reset();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7042,12 +7042,15 @@ basecamp map::hoist_submap_camp( const tripoint &p )
     return pcamp ? *pcamp : basecamp();
 }
 
-void map::add_camp( const tripoint_abs_omt &omt_pos, const std::string &name )
+void map::add_camp( const tripoint_abs_omt &omt_pos, const std::string &name, bool need_validate )
 {
     basecamp temp_camp = basecamp( name, omt_pos );
     overmap_buffer.add_camp( temp_camp );
     get_player_character().camps.insert( omt_pos );
-    g->validate_camps();
+    // Mapgen-spawned camps never need or want to validate, since they'll always be on newly generated OMTs
+    if( need_validate ) {
+        g->validate_camps();
+    }
 }
 
 void map::update_submaps_with_active_items()

--- a/src/map.h
+++ b/src/map.h
@@ -1807,7 +1807,8 @@ class map
         computer *add_computer( const tripoint &p, const std::string &name, int security );
 
         // Camps
-        void add_camp( const tripoint_abs_omt &omt_pos, const std::string &name );
+        void add_camp( const tripoint_abs_omt &omt_pos, const std::string &name,
+                       bool need_validate = true );
         void remove_submap_camp( const tripoint & );
         void remove_submap_camp( const tripoint_bub_ms & );
         basecamp hoist_submap_camp( const tripoint &p );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4555,9 +4555,6 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
 
 bool npc::consume_food_from_camp()
 {
-    if( !is_player_ally() ) {
-        return false;
-    }
     Character &player_character = get_player_character();
     std::optional<basecamp *> potential_bc;
     for( const tripoint_abs_omt &camp_pos : player_character.camps ) {
@@ -4572,46 +4569,28 @@ bool npc::consume_food_from_camp()
         return false;
     }
     basecamp *bcp = *potential_bc;
-    if( get_thirst() > 40 && bcp->has_water() ) {
+
+    // Handle water
+    if( get_thirst() > 40 && bcp->has_water() && bcp->allowed_access_by( *this, true ) ) {
         complain_about( "camp_water_thanks", 1_hours,
                         chat_snippets().snip_camp_water_thanks.translated(), false );
         // TODO: Stop skipping the stomach for this, actually put the water in there.
         set_thirst( 0 );
         return true;
     }
-    faction *yours = player_character.get_faction();
 
+    // Handle food
     int current_kcals = get_stored_kcal() + stomach.get_calories() + guts.get_calories();
     int kcal_threshold = get_healthy_kcal() * 19 / 20;
-    if( get_hunger() > 0 && current_kcals < kcal_threshold ) {
+    if( get_hunger() > 0 && current_kcals < kcal_threshold && bcp->allowed_access_by( *this ) ) {
         // Try to eat a bit more than the bare minimum so that we're not eating every 5 minutes
         // but also don't try to eat a week's worth of food in one sitting
         int desired_kcals = std::min( static_cast<int>( base_metabolic_rate ), std::max( 0,
                                       kcal_threshold + 100 - current_kcals ) );
-        int kcals_to_eat = std::min( desired_kcals, yours->food_supply.kcal() );
+        int kcals_to_eat = std::min( desired_kcals, bcp->get_owner()->food_supply.kcal() );
 
         if( kcals_to_eat > 0 ) {
-            // We need food and there's some available, so let's eat it
-            complain_about( "camp_food_thanks", 1_hours,
-                            chat_snippets().snip_camp_food_thanks.translated(), false );
-
-            // Make a fake food object here to feed the NPC with, since camp calories are abstracted away
-
-            // Fill up the stomach to "full" (half of capacity) but no further, to avoid NPCs vomiting
-            // or becoming engorged
-            units::volume filling_vol = std::max( 0_ml, stomach.capacity( *this ) / 2 - stomach.contains() );
-
-            // Returns the actual amount of calories and vitamins taken from the camp's larder.
-            nutrients nutr = bcp->camp_food_supply( -kcals_to_eat );
-
-            stomach.ingest( food_summary{
-                0_ml,
-                filling_vol,
-                nutr
-            } );
-            // Ensure our hunger is satisfied so we don't try to eat again immediately.
-            // update_stomach() usually takes care of that but it's only called once every 10 seconds for NPCs
-            set_hunger( -1 );
+            bcp->feed_workers( *this, bcp->camp_food_supply( -kcals_to_eat ) );
 
             return true;
         } else {
@@ -4636,7 +4615,7 @@ bool npc::consume_food()
     const std::vector<item *> inv_food = cache_get_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
-        if( !is_player_ally() ) {
+        if( !needs_food() ) {
             // TODO: Remove this and let player "exploit" hungry NPCs
             set_hunger( 0 );
             set_thirst( 0 );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -358,6 +358,9 @@ void talk_function::goto_location( npc &p )
         if( elem == p.global_omt_location() ) {
             continue;
         }
+        if( !overmap_buffer.seen( elem ) ) {
+            continue;
+        }
         std::optional<basecamp *> camp = overmap_buffer.find_camp( elem.xy() );
         if( !camp ) {
             continue;

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -500,6 +500,8 @@ struct overmap_special_terrain : overmap_special_locations {
                              const std::set<std::string> & );
     oter_str_id terrain;
     std::set<std::string> flags;
+    std::optional<faction_id> camp_owner;
+    translation camp_name;
 
     void deserialize( const JsonObject &om );
 };

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -549,9 +549,13 @@ class overmap
         void load_legacy_monstergroups( const JsonArray &jsin );
         void save_monster_groups( JsonOut &jo ) const;
     public:
+        static void load_oter_id_camp_migration( const JsonObject &jo );
         static void load_oter_id_migration( const JsonObject &jo );
+        static void reset_oter_id_camp_migrations();
         static void reset_oter_id_migrations();
+        static bool oter_id_should_have_camp( const oter_type_str_id &oter );
         static bool is_oter_id_obsolete( const std::string &oterid );
+        void migrate_camps( const std::vector<tripoint_abs_omt> &points ) const;
         void migrate_oter_ids( const std::unordered_map<tripoint_om_omt, std::string> &points );
         oter_id get_or_migrate_oter( const std::string &oterid );
 };

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -417,6 +417,7 @@ void overmap::unserialize( const JsonObject &jsobj )
     // Extract layers first so predecessor deduplication can happen.
     if( jsobj.has_member( "layers" ) ) {
         std::unordered_map<tripoint_om_omt, std::string> oter_id_migrations;
+        std::vector<tripoint_abs_omt> camps_to_place;
         JsonArray layers_json = jsobj.get_array( "layers" );
 
         for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
@@ -445,6 +446,11 @@ void overmap::unserialize( const JsonObject &jsobj )
                             debugmsg( "Loaded invalid oter_id '%s'", tmp_ter.c_str() );
                             tmp_otid = oter_omt_obsolete;
                         }
+                        if( oter_id_should_have_camp( oter_str_id( tmp_ter )->get_type_id() ) ) {
+                            for( int p = i; p < i + count; p++ ) {
+                                camps_to_place.emplace_back( project_combine( pos(), tripoint_om_omt( p, j, z - OVERMAP_DEPTH ) ) );
+                            }
+                        }
                     }
                     count--;
                     layer[z].terrain[i][j] = tmp_otid;
@@ -452,6 +458,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         }
         migrate_oter_ids( oter_id_migrations );
+        migrate_camps( camps_to_place );
     }
     for( JsonMember om_member : jsobj ) {
         const std::string name = om_member.name();


### PR DESCRIPTION
#### Summary
Backport 73372 - NPC Faction Camps

#### Purpose of change
Improve functionality and infrastructure of NPC "Faction camps" - a term here meaning their whole little base and owned area. The original PR included a lot of infrastructure for getting them to eat, but for the moment we're not bringing that in.

If we want to do that, we'll need to backport 71546, 71670, 72229, 72728, 73460(not sure this one is wanted or needed), 76025, and 76105. I have avoided doing that because I didn't like the method initially used, but it seems like it may have been improved since then.

#### Testing
Game runs. It's possible to load things into a larder and eat out of it. NPC faction camps seem to work properly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
