### PR TITLE
Backport DDA 74481 - Fix Mouse Overmap Migration When Using Iso tiles

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4116,7 +4116,8 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
     }
 
     const point screen_pos = coordinate - win_min;
-    const bool use_isometric = g->w_overmap && capture_win == g->w_overmap ? false : g->is_tileset_isometric();
+    const bool use_isometric = g->w_overmap &&
+                               capture_win == g->w_overmap ? false : g->is_tileset_isometric();
 
     const point_bub_ms p = cata_tiles::screen_to_player(
                                screen_pos, dim.scaled_font_size, win_size,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4116,10 +4116,11 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
     }
 
     const point screen_pos = coordinate - win_min;
+    const bool use_isometric = g->w_overmap ? false : g->is_tileset_isometric();
 
     const point_bub_ms p = cata_tiles::screen_to_player(
                                screen_pos, dim.scaled_font_size, win_size,
-                               point_bub_ms( offset ), g->is_tileset_isometric() );
+                               point_bub_ms( offset ), use_isometric );
 
     return tripoint( p.raw(), get_map().get_abs_sub().z() );
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4116,7 +4116,7 @@ std::optional<tripoint> input_context::get_coordinates( const catacurses::window
     }
 
     const point screen_pos = coordinate - win_min;
-    const bool use_isometric = g->w_overmap ? false : g->is_tileset_isometric();
+    const bool use_isometric = g->w_overmap && capture_win == g->w_overmap ? false : g->is_tileset_isometric();
 
     const point_bub_ms p = cata_tiles::screen_to_player(
                                screen_pos, dim.scaled_font_size, win_size,


### PR DESCRIPTION
#### Summary
Backport DDA 74481 - Fix Mouse Overmap Migration When Using Iso tiles

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
