### PR TITLE
downgrade specimen van monster

### DIFF
--- a/data/json/mapgen/map_extras/specimen_van.json
+++ b/data/json/mapgen/map_extras/specimen_van.json
@@ -5,7 +5,7 @@
     "update_mapgen_id": "mx_specimen_van",
     "object": {
       "place_vehicles": [ { "vehicle": "specimen_van", "x": 7, "y": 12, "chance": 100, "status": 1, "rotation": 330 } ],
-      "place_monster": [ { "group": "GROUP_LAB_MUTANT_BOSS", "x": 1, "y": 3, "chance": 80, "repeat": 1 } ],
+      "place_monster": [ { "monster": "mon_mutant_experimental", "x": 1, "y": 3, "chance": 80 } ],
       "place_loot": [
         { "group": "map_extra_science_corpse_painful", "x": 7, "y": 12, "chance": 90 },
         { "group": "map_extra_security_corpse_bloody", "x": 2, "y": 2, "chance": 90 },


### PR DESCRIPTION
#### Summary
Downgrade the specimen van monster to an experimental mutant

#### Purpose of change
On second thought, the boss mutantgroup should be confined to specific areas. Those mutants are the product of going way overboard with the mutagen and not the kind of thing you'd be driving around in a van, plus they're too hard to just be on the surface day one.

#### Describe the solution
Change the monster.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
