### PR TITLE
Fire is no longer invariably fatal

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2834,7 +2834,7 @@
       "pain_max_val": [ 35 ],
       "pain_chance": [ 2 ],
       "pain_min": [ 1 ],
-      "hurt_chance": [ 4 ],
+      "hurt_chance": [ 8 ],
       "hurt_min": [ 1 ]
     }
   },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13453,21 +13453,26 @@ void Character::pause()
             // TODO: Tools and skills
             total_left += eff.get_duration();
             // Being on the ground will smother the fire much faster because you can roll
-            const time_duration dur_removed = on_ground ? eff.get_duration() / 2 + 2_turns : 1_turns;
+            const time_duration dur_removed = on_ground ? 4_turns : 1_turns;
             eff.mod_duration( -dur_removed );
             total_removed += dur_removed;
         }
 
         // Don't drop on the ground when the ground is on fire
-        if( total_left > 1_minutes && !is_dangerous_fields( here.field_at( pos() ) ) ) {
+        if( total_left > 30_turns && !is_dangerous_fields( here.field_at( pos() ) ) ) {
             add_effect( effect_downed, 2_turns, false, 0, true );
             add_msg_player_or_npc( m_warning,
-                                   _( "You roll on the ground, trying to smother the fire!" ),
-                                   _( "<npcname> rolls on the ground!" ) );
+                                   _( "You drop and roll on the ground, trying to smother the fire!" ),
+                                   _( "<npcname> drops and rolls on the ground!" ) );
         } else if( total_removed > 0_turns ) {
+            if( on_ground ) {
+                _( "You roll on the ground, trying to smother the fire!" ),
+                _( "<npcname> rolls on the ground!" );
+            } else {
             add_msg_player_or_npc( m_warning,
                                    _( "You attempt to put out the fire on you!" ),
                                    _( "<npcname> attempts to put out the fire on them!" ) );
+            }
         }
     }
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2088,8 +2088,8 @@ void outfit::splash_attack( Character &guy, const spell &sp, Creature &caster, b
                             fire_data frd{ fire_intensity };
                             destroy = !armor.has_flag( flag_INTEGRATED ) && armor.burn( frd );
                             int fuel = roll_remainder( frd.fuel_produced );
-                            if( fuel > 0 ) {
-                                guy.add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp, false, 0, false,
+                            if( fuel > 0 && !guy.has_effect( effect_onfire, bp ) ) {
+                                guy.add_effect( effect_onfire, time_duration::from_turns( fuel * 5 ), bp, false, 0, false,
                                                 true );
                             }
                         }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1950,8 +1950,9 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             fire_data frd{ 2 };
             destroy = !armor.has_flag( flag_INTEGRATED ) && armor.burn( frd );
             int fuel = roll_remainder( frd.fuel_produced );
-            if( fuel > 0 ) {
-                guy.add_effect( effect_onfire, time_duration::from_turns( fuel + 1 ), bp, false, 0, false,
+            // Don't add fire duration to people who are already on fire, or they'll never go out.
+            if( fuel > 0 && !guy.has_effect( effect_onfire, bp ) ) {
+                guy.add_effect( effect_onfire, time_duration::from_turns( fuel * 5 ), bp, false, 0, false,
                                 true );
             }
         }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -137,7 +137,7 @@ static void eff_fun_onfire( Character &u, effect &it )
 {
     const int intense = it.get_intensity();
     u.deal_damage( nullptr, it.get_bp(), damage_instance( STATIC( damage_type_id( "heat" ) ),
-                   rng( intense, intense * 2 ) ) );
+                   rng( 1, intense * 2 ) ) );
 }
 static void eff_fun_spores( Character &u, effect &it )
 {


### PR DESCRIPTION
#### Summary
Remove infinite onfire and reduce fire damage

#### Purpose of change
Fire had a major problem: Any time you took fire damage on a body part, it would check to see if your clothes ignited there. If they did, it would add to that body part's onfire duration. Onfire deals fire damage to body parts, so this would result in you getting more stacks of onfire than you could put out.

Fire has many other issues - you also get burned by hot air AND hurt by the blisters that come from being burned by the hot air, AND slowed down by the effects and the pain, etc. so we also need to reduce the damage overall. Throwing a molotov at an adjacent enemy should be a tremendously stupid thing to do, but enemies need to be able to use fire without invariably killing the player.

So:
- Clothes damaged by fire would always apply onfire, even if you were already onfire, even if the damage source was your existing onfire, so it would stack duration faster than you could generally remove it on all parts that had flammable clothes
- Onfire was doing 1-2 to 3-6 damage per second.
- Blisters were doing 1 damage per 4 seconds.
- Being hot also does damage proportional to the temperature.
- Onfire would basically persist until your item was destroyed or removed.

#### Describe the solution
- Clothes damaged by fire apply more starting onfire than before, but they do not apply it if that body part already has onfire.
- Onfire does 1-2 to 1-6 damage per second. It still damage to clothes, but doesn't perpetuate itself.
- Blisters do 1 damage every 8 seconds.
- Being hot does the same amount of damage as before.
- The result is that in most cases is that (assuming you're not standing in fire) you will only burn for 10-20 seconds tops. This is bad, but you can still press . to beat the flames out. Going prone also helps. In all cases, it takes a bit longer to die of being in or near or on fire, which gives you a bit more wiggle room.

So if you get caught in some fire, the best thing to do is hit run, step three or four squares away, then go prone and hit . - this will not always save you, but you are FAR more likely to survive.

#### Describe alternatives you've considered
Part of the problem here is that "fuel" values for items aren't always super consistent, and sufficiently burned items should probably fall off of you rather than burning until nothing is left. But this isn't sticky fire, it's just basic stuff, and human beings, even clothed ones, are not especially flammable.

#### Testing
Blew some mollies on myself. In one or two cases I died (legs broke and I fell over and couldn't crawl out of the refugee center before it burned down on top of me), but in many others I was able to get out with anything from minor to severe damage.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
