### PR TITLE
Fix Night Vision

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -50,7 +50,7 @@
     "description": "You are wearing night vision goggles which allow you to see really well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
+    "values": [ { "value": "NIGHT_VIS", "set": 24 } ]
   },
   {
     "type": "enchantment",
@@ -59,7 +59,7 @@
     "description": "You are wearing night vision goggles which allow you to see quite well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 12 } ]
+    "values": [ { "value": "NIGHT_VIS", "set": 22 } ]
   },
   {
     "type": "enchantment",
@@ -68,7 +68,7 @@
     "description": "You are wearing night vision goggles which allow you to see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+    "values": [ { "value": "NIGHT_VIS", "set": 20 } ]
   },
   {
     "type": "enchantment",
@@ -77,7 +77,7 @@
     "description": "You are wearing night vision goggles which allow you to poorly see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
+    "values": [ { "value": "NIGHT_VIS", "set": 18 } ]
   },
   {
     "id": "ench_climate_control_warm",

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -263,6 +263,7 @@
       "msg": "Your %s deactivates.",
       "target": "military_nvg"
     },
+    "relic_data": { "passive_effects": [ { "id": "nvg_bad" } ] },
     "armor": [ { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 20, "rigid_layer_only": true } ]
   },
   {
@@ -298,7 +299,6 @@
         "default_magazine": "medium_plus_battery_cell"
       }
     ],
-    "relic_data": { "passive_effects": [ { "id": "nvg_good" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
@@ -327,6 +327,7 @@
       "msg": "Your %s deactivates.",
       "target": "advanced_gpnvg"
     },
+    "relic_data": { "passive_effects": [ { "id": "nvg_good" } ] },
     "armor": [
       { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 15, "rigid_layer_only": true },
       { "covers": [ "head" ], "encumbrance": 3, "coverage": 80, "specifically_covers": [ "head_crown" ] }
@@ -365,7 +366,6 @@
         "default_magazine": "medium_plus_battery_cell"
       }
     ],
-    "relic_data": { "passive_effects": [ { "id": "nvg_good" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
@@ -394,6 +394,7 @@
       "msg": "Your %s deactivates.",
       "target": "enhanced_nvg"
     },
+    "relic_data": { "passive_effects": [ { "id": "nvg_great" } ] },
     "armor": [
       { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 10, "rigid_layer_only": true },
       { "covers": [ "head" ], "encumbrance": 3, "coverage": 80, "specifically_covers": [ "head_crown" ] }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2806,15 +2806,16 @@ float Character::get_vision_threshold( float light_level ) const
     }
 
     // bionic night vision and other old night vision flagged items
-    if( worn_with_flag( flag_GNV_EFFECT ) || has_flag( json_flag_NIGHT_VISION ) ) {
-        range += 10;
-    } else {
-        range = enchantment_cache->modify_value( enchant_vals::mod::NIGHT_VIS, range );
+    //if( worn_with_flag( flag_GNV_EFFECT ) || has_flag( json_flag_NIGHT_VISION ) ) {
+    //    range += 10;
+    //} else 
+    if( has_nv_goggles() ) {
+        range = std::max( 1.0f, enchantment_cache->modify_value( enchant_vals::mod::NIGHT_VIS, range ) );
+        return std::min( LIGHT_AMBIENT_LOW, threshold_for_range( range ) * dimming_from_light );
     }
 
     // Clamp range to 1+, so that we can always see where we are
     range = std::max( 1.0f, range * get_limb_score( limb_score_night_vis ) );
-
     return std::min( LIGHT_AMBIENT_LOW,
                      threshold_for_range( range ) * dimming_from_light );
 }

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -231,6 +231,7 @@ class enchantment
         }
         double get_value_add( enchant_vals::mod value, const Character &guy ) const;
         double get_value_multiply( enchant_vals::mod value, const Character &guy ) const;
+        double get_value_set( enchant_vals::mod value, const Character &guy ) const;
 
         body_part_set modify_bodyparts( const body_part_set &unmodified ) const;
         // does the enchantment modify bodyparts?
@@ -260,10 +261,12 @@ class enchantment
         // values that get multiplied to the base value
         // multipliers add to each other instead of multiply against themselves
         std::map<enchant_vals::mod, dbl_or_var> values_multiply; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, dbl_or_var> values_set; // NOLINT(cata-serialize)
 
         // the exact same as above, though specifically for skills
         std::map<skill_id, dbl_or_var> skill_values_add; // NOLINT(cata-serialize)
         std::map<skill_id, dbl_or_var> skill_values_multiply; // NOLINT(cata-serialize)
+        std::map<skill_id, dbl_or_var> skill_values_set; // NOLINT(cata-serialize)
 
         std::vector<fake_spell> hit_me_effect;
         std::vector<fake_spell> hit_you_effect;
@@ -298,10 +301,12 @@ class enchant_cache : public enchantment
         void activate_passive( Character &guy ) const;
         double get_value_add( enchant_vals::mod value ) const;
         double get_value_multiply( enchant_vals::mod value ) const;
+        double get_value_set( enchant_vals::mod value ) const;
         int mult_bonus( enchant_vals::mod value_type, int base_value ) const;
 
         int get_skill_value_add( const skill_id &value ) const;
         double get_skill_value_multiply( const skill_id &value ) const;
+        int get_skill_value_set( const skill_id &value ) const;
         int skill_mult_bonus( const skill_id &value_type, int base_value ) const;
         // attempts to add two like enchantments together.
         // if their conditions don't match, return false. else true.
@@ -324,6 +329,7 @@ class enchant_cache : public enchantment
 
         void set_has( enchantment::has value );
         void add_value_mult( enchant_vals::mod value, float mult_value );
+        void add_value_set( enchant_vals::mod value, int set_value );
         void add_hit_you( const fake_spell &sp );
         void add_hit_me( const fake_spell &sp );
         void load( const JsonObject &jo, std::string_view src = {},
@@ -338,10 +344,12 @@ class enchant_cache : public enchantment
         // values that get multiplied to the base value
         // multipliers add to each other instead of multiply against themselves
         std::map<enchant_vals::mod, double> values_multiply; // NOLINT(cata-serialize)
+        std::map<enchant_vals::mod, double> values_set; // NOLINT(cata-serialize)
 
         // the exact same as above, though specifically for skills
         std::map<skill_id, int> skill_values_add; // NOLINT(cata-serialize)
         std::map<skill_id, int> skill_values_multiply; // NOLINT(cata-serialize)
+        std::map<skill_id, int> skill_values_set; // NOLINT(cata-serialize)
 };
 
 template <typename E> struct enum_traits;


### PR DESCRIPTION
#### Summary
NVGs give you a set amount of night vision, mutations add to what you naturally have.

#### Purpose of change
NVGs were just adding to your night vision, meaning people with night vision mutations etc were better at using them, which doesn't make any sense.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
