### PR TITLE
Backport DDA 74037 - Added roofs to workshop 1

### DIFF
--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_common.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_common.json
@@ -30,10 +30,30 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room1_roof_common",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "      ",
+        "  C   ",
+        "      ",
+        "      ",
+        "      ",
+        "    C "
+      ],
+      "palettes": [ "fbmw_common_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room1_common_northeast",
     "method": "json",
     "object": {
-      "place_nested": [ { "chunks": [ "fbmw_room1_common" ], "x": 15, "y": 3 } ],
+      "place_nested": [
+        { "chunks": [ "fbmw_room1_common" ], "x": 15, "y": 3, "z": 0 },
+        { "chunks": [ "fbmw_room1_roof_common" ], "x": 15, "y": 3, "z": 1 }
+      ],
       "place_loot": [ { "item": "crucible", "x": 18, "y": 4, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_construction.json
@@ -37,9 +37,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room0_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room0_construction_northeast",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmw_room0_construction" ], "x": 15, "y": 3 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbmw_room0_construction" ], "x": 15, "y": 3, "z": 0 },
+        { "chunks": [ "fbmw_room0_roof_construction" ], "x": 15, "y": 3, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -79,9 +119,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room3_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room3_construction_north",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmw_room3_construction" ], "x": 9, "y": 3 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbmw_room3_construction" ], "x": 9, "y": 3, "z": 0 },
+        { "chunks": [ "fbmw_room3_roof_construction" ], "x": 9, "y": 3, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -121,9 +201,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room4_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRRRRR",
+        "RRRRCR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room4_construction_east",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmw_room4_construction" ], "x": 15, "y": 9 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbmw_room4_construction" ], "x": 15, "y": 9, "z": 0 },
+        { "chunks": [ "fbmw_room4_roof_construction" ], "x": 15, "y": 9, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -163,9 +283,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room5_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room5_construction_center",
     "method": "json",
-    "object": { "place_nested": [ { "chunks": [ "fbmw_room5_construction" ], "x": 9, "y": 9 } ] }
+    "object": {
+      "place_nested": [
+        { "chunks": [ "fbmw_room5_construction" ], "x": 9, "y": 9, "z": 0 },
+        { "chunks": [ "fbmw_room5_roof_construction" ], "x": 9, "y": 9, "z": 1 }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -205,10 +365,48 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room6_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRR   ",
+        "RCR   ",
+        "RRR   ",
+        "RRR   ",
+        "RRR   ",
+        "RRR   "
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room6_construction_north",
     "method": "json",
     "object": {
-      "place_nested": [ { "chunks": [ "fbmw_room6_construction" ], "x": 9, "y": 3 } ],
+      "place_nested": [
+        { "chunks": [ "fbmw_room6_construction" ], "x": 9, "y": 3, "z": 0 },
+        { "chunks": [ "fbmw_room6_roof_construction" ], "x": 9, "y": 3, "z": 1 }
+      ],
       "place_loot": [
         { "item": "tongs", "x": 19, "y": 5, "chance": 100 },
         { "item": "chisel", "x": 19, "y": 5, "chance": 100 },
@@ -256,6 +454,41 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "fbmw_room7_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "fbmw_room8_construction",
     "object": {
       "parameters": {
@@ -286,6 +519,41 @@
         "      "
       ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room8_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   RRR",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
       "palettes": [ { "param": "fbmw_construction_palette" } ]
     }
   },
@@ -327,13 +595,51 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room9_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRR   ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room7to9_construction_northwest",
     "method": "json",
     "object": {
       "place_nested": [
-        { "chunks": [ "fbmw_room7_construction" ], "x": 3, "y": 3 },
-        { "chunks": [ "fbmw_room8_construction" ], "x": 3, "y": 9 },
-        { "chunks": [ "fbmw_room9_construction" ], "x": 9, "y": 9 }
+        { "chunks": [ "fbmw_room7_construction" ], "x": 3, "y": 3, "z": 0 },
+        { "chunks": [ "fbmw_room7_roof_construction" ], "x": 3, "y": 3, "z": 1 },
+        { "chunks": [ "fbmw_room8_construction" ], "x": 3, "y": 9, "z": 0 },
+        { "chunks": [ "fbmw_room8_roof_construction" ], "x": 3, "y": 9, "z": 1 },
+        { "chunks": [ "fbmw_room9_construction" ], "x": 9, "y": 9, "z": 0 },
+        { "chunks": [ "fbmw_room9_roof_construction" ], "x": 9, "y": 9, "z": 1 }
       ]
     }
   },
@@ -376,6 +682,41 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "fbmw_room11_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR",
+        "RRRRRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "fbmw_room12_construction",
     "object": {
       "parameters": {
@@ -411,12 +752,49 @@
   },
   {
     "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "fbmw_room12_roof_construction",
+    "object": {
+      "parameters": {
+        "fbmw_construction_palette": {
+          "type": "palette_id",
+          "scope": "omt",
+          "default": {
+            "distribution": [
+              "fbmw_concrete_palette",
+              "fbmw_log_palette",
+              "fbmw_metal_palette",
+              "fbmw_migo_resin_palette",
+              "fbmw_rammed_earth_palette",
+              "fbmw_rock_palette",
+              "fbmw_wad_palette",
+              "fbmw_wood_palette"
+            ]
+          }
+        }
+      },
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR",
+        "   RRR"
+      ],
+      "palettes": [ { "param": "fbmw_construction_palette" } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "fbmw_room11to12_construction_southeast",
     "method": "json",
     "object": {
       "place_nested": [
-        { "chunks": [ "fbmw_room11_construction" ], "x": 15, "y": 15 },
-        { "chunks": [ "fbmw_room12_construction" ], "x": 9, "y": 15 }
+        { "chunks": [ "fbmw_room11_construction" ], "x": 15, "y": 15, "z": 0 },
+        { "chunks": [ "fbmw_room11_roof_construction" ], "x": 15, "y": 15, "z": 1 },
+        { "chunks": [ "fbmw_room12_construction" ], "x": 9, "y": 15, "z": 0 },
+        { "chunks": [ "fbmw_room12_roof_construction" ], "x": 9, "y": 15, "z": 1 }
       ],
       "place_loot": [ { "item": "wrench", "x": 19, "y": 7, "chance": 100 }, { "item": "pliers", "x": 19, "y": 7, "chance": 100 } ],
       "set": [ { "point": "furniture", "id": "f_drophammer", "x": 19, "y": 12 } ]

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_palettes.json
@@ -10,6 +10,7 @@
       "t": "f_table",
       "x": "f_kiln_empty",
       "A": "f_anvil",
+      "C": "f_chimney",
       "L": "f_locker",
       "Q": "f_bellows"
     }
@@ -31,7 +32,9 @@
       "x": "t_thconc_floor",
       "z": "t_dirt",
       "B": "t_thconc_floor",
-      "M": "t_thconc_floor"
+      "C": "t_concrete_roof",
+      "M": "t_thconc_floor",
+      "R": "t_concrete_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -47,7 +50,9 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
-      "M": "f_armchair"
+      "C": "f_chimney",
+      "M": "f_armchair",
+      "Y": "f_chimney"
     }
   },
   {
@@ -67,7 +72,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_wood_treated_roof",
+      "M": "t_dirtfloor",
+      "R": "t_wood_treated_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -83,6 +90,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -103,7 +111,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_metal_flat_roof",
+      "M": "t_dirtfloor",
+      "R": "t_metal_flat_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -119,6 +129,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -139,7 +150,9 @@
       "x": "t_floor_resin",
       "z": "t_dirt",
       "B": "t_floor_resin",
-      "M": "t_floor_resin"
+      "C": "t_resin_roof",
+      "M": "t_floor_resin",
+      "R": "t_resin_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -155,6 +168,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -175,7 +189,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_log_sod_roof",
+      "M": "t_dirtfloor",
+      "R": "t_log_sod_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -191,6 +207,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -211,7 +228,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_wood_treated_roof",
+      "M": "t_dirtfloor",
+      "R": "t_wood_treated_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -227,6 +246,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -247,7 +267,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_log_sod_roof",
+      "M": "t_dirtfloor",
+      "R": "t_log_sod_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -263,6 +285,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   },
@@ -283,7 +306,9 @@
       "x": "t_dirtfloor",
       "z": "t_dirt",
       "B": "t_dirtfloor",
-      "M": "t_dirtfloor"
+      "C": "t_wood_treated_roof",
+      "M": "t_dirtfloor",
+      "R": "t_wood_treated_roof"
     },
     "furniture": {
       ".": "f_clear",
@@ -299,6 +324,7 @@
       "x": "f_kiln_empty",
       "z": "f_55gal_firebarrel",
       "B": "f_bookcase",
+      "C": "f_chimney",
       "M": "f_armchair"
     }
   }


### PR DESCRIPTION
#### Summary
Backport DDA 74037 - Added roofs to workshop 1


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
