### PR TITLE
Remove Apis

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2953,8 +2953,8 @@
     "connects_to": "WALL",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "PLACE_ITEM", "WALL", "NO_SCENT" ],
     "bash": {
-      "str_min": 12,
-      "str_max": 150,
+      "str_min": 11,
+      "str_max": 140,
       "sound": "crunch!",
       "sound_fail": "whump!",
       "ter_set": "t_floor_wax",

--- a/data/json/mapgen/bugs/beehive.json
+++ b/data/json/mapgen/bugs/beehive.json
@@ -85,8 +85,7 @@
         "                             ##############                             "
       ],
       "terrain": { "|": "t_wax", "#": "t_wax", ".": "t_floor_wax", ":": "t_floor_wax", "+": "t_floor_wax" },
-      "place_npcs": [ { "class": "apis", "x": 14, "y": 22 } ],
-      "item": { ".": { "item": "honeycomb", "chance": 1 }, ":": { "item": "royal_jelly", "chance": 10, "repeat": [ 1, 3 ] } },
+      "item": { ".": { "item": "honeycomb", "chance": 2 }, ":": { "item": "royal_jelly", "chance": 10, "repeat": [ 1, 3 ] } },
       "monster": { ".": { "group": "GROUP_BEEHIVE", "chance": 3 } }
     }
   },

--- a/data/json/mapgen/mi-go/mi-go_nested.json
+++ b/data/json/mapgen/mi-go/mi-go_nested.json
@@ -153,7 +153,7 @@
         "2": { "class": "mi-go_prisoner" },
         "3": { "class": "mi-go_prisoner" },
         "4": { "class": "mi-go_prisoner" },
-        "5": { "class": "apis" },
+        "5": { "class": "mi-go_prisoner" },
         "6": { "class": "mi-go_prisoner" },
         "7": { "class": "mi-go_prisoner" }
       },

--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -513,39 +513,6 @@
   },
   {
     "type": "npc_class",
-    "id": "NC_APIS",
-    "name": { "str": "Apis" },
-    "job_description": "I'm bugged - I shouldn't talk to you.",
-    "common": false,
-    "bonus_dex": { "rng": [ 5, 10 ] },
-    "bonus_int": { "rng": [ -4, -8 ] },
-    "bonus_per": { "rng": [ 4, 8 ] },
-    "skills": [
-      { "skill": "dodge", "level": { "dice": [ 2, 2 ] } },
-      { "skill": "melee", "level": { "dice": [ 2, 2 ] } },
-      { "skill": "unarmed", "level": { "dice": [ 2, 2 ] } }
-    ],
-    "worn_override": "EMPTY_GROUP",
-    "carry_override": "EMPTY_GROUP",
-    "weapon_override": "EMPTY_GROUP",
-    "//": "NPCs can't run yet and we want this one to be fast, so road runner.",
-    "//2": "This is a unique NPC who doesn't get randomly selected background traits",
-    "traits": [
-      [ "THRESH_INSECT", 100 ],
-      [ "BEE", 100 ],
-      [ "MANDIBLES", 100 ],
-      [ "TAIL_STING", 100 ],
-      [ "INSECT_ARMS_OK", 100 ],
-      [ "CHITIN3", 100 ],
-      [ "POISONOUS2", 100 ],
-      [ "PAINRESIST", 100 ],
-      [ "ADRENALINE", 100 ],
-      [ "FLEET2", 100 ],
-      [ "ANTENNAE", 100 ]
-    ]
-  },
-  {
-    "type": "npc_class",
     "id": "NC_HALLU",
     "name": { "str": "Real Person" },
     "job_description": "I'm just wandering, like a totally real and normal NP… person!",

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -481,34 +481,6 @@
   },
   {
     "type": "faction",
-    "id": "apis_hive",
-    "name": "Mutants Bees",
-    "likes_u": -25,
-    "respects_u": -25,
-    "known_by_u": false,
-    "size": 1,
-    "power": 10,
-    "//": "90 days worth of food for 1 person, at 3000kcal/day and full RDA of iron/calcium/vitC",
-    "fac_food_supply": { "calories": 270000000, "vitamins": { "iron": 8640, "calcium": 8640, "vitC": 8640 } },
-    "wealth": 0,
-    "relations": {
-      "apis_hive": {
-        "kill on sight": false,
-        "watch your back": true,
-        "share my stuff": true,
-        "guard your stuff": true,
-        "lets you in": true,
-        "defends your space": true,
-        "knows your voice": true
-      },
-      "free_merchants": { "kill on sight": true },
-      "old_guard": { "kill on sight": true },
-      "your_followers": { "kill on sight": true }
-    },
-    "description": "Mutant bees who hate everyone."
-  },
-  {
-    "type": "faction",
     "id": "isherwood_family",
     "name": "Isherwood family",
     "likes_u": 30,

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -23,18 +23,6 @@
   },
   {
     "type": "npc",
-    "id": "apis",
-    "//": "Bee mutant or mutant bee (supposed to be ambiguous). Should be 'it', but we'll go with 'she' because it's a bee.",
-    "name_unique": "Apis",
-    "class": "NC_APIS",
-    "gender": "female",
-    "attitude": 0,
-    "mission": 7,
-    "chat": "TALK_DONE",
-    "faction": "apis_hive"
-  },
-  {
-    "type": "npc",
     "id": "derelict_dweller",
     "//": "Crazy Person.",
     "name_suffix": "Psycho",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -447,7 +447,7 @@
       { "point": [ 0, 1, 0 ], "overmap": "hive_edge_01_north" },
       { "point": [ 0, 2, 0 ], "overmap": "hive_edge_02_north" },
       { "point": [ 1, 0, 0 ], "overmap": "hive_edge_10_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "hive_north", "camp": "apis_hive", "camp_name": "???" },
+      { "point": [ 1, 1, 0 ], "overmap": "hive_north" },
       { "point": [ 1, 2, 0 ], "overmap": "hive_edge_12_north" },
       { "point": [ 2, 0, 0 ], "overmap": "hive_edge_20_north" },
       { "point": [ 2, 1, 0 ], "overmap": "hive_edge_21_north" },


### PR DESCRIPTION
#### Summary
Remove the NPC named Apis

#### Purpose of change
Apis was always very weird. The source of a ton of bugs (people constantly disarming its bodyparts, or wondering why there was one in every beehive, or noticing them in mi-go towers) and never really had any story or anything. A long time ago, there was some indication that scientists had been messing with the giant bees, but that's all gone now.

We want mutant NPCs, but Apis was just a random bad guy with no loot. Meh.

#### Describe the solution
Delete

#### Testing
Compiled and ran, no warnings. Found a beehive, no Apis.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
