### PR TITLE
Backport 74486 - Fix android build

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1989,13 +1989,13 @@ bool worldfactory::valid_worldname( const std::string &name, bool automated ) co
 
 bool WORLD::create_timestamp()
 {
-#if defined( TIME_UTC ) && !defined( MACOSX )
+#if defined( TIME_UTC ) && !defined( MACOSX ) && !defined(__ANDROID__)
     std::timespec t;
     if( std::timespec_get( &t, TIME_UTC ) != TIME_UTC ) {
         return false;
     }
 #else
-    // MinGW-w64 with pthread, MacOS, etc
+    // MinGW-w64 with pthread, MacOS, Android, etc
     timespec t;
     if( clock_gettime( CLOCK_REALTIME, &t ) != 0 ) {
         return false;


### PR DESCRIPTION
#### Summary
Backport DDA 74486 to fix android build

#### Purpose of change
STD::timespec doesn't exist in Android NDK's standard library. This backport from DDA switches to a different function.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
