### PR TITLE
beef up mines but make them rarer

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -701,8 +701,8 @@
           "mx_specimen_van": 20
         }
       },
-      "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
-      "park": { "chance": 60, "extras": { "mx_fungal_zone": 40 } },
+      "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 60 } },
+      "park": { "chance": 60, "extras": { "mx_fungal_zone": 20 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 1, "mx_laststand": 1 } },
       "build": {
         "chance": 90,

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -701,7 +701,7 @@
           "mx_specimen_van": 20
         }
       },
-      "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 60 } },
+      "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 70 } },
       "park": { "chance": 60, "extras": { "mx_fungal_zone": 20 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 1, "mx_laststand": 1 } },
       "build": {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -699,7 +699,7 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( c, p, 18, 0.5, false, 8 );
+    explosion_handler::explosion( c, p, 80.0f, 0.5f, false, 30, 0.2f );
     get_map().remove_trap( p );
     return true;
 }


### PR DESCRIPTION
#### Summary
Reduce the number of mined bridges and make land mines hit a wider area

#### Purpose of change
Land mines were only affecting a 3x3 area and basically had no shrapnel to speak of. They were also way too common.

#### Describe the solution
- Adjust the casing size and power of land mines so that they function like weaker hand grenades
- Reduce incidence of mined bridges by 30%, as it was reported they were too common.

#### Testing
Land mines deal 90 to 140 damage to a zombie that steps on them. It's basically always a kill on a basic zom, and almost always on an unarmored survivor. What can I say: Don't step on land mines.

They can kill adjacent zombies too, but they're not excellent at it. This reflects IRL land mines, which are meant to wound and terrorize rather than simply evaporate all combatants.

During one test I got an unlucky hit from some shrapnel that one-shotted me even though I was standing about five tiles away from the explosion. Don't be a dummy!

#### Additional context
![image](https://github.com/user-attachments/assets/36a2fe63-b164-43b1-95aa-f5279e5ccf97)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
