### PR TITLE
Fix plastic leg guards and three professions

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -583,7 +583,7 @@
     "id": "legguard_hard",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "pair of plastic leg guards", "str_pl": "pairs of plastic guards" },
+    "name": { "str": "pair of plastic leg guards", "str_pl": "pairs of plastic leg guards" },
     "description": "A pair of polyurethane leg guards with neoprene backing.  These were used in sport, policing, and even on some job sites.",
     "weight": "625 g",
     "volume": "3 L",
@@ -601,21 +601,11 @@
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 5,
+        "encumbrance": 12,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
         "material": [
-          { "type": "plastic", "covered_by_mat": 90, "thickness": 1.5 },
-          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
-        ],
-        "coverage": 100,
-        "rigid_layer_only": true
-      },
-      {
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "arm_elbow_r", "arm_elbow_l" ],
-        "material": [
-          { "type": "plastic", "covered_by_mat": 60, "thickness": 1.5 },
-          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
+          { "type": "plastic", "covered_by_mat": 70, "thickness": 1.5 },
+          { "type": "neoprene", "covered_by_mat": 98, "thickness": 1.5 }
         ],
         "coverage": 100,
         "rigid_layer_only": true

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -605,9 +605,9 @@
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
         "material": [
           { "type": "plastic", "covered_by_mat": 70, "thickness": 1.5 },
-          { "type": "neoprene", "covered_by_mat": 98, "thickness": 1.5 }
+          { "type": "neoprene", "covered_by_mat": 100, "thickness": 1.5 }
         ],
-        "coverage": 100,
+        "coverage": 80,
         "rigid_layer_only": true
       }
     ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4365,14 +4365,7 @@
     "name": "MMA Fighter",
     "description": "You might have once dreamed of fighting in the octagon, but the Cataclysm presents a new venue for Mixed Martial Arts.",
     "points": 3,
-    "starting_styles_choices": [
-      "style_pankration",
-      "style_capoeira",
-      "style_muay_thai",
-      "style_krav_maga",
-      "style_boxing",
-      "style_kickboxing"
-    ],
+    "starting_styles_choices": [ "style_pankration", "style_capoeira", "style_muay_thai", "style_krav_maga", "style_boxing", "style_kickboxing" ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "skills": [
       { "level": 4, "name": "melee" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3013,50 +3013,6 @@
     }
   },
   {
-    "id": "emt_firefighter",
-    "type": "profession",
-    "name": "Paramedic Firefighter",
-    "description": "On your way to respond to an emergency call, you nearly drove straight into a riot in the city.  Turning off of the burning, debris-covered streets, you took a long detour only to find yourself lost.  That call will have to wait - you're in an emergency of your own now.",
-    "points": 5,
-    "skills": [
-      { "level": 6, "name": "firstaid" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "swimming" },
-      { "level": 4, "name": "driving" }
-    ],
-    "proficiencies": [ "prof_field_medic", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_dissect_humans", "prof_driver" ],
-    "vehicle": "fire_engine",
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "boots_bunker" },
-          { "item": "bunker_coat" },
-          { "item": "nomex_suit" },
-          { "item": "bunker_pants" },
-          { "item": "dress_shirt" },
-          { "item": "nomex_gloves" },
-          { "item": "fire_gauntlets" },
-          { "item": "nomex_hood" },
-          { "item": "firehelmet" },
-          { "item": "mask_bunker" },
-          { "item": "mbag" },
-          { "item": "nomex_socks" },
-          { "item": "water_clean" },
-          { "item": "wristwatch" },
-          { "item": "syringe" },
-          { "item": "morphine" },
-          { "item": "gasfilter_m" },
-          { "item": "adrenaline_injector" },
-          { "group": "full_1st_aid" },
-          { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "halligan", "container-item": "fireman_belt" }
-        ]
-      }
-    }
-  },
-  {
     "id": "handymanservice",
     "type": "profession",
     "name": { "male": "Serviceman", "female": "Servicewoman" },
@@ -3862,7 +3818,7 @@
           { "item": "fire_gauntlets" },
           { "item": "mask_bunker" },
           { "item": "nomex_hood" },
-          { "item": "gasfilter_m" },
+          { "item": "gasfilter_med" },
           { "item": "firehelmet" },
           { "item": "pocketwatch" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3046,6 +3046,7 @@
           { "item": "wristwatch" },
           { "item": "syringe" },
           { "item": "morphine" },
+          { "item": "gasfilter_m" },
           { "item": "adrenaline_injector" },
           { "group": "full_1st_aid" },
           { "group": "charged_smart_phone" },
@@ -3861,6 +3862,7 @@
           { "item": "fire_gauntlets" },
           { "item": "mask_bunker" },
           { "item": "nomex_hood" },
+          { "item": "gasfilter_m" },
           { "item": "firehelmet" },
           { "item": "pocketwatch" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -4324,7 +4326,7 @@
     "name": "Butōka",
     "description": "Your sensei prepared you for a lot of things, but somehow the end of the world never came up in traning.",
     "points": 3,
-    "starting_styles_choices": [ "style_aikido", "style_karate", "style_ninjutsu", "style_jiu_jutsu" ],
+    "starting_styles_choices": [ "style_aikido", "style_karate", "style_ninjutsu", "style_judo" ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "skills": [
       { "level": 4, "name": "melee" },
@@ -4413,8 +4415,7 @@
       "style_muay_thai",
       "style_krav_maga",
       "style_boxing",
-      "style_kickboxing",
-      "style_jiu_jutsu"
+      "style_kickboxing"
     ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "skills": [


### PR DESCRIPTION
#### Summary
Give mask cartridges to firefighters and fix plastic leg guards

#### Purpose of change
Firefighters couldn't use the masks they started with, and plastic leg guards were offering arm protection for some reason.

#### Describe the solution
- Give filters and remove jiu jitsu (nonexistent) from a few professions.
- Remove duplicate firefighter profession

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
