### PR TITLE
Fixed "Json error Expected Number" in Generic_Guns

### DIFF
--- a/data/mods/Generic_Guns/ammo/pistol.json
+++ b/data/mods/Generic_Guns/ammo/pistol.json
@@ -38,7 +38,7 @@
     "type": "AMMO",
     "name": { "str_sp": "pistol ammo, ball (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
       "recoil": 0.76,
       "dispersion": 1.2
@@ -52,7 +52,7 @@
     "type": "AMMO",
     "name": { "str_sp": "pistol ammo, JHP (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
       "recoil": 0.76,
       "dispersion": 1.2

--- a/data/mods/Generic_Guns/ammo/pistol_magnum.json
+++ b/data/mods/Generic_Guns/ammo/pistol_magnum.json
@@ -38,7 +38,7 @@
     "type": "AMMO",
     "name": { "str_sp": "magnum ammo, ball (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
       "recoil": 0.76,
       "dispersion": 1.2
@@ -52,7 +52,7 @@
     "type": "AMMO",
     "name": { "str_sp": "magnum ammo, JHP (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
       "recoil": 0.76,
       "dispersion": 1.2

--- a/data/mods/Generic_Guns/ammo/pistol_tiny.json
+++ b/data/mods/Generic_Guns/ammo/pistol_tiny.json
@@ -39,7 +39,7 @@
     "copy-from": "tiny_pistol_ball",
     "name": { "str_sp": "tiny pistol ammo, ball (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2
@@ -53,7 +53,7 @@
     "copy-from": "tiny_pistol_jhp",
     "name": { "str_sp": "tiny pistol ammo, JHP (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2

--- a/data/mods/Generic_Guns/ammo/rifle.json
+++ b/data/mods/Generic_Guns/ammo/rifle.json
@@ -38,7 +38,7 @@
     "type": "AMMO",
     "name": { "str_sp": "rifle ammo, ball (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2
@@ -52,7 +52,7 @@
     "type": "AMMO",
     "name": { "str_sp": "rifle ammo, AP (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2

--- a/data/mods/Generic_Guns/ammo/rifle_huge.json
+++ b/data/mods/Generic_Guns/ammo/rifle_huge.json
@@ -38,7 +38,7 @@
     "type": "AMMO",
     "name": { "str_sp": "rifle ammo, ball (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2
@@ -52,7 +52,7 @@
     "type": "AMMO",
     "name": { "str_sp": "rifle ammo, AP (black powder)" },
     "proportional": {
-      "price": "0.3 cent",
+      "price": 0.3,
       "damage": { "damage_type": "bullet", "amount": 0.57, "armor_penetration": 0.5 },
       "recoil": 0.57,
       "dispersion": 1.2

--- a/data/mods/Generic_Guns/ammo/shot.json
+++ b/data/mods/Generic_Guns/ammo/shot.json
@@ -13,8 +13,8 @@
     "name": { "str": "shotshell, beanbag", "str_pl": "shotshells, beanbag" },
     "description": "A beanbag round for shotguns, not deadly but designed to disable.",
     "proportional": {
-      "price": "0.5 cent",
-      "price_postapoc": "0.5 cent",
+      "price": 0.5,
+      "price_postapoc": 0.5,
       "count": 0.5,
       "damage": { "damage_type": "bullet", "amount": 0.1 },
       "recoil": 0.4,
@@ -50,8 +50,8 @@
     "name": { "str": "shotshell, pyrotechnical", "str_pl": "shotshells, pyrotechnical" },
     "description": "A novelty shotgun shell filled with a simple pyrotechnical charge.  The payload is light and won't wound very well, but the flash and sparks will certainly be impressive, in addition to being an extreme fire hazard.",
     "proportional": {
-      "price": "2 cent",
-      "price_postapoc": "2 cent",
+      "price": 2,
+      "price_postapoc": 2,
       "damage": { "damage_type": "bullet", "amount": 0.2 },
       "recoil": 0.6,
       "loudness": 0.8,

--- a/data/mods/Generic_Guns/magazines/grenade.json
+++ b/data/mods/Generic_Guns/magazines/grenade.json
@@ -6,7 +6,7 @@
     "description": "An ammo belt consisting of metal linkages which separate from the belt upon firing.  This one holds grenade cartridges and is too bulky to be worn like other ammo belts.",
     "volume": "10 L",
     "weight": "7800 g",
-    "price": "0 cent",
+    "price": 0,
     "material": [ "steel" ],
     "symbol": "#",
     "color": "light_gray",


### PR DESCRIPTION
#### Summary
Bugfixes "Fixed 'Json error Expected Number' in Generic_Guns"

#### Purpose of change
Some values of prices in generic guns were strings instead of floats, which prevented a world from loading when the mod was active.

#### Describe the solution
Changed the impacted fields from strings to floats.

#### Describe alternatives you've considered
N/A

#### Testing
World loads successfully with mod enabled after changes were made.

#### Additional context
Sample error that is thrown without this fix:

```
 DEBUG    : Error: Json error: data/mods/Generic_Guns/ammo/pistol.json:41:15: <color_white><color_cyan>Expected number</color>

    "name": { "str_sp": "pistol ammo, ball (black powder)" },
    "proportional": {
<color_light_red>      "price": "0.3 cent",
</color>
             <color_cyan>▲▲▲</color>
      "damage": { "damage_type": "bullet", "amount": 0.76, "armor_penetration": 0.5 },
      "recoil": 0.76,
</color>
```
