### PR TITLE
Backport DDA 74661 - Fixes Description for Xanax

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1959,7 +1959,6 @@
       {
         "id": "xanax",
         "name": { "str_sp": "Xanax" },
-        "append": true,
         "description": "An anti-anxiety agent with a powerful sedative effect.  May cause dissociation and loss of memory.  It is dangerously addictive, and withdrawal from regular use should be gradual."
       }
     ],


### PR DESCRIPTION
#### Summary
Backport DDA 74661 - Fixes Description for Xanax

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
