### PR TITLE
Fix typo in boots_western and adjust encumberance

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -724,7 +724,7 @@
     "copy-from": "boots",
     "type": "ARMOR",
     "name": { "str": "pair of western boots", "str_pl": "pairs of western boots" },
-    "description": "Stiff leather cowboy boots with pointed toes and a low heel.  The wide cuffs could be used as as hoc pockets, or maybe even holsters.",
+    "description": "Stiff leather cowboy boots with pointed toes and a low heel.  The wide cuffs could be used as ad hoc pockets, or maybe even holsters.",
     "price_postapoc": "7 USD 50 cent",
     "material": [ "leather_treated" ],
     "environmental_protection": 2,
@@ -749,7 +749,7 @@
           "foot_arch_l"
         ],
         "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 2.0 } ],
-        "encumbrance": 34,
+        "encumbrance": 12,
         "coverage": 100
       },
       {

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -728,7 +728,6 @@
     "price_postapoc": "7 USD 50 cent",
     "material": [ "leather_treated" ],
     "environmental_protection": 2,
-    "proportional": { "weight": 1.2, "volume": 1.2, "price": 2, "encumbrance": 2 },
     "flags": [ "VARSIZE", "RAINPROOF", "NORMAL", "OUTER" ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "250 ml", "max_contains_weight": "600 g", "moves": 80 },
@@ -749,7 +748,7 @@
           "foot_arch_l"
         ],
         "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 2.0 } ],
-        "encumbrance": 12,
+        "encumbrance": 34,
         "coverage": 100
       },
       {


### PR DESCRIPTION
#### Summary
Fix typo in boots_western description and adjust encumberance

#### Purpose of change
Fix for boots_western, refs https://github.com/Cataclysm-TLG/Cataclysm-TLG/issues/395

#### Describe the solution
Fixed the typo and adjusted the encumberance to what DDA uses :)

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
