### PR TITLE
backport DDA 74458 - Fix text typos.

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -482,7 +482,7 @@
     "//2": "The autobiography of a mountain man is included as, while an advanced survival book, it’s also a story novel in its current form. Should it be expanded with variants to include books that are not novels, then it should be removed.",
     "//3": "While a rather high-level fabrication book, this could conceivably be something that a craft shop/design and technology class would use in its current form: Plastics and Polymers: Projects for the Classroom. Should it be expanded with variants to include books that aren’t so school-based, it should be removed.",
     "//4": "While it has the potential to be a high-level tailoring book, its current form, Friendly, Humane Fashion, can be passed off as an educational library book. Should it be expanded with variants to include books that aren’t so school-based, it should be removed.",
-    "//5": "While a high-level speech book, Principles of Effective Communication, a public speaking book, isn’t unrealistic for a school library to possess,. Should it be expanded with variants to include books that aren’t so school-based, it should be removed.",
+    "//5": "While a high-level speech book, Principles of Effective Communication, a public speaking book, isn’t unrealistic for a school library to possess. Should it be expanded with variants to include books that aren’t so school-based, it should be removed.",
     "//6": "Bit of a stretch, but The Wonderful World of Arthropodology could feasibly exist as a library encyclopaedia.",
     "subtype": "distribution",
     "entries": [

--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -202,7 +202,7 @@
       {
         "id": "toy_plush_plesio",
         "name": { "str": "plesiosaurus plushie" },
-        "description": "A blueish, soft and friendly plesiosaurus plushie with big floppy flippers, a long neck and a and cute, gentle expression.",
+        "description": "A blueish, soft and friendly plesiosaurus plushie with big floppy flippers, a long neck and a cute, gentle expression.",
         "weight": 1
       },
       {
@@ -680,13 +680,13 @@
       {
         "id": "toy_plush_sheep",
         "name": { "str": "sheep plushie" },
-        "description": "This loving and fluffy sheep plushie features soft, woolly fur in white, with cute floppy ears and expressive eyes",
+        "description": "This loving and fluffy sheep plushie features soft, woolly fur in white, with cute floppy ears and expressive eyes.",
         "weight": 1
       },
       {
         "id": "toy_plush_bsheep",
         "name": { "str": "black sheep plushie" },
-        "description": "This loving and fluffy sheep plushie features soft, woolly fur in black, with cute floppy ears and somewhat careless, bored eyes",
+        "description": "This loving and fluffy sheep plushie features soft, woolly fur in black, with cute floppy ears and somewhat careless, bored eyes.",
         "weight": 1
       },
       {

--- a/data/json/npcs/godco/members/NPC_Sonia_Greene.json
+++ b/data/json/npcs/godco/members/NPC_Sonia_Greene.json
@@ -59,7 +59,7 @@
         "npc_has_var": "mission_completed_sonia_guitar_fixed",
         "value": "yes",
         "yes": "Just playing some good ol' tunes.  There's so much negativity around here, someone's gotta cheer people up, ya know?",
-        "no": "Nothin' much, just sitting around and biding my time,, getting any work I can.  I might play something to cheer everyone up, if my guitar wasn't busted."
+        "no": "Nothin' much, just sitting around and biding my time, getting any work I can.  I might play something to cheer everyone up, if my guitar wasn't busted."
       }
     ],
     "responses": [

--- a/data/json/npcs/godco/members/cook.json
+++ b/data/json/npcs/godco/members/cook.json
@@ -175,7 +175,7 @@
   {
     "id": "TALK_GODCO_chef_katherine",
     "type": "talk_topic",
-    "dynamic_line": "She's my wife, worked for the Church before <the_cataclysm>.  She used to organized charities for the needy, now we're the ones in need of charity.  She has a bit of a high horse these days, but a nice lady once you get to know her.  We've been married for 28 years, and I couldn't ask for a better wife.",
+    "dynamic_line": "She's my wife, worked for the Church before <the_cataclysm>.  She used to organize charities for the needy, now we're the ones in need of charity.  She has a bit of a high horse these days, but a nice lady once you get to know her.  We've been married for 28 years, and I couldn't ask for a better wife.",
     "responses": [
       { "text": "Who's Jeremiah?", "topic": "TALK_GODCO_chef_jeremiah" },
       {

--- a/data/json/npcs/militia/GM_Militia_Merchant.json
+++ b/data/json/npcs/militia/GM_Militia_Merchant.json
@@ -189,7 +189,7 @@
       },
       { "text": "Do you have anything to trade?", "topic": "TALK_MILITIA_TRADE" },
       {
-        "text": "Time for me to leave",
+        "text": "Time for me to leave.",
         "topic": "TALK_MILITIA_BYE",
         "condition": { "u_has_var": "talked_to_MILITIAMAIN", "type": "dialogue", "context": "first_meeting", "value": "yes" }
       }

--- a/data/mods/Megafauna/monsters/mf_domestic.json
+++ b/data/mods/Megafauna/monsters/mf_domestic.json
@@ -548,7 +548,7 @@
     "melee_damage": [ { "damage_type": "bash", "amount": 4.0 } ],
     "dodge": 2,
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FIRE" ],
-    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It squeals happily as you pet it.." },
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It squeals happily as you pet it." },
     "flags": [
       "NO_BREED",
       "SEES",

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -4173,6 +4173,7 @@ neuropsychology
 Neurosoft
 neurostimulators
 neurosynaptic
+neurotoxic
 neurotoxin
 NEURT
 neutrite


### PR DESCRIPTION
#### Summary
backport DDA 74458 - Fix text typos.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
