### PR TITLE
Backport DDA 74603 - Add CLASSIC to map extras + remove more autonote

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -8,7 +8,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "o",
     "color": "red",
-    "autonote": true
+    "autonote": true,
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_collegekids",
@@ -19,7 +20,8 @@
     "min_max_zlevel": [ -1, 0 ],
     "sym": "c",
     "color": "light_red",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_drugdeal",
@@ -30,7 +32,8 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "d",
     "color": "light_red",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_roadworks",
@@ -41,7 +44,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_mayhem",
@@ -53,7 +57,7 @@
     "sym": "M",
     "color": "light_red",
     "autonote": true,
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_roadblock",
@@ -64,7 +68,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "blue",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_roadblock_mil",
@@ -75,7 +80,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "red",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_bandits_block",
@@ -87,7 +93,8 @@
     "sym": "X",
     "color": "red",
     "//": "Can't be true because it doesn't always place anything",
-    "flags": [ "MAN_MADE" ]
+    "autonote": false,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_minefield",
@@ -98,7 +105,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "M",
     "color": "red",
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_military",
@@ -109,7 +116,8 @@
     "min_max_zlevel": [ -4, 5 ],
     "sym": "m",
     "color": "light_red",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_helicopter",
@@ -121,7 +129,7 @@
     "sym": "X",
     "color": "light_blue",
     "autonote": true,
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_science",
@@ -196,7 +204,8 @@
     "min_max_zlevel": [ -1, 1 ],
     "sym": "c",
     "color": "light_red",
-    "flags": [ "MAN_MADE" ]
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_spider",
@@ -235,7 +244,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_grove" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": "F",
-    "color": "light_green"
+    "color": "light_green",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_shrubbery",
@@ -245,7 +255,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_shrubbery" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": "s",
-    "color": "light_green"
+    "color": "light_green",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_clearcut",
@@ -255,7 +266,8 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_clearcut" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
-    "color": "brown"
+    "color": "brown",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_pond",
@@ -265,7 +277,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_pond" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": "p",
-    "color": "blue"
+    "color": "blue",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_pond_forest",
@@ -273,14 +286,16 @@
     "name": { "str": "basin" },
     "description": "Small basin is here.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_pond_forest_2",
     "type": "map_extra",
     "copy-from": "mx_pond_forest",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest_2" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_pond_swamp",
@@ -288,14 +303,16 @@
     "name": { "str": "bog" },
     "description": "Small bog is here.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_swamp" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_pond_swamp_2",
     "type": "map_extra",
     "copy-from": "mx_pond_swamp",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_swamp_2" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_trees",
@@ -303,28 +320,32 @@
     "name": { "str": "Stand of trees" },
     "description": "A copse of trees.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_trees_map" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_trees2",
     "type": "map_extra",
     "copy-from": "mx_trees",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_trees2_map" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_blackberry_patch",
     "type": "map_extra",
     "name": { "str": "Blackberry patch" },
     "description": "Blackberry bushes have spread here.",
-    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_blackberry_patch" }
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_blackberry_patch" },
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_knotweed_patch",
     "type": "map_extra",
     "name": { "str": "Japanese knotweed patch" },
     "description": "Japanese knotweed shrubs have spread here.",
-    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_knotweed_patch" }
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_knotweed_patch" },
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_grass",
@@ -332,14 +353,16 @@
     "name": { "str": "Tall grass" },
     "description": "A meadow of tall grass.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_grass_map" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_grass2",
     "type": "map_extra",
     "copy-from": "mx_grass",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_grass2_map" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_fallen_shed",
@@ -351,7 +374,7 @@
     "sym": "^",
     "color": "dark_gray",
     "autonote": true,
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_clay_deposit",
@@ -362,7 +385,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "c",
     "color": "brown",
-    "autonote": true
+    "autonote": true,
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_sand_patch",
@@ -373,7 +397,8 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "yellow",
-    "autonote": true
+    "autonote": true,
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_dead_vegetation",
@@ -383,7 +408,8 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_dead_vegetation" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
-    "color": "brown"
+    "color": "brown",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_point_dead_vegetation",
@@ -393,7 +419,8 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_point_dead_vegetation" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
-    "color": "brown"
+    "color": "brown",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_burned_ground",
@@ -403,7 +430,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_burned_ground" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
-    "color": "light_gray"
+    "color": "light_gray",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_point_burned_ground",
@@ -413,7 +441,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_point_burned_ground" },
     "min_max_zlevel": [ 0, 5 ],
     "sym": ".",
-    "color": "light_gray"
+    "color": "light_gray",
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_kelp_patch",
@@ -424,7 +453,7 @@
     "min_max_zlevel": [ -9, -9 ],
     "sym": "~",
     "color": "green",
-    "autonote": true
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_marloss_pilgrimage",
@@ -434,8 +463,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_marloss_pilgrimage" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": "F",
-    "color": "dark_gray",
-    "autonote": true
+    "color": "dark_gray"
   },
   {
     "id": "mx_casings",
@@ -446,7 +474,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "c",
     "color": "dark_gray",
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_looters",
@@ -455,7 +483,7 @@
     "description": "Some looters gathering everything not nailed down.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_looters" },
     "min_max_zlevel": [ -2, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_corpses",
@@ -464,7 +492,7 @@
     "description": "Some unfortunates from the billions lost in the Cataclysm.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_corpses" },
     "min_max_zlevel": [ -5, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_nest_wasp",
@@ -474,8 +502,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_wasp" },
     "min_max_zlevel": [ 0, 9 ],
     "sym": "W",
-    "color": "yellow",
-    "autonote": true
+    "color": "yellow"
   },
   {
     "id": "mx_nest_dermatik",
@@ -485,8 +512,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dermatik" },
     "min_max_zlevel": [ 0, 0 ],
     "sym": "D",
-    "color": "brown",
-    "autonote": true
+    "color": "brown"
   },
   {
     "id": "mx_prison_bus",
@@ -495,7 +521,7 @@
     "description": "A prison bus.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_prison_bus" },
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_mass_grave",
@@ -506,8 +532,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "autonote": true,
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_grave",
@@ -516,7 +541,7 @@
     "description": "A grave.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_grave" },
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_city_trap",
@@ -526,9 +551,8 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_city_trap" },
     "sym": "I",
     "color": "green",
-    "autonote": true,
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_laststand",
@@ -538,9 +562,8 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_laststand" },
     "sym": "X",
     "color": "green",
-    "autonote": true,
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_fungal_zone",
@@ -550,7 +573,6 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
     "sym": "F",
     "color": "yellow",
-    "autonote": true,
     "min_max_zlevel": [ 0, 0 ],
     "flags": [ "FUNGAL" ]
   },
@@ -560,7 +582,8 @@
     "name": { "str": "Reed" },
     "description": "Water vegetation.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_reed" },
-    "min_max_zlevel": [ 0, 0 ]
+    "min_max_zlevel": [ 0, 0 ],
+    "flags": [ "CLASSIC" ]
   },
   {
     "id": "mx_riverside_boat",
@@ -569,7 +592,7 @@
     "description": "A small boat.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_riverside_boat" },
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_rock_formation",
@@ -588,8 +611,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_toxic_waste" },
     "sym": "D",
     "color": "magenta",
-    "autonote": true,
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_prison_van",
@@ -598,7 +620,7 @@
     "description": "A violent escape.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_prison_van" },
     "min_max_zlevel": [ 0, 0 ],
-    "flags": [ "MAN_MADE" ]
+    "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
     "id": "mx_specimen_van",


### PR DESCRIPTION
#### Summary
Backport DDA 74603 - Add CLASSIC to map extras + remove more autonote

#### Purpose of change
While backporting, I noticed some stuff was still autonoted.



<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
