### PR TITLE
Backport DDA 74665 - Tone down hair growth times

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -7,7 +7,7 @@
     "//3": "For ease of calculation, all math will be done with centimeters for hair growth.",
     "//4": "For reference starting point, a buzzcut is 0.32 centimeters long.",
     "//5": "1 inch is 2.54 centimeters.",
-    "recurrence": { "math": [ "(648000000 - ((u_val('health') * 180000) ) )" ] },
+    "recurrence": { "math": [ "(6480000 - ((u_val('health') * 180000) ) )" ] },
     "global": false,
     "condition": { "u_has_trait": "natural_hair_growth" },
     "effect": [


### PR DESCRIPTION
#### Summary
Backport DDA 74665 - Tone down hair growth times

#### Purpose of change
![image](https://github.com/user-attachments/assets/5418a549-23f2-43c6-b345-74df2d755b1b)

#### Describe the solution
![image](https://github.com/user-attachments/assets/e8901bc1-3402-41d0-8ca6-6f6dffff5ded)

#### Describe alternatives you've considered
![image](https://github.com/user-attachments/assets/cbab2e6c-6e12-4723-85ac-67b53877f256)

#### Testing
![image](https://github.com/user-attachments/assets/e05fa3c3-0544-4c28-b308-3a0ce8fd0892)

#### Additional context
![image](https://github.com/user-attachments/assets/57d51c5e-f6d9-4379-a08b-69667aca9ebe)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
