### PR TITLE
Backport DDA 74613 - Add Mossberg 590M

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -890,6 +890,7 @@
       { "item": "benelli_sa", "variant": "sbe", "prob": 37 },
       { "item": "benelli_tsa", "variant": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 12 },
       { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 6 },
+      { "item": "mossberg_590m", "prob": 1 },
       { "item": "remington_870", "variant": "ithaca37", "prob": 6 },
       { "item": "remington_870", "variant": "remington_1100", "prob": 17 },
       { "item": "mossberg_930", "prob": 15 },
@@ -910,7 +911,8 @@
       { "group": "nested_tavor_12", "prob": 5 },
       { "group": "nested_m1014", "prob": 10 },
       { "group": "nested_SPAS_12", "prob": 2 },
-      { "group": "nested_slp", "prob": 10 }
+      { "group": "nested_slp", "prob": 10 },
+      { "group": "nested_mossberg_590m", "prob": 2 }
     ]
   },
   {
@@ -925,7 +927,8 @@
       { "item": "tavor_12", "prob": 5, "charges": [ 0, 5 ] },
       { "group": "nested_SPAS_12", "prob": 2 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges": [ 0, 8 ] },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10, "charges": [ 0, 9 ] }
+      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10, "charges": [ 0, 9 ] },
+      { "item": "mossberg_590m", "prob": 2, "charges": [ 0, 5 ] }
     ]
   },
   {
@@ -938,7 +941,8 @@
       { "item": "tavor_12", "prob": 5 },
       { "group": "nested_SPAS_12", "prob": 2 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10 },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10 }
+      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10 },
+      { "item": "mossberg_590m", "prob": 2 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
@@ -492,7 +492,11 @@
       { "item": "saiga10mag", "prob": 50 },
       { "item": "saiga30mag", "prob": 10 },
       { "item": "saiga410mag_10rd", "prob": 30 },
-      { "item": "saiga410mag_30rd", "prob": 10 }
+      { "item": "saiga410mag_30rd", "prob": 10 },
+      { "item": "mossberg_590m_mag_5", "prob": 3, "charges": 0 },
+      { "item": "mossberg_590m_mag_10", "prob": 2, "charges": 0 },
+      { "item": "mossberg_590m_mag_15", "prob": 1, "charges": 0 },
+      { "item": "mossberg_590m_mag_20", "prob": 1, "charges": 0 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -2292,6 +2292,36 @@
     "entries": [ { "item": "mossberg_590", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
+    "id": "nested_mossberg_590m",
+    "type": "item_group",
+    "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
+    "subtype": "collection",
+    "ammo": 100,
+    "entries": [
+      { "item": "mossberg_590", "charges": [ 0, 5 ] },
+      { "item": "mossberg_590m_mag_10" },
+      { "item": "mossberg_590m_mag_10", "prob": 50 },
+      {
+        "distribution": [
+          { "collection": [ { "item": "mossberg_590m_mag_5" }, { "item": "mossberg_590m_mag_5", "prob": 50 } ], "prob": 3 },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_10" }, { "item": "mossberg_590m_mag_10", "prob": 50 } ],
+            "prob": 2
+          },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_15" }, { "item": "mossberg_590m_mag_15", "prob": 50 } ],
+            "prob": 1
+          },
+          {
+            "collection": [ { "item": "mossberg_590m_mag_20" }, { "item": "mossberg_590m_mag_20", "prob": 50 } ],
+            "prob": 1
+          }
+        ]
+      },
+      { "group": "on_hand_shot" }
+    ]
+  },
+  {
     "id": "nested_remington_870_breacher",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -273,6 +273,48 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 9 } } ]
   },
   {
+    "id": "mossberg_590m",
+    "copy-from": "mossberg_590",
+    "looks_like": "mossberg_590",
+    "type": "GUN",
+    "name": { "str": "magazine-fed pump shotgun" },
+    "description": "A classic pump-action shotgun, all save for the fact that the manufacturer has modified it to use detachable box magazines instead of a standard shotgun tube.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590",
+        "name": { "str": "Mossberg 590M shotgun" },
+        "description": "A classic Mossberg 590 pump-action shotgun, modified by the manufacturer to utilize box magazines."
+      }
+    ],
+    "weight": "3628 g",
+    "volume": "2548 ml",
+    "longest_side": "1033 mm",
+    "barrel_length": "469 mm",
+    "price": "770 USD",
+    "price_postapoc": "19 USD",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "bayonet lug", 1 ],
+      [ "brass catcher", 1 ],
+      [ "grip mount", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock mount", 1 ],
+      [ "stock accessory", 2 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "mossberg_590m_mag_5", "mossberg_590m_mag_10", "mossberg_590m_mag_15", "mossberg_590m_mag_20" ]
+      }
+    ]
+  },
+  {
     "id": "mossberg_930",
     "copy-from": "shotgun_base",
     "type": "GUN",

--- a/data/json/items/magazine/shot.json
+++ b/data/json/items/magazine/shot.json
@@ -160,5 +160,100 @@
     "ammo_type": [ "shot" ],
     "flags": [ "MAG_COMPACT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_5",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 5-round magazine" },
+    "description": "A small 5-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_5",
+        "name": { "str": "Mossberg 590M 5-round magazine" },
+        "description": "A small 5-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "445 g",
+    "volume": "770 ml",
+    "longest_side": "136 mm",
+    "price": "88 USD",
+    "price_postapoc": "4 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "flags": [ "MAG_COMPACT" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 10-round magazine" },
+    "description": "A 10-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_10",
+        "name": { "str": "Mossberg 590M 10-round magazine" },
+        "description": "A 10-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "607 g",
+    "volume": "1147 ml",
+    "longest_side": "203 mm",
+    "price": "99 USD",
+    "price_postapoc": "6 USD",
+    "material": [ "lc_steel" ],
+    "symbol": "#",
+    "color": "dark_gray",
+    "ammo_type": [ "shot" ],
+    "flags": [ "MAG_BULKY" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 10 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_15",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 15-round magazine" },
+    "description": "A 15-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_15",
+        "name": { "str": "Mossberg 590M 15-round magazine" },
+        "description": "A 15-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "740 g",
+    "volume": "1487 ml",
+    "longest_side": "263 mm",
+    "price": "116 USD",
+    "price_postapoc": "4 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 15 } } ]
+  },
+  {
+    "id": "mossberg_590m_mag_20",
+    "copy-from": "mossberg_590m_mag_10",
+    "type": "MAGAZINE",
+    "name": { "str": "magazine-fed pump shotgun 20-round magazine" },
+    "description": "A 20-round box magazine for the magazine-fed pump shotgun.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "mossberg_590m_mag_20",
+        "name": { "str": "Mossberg 590M 20-round magazine" },
+        "description": "A 20-round box magazine for the Mossberg 590M shotgun."
+      }
+    ],
+    "weight": "817 g",
+    "volume": "1810 ml",
+    "longest_side": "320 mm",
+    "price": "126 USD",
+    "price_postapoc": "3 USD",
+    "symbol": "#",
+    "color": "dark_gray",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 20 } } ]
   }
 ]

--- a/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
+++ b/data/mods/Generic_Guns/firearms/gg_firearms_migration.json
@@ -429,6 +429,7 @@
       "aa_12",
       "benelli_tsa",
       "bigun",
+      "mossberg_590m",
       "USAS_12"
     ],
     "type": "MIGRATION",

--- a/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
+++ b/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
@@ -378,6 +378,10 @@
       "aa12_box_mag",
       "aa12_drum_mag",
       "aa12_vehicle_drum",
+      "mossberg_590m_mag_5",
+      "mossberg_590m_mag_10",
+      "mossberg_590m_mag_15",
+      "mossberg_590m_mag_20",
       "m26_mass_mag_3",
       "m26_mass_mag_5"
     ],


### PR DESCRIPTION
#### Summary
Backport DDA 74613 - Add Mossberg 590M

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
