### PR TITLE
Backport DDA 74823 -typification stuff

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -26,6 +26,12 @@ bool item_reference::has_watertight_container()
     } );
 }
 
+bool active_item_cache::add( item &it, point_sm_ms location, item *parent,
+                             std::vector<item_pocket const *> const &pocket_chain )
+{
+    return active_item_cache::add( it, rebase_rel( location ), parent, pocket_chain );
+}
+
 bool active_item_cache::add( item &it, point_rel_ms location, item *parent,
                              std::vector<item_pocket const *> const &pocket_chain )
 {

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -26,7 +26,7 @@ bool item_reference::has_watertight_container()
     } );
 }
 
-bool active_item_cache::add( item &it, point location, item *parent,
+bool active_item_cache::add( item &it, point_rel_ms location, item *parent,
                              std::vector<item_pocket const *> const &pocket_chain )
 {
     std::vector<item_pocket const *> pockets = pocket_chain;
@@ -140,7 +140,7 @@ std::vector<item_reference> active_item_cache::get_special( special_item_type ty
     return matching_items;
 }
 
-void active_item_cache::subtract_locations( const point &delta )
+void active_item_cache::subtract_locations( const point_rel_ms &delta )
 {
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {
@@ -149,23 +149,24 @@ void active_item_cache::subtract_locations( const point &delta )
     }
 }
 
-void active_item_cache::rotate_locations( int turns, const point &dim )
+void active_item_cache::rotate_locations( int turns, const point_rel_ms &dim )
 {
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {
-            ir.location = ir.location.rotate( turns, dim );
+            // Should 'rotate' be propaged up to the typed coordinates?
+            ir.location = point_rel_ms( ir.location.raw().rotate( turns, dim.raw() ) );
         }
     }
 }
 
-void active_item_cache::mirror( const point &dim, bool horizontally )
+void active_item_cache::mirror( const point_rel_ms &dim, bool horizontally )
 {
     for( std::pair<const int, std::list<item_reference>> &pair : active_items ) {
         for( item_reference &ir : pair.second ) {
             if( horizontally ) {
-                ir.location.x = dim.x - 1 - ir.location.x;
+                ir.location.x() = dim.x() - 1 - ir.location.x();
             } else {
-                ir.location.y = dim.y - 1 - ir.location.y;
+                ir.location.y() = dim.y() - 1 - ir.location.y();
             }
         }
     }

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -58,7 +58,11 @@ class active_item_cache
         /**
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
+         * These two operations are really the same, but tailored to their usages.
+         * The submap coordinates are for submaps, and the relative ones are for vehicles.
          */
+        bool add( item &it, point_sm_ms location, item *parent = nullptr,
+                  std::vector<item_pocket const *> const &pocket_chain = {} );
         bool add( item &it, point_rel_ms location, item *parent = nullptr,
                   std::vector<item_pocket const *> const &pocket_chain = {} );
 

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -7,7 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "point.h"
+#include "coordinates.h"
 #include "safe_reference.h"
 
 class item;
@@ -15,7 +15,7 @@ class item_pocket;
 
 // A struct used to uniquely identify an item within a submap or vehicle.
 struct item_reference {
-    point location;
+    point_rel_ms location;
     safe_reference<item> item_ref;
     // parent invalidating would also invalidate item_ref so it's safe to use a raw pointers here
     item *parent = nullptr;
@@ -59,7 +59,7 @@ class active_item_cache
          * Adds the reference to the cache. Does nothing if the reference is already in the cache.
          * Relies on the fact that item::processing_speed() is a constant.
          */
-        bool add( item &it, point location, item *parent = nullptr,
+        bool add( item &it, point_rel_ms location, item *parent = nullptr,
                   std::vector<item_pocket const *> const &pocket_chain = {} );
 
         /**
@@ -88,9 +88,9 @@ class active_item_cache
          */
         std::vector<item_reference> get_special( special_item_type type );
         /** Subtract delta from every item_reference's location */
-        void subtract_locations( const point &delta );
-        void rotate_locations( int turns, const point &dim );
-        void mirror( const point &dim, bool horizontally );
+        void subtract_locations( const point_rel_ms &delta );
+        void rotate_locations( int turns, const point_rel_ms &dim );
+        void mirror( const point_rel_ms &dim, bool horizontally );
 };
 
 #endif // CATA_SRC_ACTIVE_ITEM_CACHE_H

--- a/src/coordinate_constants.h
+++ b/src/coordinate_constants.h
@@ -1,0 +1,149 @@
+#pragma once
+#ifndef CATA_SRC_COORDINATE_CONSTANTS_H
+#define CATA_SRC_COORDINATE_CONSTANTS_H
+
+#include "coords_fwd.h"
+#include "point.h"
+
+// Typed versions of the standard set of relative location constants.
+const point_rel_ms point_rel_ms_min{ point_min };
+const point_rel_ms point_rel_ms_zero { point_zero };
+const point_rel_ms point_rel_ms_north{point_north};
+const point_rel_ms point_rel_ms_north_east{ point_north_east };
+const point_rel_ms point_rel_ms_east{point_east};
+const point_rel_ms point_rel_ms_south_east{ point_south_east };
+const point_rel_ms point_rel_ms_south {point_south};
+const point_rel_ms point_rel_ms_south_west{ point_south_west };
+const point_rel_ms point_rel_ms_west {point_west};
+const point_rel_ms point_rel_ms_north_west{ point_north_west };
+
+const point_abs_ms point_abs_ms_min{ point_min };
+const point_sm_ms point_sm_ms_min{ point_min };
+const point_omt_ms point_omt_ms_min{ point_min };
+const point_bub_ms point_bub_ms_min{ point_min };
+
+const point_abs_ms point_abs_ms_zero{ point_zero };
+const point_sm_ms point_sm_ms_zero{ point_zero };
+const point_omt_ms point_omt_ms_zero{ point_zero };
+const point_bub_ms point_bub_ms_zero{ point_zero };
+
+const point_rel_sm point_rel_sm_min{ point_min };
+const point_rel_sm point_rel_sm_zero{ point_zero };
+const point_rel_sm point_rel_sm_north{ point_north };
+const point_rel_sm point_rel_sm_north_east{ point_north_east };
+const point_rel_sm point_rel_sm_east{ point_east };
+const point_rel_sm point_rel_sm_south_east{ point_south_east };
+const point_rel_sm point_rel_sm_south{ point_south };
+const point_rel_sm point_rel_sm_south_west{ point_south_west };
+const point_rel_sm point_rel_sm_west{ point_west };
+const point_rel_sm point_rel_sm_north_west{ point_north_west };
+
+const point_abs_sm point_abs_sm_min{ point_min };
+const point_omt_sm point_sm_sm_min{ point_min };
+const point_om_sm point_omt_sm_min{ point_min };
+const point_bub_sm point_bub_sm_min{ point_min };
+
+const point_abs_sm point_abs_sm_zero{ point_zero };
+const point_omt_sm point_sm_sm_zero{ point_zero };
+const point_om_sm point_omt_sm_zero{ point_zero };
+const point_bub_sm point_bub_sm_zero{ point_zero };
+
+const point_rel_omt point_rel_omt_min{ point_min };
+const point_rel_omt point_rel_omt_zero{ point_zero };
+const point_rel_omt point_rel_omt_north{ point_north };
+const point_rel_omt point_rel_omt_north_east{ point_north_east };
+const point_rel_omt point_rel_omt_east{ point_east };
+const point_rel_omt point_rel_omt_south_east{ point_south_east };
+const point_rel_omt point_rel_omt_south{ point_south };
+const point_rel_omt point_rel_omt_south_west{ point_south_west };
+const point_rel_omt point_rel_omt_west{ point_west };
+const point_rel_omt point_rel_omt_north_west{ point_north_west };
+
+const point_rel_om point_rel_om_min{ point_min };
+const point_rel_om point_rel_om_zero{ point_zero };
+const point_rel_om point_rel_om_north{ point_north };
+const point_rel_om point_rel_om_north_east{ point_north_east };
+const point_rel_om point_rel_om_east{ point_east };
+const point_rel_om point_rel_om_south_east{ point_south_east };
+const point_rel_om point_rel_om_south{ point_south };
+const point_rel_om point_rel_om_south_west{ point_south_west };
+const point_rel_om point_rel_om_west{ point_west };
+const point_rel_om point_rel_om_north_west{ point_north_west };
+
+const point_abs_omt point_abs_omt_min{ point_min };
+const point_om_omt point_om_omt_min{ point_min };
+const point_abs_seg point_abs_seg_min{ point_min };
+const point_abs_om point_abs_om_min{ point_min };
+
+const point_abs_omt point_abs_omt_zero{ point_zero };
+const point_om_omt point_om_omt_zero{ point_zero };
+const point_abs_seg point_abs_seg_zero{ point_zero };
+const point_abs_om point_abs_om_zero{ point_zero };
+
+const tripoint_rel_ms tripoint_rel_ms_min{ tripoint_min };
+const tripoint_rel_ms tripoint_rel_ms_zero{ tripoint_zero };
+const tripoint_rel_ms tripoint_rel_ms_north{ tripoint_north };
+const tripoint_rel_ms tripoint_rel_ms_north_east{ tripoint_north_east };
+const tripoint_rel_ms tripoint_rel_ms_east{ tripoint_east };
+const tripoint_rel_ms tripoint_rel_ms_south_east{ tripoint_south_east };
+const tripoint_rel_ms tripoint_rel_ms_south{ tripoint_south };
+const tripoint_rel_ms tripoint_rel_ms_south_west{ tripoint_south_west };
+const tripoint_rel_ms tripoint_rel_ms_west{ tripoint_west };
+const tripoint_rel_ms tripoint_rel_ms_north_west{ tripoint_north_west };
+const tripoint_rel_ms tripoint_rel_ms_above{ tripoint_above };
+const tripoint_rel_ms tripoint_rel_ms_below{ tripoint_below };
+
+const tripoint_abs_ms tripoint_abs_ms_min{ tripoint_min };
+const tripoint_sm_ms tripoint_sm_ms_min{ tripoint_min };
+const tripoint_omt_ms tripoint_omt_ms_min{ tripoint_min };
+const tripoint_bub_ms tripoint_bub_ms_min{ tripoint_min };
+
+const tripoint_abs_ms tripoint_abs_ms_zero{ tripoint_zero };
+const tripoint_sm_ms tripoint_sm_ms_zero{ tripoint_zero };
+const tripoint_omt_ms tripoint_omt_ms_zero{ tripoint_zero };
+const tripoint_bub_ms tripoint_bub_ms_zero{ tripoint_zero };
+
+const tripoint_rel_sm tripoint_rel_sm_min{ tripoint_min };
+const tripoint_rel_sm tripoint_rel_sm_zero{ tripoint_zero };
+const tripoint_rel_sm tripoint_rel_sm_north{ tripoint_north };
+const tripoint_rel_sm tripoint_rel_sm_north_east{ tripoint_north_east };
+const tripoint_rel_sm tripoint_rel_sm_east{ tripoint_east };
+const tripoint_rel_sm tripoint_rel_sm_south_east{ tripoint_south_east };
+const tripoint_rel_sm tripoint_rel_sm_south{ tripoint_south };
+const tripoint_rel_sm tripoint_rel_sm_south_west{ tripoint_south_west };
+const tripoint_rel_sm tripoint_rel_sm_west{ tripoint_west };
+const tripoint_rel_sm tripoint_rel_sm_north_west{ tripoint_north_west };
+const tripoint_rel_sm tripoint_rel_sm_above{ tripoint_above };
+const tripoint_rel_sm tripoint_rel_sm_below{ tripoint_below };
+
+const tripoint_abs_sm tripoint_abs_sm_min{ tripoint_min };
+const tripoint_om_sm tripoint_om_sm_min{ tripoint_min };
+const tripoint_bub_sm tripoint_bub_sm_min{ tripoint_min };
+
+const tripoint_abs_sm tripoint_abs_sm_zero{ tripoint_zero };
+const tripoint_om_sm tripoint_om_sm_zero{ tripoint_zero };
+const tripoint_bub_sm tripoint_bub_sm_zero{ tripoint_zero };
+
+const tripoint_rel_omt tripoint_rel_omt_min{ tripoint_min };
+const tripoint_rel_omt tripoint_rel_omt_zero{ tripoint_zero };
+const tripoint_rel_omt tripoint_rel_omt_north{ tripoint_north };
+const tripoint_rel_omt tripoint_rel_omt_north_east{ tripoint_north_east };
+const tripoint_rel_omt tripoint_rel_omt_east{ tripoint_east };
+const tripoint_rel_omt tripoint_rel_omt_south_east{ tripoint_south_east };
+const tripoint_rel_omt tripoint_rel_omt_south{ tripoint_south };
+const tripoint_rel_omt tripoint_rel_omt_south_west{ tripoint_south_west };
+const tripoint_rel_omt tripoint_rel_omt_west{ tripoint_west };
+const tripoint_rel_omt tripoint_rel_omt_north_west{ tripoint_north_west };
+const tripoint_rel_omt tripoint_rel_omt_above{ tripoint_above };
+const tripoint_rel_omt tripoint_rel_omt_below{ tripoint_below };
+
+const tripoint_abs_omt tripoint_abs_omt_min{ tripoint_min };
+const tripoint_om_omt tripoint_om_omt_min{ tripoint_min };
+const tripoint_abs_seg tripoint_abs_seg_min{ tripoint_min };
+const tripoint_abs_om tripoint_abs_om_min{ tripoint_min };
+
+const tripoint_abs_omt tripoint_abs_omt_zero{ tripoint_zero };
+const tripoint_om_omt tripoint_om_omt_zero{ tripoint_zero };
+const tripoint_abs_seg tripoint_abs_seg_zero{ tripoint_zero };
+const tripoint_abs_om tripoint_abs_om_zero{ tripoint_zero };
+#endif // CATA_SRC_COORDINATE_CONSTANTS_H

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -34,6 +34,10 @@ void real_coords::fromabs( const point &abs )
     om_pos.y = om_sub.y / 2;
 }
 
+point_rel_ms rebase_rel( point_sm_ms p )
+{
+    return point_rel_ms( p.raw() );
+}
 point_rel_ms rebase_rel( point_omt_ms p )
 {
     return point_rel_ms( p.raw() );
@@ -41,6 +45,10 @@ point_rel_ms rebase_rel( point_omt_ms p )
 point_rel_ms rebase_rel( point_bub_ms p )
 {
     return point_rel_ms( p.raw() );
+}
+point_sm_ms rebase_sm( point_rel_ms p )
+{
+    return point_sm_ms( p.raw() );
 }
 point_omt_ms rebase_omt( point_rel_ms p )
 {
@@ -50,6 +58,10 @@ point_bub_ms rebase_bub( point_rel_ms p )
 {
     return point_bub_ms( p.raw() );
 }
+tripoint_rel_ms rebase_rel( tripoint_sm_ms p )
+{
+    return tripoint_rel_ms( p.raw() );
+}
 tripoint_rel_ms rebase_rel( tripoint_omt_ms p )
 {
     return tripoint_rel_ms( p.raw() );
@@ -57,6 +69,10 @@ tripoint_rel_ms rebase_rel( tripoint_omt_ms p )
 tripoint_rel_ms rebase_rel( tripoint_bub_ms p )
 {
     return tripoint_rel_ms( p.raw() );
+}
+tripoint_sm_ms rebase_sm( tripoint_rel_ms p )
+{
+    return tripoint_sm_ms( p.raw() );
 }
 tripoint_omt_ms rebase_omt( tripoint_rel_ms p )
 {

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -655,13 +655,17 @@ using coords::project_combine;
 using coords::project_bounds;
 
 // Rebase relative coordinates to the base you know they're actually relative to.
+point_rel_ms rebase_rel( point_sm_ms );
 point_rel_ms rebase_rel( point_omt_ms p );
 point_rel_ms rebase_rel( point_bub_ms p );
+point_sm_ms rebase_sm( point_rel_ms p );
 point_omt_ms rebase_omt( point_rel_ms p );
 point_bub_ms rebase_bub( point_rel_ms p );
 
+tripoint_rel_ms rebase_rel( tripoint_sm_ms p );
 tripoint_rel_ms rebase_rel( tripoint_omt_ms p );
 tripoint_rel_ms rebase_rel( tripoint_bub_ms p );
+tripoint_sm_ms rebase_sm( tripoint_rel_ms p );
 tripoint_omt_ms rebase_omt( tripoint_rel_ms p );
 tripoint_bub_ms rebase_bub( tripoint_rel_ms p );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14297,12 +14297,19 @@ bool item::process_gun_cooling( Character *carrier )
 bool item::process( map &here, Character *carrier, const tripoint &pos, float insulation,
                     temperature_flag flag, float spoil_multiplier_parent, bool watertight_container, bool recursive )
 {
-    process_relic( carrier, pos );
+    return item::process( here, carrier, tripoint_bub_ms( pos ), insulation, flag,
+                          spoil_multiplier_parent, watertight_container, recursive );
+}
+
+bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,
+                    temperature_flag flag, float spoil_multiplier_parent, bool watertight_container, bool recursive )
+{
+    process_relic( carrier, pos.raw() );
     if( recursive ) {
-        contents.process( here, carrier, pos, type->insulation_factor * insulation, flag,
+        contents.process( here, carrier, pos.raw(), type->insulation_factor * insulation, flag,
                           spoil_multiplier_parent, watertight_container );
     }
-    return process_internal( here, carrier, pos, insulation, flag, spoil_multiplier_parent,
+    return process_internal( here, carrier, pos.raw(), insulation, flag, spoil_multiplier_parent,
                              watertight_container );
 }
 
@@ -14959,6 +14966,11 @@ bool item::on_drop( const tripoint &pos )
 }
 
 bool item::on_drop( const tripoint &pos, map &m )
+{
+    return item::on_drop( tripoint_bub_ms( pos ), m );
+}
+
+bool item::on_drop( const tripoint_bub_ms &pos, map &m )
 {
     // dropping liquids, even currently frozen ones, on the ground makes them
     // dirty

--- a/src/item.h
+++ b/src/item.h
@@ -799,7 +799,9 @@ class item : public visitable
          * @param map A map object associated with that position.
          * @return true if the item was destroyed during placement.
          */
+        // TODO: Get rid of untyped overload.
         bool on_drop( const tripoint &pos, map &map );
+        bool on_drop( const tripoint_bub_ms &pos, map &map );
 
         /**
          * Consume a specific amount of items of a specific type.
@@ -1447,7 +1449,11 @@ class item : public visitable
          * should than delete the item wherever it was stored.
          * Returns false if the item is not destroyed.
          */
+        // TODO: Get rid of untyped overload.
         bool process( map &here, Character *carrier, const tripoint &pos, float insulation = 1,
+                      temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
+                      bool watertight_container = false, bool recursive = true );
+        bool process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation = 1,
                       temperature_flag flag = temperature_flag::NORMAL, float spoil_multiplier_parent = 1.0f,
                       bool watertight_container = false, bool recursive = true );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -31,7 +31,9 @@
 #include "colony.h"
 #include "color.h"
 #include "construction.h"
+#include "coordinate_constants.h"
 #include "coordinate_conversions.h"
+#include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
@@ -5355,21 +5357,27 @@ units::volume map::free_volume( const tripoint_bub_ms &p )
 
 item_location map::add_item_ret_loc( const tripoint &pos, item obj, bool overflow )
 {
+    return map::add_item_ret_loc( tripoint_bub_ms( pos ), std::move( obj ), overflow );
+}
+
+item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
+{
     int copies = 1;
-    std::pair<item *, tripoint> ret = _add_item_or_charges( pos, std::move( obj ), copies, overflow );
+    std::pair<item *, tripoint_bub_ms> ret = _add_item_or_charges( pos, std::move( obj ), copies,
+            overflow );
     if( ret.first != nullptr && !ret.first->is_null() ) {
-        return item_location { map_cursor{ tripoint_bub_ms( ret.second ) }, ret.first };
+        return item_location{ map_cursor{ tripoint_bub_ms( ret.second ) }, ret.first };
     }
 
     return {};
 }
 
-item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
+item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
 {
-    return map::add_item_ret_loc( pos.raw(), std::move( obj ), overflow );
+    return map::add_item_or_charges( tripoint_bub_ms( pos ), obj, overflow );
 }
 
-item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
+item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow )
 {
     int copies = 1;
     return *_add_item_or_charges( pos, std::move( obj ), copies, overflow ).first;
@@ -5378,14 +5386,17 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
 item &map::add_item_or_charges( const tripoint &pos, item obj, int &copies_remaining,
                                 bool overflow )
 {
-    return *_add_item_or_charges( pos, std::move( obj ), copies_remaining, overflow ).first;
+    return add_item_or_charges( tripoint_bub_ms( pos ), std::move( obj ), copies_remaining, overflow );
 }
 
-std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item obj,
+// clang-tidy is confused and thinks obj can be made into a const reference, but it can't
+// on_drop is not a const function
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub_ms &pos, item obj,
         int &copies_remaining, bool overflow )
 {
     // Checks if item would not be destroyed if added to this tile
-    auto valid_tile = [&]( const tripoint & e ) {
+    auto valid_tile = [&]( const tripoint_bub_ms & e ) {
         if( !inbounds( e ) ) {
             dbg( D_INFO ) << e; // should never happen
             return false;
@@ -5405,14 +5416,14 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
     };
 
     // Get how many copies of the item can fit in a tile
-    auto how_many_copies_fit = [&]( const tripoint & e ) {
+    auto how_many_copies_fit = [&]( const tripoint_bub_ms & e ) {
         return std::min( { copies_remaining,
                            obj.volume() == 0_ml ? INT_MAX : free_volume( e ) / obj.volume(),
                            static_cast<int>( MAX_ITEM_IN_SQUARE - i_at( e ).size() ) } );
     };
 
     // Performs the actual insertion of the object onto the map
-    auto place_item = [&]( const tripoint & tile, int &copies ) -> item& {
+    auto place_item = [&]( const tripoint_bub_ms & tile, int &copies ) -> item& {
         if( obj.count_by_charges() )
         {
             for( item &e : i_at( tile ) ) {
@@ -5422,25 +5433,25 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
             }
         }
 
-        support_dirty( tile );
+        support_dirty( tile.raw() );
         return add_item( tile, obj, copies );
     };
 
     if( item_is_blacklisted( obj.typeId() ) ) {
-        return { &null_item_reference(), tripoint_min };
+        return { &null_item_reference(), tripoint_bub_ms_min };
     }
 
     // Some items never exist on map as a discrete item (must be contained by another item)
     if( obj.has_flag( flag_NO_DROP ) ) {
-        return { &null_item_reference(), tripoint_min };
+        return { &null_item_reference(), tripoint_bub_ms_min };
     }
 
     // If intended drop tile destroys the item then we don't attempt to overflow
     if( !valid_tile( pos ) ) {
-        return { &null_item_reference(), tripoint_min };
+        return { &null_item_reference(), tripoint_bub_ms_min };
     }
 
-    std::optional<std::pair<item *, tripoint>> first_added;
+    std::optional<std::pair<item *, tripoint_bub_ms>> first_added;
     int copies_to_add_here = how_many_copies_fit( pos );
 
     if( ( !has_flag( ter_furn_flag::TFLAG_NOITEM, pos ) ||
@@ -5449,7 +5460,7 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
         // Pass map into on_drop, because this map may not be the global map object (in mapgen, for instance).
         if( obj.made_of( phase_id::LIQUID ) || !obj.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID ) ) {
             if( obj.on_drop( pos, *this ) ) {
-                return { &null_item_reference(), tripoint_min };
+                return { &null_item_reference(), tripoint_bub_ms_min };
             }
         }
         // If tile can contain items place here...
@@ -5460,12 +5471,12 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
     if( overflow && copies_remaining > 0 ) {
         // ...otherwise try to overflow to adjacent tiles (if permitted)
         const int max_dist = 2;
-        std::vector<tripoint> tiles = closest_points_first( pos, max_dist );
+        std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, max_dist );
         tiles.erase( tiles.begin() ); // we already tried this position
         const int max_path_length = 4 * max_dist;
         const pathfinding_settings setting( 0, max_dist, max_path_length, 0, false, false, true, false,
                                             false, false );
-        for( const tripoint &e : tiles ) {
+        for( const tripoint_bub_ms &e : tiles ) {
             if( copies_remaining <= 0 ) {
                 break;
             }
@@ -5478,7 +5489,8 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
             }
             if( obj.made_of( phase_id::LIQUID ) || !obj.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID ) ) {
                 if( obj.on_drop( e, *this ) ) {
-                    return first_added ? first_added.value() : std::make_pair( &null_item_reference(), tripoint_min );
+                    return first_added ? first_added.value() : std::make_pair( &null_item_reference(),
+                            tripoint_bub_ms_min );
                 }
             }
 
@@ -5488,24 +5500,20 @@ std::pair<item *, tripoint> map::_add_item_or_charges( const tripoint &pos, item
                 continue;
             }
             copies_remaining -= copies_to_add_here;
-            std::pair<item *, tripoint> new_item = { &place_item( e, copies_to_add_here ), e };
+            std::pair<item *, tripoint_bub_ms> new_item = { &place_item( e, copies_to_add_here ), e };
             first_added = first_added ? first_added : new_item;
         }
     }
 
     // If first_added has no value, no items were added due to lack of space at target tile (+/- overflow tiles)
-    return first_added ? first_added.value() : std::make_pair( &null_item_reference(), tripoint_min );
-}
-
-item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow )
-{
-    return add_item_or_charges( pos.raw(), std::move( obj ), overflow );
+    return first_added ? first_added.value() : std::make_pair( &null_item_reference(),
+            tripoint_bub_ms_min );
 }
 
 item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, int &copies_remaining,
                                 bool overflow )
 {
-    return add_item_or_charges( pos.raw(), std::move( obj ), copies_remaining, overflow );
+    return *_add_item_or_charges( pos, std::move( obj ), copies_remaining, overflow ).first;
 }
 
 float map::item_category_spawn_rate( const item &itm )
@@ -5518,16 +5526,16 @@ float map::item_category_spawn_rate( const item &itm )
 
 item &map::add_item( const tripoint &p, item new_item )
 {
-    int copies = 1;
-    return add_item( p, std::move( new_item ), copies );
+    return map::add_item( tripoint_bub_ms( p ), std::move( new_item ) );
 }
 
 item &map::add_item( const tripoint_bub_ms &p, item new_item )
 {
-    return map::add_item( p.raw(), std::move( new_item ) );
+    int copies = 1;
+    return add_item( p, std::move( new_item ), copies );
 }
 
-item &map::add_item( const tripoint &p, item new_item, int copies )
+item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
 {
     if( item_is_blacklisted( new_item.typeId() ) ) {
         return null_item_reference();
@@ -5541,10 +5549,10 @@ item &map::add_item( const tripoint &p, item new_item, int copies )
         return null_item_reference();
     }
 
-    point l;
+    point_sm_ms l;
     submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
-        debugmsg( "Tried to add items at (%d,%d) but the submap is not loaded", l.x, l.y );
+        debugmsg( "Tried to add items at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return null_item_reference();
     }
 
@@ -5592,7 +5600,7 @@ item &map::add_item( const tripoint &p, item new_item, int copies )
     }
 
     current_submap->ensure_nonuniform();
-    invalidate_max_populated_zlev( p.z );
+    invalidate_max_populated_zlev( p.z() );
 
     current_submap->update_lum_add( l, new_item );
 
@@ -5601,9 +5609,9 @@ item &map::add_item( const tripoint &p, item new_item, int copies )
         current_submap->get_items( l ).insert( new_item );
     }
 
-    if( current_submap->active_items.add( *new_pos, l ) ) {
+    if( current_submap->active_items.add( *new_pos, rebase_rel( l ) ) ) {
         // TODO: fix point types
-        tripoint_abs_sm const loc( abs_sub.x() + p.x / SEEX, abs_sub.y() + p.y / SEEY, p.z );
+        tripoint_abs_sm const loc( abs_sub.x() + p.x() / SEEX, abs_sub.y() + p.y() / SEEY, p.z() );
         submaps_with_active_items_dirty.insert( loc );
         if( this != &get_map() && get_map().inbounds( loc ) ) {
             get_map().make_active( loc );
@@ -5657,7 +5665,7 @@ void map::make_active( item_location &loc )
     cata::colony<item> &item_stack = current_submap->get_items( l );
     cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
 
-    if( current_submap->active_items.add( *iter, l ) ) {
+    if( current_submap->active_items.add( *iter, point_rel_ms( l ) ) ) {
         // TODO: fix point types
         tripoint_abs_sm const smloc( abs_sub.x() + loc.position().x / SEEX,
                                      abs_sub.y() + loc.position().y / SEEY, loc.position().z );
@@ -5873,7 +5881,7 @@ void map::process_items_in_submap( submap &current_submap, const tripoint &gridp
             continue;
         }
 
-        const tripoint map_location = tripoint( grid_offset + active_item_ref.location, gridp.z );
+        const tripoint map_location = tripoint( grid_offset + active_item_ref.location.raw(), gridp.z );
         const furn_t &furn = this->furn( map_location ).obj();
 
         if( furn.has_flag( ter_furn_flag::TFLAG_DONT_REMOVE_ROTTEN ) ) {
@@ -5945,7 +5953,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
         }
         const auto it = std::find_if( begin( cargo_parts ),
         end( cargo_parts ), [&]( const vpart_reference & part ) {
-            return active_item_ref.location == part.mount();
+            return active_item_ref.location.raw() == part.mount();
         } );
 
         if( it == end( cargo_parts ) ) {
@@ -10523,7 +10531,7 @@ std::list<item_location> map::get_active_items_in_radius( const tripoint &center
         std::vector<item_reference> items = type == special_item_type::none ? sm->active_items.get() :
                                             sm->active_items.get_special( type );
         for( const item_reference &elem : items ) {
-            const tripoint pos( sm_offset + elem.location, submap_loc.z );
+            const tripoint pos( sm_offset + elem.location.raw(), submap_loc.z );
 
             if( rl_dist( pos, center ) > radius ) {
                 continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5389,9 +5389,6 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, int &copies_remai
     return add_item_or_charges( tripoint_bub_ms( pos ), std::move( obj ), copies_remaining, overflow );
 }
 
-// clang-tidy is confused and thinks obj can be made into a const reference, but it can't
-// on_drop is not a const function
-// NOLINTNEXTLINE(performance-unnecessary-value-param)
 std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub_ms &pos, item obj,
         int &copies_remaining, bool overflow )
 {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5609,7 +5609,7 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
         current_submap->get_items( l ).insert( new_item );
     }
 
-    if( current_submap->active_items.add( *new_pos, rebase_rel( l ) ) ) {
+    if( current_submap->active_items.add( *new_pos, l ) ) {
         // TODO: fix point types
         tripoint_abs_sm const loc( abs_sub.x() + p.x() / SEEX, abs_sub.y() + p.y() / SEEY, p.z() );
         submaps_with_active_items_dirty.insert( loc );
@@ -5656,17 +5656,16 @@ void map::make_active( item_location &loc )
 {
     item *target = loc.get_item();
 
-    point l;
-    submap *const current_submap = get_submap_at( loc.position(), l );
+    point_sm_ms l;
+    submap *const current_submap = get_submap_at( loc.position(), l.raw() );
     if( current_submap == nullptr ) {
-        debugmsg( "Tried to make active at (%d,%d) but the submap is not loaded", l.x, l.y );
+        debugmsg( "Tried to make active at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
     }
     cata::colony<item> &item_stack = current_submap->get_items( l );
     cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
 
-    if( current_submap->active_items.add( *iter, point_rel_ms( l ) ) ) {
-        // TODO: fix point types
+    if( current_submap->active_items.add( *iter, l ) ) {
         tripoint_abs_sm const smloc( abs_sub.x() + loc.position().x / SEEX,
                                      abs_sub.y() + loc.position().y / SEEY, loc.position().z );
         submaps_with_active_items_dirty.insert( smloc );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5374,7 +5374,7 @@ item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool 
 
 item &map::add_item_or_charges( const tripoint &pos, item obj, bool overflow )
 {
-    return map::add_item_or_charges( tripoint_bub_ms( pos ), obj, overflow );
+    return map::add_item_or_charges( tripoint_bub_ms( pos ), std::move( obj ), overflow );
 }
 
 item &map::add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow )

--- a/src/map.h
+++ b/src/map.h
@@ -1437,6 +1437,7 @@ class map
         // TODO: fix point types (remove the first overload)
         item_location add_item_ret_loc( const tripoint &pos, item obj, bool overflow = true );
         item_location add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
+        // TODO: fix point types (remove the first overload)
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint &pos, item obj, int &copies_remaining,
                                    bool overflow = true );
@@ -1460,7 +1461,7 @@ class map
          *
          * @returns The item that got added, or nulitem.
          */
-        item &add_item( const tripoint &p, item new_item, int copies );
+        item &add_item( const tripoint_bub_ms &p, item new_item, int copies );
         // TODO: Get rid of untyped overload
         item &add_item( const tripoint &p, item new_item );
         item &add_item( const tripoint_bub_ms &p, item new_item );
@@ -1778,7 +1779,7 @@ class map
         static cata::copy_const<Map, field_entry> *get_field_helper(
             Map &m, const tripoint &p, const field_type_id &type );
 
-        std::pair<item *, tripoint> _add_item_or_charges( const tripoint &pos, item obj,
+        std::pair<item *, tripoint_bub_ms> _add_item_or_charges( const tripoint_bub_ms &pos, item obj,
                 int &copies_remaining, bool overflow = true );
     public:
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -17,6 +17,7 @@
 #include "cata_io.h"
 #include "cata_path.h"
 #include "city.h"
+#include "coordinates.h"
 #include "creature_tracker.h"
 #include "debug.h"
 #include "faction.h"

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4983,7 +4983,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 if( it.is_emissive() ) {
                     update_lum_add( p, it );
                 }
-                active_items.add( it, point_rel_ms( p ) );
+                active_items.add( it, point_sm_ms( p ) );
             }
         }
     } else if( member_name == "traps" ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4983,7 +4983,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 if( it.is_emissive() ) {
                     update_lum_add( p, it );
                 }
-                active_items.add( it, p );
+                active_items.add( it, point_rel_ms( p ) );
             }
         }
     } else if( member_name == "traps" ) {

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -341,7 +341,7 @@ void submap::revert_submap( submap &sr )
                 if( itm.is_emissive() ) {
                     this->update_lum_add( pt, itm );
                 }
-                active_items.add( itm, point_rel_ms( pt ) );
+                active_items.add( itm, point_sm_ms( pt ) );
             }
         }
     }

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -341,7 +341,7 @@ void submap::revert_submap( submap &sr )
                 if( itm.is_emissive() ) {
                     this->update_lum_add( pt, itm );
                 }
-                active_items.add( itm, pt );
+                active_items.add( itm, point_rel_ms( pt ) );
             }
         }
     }

--- a/src/submap.h
+++ b/src/submap.h
@@ -183,21 +183,30 @@ class submap
         }
 
         void update_lum_add( const point &p, const item &i ) {
+            update_lum_add( point_sm_ms( p ), i );
+        }
+
+        void update_lum_add( const point_sm_ms &p, const item &i ) {
             ensure_nonuniform();
-            if( i.is_emissive() && m->lum[p.x][p.y] < 255 ) {
-                m->lum[p.x][p.y]++;
+            if( i.is_emissive() && m->lum[p.x()][p.y()] < 255 ) {
+                m->lum[p.x()][p.y()]++;
             }
         }
 
         void update_lum_rem( const point &p, const item &i );
 
         // TODO: Replace this as it essentially makes itm public
+        // TODO: Get rid of untyped overload.
         cata::colony<item> &get_items( const point &p ) {
+            return get_items( point_sm_ms( p ) );
+        }
+
+        cata::colony<item> &get_items( const point_sm_ms &p ) {
             if( is_uniform() ) {
                 cata::colony<item> static noitems;
                 return noitems;
             }
-            return m->itm[p.x][p.y];
+            return m->itm[p.x()][p.y()];
         }
 
         const cata::colony<item> &get_items( const point &p ) const {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5882,7 +5882,7 @@ void vehicle::make_active( item_location &loc )
     }
     // System insures that there is only one part in this vector.
     vehicle_part *cargo_part = cargo_parts.front();
-    active_items.add( target, cargo_part->mount );
+    active_items.add( target, point_rel_ms( cargo_part->mount ) );
 }
 
 int vehicle::add_charges( vehicle_part &vp, const item &itm )
@@ -5941,7 +5941,7 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( vehicle_part &vp, cons
     }
 
     const vehicle_stack::iterator new_pos = vp.items.insert( itm_copy );
-    active_items.add( *new_pos, vp.mount );
+    active_items.add( *new_pos, point_rel_ms( vp.mount ) );
 
     invalidate_mass();
     return std::optional<vehicle_stack::iterator>( new_pos );
@@ -6218,7 +6218,7 @@ void vehicle::refresh_active_item_cache()
         auto it = vs.begin();
         auto end = vs.end();
         for( ; it != end; ++it ) {
-            active_items.add( *it, vp.mount() );
+            active_items.add( *it, point_rel_ms( vp.mount() ) );
         }
     }
 }
@@ -7304,7 +7304,7 @@ void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type, const 
 void vehicle::shift_parts( map &here, const point &delta )
 {
     // Don't invalidate the active item cache's location!
-    active_items.subtract_locations( delta );
+    active_items.subtract_locations( point_rel_ms( delta ) );
     for( vehicle_part &elem : parts ) {
         elem.mount -= delta;
     }


### PR DESCRIPTION
#### Summary
Backport DDA 74823 - typification stuff

#### Purpose of change
Prereqs for other stuff and a good project in its own right.

#### Describe the solution
Backport. During backporting a comment and no-lint was briefly added to map.cpp and then removed, this comment in the commit history is from DDA 74740 by Maleclypse. That'll be backported next for proper attribution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
