### PR TITLE
Update upgrade_missions.json to fix error with Sky Island

### DIFF
--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -1181,7 +1181,7 @@
     "reversible": false,
     "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
     "components": [
-      [ [ "fp_loyalty_card", 1 ] ],
+      [ [ "loyalty_card", 1 ] ],
       [ [ "coin_penny", 1 ] ],
       [ [ "coin_nickel", 1 ] ],
       [ [ "coin_dime", 1 ] ],


### PR DESCRIPTION

#### Summary

Changed fp_loyalty_card to loyalty_card, allowing this recipe to be crafted and not run an error. Tested in my game. Fixes https://github.com/Cataclysm-TLG/Cataclysm-TLG/issues/399 . Apologies if I have bumbled the formatting or something here, first time using Github.


#### Purpose of change

Fixes small error.
#### Describe the solution

Changed fp_loyalty_card to loyalty_card , as it's the same thing as the old (removed?) 'Foodperson's Loyalty Card' that the recipe was referring to, and spawns in wallets like the rest of the items in the recipe.
#### Describe alternatives you've considered

Changing it to a score card or a cash card, leaving it broken
#### Testing

Booted up on my PC with the change in effect, no issues. Have not tested with a world that has been running Sky Island, however.
#### Additional context

Recipe now calls for a normal item and doesn't run an error on startup. Again, apologies if I've messed up the formatting or what-have-you, this is my first PR.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
