### PR TITLE
Backport dda 74555 - clang-tidy: fix cata-unsequenced-calls

### DIFF
--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -8,7 +8,7 @@
 #include "item_pocket.h"
 #include "safe_reference.h"
 
-float item_reference::spoil_multiplier()
+float item_reference::spoil_multiplier() const
 {
     return std::accumulate(
                pocket_chain.begin(), pocket_chain.end(), 1.0F,
@@ -17,7 +17,7 @@ float item_reference::spoil_multiplier()
     } );
 }
 
-bool item_reference::has_watertight_container()
+bool item_reference::has_watertight_container() const
 {
     return std::any_of(
                pocket_chain.begin(), pocket_chain.end(),

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -21,8 +21,8 @@ struct item_reference {
     item *parent = nullptr;
     std::vector<item_pocket const *> pocket_chain;
 
-    float spoil_multiplier();
-    bool has_watertight_container();
+    float spoil_multiplier() const;
+    bool has_watertight_container() const;
 };
 
 enum class special_item_type : int {


### PR DESCRIPTION
#### Summary
Backport dda 74555 - clang-tidy: fix cata-unsequenced-calls

#### Purpose of change
More clang-tidy stuff.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
