### PR TITLE
Backport DDA 62126 - Fix displaying of stats for ablative armor

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -293,7 +293,7 @@ std::vector<std::string> clothing_properties(
     add_folded_name_and_value( props, _( "Encumbrance:" ), string_format( "%3d", encumbrance ),
                                width );
     add_folded_name_and_value( props, _( "Warmth:" ), string_format( "%3d",
-                               worn_item.get_warmth() ), width );
+                               worn_item.get_warmth( used_bp ) ), width );
     return props;
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -2072,11 +2072,11 @@ class item : public visitable
         /**
          * Whether this item (when worn) covers the given body part.
          */
-        bool covers( const bodypart_id &bp ) const;
+        bool covers( const bodypart_id &bp, bool check_ablative_armor = true ) const;
         /**
          * Whether this item (when worn) covers the given sub body part.
          */
-        bool covers( const sub_bodypart_id &bp ) const;
+        bool covers( const sub_bodypart_id &bp, bool check_ablative_armor = true ) const;
         // do both items overlap a bodypart at all? returns the side that conflicts via rhs
         std::optional<side> covers_overlaps( const item &rhs ) const;
         /**
@@ -3009,9 +3009,11 @@ class item : public visitable
         bool process_internal( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
                                temperature_flag flag = temperature_flag::NORMAL, float spoil_modifier = 1.0f );
         void iterate_covered_body_parts_internal( side s,
-                const std::function<void( const bodypart_str_id & )> &cb ) const;
+                const std::function<void( const bodypart_str_id & )> &cb,
+                bool check_ablative_armor = true ) const;
         void iterate_covered_sub_body_parts_internal( side s,
-                const std::function<void( const sub_bodypart_str_id & )> &cb ) const;
+                const std::function<void( const sub_bodypart_str_id & )> &cb,
+                bool check_ablative_armor = true ) const;
         /**
          * Calculate the thermal energy and temperature change of the item
          * @param temp Temperature of surroundings

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -27,6 +27,8 @@ static constexpr tripoint dude_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y, 0 );
 static constexpr tripoint mon_pos( HALF_MAPSIZE_X + 3, HALF_MAPSIZE_Y, 0 );
 static constexpr tripoint badguy_pos( HALF_MAPSIZE_X + 1, HALF_MAPSIZE_Y, 0 );
 
+static const sub_bodypart_str_id sub_body_part_eyes_right( "eyes_right" );
+
 static void check_near( const std::string &subject, float actual, const float expected,
                         const float tolerance )
 {
@@ -235,6 +237,45 @@ TEST_CASE( "Ghost_ablative_vest", "[coverage]" )
         // make sure the armor is counting even if the base vest doesn't do anything
         check_not_near( "Average damage", dmg_full, dmg_empty, 0.5f );
     }
+}
+
+TEST_CASE( "helmet_with_face_shield_coverage", "[coverage]" )
+{
+    Character &dummy = get_player_character();
+    clear_avatar();
+
+    item hat_hard( "hat_hard" );
+    CHECK( hat_hard.get_coverage( body_part_eyes ) == 0 );
+
+    WHEN( "wearing helmet with face shield should cover eyes and mouth" ) {
+        item face_shield( "face_shield" );
+        REQUIRE( hat_hard.put_in( face_shield, pocket_type::CONTAINER ).success() );
+        dummy.wear_item( hat_hard );
+
+        CHECK( hat_hard.get_coverage( body_part_eyes ) == 100 );
+        CHECK( hat_hard.get_coverage( body_part_mouth ) == 100 );
+        CHECK( hat_hard.get_coverage( sub_body_part_eyes_right ) == 100 );
+    }
+
+}
+
+TEST_CASE( "vest_with_plate_coverage", "[coverage]" )
+{
+    //Vest covers torso_upper and torso_lower
+    item vest = item( "ballistic_vest_esapi" );
+    //100 (torso_upper coverage) * 0.6 (torso_upper max_coverage) + 80 (torso_lower coverage) * 0.4
+    CHECK( vest.get_coverage( body_part_torso ) == 92 );
+
+    WHEN( "inserting 2 plates" ) {
+        //Each plate covers torso_upper with coverage 45
+        CHECK( vest.put_in( item( "test_plate" ), pocket_type::CONTAINER ).success() );
+        CHECK( vest.put_in( item( "test_plate" ), pocket_type::CONTAINER ).success() );
+
+        THEN( "vest with plates should retain the same coverage" ) {
+            CHECK( vest.get_coverage( body_part_torso ) == 92 );
+        }
+    }
+
 }
 
 TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -50,6 +50,10 @@ static const trait_id trait_ANTIFRUIT( "ANTIFRUIT" );
 static const trait_id trait_CANNIBAL( "CANNIBAL" );
 static const trait_id trait_WOOLALLERGY( "WOOLALLERGY" );
 
+static const vitamin_id vitamin_human_flesh_vitamin( "human_flesh_vitamin" );
+
+static const sub_bodypart_str_id sub_body_part_eyes_right( "eyes_right" );
+
 // ITEM INFO
 // =========
 //
@@ -1233,6 +1237,95 @@ TEST_CASE( "armor_stats", "[armor][protection]" )
     expected_armor_values( item( itype_zentai ), 0.1f, 0.1f, 0.08f, 0.1f, 9.0f, 2.0f );
     expected_armor_values( item( itype_tshirt ), 0.1f, 0.1f, 0.08f, 0.1f, 3.0f );
     expected_armor_values( item( itype_dress_shirt ), 0.1f, 0.1f, 0.08f, 0.1f, 3.0f );
+
+}
+
+
+TEST_CASE( "helmet_with_pockets_stats", "[iteminfo][armor][protection]" )
+{
+    bodypart_id bp_head = body_part_head.id();
+    bodypart_id bp_eyes = body_part_eyes.id();
+    sub_bodypart_id eye_r = sub_body_part_eyes_right.id();
+
+    item hh( "hat_hard" );
+    THEN( "base stats" ) {
+        //resistance stats
+        CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, bp_head ) == Approx( 8.f ) );
+        CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, bp_eyes ) == Approx( 0.f ) );
+        CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, eye_r ) == Approx( 0.f ) );
+        //warmth stats: 5 (hat's warmth) * 0.4 (hat's body part coverage)
+        CHECK( hh.get_warmth( bp_head ) == 2 );
+        CHECK( hh.get_warmth( bp_eyes ) == 0 );
+    }
+
+
+    WHEN( "inserting face shield" ) {
+        item face_shield( "face_shield" );
+        REQUIRE( hh.put_in( face_shield, pocket_type::CONTAINER ).success() );
+        THEN( "eyes should be protected" ) {
+            CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, bp_head ) == Approx( 8.f ) );
+            CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, bp_eyes ) == Approx( 6.f ) );
+            CHECK( hh.resist( STATIC( damage_type_id( "bash" ) ), false, eye_r ) == Approx( 6.f ) );
+        }
+        THEN( "warmth should not change" ) {
+            CHECK( hh.get_warmth( bp_head ) == 2 );
+            CHECK( hh.get_warmth( bp_eyes ) == 0 );
+        }
+        THEN( "breathbility should be 0" ) {
+            CHECK( hh.breathability( bp_eyes ) == 0 );
+        }
+    }
+    WHEN( "adding nape protector to the helmet" ) {
+        item nape_protector( "nape_protector" );
+        REQUIRE( hh.put_in( nape_protector, pocket_type::CONTAINER ).success() );
+        THEN( "head's warmth is increased" ) {
+            CHECK( nape_protector.get_warmth( bp_head ) == 2 );
+            //2 (base warmth) + 4 (nape's warmth) * 0.4 (nape's body part coverage)
+            CHECK( hh.get_warmth( bp_head ) == 4 );
+        }
+        WHEN( "adding ear muffs to the helmet" ) {
+            item ear_muffs( "attachable_ear_muffs" );
+            REQUIRE( hh.put_in( ear_muffs, pocket_type::CONTAINER ).success() );
+            THEN( "head's warmth should be increased even more" ) {
+                CHECK( ear_muffs.get_warmth( bp_head ) == 2 );
+                CHECK( hh.get_warmth( bp_head ) == 6 );
+            }
+        }
+    }
+
+}
+
+
+TEST_CASE( "vest_with_plate_stats", "[iteminfo][armor][protection]" )
+{
+    bodypart_id bp_torso = body_part_torso.id();
+
+    item vest = item( "ballistic_vest_esapi" );
+    //nylon: 1 (mat resist) * 1 (thickness)
+    //kevlar: 1.5 * 4.4
+    CHECK( vest.resist( STATIC( damage_type_id( "bash" ) ), false, bp_torso ) == Approx( 7.6f ) );
+
+    WHEN( "inserting plate" ) {
+        CHECK( vest.put_in( item( "test_plate" ), pocket_type::CONTAINER ).success() );
+
+        THEN( "resist should be increased" ) {
+            //previous + 1 * 25
+            CHECK( vest.resist( STATIC( damage_type_id( "bash" ) ), false, bp_torso ) == Approx( 32.6f ) );
+        }
+    }
+
+}
+
+// Check that a string is provided in some iteminfo
+// By providing last_pos, order can also be checked
+static void test_string( const std::string &info, const std::string &tested, size_t &last_pos )
+{
+    INFO( string_format( "Checking for \"%s\" in:", tested ) );
+    INFO( info );
+    size_t pos = info.find( tested );
+    CHECK( pos != std::string::npos );
+    CHECK( pos >= last_pos );
+    last_pos = pos;
 }
 
 // Armor protction is based on materials, thickness, and/or environmental protection rating.


### PR DESCRIPTION
#### Summary
Category "Brief description"

#### Purpose of change
Currently protection/coverage stats are not displayed in 'sort armor screen' and 'body status screen'.

I thought this would fix a bug I was working on, but it didn't. Alas.

#### Describe the solution
Straightforward backport, making sure we keep adjusted_coverage in item.cpp

#### Testing
Compiles, runs, looks fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
