### PR TITLE
Fix cmake "unused argument" errors in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ else ()
                 "${CMAKE_SOURCE_DIR}/src/prefix.h.in"
                 "${CMAKE_SOURCE_DIR}/src/prefix.h"
                 @ONLY)
-            add_definitions(-TLGTA_DIR_PREFIX)
+            add_definitions(-DDATA_DIR_PREFIX)
         endif ()
     else()
         set(CMAKE_INSTALL_DATADIR   data)


### PR DESCRIPTION
#### Summary
Noticed a bunch of builds failing with `clang++-17: error: argument unused during compilation: '-T LGTA_DIR_PREFIX' [-Werror,-Wunused-command-line-argument]`.
Looks like it got caught up in the DDA -> TLG renaming, but Cmake interprets the first two chars as the actual flag (this would result in `-T GTA_DIR_PREFIX`, which isn't referenced anywhere, but `DATA_DIR_PREFIX` is). 

#### Purpose of change
Hopefully fix the clang-tidy builds. Haven't tested but I'm hoping. 

### Describe the solution
Change the string back to `-DDATA_DIR_PREFIX` from `-TLGTA_DIR_PREFIX`

#### Describe alternatives you've considered
- rewriting the entire thing in a less janky build system
- installing several clang/cmake setups to build locally
- removing the workflows entirely

#### Testing
Relying on CI to test, fingers crossed it'll be greener.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
