### PR TITLE
Curb preposterous armor penetration on insect attacks

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -649,7 +649,7 @@
     "melee_skill": 6,
     "melee_dice": 3,
     "melee_dice_sides": 6,
-    "melee_damage": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 25 } ],
+    "melee_damage": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 18 } ],
     "grab_strength": 75,
     "special_attacks": [
       {
@@ -667,7 +667,7 @@
         "type": "bite",
         "cooldown": 5,
         "move_cost": 100,
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 20, "armor_penetration": 110 } ],
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 20, "armor_penetration": 20 } ],
         "min_mul": 0.8,
         "max_mul": 1.1,
         "infection_chance": 3,
@@ -1883,7 +1883,7 @@
         "id": "sting",
         "move_cost": 300,
         "cooldown": 5,
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 10, "armor_penetration": 25 } ],
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 10, "armor_penetration": 8 } ],
         "min_mul": 0.5,
         "max_mul": 2
       },
@@ -1891,7 +1891,7 @@
         "type": "bite",
         "cooldown": 5,
         "move_cost": 130,
-        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 20 } ],
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 6 } ],
         "body_parts": [ [ "leg_l", 2 ], [ "leg_r", 2 ], [ "head", 1 ], [ "arm_l", 2 ], [ "arm_r", 2 ], [ "torso", 4 ] ],
         "min_mul": 0.5,
         "max_mul": 1.5,
@@ -1900,7 +1900,7 @@
       [ "EAT_CARRION", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
-    "//": "sting 5-15 damage, 8 hits to max intensity, 9 to max duration",
+    "//": "sting 10-15 damage, 8 hits to max intensity, 9 to max duration",
     "dodge": 7,
     "bleed_rate": 80,
     "weakpoint_sets": [ "wps_arthropod", "wps_arthropod_flying", "wps_arthropod_hymenoptera" ],
@@ -1951,7 +1951,7 @@
         "id": "sting",
         "cooldown": 5,
         "move_cost": 200,
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 60 } ],
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 14 } ],
         "min_mul": 1,
         "max_mul": 3,
         "effects": [ { "id": "venom_weaken", "duration": 600 }, { "id": "downed", "duration": 1, "chance": 50 } ]
@@ -1960,7 +1960,7 @@
         "type": "bite",
         "cooldown": 3,
         "move_cost": 100,
-        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 30 } ],
+        "damage_max_instance": [ { "damage_type": "cut", "amount": 10, "armor_penetration": 12 } ],
         "min_mul": 1,
         "max_mul": 3,
         "body_parts": [ [ "leg_l", 2 ], [ "leg_r", 2 ], [ "head", 1 ], [ "arm_l", 2 ], [ "arm_r", 2 ], [ "torso", 4 ] ],


### PR DESCRIPTION
#### Summary
Curb preposterous armor penetration on insect attacks

#### Purpose of change
Insects for some reason get to have a ton of armor penetration on their attacks, a power no other enemy type enjoys. This is unacceptable and it's weird that it's just this one enemy type. The giant wasp queen had 60 arpen on her sting and the armored centipede had ONE HUNDRED AND TEN on its bite. This is the epitome of lasagna design - layering a new mechanic over old unfixed systems that totally obviates them is not the way to go about things.

#### Describe the solution
Drop everything to like 10-20 tops. I don't really want one enemy type to have all this bespoke arpen when nobody else gets it, but it's not totally unreasonable for certain kinds of attacks - the player gets tons of arpen and nobody complains about that.

As a simple fix, for now I'll leave it in place and just bring it down to a reasonable level. Totally re-evaluating this stuff can come another time.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
