### PR TITLE
Borrow 74754 fix

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3343,7 +3343,7 @@ static void map_extra()
     if( mx_choice >= 0 && mx_choice < static_cast<int>( mx_str.size() ) ) {
         const tripoint_abs_omt where_omt( ui::omap::choose_point( true ) );
         if( where_omt != overmap::invalid_tripoint ) {
-            tinymap mx_map;
+            smallmap mx_map;
             mx_map.load( where_omt, false );
             MapExtras::apply_function( mx_str[mx_choice], mx_map, where_omt );
             g->load_npcs();


### PR DESCRIPTION
#### Summary
Debug mx spawn tinymap -> smallmap

#### Purpose of change
Backport 74754 fix to debug location spawns

#### Describe the solution
Backport manually (for some reason the script isn't working) with attribution in commit comment.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
