### PR TITLE
Backport DDA 74810 - Fix concentration metamagic sign flipping

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1427,6 +1427,9 @@ float spell::spell_fail( const Character &guy ) const
         }
         float concentration_loss = ( 1.0f - ( guy.get_focus() / 100.0f ) ) *
                                    temp_concentration_difficulty_multiplyer;
+        if( concentration_loss >= 1.0f ) {
+            return 1.0f;
+        }
         fail_chance /= 1.0f - concentration_loss;
         psi_fail_chance /= 1.0f - concentration_loss;
     }


### PR DESCRIPTION
#### Summary
Backport DDA 74810 - Fix concentration metamagic sign flipping

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
