### PR TITLE
Improve NPC weapon selection

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4270,6 +4270,20 @@ body_part_set Character::exclusive_flag_coverage( const flag_id &flag ) const
     return worn.exclusive_flag_coverage( ret, flag );
 }
 
+double Character::dispersion_variance() const
+{
+return rng( 900.0 - ( std::min( 800.0,
+    ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
+            limb_score_vision ) ) / 2.0 ) ) ) ) ), -200 );
+}
+
+double Character::expected_dispersion_variance() const
+{
+    return (900.0 - ( std::min( 800.0,
+        ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
+                limb_score_vision ) ) / 2.0 ) ) ) ) ) - 200) / 2.0;
+}
+
 /*
  * Innate stats getters
  */

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4272,16 +4272,16 @@ body_part_set Character::exclusive_flag_coverage( const flag_id &flag ) const
 
 double Character::dispersion_variance() const
 {
-return rng( 900.0 - ( std::min( 800.0,
-    ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
-            limb_score_vision ) ) / 2.0 ) ) ) ) ), -200 );
+    return rng( 900.0 - ( std::min( 800.0,
+                                    ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
+                                            limb_score_vision ) ) / 2.0 ) ) ) ) ), -200 );
 }
 
 double Character::expected_dispersion_variance() const
 {
-    return (900.0 - ( std::min( 800.0,
-        ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
-                limb_score_vision ) ) / 2.0 ) ) ) ) ) - 200) / 2.0;
+    return ( 900.0 - ( std::min( 800.0,
+                                 ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
+                                         limb_score_vision ) ) / 2.0 ) ) ) ) ) - 200 ) / 2.0;
 }
 
 /*

--- a/src/character.h
+++ b/src/character.h
@@ -1050,6 +1050,12 @@ class Character : public Creature, public visitable
         /** Bitset of all the body parts covered only with items with `flag` (or nothing) */
         body_part_set exclusive_flag_coverage( const flag_id &flag ) const;
 
+        /** Stat-weighted RNG used in fire_gun() to ensure shooting is non deterministic. */
+        double dispersion_variance() const;
+
+        /** Average of the above calculation for aim prediction purposes. */
+        double expected_dispersion_variance() const;
+
         /** Processes effects which may prevent the Character from moving (bear traps, crushed, etc.).
          *  Returns false if movement is stopped. */
         bool move_effects( bool attacking ) override;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1998,8 +1998,10 @@ void npc::evaluate_best_attack( const Creature *target )
     compare( std::make_shared<npc_attack_melee>( null_item_reference() ) );
     visit_items( [&compare, this]( item * it, item * ) {
         // you can theoretically melee with anything.
+        if( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) {
         compare( std::make_shared<npc_attack_melee>( *it ) );
-        if( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) {
+        }
+        if( ( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) && ( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) ) {
             compare( std::make_shared<npc_attack_throw>( *it ) );
         }
         if( !it->type->use_methods.empty() ) {
@@ -2118,6 +2120,9 @@ item_location npc::find_reloadable()
     // TODO: Make it understand smaller and bigger magazines
     item_location reloadable;
     visit_items( [this, &reloadable]( item * node, item * parent ) {
+        if( !node->is_gun() && !node->is_tool() && !node->is_magazine() ) {
+            return VisitResponse::NEXT;
+        }
         if( !wants_to_reload( *this, *node ) ) {
             return VisitResponse::NEXT;
         }
@@ -2691,7 +2696,7 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
 
     // Same calculation as in @ref item::info
     // TODO: Extract into common method
-    double max_dispersion = get_weapon_dispersion( *( gun.target ) ).max() + at_recoil;
+    double max_dispersion = get_weapon_dispersion( *( gun.target ) ).max() + at_recoil + expected_dispersion_variance();
     double even_chance_range = range_with_even_chance_of_good_hit( max_dispersion );
     double confident_range = even_chance_range * confidence_mult();
     add_msg_debug( debugmode::DF_NPC, "confident_gun (%s<=%.2f) at %.1f", gun.tname(), confident_range,
@@ -4055,7 +4060,7 @@ bool npc::do_player_activity()
 
 double npc::evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const
 {
-    bool allowed = can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() );
+    bool allowed = ( !maybe_weapon.is_gun() && !is_worn( maybe_weapon ) && !maybe_weapon.has_flag( flag_INTEGRATED ) ) || ( can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() ) );
     // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
     // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
     // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
@@ -4064,7 +4069,7 @@ double npc::evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_sile
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",
                    disp_name( true ), maybe_weapon.type->get_id().str(), val_gun );
-    double val_melee = melee_value( maybe_weapon );
+    double val_melee = allowed ? melee_value( maybe_weapon ) : 0;
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a melee weapon to wield</color>.", disp_name( true ),
                    maybe_weapon.type->get_id().str(), val_melee );
@@ -4102,7 +4107,7 @@ item *npc::evaluate_best_weapon() const
                                              && node != &weap
                                              && node->type->get_id() == weap.type->get_id();
 
-        if( node->is_melee() || node->is_gun() ) {
+        if( ( node->is_melee() || node->is_gun() ) && ( !node->has_flag( flag_INTEGRATED ) && !is_worn( *node ) ) ) {
             weapon_value = evaluate_weapon( *node, can_use_gun, use_silent );
             if( weapon_value > best_value && !using_same_type_bionic_weapon ) {
                 best = const_cast<item *>( node );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1999,9 +1999,10 @@ void npc::evaluate_best_attack( const Creature *target )
     visit_items( [&compare, this]( item * it, item * ) {
         // you can theoretically melee with anything.
         if( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) {
-        compare( std::make_shared<npc_attack_melee>( *it ) );
+            compare( std::make_shared<npc_attack_melee>( *it ) );
         }
-        if( ( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) && ( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) ) {
+        if( ( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) &&
+            ( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) ) {
             compare( std::make_shared<npc_attack_throw>( *it ) );
         }
         if( !it->type->use_methods.empty() ) {
@@ -2696,7 +2697,8 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
 
     // Same calculation as in @ref item::info
     // TODO: Extract into common method
-    double max_dispersion = get_weapon_dispersion( *( gun.target ) ).max() + at_recoil + expected_dispersion_variance();
+    double max_dispersion = get_weapon_dispersion( *( gun.target ) ).max() + at_recoil +
+                            expected_dispersion_variance();
     double even_chance_range = range_with_even_chance_of_good_hit( max_dispersion );
     double confident_range = even_chance_range * confidence_mult();
     add_msg_debug( debugmode::DF_NPC, "confident_gun (%s<=%.2f) at %.1f", gun.tname(), confident_range,
@@ -4060,7 +4062,9 @@ bool npc::do_player_activity()
 
 double npc::evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const
 {
-    bool allowed = ( !maybe_weapon.is_gun() && !is_worn( maybe_weapon ) && !maybe_weapon.has_flag( flag_INTEGRATED ) ) || ( can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() ) );
+    bool allowed = ( !maybe_weapon.is_gun() && !is_worn( maybe_weapon ) &&
+                     !maybe_weapon.has_flag( flag_INTEGRATED ) ) || ( can_use_gun && maybe_weapon.is_gun() &&
+                             ( !use_silent || maybe_weapon.is_silent() ) );
     // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
     // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
     // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
@@ -4107,7 +4111,8 @@ item *npc::evaluate_best_weapon() const
                                              && node != &weap
                                              && node->type->get_id() == weap.type->get_id();
 
-        if( ( node->is_melee() || node->is_gun() ) && ( !node->has_flag( flag_INTEGRATED ) && !is_worn( *node ) ) ) {
+        if( ( node->is_melee() || node->is_gun() ) && ( !node->has_flag( flag_INTEGRATED ) &&
+                !is_worn( *node ) ) ) {
             weapon_value = evaluate_weapon( *node, can_use_gun, use_silent );
             if( weapon_value > best_value && !using_same_type_bionic_weapon ) {
                 best = const_cast<item *>( node );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1027,12 +1027,9 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun, item_loca
         dispersion_sources dispersion = get_weapon_dispersion( gun );
         dispersion.add_range( recoil_total() );
         dispersion.add_spread( proj.shot_spread );
-        // Shooting is never completely deterministic.
-        // Peak Human (18+) perception can get a bit better than - 200 variance, but it caps at -100.
-        double variance_min = 900.0 - ( std::min( 800.0,
-                                        ( 40.0 * ( get_per() * ( ( get_limb_score( limb_score_manip ) + get_limb_score(
-                                                limb_score_vision ) ) / 2.0 ) ) ) ) );
-        dispersion.add_range( rng( variance_min, -200 ) );
+
+        // Keeps shooting non-deterministic, but perception helps a lot.
+        dispersion.add_range( dispersion_variance() );
 
         bool first = true;
         bool headshot = false;


### PR DESCRIPTION
#### Summary
Improve NPC weapon selection

#### Purpose of change
NPCs have a long, long way to go. I want them to act like RPG party members. They're still a bit squirrely for that, but we can make a start of it here.

Somebody caught one trying to wield integrated weapons. I looked into this and saw that they were totally indiscriminate in selecting melee weapons, which was leading to the ancient and entirely stupid behavior of taking their armor off to hit you with it.

#### Describe the solution
- Worn and integrated items are no longer considered valid choices for melee or thrown weapons by NPCs.
- Moved the dispersion RNG to a standardized function, added another function that gets the average of whatever your RNG roll would be, and added that to the NPC's aim confidence calculation. I'm not 1000% sure this is working as intended, but it seemed to fix the issues related to higher than expected dispersion interfering with their AI.
- NPCs will no longer iterate through their entire inventory looking for things to reload. They will only try to reload tools, guns, and magazines. This was already effectively the case, but now we bail out much earlier which should save some CPU cycles.

#### Describe alternatives you've considered
- The player needs a shout command that is just "Switch to melee!" or "Switch to ranged!"
- Players need more feedback about why their NPCs are doing what they are doing. Can we declutter the dialog menu and create a simpler readout? User error is the cause of most NPC problems, so this would help a lot.
- Similarly, sometimes you'll set an NPC to use a gun but they'll use melee anyway because they are trying to keep up with you and they know they don't have time to aim. Giving an effect with a visible indicator or something might help.

#### Testing
Ran around with an NPC, gave her a knife and an MP5, got her to use either in various situations. Gave her fangs. She did not try to wield them.

#### Additional context
aouughhogohuhh

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
