### PR TITLE
Backport DDA 75020 - Fix deconstruction save/load item_location loss and screwed progress

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1256,7 +1256,7 @@ class disassemble_activity_actor : public activity_actor
         int moves_total;
         float activity_override = NO_EXERCISE; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)
-        bool use_cached_workbench_multiplier; // NOLINT(cata-serialize)
+        bool use_cached_workbench_multiplier = false; // NOLINT(cata-serialize)
     public:
         item_location target;
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -471,8 +471,13 @@ const
 VisitResponse map_cursor::visit_items(
     const std::function<VisitResponse( item *, item * )> &func ) const
 {
-    map &here = get_map();
-    tripoint p = pos().raw();
+    smallmap here;  // tinymap would work as well, as we're only looking at a single position.
+    // pos returns the pos_bub location of the target relative to the reality bubble
+    // even if the location isn't actually inside of it. Thus, we're loading a map
+    // around that location to do our work.
+    tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
+    here.load( project_to<coords::omt>( abs_pos ), false );
+    tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
 
     // check furniture pseudo items
     if( here.furn( p ) != furn_str_id::NULL_ID() ) {
@@ -486,12 +491,12 @@ VisitResponse map_cursor::visit_items(
     }
 
     // skip inaccessible items
-    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) &&
-        !here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, p.raw() ) &&
+        !here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, p.raw() ) ) {
         return VisitResponse::NEXT;
     }
 
-    for( item &e : here.i_at( p ) ) {
+    for( item &e : here.i_at( p.raw() ) ) {
         if( visit_internal( func, &e ) == VisitResponse::ABORT ) {
             return VisitResponse::ABORT;
         }


### PR DESCRIPTION
#### Summary
Backport DDA 75020 - Fix deconstruction save/load item_location loss and screwed progress

#### Purpose of change
It was possible when save/loads happened during deconstruction for progress to either be lost or (when NPCs were doing it) for the progress to shoot waaaay into the negative. This should fix both cases.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
