### PR TITLE
Make Untyped Mutagen Work

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1085,7 +1085,9 @@
   },
   {
     "type": "effect_type",
-    "id": "mutagen"
+    "id": "mutagen",
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Mutagen"
   },
   {
     "type": "effect_type",

--- a/data/json/mutations/mutation_category.json
+++ b/data/json/mutations/mutation_category.json
@@ -4,6 +4,7 @@
     "id": "ANY",
     "name": "Any",
     "threshold_mut": "",
+    "vitamin": "mutagen",
     "mutagen_message": "You feel strange."
   },
   {


### PR DESCRIPTION
#### Summary
Make untyped mutagen cause random mutations.

#### Purpose of change
#37 got rid of the primer/catalyst system. The intent was that untyped mutagen would cause random mutations, but it didn't work because from_mutagen() in suffer.cpp was set up to look for typed mutagen.

#### Describe the solution
Apply the untyped mutagen effect to the "All" mutation category. Now untyped mutagen picks fully random mutations.

Note that typed mutagens have a small amount of untyped mutagen in them. If you take too much, you'll start getting random mutations that you might not want...or you might be pleasantly surprised. If you'd like to ensure that you ONLY get the mutations from your line, use typed infusions instead, which lack untyped mutagen.

#### Testing
Loaded in, drank untyped mutagen. Became disease resistant and grew rabbit ears. Not bad.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
