### PR TITLE
Backport 74450 - Fix calculation error in potassium iodide recipe

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -574,7 +574,7 @@
     "skills_required": [ "firstaid", 1 ],
     "difficulty": 4,
     "time": "24 m",
-    "charges": 3,
+    "charges": 9,
     "book_learn": [ [ "adv_chemistry", 4 ], [ "textbook_chemistry", 4 ], [ "recipe_labchem", 4 ], [ "atomic_survival", 5 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
@@ -585,8 +585,8 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 25, "LIST" ] ] ],
     "components": [
-      [ [ "iodine_crystal", 1 ] ],
-      [ [ "chem_potassium_hydroxide", 2 ] ],
+      [ [ "iodine_crystal", 2 ] ],
+      [ [ "chem_potassium_hydroxide", 5 ] ],
       [ [ "formic_acid", 1 ] ],
       [ [ "water", 1 ], [ "water_clean", 1 ] ]
     ]


### PR DESCRIPTION
#### Summary
Backport 74450 - Fix calculation error in potassium iodide recipe


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
