### PR TITLE
Nerf chain whip, fix dog

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -85,7 +85,7 @@
     "category": "weapons",
     "name": { "str": "chain whip" },
     "description": "A long spool of chain with a steel weight at one end.  What a terrible night it'll be for anyone who gets hit by this thing.",
-    "weight": "1850 g",
+    "weight": "1950 g",
     "color": "dark_gray",
     "symbol": "/",
     "material": [ "steel" ],
@@ -96,7 +96,7 @@
     "flags": [ "ALWAYS_TWOHAND", "REACH_ATTACK", "WHIP", "DURABLE_MELEE" ],
     "price_postapoc": "75 cent",
     "weapon_category": [ "WHIPS", "NINJUTSU_WEAPONS", "KUNG_FU_WEAPONS" ],
-    "melee_damage": { "bash": 22 }
+    "melee_damage": { "bash": 20 }
   },
   {
     "type": "GENERIC",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -815,7 +815,6 @@
     "name": { "str": "attack dog", "str_pl": "attack dogs" },
     "description": "This average-sized dog has clearly had some training.  It is toned and attentive, and seems likely to respond with aggression.",
     "hp": 50,
-    "weight": "25 kg",
     "speed": 140,
     "aggression": 4,
     "morale": 20,


### PR DESCRIPTION
#### Summary
Nerf chain whip, fix dog weight

#### Purpose of change
Attack dogs had the wrong weight, chain whips were a bit too strong. The chain whip should be kind of a bad weapon that does a unique thing, which is bash damage that has a reach attack and no range penalty.

#### Describe the solution
Make the whip heavier and reduce its damage by 2.
Fix Dog Weight

#### Describe alternatives you've considered
The whip should probably have a special attack that just takes longer or something, so it's a bit harder to kite with.

#### Testing
Whip looks better, dog can wear armor.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
