### PR TITLE
backport dda 74389 - Add brick construction to camp expansions

### DIFF
--- a/data/json/mapgen/basecamps/expansion/modular_canteen/version_1/modular_canteen_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_canteen/version_1/modular_canteen_construction.json
@@ -17,7 +17,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -54,7 +55,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -101,7 +103,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -138,7 +141,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -185,7 +189,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -222,7 +227,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -269,7 +275,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -306,7 +313,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -353,7 +361,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -390,7 +399,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -438,7 +448,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -475,7 +486,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -522,7 +534,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }
@@ -559,7 +572,8 @@
               "fbmk_rammed_earth_palette",
               "fbmk_rock_palette",
               "fbmk_wad_palette",
-              "fbmk_wood_palette"
+              "fbmk_wood_palette",
+              "fbmk_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_canteen/version_1/modular_canteen_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_canteen/version_1/modular_canteen_palettes.json
@@ -81,5 +81,11 @@
     "id": "fbmk_wood_palette",
     "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "R": "t_wood_treated_roof", "w": "t_wall_wood" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
+  },
+  {
+    "type": "palette",
+    "id": "fbmk_brick_palette",
+    "terrain": { ".": "t_floor", "d": "t_rdoor_c", "o": "t_window_no_curtains", "R": "t_wood_treated_roof", "w": "t_brick_wall" },
+    "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_canteen/version_2/modular_canteen_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_canteen/version_2/modular_canteen_construction.json
@@ -17,7 +17,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -54,7 +55,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -101,7 +103,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -138,7 +141,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -185,7 +189,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -220,7 +225,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -265,7 +271,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -304,7 +311,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -353,7 +361,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -390,7 +399,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -437,7 +447,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -474,7 +485,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -521,7 +533,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }
@@ -558,7 +571,8 @@
               "fbmk_2_rammed_earth_palette",
               "fbmk_2_rock_palette",
               "fbmk_2_wad_palette",
-              "fbmk_2_wood_palette"
+              "fbmk_2_wood_palette",
+              "fbmk_2_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_canteen/version_2/modular_canteen_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_canteen/version_2/modular_canteen_palettes.json
@@ -141,5 +141,18 @@
       "w": "t_wall_wood"
     },
     "furniture": {  }
+  },
+  {
+    "type": "palette",
+    "id": "fbmk_2_brick_palette",
+    "terrain": {
+      ",": "t_dirtfloor",
+      ".": "t_floor",
+      "+": "t_rdoor_c",
+      "r": "t_wood_treated_roof",
+      "v": "t_window_no_curtains",
+      "w": "t_brick_wall"
+    },
+    "furniture": {  }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_garage/version_2/modular_garage_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_garage/version_2/modular_garage_construction.json
@@ -17,7 +17,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -83,7 +84,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -149,7 +151,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -200,7 +203,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -253,7 +257,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -303,7 +308,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -367,7 +373,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -431,7 +438,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -495,7 +503,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -559,7 +568,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }
@@ -623,7 +633,8 @@
               "fbmg_2_rammed_earth_palette",
               "fbmg_2_rock_palette",
               "fbmg_2_wad_palette",
-              "fbmg_2_wood_palette"
+              "fbmg_2_wood_palette",
+              "fbmg_2_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_garage/version_2/modular_garage_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_garage/version_2/modular_garage_palettes.json
@@ -71,5 +71,11 @@
     "id": "fbmg_2_wood_palette",
     "terrain": { ",": "t_dirtfloor", ".": "t_floor", "+": "t_door_c", "v": "t_window_no_curtains", "w": "t_wall_wood" },
     "furniture": {  }
+  },
+  {
+    "type": "palette",
+    "id": "fbmg_2_brick_palette",
+    "terrain": { ",": "t_dirtfloor", ".": "t_floor", "+": "t_rdoor_c", "v": "t_window_no_curtains", "w": "t_brick_wall" },
+    "furniture": {  }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_livestock/version_1/modular_livestock_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_livestock/version_1/modular_livestock_construction.json
@@ -17,7 +17,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -54,7 +55,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -100,7 +102,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -136,7 +139,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -182,7 +186,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -219,7 +224,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -265,7 +271,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }
@@ -313,7 +320,8 @@
               "fbml_rammed_earth_palette",
               "fbml_rock_palette",
               "fbml_wad_palette",
-              "fbml_wood_palette"
+              "fbml_wood_palette",
+              "fbml_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_livestock/version_1/modular_livestock_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_livestock/version_1/modular_livestock_palettes.json
@@ -70,5 +70,11 @@
     "id": "fbml_wood_palette",
     "terrain": { "+": "t_door_c", "o": "t_window_no_curtains", "R": "t_wood_treated_roof", "w": "t_wall_wood" },
     "furniture": { "+": "f_clear", "o": "f_clear", "R": "f_clear", "w": "f_clear" }
+  },
+  {
+    "type": "palette",
+    "id": "fbml_brick_palette",
+    "terrain": { "+": "t_rdoor_c", "o": "t_window_no_curtains", "R": "t_wood_treated_roof", "w": "t_brick_wall" },
+    "furniture": { "+": "f_clear", "o": "f_clear", "R": "f_clear", "w": "f_clear" }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_livestock/version_2/modular_livestock_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_livestock/version_2/modular_livestock_construction.json
@@ -17,7 +17,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -55,7 +56,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -103,7 +105,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -138,7 +141,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -184,7 +188,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -220,7 +225,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -267,7 +273,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -303,7 +310,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -350,7 +358,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -410,7 +419,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }
@@ -446,7 +456,8 @@
               "fbml_2_rammed_earth_palette",
               "fbml_2_rock_palette",
               "fbml_2_wad_palette",
-              "fbml_2_wood_palette"
+              "fbml_2_wood_palette",
+              "fbml_2_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_livestock/version_2/modular_livestock_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_livestock/version_2/modular_livestock_palettes.json
@@ -114,5 +114,18 @@
       "w": "t_wall_wood"
     },
     "furniture": {  }
+  },
+  {
+    "type": "palette",
+    "id": "fbml_2_brick_palette",
+    "terrain": {
+      ",": "t_dirtfloor",
+      ".": "t_floor",
+      "+": "t_rdoor_c",
+      "r": "t_wood_treated_roof",
+      "v": "t_window_no_curtains",
+      "w": "t_brick_wall"
+    },
+    "furniture": {  }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_saltworks/version_1/modular_saltworks_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_saltworks/version_1/modular_saltworks_construction.json
@@ -22,7 +22,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }
@@ -58,7 +59,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }
@@ -104,7 +106,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }
@@ -139,7 +142,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }
@@ -184,7 +188,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }
@@ -220,7 +225,8 @@
               "fbmsw_rammed_earth_palette",
               "fbmsw_rock_palette",
               "fbmsw_wad_palette",
-              "fbmsw_wood_palette"
+              "fbmsw_wood_palette",
+              "fbmsw_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_saltworks/version_1/modular_saltworks_palette.json
+++ b/data/json/mapgen/basecamps/expansion/modular_saltworks/version_1/modular_saltworks_palette.json
@@ -244,5 +244,38 @@
       "w": "f_clear",
       "+": "f_clear"
     }
+  },
+  {
+    "type": "palette",
+    "id": "fbmsw_brick_palette",
+    "terrain": {
+      ".": "t_floor",
+      "b": "t_floor",
+      "r": "t_floor",
+      "t": "t_floor",
+      "#": "t_floor",
+      "c": "t_floor",
+      "H": "t_floor",
+      "O": "t_floor",
+      "~": "t_swater_sh",
+      "o": "t_window_no_curtains",
+      "w": "t_brick_wall",
+      "+": "t_rdoor_c",
+      "R": "t_wood_treated_roof"
+    },
+    "furniture": {
+      ".": "f_clear",
+      "b": "f_bench",
+      "r": "f_rack",
+      "t": "f_table",
+      "#": "f_stool",
+      "c": "f_counter",
+      "H": "f_wood_keg",
+      "O": "f_fvat_empty",
+      "~": "f_clear",
+      "o": "f_clear",
+      "w": "f_clear",
+      "+": "f_clear"
+    }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_construction.json
@@ -17,7 +17,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -53,7 +54,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -99,7 +101,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -135,7 +138,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -181,7 +185,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -217,7 +222,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -263,7 +269,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -299,7 +306,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -345,7 +353,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -381,7 +390,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -427,7 +437,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -463,7 +474,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -509,7 +521,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -545,7 +558,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -591,7 +605,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -627,7 +642,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -673,7 +689,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -709,7 +726,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -744,7 +762,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -780,7 +799,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -815,7 +835,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }
@@ -851,7 +872,8 @@
               "fbms_rammed_earth_palette",
               "fbms_rock_palette",
               "fbms_wad_palette",
-              "fbms_wood_palette"
+              "fbms_wood_palette",
+              "fbms_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_1/modular_storehouse_palettes.json
@@ -76,5 +76,11 @@
     "id": "fbms_wood_palette",
     "terrain": { ".": "t_floor", "d": "t_door_c", "o": "t_window_no_curtains", "r": "t_wood_treated_roof", "w": "t_wall_wood" },
     "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
+  },
+  {
+    "type": "palette",
+    "id": "fbms_brick_palette",
+    "terrain": { ".": "t_floor", "d": "t_rdoor_c", "o": "t_window_no_curtains", "r": "t_wood_treated_roof", "w": "t_brick_wall" },
+    "furniture": { ".": "f_clear", "d": "f_clear", "o": "f_clear", "w": "f_clear" }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_2/modular_storehouse_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_2/modular_storehouse_construction.json
@@ -17,7 +17,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -54,7 +55,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -101,7 +103,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -138,7 +141,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -185,7 +189,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -233,7 +238,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -270,7 +276,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -317,7 +324,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -353,7 +361,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -399,7 +408,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -447,7 +457,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -484,7 +495,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -531,7 +543,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -567,7 +580,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -613,7 +627,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -661,7 +676,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -709,7 +725,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }
@@ -756,7 +773,8 @@
               "fbms_2_rammed_earth_palette",
               "fbms_2_rock_palette",
               "fbms_2_wad_palette",
-              "fbms_2_wood_palette"
+              "fbms_2_wood_palette",
+              "fbms_2_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_storehouse/version_2/modular_storehouse_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_storehouse/version_2/modular_storehouse_palettes.json
@@ -144,5 +144,18 @@
       "w": "t_wall_wood"
     },
     "furniture": {  }
+  },
+  {
+    "type": "palette",
+    "id": "fbms_2_brick_palette",
+    "terrain": {
+      ",": "t_dirtfloor",
+      ".": "t_floor",
+      "+": "t_rdoor_c",
+      "r": "t_wood_treated_roof",
+      "v": "t_window_no_curtains",
+      "w": "t_brick_wall"
+    },
+    "furniture": {  }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_construction.json
@@ -17,7 +17,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -53,7 +54,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -99,7 +101,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -135,7 +138,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -181,7 +185,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -217,7 +222,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -263,7 +269,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -299,7 +306,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -345,7 +353,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -381,7 +390,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -433,7 +443,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -469,7 +480,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -504,7 +516,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -540,7 +553,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -575,7 +589,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -611,7 +626,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -661,7 +677,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -697,7 +714,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -732,7 +750,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }
@@ -768,7 +787,8 @@
               "fbmw_rammed_earth_palette",
               "fbmw_rock_palette",
               "fbmw_wad_palette",
-              "fbmw_wood_palette"
+              "fbmw_wood_palette",
+              "fbmw_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_1/modular_workshop_palettes.json
@@ -327,5 +327,44 @@
       "C": "f_chimney",
       "M": "f_armchair"
     }
+  },
+  {
+    "type": "palette",
+    "id": "fbmw_brick_palette",
+    "terrain": {
+      ".": "t_dirtfloor",
+      "b": "t_grass",
+      "c": "t_dirtfloor",
+      "d": "t_rdoor_c",
+      "h": "t_dirtfloor",
+      "k": "t_dirtfloor",
+      "o": "t_window_no_curtains",
+      "r": "t_dirtfloor",
+      "t": "t_dirtfloor",
+      "w": "t_brick_wall",
+      "x": "t_dirtfloor",
+      "z": "t_dirt",
+      "B": "t_dirtfloor",
+      "C": "t_wood_treated_roof",
+      "M": "t_dirtfloor",
+      "R": "t_wood_treated_roof"
+    },
+    "furniture": {
+      ".": "f_clear",
+      "b": "f_bench",
+      "c": "f_workbench",
+      "d": "f_clear",
+      "h": "f_stool",
+      "k": "f_clay_kiln",
+      "o": "f_clear",
+      "r": "f_rack_wood",
+      "t": "f_table",
+      "w": "f_clear",
+      "x": "f_kiln_empty",
+      "z": "f_55gal_firebarrel",
+      "B": "f_bookcase",
+      "C": "f_chimney",
+      "M": "f_armchair"
+    }
   }
 ]

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_2/modular_workshop_construction.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_2/modular_workshop_construction.json
@@ -17,7 +17,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -53,7 +54,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -99,7 +101,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -135,7 +138,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -181,7 +185,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -219,7 +224,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -267,7 +273,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -304,7 +311,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -351,7 +359,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -387,7 +396,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }
@@ -433,7 +443,8 @@
               "fbmw_2_rammed_earth_palette",
               "fbmw_2_rock_palette",
               "fbmw_2_wad_palette",
-              "fbmw_2_wood_palette"
+              "fbmw_2_wood_palette",
+              "fbmw_2_brick_palette"
             ]
           }
         }

--- a/data/json/mapgen/basecamps/expansion/modular_workshop/version_2/modular_workshop_palettes.json
+++ b/data/json/mapgen/basecamps/expansion/modular_workshop/version_2/modular_workshop_palettes.json
@@ -125,5 +125,18 @@
       "w": "t_wall_wood"
     },
     "furniture": {  }
+  },
+  {
+    "type": "palette",
+    "id": "fbmw_2_brick_palette",
+    "terrain": {
+      ",": "t_dirtfloor",
+      ".": "t_floor",
+      "+": "t_rdoor_c",
+      "r": "t_wood_treated_roof",
+      "v": "t_window_no_curtains",
+      "w": "t_brick_wall"
+    },
+    "furniture": {  }
   }
 ]

--- a/data/json/recipes/basecamps/expansion/recipe_modular_canteen/version_1/recipe_modular_canteen_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_canteen/version_1/recipe_modular_canteen_construction.json
@@ -19,7 +19,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_0" } ],
@@ -46,7 +47,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_center" } ],
@@ -73,7 +75,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_center2" } ],
@@ -100,7 +103,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_center2" } ],
@@ -127,7 +131,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_pantry_room" } ],
@@ -154,7 +159,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_canteen_dining_west" }, { "id": "fbmk_smoking_area" } ],
@@ -181,7 +187,8 @@
         "fbmk_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_rock_palette": "Rock walls and wooden roof",
         "fbmk_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_canteen_dining_east" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_canteen/version_2/recipe_modular_canteen_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_canteen/version_2/recipe_modular_canteen_construction.json
@@ -19,7 +19,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2" } ],
@@ -58,7 +59,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2_center" } ],
@@ -97,7 +99,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2_center_2" } ],
@@ -136,7 +139,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2_center_2" } ],
@@ -175,7 +179,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2_smoking_area" } ],
@@ -214,7 +219,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2_dining_1" } ],
@@ -253,7 +259,8 @@
         "fbmk_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmk_2_rock_palette": "Rock walls and wooden roof",
         "fbmk_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmk_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmk_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmk_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmk_2" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_garage/version_2/recipe_modular_garage_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_garage/version_2/recipe_modular_garage_construction.json
@@ -19,7 +19,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2" } ],
@@ -58,7 +59,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_1" } ],
@@ -98,7 +100,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_3" } ],
@@ -137,7 +140,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_3" } ],
@@ -176,7 +180,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_4" } ],
@@ -215,7 +220,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_6" } ],
@@ -254,7 +260,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_7" } ],
@@ -293,7 +300,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_9" } ],
@@ -332,7 +340,8 @@
         "fbmg_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmg_2_rock_palette": "Rock walls and wooden roof",
         "fbmg_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmg_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmg_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmg_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmg_2_10" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_livestock/version_1/recipe_modular_livestock_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_livestock/version_1/recipe_modular_livestock_construction.json
@@ -19,7 +19,8 @@
         "fbml_rammed_earth_palette": "Rammed earth walls",
         "fbml_rock_palette": "Rock walls",
         "fbml_wad_palette": "Wattle-and-daub walls",
-        "fbml_wood_palette": "Wooden walls"
+        "fbml_wood_palette": "Wooden walls",
+        "fbml_brick_palette": "Brick walls"
       }
     },
     "blueprint_requires": [ { "id": "fbml_0" } ],
@@ -46,7 +47,8 @@
         "fbml_rammed_earth_palette": "Rammed earth walls",
         "fbml_rock_palette": "Rock walls",
         "fbml_wad_palette": "Wattle-and-daub walls",
-        "fbml_wood_palette": "Wooden walls"
+        "fbml_wood_palette": "Wooden walls",
+        "fbml_brick_palette": "Brick walls"
       }
     },
     "blueprint_requires": [ { "id": "fbml_0" } ],
@@ -73,7 +75,8 @@
         "fbml_rammed_earth_palette": "Rammed earth walls",
         "fbml_rock_palette": "Rock walls",
         "fbml_wad_palette": "Wattle-and-daub walls",
-        "fbml_wood_palette": "Wooden walls"
+        "fbml_wood_palette": "Wooden walls",
+        "fbml_brick_palette": "Brick walls"
       }
     },
     "blueprint_requires": [ { "id": "fbml_0" } ],
@@ -100,7 +103,8 @@
         "fbml_rammed_earth_palette": "Rammed earth walls",
         "fbml_rock_palette": "Rock walls",
         "fbml_wad_palette": "Wattle-and-daub walls",
-        "fbml_wood_palette": "Wooden walls"
+        "fbml_wood_palette": "Wooden walls",
+        "fbml_brick_palette": "Brick walls"
       }
     },
     "blueprint_requires": [ { "id": "fbml_southwest" } ],
@@ -127,7 +131,8 @@
         "fbml_rammed_earth_palette": "Rammed earth walls",
         "fbml_rock_palette": "Rock walls",
         "fbml_wad_palette": "Wattle-and-daub walls",
-        "fbml_wood_palette": "Wooden walls"
+        "fbml_wood_palette": "Wooden walls",
+        "fbml_brick_palette": "Brick walls"
       }
     },
     "blueprint_requires": [ { "id": "fbml_west" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_livestock/version_2/recipe_modular_livestock_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_livestock/version_2/recipe_modular_livestock_construction.json
@@ -19,7 +19,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbml_2" } ],
@@ -57,7 +58,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_name": "storage shack",
@@ -97,7 +99,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_name": "stable section 1",
@@ -137,7 +140,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbml_2_stall_1" } ],
@@ -176,7 +180,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbml_2_stall_2" } ],
@@ -215,7 +220,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbml_2_stall_3" } ],
@@ -254,7 +260,8 @@
         "fbml_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbml_2_rock_palette": "Rock walls and wooden roof",
         "fbml_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbml_2_wood_palette": "Wooden walls and wooden roof"
+        "fbml_2_wood_palette": "Wooden walls and wooden roof",
+        "fbml_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbml_2_stall_4" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_saltworks/version_1/recipe_modular_saltworks_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_saltworks/version_1/recipe_modular_saltworks_construction.json
@@ -18,7 +18,8 @@
         "fbmsw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmsw_rock_palette": "Rock walls and wooden roof",
         "fbmsw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmsw_wood_palette": "Wooden walls and wooden roof"
+        "fbmsw_wood_palette": "Wooden walls and wooden roof",
+        "fbmsw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmsw_0" } ],
@@ -44,7 +45,8 @@
         "fbmsw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmsw_rock_palette": "Rock walls and wooden roof",
         "fbmsw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmsw_wood_palette": "Wooden walls and wooden roof"
+        "fbmsw_wood_palette": "Wooden walls and wooden roof",
+        "fbmsw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmsw_0" } ],
@@ -70,7 +72,8 @@
         "fbmsw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmsw_rock_palette": "Rock walls and wooden roof",
         "fbmsw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmsw_wood_palette": "Wooden walls and wooden roof"
+        "fbmsw_wood_palette": "Wooden walls and wooden roof",
+        "fbmsw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmsw_0" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_storehouse/version_1/recipe_modular_storehouse_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_storehouse/version_1/recipe_modular_storehouse_construction.json
@@ -19,7 +19,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_0" } ],
@@ -46,7 +47,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_0" } ],
@@ -73,7 +75,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_west" } ],
@@ -100,7 +103,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_west" } ],
@@ -127,7 +131,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_east" } ],
@@ -154,7 +159,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_east" } ],
@@ -181,7 +187,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_southeast" }, { "id": "fbms_southwest" } ],
@@ -208,7 +215,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_northeast" }, { "id": "fbms_northwest" } ],
@@ -235,7 +243,8 @@
         "fbms_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_rock_palette": "Rock walls and wooden roof",
         "fbms_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_wood_palette": "Wooden walls and wooden roof"
+        "fbms_wood_palette": "Wooden walls and wooden roof",
+        "fbms_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_north" }, { "id": "fbms_south" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_storehouse/version_2/recipe_modular_storehouse_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_storehouse/version_2/recipe_modular_storehouse_construction.json
@@ -19,7 +19,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2" } ],
@@ -58,7 +59,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_1" } ],
@@ -97,7 +99,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_2" } ],
@@ -136,7 +139,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_3" } ],
@@ -175,7 +179,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_4" } ],
@@ -214,7 +219,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_5" } ],
@@ -253,7 +259,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_6" } ],
@@ -292,7 +299,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_7" } ],
@@ -331,7 +339,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_8" } ],
@@ -370,7 +379,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_9" } ],
@@ -409,7 +419,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_10" } ],
@@ -448,7 +459,8 @@
         "fbms_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbms_2_rock_palette": "Rock walls and wooden roof",
         "fbms_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbms_2_wood_palette": "Wooden walls and wooden roof"
+        "fbms_2_wood_palette": "Wooden walls and wooden roof",
+        "fbms_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbms_2_11" } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_1/recipe_modular_workshop_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_1/recipe_modular_workshop_construction.json
@@ -19,7 +19,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_0" } ],
@@ -46,7 +47,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_northeast", "amount": 3 } ],
@@ -73,7 +75,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_north" } ],
@@ -100,7 +103,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_east" } ],
@@ -127,7 +131,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_center" } ],
@@ -156,7 +161,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_north", "amount": 2 } ],
@@ -183,7 +189,8 @@
         "fbmw_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_rock_palette": "Rock walls and wooden roof",
         "fbmw_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_northeast", "amount": 4 } ],

--- a/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/recipe_modular_workshop_construction.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/recipe_modular_workshop_construction.json
@@ -19,7 +19,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2" } ],
@@ -58,7 +59,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2_smithy_1" } ],
@@ -97,7 +99,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2_smithy_2" } ],
@@ -136,7 +139,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2" } ],
@@ -175,7 +179,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2" } ],
@@ -214,7 +219,8 @@
         "fbmw_2_rammed_earth_palette": "Rammed earth walls and sod roof",
         "fbmw_2_rock_palette": "Rock walls and wooden roof",
         "fbmw_2_wad_palette": "Wattle-and-daub walls and sod roof",
-        "fbmw_2_wood_palette": "Wooden walls and wooden roof"
+        "fbmw_2_wood_palette": "Wooden walls and wooden roof",
+        "fbmw_2_brick_palette": "Brick walls and wooden roof"
       }
     },
     "blueprint_requires": [ { "id": "fbmw_2" } ],


### PR DESCRIPTION
#### Summary
backport dda 74389 - Add brick construction to camp expansions

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
