### PR TITLE
Nudge overmap settings

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2922,7 +2922,7 @@
     "connections": [ { "point": [ -1, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 5, -1 ],
-    "occurrences": [ 0, 5 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "FARM", "MAN_MADE" ]
   },
   {
@@ -2979,7 +2979,7 @@
     "locations": [ "field", "forest_without_trail" ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "city_distance": [ 30, -1 ],
-    "occurrences": [ 0, 5 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "WILDERNESS", "MAN_MADE" ]
   },
   {
@@ -3248,7 +3248,7 @@
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ -1, 10 ],
     "city_sizes": [ 8, -1 ],
-    "occurrences": [ 0, 5 ],
+    "occurrences": [ 0, 4 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3276,7 +3276,7 @@
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 2, 5 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 5 ],
+    "occurrences": [ 0, 4 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3306,7 +3306,7 @@
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 1, 10 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 5 ],
+    "occurrences": [ 0, 3 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {


### PR DESCRIPTION
#### Summary
Nudge overmap settings to reduce apple orchard spam

#### Purpose of change
Apple orchards can spawn as part of mutable farms, so we don't ALSO need 5 freestanding apple orchards per overmap (at maximum).

#### Describe the solution
Reduced the max number of freestanding orchards to 3, nudged a few other things that were especially common.

#### Testing
![image](https://github.com/user-attachments/assets/1f5d6380-02b3-4310-9475-8775b05ed045)
Three orchrds on this entire overmap. Not too bad.

#### Additional context
This is gonna be one of those forever projects.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
