### PR TITLE
Backport DDA 74740 - Silence erroneous clang-tidy warning

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5389,6 +5389,9 @@ item &map::add_item_or_charges( const tripoint &pos, item obj, int &copies_remai
     return add_item_or_charges( tripoint_bub_ms( pos ), std::move( obj ), copies_remaining, overflow );
 }
 
+// clang-tidy is confused and thinks obj can be made into a const reference, but it can't
+// on_drop is not a const function
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub_ms &pos, item obj,
         int &copies_remaining, bool overflow )
 {


### PR DESCRIPTION
#### Summary
Backport DDA 74740 - Silence erroneous clang-tidy warning

#### Purpose of change
I haven't been using clang-tidy but I remember NetSysFire saying I should for some reason, and they're usually right. So I'll just quietly backport this. Note that this code accidentally appeared in #534 (in the commit history) but wasn't merged with it. Backporting it here and linking it there (it's also mentioned in the PR body there) should be sufficient for attribution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
