### PR TITLE
Backport DDA 74476 - allow mod exclusions in get_all_mods.py

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -23,11 +23,14 @@ def add_mods(mods):
             # Either an invalid mod id, or blacklisted.
             return False
     for mod in mods:
-        if mod not in mods_this_time and compatible_with(mod, mods_this_time):
-            if add_mods(all_mod_dependencies[mod]):
-                mods_this_time.append(mod)
-            else:
-                return False
+        if mod in mods_this_time:
+            continue
+        if not compatible_with(mod, mods_this_time):
+            return False
+        if add_mods(all_mod_dependencies[mod]):
+            mods_this_time.append(mod)
+        else:
+            return False
     return True
 
 

--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -10,10 +10,20 @@ import json
 
 mods_this_time = []
 
+exclusions = [
+    # #74443 - incompatibility between mindovermatter and aftershock due to bug
+    ('mindovermatter', 'aftershock')
+]
+
 
 def compatible_with(mod, existing_mods):
     if mod in total_conversions and total_conversions & set(existing_mods):
         return False
+    for entry in exclusions:
+        if entry[0] == mod and entry[1] in existing_mods:
+            return False
+        if entry[1] == mod and entry[0] in existing_mods:
+            return False
     return True
 
 


### PR DESCRIPTION
#### Summary
Backport DDA 74476 - allow mod exclusions in get_all_mods.py


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
