### PR TITLE
Fix riot armor foot coverage

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -690,6 +690,7 @@
         "coverage": 75,
         "material": [ { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.5 } ],
         "specifically_covers": [ "foot_arch_l", "foot_arch_r", "foot_ankle_r", "foot_ankle_l" ],
+        "layers": [ "BELTED" ],
         "rigid_layer_only": true
       }
     ]


### PR DESCRIPTION
#### Summary
Fix riot armor foot coverage

#### Purpose of change
Riot armor has boot covers that were conflicting with other gear. This issue was not present in the riot leg guards, which are a component of riot armor.

#### Describe the solution
Give the foot part of riot armor the BELTED flag so it fits where it's supposed to. Now you can wear it with most shoes!

#### Testing
![image](https://github.com/user-attachments/assets/20c3b8a0-17ba-44c0-a311-79c474f2ef89)
Look at that, sneakers and all.

#### Additional context
You people are OBSESSED with riot armor.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
