### PR TITLE
Rubber spray fix

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -235,7 +235,8 @@
       { "group": "ammo_pocket_batteries_full", "prob": 50 },
       [ "pilot_light", 50 ],
       { "item": "duct_tape", "prob": 200, "charges": [ 50, 200 ] },
-      [ "rubber_spray_can", 20 ],
+      { "group": "rubber_sealant_spray", "prob": 10 },
+      { "group": "rubber_sealant_spray_used", "prob": 10 },
       [ "superglue", 100 ],
       [ "string_6", 100 ],
       [ "string_36", 100 ],
@@ -265,7 +266,7 @@
       { "item": "solder_wire", "prob": 50, "count": [ 2, 6 ] },
       { "item": "pilot_light", "prob": 50, "count": [ 1, 2 ] },
       { "item": "metal_tank_little", "prob": 50, "count": [ 1, 2 ] },
-      [ "rubber_spray_can", 20 ],
+      { "group": "rubber_sealant_spray", "prob": 20 },
       [ "metal_tank", 10 ],
       [ "jerrycan", 10 ],
       [ "rubber_cement", 50 ],
@@ -433,7 +434,7 @@
       { "item": "chem_turpentine", "prob": 20, "charges": [ 20, -1 ] },
       { "item": "silicone", "prob": 15, "charges": [ 29, -1 ], "container-item": "squeeze_tube", "sealed": true },
       { "item": "silicone", "prob": 35, "charges": [ 8, -1 ], "container-item": "squeeze_tube_small", "sealed": true },
-      [ "rubber_spray_can", 20 ]
+      { "group": "rubber_sealant_spray", "prob": 20 }
     ]
   },
   {
@@ -640,7 +641,7 @@
       { "item": "seatbelt", "prob": 10, "count": [ 3, 10 ] },
       { "item": "five-point_harness", "prob": 3, "count": [ 2, 4 ] },
       { "item": "rubber_cement", "prob": 15, "count": [ 3, 9 ] },
-      { "item": "rubber_spray_can", "prob": 3 },
+      { "group": "rubber_sealant_spray_used", "prob": 5 },
       [ "vac_mold", 1 ],
       [ "wheel_wide", 10 ],
       [ "wheel_bicycle", 10 ],
@@ -955,5 +956,17 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [ { "item": "hair_dye_kit", "prob": 100 }, { "group": "hair_dye", "prob": 90 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "rubber_sealant_spray",
+    "subtype": "collection",
+    "entries": [ { "item": "liquid_rubber_spray", "container-item": "rubber_spray_can", "charges": 10 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "rubber_sealant_spray_used",
+    "subtype": "collection",
+    "entries": [ { "item": "liquid_rubber_spray", "container-item": "rubber_spray_can", "charges": [ 0, 10 ] } ]
   }
 ]

--- a/data/json/mapgen/basement/basement_bionic.json
+++ b/data/json/mapgen/basement/basement_bionic.json
@@ -69,10 +69,10 @@
         { "group": "bionics_retail", "x": [ 3, 5 ], "y": 9, "chance": 50 },
         { "item": "television", "x": 21, "y": 16, "chance": 95 },
         { "item": "soap", "x": 19, "y": 21, "chance": 80 },
-        { "item": "towel", "x": 20, "y": 21, "chance": 80 },  
-        { "item": "towel", "x": 3, "y": 13, "chance": 60 }, 
-        { "item": "stereo", "x": 2, "y": 13, "chance": 50 } 
-      ],  
+        { "item": "towel", "x": 20, "y": 21, "chance": 80 },
+        { "item": "towel", "x": 3, "y": 13, "chance": 60 },
+        { "item": "stereo", "x": 2, "y": 13, "chance": 50 }
+      ],
       "items": { "?": { "item": "autodoc_supplies", "chance": 100 } },
       "place_monster": [ { "monster": "mon_broken_cyborg", "x": 14, "y": 3, "chance": 100 } ]
     }


### PR DESCRIPTION
#### Summary
Fix rubber sealant spray cans being empty all the time.

#### Purpose of change
They were empty

#### Describe the solution
Fill them

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
