### PR TITLE
Backport DDA 74614 - add tiny bottles and modify nicotine liquid bottles

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -1193,12 +1193,12 @@
     "symbol": "=",
     "color": "yellow",
     "description": "Liquid made up of propylene glycol, vegetable glycerin, flavorings, and nicotine.  Intended for use in an advanced electronic cigarette.",
-    "container": "bottle_plastic_small",
+    "container": "bottle_plastic_tiny",
     "phase": "liquid",
-    "volume": "250 ml",
-    "weight": "2 g",
+    "volume": "30 ml",
+    "weight": "1 g",
     "ammo_type": "components",
-    "count": 50
+    "count": 30
   },
   {
     "id": "fish_bait",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -629,6 +629,37 @@
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
   {
+    "id": "bottle_plastic_tiny",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "tiny plastic bottle" },
+    "looks_like": "bottle_plastic",
+    "description": "A watertight plastic bottle, holds 30 mL of liquid.",
+    "ascii_picture": "bottle_plastic_small",
+    "weight": "2 g",
+    "volume": "35 ml",
+    "longest_side": "4 cm",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": true,
+        "rigid": true,
+        "transparent": true,
+        "max_contains_volume": "30 ml",
+        "max_item_volume": "1 ml",
+        "max_contains_weight": "1 kg",
+        "moves": 400
+      }
+    ],
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "to_hit": 1,
+    "material": [ "plastic" ],
+    "symbol": ")",
+    "color": "white",
+    "flags": [ "COLLAPSE_CONTENTS" ]
+  },
+  {
     "id": "bottle_plastic_pill_prescription",
     "type": "GENERIC",
     "category": "container",


### PR DESCRIPTION
#### Summary
Backport DDA 74614 - add tiny bottles and modify nicotine liquid bottles

#### Purpose of change
Smaller, less useful containers!

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
