### PR TITLE
Fix Pants Encumbrance

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -31,7 +31,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_upper_l", "leg_upper_r", "leg_knee_r", "leg_knee_l" ]
       },
-      { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_r", "leg_lower_l" ] }
+      {
+        "coverage": 90,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -72,9 +77,14 @@
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.7
+        "encumbrance": [ 6, 10 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -156,7 +166,14 @@
     "color": "light_red",
     "material_thickness": 0.1,
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 75,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 4
+      }
+    ]
   },
   {
     "id": "hot_pants_fur",
@@ -174,7 +191,14 @@
     "warmth": 10,
     "material_thickness": 1.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 75,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 8
+      }
+    ]
   },
   {
     "id": "hot_pants_leather",
@@ -192,7 +216,14 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 75,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 6
+      }
+    ]
   },
   {
     "id": "jeans",
@@ -244,17 +275,23 @@
     "flags": [ "VARSIZE", "POCKETS" ],
     "armor": [
       {
-        "encumbrance": [ 14, 16 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": [ 14, 16 ]
       },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -274,36 +311,36 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "750 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "900 g",
         "max_item_length": "10 cm",
         "moves": 60
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "750 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_volume": "500 ml",
+        "max_contains_weight": "900 g",
         "max_item_length": "10 cm",
         "moves": 60
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "680 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_volume": "600 ml",
+        "max_contains_weight": "1 kg",
         "max_item_length": "8 cm",
         "moves": 80
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "680 ml",
-        "max_contains_weight": "2 kg",
+        "max_contains_volume": "600 ml",
+        "max_contains_weight": "1 kg",
         "max_item_length": "8 cm",
         "moves": 80
       }
     ],
     "warmth": 10,
     "material_thickness": 0.52,
-    "//": "Lightweight 8 oz denim jeans.",
+    "//": "Lightweight 8 oz stretch denim jeans.",
     "flags": [ "VARSIZE", "POCKETS" ],
     "armor": [
       {
@@ -346,8 +383,18 @@
     "material_thickness": 0.3,
     "flags": [ "VARSIZE" ],
     "armor": [
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": [ 8, 10 ]
+      },
+      {
+        "coverage": 95,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -376,8 +423,18 @@
     "material_thickness": 1.5,
     "flags": [ "VARSIZE" ],
     "armor": [
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": [ 12, 16 ]
+      },
+      {
+        "coverage": 95,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -393,17 +450,28 @@
     "symbol": "[",
     "looks_like": "pants_leather",
     "color": "dark_gray",
-    "warmth": 20,
+    "warmth": 8,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 4
+      },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": 0
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -421,7 +489,14 @@
     "color": "brown",
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 25, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 4
+      }
+    ]
   },
   {
     "id": "loincloth_fur",
@@ -439,7 +514,14 @@
     "warmth": 5,
     "material_thickness": 1.5,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 25, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 8
+      }
+    ]
   },
   {
     "id": "loincloth_leather",
@@ -456,7 +538,14 @@
     "color": "brown",
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 25, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 6
+      }
+    ]
   },
   {
     "id": "loincloth_wool",
@@ -474,7 +563,14 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "VARSIZE", "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 25, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "armor": [
+      {
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": 6
+      }
+    ]
   },
   {
     "id": "nanoskirt",
@@ -522,15 +618,20 @@
         "encumbrance": [ 8, 8 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.6
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -550,22 +651,22 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "4 kg",
-        "max_item_length": "19 cm",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1800 g",
+        "max_item_length": "16 cm",
         "moves": 80
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "4 kg",
-        "max_item_length": "19 cm",
+        "max_contains_volume": "1000 ml",
+        "max_contains_weight": "1800 g",
+        "max_item_length": "16 cm",
         "moves": 80
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "1080 ml",
-        "max_contains_weight": "4 kg",
+        "max_contains_weight": "2 kg",
         "max_item_length": "165 mm",
         "moves": 100
       },
@@ -580,7 +681,26 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "POCKETS" ],
-    "armor": [ { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "encumbrance": [ 8, 12 ] } ]
+    "armor": [
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "encumbrance": [ 10, 14 ]
+      },
+      {
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
+      },
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
+    ]
   },
   {
     "id": "pants_checkered",
@@ -665,18 +785,23 @@
     "flags": [ "VARSIZE", "POCKETS", "SOFT" ],
     "armor": [
       {
-        "encumbrance": [ 6, 10 ],
+        "encumbrance": [ 10, 18 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.6
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -741,18 +866,23 @@
     "flags": [ "VARSIZE", "POCKETS" ],
     "armor": [
       {
-        "encumbrance": [ 7, 11 ],
+        "encumbrance": [ 7, 12 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.6
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -813,9 +943,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -870,9 +1006,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -932,16 +1074,22 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
     "id": "police_breeches",
     "type": "ARMOR",
     "name": { "str_sp": "police breeches" },
-    "description": "A pair of tight-fitting police breeches.  Offers lots of mobility for motorized officers.",
+    "description": "A pair of tight-fitting police breeches.  They offer plenty of mobility for motorized officers.",
     "weight": "560 g",
     "volume": "1500 ml",
     "price": "49 USD",
@@ -953,11 +1101,10 @@
     "color": "dark_gray",
     "armor": [
       {
-        "encumbrance": [ 5, 12 ],
+        "encumbrance": [ 10, 14 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.6
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 100,
@@ -1050,17 +1197,16 @@
     "flags": [ "VARSIZE" ],
     "armor": [
       {
-        "encumbrance": [ 2, 5 ],
+        "encumbrance": [ 2, 6 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.7
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 80,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
-        "volume_encumber_modifier": 0.0
+        "encumbrance": [ 0, 0 ]
       }
     ]
   },
@@ -1130,14 +1276,13 @@
         "encumbrance": [ 2, 12 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.7
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 90,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
-        "volume_encumber_modifier": 0.7
+        "encumbrance": [ 0, 0 ]
       }
     ]
   },
@@ -1180,14 +1325,13 @@
         "encumbrance": [ 3, 10 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.7
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 90,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
-        "volume_encumber_modifier": 0.0
+        "encumbrance": [ 0, 0 ]
       }
     ]
   },
@@ -1213,7 +1357,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 60, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 60,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": 0
+      }
     ],
     "material_thickness": 0.65,
     "flags": [ "VARSIZE" ]
@@ -1242,7 +1391,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 75,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -1271,9 +1425,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": 0
       },
-      { "coverage": 90, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 90,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -1299,7 +1459,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 38,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -1325,7 +1490,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 38,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -1385,9 +1555,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -1460,9 +1636,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -1491,9 +1673,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": 0
       },
-      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 95,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": 0
+      }
     ]
   },
   {
@@ -1559,9 +1747,15 @@
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -1700,15 +1894,20 @@
         "encumbrance": [ 8, 22 ],
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "volume_encumber_modifier": 0.6
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ]
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r", "leg_knee_l", "leg_knee_r" ],
+        "encumbrance": [ 0, 0 ]
       },
-      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_lower_l", "leg_lower_r" ] }
+      {
+        "coverage": 98,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r" ],
+        "encumbrance": [ 0, 0 ]
+      }
     ]
   },
   {
@@ -1734,7 +1933,12 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
-      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      {
+        "coverage": 38,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "encumbrance": 0
+      }
     ]
   }
 ]

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -825,8 +825,7 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 100,
-        "encumbrance": 4,
-        "volume_encumber_modifier": 0.25,
+        "encumbrance": [ 4, 20 ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       },
       {
@@ -837,6 +836,7 @@
         ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 50,
+        "encumbrance": 0,
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
       }
     ],

--- a/data/mods/innawood/recipes/armor/head.json
+++ b/data/mods/innawood/recipes/armor/head.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "result": "helmet_skull",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/innawood/recipes/armor/storage.json
+++ b/data/mods/innawood/recipes/armor/storage.json
@@ -20,7 +20,7 @@
     ],
     "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
   },
-    {
+  {
     "result": "ragpouch",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
@@ -32,7 +32,7 @@
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork_simple", 1 ] ]
   },
-    {
+  {
     "result": "stone_pouch",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
@@ -61,7 +61,7 @@
     "using": [ [ "strap_large", 1 ], [ "tailoring_leather_patchwork_simple", 6 ], [ "fastener_small", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ]
   },
-    {
+  {
     "result": "trapper_pack",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/innawood/recipes/armor/torso.json
+++ b/data/mods/innawood/recipes/armor/torso.json
@@ -1,5 +1,5 @@
 [
-   {
+  {
     "result": "tunic_rag",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",

--- a/data/mods/innawood/recipes/weapon/ranged.json
+++ b/data/mods/innawood/recipes/weapon/ranged.json
@@ -271,7 +271,7 @@
     ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "swage", -1 ] ] ]
   },
-    {
+  {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "atlatl",
@@ -282,11 +282,8 @@
     "difficulty": 3,
     "time": "1 h",
     "autolearn": true,
-    "qualities": [
-		{ "id": "CUT", "level": 1 },
-		{ "id": "CHISEL_WOOD", "level": 1 }
-	],
-    "proficiencies": [{ "proficiency": "prof_carving" }],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "CHISEL_WOOD", "level": 1 } ],
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
     "components": [ [ [ "stick_long", 1 ] ], [ [ "cordage_short", 1, "LIST" ] ], [ [ "splinter", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Fix most encumbrance issues with pants.

#### Purpose of change
DDA has, to my knowledge, SIX methods for determining encumbrance:
1) A single encumbrance value per "covers": entry in the armor definition.
2) volume_encumbrance_modifier, which attempts to automatically determine extra encumbrance from pocket fullness.
3) A bracketed pair of encumbrance values, min and max, which do the same as the above.
4) Proportional encumbrance, used in copy-from.
5) Flag-based encumbrance, used for helmets.
6) Extra_encumbrance, defined on individual pockets.

This is all layered overtop of the VARSIZE, OVERSIZE, and UNDERSIZE flags, and it just sucks so bad. All we need is 1 ,3, and 6. All other methods are to be phased out. 

There is a bug with method 3: if multiple sub-bodyparts are defined and one of them has paired encumbrance values, all other sub-bodypart entries need to have [ 0, 0 ] manually defined for their encumbrance or else they will produce some really bizarre behavior. This is because the defailt max_encumbrance is -1 for mystrerious code reasons, which causes things to get all squirrely.

#### Describe the solution
- Manually enter an encumbrance of [ 0, 0 ] on any undefined sub-bodypart for all pants.
- Remove all other methods of determining encumbrance from all pants, except methods 1, 3, and 6.

#### Describe alternatives you've considered
I shouldn't have to manually enter 0, 0, the game should assume that a sub-bodypart with no encumbrance defined has no encumbrance, but this is all coded in a vastly more complicated way than is necessary (whhyyyy) and fixing it would probably wind up with a rewrite, so for now I'm just doing this,

#### Testing
Load the game, spawn some pants. They look normal.

#### Additional context
Helmets are next.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
