### PR TITLE
Backport 76969 - fix spells segfaulting from wrong creature

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1170,7 +1170,7 @@ bool spell::can_learn( const Character &guy ) const
     return guy.has_trait( type->spell_class );
 }
 
-int spell::get_amount_of_projectiles( const Character &guy ) const
+int spell::get_amount_of_projectiles( const Creature &guy ) const
 {
     dialogue d( get_talker_for( guy ), nullptr );
     return type->multiple_projectiles.evaluate( d );

--- a/src/magic.h
+++ b/src/magic.h
@@ -590,7 +590,8 @@ class spell
         bool can_cast( const Character &guy ) const;
         // can the Character learn this spell?
         bool can_learn( const Character &guy ) const;
-        int get_amount_of_projectiles( const Character &guy ) const;
+        // if spell shoots more than one projectile
+        int get_amount_of_projectiles( const Creature &guy ) const;
         // is this spell valid
         bool is_valid() const;
         int bps_affected() const;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -654,7 +654,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 val.amount *= damage_mitigation_multiplier;
             }
             if( cr->as_character() != nullptr && ( liquid_damage_target || !liquid ) ) {
-                int multishot = sp.get_amount_of_projectiles( *caster.as_character() );
+                int multishot = sp.get_amount_of_projectiles( caster );
                 std::vector<bodypart_id> target_bdpts = cr->get_all_body_parts( get_body_part_flags::only_main );
 
                 if( sp.bps_affected() > 0 ) {


### PR DESCRIPTION
#### Summary
Backport 76969 - fix spells segfaulting from wrong creature

#### Purpose of change
The game was crashing when monsters cast damaging spells.

#### Describe the solution
Backport stops assuming spells only come from characters.

#### Testing
Compiles, runs, bombardier boomers and phase shrikes no longer crash the game.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
