### PR TITLE
Reduce damage to specimen van map extra

### DIFF
--- a/data/json/mapgen/map_extras/specimen_van.json
+++ b/data/json/mapgen/map_extras/specimen_van.json
@@ -3,8 +3,9 @@
     "type": "mapgen",
     "method": "json",
     "update_mapgen_id": "mx_specimen_van",
+    "//": "This van was transporting a mutant to or from a lab. It crashed and the mutant broke out, and either escaped or is still hanging around.",
     "object": {
-      "place_vehicles": [ { "vehicle": "specimen_van", "x": 7, "y": 12, "chance": 100, "status": 1, "rotation": 330 } ],
+      "place_vehicles": [ { "vehicle": "specimen_van", "x": 7, "y": 12, "chance": 100, "rotation": 330 } ],
       "place_monster": [ { "monster": "mon_mutant_experimental", "x": 1, "y": 3, "chance": 80 } ],
       "place_loot": [
         { "group": "map_extra_science_corpse_painful", "x": 7, "y": 12, "chance": 90 },


### PR DESCRIPTION
#### Summary
Reduce damage to specimen van map extra

#### Purpose of change
The specimen van accidentally had its condition set to 1 (heavily damaged) instead of -1 (lightly damaged). This meant the player was unlikely to be able to recover any of the intended goodies from inside.

#### Describe the solution
Delete the "condition": object, as it defaults to -1.

#### Testing
The game loads but there's no way to spawn map extras. I looked around a bit but I can't be assed to find one so I'll just wait for a player to find one and ask them how it went. I'm not working hard, I'm working smrat.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
