### PR TITLE
Recipe Tweaks

### DIFF
--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -392,6 +392,20 @@
     "byproducts": [ [ "scrap_leather", 2 ] ],
     "using": [ [ "tailoring_leather", 2 ] ]
   },
+    {
+    "result": "leather_pauldrons",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "time": "180 m",
+    "autolearn": true,
+    "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 2 ] ],
+    "using": [ [ "tailoring_leather_patchwork", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ]
+  },
   {
     "result": "chainmail_sleeves",
     "type": "recipe",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -731,7 +731,7 @@
     "time": "3 h",
     "autolearn": true,
     "reversible": { "time": "25 m" },
-    "using": [ [ "tailoring_cotton_patchwork", 40 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 6 ] ]
   },
   {
     "result": "sweatshirt",
@@ -2382,7 +2382,7 @@
     "time": "3 h 30 m",
     "autolearn": true,
     "reversible": true,
-    "using": [ [ "tailoring_felt_patchwork", 20 ] ]
+    "using": [ [ "tailoring_felt_patchwork", 6 ] ]
   },
   {
     "result": "chainmail_vest",


### PR DESCRIPTION
#### Summary
Category "Brief description"
Added/Updated armor recipes

#### Purpose of change
Leather Pauldrons are a requirement for crafting the leather armor suit, but didnt have a recipe
Hoodies require 40 sheets or approximately 69sqft (nice) of material
#### Describe the solution
Readded recipe for Leather Pauldrons. Based on leather vambraces as per Wormgirl
Lowered sheet requirement from 40/20 sheets to 6 or 12sqft
#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
