### PR TITLE
Renamed data/xdg files' names to match the actual name of the produced files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1147,9 +1147,9 @@ install: version $(TARGET)
 	cp -R --no-preserve=ownership data/help $(DATA_PREFIX)
 ifeq ($(TILES), 1)
 	cp -R --no-preserve=ownership gfx $(DATA_PREFIX)
-	install -Dm644 -t $(SHARE_DIR)/applications/ data/xdg/com.cataclysm-tlg.cataclysm-tlg.desktop
-	install -Dm644 -t $(SHARE_DIR)/metainfo/ data/xdg/com.cataclysm-tlg.cataclysm-tlg.appdata.xml
-	install -Dm644 -t $(SHARE_DIR)/icons/hicolor/scalable/apps/ data/xdg/com.cataclysm-tlg.cataclysm-tlg.svg
+	install -Dm644 -t $(SHARE_DIR)/applications/ data/xdg/com.cataclysmtlg.CataclysmTLG.desktop
+	install -Dm644 -t $(SHARE_DIR)/metainfo/ data/xdg/com.cataclysmtlg.CataclysmTLG.appdata.xml
+	install -Dm644 -t $(SHARE_DIR)/icons/hicolor/scalable/apps/ data/xdg/com.cataclysmtlg.CataclysmTLG.svg
 endif
 ifeq ($(SOUND), 1)
 	cp -R --no-preserve=ownership data/sound $(DATA_PREFIX)


### PR DESCRIPTION
…d files

Renamed data/xdg files' names to match the actual name of the produced files

#### Summary
Category "Compiling"
The MAKEFILE was searching for the wrong files for the installation

#### Purpose of change
The MAKEFILE will be able to find the right files for the installation

#### Describe the solution
Change the name of the files inside the MAKEFILE

#### Describe alternatives you've considered
Noone

#### Testing
The compiling works with the command `make -j6 PREFIX=/usr PCH=0 CCACHE=1 RELEASE=1 USE_XDG_DIR=1 TESTS=0 LOCALIZE=1 LANGUAGES=all TILES=1 SOUND=1 install` and install correctly

#### Additional context
In order to work, it also needs the PR #476 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
