### PR TITLE
Backport DDA 74841 - fix android bug

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2920,7 +2920,7 @@ static void CheckMessages()
                         }
 
                         // Check for actions that work on nearby tiles and own tile
-                        if( can_interact_at( ACTION_PICKUP, pos ) ) {
+                        if( can_interact_at( ACTION_PICKUP, tripoint_bub_ms( pos ) ) ) {
                             actions.insert( ACTION_PICKUP );
                         }
                     }


### PR DESCRIPTION
#### Summary
Backport DDA 74841

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
