### PR TITLE
Backport DDA 73998 - Explicit roof on storehouse 1

### DIFF
--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_construction.json
@@ -37,9 +37,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room0_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "  rrrr",
+        "  rrrr",
+        "  rrrr",
+        "  rrrr",
+        "  rrrr",
+        "  rrrr"
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room0_construction_east",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room0_construction" ], "x": 15, "y": 9 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room0_construction" ], "x": 15, "y": 9, "z": 0 },
+        { "chunks": [ "fbms_room0_roof_construction" ], "x": 15, "y": 9, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -79,9 +119,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room1_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrrr  ",
+        "rrrr  ",
+        "rrrr  ",
+        "rrrr  ",
+        "rrrr  ",
+        "rrrr  "
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room1_construction_west",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room1_construction" ], "x": 3, "y": 9 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room1_construction" ], "x": 3, "y": 9, "z": 0 },
+        { "chunks": [ "fbms_room1_roof_construction" ], "x": 3, "y": 9, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -121,9 +201,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room2_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "   rrr",
+        "   rrr",
+        "   rrr"
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room2_construction_northwest",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room2_construction" ], "x": 3, "y": 3 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room2_construction" ], "x": 3, "y": 3, "z": 0 },
+        { "chunks": [ "fbms_room2_roof_construction" ], "x": 3, "y": 3, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -163,9 +283,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room3_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   rrr",
+        "   rrr",
+        "   rrr",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room3_construction_southwest",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room3_construction" ], "x": 3, "y": 15 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room3_construction" ], "x": 3, "y": 15, "z": 0 },
+        { "chunks": [ "fbms_room3_roof_construction" ], "x": 3, "y": 15, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -205,9 +365,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room4_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "rrr   ",
+        "rrr   ",
+        "rrr   "
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room4_construction_northeast",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room4_construction" ], "x": 15, "y": 3 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room4_construction" ], "x": 15, "y": 3, "z": 0 },
+        { "chunks": [ "fbms_room4_roof_construction" ], "x": 15, "y": 3, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -247,9 +447,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room5_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrr   ",
+        "rrr   ",
+        "rrr   ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room5_construction_southeast",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room5_construction" ], "x": 15, "y": 15 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room5_construction" ], "x": 15, "y": 15, "z": 0 },
+        { "chunks": [ "fbms_room5_roof_construction" ], "x": 15, "y": 15, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -289,9 +529,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room6_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        " rrrr ",
+        " rrrr ",
+        "rrrrrr"
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room6_construction_south",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room6_construction" ], "x": 9, "y": 15 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room6_construction" ], "x": 9, "y": 15, "z": 0 },
+        { "chunks": [ "fbms_room6_roof_construction" ], "x": 9, "y": 15, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -331,9 +611,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room7_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrrrrr",
+        " rrrr ",
+        " rrrr ",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr"
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room7_construction_north",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbms_room7_construction" ], "x": 9, "y": 3 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbms_room7_construction" ], "x": 9, "y": 3, "z": 0 },
+        { "chunks": [ "fbms_room7_roof_construction" ], "x": 9, "y": 3, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -368,6 +688,41 @@
         "......"
       ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room8_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr",
+        "rrrrrr"
+      ],
       "palettes": [ { "param": "fbms_construction_palette" } ]
     }
   },
@@ -410,6 +765,41 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "fbms_room9_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "    rr",
+        "    rr",
+        "    rr",
+        "    rr",
+        "    rr",
+        "    rr"
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "fbms_room10_construction",
     "object": {
       "parameters": {
@@ -445,13 +835,51 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbms_room10_roof_construction",
+    "object": {
+      "parameters": {
+        "fbms_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbms_concrete_palette",
+              "fbms_log_palette",
+              "fbms_metal_palette",
+              "fbms_migo_resin_palette",
+              "fbms_rammed_earth_palette",
+              "fbms_rock_palette",
+              "fbms_wad_palette",
+              "fbms_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "rr    ",
+        "rr    ",
+        "rr    ",
+        "rr    ",
+        "rr    ",
+        "rr    "
+      ],
+      "palettes": [ { "param": "fbms_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbms_room8_construction_center",
     "method": "json",
     "object": {
       "place_nested": [
-        { "chunks": [ "fbms_room9_construction" ], "x": 3, "y": 9 },
-        { "chunks": [ "fbms_room10_construction" ], "x": 15, "y": 9 },
-        { "chunks": [ "fbms_room8_construction" ], "x": 9, "y": 9 }
+        { "chunks": [ "fbms_room8_construction" ], "x": 9, "y": 9, "z": 0 },
+        { "chunks": [ "fbms_room8_roof_construction" ], "x": 9, "y": 9, "z": 1 },
+        { "chunks": [ "fbms_room9_construction" ], "x": 3, "y": 9, "z": 0 },
+        { "chunks": [ "fbms_room9_roof_construction" ], "x": 3, "y": 9, "z": 1 },
+        { "chunks": [ "fbms_room10_construction" ], "x": 15, "y": 9, "z": 0 },
+        { "chunks": [ "fbms_room10_roof_construction" ], "x": 15, "y": 9, "z": 1 }
       ]
     }
   }

--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_palettes.json
@@ -8,49 +8,73 @@
   {
     "type": "palette",
     "id": "fbms_concrete_palette",
-    "terrain": { ".": "t_thconc_floor", "d": "t_door_metal_c", "o": "t_window_no_curtains", "w": "t_sconc_wall" },
+    "terrain": {
+      ".": "t_thconc_floor",
+      "d": "t_door_metal_c",
+      "o": "t_window_no_curtains",
+      "r": "t_concrete_roof",
+      "w": "t_sconc_wall"
+    },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_log_palette",
-    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "w": "t_wall_log" },
+    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "r": "t_wood_treated_roof", "w": "t_wall_log" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_metal_palette",
-    "terrain": { ".": "t_scrap_floor", "d": "t_door_metal_c", "o": "t_window_no_curtains", "w": "t_scrap_wall" },
+    "terrain": {
+      ".": "t_scrap_floor",
+      "d": "t_door_metal_c",
+      "o": "t_window_no_curtains",
+      "r": "t_metal_flat_roof",
+      "w": "t_scrap_wall"
+    },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_migo_resin_palette",
-    "terrain": { ".": "t_floor_resin", "d": "t_resin_hole_c", "o": "t_wall_resin_cage", "w": "t_wall_resin" },
+    "terrain": { ".": "t_floor_resin", "d": "t_resin_hole_c", "o": "t_wall_resin_cage", "r": "t_resin_roof", "w": "t_wall_resin" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_rammed_earth_palette",
-    "terrain": { ".": "t_floor_primitive", "d": "t_door_makeshift_c", "o": "t_window_empty", "w": "t_wall_rammed_earth" },
+    "terrain": {
+      ".": "t_floor_primitive",
+      "d": "t_door_makeshift_c",
+      "o": "t_window_empty",
+      "r": "t_log_sod_roof",
+      "w": "t_wall_rammed_earth"
+    },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_rock_palette",
-    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "w": "t_rock_wall" },
+    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "r": "t_wood_treated_roof", "w": "t_rock_wall" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_wad_palette",
-    "terrain": { ".": "t_floor_primitive", "d": "t_door_makeshift_c", "o": "t_wall_wattle_half", "w": "t_wall_wattle" },
+    "terrain": {
+      ".": "t_floor_primitive",
+      "d": "t_door_makeshift_c",
+      "o": "t_wall_wattle_half",
+      "r": "t_log_sod_roof",
+      "w": "t_wall_wattle"
+    },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   },
   {
     "type": "palette",
     "id": "fbms_wood_palette",
-    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "w": "t_wall_wood" },
+    "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "r": "t_wood_treated_roof", "w": "t_wall_wood" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   }
 ]


### PR DESCRIPTION
#### Summary
Backport DDA 73998 - Explicit roof on storehouse 1

#### Purpose of change
Confusing how this got missed, but it's needed for the next backport.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
