### PR TITLE
Metal Armor fix-ups

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -21,7 +21,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 9,
+        "encumbrance": 16,
         "coverage": 80,
         "cover_melee": 80,
         "cover_ranged": 80,
@@ -59,7 +59,7 @@
           { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 5,
+        "encumbrance": 15,
         "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ]
       }
@@ -92,7 +92,7 @@
           { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 3,
+        "encumbrance": 10,
         "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
       }
@@ -112,7 +112,7 @@
     "material": [ "chitin" ],
     "symbol": "[",
     "looks_like": "armguard_hard",
-    "color": "green",
+    "color": "brown",
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 2,
@@ -120,7 +120,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 4,
+        "encumbrance": 8,
         "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l" ],
         "rigid_layer_only": true
@@ -221,7 +221,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 5,
+        "encumbrance": 12,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "material": [
           { "type": "plastic", "covered_by_mat": 90, "thickness": 1.5 },
@@ -290,7 +290,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 5,
+        "encumbrance": 9,
         "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l", "arm_upper_l", "arm_upper_r" ]
       }
@@ -333,7 +333,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 4,
+        "encumbrance": 10,
         "coverage": 80,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
@@ -361,8 +361,8 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 4,
-        "coverage": 80,
+        "encumbrance": 8,
+        "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
       }
@@ -408,7 +408,7 @@
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 6,
+        "encumbrance": 8,
         "coverage": 75,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
@@ -595,7 +595,7 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_upper_l", "arm_upper_r" ],
         "coverage": 100,
-        "encumbrance": 1
+        "encumbrance": 2
       },
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -762,7 +762,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 5,
+        "encumbrance": 8,
         "coverage": 95,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
@@ -807,7 +807,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 2,
+        "encumbrance": 8,
         "coverage": 95,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
       }
@@ -868,7 +868,7 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l", "arm_upper_r", "arm_upper_l" ],
         "coverage": 85,
-        "encumbrance": 10,
+        "encumbrance": 12,
         "rigid_layer_only": true
       }
     ],
@@ -916,7 +916,7 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "encumbrance": 10,
+        "encumbrance": 4,
         "rigid_layer_only": true
       }
     ],
@@ -964,7 +964,7 @@
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,
-        "encumbrance": 6,
+        "encumbrance": 4,
         "rigid_layer_only": true
       }
     ]

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -136,7 +136,7 @@
           { "type": "rubber", "covered_by_mat": 100, "thickness": 2.25 },
           { "type": "nomex", "covered_by_mat": 100, "thickness": 2.25 }
         ],
-        "encumbrance": 30,
+        "encumbrance": 45,
         "coverage": 100
       },
       {
@@ -2156,7 +2156,7 @@
           { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
         ],
-        "encumbrance": 10,
+        "encumbrance": 5,
         "coverage": 90
       }
     ]
@@ -2165,15 +2165,15 @@
     "id": "platemail_sollerets_xl",
     "type": "ARMOR",
     "copy-from": "platemail_sollerets",
-    "name": { "str": "pair of platemail_sollerets", "str_pl": "pairs of platemail_sollerets" },
+    "name": { "str": "pair of plate sollerets", "str_pl": "pairs of plate sollerets" },
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE", "PREFIX_XS" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "platemail_sollerets_xs",
     "type": "ARMOR",
     "copy-from": "platemail_sollerets",
-    "name": { "str": "pair of platemail_sollerets", "str_pl": "pairs of platemail_sollerets" },
+    "name": { "str": "pair of plate sollerets", "str_pl": "pairs of plate sollerets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -61,7 +61,7 @@
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 98,
-        "encumbrance": 9
+        "encumbrance": 10
       }
     ]
   },
@@ -137,7 +137,7 @@
         "rigid_layer_only": true
       },
       {
-        "encumbrance": 7,
+        "encumbrance": 6,
         "coverage": 70,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -867,8 +867,18 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "encumbrance": 8,
+        "coverage": 30,
+        "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
+      },
+      {
+        "material": [
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "leather", "covered_by_mat": 2, "thickness": 1.0 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "encumbrance": 8,
         "coverage": 85,
-        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l", "leg_upper_r", "leg_upper_l" ]
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ]
       }
     ]
   },

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -244,8 +244,7 @@
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
-        "coverage": 40,
-        "encumbrance": 1
+        "coverage": 40
       },
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -504,7 +504,7 @@
           "foot_arch_l"
         ],
         "coverage": 100,
-        "encumbrance": 54,
+        "encumbrance": 30,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL", "BELTED" ]
       },
@@ -1165,7 +1165,7 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
         "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 3 } ],
-        "encumbrance": 49,
+        "encumbrance": 25,
         "coverage": 100,
         "layers": [ "OUTER", "NORMAL" ]
       },

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -326,21 +326,21 @@
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 17,
+        "encumbrance": 16,
         "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
-        "encumbrance": 17,
+        "encumbrance": 16,
         "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
-        "encumbrance": 17,
+        "encumbrance": 16,
         "rigid_layer_only": true
       },
       {
@@ -356,6 +356,26 @@
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],
         "rigid_layer_only": true
+      },
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "layers": [ "BELTED" ],
+        "material": [
+          { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
+        ],
+        "encumbrance": 5,
+        "coverage": 90
       }
     ],
     "melee_damage": { "bash": 8 }
@@ -403,7 +423,7 @@
         ],
         "covers": [ "head" ],
         "coverage": 100,
-        "encumbrance": 18,
+        "encumbrance": 21,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -434,7 +454,7 @@
         ],
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": 26,
+        "encumbrance": 29,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -442,7 +462,7 @@
           { "type": "steel", "covered_by_mat": 70, "thickness": 1.3 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 2 }
         ],
-        "encumbrance": 7,
+        "encumbrance": 26,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "layers": [ "OUTER", "NORMAL" ]
@@ -454,7 +474,7 @@
         ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": 20,
+        "encumbrance": 27,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -464,7 +484,7 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
-        "encumbrance": 20,
+        "encumbrance": 27,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -484,7 +504,7 @@
           "foot_arch_l"
         ],
         "coverage": 100,
-        "encumbrance": 27,
+        "encumbrance": 54,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL", "BELTED" ]
       },
@@ -795,7 +815,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 95,
-        "encumbrance": 8
+        "encumbrance": 10
       },
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -807,7 +827,7 @@
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "arm_r", "arm_l" ],
         "coverage": 95,
-        "encumbrance": 8
+        "encumbrance": 10
       },
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -952,7 +972,7 @@
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 95,
-        "encumbrance": 15,
+        "encumbrance": 10,
         "rigid_layer_only": true
       },
       {
@@ -1053,7 +1073,7 @@
         ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
-        "encumbrance": 30,
+        "encumbrance": 23,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1064,7 +1084,7 @@
         ],
         "covers": [ "head" ],
         "coverage": 100,
-        "encumbrance": 15,
+        "encumbrance": 21,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1096,7 +1116,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 28,
+        "encumbrance": 21,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1118,7 +1138,7 @@
         ],
         "covers": [ "arm_r", "arm_l" ],
         "coverage": 100,
-        "encumbrance": 28,
+        "encumbrance": 21,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1129,7 +1149,7 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
-        "encumbrance": 28,
+        "encumbrance": 21,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1145,7 +1165,7 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
         "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 3 } ],
-        "encumbrance": 25,
+        "encumbrance": 49,
         "coverage": 100,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1199,7 +1219,7 @@
         "material": [ { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
-        "encumbrance": 25,
+        "encumbrance": 26,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1245,7 +1265,7 @@
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
         "material": [ { "type": "rubber", "covered_by_mat": 100, "thickness": 3 } ],
-        "encumbrance": 25,
+        "encumbrance": 49,
         "coverage": 100,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1289,7 +1309,7 @@
         ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 100,
-        "encumbrance": 35,
+        "encumbrance": 38,
         "rigid_layer_only": true,
         "layers": [ "OUTER", "NORMAL" ]
       },
@@ -1302,7 +1322,7 @@
         ],
         "covers": [ "head" ],
         "coverage": 100,
-        "encumbrance": 25,
+        "encumbrance": 28,
         "layers": [ "OUTER", "NORMAL", "BELTED" ]
       },
       {
@@ -1337,7 +1357,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 100,
-        "encumbrance": 35,
+        "encumbrance": 38,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -1361,7 +1381,7 @@
         ],
         "covers": [ "arm_r", "arm_l" ],
         "coverage": 100,
-        "encumbrance": 35,
+        "encumbrance": 38,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -1373,7 +1393,7 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
-        "encumbrance": 35,
+        "encumbrance": 38,
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
@@ -1385,7 +1405,7 @@
         ],
         "covers": [ "foot_l", "foot_r" ],
         "coverage": 100,
-        "encumbrance": 35,
+        "encumbrance": 50,
         "layers": [ "OUTER", "NORMAL", "BELTED" ],
         "rigid_layer_only": true
       }

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -246,11 +246,11 @@
       {
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 16,
+        "encumbrance": 12,
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 } ]
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 14 },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 14 }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": 12 },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 85, "encumbrance": 12 }
     ],
     "warmth": 25,
     "material_thickness": 4,
@@ -295,7 +295,7 @@
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
     "armor": [
       {
-        "encumbrance": 35,
+        "encumbrance": 34,
         "coverage": 95,
         "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
         "rigid_layer_only": true
@@ -326,21 +326,21 @@
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 20,
+        "encumbrance": 17,
         "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
-        "encumbrance": 10,
+        "encumbrance": 17,
         "rigid_layer_only": true
       },
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
-        "encumbrance": 10,
+        "encumbrance": 17,
         "rigid_layer_only": true
       },
       {
@@ -351,7 +351,7 @@
         "rigid_layer_only": true
       },
       {
-        "encumbrance": 7,
+        "encumbrance": 6,
         "coverage": 70,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -72,7 +72,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "flags": [ "OUTER", "STURDY" ],
-    "armor": [ { "encumbrance": 12, "coverage": 85, "covers": [ "torso" ], "rigid_layer_only": true } ],
+    "armor": [ { "encumbrance": 17, "coverage": 95, "covers": [ "torso" ], "rigid_layer_only": true } ],
     "melee_damage": { "bash": 6 }
   },
   {
@@ -161,9 +161,9 @@
     "material_thickness": 2,
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
     "armor": [
-      { "encumbrance": 26, "coverage": 90, "covers": [ "torso" ] },
+      { "encumbrance": 30, "coverage": 90, "covers": [ "torso" ] },
       {
-        "encumbrance": 3,
+        "encumbrance": 4,
         "coverage": 90,
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
@@ -325,7 +325,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 90,
-        "encumbrance": 14,
+        "encumbrance": 17,
         "rigid_layer_only": true
       },
       {

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -207,7 +207,7 @@
     "longest_side": "40 cm",
     "material_thickness": 4,
     "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 20, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 22, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
   },
   {
     "id": "cloth_shirt_padded",
@@ -325,7 +325,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 90,
-        "encumbrance": 12,
+        "encumbrance": 14,
         "rigid_layer_only": true
       },
       {
@@ -372,7 +372,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 20, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 22, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
   },
   {
     "id": "tire_cuirass_xl",
@@ -427,7 +427,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 26, 30 ],
+        "encumbrance": [ 28, 32 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -437,7 +437,7 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 26, 26 ],
+        "encumbrance": [ 28, 28 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -582,7 +582,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 32, 32 ],
+        "encumbrance": [ 24, 28 ],
         "material": [
           { "type": "rubber", "covered_by_mat": 80, "thickness": 3.0 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -753,7 +753,7 @@
     "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY" ],
     "armor": [
       {
-        "encumbrance": [ 26, 30 ],
+        "encumbrance": [ 28, 32 ],
         "coverage": 90,
         "covers": [ "torso" ],
         "material": [
@@ -941,7 +941,7 @@
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper" ],
         "coverage": 90,
-        "encumbrance": 8
+        "encumbrance": 10
       },
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1519,7 +1519,7 @@
       { "fuel": 0.001, "smoke": 3, "burn": 0.002, "volume_per_turn": "5 ml" },
       { "fuel": 0.003, "smoke": 3, "burn": 0.005 }
     ],
-    "resist": { "bash": 2, "cut": 1, "acid": 8, "heat": 2, "bullet": 1 },
+    "resist": { "bash": 1, "cut": 1, "acid": 8, "heat": 2, "bullet": 1 },
     "repair_difficulty": 3
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -325,6 +325,58 @@
     ]
   },
   {
+    "result": "platemail_suit",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "20 m",
+    "reversible": true,
+    "autolearn": true,
+    "flags": [ "NO_RESIZE" ],
+    "components": [
+      [ [ "platemail_cuirass", 1 ] ],
+      [ [ "platemail_gauntlets", 1 ] ],
+      [ [ "platemail_sollerets", 1 ] ],
+      [ [ "platemail_arm_guards", 1 ] ],
+      [ [ "platemail_leg_guards", 1 ] ],
+      [ [ "platemail_pauldrons", 1 ] ],
+      [ [ "platemail_tasset", 1 ], [ "platemail_tasset_loose", 1 ] ]
+    ]
+  },
+  {
+    "result": "platemail_suit_xs",
+    "type": "recipe",
+    "copy-from": "platemail_suit",
+    "time": "20 m",
+    "components": [
+      [ [ "platemail_cuirass_xs", 1 ] ],
+      [ [ "platemail_gauntlets_xs", 1 ] ],
+      [ [ "platemail_sollerets_xs", 1 ] ],
+      [ [ "platemail_arm_guards_xs", 1 ] ],
+      [ [ "platemail_leg_guards_xs", 1 ] ],
+      [ [ "platemail_pauldrons_xs", 1 ] ],
+      [ [ "platemail_tasset_xs", 1 ], [ "platemail_tasset_loose_xs", 1 ] ]
+    ]
+  },
+  {
+    "result": "platemail_suit_xl",
+    "type": "recipe",
+    "copy-from": "platemail_suit",
+    "time": "20 m",
+    "components": [
+      [ [ "platemail_cuirass_xl", 1 ] ],
+      [ [ "platemail_gauntlets_xl", 1 ] ],
+      [ [ "platemail_sollerets_xl", 1 ] ],
+      [ [ "platemail_arm_guards_xl", 1 ] ],
+      [ [ "platemail_leg_guards_xl", 1 ] ],
+      [ [ "platemail_pauldrons_xl", 1 ] ],
+      [ [ "platemail_tasset_xl", 1 ], [ "platemail_tasset_loose_xl", 1 ] ]
+    ]
+  },
+  {
     "result": "chainmail_hauberk",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Continue auditing armor and ensuring suits and separates match warmth/enc/coverage/etc

#### Purpose of change
Platemail, leather, chitin, and chainmail armor exist as separates, but for convenience or a few other purposes, can be combined into sets represented by a single item. There were a few little errors in this process, mismatched encumbrance values and the like.

Platemail tassets and leg guards weren't quite right, coverage wise.

The Faraday sets are more or less the same thing but incorporate a cleansuit, so I also wanted to ensure the values were roughly equivalent to combining a cleansuit with the set in question.

Lastly, full plate wasn't craftable. I added a recipe which just involves putting the whole set together.

#### Describe the solution
Manually compare and adjust encumbrance values for
- Chain
- Plate
- Brigandine
- Armored Riding Jacket & Vest
- Armored Denim Jacket & Vest
- Faraday Plate and Chain

#### Describe alternatives you've considered
im tired boss

#### Testing
Compiles, runs, new values look good. I'm sure something, somewhere, is wrong, but you can craft full plate and wear it and so far as I can tell, no weirdness is happening with encumbrance.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
