### PR TITLE
Backport DDA 74415 - KA-BAR now looks like National Guard Bayonet

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -524,6 +524,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "good" },
     "material": [ "steel", "leather" ],
     "repairs_with": [ "steel" ],
+    "looks_like": "knife_combat",
     "symbol": "/",
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 27 ] ],


### PR DESCRIPTION
#### Summary
Backport DDA 74415 - KA-BAR now looks like National Guard Bayonet

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
