### PR TITLE
Backport dda 74652 - Give gun show tent a roof

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -3707,7 +3707,12 @@
   {
     "type": "overmap_special",
     "id": "gun_show",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "gunshow_0_north" }, { "point": [ 1, 0, 0 ], "overmap": "gunshow_1_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "gunshow_0_north" },
+      { "point": [ 1, 0, 0 ], "overmap": "gunshow_1_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "gunshow_0_roof_north" },
+      { "point": [ 1, 0, 1 ], "overmap": "gunshow_1_roof_north" }
+    ],
     "locations": [ "field" ],
     "connections": [ { "point": [ 0, 5, 0 ], "terrain": "road", "connection": "local_road", "existing": true } ],
     "city_distance": [ 3, -1 ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -1048,6 +1048,6 @@
     "name": "gun show",
     "sym": "G",
     "color": "red",
-    "see_cost": 3
+    "see_cost": 5
   }
 ]


### PR DESCRIPTION
#### Summary
Backport dda 74652 - Give gun show tent a roof

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
