### PR TITLE
Backport 74406 - See NPC morale, edit name/gender etc in @ menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4433,7 +4433,7 @@
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
-    "name": "Change sprite of armor.",
+    "name": "Change armor sprite",
     "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -54,7 +54,6 @@
 #include "martialarts.h"
 #include "messages.h"
 #include "mission.h"
-#include "morale.h"
 #include "move_mode.h"
 #include "mutation.h"
 #include "npc.h"
@@ -84,8 +83,6 @@
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vpart_position.h"
-
-class monfaction;
 
 static const bionic_id bio_cloak( "bio_cloak" );
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
@@ -139,7 +136,6 @@ static const ter_str_id ter_t_pit_shallow( "t_pit_shallow" );
 
 static const trait_id trait_ARACHNID_ARMS( "ARACHNID_ARMS" );
 static const trait_id trait_ARACHNID_ARMS_OK( "ARACHNID_ARMS_OK" );
-static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_CHITIN2( "CHITIN2" );
 static const trait_id trait_CHITIN3( "CHITIN3" );
 static const trait_id trait_CHITIN_FUR3( "CHITIN_FUR3" );
@@ -959,26 +955,6 @@ mfaction_id avatar::get_monster_faction() const
     return monfaction_player.id();
 }
 
-void avatar::disp_morale()
-{
-    int equilibrium = calc_focus_equilibrium();
-
-    int fatigue_penalty = 0;
-    const int fatigue_cap = focus_equilibrium_fatigue_cap( equilibrium );
-
-    if( fatigue_cap < equilibrium ) {
-        fatigue_penalty = equilibrium - fatigue_cap;
-        equilibrium = fatigue_cap;
-    }
-
-    int pain_penalty = 0;
-    if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
-        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - fatigue_penalty;
-    }
-
-    morale->display( equilibrium, pain_penalty, fatigue_penalty );
-}
-
 void avatar::reset_stats()
 {
     const int current_stim = get_stim();
@@ -987,7 +963,7 @@ void avatar::reset_stats()
     if( has_trait( trait_THICK_SCALES ) ) {
         add_miss_reason( _( "Your thick scales get in the way." ), 2 );
     }
-    if( has_trait( trait_CHITIN2 ) || has_trait( trait_CHITIN3 ) || has_trait( trait_CHITIN_FUR3 ) ) {
+    if( has_trait( trait_CHITIN2 ) ) {
         add_miss_reason( _( "Your chitin gets in the way." ), 1 );
     }
     if( has_trait( trait_COMPOUND_EYES ) && !wearing_something_on( bodypart_id( "eyes" ) ) ) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -159,10 +159,6 @@ class avatar : public Character
         nc_color basic_symbol_color() const override;
         int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const override;
 
-        /** Provides the window and detailed morale data */
-        void disp_morale();
-        /** Opens the medical window */
-        void disp_medical();
         /** Resets stats, and applies effects in an idempotent manner */
         void reset_stats() override;
         /** Resets all missions before saving character to template */

--- a/src/character.h
+++ b/src/character.h
@@ -1941,6 +1941,10 @@ class Character : public Creature, public visitable
         bool enough_power_for( const bionic_id &bid ) const;
         /** Handles and displays detailed character info for the '@' screen */
         void disp_info( bool customize_character = false );
+        /** Provides the window and detailed morale data */
+        void disp_morale();
+        /** Opens the medical window */
+        void disp_medical();
         void conduct_blood_analysis();
         // --------------- Generic Item Stuff ---------------
 

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -35,6 +35,7 @@ static const morale_type morale_perm_hoarder( "morale_perm_hoarder" );
 static const morale_type morale_perm_noface( "morale_perm_noface" );
 static const morale_type morale_perm_nomad( "morale_perm_nomad" );
 
+static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_HOARDER( "HOARDER" );
 static const trait_id trait_NOMAD( "NOMAD" );
 static const trait_id trait_NOMAD2( "NOMAD2" );
@@ -210,3 +211,22 @@ void Character::check_and_recover_morale()
     }
 }
 
+void Character::disp_morale()
+{
+    int equilibrium = calc_focus_equilibrium();
+
+    int sleepiness_penalty = 0;
+    const int sleepiness_cap = focus_equilibrium_sleepiness_cap( equilibrium );
+
+    if( sleepiness_cap < equilibrium ) {
+        sleepiness_penalty = equilibrium - sleepiness_cap;
+        equilibrium = sleepiness_cap;
+    }
+
+    int pain_penalty = 0;
+    if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
+        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - sleepiness_penalty;
+    }
+
+    morale->display( equilibrium, pain_penalty, sleepiness_penalty );
+}

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -215,18 +215,18 @@ void Character::disp_morale()
 {
     int equilibrium = calc_focus_equilibrium();
 
-    int sleepiness_penalty = 0;
-    const int sleepiness_cap = focus_equilibrium_sleepiness_cap( equilibrium );
+    int fatigue_penalty = 0;
+    const int fatigue_cap = focus_equilibrium_fatigue_cap( equilibrium );
 
-    if( sleepiness_cap < equilibrium ) {
-        sleepiness_penalty = equilibrium - sleepiness_cap;
-        equilibrium = sleepiness_cap;
+    if( fatigue_cap < equilibrium ) {
+        fatigue_penalty = equilibrium - fatigue_cap;
+        equilibrium = fatigue_cap;
     }
 
     int pain_penalty = 0;
     if( get_perceived_pain() && !has_trait( trait_CENOBITE ) ) {
-        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - sleepiness_penalty;
+        pain_penalty = calc_focus_equilibrium( true ) - equilibrium - fatigue_penalty;
     }
 
-    morale->display( equilibrium, pain_penalty, sleepiness_penalty );
+    morale->display( equilibrium, pain_penalty, fatigue_penalty );
 }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1363,7 +1363,7 @@ std::string display::colorized_compass_legend_text( int width, int max_height, i
                     name = colorize( "@", c_pink );
                     break;
             }
-            name = string_format( "%s %s", name, n->name );
+            name = string_format( "%s %s", name, n->get_name() );
             names.emplace_back( name );
         }
     }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -495,7 +495,7 @@ void talk_function::wake_up( npc &p )
 
 void talk_function::reveal_stats( npc &p )
 {
-    p.disp_info();
+    p.disp_info( true );
 }
 
 void talk_function::end_conversation( npc &p )

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1152,7 +1152,7 @@ static void on_customize_character( Character &you )
     }
 }
 
-static void change_armor_sprite( avatar &you )
+static void change_armor_sprite( Character &you )
 {
     item_location target_loc;
     target_loc = game_menus::inv::change_sprite( you );
@@ -1168,17 +1168,14 @@ static void change_armor_sprite( avatar &you )
         menu.query();
         if( menu.ret == 0 ) {
             item_location sprite_loc;
-            avatar *you = get_player_character().as_avatar();
             auto armor_filter = [&]( const item & i ) {
                 return i.is_armor();
             };
-            if( you != nullptr ) {
-                sprite_loc = game_menus::inv::titled_filter_menu( armor_filter,
-                             *you,
-                             _( "Select appearance of this armor:" ),
-                             -1,
-                             _( "You have nothing to wear." ) );
-            }
+            sprite_loc = game_menus::inv::titled_filter_menu( armor_filter,
+                         you,
+                         _( "Select appearance of this armor:" ),
+                         -1,
+                         _( "You have nothing to wear." ) );
             if( sprite_loc && sprite_loc.get_item() ) {
                 const item *sprite_item = sprite_loc.get_item();
                 const std::string variant = sprite_item->has_itype_variant() ? sprite_item->itype_variant().id : "";
@@ -1375,9 +1372,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                         }
                         break;
                     case 1:
-                        if( you.is_avatar() ) {
-                            you.as_avatar()->disp_morale();
-                        }
+                        you.disp_morale();
                         break;
                     case 2:
                         ctxt.display_menu();
@@ -1431,9 +1426,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         show_proficiencies_window( you );
 
     } else if( action == "morale" ) {
-        if( you.is_avatar() ) {
-            you.as_avatar()->disp_morale( );
-        }
+        you.disp_morale( );
     } else if( action == "VIEW_BODYSTAT" ) {
         display_bodygraph( you );
     } else if( customize_character && action == "SWITCH_GENDER" ) {
@@ -1447,9 +1440,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         ++info_line;
         ui_info.invalidate_ui();
     } else if( action == "MEDICAL_MENU" ) {
-        if( you.is_avatar() ) {
-            you.as_avatar()->disp_medical();
-        }
+        you.disp_medical();
     } else if( action == "SELECT_STATS_TAB" ) {
         invalidate_tab( curtab );
         curtab = player_display_tab::stats;
@@ -1500,9 +1491,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
         info_line = 0;
         ui_info.invalidate_ui();
     } else if( action == "CHANGE_ARMOR_SPRITE" ) {
-        if( you.as_avatar() ) {
-            change_armor_sprite( *you.as_avatar() );
-        }
+        change_armor_sprite( you );
     }
     return done;
 }


### PR DESCRIPTION
#### Summary
Backport 74406 - See NPC morale, edit name/gender etc in @ menu


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
