### PR TITLE
make SANITIZE=all possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,11 @@ AR  = $(CROSS)ar
 LDFLAGS += $(PROFILE)
 
 ifneq ($(SANITIZE),)
-  SANITIZE_FLAGS := -fsanitize=$(SANITIZE) -fno-sanitize-recover=all -fno-omit-frame-pointer
+  ifeq ($(SANITIZE), all)
+    SANITIZE_FLAGS := -fsanitize=address -fsanitize=undefined -fno-sanitize-recover=all -fno-omit-frame-pointer
+  else
+    SANITIZE_FLAGS := -fsanitize=$(SANITIZE) -fno-sanitize-recover=all -fno-omit-frame-pointer
+  endif
   CXXFLAGS += $(SANITIZE_FLAGS)
   LDFLAGS += $(SANITIZE_FLAGS)
 endif


### PR DESCRIPTION
#### Summary

#### Purpose of change

Add a check if SANITIZE equals all, if yes, enable both ASan and UBSan.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Compiles and runs.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
