### PR TITLE
Backport 74565 - Use std::string_view in mod_tracker

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -306,7 +306,7 @@ static social_modifiers load_bionic_social_mods( const JsonObject &jo )
     return ret;
 }
 
-void bionic_data::load( const JsonObject &jsobj, const std::string &src )
+void bionic_data::load( const JsonObject &jsobj, const std::string_view src )
 {
 
     mandatory( jsobj, was_loaded, "id", id );

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -184,7 +184,7 @@ struct bionic_data {
 
     itype_id itype() const;
 
-    void load( const JsonObject &obj, const std::string &src );
+    void load( const JsonObject &obj, std::string_view src );
     void finalize();
     static void load_bionic( const JsonObject &jo, const std::string &src );
     static void finalize_bionic();

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -117,7 +117,7 @@ void effect_on_condition::load( const JsonObject &jo, const std::string_view )
 }
 
 effect_on_condition_id effect_on_conditions::load_inline_eoc( const JsonValue &jv,
-        const std::string &src )
+        std::string_view src )
 {
     if( jv.test_string() ) {
         return effect_on_condition_id( jv.get_string() );

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -96,7 +96,7 @@ void load_new_character( Character &you );
 /** Load any new eocs that don't exist in the save. */
 void load_existing_character( Character &you );
 /** Loads an inline eoc */
-effect_on_condition_id load_inline_eoc( const JsonValue &jv, const std::string &src );
+effect_on_condition_id load_inline_eoc( const JsonValue &jv, std::string_view src );
 /** queue an eoc to happen in the future */
 void queue_effect_on_condition( time_duration duration, effect_on_condition_id eoc,
                                 Character &you, const std::unordered_map<std::string, std::string> &context );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4473,10 +4473,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     check_and_create_magazine_pockets( def );
     add_special_pockets( def );
 
-    if( !def.src.empty() && def.src.back().first != def.id ) {
-        def.src.clear();
-    }
-    def.src.emplace_back( def.id, mod_id( src ) );
+    mod_tracker::assign_src( def, src );
 
     if( def.magazines.empty() ) {
         migrate_mag_from_pockets( def );

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -263,7 +263,7 @@ void ma_requirements::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
 }
 
-void ma_technique::load( const JsonObject &jo, const std::string &src )
+void ma_technique::load( const JsonObject &jo, const std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "description", description, translation() );
@@ -409,7 +409,7 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
         }
 };
 
-void martialart::load( const JsonObject &jo, const std::string &src )
+void martialart::load( const JsonObject &jo, const std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -168,7 +168,7 @@ class ma_technique
     public:
         ma_technique();
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static void verify_ma_techniques();
         void check() const;
 
@@ -333,7 +333,7 @@ class martialart
     public:
         martialart();
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 
         void remove_all_buffs( Character &u ) const;
 

--- a/src/mod_tracker.h
+++ b/src/mod_tracker.h
@@ -47,7 +47,7 @@ struct has_src_member<T, std::void_t<decltype( std::declval<T &>().src.emplace_b
 
     /** If those conditions are satisfied, keep track of where this item has been modified */
     template<typename T, typename std::enable_if_t<has_src_member<T>::value > * = nullptr>
-    static void assign_src( T &def, const std::string &src ) {
+    static void assign_src( T &def, const std::string_view src ) {
         // We need to make sure we're keeping where this entity has been loaded
         // If the id this was last loaded with is not this one, discard the history and start again
         if( !def.src.empty() && def.src.back().first != def.id ) {

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -398,7 +398,7 @@ struct mutation_branch {
         // For init.cpp: reset (clear) the mutation data
         static void reset_all();
         // For init.cpp: load mutation data from json
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         static void load_trait( const JsonObject &jo, const std::string &src );
         // For init.cpp: check internal consistency (valid ids etc.) of all mutations
         static void check_consistency();

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -299,7 +299,7 @@ void mutation_variant::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void mutation_branch::load( const JsonObject &jo, const std::string &src )
+void mutation_branch::load( const JsonObject &jo, const std::string_view src )
 {
     mandatory( jo, was_loaded, "name", raw_name );
     mandatory( jo, was_loaded, "description", raw_desc );


### PR DESCRIPTION
#### Summary
Backport 74565 - Use std::string_view in mod_tracker


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
