### PR TITLE
Add encumbrance to ponchos

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1695,7 +1695,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 2,
+        "encumbrance": 3,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1938,7 +1938,7 @@
     "flags": [ "RAINPROOF", "OVERSIZE", "HOOD", "BELTED" ],
     "environmental_protection": 1,
     "material_thickness": 0.1,
-    "armor": [ { "coverage": 90, "covers": [ "torso" ] } ]
+    "armor": [ { "coverage": 90, "covers": [ "torso" ], "encumbrance": 3 } ]
   },
   {
     "id": "folding_poncho",
@@ -1958,11 +1958,11 @@
     "material_thickness": 0.4,
     "variant_type": "generic",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100 },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 4  },
       {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
-        "coverage": 100
+        "coverage": 100, "encumbrance": 4 
       },
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 }
     ]


### PR DESCRIPTION
#### Summary
Add a small amount of encumbance to ponchos that lacked it

#### Purpose of change
The rain poncho didn't have any encumbrance, but most other cloak-type items did.

#### Describe the solution
The rain and makeshift ponchos were given a small amount of encumbrance.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
