### PR TITLE
Messenger Bag Fix

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1889,7 +1889,7 @@
     "name": { "str": "messenger bag" },
     "copy-from": "mbag",
     "sided": true,
-    "flags": [ "OUTER", "WATER_FRIENDLY", "OVERSIZE" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 4,


### PR DESCRIPTION
#### Summary
Move the transformed messenger bag from OUTER to OVERTOP

#### Purpose of change
Fixes a DDA bug where an adjusted messenger bag was fitting on the wrong layer. This was making it conflict with a lot of clothing and armor.

#### Describe the solution
Outer->overtop

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
