### PR TITLE
Fix some incorrect xdg filenames

### DIFF
--- a/data/xdg/com.cataclysmtlg.CataclysmTLG.appdata.xml
+++ b/data/xdg/com.cataclysmtlg.CataclysmTLG.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.cataclysmtlg.CataclysmTLG</id>
+  <id>com.cataclysm-tlg.cataclysm-tlg</id>
   <metadata_license>CC-BY-SA-3.0</metadata_license>
   <project_license>CC-BY-SA-3.0</project_license>
   <name>Cataclysm: The Last Generation</name>
@@ -60,7 +60,7 @@
   <url type="contribute">
     https://github.com/Cataclysm-TLG/Cataclysm-TLG
   </url>
-  <launchable type="desktop-id">org.cataclysmtlg.CataclysmTLG.desktop</launchable>
+  <launchable type="desktop-id">com.cataclysm-tlg.cataclysm-tlg.desktop</launchable>
   <provides>
     <binary>cataclysm-tiles</binary>
   </provides>

--- a/data/xdg/com.cataclysmtlg.CataclysmTLG.desktop
+++ b/data/xdg/com.cataclysmtlg.CataclysmTLG.desktop
@@ -2,7 +2,7 @@
 Name=Cataclysm: The Last Generation
 GenericName=Post-apocalyptic survival game
 Comment=A turn-based survival game set in a post-apocalyptic world.
-Icon=com.cataclysmtlg.CataclysmTLG
+Icon=com.cataclysm-tlg.cataclysm-tlg
 Type=Application
 Exec=cataclysm-tlg-tiles
 Categories=Game;RolePlaying;


### PR DESCRIPTION
#### Summary
Fix some incorrect xdg filenames

#### Purpose of change
Some xdg files were pointing to incorrect filenames. This fixes them to be consistent.

#### Describe the solution
cataclysmtlg->cataclysm-tlg

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
