### PR TITLE
Migrate a few missed items

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -241,8 +241,8 @@
   },
   {
     "type": "MIGRATION",
-    "id": "hammer_sledge_heavy",
-    "replace": "hammer_sledge"
+    "id": "hammer_sledge_short",
+    "replace": "hammer_sledge_engineer"
   },
   {
     "type": "MIGRATION",
@@ -525,5 +525,15 @@
     "type": "MIGRATION",
     "id": "heavy_crowbar",
     "replace": "crowbar"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "integrated_chitin3",
+    "replace": "integrated_chitin2"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "integrated_chitin3_claws",
+    "replace": "integrated_claws"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate chitin3 integrateds and the short sledge hammer.

#### Purpose of change
#506 got rid of the short sledge hammer but I missed migrating it. #472 got rid of CHITIN3 but I didn't migrate Apis's integrated items. This only matters for save compatibility, but there's no good reason not to fix it.

#### Describe the solution
Short sledge -> Engineer's hammer. This is the item it always should have been. Making the regular sledgehammer have a one-handed variant was not an appropriate solution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
