### PR TITLE
Give Luo a switch-to option in her dialog

### DIFF
--- a/data/json/npcs/your_followers/luo_follower.json
+++ b/data/json/npcs/your_followers/luo_follower.json
@@ -173,6 +173,19 @@
       { "text": "Let's talk about your current activity.", "topic": "TALK_ACTIVITIES" },
       { "text": "Let's talk about the camp.", "topic": "TALK_CAMP" },
       { "text": "Change your martial arts style.", "topic": "TALK_DONE", "effect": "pick_style" },
+      {
+        "text": "You should take over for now.",
+        "condition": { "not": { "npc_has_trait": "HALLUCINATION" } },
+        "topic": "TALK_DONE",
+        "effect": "switch_to",
+        "switch": true
+      },
+      {
+        "text": "You should take over for now.",
+        "condition": { "npc_has_trait": "HALLUCINATION" },
+        "topic": "TALK_DONE",
+        "switch": true
+      },
       { "text": "Let's go.", "topic": "TALK_DONE" }
     ]
   },


### PR DESCRIPTION
#### Summary
Give Luo a switch-to option in her dialog

#### Purpose of change
Luo (the mycologist at the refugee center) is recruitable, and has her own version of the regular ally dialog. I forgot to give her an option to switch like everyone else got in #528 

#### Describe the solution
copy paste

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
