### PR TITLE
Backport DDA 74318 - Properly warn if food will cause you to overeat

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6573,6 +6573,11 @@ float Character::get_bmi_fat() const
             2 ) * get_cached_organic_size() );
 }
 
+bool Character::has_calorie_deficit() const
+{
+    return get_bmi_fat() < character_weight_category::normal;
+}
+
 units::mass Character::bodyweight() const
 {
     return bodyweight_fat() + bodyweight_lean();

--- a/src/character.h
+++ b/src/character.h
@@ -3052,6 +3052,7 @@ class Character : public Creature, public visitable
         float get_bmi() const;
         float get_bmi_fat() const;
         float get_bmi_lean() const;
+        bool has_calorie_deficit() const;
         // returns amount of calories burned in a day given various metabolic factors
         int get_bmr() const;
         // add spent calories to calorie diary (if avatar)

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1046,7 +1046,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         set_thirst( 0 );
     }
 
-    const bool calorie_deficit = get_bmi_fat() < character_weight_category::normal;
+    const bool calorie_deficit = has_calorie_deficit();
     const units::volume contains = stomach.contains();
     const units::volume cap = stomach.capacity( *this );
 
@@ -1063,9 +1063,9 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         // > 3/4 cap    full        full        full
         // > 1/2 cap    satisfied   v. hungry   famished/(near)starving
         // <= 1/2 cap   hungry      v. hungry   famished/(near)starving
-        if( contains >= cap ) {
+        if( stomach.would_be_engorged_with( *this, 0_ml, calorie_deficit ) ) {
             hunger_effect = effect_hunger_engorged;
-        } else if( contains > cap * 3 / 4 ) {
+        } else if( stomach.would_be_full_with( *this, 0_ml, calorie_deficit ) ) {
             hunger_effect = effect_hunger_full;
         } else if( just_ate && contains > cap / 2 ) {
             hunger_effect = effect_hunger_satisfied;
@@ -1088,9 +1088,9 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         // >= 3/8 cap   satisfied   satisfied   blank
         // > 0          blank       blank       blank
         // 0            blank       blank       (v.) hungry
-        if( contains >= cap * 5 / 6 ) {
+        if( stomach.would_be_engorged_with( *this, 0_ml, calorie_deficit ) ) {
             hunger_effect = effect_hunger_engorged;
-        } else if( contains > cap * 11 / 20 ) {
+        } else if( stomach.would_be_full_with( *this, 0_ml, calorie_deficit ) ) {
             hunger_effect = effect_hunger_full;
         } else if( recently_ate && contains >= cap * 3 / 8 ) {
             hunger_effect = effect_hunger_satisfied;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1009,8 +1009,10 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
         add_consequence( _( "Your stomach won't be happy (not rotten enough)." ), ALLERGY_WEAK );
     }
 
+    units::volume in_stomach_volume =
+        food.volume( false, false, 1 ) * compute_effective_food_volume_ratio( food );
     if( food.is_food() &&
-        ( food.charges_per_volume( stomach.stomach_remaining( *this ) ) < 1 ||
+        ( stomach.would_be_engorged_with( *this, in_stomach_volume, has_calorie_deficit() ) ||
           has_effect( effect_hunger_full ) || has_effect( effect_hunger_engorged ) ) ) {
         if( edible ) {
             add_consequence( _( "You're full already and will be forcing yourself to eat." ), TOO_FULL );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1580,7 +1580,14 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
 
 void basecamp::player_eats_meal()
 {
-    int kcal_to_eat = 3000;
+    uilist smenu;
+    smenu.text = _( "Have a meal?" );
+    int i = 1;
+    smenu.addentry( i++, true, '1', _( "Snack" ) );
+    smenu.addentry( i++, true, '2', _( "Meal" ) );
+    smenu.addentry( i++, true, '3', _( "Just stuff your face.  You're hungry!" ) );
+    smenu.query();
+    int kcal_to_eat = smenu.ret * 750 - 250; // 500, 1250, 2000 kcal
     Character &you = get_player_character();
     const int &food_available = fac()->food_supply.kcal();
     if( you.stomach.contains() >= ( you.stomach.capacity( you ) / 2 ) ) {

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -313,6 +313,20 @@ units::volume stomach_contents::stomach_remaining( const Character &owner ) cons
     return capacity( owner ) - contents - water;
 }
 
+bool stomach_contents::would_be_engorged_with( const Character &owner, units::volume intake,
+        bool calorie_deficit ) const
+{
+    const double fullness_ratio = ( contains() + intake ) / capacity( owner );
+    return ( calorie_deficit && fullness_ratio >= 1.0 ) || ( fullness_ratio >= 5.0 / 6.0 );
+}
+
+bool stomach_contents::would_be_full_with( const Character &owner, units::volume intake,
+        bool calorie_deficit ) const
+{
+    const double fullness_ratio = ( contains() + intake ) / capacity( owner );
+    return ( calorie_deficit && fullness_ratio >= 11.0 / 20.0 ) || ( fullness_ratio >= 3.0 / 4.0 );
+}
+
 units::volume stomach_contents::contains() const
 {
     return contents + water;

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -164,6 +164,10 @@ class stomach_contents
          * @return This stomach's capacity, in units::volume
          */
         units::volume capacity( const Character &owner ) const;
+        // These functions need a ref to the stomach's owner because capacity() does
+        bool would_be_engorged_with( const Character &owner, units::volume intake,
+                                     bool calorie_deficit ) const;
+        bool would_be_full_with( const Character &owner, units::volume intake, bool calorie_deficit ) const;
         // how much stomach capacity you have left before you puke from stuffing your gob
         units::volume stomach_remaining( const Character &owner ) const;
         // how much volume is in the stomach_contents


### PR DESCRIPTION
#### Summary
Backport DDA 74318 - Properly warn if food will cause you to overeat


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
