### PR TITLE
Fix windows build action maybe

### DIFF
--- a/msvc-object_creator/ObjectCreator-vcpkg-static.vcxproj
+++ b/msvc-object_creator/ObjectCreator-vcpkg-static.vcxproj
@@ -81,7 +81,7 @@
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Debug'">.\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\debug\plugins\platforms;.\vcpkg_installed\$(VcpkgTriplet)\debug\plugins\platforms;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Release'">.\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\plugins\platforms;.\vcpkg_installed\$(VcpkgTriplet)\plugins\platforms;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
-    <Link Condition="$(_CDDA_USE_LLD_LINK)">
+    <Link Condition="$(_CTLG_USE_LLD_LINK)">
       <AdditionalDependencies>
         double-conversion.lib;
         harfbuzz.lib;


### PR DESCRIPTION
#### Summary
Change a DDA reference in msvc build workflow to TLG

#### Purpose of change
make it go

#### Describe the solution
do it

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
