### PR TITLE
fix mansion trash

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1958,11 +1958,12 @@
     "material_thickness": 0.4,
     "variant_type": "generic",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 4  },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper", "torso_lower" ], "coverage": 100, "encumbrance": 4 },
       {
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r", "arm_upper_r", "arm_upper_l", "arm_elbow_r", "arm_elbow_l" ],
-        "coverage": 100, "encumbrance": 4 
+        "coverage": 100,
+        "encumbrance": 4
       },
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 }
     ]

--- a/data/json/mapgen/mansion.json
+++ b/data/json/mapgen/mansion.json
@@ -37,7 +37,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "?": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": {
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 100 },
         "q": { "item": "tool_common_stack", "chance": 100 }
       },
@@ -81,7 +81,7 @@
       "palettes": [ "standard_domestic_palette", "standard_domestic_landscaping_palette" ],
       "terrain": { "?": "t_water_pool_shallow_outdoors" },
       "items": {
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "K": { "item": "crate_cleaning", "chance": 100 },
         "I": { "item": "table_foyer", "chance": 40 }
       },
@@ -181,7 +181,7 @@
       "furniture": { "=": "f_table", "?": "f_glass_fridge", "!": "f_speaker_cabinet" },
       "place_loot": [ { "item": "stereo", "x": 23, "y": 16, "chance": 100 }, { "item": "television", "x": 4, "y": 11, "chance": 100 } ],
       "items": {
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "table_card", "chance": 40 },
         "J": { "item": "wetbar_counter", "chance": 30 },
         "?": { "item": "wetbar_fridge", "chance": 80 },
@@ -227,8 +227,8 @@
       "palettes": [ "standard_domestic_palette", "standard_domestic_landscaping_palette" ],
       "terrain": { "?": "t_water_pool_shallow_outdoors", "~": "t_thconc_floor", "&": "t_column", "-": "t_carpet_red" },
       "items": {
-        " ": { "item": "clutter_mansion" },
-        ".": { "item": "clutter_yard" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "s": { "item": "table_foyer", "chance": 40 },
         "c": { "item": "suit_of_armor", "chance": 100 }
       },
@@ -283,7 +283,7 @@
       },
       "furniture": { "&": "f_sofa" },
       "items": {
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "c": { "item": "suit_of_armor", "chance": 10 },
         "s": { "item": "table_foyer", "chance": 40 },
         "l": { "item": "table_foyer", "chance": 40 }
@@ -372,7 +372,7 @@
       "furniture": { "&": "f_dive_block" },
       "items": {
         "j": { "item": "pool_side", "chance": 30 },
-        ".": { "item": "clutter_yard" },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "a": { "item": "fireplace_fill", "chance": 30 },
         "K": { "item": "wetbar_counter", "chance": 20 }
       },
@@ -498,7 +498,7 @@
           { "item": "tailorbooks", "chance": 60, "repeat": [ 0, 1 ] },
           { "item": "SUS_tailoring_fasteners", "chance": 30, "repeat": [ 2, 6 ] }
         ],
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "=": { "item": "sex_lair", "chance": 25, "repeat": [ 2, 4 ] },
         "!": { "item": "crate_stack", "chance": 100 },
         "D": { "item": "sex_lair", "chance": 55, "repeat": [ 2, 6 ] },
@@ -551,7 +551,7 @@
         ")": { "item": "bed", "chance": 40 },
         "-": { "item": "clutter_bedroom", "chance": 2 },
         " ": { "item": "clutter_bedroom", "chance": 2 },
-        ".": { "item": "clutter_yard" },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "~": { "item": "clutter_bathroom", "chance": 10 },
         "I": { "item": "vanity", "chance": 40 },
         "s": { "item": "nightstand", "chance": 40 },
@@ -600,7 +600,7 @@
         "v": { "item": "mansion_safe", "chance": 100 },
         ",": { "item": "clutter_bedroom", "chance": 2 },
         " ": { "item": "clutter_bedroom", "chance": 2 },
-        ".": { "item": "clutter_yard" },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "~": { "item": "clutter_bathroom", "chance": 10 },
         ")": { "item": "bed", "chance": 40 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
@@ -719,7 +719,7 @@
       },
       "furniture": { "&": "f_table", "=": "f_machinery_old", "}": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": {
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 100 },
         "H": { "item": "mansion_ammo", "chance": 40 },
         "x": { "item": "a_television", "chance": 100 },
@@ -830,7 +830,7 @@
         "!": { "item": "crate_stack", "chance": 100 },
         "0": { "item": "keg_wine", "chance": 100 },
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
-        ".": { "item": "clutter_basement" }
+        ".": { "item": "clutter_basement", "chance": 1 }
       },
       "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 12 ], "density": 0.1 } ]
     }
@@ -878,8 +878,8 @@
       "furniture": { ")": "f_speaker_cabinet" },
       "place_loot": [ { "item": "stereo", "x": 18, "y": 0, "chance": 100 } ],
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_mansion" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "J": { "item": "table_sideboard", "chance": 35 },
         "x": { "item": "table_livingroom", "chance": 35 }
       },
@@ -1041,8 +1041,8 @@
         { "item": "television", "x": 18, "y": 0, "chance": 100 }
       ],
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_mansion" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "r": { "item": "art", "chance": 20 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
         "&": { "item": "mansion_bookcase", "chance": 20 }
@@ -1218,9 +1218,9 @@
       },
       "furniture": { ")": "f_bed" },
       "items": {
-        ".": { "item": "clutter_yard" },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "-": { "item": "clutter_bedroom", "chance": 2 },
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "~": { "item": "clutter_bathroom", "chance": 10 },
         "a": { "item": "fireplace_fill", "chance": 30 },
         ")": { "item": "bed", "chance": 30 },
@@ -1288,7 +1288,7 @@
       "place_loot": [ { "item": "laptop", "x": 16, "y": 10, "chance": 100 }, { "item": "stereo", "x": 6, "y": 9, "chance": 100 } ],
       "items": {
         "-": { "item": "clutter_bedroom", "chance": 3 },
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "v": { "item": "mansion_guns", "chance": 30 },
         ",": { "item": "clutter_bathroom", "chance": 10 },
         "D": { "item": "dresser_servant", "chance": 45 }
@@ -1342,8 +1342,8 @@
       },
       "furniture": { "&": "f_table", "!": [ "f_cardboard_box", "f_crate_c" ], "?": "f_sofa" },
       "items": {
-        "-": { "item": "clutter_mansion" },
-        ".": { "item": "clutter_basement" },
+        "-": { "item": "clutter_mansion", "chance": 1 },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "x": { "item": "a_television", "chance": 100 },
         "J": { "item": "fridgesnacks", "chance": 45 },
         "!": { "item": "crate_stack", "chance": 100 },
@@ -1391,8 +1391,8 @@
       "terrain": { "-": "t_carpet_green", "l": "t_carpet_green", "≠": "t_carpet_green", "‡": "t_carpet_green" },
       "furniture": { "‡": "f_sofa", "&": "f_table", ")": "f_speaker_cabinet" },
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_mansion" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "l": { "item": "mansion_bookcase", "chance": 100 },
         "&": { "item": "table_card", "chance": 35 },
         "c": { "item": "suit_of_armor", "chance": 100 }
@@ -1496,7 +1496,7 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "terrain": { " ": "t_soil", ".": "t_thconc_floor" },
-      "items": { ".": { "item": "clutter_basement" } }
+      "items": { ".": { "item": "clutter_basement", "chance": 1 } }
     }
   },
   {
@@ -1537,8 +1537,8 @@
       "terrain": { "&": "t_door_glass_c", "~": "t_water_pool_shallow_outdoors" },
       "furniture": { "@": [ "f_statue", "f_statue", "f_statue", "f_null", "f_null" ] },
       "items": {
-        " ": { "item": "clutter_mansion" },
-        ".": { "item": "clutter_yard" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "C": { "item": "garden_shed", "chance": 40 },
         "G": { "item": "snacks_fancy", "chance": 20 }
       },
@@ -1580,7 +1580,7 @@
       ],
       "palettes": [ "standard_domestic_palette", "standard_domestic_lino_bathroom" ],
       "terrain": { "~": "t_open_air", "_": "t_floor_noroof", " ": "t_floor", "i": "t_floor", ")": "t_door_glass_c", "%": "t_railing" },
-      "items": { " ": { "item": "clutter_mansion" } }
+      "items": { " ": { "item": "clutter_mansion", "chance": 1 } }
     }
   },
   {
@@ -1638,7 +1638,7 @@
       },
       "items": {
         "$": { "item": "mansion_safe", "chance": 100 },
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 100 },
         "&": { "item": "snacks_fancy", "chance": 40 },
         "U": { "item": "home_hw", "chance": 25 },
@@ -1693,7 +1693,7 @@
       },
       "furniture": { "&": "f_table", "?": "f_cardboard_box" },
       "items": {
-        " ": { "item": "clutter_ballroom" },
+        " ": { "item": "clutter_ballroom", "chance": 1 },
         "h": { "item": "clutter_ballroom", "chance": 20 },
         "~": { "item": "clutter_ballroom", "chance": 3 },
         "?": { "item": "dining", "chance": 45 },
@@ -1738,7 +1738,7 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "terrain": { "~": "t_open_air", "=": "t_open_air_rooved", "%": "t_railing" },
-      "items": { " ": { "item": "clutter_mansion" }, "K": { "item": "wetbar_counter", "chance": 35 } }
+      "items": { " ": { "item": "clutter_mansion", "chance": 1 }, "K": { "item": "wetbar_counter", "chance": 35 } }
     }
   },
   {
@@ -1785,7 +1785,7 @@
       },
       "items": {
         "$": { "item": "mansion_gunsafe", "chance": 100 },
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 100 },
         "J": { "item": "hardware_plumbing", "chance": 35 },
         "&": { "item": "hardware_bulk", "chance": 30 },
@@ -1852,7 +1852,7 @@
         "~": { "item": "clutter_gym", "chance": 2 },
         "z": { "item": "crate_sports", "chance": 100 },
         "?": { "item": "locker_gym", "chance": 45 },
-        "`": { "item": "clutter_gym" },
+        "`": { "item": "clutter_gym", "chance": 1 },
         "F": { "item": "vending_drink", "chance": 45 },
         "w": { "item": "sports", "chance": 35 }
       },
@@ -1894,7 +1894,7 @@
       ],
       "palettes": [ "standard_domestic_palette" ],
       "terrain": { "=": "t_open_air_rooved", "%": "t_railing" },
-      "items": { " ": { "item": "clutter_mansion" }, "i": { "item": "snacks_fancy", "chance": 20 } }
+      "items": { " ": { "item": "clutter_mansion", "chance": 1 }, "i": { "item": "snacks_fancy", "chance": 20 } }
     }
   },
   {
@@ -1945,7 +1945,7 @@
       "furniture": { "!": [ "f_cardboard_box", "f_crate_c" ], "&": "f_console_broken", "?": "f_glass_fridge" },
       "items": {
         "t": { "item": "harddrugs", "chance": 30 },
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "J": { "item": "vending_food", "chance": 25 },
         "?": { "item": "fridgesnacks", "chance": 45 },
         "!": { "item": "crate_stack", "chance": 100 }
@@ -2000,8 +2000,8 @@
       },
       "furniture": { "?": "f_sofa" },
       "items": {
-        " ": { "item": "clutter_mansion" },
-        ".": { "item": "clutter_yard" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "x": { "item": "medieval", "chance": 20 },
         "l": { "item": "mansion_bookcase", "chance": 100 },
         "q": { "item": "garden_shed", "chance": 40 }
@@ -2076,7 +2076,11 @@
         "%": "t_railing"
       },
       "furniture": { "&": "f_sofa" },
-      "items": { "_": { "item": "clutter_mansion" }, " ": { "item": "clutter_mansion" }, "-": { "item": "clutter_mansion" } },
+      "items": {
+        "_": { "item": "clutter_mansion", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
+        "-": { "item": "clutter_mansion", "chance": 1 }
+      },
       "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 7 ], "density": 0.1 } ]
     }
   },
@@ -2117,7 +2121,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "=": "f_machinery_old", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": {
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "K": { "item": "crate_stack", "chance": 100 },
         "m": { "item": "hardware_plumbing", "chance": 40 },
         "r": { "item": "pantry", "chance": 25 }
@@ -2167,7 +2171,7 @@
       },
       "furniture": { "&": "f_dive_block" },
       "items": {
-        ".": { "item": "clutter_yard" },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "i": { "item": "pool_side", "chance": 30 },
         "=": { "item": "pool_side", "chance": 2 }
       },
@@ -2226,7 +2230,7 @@
         { "item": "lawn_dart", "x": [ 11, 14 ], "y": [ 4, 6 ], "chance": 100, "repeat": [ 1, 2 ] }
       ],
       "items": {
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "J": { "item": "wetbar_counter", "chance": 25 },
         "m": { "item": "wetbar_fridge", "chance": 45 },
         "1": { "item": "wetbar_stack", "chance": 100 },
@@ -2271,7 +2275,7 @@
       "palettes": [ "standard_domestic_palette" ],
       "terrain": { " ": "t_soil", ".": "t_thconc_floor", "]": "t_sewage_pipe", ")": "t_sewage_pump" },
       "furniture": { "=": "f_machinery_old", "&": "f_table", "?": "f_generator_broken", "!": [ "f_crate_c", "f_cardboard_box" ] },
-      "items": { ".": { "item": "clutter_basement" }, "!": { "item": "crate_stack", "chance": 100 } },
+      "items": { ".": { "item": "clutter_basement", "chance": 1 }, "!": { "item": "crate_stack", "chance": 100 } },
       "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 8, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
   },
@@ -2319,8 +2323,8 @@
       },
       "place_loot": [ { "item": "stereo", "x": 8, "y": 14, "chance": 100 }, { "item": "television", "x": 9, "y": 14, "chance": 100 } ],
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_mansion" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "x": { "item": "mansion_bookcase", "chance": 100 },
         "&": { "item": "table_card", "chance": 35 },
         "c": { "item": "suit_of_armor", "chance": 100 },
@@ -2429,7 +2433,7 @@
       "terrain": { " ": "t_soil", ".": "t_thconc_floor" },
       "furniture": { "=": "f_table", "!": [ "f_crate_c", "f_cardboard_box" ] },
       "items": {
-        ".": { "item": "clutter_basement" },
+        ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 100 },
         "x": { "item": "a_television", "chance": 100 }
       },
@@ -2480,8 +2484,8 @@
       },
       "furniture": { ")": "f_table" },
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_mansion" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "a": { "item": "fireplace_fill", "chance": 30 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
         ")": { "item": "table_livingroom", "chance": 30 }
@@ -2541,7 +2545,7 @@
       "furniture": { "&": "f_speaker_cabinet" },
       "place_loot": [ { "item": "stereo", "x": 22, "y": 15, "chance": 100 } ],
       "items": {
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "M": { "item": "art", "chance": 100 },
         "s": { "item": "snacks_fancy", "chance": 20 },
         "∞": { "item": "mansion_guns", "chance": 100 }
@@ -2654,8 +2658,8 @@
       "terrain": { "-": "t_carpet_purple", "E": "t_carpet_purple", ")": "t_carpet_purple" },
       "furniture": { ")": "f_bed" },
       "items": {
-        ".": { "item": "clutter_yard" },
-        " ": { "item": "clutter_bedroom" },
+        ".": { "item": "clutter_yard", "chance": 1 },
+        " ": { "item": "clutter_bedroom", "chance": 1 },
         "~": { "item": "clutter_bathroom", "chance": 10 },
         "i": { "item": "table_foyer", "chance": 20 },
         "R": { "item": "mansion_bookcase", "chance": 100 },
@@ -2707,7 +2711,7 @@
       },
       "furniture": { "?": "f_dresser" },
       "items": {
-        " ": { "item": "clutter_mansion" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
         "s": { "item": "nightstand", "chance": 20 },
         ",": { "item": "softdrugs", "chance": 40 },
         "?": { "item": "dresser_servant", "chance": 45 }
@@ -2765,7 +2769,7 @@
         "m": { "item": "chilled_wine", "chance": 40, "repeat": [ 1, 4 ] },
         "0": { "item": "keg_wine", "chance": 100 },
         "&": { "item": "table_wine", "chance": 100, "repeat": [ 1, 4 ] },
-        ".": { "item": "clutter_basement" }
+        ".": { "item": "clutter_basement", "chance": 1 }
       },
       "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 11, 21 ], "y": [ 8, 21 ], "density": 0.1 } ]
     }
@@ -2814,8 +2818,8 @@
         "f": "t_carpet_green"
       },
       "items": {
-        " ": { "item": "clutter_mansion" },
-        ".": { "item": "clutter_yard" },
+        " ": { "item": "clutter_mansion", "chance": 1 },
+        ".": { "item": "clutter_yard", "chance": 1 },
         "r": { "item": "table_sideboard", "chance": 40 }
       },
       "place_monsters": [ { "monster": "GROUP_MANSION", "x": [ 2, 21 ], "y": [ 2, 21 ], "density": 0.1 } ],


### PR DESCRIPTION
#### Summary
Fix mansion clutter probability

#### Purpose of change
fixes #386 

DDA changed the default probability for item placement in mapgen from 1% to 100%. So mansions were carpeted in trash that was supposed to be very infrequent.

#### Describe the solution
Manually set 1 probaility.

#### Testing
![image](https://github.com/user-attachments/assets/25228073-8e72-4933-96f9-c52893e6ed01)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
