### PR TITLE
Fix debug mutation

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/changing_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/changing_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "changing_initiate_check",
-    "//": "Give player the CHANGING trait when they have enough basic mutagen in their blood.",
+    "//": "Give player the CHANGING trait when they have enough mutagen in their blood.",
     "recurrence": [ "30 m", "45 m" ],
     "condition": { "and": [ { "math": [ "u_vitamin('mutagen')", ">=", "450" ] }, { "not": { "u_has_flag": "CHANGING" } } ] },
     "deactivate_condition": { "u_has_flag": "CHANGING" },
@@ -86,10 +86,9 @@
     "type": "snippet",
     "category": "<CHANGING_ENDS>",
     "text": [
-      "You can palpably feel the churning sensation within fade, your mutation cut short by a lack of nutrients.",
-      "The strain of mutation fades, leaving a throbbing sensation like a bad headache.  Or an afterglow.",
-      "You're pulled back to reality as your body stops warping, leaving you in your current state for the time being.",
-      "Your mutation abruptly ends from a lack of nutrients.  Back to Earth for now."
+      "You can palpably feel the churning sensation within fade.",
+      "The strain of mutation fades, leaving a throbbing sensation like a bad headache.",
+      "You're pulled back to reality as your body stops warping, leaving you in your current state for the time being."
     ]
   }
 ]

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1893,7 +1893,7 @@ bool Character::mutate_towards( const trait_id &mut, const mutation_category_id 
 
 bool Character::mutate_towards( const trait_id &mut, const mutation_variant *chosen_var )
 {
-    return mutate_towards( mut, mutation_category_ANY, chosen_var );
+    return mutate_towards( mut, mutation_category_ANY, chosen_var, false );
 }
 
 bool Character::has_conflicting_trait( const trait_id &flag ) const


### PR DESCRIPTION
#### Summary
Fix debug menu mutation

#### Purpose of change
#485 broke debug menu mutations by making the ANY category require vitamins.

#### Describe the solution
- Slip in an exemption for debug stuff.
- Remove reference to "nutrients" in some mutagen messaging. Mutagen is NOT nutrients.

#### Testing
Mutated all the ways I could think of, purified, saw costs were appropriate at all times.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
