### PR TITLE
Clean up PATH_AVOID_DANGER_1 flags

### DIFF
--- a/data/json/monsters/zed_command.json
+++ b/data/json/monsters/zed_command.json
@@ -48,7 +48,7 @@
       "PRIORITIZE_TARGETS",
       "NO_FUNG_DMG",
       "FILTHY",
-      "PATH_AVOID_DANGER_1"
+      "PATH_AVOID_DANGER"
     ],
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 24, "electric": 3 }
   },
@@ -97,7 +97,7 @@
       "POISON",
       "NO_BREATHE",
       "REVIVES",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "CAN_OPEN_DOORS",
       "PRIORITIZE_TARGETS",
       "NO_FUNG_DMG",

--- a/data/mods/Megafauna/monsters/mf_domestic.json
+++ b/data/mods/Megafauna/monsters/mf_domestic.json
@@ -37,7 +37,7 @@
       "feed": "The %s seems to like you!  It lets you pat its shaggy-haired head and seems friendly.",
       "pet": "The %s lets you pet its shaggy-haired head, mooing loudly in satisfaction."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 5, "cut": 7, "stab": 3 }
   },
   {
@@ -68,7 +68,7 @@
     "upgrades": { "age_grow": 240, "into": "mon_shrubox" },
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY" ]
   },
   {
     "id": "mon_woodox",
@@ -111,7 +111,7 @@
       "feed": "The %s seems to like you!  It lets you pat its shaggy-haired head and seems friendly.",
       "pet": "The %s lets you pet its shaggy-haired head, mooing loudly in satisfaction."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ],
     "armor": { "bash": 5, "cut": 7, "stab": 3 }
   },
   {
@@ -142,7 +142,7 @@
     "upgrades": { "age_grow": 240, "into": "mon_woodox" },
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY" ]
   },
   {
     "id": "mon_soergoat",
@@ -182,7 +182,7 @@
       "feed": "The %s seems to tolerate you!  It cocks its head and stares at you with its strange goat-eyes as you approach.",
       "pet": "The %s lets you scratch its big belly, letting of a sonorous bleat in satisfaction."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 3, "cut": 4, "stab": 2 }
   },
   {
@@ -212,7 +212,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "upgrades": { "age_grow": 240, "into": "mon_soergoat" },
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY" ]
   },
   {
     "id": "mon_bison",
@@ -248,7 +248,7 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "special_attacks": [ [ "EAT_CROP", 120 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "MILKABLE" ],
     "armor": { "bash": 5, "cut": 7, "stab": 3 }
   },
   {
@@ -279,7 +279,7 @@
     "upgrades": { "age_grow": 240, "into": "mon_bison" },
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "NO_BREED", "CANPLAY" ]
   },
   {
     "id": "mon_scotts_horse",
@@ -315,7 +315,7 @@
     "baby_flags": [ "AUTUMN" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "mountable_weight_ratio": 0.35,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 3, "cut": 4, "stab": 3 }
   },
   {
@@ -349,7 +349,7 @@
       "ANIMAL",
       "PET_WONT_FOLLOW",
       "PET_MOUNTABLE",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "WARM",
       "NO_BREED",
       "CANPLAY"
@@ -389,7 +389,7 @@
     "baby_flags": [ "AUTUMN" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "mountable_weight_ratio": 0.35,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 5, "cut": 7, "stab": 3 }
   },
   {
@@ -423,7 +423,7 @@
       "ANIMAL",
       "PET_WONT_FOLLOW",
       "PET_MOUNTABLE",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "WARM",
       "NO_BREED",
       "CANPLAY"
@@ -463,7 +463,7 @@
     "reproduction": { "baby_monster": "mon_camelops_foal", "baby_count": 1, "baby_timer": 360 },
     "baby_flags": [ "SUMMER" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 6, "cut": 9, "stab": 4 }
   },
   {
@@ -491,7 +491,7 @@
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
     "upgrades": { "age_grow": 240, "into": "mon_camelops" },
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "NO_BREED" ]
   },
   {
     "id": "mon_peccary_flathead",
@@ -527,7 +527,7 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "HURT", "FIRE" ],
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It squeals happily as you pet it." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CANPLAY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "CANPLAY" ],
     "armor": { "bash": 2, "cut": 3, "stab": 2 }
   },
   {
@@ -555,7 +555,7 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PET_WONT_FOLLOW",
       "WARM",
       "KEENNOSE",
@@ -584,7 +584,7 @@
     "anger_triggers": [ "PLAYER_NEAR_BABY", "FRIEND_ATTACKED" ],
     "fear_triggers": [ "SOUND", "FIRE" ],
     "reproduction": { "baby_monster": "mon_longnose_piglet", "baby_count": 1, "baby_timer": 200 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_MOUNTABLE", "WARM", "CANPLAY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER", "PET_MOUNTABLE", "WARM", "CANPLAY" ],
     "armor": { "bash": 4, "cut": 6, "stab": 4 }
   },
   {
@@ -593,6 +593,6 @@
     "copy-from": "mon_flathead_piglet",
     "name": { "str": "long-nosed peccary piglet" },
     "description": "A juvenile long-nosed peccary - a stocky, short-legged, pig-like animal.  Its playful squeals delight your heart.",
-    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CANPLAY" ]
+    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "CANPLAY" ]
   }
 ]

--- a/data/mods/Megafauna/monsters/mf_predators.json
+++ b/data/mods/Megafauna/monsters/mf_predators.json
@@ -47,7 +47,7 @@
       "KEENNOSE",
       "GOODHEARING",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PET_MOUNTABLE",
       "WARM",
       "CANPLAY",
@@ -74,7 +74,7 @@
     "melee_damage": [ { "damage_type": "stab", "amount": 4.0 } ],
     "dodge": 2,
     "upgrades": { "age_grow": 270, "into": "mon_direwolf" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "NO_BREED", "WARM", "CANPLAY", "KEENNOSE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "NO_BREED", "WARM", "CANPLAY", "KEENNOSE" ]
   },
   {
     "id": "mon_sabcat",
@@ -130,7 +130,7 @@
       "KEENNOSE",
       "ANIMAL",
       "GRABS",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "KEEP_DISTANCE",
       "WARM",
@@ -168,7 +168,7 @@
       "GOODHEARING",
       "KEENNOSE",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "KEEP_DISTANCE",
       "WARM",
@@ -216,7 +216,7 @@
       "GOODHEARING",
       "KEENNOSE",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "WARM",
       "HIT_AND_RUN"
@@ -251,7 +251,7 @@
       "GOODHEARING",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "WARM",
       "HIT_AND_RUN",
@@ -289,7 +289,7 @@
     "petfood": { "food": [ "CATFOOD" ], "feed": "The %s seems to like you!  It emits a satisfied purr as you pet it." },
     "harvest": "mammal_small_fur",
     "dissect": "dissect_feline_sample_single",
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN" ]
   },
   {
     "id": "mon_bobcat_cub",
@@ -309,7 +309,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1.0 } ],
     "dodge": 2,
     "upgrades": { "age_grow": 90, "into": "mon_bobcat" },
-    "flags": [ "NO_BREED", "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "HIT_AND_RUN" ]
+    "flags": [ "NO_BREED", "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN" ]
   },
   {
     "type": "MONSTER",
@@ -352,7 +352,7 @@
       "HEARS",
       "GOODHEARING",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "KEENNOSE",
       "WARM",
       "HIT_AND_RUN",
@@ -391,6 +391,6 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 4.0 } ],
     "dodge": 3,
     "upgrades": { "age_grow": 315, "into": "mon_titanis_walleri" },
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "NO_BREED", "WARM", "KEENNOSE", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "NO_BREED", "WARM", "KEENNOSE", "CANPLAY" ]
   }
 ]

--- a/data/mods/Megafauna/monsters/mf_wild.json
+++ b/data/mods/Megafauna/monsters/mf_wild.json
@@ -32,7 +32,7 @@
     "fear_triggers": [ "SOUND", "FIRE" ],
     "reproduction": { "baby_monster": "mon_giant_beaver_cub", "baby_count": 4, "baby_timer": 360 },
     "baby_flags": [ "AUTUMN" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM" ],
     "armor": { "bash": 5, "cut": 10, "stab": 5 }
   },
   {
@@ -53,7 +53,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 2.0 } ],
     "dodge": 2,
     "upgrades": { "age_grow": 160, "into": "mon_giant_beaver" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "NO_BREED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "NO_BREED" ]
   },
   {
     "id": "mon_large_claw_sloth",
@@ -94,7 +94,7 @@
       "feed": "The %s seems to like you!  It lets you pat its head, giving off a bassy hum.",
       "pet": "The %s turns on its back and lets you scratch its huge, moss-overgrown belly."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "PET_MOUNTABLE", "CANPLAY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "PET_MOUNTABLE", "CANPLAY" ],
     "armor": { "bash": 5, "cut": 15, "stab": 10 }
   },
   {
@@ -116,7 +116,7 @@
     "melee_damage": [ { "damage_type": "bash", "amount": 4.0, "armor_penetration": 2 } ],
     "dodge": 1,
     "upgrades": { "age_grow": 720, "into": "mon_large_claw_sloth" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "SWIMS", "WARM", "NO_BREED", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "NO_BREED", "CANPLAY" ]
   },
   {
     "id": "mon_stagmoose",
@@ -157,7 +157,7 @@
       "feed": "The %s seems to tolerate you.  It cautiously lets you pat its head and seems friendly for now.",
       "pet": "The %s bows down its massive antlered head to nuzzle your face."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "MILKABLE", "WARM", "CANPLAY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER", "MILKABLE", "WARM", "CANPLAY" ],
     "armor": { "bash": 5, "cut": 5, "stab": 5 }
   },
   {
@@ -184,7 +184,7 @@
       "feed": "The %s seems to like you.  It lets you pat its head and seems friendly for now.",
       "pet": "The %s nuzzles you, pressing its head against your petting hand."
     },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "NO_BREED", "WARM", "CANPLAY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "NO_BREED", "WARM", "CANPLAY" ]
   },
   {
     "id": "mon_mammoth",
@@ -253,7 +253,7 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "PET_MOUNTABLE",
       "WARM",
@@ -293,7 +293,7 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PATH_AVOID_FIRE",
       "PET_WONT_FOLLOW",
       "WARM",
@@ -368,7 +368,7 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PET_MOUNTABLE",
       "WARM",
       "BASHES",
@@ -407,7 +407,7 @@
       "HEARS",
       "SMELLS",
       "ANIMAL",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "PET_WONT_FOLLOW",
       "WARM",
       "KEENNOSE",
@@ -459,7 +459,7 @@
         "damage_max_instance": [ { "damage_type": "bash", "amount": 40 } ]
       }
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "BASHES", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "BASHES", "PUSH_MON" ],
     "armor": { "bash": 10, "cut": 15, "stab": 5 }
   },
   {
@@ -483,7 +483,7 @@
     "dodge": 2,
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "upgrades": { "age_grow": 360, "into": "mon_shortface" },
-    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ]
+    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM" ]
   },
   {
     "id": "mon_auk",
@@ -515,7 +515,7 @@
     "reproduction": { "baby_egg": "egg_auk", "baby_count": 1, "baby_timer": 360 },
     "baby_flags": [ "SUMMER" ],
     "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "SWIMS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "SWIMS" ]
   },
   {
     "id": "mon_auk_chick",
@@ -567,7 +567,7 @@
         "damage_max_instance": [ { "damage_type": "bash", "amount": 50 } ]
       }
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "KEENNOSE", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PUSH_MON" ],
     "armor": { "bash": 10, "cut": 25, "stab": 20 }
   },
   {
@@ -592,7 +592,7 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "harvest": "mammal_large_leather",
     "upgrades": { "age_grow": 360, "into": "mon_glyptotherium" },
-    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "flags": [ "NO_BREED", "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM" ],
     "armor": { "bash": 4, "cut": 10, "stab": 5 }
   },
   {
@@ -629,7 +629,7 @@
     "baby_flags": [ "AUTUMN" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "mountable_weight_ratio": 0.3,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "MILKABLE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "MILKABLE" ],
     "armor": { "bash": 5, "cut": 10, "stab": 5 }
   },
   {
@@ -656,6 +656,6 @@
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
     "upgrades": { "age_grow": 240, "into": "mon_american_zebra" },
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER_1", "WARM", "NO_BREED" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PET_WONT_FOLLOW", "PET_MOUNTABLE", "PATH_AVOID_DANGER", "WARM", "NO_BREED" ]
   }
 ]

--- a/data/mods/Mythos-Creatures/monsters/mythos.json
+++ b/data/mods/Mythos-Creatures/monsters/mythos.json
@@ -41,7 +41,7 @@
       "POISON",
       "NO_BREATHE",
       "ARTHROPOD_BLOOD",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "CAN_OPEN_DOORS",
       "PRIORITIZE_TARGETS",
       "SWIMS",
@@ -78,7 +78,7 @@
     "path_settings": { "max_dist": 10 },
     "fear_triggers": [ "FIRE", "HURT" ],
     "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED", "FRIEND_DIED" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "HAS_MIND", "WARM", "SWIMS", "CLIMBS", "SWARMS", "PATH_AVOID_DANGER_1" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "HAS_MIND", "WARM", "SWIMS", "CLIMBS", "SWARMS", "PATH_AVOID_DANGER" ]
   },
   {
     "id": "mon_shantak",
@@ -115,7 +115,7 @@
       "SMELLS",
       "PET_MOUNTABLE",
       "FLIES",
-      "PATH_AVOID_DANGER_1",
+      "PATH_AVOID_DANGER",
       "WARM",
       "NO_BREATHE",
       "LOUDMOVES",

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -11,7 +11,7 @@
     "weight": "81500 g",
     "hp": 100,
     "speed": 50,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW" ],
     "upgrades": { "half_life": 0, "into_group": "test_upgrades_multi", "multiple_spawns": true, "spawn_range": 5 }
   },
   {
@@ -182,7 +182,7 @@
     "weight": "81500 g",
     "hp": 100,
     "speed": 50,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW" ],
     "upgrades": { "half_life": 0, "into_group": "test_upgrades_multi_late", "multiple_spawns": true, "spawn_range": 5 }
   },
   {
@@ -218,7 +218,7 @@
     "weight": "81500 g",
     "hp": 100,
     "speed": 50,
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW" ],
     "upgrades": {
       "half_life": 0,
       "into_group": "test_upgrades_multi_null",


### PR DESCRIPTION
#### Summary
Clean up PATH_AVOID_DANGER_1 flags

#### Purpose of change
Some of the mods and a few random spots still had the PATH_AVOID_DANGER_1 flag.

#### Describe the solution
PATH_AVOID_DANGER_1 -> PATH_AVOID_DANGER

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
