### PR TITLE
Acidic monsters are acidproof

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2170,6 +2170,7 @@
     "weight": "40 kg",
     "stomach_size": 300,
     "upgrades": { "age_grow": 30, "into": "mon_ant_acid" },
+    "extend": { "flags": [ "ACIDPROOF" ] },
     "special_attacks": [
       {
         "type": "spell",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -86,6 +86,7 @@ static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
+static const efftype_id effect_corroding( "corroding" );
 static const efftype_id effect_cramped_space( "cramped_space" );
 static const efftype_id effect_critter_underfed( "critter_underfed" );
 static const efftype_id effect_critter_well_fed( "critter_well_fed" );
@@ -1782,6 +1783,7 @@ bool monster::is_elec_immune() const
     return is_immune_damage( damage_electric );
 }
 
+
 bool monster::is_immune_effect( const efftype_id &effect ) const
 {
     if( effect == effect_onfire ) {
@@ -1817,6 +1819,10 @@ bool monster::is_immune_effect( const efftype_id &effect ) const
 
     if( effect == effect_stunned ) {
         return has_flag( mon_flag_STUN_IMMUNE );
+    }
+
+    if( effect == effect_corroding ) {
+        return has_flag( mon_flag_ACIDPROOF );
     }
 
     if( effect == effect_downed ) {


### PR DESCRIPTION
#### Summary
Make ACIDPROOF monsters immune to acid effects.

#### Purpose of change
Ensure that monsters intended to be acidproof (mostly those who spit acid) are unable to be killed by their own puddles.

#### Describe the solution
- Ensure that the oversized acidic ant has the ACIDPROOF flag
- Ensure that ACIDPROOF grants monsters immunity to the corroding effect

#### Testing
Spawned some acid ants and watched them not die in their own acid.

#### Additional context
Previously, acid armor incidentally made monsters resistant to acid puddles. That is no longer the case. That needs a fix, but not this instant.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
