### PR TITLE
Fix enemies attack order

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -843,13 +843,35 @@ void monster::move()
 
     const bool pacified = has_effect( effect_pacified );
 
+    uint attacks_size = type->special_attacks.size();
+
+    std::vector<uint> random;
+    uint array_offset = rng(0, attacks_size - 1);
+
+    // Offsets which special attack will be checked first by
+    // random number making it seems like its completely random
+    for (uint i = 0; i < attacks_size; i++)
+    {
+        uint value = i + array_offset;
+
+        if( value > attacks_size - 1) 
+            value -= attacks_size;
+
+        random.push_back(value);
+    }
+
+    std::vector<std::string> keys_copy;
+    for( const auto &sp_type : type->special_attacks )
+        keys_copy.push_back(sp_type.first);
+    
     // First, use the special attack, if we can!
     // The attack may change `monster::special_attacks` (e.g. by transforming
     // this into another monster type). Therefore we can not iterate over it
     // directly and instead iterate over the map from the monster type
     // (properties of monster types should never change).
-    for( const auto &sp_type : type->special_attacks ) {
-        const std::string &special_name = sp_type.first;
+    for (uint i = 0; i < attacks_size; i++)
+    {
+        const std::string &special_name = keys_copy[random[i]];
         const auto local_iter = special_attacks.find( special_name );
         if( local_iter == special_attacks.end() ) {
             continue;
@@ -858,14 +880,13 @@ void monster::move()
         if( !local_attack_data.enabled ) {
             continue;
         }
-
         add_msg_debug( debugmode::DF_MATTACK, "%s attempting a special attack %s, cooldown %d", name(),
-                       sp_type.first, local_attack_data.cooldown );
+                       special_name, local_attack_data.cooldown );
 
         // Cooldowns are decremented in monster::process_turn
-
+        const mtype_special_attack &attack_ref = type->special_attacks.at(keys_copy[random[i]]);
         if( local_attack_data.cooldown == 0 && !pacified && !is_hallucination() ) {
-            if( !sp_type.second->call( *this ) ) {
+            if( !attack_ref->call( *this ) ) {
                 add_msg_debug( debugmode::DF_MATTACK, "Attack failed" );
                 continue;
             }


### PR DESCRIPTION
#### Summary
Fixes an issue where enemies will always pick first attack in the list, which is always in alphabetical order causing enemies to always use same attack when possible f.e zombie always trying to grab player instead of trying to scratch them.

#### Purpose of change
Read below.

#### Describe the solution
Instead of iterating attacks list from the start, now it doesn't make it fully random, but just offsets attacks list by random number to start iterating from different attack (bite, grab, scratch) -> (scratch, bite, grab).

#### Describe alternatives you've considered
Make it fully random.

#### Testing
Skeletal juggernaut leaves our throat alone and picks other attacks.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
