### PR TITLE
Fix translations and clean up lingering "dda"s in code

### DIFF
--- a/build-data/web/index.html
+++ b/build-data/web/index.html
@@ -162,7 +162,7 @@
       <div>
         <a
           target="_blank"
-          href="https://github.com/CleverRaven/Cataclysm-DDA"
+          href="https://github.com/Cataclysm-TLG/Cataclysm-TLG"
         >
           <div id="browse-code" class="menu-button">
             <i class="fa-brands fa-github"></i
@@ -237,7 +237,7 @@
           }
         }
 
-        recurse("/home/web_user/.cataclysm-dda", "");
+        recurse("/home/web_user/.cataclysm-tlg", "");
 
         saveAs(await zip.generateAsync({ type: "blob" }), "saves.zip");
       };

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1534,7 +1534,6 @@
     "volume": "3 L",
     "price": "50 USD",
     "price_postapoc": "50 cent",
-    "to_hit": -5,
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "kimono",

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -1147,7 +1147,6 @@
   {
     "id": "shock_staff",
     "type": "TOOL",
-    "category": "weapons",
     "name": { "str": "powered quarterstaff", "str_pl": "powered quarterstaves" },
     "copy-from": "i_staff",
     "description": "An ironshod quarterstaff that has a high-voltage stun gun built into the handle.  The stun gun is wired to the metal caps at either end of the staff, allowing you to zap a dangerous opponent should beating them senseless with it prove too hazardous.",

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -715,7 +715,6 @@
     "melee_dice": 3,
     "melee_dice_sides": 5,
     "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
-    "dodge": 0,
     "families": [ "prof_intro_biology", "prof_wp_zombie" ],
     "vision_day": 5,
     "vision_night": 3,

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -469,7 +469,6 @@
     "melee_dice": 3,
     "melee_dice_sides": 5,
     "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
-    "dodge": 0,
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "vision_day": 30,
     "vision_night": 10,

--- a/doxygen_doc/doxygen_conf.txt
+++ b/doxygen_doc/doxygen_conf.txt
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "Cataclysm DDA"
+PROJECT_NAME           = "Cataclysm TLG"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or

--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -52,8 +52,8 @@ def parse_dynamic_line(json, origin, comment=[]):
                 *comment,
                 "You don't need to translate genders that "
                 "aren't in your language",
-                "Check: https://github.com/CleverRaven/"
-                "Cataclysm-DDA/blob/master/doc/"
+                "Check: https://github.com/Cataclysm-TLG/"
+                "Cataclysm-TLG/blob/master/doc/"
                 "TRANSLATING.md#grammatical-gender"]
             for context_list in itertools.product(*options):
                 context = " ".join(context_list)

--- a/object_creator/creator_main.cpp
+++ b/object_creator/creator_main.cpp
@@ -96,7 +96,7 @@ int main( int argc, char *argv[] )
 
 #if defined(__ANDROID__)
     // Start the standard output logging redirector
-    start_logger( "cdda" );
+    start_logger( "ctlg" );
 
     // On Android first launch, we copy all data files from the APK into the app's writeable folder so std::io stuff works.
     // Use the external storage so it's publicly modifiable data (so users can mess with installed data, save games etc.)
@@ -145,7 +145,7 @@ int main( int argc, char *argv[] )
     app.processEvents();
 
     QSettings settings( QSettings::IniFormat, QSettings::UserScope,
-                        "CleverRaven", "Cataclysm - DDA" );
+                        "CataclysmTLG", "Cataclysm - TLG" );
 
     cli_opts cli;
 
@@ -175,7 +175,7 @@ int main( int argc, char *argv[] )
     world_generator->init();
 
     std::vector<mod_id> mods;
-    mods.push_back( mod_id( "dda" ) );
+    mods.push_back( mod_id( "tlg" ) );
     if( settings.contains( "mods/include" ) ) {
         QStringList modlist = settings.value( "mods/include" ).value<QStringList>();
         for( const QString &i : modlist ) {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,12 +1,12 @@
 name: cataclysm
 version: git
 summary: Post-apocalyptic turn-based survival game
-icon: data/xdg/cataclysm-dda.svg
+icon: data/xdg/cataclysm-tlg.svg
 architectures:
   - build-on: [amd64]
     run-on: [amd64]
 description: |
-  Cataclysm: Dark Days Ahead is a turn-based survival game set in a post-apocalyptic world. Surviving is difficult, you have been thrown, ill-equipped, into a landscape now riddled with monstrosities of which flesh eating zombies are neither the strangest nor the deadliest.
+  Cataclysm: The Last Generation is a turn-based survival game set in a post-apocalyptic world based on Cataclysm: Dark Days Ahead. Surviving is difficult, you have been thrown, ill-equipped, into a landscape now riddled with monstrosities of which flesh eating zombies are neither the strangest nor the deadliest.
 
   Note: This snap install the ncurses version of the game. Start playing by running the command `cataclysm` on your favorite terminal after installation.
 

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -288,7 +288,7 @@ class generic_factory
          * @throws JsonError If loading fails for any reason (thrown by `T::load`).
          */
         void load( const JsonObject &jo, const std::string &src ) {
-            bool strict = src == "dda";
+            bool strict = src == "tlg";
 
             static const std::string abstract_member_name( "abstract" );
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2712,7 +2712,7 @@ void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
 {
     itype def;
     if( load_definition( jo, src, def ) ) {
-        assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
+        assign( jo, "stack_size", def.stack_size, src == "tlg", 1 );
         if( def.was_loaded ) {
             if( def.ammo ) {
                 def.ammo->was_loaded = true;
@@ -2810,7 +2810,7 @@ void itype_variant_data::load( const JsonObject &jo )
 
 void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
     assign( jo, "skill", slot.skill_used, strict );
     assign( jo, "ammo", slot.ammo, strict );
     assign( jo, "range", slot.range, strict );
@@ -3120,7 +3120,7 @@ void islot_pet_armor::deserialize( const JsonObject &jo )
 
 void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     assign( jo, "ammo", slot.ammo_id, strict );
     assign( jo, "max_charges", slot.max_charges, strict, 0 );
@@ -3172,7 +3172,7 @@ void Item_factory::load( relic &slot, const JsonObject &jo, const std::string_vi
 
 void Item_factory::load( islot_mod &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     if( jo.has_array( "ammo_modifier" ) ) {
         for( const std::string id : jo.get_array( "ammo_modifier" ) ) {
@@ -3281,7 +3281,7 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     JsonObject relative = jo.get_object( "relative" );
     JsonObject proportional = jo.get_object( "proportional" );
@@ -3458,7 +3458,7 @@ void Item_factory::load_comestible( const JsonObject &jo, const std::string &src
 {
     itype def;
     if( load_definition( jo, src, def ) ) {
-        assign( jo, "stack_size", def.stack_size, src == "dda", 1 );
+        assign( jo, "stack_size", def.stack_size, src == "tlg", 1 );
         load_slot( def.comestible, jo, src );
         load_basic_info( jo, def, src );
     }
@@ -3483,7 +3483,7 @@ void islot_seed::deserialize( const JsonObject &jo )
 
 void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     assign( jo, "damage_modifier", slot.damage, strict,
             damage_instance( damage_type_id::NULL_ID(), -20, -20, -20, -20 ) );
@@ -3565,7 +3565,7 @@ void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_magazine &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
     assign( jo, "ammo_type", slot.type, strict );
     assign( jo, "capacity", slot.capacity, strict, 0 );
     assign( jo, "count", slot.count, strict, 0 );
@@ -3614,7 +3614,7 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
 
 void Item_factory::load( islot_bionic &slot, const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     if( jo.has_member( "bionic_id" ) ) {
         assign( jo, "bionic_id", slot.id, strict );
@@ -4155,7 +4155,7 @@ static void replace_materials( const JsonObject &jo, itype &def )
 
 void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     restore_on_out_of_scope<check_plural_t> restore_check_plural( check_plural );
     if( jo.has_string( "abstract" ) ) {
@@ -4442,17 +4442,17 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         }
     }
 
-    assign( jo, "armor_data", def.armor, src == "dda" );
-    assign( jo, "pet_armor_data", def.pet_armor, src == "dda" );
-    assign( jo, "book_data", def.book, src == "dda" );
+    assign( jo, "armor_data", def.armor, src == "tlg" );
+    assign( jo, "pet_armor_data", def.pet_armor, src == "tlg" );
+    assign( jo, "book_data", def.book, src == "tlg" );
     load_slot_optional( def.gun, jo, "gun_data", src );
     load_slot_optional( def.bionic, jo, "bionic_data", src );
-    assign( jo, "ammo_data", def.ammo, src == "dda" );
-    assign( jo, "seed_data", def.seed, src == "dda" );
-    assign( jo, "brewable", def.brewable, src == "dda" );
-    assign( jo, "compostable", def.compostable, src == "dda" );
+    assign( jo, "ammo_data", def.ammo, src == "tlg" );
+    assign( jo, "seed_data", def.seed, src == "tlg" );
+    assign( jo, "brewable", def.brewable, src == "tlg" );
+    assign( jo, "compostable", def.compostable, src == "tlg" );
     load_slot_optional( def.relic_data, jo, "relic_data", src );
-    assign( jo, "milling", def.milling_data, src == "dda" );
+    assign( jo, "milling", def.milling_data, src == "tlg" );
 
     // optional gunmod slot may also specify mod data
     if( jo.has_member( "gunmod_data" ) ) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ class ui_adaptor;
 
 static int pfd[2];
 static pthread_t thr;
-static const char *tag = "cdda";
+static const char *tag = "ctlg";
 
 static void *thread_func( void * )
 {
@@ -310,7 +310,7 @@ cli_opts parse_commandline( int argc, const char **argv )
             },
             {
                 "--jsonverify", {},
-                "Checks the CDDA json files and exits",
+                "Checks the CTLG json files and exits",
                 section_default,
                 0,
                 [&result]( int, const char ** ) -> int {
@@ -320,7 +320,7 @@ cli_opts parse_commandline( int argc, const char **argv )
             },
             {
                 "--check-mods", "[mod…]",
-                "Checks the json files belonging to given CDDA mod and exits",
+                "Checks the json files belonging to given CTLG mod and exits",
                 section_default,
                 1,
                 [&result]( int n, const char **params ) -> int {
@@ -584,8 +584,8 @@ bool assure_essential_dirs_exist()
 #if defined(EMSCRIPTEN)
 EM_ASYNC_JS( void, mount_idbfs, (), {
     console.log( "Mounting IDBFS for persistence..." );
-    FS.mkdir( '/home/web_user/.cataclysm-dda' );
-    FS.mount( IDBFS, {}, '/home/web_user/.cataclysm-dda' );
+    FS.mkdir( '/home/web_user/.cataclysm-tlg' );
+    FS.mount( IDBFS, {}, '/home/web_user/.cataclysm-tlg' );
     await new Promise( function( resolve, reject )
     {
         FS.syncfs( true, function( err ) {
@@ -665,7 +665,7 @@ int main( int argc, const char *argv[] )
 #endif
 #if defined(__ANDROID__)
     // Start the standard output logging redirector
-    start_logger( "cdda" );
+    start_logger( "ctlg" );
 
     // On Android first launch, we copy all data files from the APK into the app's writeable folder so std::io stuff works.
     // Use the external storage so it's publicly modifiable data (so users can mess with installed data, save games etc.)

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -877,7 +877,7 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "move_cost", movecost );
     optional( jo, was_loaded, "coverage", coverage );
-    assign( jo, "max_volume", max_volume, src == "dda" );
+    assign( jo, "max_volume", max_volume, src == "tlg" );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );
     optional( jo, was_loaded, "light_emitted", light_emitted );

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -315,7 +315,7 @@ void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
 
 void mission_type::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = src == "tlg";
 
     mandatory( jo, was_loaded, "name", name );
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -739,7 +739,7 @@ void mon_effect_data::load( const JsonObject &jo )
 
 void mtype::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     MonsterGenerator &gen = MonsterGenerator::generator();
 
@@ -1619,7 +1619,7 @@ void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::stri
 void MonsterGenerator::check_monster_definitions() const
 {
     for( const mtype &mon : mon_templates->get_all() ) {
-        if( !mon.src.empty() && mon.src.back().second.str() == "dda" ) {
+        if( !mon.src.empty() && mon.src.back().second.str() == "tlg" ) {
             std::string mon_id = mon.id.str();
             std::string suffix_id = mon_id.substr( 0, mon_id.find( '_' ) );
             if( suffix_id != "mon" && suffix_id != "pseudo" ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -652,7 +652,7 @@ void mutation_branch::check_consistency()
     for( const mutation_branch &mdata : get_all() ) {
         const trait_id &mid = mdata.id;
         const mod_id &trait_source = mdata.src.back().second;
-        const bool basegame_trait = trait_source.str() == "dda";
+        const bool basegame_trait = trait_source.str() == "tlg";
         const std::optional<scenttype_id> &s_id = mdata.scent_typeid;
         const std::map<species_id, int> &an_id = mdata.anger_relations;
         for( const auto &style : mdata.initial_ma_styles ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -436,7 +436,7 @@ std::string overmap_land_use_code::get_symbol() const
 
 void overmap_land_use_code::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = src == "tlg";
     assign( jo, "land_use_code", land_use_code, strict );
     assign( jo, "name", name, strict );
     assign( jo, "detailed_definition", detailed_definition, strict );
@@ -763,7 +763,7 @@ std::string enum_to_string<oter_travel_cost_type>( oter_travel_cost_type data )
 
 void oter_type_t::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = src == "tlg";
 
     optional( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader, NULL_UNICODE );
 
@@ -2783,7 +2783,7 @@ mapgen_arguments overmap_special::get_args( const mapgendata &md ) const
 
 void overmap_special::load( const JsonObject &jo, const std::string &src )
 {
-    const bool strict = src == "dda";
+    const bool strict = src == "tlg";
     // city_building is just an alias of overmap_special
     // TODO: This comparison is a hack. Separate them properly.
     const bool is_special = jo.get_string( "type", "" ) == "overmap_special";

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -149,7 +149,7 @@ bool recipe::has_flag( const std::string &flag_name ) const
 
 void recipe::load( const JsonObject &jo, const std::string &src )
 {
-    bool strict = src == "dda";
+    bool strict = src == "tlg";
 
     abstract = jo.has_string( "abstract" );
 

--- a/src/rotatable_symbols.cpp
+++ b/src/rotatable_symbols.cpp
@@ -38,7 +38,7 @@ namespace rotatable_symbols
 void load( const JsonObject &jo, const std::string &src )
 {
     const std::string tuple_key = "tuple";
-    const bool strict = src == "dda";
+    const bool strict = src == "tlg";
 
     std::vector<std::string> tuple_temp;
 

--- a/src/translation_manager_impl.cpp
+++ b/src/translation_manager_impl.cpp
@@ -65,7 +65,7 @@ void TranslationManager::Impl::ScanTranslationDocuments()
     if( dir_exist( locale_dir() ) ) {
         DebugLog( D_INFO, DC_ALL ) << "[i18n] Scanning core translations from " << locale_dir();
         for( const std::string &dir : get_files_from_path( "LC_MESSAGES", locale_dir(), true ) ) {
-            mo_dirs.emplace_back( dir, "cataclysm-dda.mo" );
+            mo_dirs.emplace_back( dir, "cataclysm-tlg.mo" );
         }
     }
     for( const std::pair<std::string, std::string> &entry : mo_dirs ) {

--- a/tools/auto_doc_mutations.py
+++ b/tools/auto_doc_mutations.py
@@ -110,7 +110,7 @@ def write_mutations(mutations: list[Mutation], filename: Path) -> None:
             fd.write("\n\n")
 
 
-def extract_mutations(file: Path, mod: str = "dda") -> list[Mutation]:
+def extract_mutations(file: Path, mod: str = "tlg") -> list[Mutation]:
     """Extract mutations from :file:."""
 
     with open(file, "rb") as fd:
@@ -177,7 +177,7 @@ class Mod:
     "--outfile",
     type=click.Path(resolve_path=True, path_type=Path, dir_okay=False),
     default="mutations.md",
-    help="""Specify the filepath to write the documentation for DDA to.
+    help="""Specify the filepath to write the documentation for TLG to.
     If mods are included, their documentation will be written to the same
     directory.""",
     show_default=True,
@@ -203,9 +203,9 @@ def cli(paths, outfile, include_mods) -> None:
         write_mutations(mutations, outfile)
         click.echo(f"Mutations written to {outfile}")
     else:
-        dda = Mod("dda", [], [])
-        mod_stack: list[tuple[Mod, str]] = [(dda, "PLACEHOLDER")]
-        mods: dict[str, Mod] = {"dda": dda}
+        tlg = Mod("tlg", [], [])
+        mod_stack: list[tuple[Mod, str]] = [(tlg, "PLACEHOLDER")]
+        mods: dict[str, Mod] = {"tlg": tlg}
 
         def move_stack(
             file, mod_stack: list[tuple[Mod, str]]
@@ -225,8 +225,8 @@ def cli(paths, outfile, include_mods) -> None:
                     extract_mutations(file, mod_stack[-1][0].id_)
                 )
 
-            elif os.path.split(os.path.split(file)[0])[1] == "dda":
-                # Skip DDA
+            elif os.path.split(os.path.split(file)[0])[1] == "tlg":
+                # Skip TLG
                 continue
             else:
                 # Add a new mod to the stack.
@@ -285,7 +285,7 @@ def cli(paths, outfile, include_mods) -> None:
             except AttributeError:
                 breakpoint()
 
-            if mod.id_ == "dda":
+            if mod.id_ == "tlg":
                 writepath = outfile
             else:
                 writepath = outfile.parent.joinpath(mod.id_ + ".md")

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -121,7 +121,7 @@ class CataModule : public ClangTidyModule
 // Register the MiscTidyModule using this statically initialized variable.
 // NOLINTNEXTLINE(cata-unused-statics)
 static ClangTidyModuleRegistry::Add<cata::CataModule>
-X( "cata-module", "Adds Cataclysm-DDA checks." );
+X( "cata-module", "Adds Cataclysm-TLG checks." );
 
 } // namespace clang::tidy
 


### PR DESCRIPTION
#### Summary
Fix translations and clean up lingering "dda"s in code

#### Purpose of change
Translations weren't working because of a misnamed pointer in a file. I found a few others.

#### Describe the solution
- dda -> tlg
- Fix some minor json errors that weren't throwing messages before due to the bad pointers.

#### Testing
![image](https://github.com/user-attachments/assets/a71fb97c-e075-4a53-b50c-99b27336abc4)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
