### PR TITLE
Reduce incidence and lifespan of shockers

### DIFF
--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -152,9 +152,11 @@
     "name": "GROUP_ZOMBIE_ELECTRIC_UPGRADE",
     "//": "Note that 'freq' units are tenth of a percent, with default filling in the gap.",
     "monsters": [
-      { "monster": "mon_zombie_nullfield", "weight": 400 },
-      { "monster": "mon_zombie_brute_shocker", "weight": 300 },
-      { "monster": "mon_skeleton_electric", "weight": 300 }
+      { "monster": "mon_zombie_nullfield", "weight": 40 },
+      { "monster": "mon_zombie_scorched", "weight": 800 },
+      { "monster": "mon_zombie_electric", "weight": 100 },
+      { "monster": "mon_zombie_brute_shocker", "weight": 30 },
+      { "monster": "mon_skeleton_electric", "weight": 30 }
     ]
   },
   {

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -120,7 +120,7 @@
       { "monster": "mon_zombie_hazmat", "weight": 100, "cost_multiplier": 3 },
       { "monster": "mon_zombie_fireman", "weight": 100, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 100, "cost_multiplier": 5 },
-      { "monster": "mon_zombie_static", "weight": 100, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 5, "cost_multiplier": 5 },
       { "monster": "mon_zombie_paramilitary", "weight": 10, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor", "weight": 10, "cost_multiplier": 25, "starts": "30 days" },
       { "monster": "mon_zombie_survivor_elite", "weight": 10, "cost_multiplier": 25, "starts": "60 days" },
@@ -160,7 +160,7 @@
       { "monster": "mon_zombie_hazmat", "weight": 10, "cost_multiplier": 3 },
       { "monster": "mon_zombie_fireman", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 10, "cost_multiplier": 5 },
-      { "monster": "mon_zombie_static", "weight": 10, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 2, "cost_multiplier": 5 },
       { "monster": "mon_zombie_paramilitary", "weight": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor", "weight": 1, "cost_multiplier": 25, "starts": "30 days" },
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "60 days" },
@@ -263,7 +263,7 @@
       { "monster": "mon_zombie_dog", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_dog_zombie_rot", "weight": 5, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_static", "weight": 30, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 6, "cost_multiplier": 5 },
       { "monster": "mon_zombie_paramilitary", "weight": 10, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor", "weight": 1, "cost_multiplier": 25, "starts": "30 days" },
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "60 days" }
@@ -302,7 +302,7 @@
       { "monster": "mon_dog_zombie_cop", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_dog_zombie_rot", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_static", "weight": 30, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 6, "cost_multiplier": 5 },
       { "monster": "mon_feral_prepper", "weight": 1, "cost_multiplier": 2, "starts": "10 days" },
       { "monster": "mon_feral_survivalist", "weight": 1, "cost_multiplier": 2, "starts": "29 days" },
       { "monster": "mon_zombie_paramilitary", "weight": 1, "cost_multiplier": 25 },
@@ -357,7 +357,7 @@
       { "monster": "mon_dog_zombie_cop", "weight": 15, "cost_multiplier": 2 },
       { "monster": "mon_dog_zombie_rot", "weight": 40, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_static", "weight": 30, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 6, "cost_multiplier": 5 },
       { "monster": "mon_zombie_paramilitary", "weight": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor", "weight": 1, "cost_multiplier": 25, "starts": "270 hours" },
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "540 hours" },
@@ -413,7 +413,7 @@
       { "monster": "mon_dog_zombie_cop", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_dog_zombie_rot", "weight": 10, "cost_multiplier": 2 },
       { "monster": "mon_zombie_swimmer_base", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_static", "weight": 30, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 6, "cost_multiplier": 5 },
       { "monster": "mon_zombie_paramilitary", "weight": 1, "cost_multiplier": 25 },
       { "monster": "mon_zombie_survivor", "weight": 1, "cost_multiplier": 25, "starts": "270 hours" },
       { "monster": "mon_zombie_survivor_elite", "weight": 1, "cost_multiplier": 25, "starts": "540 hours" }
@@ -430,7 +430,8 @@
       { "monster": "mon_zombie_tough", "weight": 654, "cost_multiplier": 5 },
       { "monster": "mon_zombie_rot", "weight": 6, "cost_multiplier": 5 },
       { "monster": "mon_zombie_crawler", "weight": 4, "cost_multiplier": 5 },
-      { "monster": "mon_zombie_static", "weight": 200, "cost_multiplier": 5 }
+      { "monster": "mon_zombie_technician", "weight": 80 },
+      { "monster": "mon_zombie_static", "weight": 100, "cost_multiplier": 5 }
     ]
   },
   {

--- a/data/json/monsters/zed_burned.json
+++ b/data/json/monsters/zed_burned.json
@@ -29,7 +29,6 @@
     "vision_night": 3,
     "harvest": "zombie_humanoid",
     "death_function": { "effect": { "id": "death_zombie_kinderling", "min_level": 4 }, "message": "The %s explodes!" },
-    "upgrades": { "half_life": 28, "into_group": "GROUP_CHILD_ZOMBIE_UPGRADE" },
     "flags": [ "SEES", "HEARS", "STUMBLES", "POISON", "GRABS", "NO_BREATHE", "REVIVES", "REVIVES_HEALTHY", "NO_NECRO", "FILTHY" ],
     "armor": { "bash": 4, "cut": 5, "acid": 3, "heat": 15, "bullet": 4, "electric": 3 }
   },
@@ -64,7 +63,6 @@
     "harvest": "zombie_humanoid",
     "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
     "special_attacks": [ { "id": "smash", "throw_strength": 30, "cooldown": 30 }, { "id": "grab", "cooldown": 7 } ],
-    "upgrades": { "half_life": 42, "into_group": "GROUP_ZOMBIE_BRUTE" },
     "flags": [ "SEES", "HEARS", "GRABS", "STUMBLES", "POISON", "NO_BREATHE", "REVIVES", "REVIVES_HEALTHY", "NO_NECRO", "FILTHY" ],
     "armor": { "bash": 6, "cut": 12, "acid": 5, "heat": 15, "bullet": 10, "electric": 3 }
   },
@@ -98,7 +96,7 @@
     "grab_strength": 20,
     "special_attacks": [ { "id": "grab", "cooldown": 7 } ],
     "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
-    "upgrades": { "half_life": 28, "into_group": "GROUP_ZOMBIE_UPGRADE" },
+    "upgrades": { "half_life": 40, "into": "mon_zombie_fiend" },
     "flags": [ "SEES", "HEARS", "STUMBLES", "POISON", "NO_BREATHE", "REVIVES", "REVIVES_HEALTHY", "NO_NECRO", "FILTHY" ],
     "armor": { "bash": 2, "cut": 9, "acid": 3, "heat": 15, "bullet": 7, "electric": 3 }
   },
@@ -107,6 +105,7 @@
     "type": "MONSTER",
     "description": "A heavily burned zombie that still reeks of charred meat.  Its flesh has mended into a leathery shell.  This one appears to have metal fragments sticking out of its body.",
     "copy-from": "mon_zombie_scorched",
+    "upgrades": { "half_life": 40, "into": "mon_zombie_fiend_rust" },
     "harvest": "zombie_rust"
   },
   {

--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -23,6 +23,7 @@
     "melee_damage": [ { "damage_type": "electric", "amount": 4 }, { "damage_type": "cut", "amount": 2 } ],
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_electromagnetics" ],
+    "upgrades": { "half_life": 9, "into": "mon_zombie_fiend" },
     "bleed_rate": 0,
     "vision_night": 3,
     "luminance": 16,
@@ -80,7 +81,7 @@
     "special_attacks": [ [ "PARROT", 8 ], [ "SHOCKSTORM", 25 ] ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_drops": "default_zombie_death_drops",
-    "upgrades": { "half_life": 42, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
+    "upgrades": { "half_life": 12, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",
@@ -129,6 +130,7 @@
     "harvest": "zombie_humanoid_electric",
     "special_attacks": [ [ "PARROT", 5 ] ],
     "emit_fields": [ { "emit_id": "emit_shock_cloud", "delay": "1 s" } ],
+    "upgrades": { "half_life": 6, "into": "mon_zombie_fiend" },
     "special_when_hit": [ "ZAPBACK", 75 ],
     "death_drops": "default_zombie_death_drops",
     "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "POISON", "ELECTRIC", "NO_BREATHE", "REVIVES", "ELECTRIC_FIELD", "FILTHY" ]
@@ -163,7 +165,7 @@
     "harvest": "zombie_humanoid_electric",
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_drops": "default_zombie_death_drops",
-    "upgrades": { "half_life": 28, "into": "mon_zombie_electric" },
+    "upgrades": { "half_life": 24, "into": "mon_zombie_electric" },
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
#### Summary
Give shocker zombies a short lifespan and make them very rare

#### Purpose of change
Shockers are really oppressive enemies that are super cool, but ruined by their ubiquity. Rather than being an odd surprise, they're constant, pushing players to want to always have shockproof gear. That's not ideal!

#### Describe the solution
- Shockers are about 1/20th as common as they were in the general zombie pools.
- Shockers have a short lifespan, generally becoming scorched zombies (or fiends) within about a week.
- Shocker brutes etc. still exist, and also have short lifespans.
- Zaptors are less common, but don't have a shortened lifespan because they're already part of another monster's lifespan and there wasn't a burned variant so I don't care that much.
- Shockers still show up at more or less the same rate in power plants and other industrial locations.
- Masters still upgrade zombies into shockers at the same rate as ever.
- Scorched zombies no longer upgrade into normal types, but into fiends, which are an endstage evolution. We probably need more burnt types, including a type that makes you regret setting all those house fires.

#### Describe alternatives you've considered
This isn't the end of this process. There will be things that upgrade regular zombies into shockers at specific times and places. That'll come later, for now I want these things off the street.

#### Testing
Spawned in and ran around, messed with the calendar, seems good.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
