### PR TITLE
Backport DDA 74467 - Remove weird DUKW spawns

### DIFF
--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -129,14 +129,7 @@
   {
     "type": "vehicle_group",
     "id": "boatrent",
-    "vehicles": [
-      [ "canoe", 2000 ],
-      [ "kayak", 1500 ],
-      [ "kayak_racing", 500 ],
-      [ "DUKW", 250 ],
-      [ "raft", 2000 ],
-      [ "wood_rowboat_double", 1500 ]
-    ]
+    "vehicles": [ [ "canoe", 2000 ], [ "kayak", 1500 ], [ "kayak_racing", 500 ], [ "raft", 2000 ], [ "wood_rowboat_double", 1500 ] ]
   },
   {
     "type": "vehicle_group",
@@ -146,7 +139,7 @@
   {
     "type": "vehicle_group",
     "id": "lake",
-    "vehicles": [ [ "DUKW", 250 ], [ "cabin_cruiser_wood", 1500 ] ]
+    "vehicles": [ [ "cabin_cruiser_wood", 1500 ] ]
   },
   {
     "type": "vehicle_group",


### PR DESCRIPTION
#### Summary
Backport DDA 74467 - Remove weird DUKW spawns


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
