### PR TITLE
Firestarting bug fix

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2036,6 +2036,10 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
         inv_s.add_nearby_items( PICKUP_RANGE );
         inv_s.add_character_items( *you );
 
+        // Removes firestarter from potential tinder options
+        item *firestarter_ptr = act->targets.front().get_item();
+        inv_s.RemoveItem(firestarter_ptr);
+
         inv_s.set_title( _( "Select tinder to use for lighting a fire" ) );
 
         item_location tinder;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2093,6 +2093,38 @@ void inventory_selector::add_character_items( Character &character )
     }
 }
 
+bool inventory_column::RemoveItem(item *&remove)
+{
+    for (inventory_entry &entry : entries)
+    {
+        std::vector<item_location> &item_locations = entry.locations;
+        for (unsigned int i = 0; i < item_locations.size(); i++)
+        {
+            if (item_locations.at(i).get_item() == remove)
+            {
+                item_locations.erase(item_locations.begin() + i);
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void inventory_selector::RemoveItem(item *&remove)
+{
+    for (inventory_column *column : columns)
+        if (column->RemoveItem(remove))
+            return;
+
+    if (own_inv_column.RemoveItem(remove))
+        return;
+    if (own_gear_column.RemoveItem(remove))
+        return;
+    if (map_column.RemoveItem(remove))
+        return;
+}
+
 void inventory_selector::add_map_items( const tripoint &target )
 {
     map &here = get_map();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -363,6 +363,11 @@ class inventory_column
             return true;
         }
 
+        // Removes reference to item from column
+        // True means item was found and removed
+        // False means no item was found
+        bool RemoveItem(item *&remove);
+
         size_t page_index() const {
             return page_of( page_offset );
         }
@@ -620,6 +625,8 @@ class inventory_selector
         void add_nearby_items( int radius = 1 );
         void add_remote_map_items( tinymap *remote_map, const tripoint &target );
         void add_basecamp_items( const basecamp &camp );
+
+        void RemoveItem(item *&remove);
         /** Remove all items */
         void clear_items();
         /** Assigns a title that will be shown on top of the menu. */


### PR DESCRIPTION
#### Summary
Fixes a bug where you can try to use firestarter object as a tinder making you fail to start fire, cause firestarter is moved to fireplace position.

#### Purpose of change
Bug fix.

#### Describe the solution
After collecting all possible tinder options RemoveItem is run and compare to all possible options we got to the firestarter item and if items pointers are the same(items point to the same object in memory) item is removed from possible tinder list.

#### Describe alternatives you've considered
Due to the way the code is structured, it's the simplest solution I could think of.

#### Testing
Tested with 2 matchboxes, one is empty and other is full with no other option to start fire. Before fix both showed up and on trying to start fire with full matchbox we failed to start fire. After fix only empty showed up.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
