### PR TITLE
Added chance to spawn both common and retail bionics to the High Tech…

### DIFF
--- a/data/json/mapgen/basement/basement_bionic.json
+++ b/data/json/mapgen/basement/basement_bionic.json
@@ -65,6 +65,8 @@
         { "group": "swimmer_set_any", "x": 11, "y": 8, "chance": 75, "repeat": [ 1, 4 ] },
         { "group": "cleaning", "x": [ 11, 12 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
         { "group": "surgery", "x": [ 8, 9 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
+        { "group": "bionics_common", "x": [ 3, 5 ], "y": 9, "chance": 30, "repeat": [ 1, 6 ] },
+        { "group": "bionics_retail", "x": [ 7, 9 ], "y": 9, "chance": 30, "repeat": [ 1, 3 ] },
         { "item": "television", "x": 21, "y": 16, "chance": 95 },
         { "item": "soap", "x": 19, "y": 21, "chance": 80 },
         { "item": "towel", "x": 20, "y": 21, "chance": 80 },

--- a/data/json/mapgen/basement/basement_bionic.json
+++ b/data/json/mapgen/basement/basement_bionic.json
@@ -65,14 +65,14 @@
         { "group": "swimmer_set_any", "x": 11, "y": 8, "chance": 75, "repeat": [ 1, 4 ] },
         { "group": "cleaning", "x": [ 11, 12 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
         { "group": "surgery", "x": [ 8, 9 ], "y": 9, "chance": 70, "repeat": [ 1, 2 ] },
-        { "group": "bionics_common", "x": [ 3, 5 ], "y": 9, "chance": 30, "repeat": [ 1, 6 ] },
-        { "group": "bionics_retail", "x": [ 7, 9 ], "y": 9, "chance": 30, "repeat": [ 1, 3 ] },
+        { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 100 },
+        { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 50 },
         { "item": "television", "x": 21, "y": 16, "chance": 95 },
         { "item": "soap", "x": 19, "y": 21, "chance": 80 },
-        { "item": "towel", "x": 20, "y": 21, "chance": 80 },
-        { "item": "towel", "x": 3, "y": 13, "chance": 60 },
-        { "item": "stereo", "x": 2, "y": 13, "chance": 50 }
-      ],
+        { "item": "towel", "x": 20, "y": 21, "chance": 80 },  
+        { "item": "towel", "x": 3, "y": 13, "chance": 60 }, 
+        { "item": "stereo", "x": 2, "y": 13, "chance": 50 } 
+      ],  
       "items": { "?": { "item": "autodoc_supplies", "chance": 100 } },
       "place_monster": [ { "monster": "mon_broken_cyborg", "x": 14, "y": 3, "chance": 100 } ]
     }


### PR DESCRIPTION
… Lowlife scenario

#### Summary
Category "Brief description"
Added chance for both Common and Retail Bionics to spawn in the High Tech Lowlife scenario. The chance of Retail Bionics to spawn is lower to reflect their increased value and lower availability in an underground clinic.

#### Purpose of change
To add CBMs to the High Tech Lowlife scenario

#### Describe the solution
Changed the Basement_Bionic mapgen to include CBM Spawns

#### Describe alternatives you've considered
Making the spawn Static rather than chance based to reduce variance.

#### Testing
Started with the scenario High Tech Lowlife sever times to verify the spawns were working.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
