### PR TITLE
Replace libz with built-in copy on macOS <10.15

### DIFF
--- a/build-data/osx/Cataclysm.sh
+++ b/build-data/osx/Cataclysm.sh
@@ -13,6 +13,12 @@ else
     K_FRAMEWORK_PATH=DYLD_FALLBACK_FRAMEWORK_PATH
 fi
 
+V_OS_VERSION=$(sw_vers -productVersion | cut -d. -f1)
+if [[ "${V_OS_VERSION}" -lt 11 ]] && [[ ! -f "libz_patched.txt" ]]; then
+    cp "/usr/lib/libz.1.dylib" "libz.1.3.1.dylib"
+    echo "This file signifies (to the launch script) that libz.1.3.1.dylib has been patched by replacing it with /usr/lib/libz.1.dylib. This happened because the included libz is unreadable on Mac OS versions below 10.15. The game will function normally." > "libz_patched.txt"
+fi
+
 if [[ -f cataclysm ]]; then
     V_SHELL_SCRIPT="export PATH=${PATH} ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.; cd '${PWD}' && ./cataclysm; exit"
     osascript -e "tell application \"Terminal\" to activate do script \"${V_SHELL_SCRIPT}\""


### PR DESCRIPTION
#### Summary

The included libz is unreadable by macOS <10.15. In that case, we can replace it with a built-in copy.

#### Purpose of change

Let CTLG run on macOS 10.14 (and probably 10.13 because that's the compilation target, but I haven't checked).

#### Describe the solution

When launching CTLG for the first time, replace the included libz with a copy included in the OS. Then, write a sigil file so the replacement is only done once. 

#### Describe alternatives you've considered

It's theoretically possible that CTLG could directly use the OS copy of libz. I think this would make the process of building for macOS significantly different from other targets and generally seems like an avoidable can of worms.

#### Testing

Launched the game using the script from different states (including bad/missing libz) and made sure the sigil file prevents repeat copying.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
