### PR TITLE
Innawood water filter

### DIFF
--- a/data/mods/innawood/items/misc.json
+++ b/data/mods/innawood/items/misc.json
@@ -51,5 +51,21 @@
     "symbol": "=",
     "color": "light_gray",
     "looks_like": "battery"
+  },
+  {
+    "id": "water_filter_sand",
+    "type": "TOOL",
+    "name": { "str": "slow-sand water filter" },
+    "//": "Slow sand biofilter: https://wwwnc.cdc.gov/travel/yellowbook/2024/preparing/water-disinfection#:~:text=Figure%202%2D02.%20Emergency%20gravel%20and%20sand%20filter",
+    "description": "An improvised water filter made from a clay hydria filled with a layer of sand and a layer of gravel.  It can be used to remove particulates and some pathogens from water, but it is not 100% effective.",
+    "//1": "Weight = 8 kg gravel + 20 kg sand + 1995 g hydria + a bit extra for mesh and any residual water",
+    "weight": "30940 g",
+    "volume": "21000 ml",
+    "price": 1000,
+    "price_postapoc": 150,
+    "to_hit": -3,
+    "material": [ { "type": "sand", "portion": 29 }, { "type": "clay", "portion": 1 } ],
+    "symbol": ";",
+    "color": "brown"
   }
 ]

--- a/data/mods/innawood/recipes/recipe_food.json
+++ b/data/mods/innawood/recipes/recipe_food.json
@@ -1073,5 +1073,26 @@
     "qualities": [ { "id": "OVEN", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 8, "LIST" ] ] ],
     "components": [ [ [ "flour", 20 ], [ "bread_flour", 20 ] ], [ [ "yeast", 1 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "water_filter_sand",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "skills_required": [ [ "survival", 2 ] ],
+    "difficulty": 2,
+    "time": "30 m",
+    "autolearn": true,
+    "reversible": true,
+    "//": "Slow sand biofilter: https://wwwnc.cdc.gov/travel/yellowbook/2024/preparing/water-disinfection#:~:text=Figure%202%2D02.%20Emergency%20gravel%20and%20sand%20filter",
+    "//1": "Density of sand is around 1.6g/cm^3. Gravel is similar. In a 10 in diameter bucket, 4 in of gravel is about 8 kg and 10 in of sand is about 20 kg.",
+    "components": [
+      [ [ "clay_hydria", 1 ] ],
+      [ [ "material_sand", 2500 ] ],
+      [ [ "material_gravel", 1000 ] ],
+      [ [ "cotton_patchwork", 4 ], [ "wire_mesh", 4 ], [ "fibercloth_patchwork", 4 ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Adjust slow-sand water filter to use innawood materials

#### Purpose of change
The water filtration system added to DDA was causing problems for innawood.

#### Describe the solution
Switch from a bucket to a clay hydria. Change the material of the filter to clay.

#### Testing
Saw the filter in the construction menu with the proper ingredients, spawned the item and it looks as intended.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
