### PR TITLE
Fix incorrect dda->tlg in macro def

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -976,13 +976,13 @@ endif
 
 ifeq ($(TARGETSYSTEM), LINUX)
   ifneq ($(PREFIX),)
-    DEFINES += -DPREFIX="$(PREFIX)" -tlgTA_DIR_PREFIX
+    DEFINES += -DPREFIX="$(PREFIX)" -DDATA_DIR_PREFIX
   endif
 endif
 
 ifeq ($(TARGETSYSTEM), CYGWIN)
   ifneq ($(PREFIX),)
-    DEFINES += -DPREFIX="$(PREFIX)" -tlgTA_DIR_PREFIX
+    DEFINES += -DPREFIX="$(PREFIX)" -DDATA_DIR_PREFIX
   endif
 endif
 


### PR DESCRIPTION
#### Summary
Fixes #468 

#### Purpose of change
The macro def flag `-DDATA_DIR_PREFIX` was replaced with `-tlgTA_DIR_PREFIX`. The DDA in this flag is not the name of the game.

#### Describe the solution
Change it back. I checked the rest of the repo for `-tlg`, this is the only sus occurrence.

#### Describe alternatives you've considered
Forking the compiler to recognize -tlg as a macro def that starts with DA.

#### Testing
@Reledia said it works.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
