### PR TITLE
Backport DDA 74651 - Provide roof for regional dump shack

### DIFF
--- a/data/json/mapgen/ws_regional_dump.json
+++ b/data/json/mapgen/ws_regional_dump.json
@@ -61,6 +61,40 @@
   },
   {
     "type": "mapgen",
+    "om_terrain": [ "ws_regional_dump_3_0_roof" ],
+    "method": "json",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  -------               ",
+        "  -.....-               ",
+        "  -.....-               ",
+        "  -.....-               ",
+        "  -.....-               ",
+        "  -.....-               ",
+        "  -------               ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "om_terrain": [ [ "ws_regional_dump_0_1", "ws_regional_dump_1_1", "ws_regional_dump_2_1", "ws_regional_dump_3_1" ] ],
     "method": "json",
     "weight": 1000,

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -75,7 +75,12 @@
     "destination": "dairy_farm_isherwood_W",
     "start": {
       "effect": [ { "u_add_var": "general_meeting_u_have_barry_escape", "value": "yes" } ],
-      "assign_mission_target": { "om_terrain": "dairy_farm_isherwood_W", "om_special": "Isherwood Farm Mutable", "reveal_radius": 3, "search_range": 240 }
+      "assign_mission_target": {
+        "om_terrain": "dairy_farm_isherwood_W",
+        "om_special": "Isherwood Farm Mutable",
+        "reveal_radius": 3,
+        "search_range": 240
+      }
     },
     "end": {
       "opinion": { "trust": 5, "value": 5 },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -4102,6 +4102,7 @@
       { "point": [ 1, 0, 0 ], "overmap": "ws_regional_dump_1_0_north" },
       { "point": [ 2, 0, 0 ], "overmap": "ws_regional_dump_2_0_north" },
       { "point": [ 3, 0, 0 ], "overmap": "ws_regional_dump_3_0_north" },
+      { "point": [ 3, 0, 1 ], "overmap": "ws_regional_dump_3_0_roof_north" },
       { "point": [ 0, 1, 0 ], "overmap": "ws_regional_dump_0_1_north" },
       { "point": [ 1, 1, 0 ], "overmap": "ws_regional_dump_1_1_north" },
       { "point": [ 2, 1, 0 ], "overmap": "ws_regional_dump_2_1_north" },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -236,6 +236,7 @@
       "ws_regional_dump_1_0",
       "ws_regional_dump_2_0",
       "ws_regional_dump_3_0",
+      "ws_regional_dump_3_0_roof",
       "ws_regional_dump_0_1",
       "ws_regional_dump_1_1",
       "ws_regional_dump_2_1",


### PR DESCRIPTION
#### Summary
Backport DDA 74651 - Provide roof for regional dump shack


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
