### PR TITLE
Backport 74732 - map rotation fix

### DIFF
--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -37,6 +37,13 @@ tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m )
                tripoint_bub_ms( SEEX * m.getmapsize() - 1, SEEY * m.getmapsize() - 1, OVERMAP_HEIGHT ) );
 }
 
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z )
+{
+    return tripoint_range<tripoint_bub_ms>(
+               tripoint_bub_ms( 0, 0, z ),
+               tripoint_bub_ms( SEEX * m.getmapsize() - 1, SEEY * m.getmapsize() - 1, z ) );
+}
+
 std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate )
 {
@@ -47,6 +54,12 @@ std::optional<tripoint_bub_ms> random_point( const map &m,
         const std::function<bool( const tripoint_bub_ms & )> &predicate )
 {
     return random_point( points_in_range_bub( m ), predicate );
+}
+
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
+        const std::function<bool( const tripoint_bub_ms & )> &predicate )
+{
+    return random_point( points_in_level_range( m, z ), predicate );
 }
 
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -367,11 +367,11 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                         if( !mgr.name ) {
                             continue;
                         }
-                        if( const std::optional<tripoint> pt =
-                        random_point( *this, [this]( const tripoint & n ) {
+                        if( const std::optional<tripoint_bub_ms> pt =
+                        random_point_on_level( *this, gridz, [this]( const tripoint_bub_ms & n ) {
                         return passable( n );
                         } ) ) {
-                            const tripoint_bub_ms pnt = tripoint_bub_ms( pt.value() );
+                            const tripoint_bub_ms pnt = pt.value();
                             add_spawn( mgr, pnt );
                         }
                     }
@@ -5353,7 +5353,9 @@ void mapgen_function_json::generate( mapgendata &md )
     // Note that we need to perform rotations even if there is no predecessor, as other Z levels
     // have to be kept aligned regardless.
 
-    m->rotate( ( -rotation.get() + 4 ) % 4 );
+    // rotation.get can return a random value if val differs from valmax. Use same value in both directions.
+    const int rot = rotation.get() % 4;
+    m->rotate( 4 - rot );
 
     if( ter.is_rotatable() || ter.is_linear() ) {
         m->rotate( ( -ter.get_rotation() + 4 ) % 4 );
@@ -5364,7 +5366,7 @@ void mapgen_function_json::generate( mapgendata &md )
     apply_mapgen_in_phases( md_with_params, setmap_points, objects, tripoint_rel_ms( tripoint_zero ),
                             context_ );
 
-    m->rotate( rotation.get() );
+    m->rotate( rot );
 
     if( ter.is_rotatable() || ter.is_linear() ) {
         m->rotate( ter.get_rotation() );
@@ -5546,6 +5548,19 @@ void map::draw_lab( mapgendata &dat )
             lw = EAST_EDGE + 1;
         }
         if( dat.zlevel() == 0 ) { // We're on ground level
+            int rot = 0;
+
+            if( dat.east()->get_type_id() == oter_type_road ) {
+                rot = 1;
+            } else if( dat.south()->get_type_id() == oter_type_road ) {
+                rot = 2;
+            } else if( dat.west()->get_type_id() == oter_type_road ) {
+                rot = 3;
+            }
+
+            // Rotate the map backwards so contents can be placed in the 'normal' orientation.
+            rotate( 4 - rot );
+
             for( int i = 0; i < SEEX * 2; i++ ) {
                 for( int j = 0; j < SEEY * 2; j++ ) {
                     if( i <= 1 || i >= SEEX * 2 - 2 ||
@@ -5574,13 +5589,9 @@ void map::draw_lab( mapgendata &dat )
             place_spawns( GROUP_TURRET, 1, point_bub_ms( SEEX, 5 ), point_bub_ms( SEEX, 5 ), dat.zlevel(), 1,
                           true );
 
-            if( dat.east()->get_type_id() == oter_type_road ) {
-                rotate( 1 );
-            } else if( dat.south()->get_type_id() == oter_type_road ) {
-                rotate( 2 );
-            } else if( dat.west()->get_type_id() == oter_type_road ) {
-                rotate( 3 );
-            }
+            // Rotate everything back to normal, giving rotated addition its proper rotation.
+            rotate( rot );
+
         } else if( tw != 0 || rw != 0 || lw != 0 || bw != 0 ) { // Sewers!
             for( int i = 0; i < SEEX * 2; i++ ) {
                 for( int j = 0; j < SEEY * 2; j++ ) {
@@ -5654,19 +5665,29 @@ void map::draw_lab( mapgendata &dat )
             //A lab area with only one entrance
             if( boarders == 1 ) {
                 // If you remove the usage of "lab_1side" here, remove it from mapgen_factory::get_usages above as well.
-                if( oter_mapgen.generate( dat, "lab_1side" ) ) {
-                    if( tw == 2 ) {
-                        rotate( 2 );
-                    }
-                    if( rw == 2 ) {
-                        rotate( 1 );
-                    }
-                    if( lw == 2 ) {
-                        rotate( 3 );
-                    }
-                } else {
+                int rot = 0;
+
+                if( tw == 2 ) {
+                    rot += 2;
+                }
+                if( rw == 2 ) {
+                    rot += 1;
+                }
+                if( lw == 2 ) {
+                    rot += 3;
+                }
+                rot %= 4;
+
+                // Rotate the map backwards so the new material can be placed in its 'normal' orientation.
+                rotate( 4 - rot );
+
+                if( !oter_mapgen.generate( dat, "lab_1side" ) ) {
                     debugmsg( "Error: Tried to generate 1-sided lab but no lab_1side json exists." );
                 }
+
+                // Rotate the map back to its normal orientation, resulting in the new addition being rotated properly.
+                rotate( rot );
+
                 maybe_insert_stairs( dat.above(), ter_t_stairs_up );
                 maybe_insert_stairs( terrain_type, ter_t_stairs_down );
             } else {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -328,6 +328,9 @@ void mapgen_subway( mapgendata &dat )
             break;
     }
 
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     // rotate the arrays left by rot steps
     nesw_array_rotate( subway_nesw, rot );
     nesw_array_rotate( curvedir_nesw, rot );
@@ -554,7 +557,7 @@ void mapgen_subway( mapgendata &dat )
             break;
     }
 
-    // finally, unrotate the map
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
     m->rotate( rot );
 }
 
@@ -566,6 +569,19 @@ void mapgen_river_center( mapgendata &dat )
 void mapgen_river_curved_not( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_c_not_se ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_c_not_sw ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_c_not_nw ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
     // this is not_ne, so deep on all sides except ne corner, which is shallow
     // shallow is 20,0, 23,4
@@ -586,20 +602,26 @@ void mapgen_river_curved_not( mapgendata &dat )
         }
     }
 
-    if( dat.terrain_type() == oter_river_c_not_se ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_c_not_sw ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_c_not_nw ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_river_straight( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_east ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_south ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_west ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
 
     for( int x = 0; x < SEEX * 2; x++ ) {
@@ -612,20 +634,26 @@ void mapgen_river_straight( mapgendata &dat )
         line( m, ter_t_water_moving_sh, point( x, ++ground_edge ), point( x, shallow_edge ), dat.zlevel() );
     }
 
-    if( dat.terrain_type() == oter_river_east ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_south ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_west ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_river_curved( mapgendata &dat )
 {
     map *const m = &dat.m;
+    int rot = 0;
+
+    if( dat.terrain_type() == oter_river_se ) {
+        rot = 1;
+    } else if( dat.terrain_type() == oter_river_sw ) {
+        rot = 2;
+    } else if( dat.terrain_type() == oter_river_nw ) {
+        rot = 3;
+    }
+
+    // Rotate the map backwards so things can can be placed in their 'normal' orientation.
+    m->rotate( 4 - rot );
+
     fill_background( m, ter_t_water_moving_dp );
     // NE corner deep, other corners are shallow.  do 2 passes: one x, one y
     for( int x = 0; x < SEEX * 2; x++ ) {
@@ -647,15 +675,8 @@ void mapgen_river_curved( mapgendata &dat )
         line( m, ter_t_water_moving_sh, point( shallow_edge, y ), point( --ground_edge, y ), dat.zlevel() );
     }
 
-    if( dat.terrain_type() == oter_river_se ) {
-        m->rotate( 1 );
-    }
-    if( dat.terrain_type() == oter_river_sw ) {
-        m->rotate( 2 );
-    }
-    if( dat.terrain_type() == oter_river_nw ) {
-        m->rotate( 3 );
-    }
+    // finally, unrotate the map back to its normal orientation, resulting in the new addition being rotated.
+    m->rotate( rot );
 }
 
 void mapgen_rock_partial( mapgendata &dat )
@@ -2111,47 +2132,81 @@ void mapgen_ravine_edge( mapgendata &dat )
 
     //With that done, we generate the maps.
     if( straight ) {
+        int rot = 0;
+
+        if( w_ravine ) {
+            rot += 1;
+        }
+        if( n_ravine ) {
+            rot += 2;
+        }
+        if( e_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge = 12 + rng( 1, 3 );
             line( m, ter_str_id::NULL_ID(), point( x, ++ground_edge ), point( x, SEEY * 2 ), dat.zlevel() );
         }
-        if( w_ravine ) {
-            m->rotate( 1 );
-        }
-        if( n_ravine ) {
-            m->rotate( 2 );
-        }
-        if( e_ravine ) {
-            m->rotate( 3 );
-        }
+
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
+
     } else if( interior_corner ) {
+        int rot = 0;
+
+        if( nw_ravine ) {
+            rot += 1;
+        }
+        if( ne_ravine ) {
+            rot += 2;
+        }
+        if( se_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge = 12 + rng( 1, 3 ) + x;
             line( m, ter_str_id::NULL_ID(), point( x, ++ground_edge ), point( x, SEEY * 2 ), dat.zlevel() );
         }
-        if( nw_ravine ) {
-            m->rotate( 1 );
-        }
-        if( ne_ravine ) {
-            m->rotate( 2 );
-        }
-        if( se_ravine ) {
-            m->rotate( 3 );
-        }
+
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
+
     } else if( exterior_corner ) {
+        int rot = 0;
+
+        if( w_ravine && s_ravine ) {
+            rot += 1;
+        }
+        if( w_ravine && n_ravine ) {
+            rot += 2;
+        }
+        if( e_ravine && n_ravine ) {
+            rot += 3;
+        }
+
+        rot %= 4;
+
+        // Rotate the map 'backwards' to allow the new addition to be placed at its normal orientation.
+        m->rotate( 4 - rot );
+
         for( int x = 0; x < SEEX * 2; x++ ) {
             int ground_edge =  12  + rng( 1, 3 ) - x;
             line( m, ter_str_id::NULL_ID(), point( x, --ground_edge ), point( x, SEEY * 2 - 1 ), dat.zlevel() );
         }
-        if( w_ravine && s_ravine ) {
-            m->rotate( 1 );
-        }
-        if( w_ravine && n_ravine ) {
-            m->rotate( 2 );
-        }
-        if( e_ravine && n_ravine ) {
-            m->rotate( 3 );
-        }
+        // Rotate the map back to its normal rotation, resulting in the new contents becoming rotated.
+        m->rotate( rot );
     }
     // The placed t_null terrains are converted into the regional groundcover in the ravine's bottom level,
     // in the other levels they are converted into open air to generate the cliffside.

--- a/src/rng.h
+++ b/src/rng.h
@@ -198,7 +198,7 @@ inline V random_entry_removed( C &container )
 tripoint_range<tripoint> points_in_range( const map &m );
 tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m );
 // Restricts the points to the specified Z level.
-tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z );
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, int z );
 /// Returns a random point in the given range that satisfies the given predicate ( if any ).
 // TODO: Remove untyped overload
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
@@ -211,7 +211,7 @@ std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate );
 std::optional<tripoint_bub_ms> random_point( const map &m,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
-std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, int z,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
 
 #endif // CATA_SRC_RNG_H

--- a/src/rng.h
+++ b/src/rng.h
@@ -197,6 +197,8 @@ inline V random_entry_removed( C &container )
 // TODO: Remove untyped overload
 tripoint_range<tripoint> points_in_range( const map &m );
 tripoint_range<tripoint_bub_ms> points_in_range_bub( const map &m );
+// Restricts the points to the specified Z level.
+tripoint_range<tripoint_bub_ms> points_in_level_range( const map &m, const int z );
 /// Returns a random point in the given range that satisfies the given predicate ( if any ).
 // TODO: Remove untyped overload
 std::optional<tripoint> random_point( const tripoint_range<tripoint> &range,
@@ -208,6 +210,8 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
 std::optional<tripoint> random_point( const map &m,
                                       const std::function<bool( const tripoint & )> &predicate );
 std::optional<tripoint_bub_ms> random_point( const map &m,
+        const std::function<bool( const tripoint_bub_ms & )> &predicate );
+std::optional<tripoint_bub_ms> random_point_on_level( const map &m, const int z,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
 
 #endif // CATA_SRC_RNG_H


### PR DESCRIPTION
#### Summary
Backport DDA 74732 - map rotation fix

#### Purpose of change
Some lab and lab-adjacent maps weren't properly rotating following a recent backport.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
