### PR TITLE
Backport 74489 - Phosphorus from Matchboxes and Potassium Chloride From Match-heads

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1494,7 +1494,7 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "red_phosphorous",
-    "charges": 5,
+    "charges": 1,
     "batch_time_factors": [ 60, 5 ],
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_OTHER",
@@ -1502,7 +1502,8 @@
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "FINE_GRIND", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "SIEVE", "level": 1 } ],
-    "components": [ [ [ "match", 85 ] ] ]
+    "//": "calculation based on https://www.youtube.com/watch?v=5ZrfNAHDjWU; 1 matchbox contains 30 mg phosphorus and 1 unit of phosphor is 100 mg",
+    "components": [ [ [ "survival_match", 1 ], [ "ref_matches", 3 ], [ "matches", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -2606,5 +2607,21 @@
     "//4": "460kJ per mole @ 70% energy efficiency",
     "tools": [ [ [ "fake_arc_furnace", 650 ] ] ],
     "components": [ [ [ "cac2powder", 100 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "chem_potassium_chloride",
+    "charges": 1,
+    "batch_time_factors": [ 99, 1 ],
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_OTHER",
+    "skill_used": "fabrication",
+    "time": "2 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ] ],
+    "//": "basically burning potassium chlorate to form KCl in the ratio 1.6:1, i.e 20 matches produce 71 mg of KCl.  A survial match burns for 15-20 seconds and have a thicker coating of Potassium Chlorate to make it windproof.",
+    "components": [ [ [ "survival_match", 1 ], [ "match", 28 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Backport 74489 - Phosphorus from Matchboxes and Potassium Chloride From Match-heads


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
