### PR TITLE
Deadlier but more variable grenades

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -621,12 +621,12 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
                           !corpse.in_species( species_ZOMBIE ) );
 
     // Applies to all butchery actions except for dissections. Bloodfeeders are OK with draining humans for blood.
-    if( is_human && 
-        action != butcher_type::DISSECT && 
-        !(  you.has_flag( json_flag_CANNIBAL ) || 
-            you.has_flag( json_flag_PSYCHOPATH ) || 
-            you.has_flag( json_flag_SAPIOVORE ) ||
-            (you.has_flag( json_flag_BLOODFEEDER) && action == butcher_type::BLEED) ) ) {
+    if( is_human &&
+        action != butcher_type::DISSECT &&
+        !( you.has_flag( json_flag_CANNIBAL ) ||
+           you.has_flag( json_flag_PSYCHOPATH ) ||
+           you.has_flag( json_flag_SAPIOVORE ) ||
+           ( you.has_flag( json_flag_BLOODFEEDER ) && action == butcher_type::BLEED ) ) ) {
         // First determine if the butcherer has the dissect_humans proficiency.
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
             // If it's player doing the butchery, ask them first.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2255,22 +2255,26 @@ bool Character::movement_mode_is( const move_mode_id &mode ) const
 
 bool Character::is_running() const
 {
-    return move_mode->type() == move_mode_type::RUNNING;
+    return move_mode->type() == move_mode_type::RUNNING && !has_effect( effect_downed ) &&
+           !has_effect( effect_lying_down );
 }
 
 bool Character::is_walking() const
 {
-    return move_mode->type() == move_mode_type::WALKING;
+    return move_mode->type() == move_mode_type::WALKING && !has_effect( effect_downed ) &&
+           !has_effect( effect_lying_down );
 }
 
 bool Character::is_crouching() const
 {
-    return move_mode->type() == move_mode_type::CROUCHING;
+    return move_mode->type() == move_mode_type::CROUCHING && !has_effect( effect_downed ) &&
+           !has_effect( effect_lying_down );
 }
 
 bool Character::is_prone() const
 {
-    return move_mode->type() == move_mode_type::PRONE;
+    return move_mode->type() == move_mode_type::PRONE || has_effect( effect_downed ) ||
+           has_effect( effect_lying_down );
 }
 
 int Character::footstep_sound() const

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -448,8 +448,10 @@ static std::vector<tripoint> shrapnel( const Creature *source, const tripoint &s
         if( damage > 0 && critter && !critter->is_dead_state() ) {
             std::poisson_distribution<> d( cloud.density );
             int hits = d( rng_get_engine() );
-            hits = std::max( 0, rng( ( -hits / 2.5 ) / critter->ranged_target_size(),
-                                     hits * critter->ranged_target_size() ) );
+            double size_1 = rng_float( critter->ranged_target_size() + 1.0, 5.0 );
+            double size_2 = rng_float( critter->ranged_target_size(), std::min( 5.0,
+                                       critter->ranged_target_size() + 1.0 ) );
+            hits = rng( ( -hits / size_1 ), ( hits * size_2 ) );
             dealt_projectile_attack frag;
             frag.proj = proj;
             frag.proj.speed = cloud.velocity;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -607,9 +607,14 @@ double Creature::ranged_target_size() const
     if( const Character *character = this->as_character() ) {
         if( character->is_crouching() || ( character->has_effect( effect_quadruped_full ) &&
                                            character->is_running() ) ) {
-            stance_factor = 0.6;
+            stance_factor = 0.75;
         } else if( character->is_prone() ) {
-            stance_factor = 0.25;
+            stance_factor = 0.5;
+        }
+    }
+    if( const monster *monster = this->as_monster() ) {
+        if( monster->has_effect( effect_downed ) ) {
+            stance_factor = 0.5;
         }
     }
     if( has_flag( mon_flag_HARDTOSHOOT ) ) {


### PR DESCRIPTION
#### Summary
Grenades are deadlier but more variable, improved crouch/prone behavior

#### Purpose of change
fixes #459 

Grenades were undertuned, being way too safe to be near and not effective enough on monsters.

#### Describe the solution
- Rework the shrapnel calculations, reducing the likelihood that no shrapnel will hit a target, and allowing targets to be hit by more shrapnel than was previously possible. It's now also more likely that instead of taking minimal damage or getting whammied, you'll get something in between, especially if you armor up.
- Reduce the effectiveness of crouching and going prone. Previously they were 0.6 and 0.25 stance_factor, now they're 0.75 and 0.5. Going prone is still very effective, but not foolproof.
- Ensure that characters who have the lying_down or downed effects are given the benefit of stance_factor.
- Extend the same courtesy to monsters.

#### Testing

![image](https://github.com/user-attachments/assets/b57b788f-e531-4035-9a1f-20e538dd697f)
![image](https://github.com/user-attachments/assets/da401d80-e1ad-4de0-b3c5-1e71bc5452d2)

Lying down one tile away from a grenade is often but not invariably fatal. You can still get hit pretty hard if you're within a few tiles, so exercise due caution.

Land mines tend to do 70-100 damage to the zombie that stepped on them and a bit less to anyone standing adjacent to them. That seems about right, but maybe they need more range.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
