### PR TITLE
Make messenger bag swappable when worn on hip

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1842,7 +1842,6 @@
     "id": "mbag",
     "type": "ARMOR",
     "name": { "str": "messenger bag" },
-    "//": "KA101's ran about $90 but is ballistic nylon.  Bit tougher than the DDA model.",
     "description": "Light and easy to wear, but doesn't offer much storage.",
     "weight": "690 g",
     "volume": "2625 ml",
@@ -1894,9 +1893,9 @@
       {
         "encumbrance": 4,
         "volume_encumber_modifier": 0.25,
-        "coverage": 40,
+        "coverage": 60,
         "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_hip_r", "leg_upper_r" ]
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
       }
     ],
     "use_action": { "type": "transform", "msg": "You move the bag to your back.", "menu_text": "Adjust", "target": "mbag", "moves": 120 }


### PR DESCRIPTION
#### Summary
Make messenger bag swappable when worn on hip

#### Purpose of change
Did you know you can activate the messenger bag to wear it at your side rather than on your back? You've always been able to, except it sort of didn't work right. The bag was laying over both legs, and its swap sides mechanic wasn't working. This was because swappable items can only go on one sub-bodypart. While that's an issue that deserves its own fix, this is easy enough to remedy here.

#### Describe the solution
Make the messenger bag just go on the hip, not the hip and leg_upper. It can now be worn on either side.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
