### PR TITLE
Electronic night vision overrides biological

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -50,7 +50,7 @@
     "description": "You are wearing night vision goggles which allow you to see really well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 19 } ]
   },
   {
     "type": "enchantment",
@@ -59,7 +59,7 @@
     "description": "You are wearing night vision goggles which allow you to see quite well in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 12 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 17 } ]
   },
   {
     "type": "enchantment",
@@ -68,7 +68,7 @@
     "description": "You are wearing night vision goggles which allow you to see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
   },
   {
     "type": "enchantment",
@@ -77,7 +77,7 @@
     "description": "You are wearing night vision goggles which allow you to poorly see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 11 } ]
   },
   {
     "id": "ench_climate_control_warm",

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -68,7 +68,7 @@
     "description": "You are wearing night vision goggles which allow you to see in the dark.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
+    "values": [ { "value": "NIGHT_VIS", "add": 13 } ]
   },
   {
     "type": "enchantment",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2805,9 +2805,15 @@ float Character::get_vision_threshold( float light_level ) const
         range++;
     }
 
+    // Electronics override biological night vision.  Perception still helps you pick details out of the feed.
+    if( vision_mode_cache[NV_GOGGLES] ) {
+        range = get_per() / 9;
+    }
+
+
     // bionic night vision and other old night vision flagged items
     if( worn_with_flag( flag_GNV_EFFECT ) || has_flag( json_flag_NIGHT_VISION ) ) {
-        range += 10;
+        range += 14;
     } else {
         range = enchantment_cache->modify_value( enchant_vals::mod::NIGHT_VIS, range );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2813,7 +2813,7 @@ float Character::get_vision_threshold( float light_level ) const
 
     // bionic night vision and other old night vision flagged items
     if( worn_with_flag( flag_GNV_EFFECT ) || has_flag( json_flag_NIGHT_VISION ) ) {
-        range += 14;
+        range += 15;
     } else {
         range = enchantment_cache->modify_value( enchant_vals::mod::NIGHT_VIS, range );
     }


### PR DESCRIPTION
#### Summary
Electronic night vision overrides biological

#### Purpose of change
NVGs were way too powerful because the game was totaling up all sources of night vision. This does not reflect how these devices work in real life - NVGs use an electronic system to intensift visible spectra and/or convert non-visible spectra into visible wavelengths. In effect, the user is watching a camera feed, and not actually looking directly at the subject - even if that wasn't true, the NVGs are only "illuminating" the same areas which animalistic night vision would be able to see, there's no reason the two should stack additively, to say nothing of whether an electronic screen designed for humans would even be visible to an animal's eyes.

#### Describe the solution
Mutation-related NV remains the same. However, if you are using bionic or item-based NV, your new range formula is per/9 + the NV value of your equipped item/bionic. If you have both an active night vision bionic and an item on, the system will use your bionic instead of the goggles - this is sort of an arbitrary call and will go away when bionic night vision is jsonized.

The perception stat is partly meant to represent your capacity to make sense of incoming sensory information. Perceptive people have better night vision not because their eyes are necessarily stronger, but because they're better at picking details out of what they can see. For this reason, perception still adds a partial bonus to night vision with goggles - you are better at noticing the green blob under that tree is a stalking wolf and not just a bush.

This PR also adjusts the range of different NVGs. This represents a downgrade for the best ones and an upgrade for the worst ones. Bionic NV is right in the middle.

#### Testing
- Made a character, checked their sight ranges on a clear night at 1, 10, and 20 perception.
- Gave them NVGs, did the same.
- Changed the weather to cloudy. This reduced the available light and made regular vision much worse. NVGs were still impaired, but remained superior to normal vision in basically all cases.
- Added NV mutations and saw that they helped when the goggles were off, but did nothing when they were on.
- Checked NV bionics and saw that they performed as expected.

#### Additional context
- Ranges on these goggles are not super great. IRL NVs can see extremely far, but as with gun ranges and other stuff, we have to kind of squash the distances for gameplay purposes. See #130 for more info.
- At 10 per, panoramic NVs (the best ones) see to around 21 tiles on a clear night, 16 on a cloudy night.
- At 10 per, that same character saw to 18 tiles on a clear night and 3 on a cloudy night. So you get the most mileage out of NVGs when it's very dark, but they do help when it isn't, and will generally be better than your unaided vision unless you have a particularly good mutation (and even then!)
- Perception is 3 times more effective for boosting night vision when not wearing goggles. Very high per characters may find they do better without them sometimes. This is more or less intended. If your eyes are really good and it's a clear night, you might see better naturally than by staring at some fuzzy green screen.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
