### PR TITLE
Backport DDA 74649 - Vegan profession item substitutions

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -361,7 +361,7 @@
     "id": "kilt",
     "type": "ARMOR",
     "name": { "str": "kilt" },
-    "description": "No true Scotsman would leave home without his kilt.",
+    "description": "No true Scotsman would leave home without his kilt.  Kilts lack pockets and thus a belt and sporran are necessary accessories.",
     "weight": "500 g",
     "volume": "1500 ml",
     "price": "65 USD",
@@ -369,6 +369,27 @@
     "material": [ "wool" ],
     "symbol": "[",
     "looks_like": "skirt",
+    "color": "brown_yellow",
+    "warmth": 20,
+    "material_thickness": 0.3,
+    "flags": [ "VARSIZE" ],
+    "armor": [
+      { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
+      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+    ]
+  },
+  {
+    "id": "kilt_utility",
+    "type": "ARMOR",
+    "name": { "str": "utility kilt" },
+    "description": "Common among American nerds and rivetheads, the utility kilt is a durabable canvas kilt with a large front pocket.",
+    "weight": "500 g",
+    "volume": "1500 ml",
+    "price": "35 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "canvas" ],
+    "symbol": "[",
+    "looks_like": "kilt",
     "color": "dark_gray",
     "pocket_data": [
       {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -374,8 +374,10 @@
     "material_thickness": 0.3,
     "flags": [ "VARSIZE" ],
     "armor": [
-      { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
-      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+      { "coverage": 98, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+      "encumbrance": 3 },
+      { "coverage": 95, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+      "encumbrance": 0 }
     ]
   },
   {
@@ -401,14 +403,14 @@
       }
     ],
     "warmth": 20,
-    "material_thickness": 0.3,
+    "material_thickness": 0.5,
     "flags": [ "VARSIZE" ],
     "armor": [
       {
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "encumbrance": [ 8, 10 ]
+        "encumbrance": [ 4, 8 ]
       },
       {
         "coverage": 95,
@@ -448,7 +450,7 @@
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
-        "encumbrance": [ 12, 16 ]
+        "encumbrance": [ 6, 10 ]
       },
       {
         "coverage": 95,
@@ -1438,7 +1440,7 @@
     "flags": [ "VARSIZE" ],
     "armor": [
       {
-        "encumbrance": 4,
+        "encumbrance": 6,
         "coverage": 98,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -492,7 +492,7 @@
   {
     "type": "profession_item_substitutions",
     "item": "mask_ski",
-    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "balclava" ] } ]
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "balaclava" ] } ]
   },
   {
     "type": "profession_item_substitutions",
@@ -502,7 +502,7 @@
   {
     "type": "profession_item_substitutions",
     "trait": "VEGAN",
-    "sub": [ { "item": "dress_shoes", "new": [ "espadrilles" ] } ]
+    "sub": [ { "item": "dress_shoes", "new": [ "shoes_slip_on" ] } ]
   },
   {
     "type": "profession_item_substitutions",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -401,20 +401,108 @@
   },
   {
     "type": "profession_item_substitutions",
-    "trait": "WOOLALLERGY",
+    "item": "blazer",
     "sub": [
-      { "item": "blazer", "new": [ "jacket_leather" ] },
-      { "item": "hat_hunting", "new": [ "hat_cotton" ] },
-      { "item": "hat_newsboy", "new": [ "hat_cotton" ] },
-      { "item": "peacoat", "new": [ "jacket_flannel" ] },
-      { "item": "sweater", "new": [ "sweatshirt" ] },
-      { "item": "boots_winter", "new": [ "boots_fur" ] },
-      { "item": "cloak_wool", "new": [ "cloak_leather" ] },
-      { "item": "gloves_wool", "new": [ "gloves_leather" ] },
-      { "item": "socks_wool", "new": [ "socks" ] },
-      { "item": "kilt", "new": [ "kilt_leather" ] },
-      { "item": "mask_ski", "new": [ "balaclava" ] }
+      { "present": [ "WOOLALLERGY" ], "new": [ "jacket_leather" ] },
+      { "present": [ "VEGAN" ], "new": [ "jacket_light" ] }
     ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "jacket_leather",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "jacket_jean" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "leather_police_jacket",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "jacket_jean" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "pants_leather",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "jeans_skinny" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "motor_police_boots",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "motorbike_boots" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "boots",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "motorbike_boots" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "boots_hiking",
+    "sub": [
+      { "present": [ "VEGAN" ], "new": [ "motorbike_boots" ] }
+    ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "hat_hunting",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "hat_cotton" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "hat_newsboy",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "hat_cotton" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "peacoat",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "jacket_flannel" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "sweater",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "sweatshirt" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "boots_winter",
+    "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "boots_fur" ] }, { "present": [ "VEGAN" ], "new": [ "boots_faux_fur" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "cloak_wool",
+    "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "cloak_leather" ] }, { "present": [ "VEGAN" ], "new": [ "cloak" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "gloves_wool",
+    "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "gloves_leather" ] }, { "present": [ "VEGAN" ], "new": [ "gloves_light" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "socks_wool",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "socks" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "mask_ski",
+    "sub": [ { "present": [ "WOOLALLERGY", "VEGAN" ], "new": [ "balclava" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "item": "kilt",
+    "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "kilt_leather" ] }, { "present": [ "VEGAN" ], "new": [ "kilt_utility" ] } ]
+  },
+  {
+    "type": "profession_item_substitutions",
+    "trait": "VEGAN",
+    "sub": [ { "item": "dress_shoes", "new": [ "espadrilles" ] } ]
   },
   {
     "type": "profession_item_substitutions",
@@ -480,6 +568,7 @@
       { "present": [ "ANTIWHEAT", "ANTIJUNK", "MEATARIAN" ], "new": [ "fried_spam", "fork" ] },
       { "present": [ "LACTOSE" ], "absent": [ "ANTIWHEAT", "VEGETARIAN" ], "new": [ "hamburger" ] },
       { "present": [ "LACTOSE", "VEGETARIAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "sandwich_veggy" ] },
+      { "present": [ "VEGAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "sandwich_veggy" ] },
       {
         "present": [ "VEGETARIAN" ],
         "absent": [ "ANTIWHEAT", "LACTOSE" ],
@@ -492,7 +581,9 @@
     "item": "pizza_meat",
     "sub": [
       { "present": [ "VEGETARIAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "pizza_veggy" ] },
+      { "present": [ "VEGAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "pizza_veggy" ] },
       { "present": [ "VEGETARIAN", "ANTIWHEAT" ], "new": [ "veggy_salad", "fork" ] },
+      { "present": [ "VEGAN", "ANTIWHEAT" ], "new": [ "veggy_salad", "fork" ] },
       {
         "present": [ "ANTIWHEAT" ],
         "absent": [ "VEGETARIAN", "ANTIJUNK" ],
@@ -510,6 +601,7 @@
     "item": "pizza_veggy",
     "sub": [
       { "present": [ "ANTIWHEAT", "VEGETARIAN" ], "new": [ "veggy_salad", "fork" ] },
+      { "present": [ "ANTIWHEAT", "VEGAN" ], "new": [ "veggy_salad", "fork" ] },
       {
         "present": [ "ANTIWHEAT" ],
         "absent": [ "VEGETARIAN", "ANTIJUNK" ],

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -346,6 +346,19 @@
     "using": [ [ "tailoring_felt_patchwork", 20 ], [ "strap_small", 1 ], [ "clasps", 1 ] ]
   },
   {
+    "result": "kilt_utility",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "6 h",
+    "book_learn": [ [ "scots_tailor", 4 ], [ "scots_cookbook", 7 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ],
+    "using": [ [ "tailoring_canvas_patchwork", 7 ], [ "strap_small", 1 ], [ "clasps", 1 ] ]
+  },
+  {
     "result": "knee_pads",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -785,7 +785,7 @@ void json_item_substitution::load( const JsonObject &jo )
             itype_id old_it;
             sub.read( "item", old_it, true );
             if( check_duplicate_item( old_it ) ) {
-                sub.throw_error( "Duplicate definition of item" );
+                sub.throw_error( "Item substitutions can only be defined once.  Items with multiple substition traits should use arrays." );
             }
             s.trait_reqs.present.emplace_back( jo.get_string( "trait" ) );
             for( const JsonValue info : sub.get_array( "new" ) ) {


### PR DESCRIPTION
#### Summary
Backport DDA 74649 - Vegan profession item substitutions, plus additions

#### Purpose of change
fixes #440 

This was a desired PR for backport but it got bumped up because of a request.

#### Describe the solution
Backports the PR, adds a recipe for making the utility kilt, makes it out of canvas instead of cotton (really now!), brings its encumbrance in line with the other skirt-type items, updates said items, and assigns a few vegan substitutions for common profession items.

Subs in our slip-on shoes for DDA's espadrilles.

#### Describe alternatives you've considered

We need more substitutions defined but that's another PR.

#### Testing
Loads, can play as vegan razorgirl.

#### Additional context
![image](https://github.com/user-attachments/assets/a372fe6c-ae9e-416c-bf69-e37deb04bd40)
Vegan Razorgirl

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
