### PR TITLE
Backport DDA 74344 - Make farm plots re-tillable in farming extension version 2

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -335,7 +335,7 @@ class basecamp
         std::string gathering_description();
         /// Returns a string for the number of plants that are harvestable, plots ready to plant,
         /// and ground that needs tilling
-        std::string farm_description( const tripoint_abs_omt &farm_pos, size_t &plots_count,
+        std::string farm_description( const point &dir, size_t &plots_count,
                                       farm_ops operation );
         /// Returns the description of a camp crafting options. converts fire charges to charcoal,
         /// allows dark crafting
@@ -391,7 +391,7 @@ class basecamp
         void start_salt_water_pipe( const mission_id &miss_id );
         void continue_salt_water_pipe( const mission_id &miss_id );
         void start_combat_mission( const mission_id &miss_id, float exertion_level );
-        void start_farm_op( const tripoint_abs_omt &omt_tgt, const mission_id &miss_id,
+        void start_farm_op( const point &dir, const mission_id &miss_id,
                             float exertion_level );
         ///Display items listed in @ref equipment to let the player pick what to give the departing
         ///NPC, loops until quit or empty.
@@ -441,7 +441,9 @@ class basecamp
         * @param omt_tgt the overmap pos3 of the farm_ops
         * @param op whether to plow, plant, or harvest
         */
-        bool farm_return( const mission_id &miss_id, const tripoint_abs_omt &omt_tgt );
+        bool farm_return( const mission_id &miss_id, const point &dir );
+        std::pair<size_t, std::string> farm_action( const point &dir, farm_ops op,
+                const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,
                                            const comp_list &npc_list );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -782,7 +782,6 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
 
     const std::string dir_id = base_camps::all_directions.at( dir ).id;
     const std::string dir_abbr = base_camps::all_directions.at( dir ).bracket_abbr.translated();
-    const tripoint_abs_omt omt_trg = omt_pos + dir;
 
     {
         // return legacy workers. How old is this legacy?...
@@ -1292,12 +1291,12 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
                        "Plow any spaces that have reverted to dirt or grass.\n\n" ) +
-                    farm_description( omt_trg, plots, farm_ops::plow ) +
+                    farm_description( dir, plots, farm_ops::plow ) +
                     _( "\n\n"
                        "Skill used: fabrication\n"
                        "Difficulty: N/A\n"
                        "Effects:\n"
-                       "> Restores only the plots created in the last expansion upgrade.\n"
+                       "> Restores farm plots created in previous expansion upgrades.\n"
                        "> Does not damage existing crops.\n\n"
                        "Risk: None\n"
                        "Intensity: Moderate\n"
@@ -1320,7 +1319,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
             entry = _( "Notes:\n"
                        "Plant designated seeds in the spaces that have already been "
                        "tilled.\n\n" ) +
-                    farm_description( omt_trg, plots, farm_ops::plant ) +
+                    farm_description( dir, plots, farm_ops::plant ) +
                     _( "\n\n"
                        "Skill used: survival\n"
                        "Difficulty: N/A\n"
@@ -1334,7 +1333,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                        "Positions: 0/1\n" );
             mission_key.add_start( miss_id,
                                    name_display_of( miss_id ), entry,
-                                   plots > 0 && warm_enough_to_plant( omt_trg ) );
+                                   plots > 0 && warm_enough_to_plant( omt_pos + dir ) );
         } else {
             entry = action_of( miss_id.id );
             bool avail = update_time_left( entry, npc_list );
@@ -1349,7 +1348,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
         if( npc_list.empty() ) {
             entry = _( "Notes:\n"
                        "Harvest any plants that are ripe and bring the produce back.\n\n" ) +
-                    farm_description( omt_trg, plots, farm_ops::harvest ) +
+                    farm_description( dir, plots, farm_ops::harvest ) +
                     _( "\n\n"
                        "Skill used: survival\n"
                        "Difficulty: N/A\n"
@@ -1608,8 +1607,6 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
     const point &miss_dir = miss_id.id.dir.value();
     //  All missions should supply dir. Bug if they don't, so blow up during testing.
 
-    const tripoint_abs_omt omt_trg = omt_pos + miss_dir;
-
     switch( miss_id.id.id ) {
         case Camp_Distribute_Food:
             distribute_food();
@@ -1829,9 +1826,9 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
         case Camp_Plant:
         case Camp_Harvest:
             if( miss_id.ret ) {
-                farm_return( miss_id.id, omt_trg );
+                farm_return( miss_id.id, miss_dir );
             } else {
-                start_farm_op( omt_trg, miss_id.id, MODERATE_EXERCISE );
+                start_farm_op( miss_dir, miss_id.id, MODERATE_EXERCISE );
             }
             break;
 
@@ -3429,11 +3426,14 @@ static bool farm_valid_seed( const item &itm )
     return itm.is_seed() && itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
 }
 
-static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_tgt, farm_ops op,
-        const npc_ptr &comp = nullptr )
+std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops op,
+        const npc_ptr &comp )
 {
     size_t plots_cnt = 0;
     std::string crops;
+
+    const auto e_data = expansions.find( dir );
+    const tripoint_abs_omt omt_tgt = e_data->second.pos;
 
     const auto is_dirtmound = []( const tripoint & pos, tinymap & bay1, tinymap & bay2 ) {
         return ( bay1.ter( pos ) == ter_t_dirtmound ) && ( !bay2.has_furn( pos ) );
@@ -3450,10 +3450,10 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
     }
 
     // farm_map is what the area actually looks like
-    tinymap farm_map;
+    smallmap farm_map;
     farm_map.load( omt_tgt, false );
     // farm_json is what the area should look like according to jsons (loaded on demand)
-    std::unique_ptr<fake_map> farm_json;
+    std::unique_ptr<small_fake_map> farm_json;
     tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
     tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
     bool done_planting = false;
@@ -3466,11 +3466,43 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
         switch( op ) {
             case farm_ops::plow: {
                 if( !farm_json ) {
-                    farm_json = std::make_unique<fake_map>();
+                    farm_json = std::make_unique<small_fake_map>();
                     mapgendata dat( omt_tgt, *farm_json->cast_to_map(), 0, calendar::turn, nullptr );
-                    if( !run_mapgen_func( dat.terrain_type()->get_mapgen_id(), dat ) ) {
+                    std::string omt_id = dat.terrain_type()->get_mapgen_id();
+                    if( !run_mapgen_func( omt_id, dat ) ) {
                         debugmsg( "Failed to run mapgen for farm map" );
                         break;
+                    }
+                    // Add mapgen from expansion upgrades to fake_map
+                    for( auto const &provide : e_data->second.provides ) {
+                        if( !recipe_id( provide.first ).is_valid() ) {
+                            continue;
+                        }
+                        const recipe &making = *recipe_id( provide.first );
+                        const update_mapgen_id update_id = making.get_blueprint();
+                        if( !has_update_mapgen_for( update_id ) ) {
+                            continue;
+                        }
+                        bool mirror_horizontal;
+                        bool mirror_vertical;
+                        int rotation;
+                        if( !extract_and_check_orientation_flags( making.ident(),
+                                dir,
+                                mirror_horizontal,
+                                mirror_vertical,
+                                rotation,
+                                "%s failed to apply orientation flags to the %s upgrade",
+                                "farm_action" ) ) {
+                            continue;
+                        }
+                        farm_json->rotate( 4 - rotation );
+                        farm_json->mirror( mirror_horizontal, mirror_vertical );
+                        if( !run_mapgen_update_func( update_id, dat, false ) ) {
+                            debugmsg( "farm_action failed to apply the %s map update to %s",
+                                      provide.first, omt_id );
+                        }
+                        farm_json->rotate( rotation );
+                        farm_json->mirror( mirror_horizontal, mirror_vertical );
                     }
                 }
                 // Needs to be plowed to match json
@@ -3561,7 +3593,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
     return std::make_pair( plots_cnt, crops );
 }
 
-void basecamp::start_farm_op( const tripoint_abs_omt &omt_tgt, const mission_id &miss_id,
+void basecamp::start_farm_op( const point &dir, const mission_id &miss_id,
                               float exertion_level )
 {
     farm_ops op = farm_ops::plow;
@@ -3576,7 +3608,7 @@ void basecamp::start_farm_op( const tripoint_abs_omt &omt_tgt, const mission_id 
         return;
     }
 
-    std::pair<size_t, std::string> farm_data = farm_action( omt_tgt, op );
+    std::pair<size_t, std::string> farm_data = farm_action( dir, op );
     size_t plots_cnt = farm_data.first;
     if( !plots_cnt ) {
         return;
@@ -4477,7 +4509,7 @@ bool basecamp::survey_return( const mission_id &miss_id )
     return true;
 }
 
-bool basecamp::farm_return( const mission_id &miss_id, const tripoint_abs_omt &omt_tgt )
+bool basecamp::farm_return( const mission_id &miss_id, const point &dir )
 {
     farm_ops op;
     if( miss_id.id == Camp_Plow ) {
@@ -4498,7 +4530,7 @@ bool basecamp::farm_return( const mission_id &miss_id, const tripoint_abs_omt &o
         return false;
     }
 
-    farm_action( omt_tgt, op, comp );
+    farm_action( dir, op, comp );
 
     Character &player_character = get_player_character();
     //Give any seeds the NPC didn't use back to you.
@@ -5374,10 +5406,10 @@ std::string basecamp::gathering_description()
     return output;
 }
 
-std::string basecamp::farm_description( const tripoint_abs_omt &farm_pos, size_t &plots_count,
+std::string basecamp::farm_description( const point &dir, size_t &plots_count,
                                         farm_ops operation )
 {
-    std::pair<size_t, std::string> farm_data = farm_action( farm_pos, operation );
+    std::pair<size_t, std::string> farm_data = farm_action( dir, operation );
     std::string entry;
     plots_count = farm_data.first;
     switch( operation ) {


### PR DESCRIPTION
#### Summary
Backport DDA 74344 - Make farm plots re-tillable in farming extension version 2

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
