### PR TITLE
Pawn shops please chill

### DIFF
--- a/data/json/mapgen/pawn_shop.json
+++ b/data/json/mapgen/pawn_shop.json
@@ -71,17 +71,17 @@
       },
       "toilets": { "&": {  } },
       "items": {
-        "X": { "item": "my_precious", "chance": 80, "repeat": [ 1, 3 ] },
-        "{": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "}": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "[": { "item": "pawn_valuable", "chance": 80, "repeat": [ 1, 3 ] },
-        "]": { "item": "pawn_valuable", "chance": 80, "repeat": [ 1, 3 ] },
-        "O": { "item": "pawn_guns", "chance": 50, "repeat": [ 1, 3 ] }
+        "X": { "item": "my_precious", "chance": 10, "repeat": [ 1, 3 ] },
+        "{": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "}": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "[": { "item": "pawn_valuable", "chance": 10, "repeat": [ 1, 3 ] },
+        "]": { "item": "pawn_valuable", "chance": 10, "repeat": [ 1, 3 ] },
+        "O": { "item": "pawn_guns", "chance": 80, "repeat": [ 1, 3 ] }
       },
       "place_loot": [
-        { "group": "office", "x": 18, "y": [ 17, 19 ], "chance": 90 },
-        { "group": "homeguns", "x": 21, "y": [ 18, 21 ], "chance": 50, "repeat": [ 1, 2 ] },
-        { "group": "harddrugs", "x": [ 16, 17 ], "y": 21, "chance": 20, "repeat": [ 1, 2 ] },
+        { "group": "office", "x": 18, "y": [ 17, 19 ], "chance": 15 },
+        { "group": "homeguns", "x": 21, "y": [ 18, 21 ], "chance": 5, "repeat": [ 1, 2 ] },
+        { "group": "harddrugs", "x": [ 16, 17 ], "y": 21, "chance": 2, "repeat": [ 1, 2 ] },
         { "group": "cash_register_random", "x": 16, "y": [ 6, 8 ] }
       ]
     }
@@ -216,17 +216,17 @@
       },
       "toilets": { "&": {  } },
       "items": {
-        "X": { "item": "my_precious", "chance": 80, "repeat": [ 1, 3 ] },
-        "C": { "item": "pawn_valuable", "chance": 80, "repeat": [ 1, 3 ] },
-        "{": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "}": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "#": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "O": { "item": "pawn_guns", "chance": 50, "repeat": [ 1, 3 ] }
+        "X": { "item": "my_precious", "chance": 10, "repeat": [ 1, 3 ] },
+        "C": { "item": "pawn_valuable", "chance": 10, "repeat": [ 1, 3 ] },
+        "{": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "}": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "#": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "O": { "item": "pawn_guns", "chance": 60, "repeat": [ 1, 3 ] }
       },
       "place_loot": [
-        { "group": "office", "x": [ 8, 10 ], "y": 18, "chance": 90 },
-        { "group": "homeguns", "x": 12, "y": [ 18, 21 ], "chance": 50, "repeat": [ 1, 2 ] },
-        { "group": "harddrugs", "x": 6, "y": [ 18, 20 ], "chance": 20, "repeat": [ 1, 2 ] },
+        { "group": "office", "x": [ 8, 10 ], "y": 18, "chance": 50 },
+        { "group": "homeguns", "x": 12, "y": [ 18, 21 ], "chance": 5, "repeat": [ 1, 2 ] },
+        { "group": "harddrugs", "x": 6, "y": [ 18, 20 ], "chance": 2, "repeat": [ 1, 2 ] },
         { "group": "cash_register_random", "x": 7, "y": 18 }
       ]
     }
@@ -358,12 +358,12 @@
       },
       "toilets": { "&": {  } },
       "items": {
-        "}": { "item": "mussto_stringinst", "chance": 80, "repeat": [ 1, 3 ] },
-        "{": { "item": "pawn_shop_electronics", "chance": 80, "repeat": [ 1, 3 ] },
-        "[": { "item": "pawn", "chance": 80, "repeat": [ 1, 3 ] },
-        "d": { "item": "elecsto_persele", "chance": 80, "repeat": [ 1, 3 ] },
-        "c": { "item": "cash_register_random", "chance": 100 },
-        "@": { "item": "armor_suit", "chance": 90 }
+        "}": { "item": "mussto_stringinst", "chance": 10, "repeat": [ 1, 3 ] },
+        "{": { "item": "pawn_shop_electronics", "chance": 10, "repeat": [ 1, 3 ] },
+        "[": { "item": "pawn", "chance": 10, "repeat": [ 1, 3 ] },
+        "d": { "item": "elecsto_persele", "chance": 10, "repeat": [ 1, 3 ] },
+        "c": { "item": "cash_register_random", "chance": 60 },
+        "@": { "item": "armor_suit", "chance": 10 }
       },
       "place_loot": [
         { "item": "hammer", "x": 16, "y": 12 },
@@ -425,8 +425,8 @@
         "p": "f_drill_press"
       },
       "items": {
-        "t": { "item": "bondage", "chance": 80, "repeat": [ 2, 4 ] },
-        "f": { "item": "office", "chance": 80, "repeat": [ 1, 2 ] },
+        "t": { "item": "bondage", "chance": 30, "repeat": [ 2, 4 ] },
+        "f": { "item": "office", "chance": 50, "repeat": [ 1, 2 ] },
         "G": { "item": "Gimp", "chance": 100 },
         "M": { "item": "Maynard", "chance": 100 }
       },


### PR DESCRIPTION
#### Summary
Fix pawn shop loot bonanza

#### Purpose of change
Pawn shop mapgen got a bit messed up during some manual adjustments and backports. This fixes them.

#### Describe the solution
Go through and manually cut the probabilities by ~7/8

#### Testing
![image](https://github.com/user-attachments/assets/04a1f6fc-e8cf-4075-8552-0588461acf9b)
They look OK now (ignore the cash register in the parking lot)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
