### PR TITLE
Backport 75083 - corrected nemesis respawn logic

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -170,14 +170,14 @@ void mission::on_creature_death( Creature &poor_dead_dude )
             avatar &player_character = get_avatar();
             for( std::pair<const int, mission> &e : world_missions ) {
                 mission &i = e.second;
-                if( i.type->monster_kill_goal == 1 ) {
-                    if( i.type->goal == MGOAL_KILL_NEMESIS && player_character.getID() == i.player_id ) {
+                if( i.type->goal == MGOAL_KILL_NEMESIS && player_character.getID() == i.player_id ) {
+                    if( i.type->monster_kill_goal == 1 ) {
                         i.step_complete( 1 );
-                        return;
+                    } else {
+                        // Recurring nemesis!!
+                        mission_start::kill_nemesis( &i );
                     }
-                } else {
-                    // Recurring nemesis!!
-                    mission_start::kill_nemesis( &i );
+                    return;
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Backport 75083 - corrected nemesis respawn logic

#### Purpose of change
Relentless hulks were respawning when killed even on the normal Hunted scenario.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
