### PR TITLE
MA update addendum

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2399,6 +2399,16 @@ void Character::process_turn()
     clear_miss_reasons();
     migrate_items_to_storage( false );
 
+    if( grab_1.victim == nullptr || grab_1.victim->is_dead_state() ) {
+        for( const effect &eff : get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
+            const efftype_id effid = eff.get_id();
+            add_msg_debug( debugmode::DF_CHARACTER, "Orphan grabbing effect found and removed from %s.",
+                           disp_name() );
+            remove_effect( effid );
+        }
+        grab_1.clear();
+    }
+
     for( bionic &i : *my_bionics ) {
         if( i.incapacitated_time > 0_turns ) {
             i.incapacitated_time -= 1_turns;
@@ -2544,16 +2554,6 @@ void Character::process_turn()
             }
             it++;
         }
-    }
-
-    if( grab_1.victim == nullptr || grab_1.victim->is_dead_state() ) {
-        for( const effect &eff : get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
-            const efftype_id effid = eff.get_id();
-            add_msg_debug( debugmode::DF_CHARACTER, "Orphan grabbing effect found and removed from %s.",
-                           disp_name() );
-            remove_effect( effid );
-        }
-        grab_1.clear();
     }
 
     // Persist grabs as long as our target is adjacent.


### PR DESCRIPTION
#### Summary
Fix one more grappling-related crash

#### Purpose of change
It was still possible to crash the game while grappling if you turbo mashed the attack button.

#### Describe the solution
Move the nullptr/is_dead_state() check to the top of Character::process_turn() so that orphan grabs are cleared before anything else happens, no matter how fast you button mash.

#### Describe alternatives you've considered
Getting into hard drugs

#### Testing
Grappled things a lot and killed them and experienced no crashes or orphan grabs.

#### Additional context
There are probably still ways to get crashes and orphan grabs. They'll be fixed as we go.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
