### PR TITLE
Backport DDA 74617 - Only get valid rotations for SDL overmaps

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2611,6 +2611,9 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             const oter_type_str_id tmp( id );
             if( tmp.is_valid() ) {
                 if( !tmp->is_linear() ) {
+                    // if rota is for a omt with connections, it can be outside the bounds of
+                    // om_direction::type. We can't do anything about that now, so just stay inbounds
+                    rota %= om_direction::size;
                     sym = tmp->get_rotated( static_cast<om_direction::type>( rota ) )->get_uint32_symbol();
                 } else {
                     sym = tmp->symbol;


### PR DESCRIPTION
#### Summary
Backport DDA 74617 - Only get valid rotations for SDL overmaps

#### Purpose of change
Attempt to fix an issue reported on Discord

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
