### PR TITLE
Fix Psychopath butchery/dissection morale penalty

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -621,9 +621,12 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
                           !corpse.in_species( species_ZOMBIE ) );
 
     // Applies to all butchery actions except for dissections. Bloodfeeders are OK with draining humans for blood.
-    if( ( is_human && action != butcher_type::DISSECT && !( you.has_flag( json_flag_CANNIBAL ) ) ) || (
-            is_human && action == butcher_type::BLEED && !( you.has_flag( json_flag_BLOODFEEDER ) ) ) ||
-        you.has_flag( json_flag_PSYCHOPATH ) || you.has_flag( json_flag_SAPIOVORE ) ) {
+    if( is_human && 
+        action != butcher_type::DISSECT && 
+        !(  you.has_flag( json_flag_CANNIBAL ) || 
+            you.has_flag( json_flag_PSYCHOPATH ) || 
+            you.has_flag( json_flag_SAPIOVORE ) ||
+            (you.has_flag( json_flag_BLOODFEEDER) && action == butcher_type::BLEED) ) ) {
         // First determine if the butcherer has the dissect_humans proficiency.
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
             // If it's player doing the butchery, ask them first.


### PR DESCRIPTION
#### Summary
Characters with the Psychopath trait don't get a penalty, those without do.

#### Purpose of change
Fixes #392 "Psychopath receiving morale penalties for dissection." 

#### Describe the solution
Changed the logic.

#### Describe alternatives you've considered
None

#### Testing
Tried butchering and dissecting a zombie and an unfortunate starting NPC on a fresh character with the Psychopath trait.
=> No popup, no morale penalty.
Debug-removed Psychopath trait and tried the same.
=> Popups for NPC, no popup for the zombie. Got sad dissecting the NPC, as expected.

#### Additional context
None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
