### PR TITLE
Fix segfault from bad combat message indexing

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2551,19 +2551,21 @@ std::string melee_message( const ma_technique &tec, Character &p,
         }
     };
 
-    static const std::array<std::string, 6> player_bash = {{
+    static const std::array<std::string, 7> player_bash = {{
             translate_marker( "You clobber %s" ),
             translate_marker( "You smash %s" ),
             translate_marker( "You thrash %s" ),
+            translate_marker( "You bash %s" ),
             translate_marker( "You batter %s" ),
             translate_marker( "You whack %s" ),
             translate_marker( "You hit %s" )
         }
     };
-    static const std::array<std::string, 6> npc_bash = {{
+    static const std::array<std::string, 7> npc_bash = {{
             translate_marker( "<npcname> clobbers %s" ),
             translate_marker( "<npcname> smashes %s" ),
             translate_marker( "<npcname> thrashes %s" ),
+            translate_marker( "<npcname> bashes %s" ),
             translate_marker( "<npcname> batters %s" ),
             translate_marker( "<npcname> whacks %s" ),
             translate_marker( "<npcname> hits %s" )
@@ -2604,9 +2606,9 @@ std::string melee_message( const ma_technique &tec, Character &p,
     } else if( total_dam > 20 ) {
         index = cutting ? rng( 5, 6 ) : 3;
     } else if( total_dam > 10 ) {
-        index = cutting ? 7 : 4;
+        index = cutting ? 6 : 4;
     } else {
-        index = cutting ? 8 : 5;
+        index = cutting ? 7 : 5;
     }
 
     std::string message;


### PR DESCRIPTION
#### Summary
Fix segfault from bad combat message indexing

#### Purpose of change
#472 slightly changed the combat messaging in melee.cpp and I messed up the indexing on the combat messages (ie you clobber X for 72 damage!). This led to some segfaults if you did a lot of damage.

#### Describe the solution
Fix the index, add a message to make it easier to keep track of.

#### Testing
Tried a few different weapons, no segfaults.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
