### PR TITLE
Fix some issues with bionic faults

### DIFF
--- a/data/json/effects_on_condition/bionic_eocs.json
+++ b/data/json/effects_on_condition/bionic_eocs.json
@@ -111,7 +111,7 @@
     "condition": { "and": [ { "u_has_bionics": "bio_noise" }, { "not": { "u_has_effect": "narcosis" } } ] },
     "deactivate_condition": { "not": { "u_has_bionics": "bio_noise" } },
     "effect": [
-      { "u_make_sound": "Crackle!", "volume": 60, "type": "movement" },
+      { "u_make_sound": "Crackle!", "volume": 40, "type": "movement" },
       {
         "run_eocs": [
           {
@@ -137,8 +137,8 @@
   {
     "type": "effect_on_condition",
     "id": "bio_leaky",
-    "recurrence": [ "3 minutes", "9 minutes" ],
-    "condition": { "u_has_bionics": "bio_leaky" },
+    "recurrence": [ "6 minutes", "12 minutes" ],
+    "condition": { "and": [ { "u_has_bionics": "bio_leaky" }, { "one_in_chance": 2 } ] },
     "deactivate_condition": { "not": { "u_has_bionics": "bio_leaky" } },
     "effect": [ { "u_mod_healthy": -1, "cap": -200 } ]
   },

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -50,7 +50,7 @@
     "description": "You are wearing night vision goggles which allow you to see really well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
   },
   {
     "type": "enchantment",
@@ -59,7 +59,7 @@
     "description": "You are wearing night vision goggles which allow you to see quite well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 12 } ]
   },
   {
     "type": "enchantment",
@@ -68,7 +68,7 @@
     "description": "You are wearing night vision goggles which allow you to see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 6 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
   },
   {
     "type": "enchantment",
@@ -77,7 +77,7 @@
     "description": "You are wearing night vision goggles which allow you to poorly see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 4 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
   },
   {
     "id": "ench_climate_control_warm",

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -41,7 +41,7 @@
     "type": "enchantment",
     "id": "SQUEAKY_ANKLES",
     "condition": "ALWAYS",
-    "values": [ { "value": "FOOTSTEP_NOISE", "multiply": 3 } ]
+    "values": [ { "value": "FOOTSTEP_NOISE", "multiply": 1.0 } ]
   },
   {
     "type": "enchantment",
@@ -50,7 +50,7 @@
     "description": "You are wearing night vision goggles which allow you to see really well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
   },
   {
     "type": "enchantment",
@@ -59,7 +59,7 @@
     "description": "You are wearing night vision goggles which allow you to see quite well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 12 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
   },
   {
     "type": "enchantment",
@@ -68,7 +68,7 @@
     "description": "You are wearing night vision goggles which allow you to see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 6 } ]
   },
   {
     "type": "enchantment",
@@ -77,7 +77,7 @@
     "description": "You are wearing night vision goggles which allow you to poorly see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 4 } ]
   },
   {
     "id": "ench_climate_control_warm",


### PR DESCRIPTION
#### Summary
Fix some issues with bionic faults

#### Purpose of change
Bionic ankles were mistakenly quadrupling step sound instead of doubling it, resulting in some preposterous stomps. Bionic noisemaker was as loud as a gunshot, and leaky bionic was reducing health to -200 in like a day or two.

#### Describe the solution
- Bionic noisemaker now makes sound at volume 40. This is louder than a typical person's shout, but not gunshot-loud.
- Bionic ankles now double instead of quadrupling step sound.
- Leaky bionic triggers 1/2 as often and now only has a 50% rather than a 100% chance to reduce lifestyle. This will still make you unable to naturally heal within a couple of days (especially combined with the radiation you're getting from the other bionic). The idea is that you have about a week to get this crap out of you before it bricks your run.

#### Describe alternatives you've considered
- I should make more bad bionics.

#### Testing
- Loaded in and ran around. As a protoborg I saw my lifestyle drop over a couple of days rather than all at once.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
