### PR TITLE
Backport 74869 - Typify for android build

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2863,7 +2863,7 @@ static void CheckMessages()
                         int y = player_character.posy() + dy;
                         int z = player_character.posz();
                         const tripoint pos( x, y, z );
-                        const tripoint_bub_ms bub_pos(pos);
+                        const tripoint_bub_ms bub_pos( pos );
                         // Check if we're near a vehicle, if so, vehicle controls should be top.
                         {
                             const optional_vpart_position vp = here.veh_at( pos );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2863,7 +2863,7 @@ static void CheckMessages()
                         int y = player_character.posy() + dy;
                         int z = player_character.posz();
                         const tripoint pos( x, y, z );
-
+                        const tripoint_bub_ms bub_pos(pos);
                         // Check if we're near a vehicle, if so, vehicle controls should be top.
                         {
                             const optional_vpart_position vp = here.veh_at( pos );
@@ -2892,27 +2892,27 @@ static void CheckMessages()
                             //if( can_interact_at( ACTION_OPEN, pos ) ) {
                             // don't bother with open since user can just walk into target
                             //}
-                            if( can_interact_at( ACTION_CLOSE, pos ) ) {
+                            if( can_interact_at( ACTION_CLOSE, bub_pos ) ) {
                                 actions.insert( ACTION_CLOSE );
                             }
-                            if( can_interact_at( ACTION_EXAMINE, pos ) ) {
+                            if( can_interact_at( ACTION_EXAMINE, bub_pos ) ) {
                                 actions.insert( ACTION_EXAMINE );
                             }
                         } else {
                             // Check for actions that work on own tile only
-                            if( can_interact_at( ACTION_BUTCHER, pos ) ) {
+                            if( can_interact_at( ACTION_BUTCHER, bub_pos ) ) {
                                 actions.insert( ACTION_BUTCHER );
                             } else {
                                 actions_remove.insert( ACTION_BUTCHER );
                             }
 
-                            if( can_interact_at( ACTION_MOVE_UP, pos ) ) {
+                            if( can_interact_at( ACTION_MOVE_UP, bub_pos ) ) {
                                 actions.insert( ACTION_MOVE_UP );
                             } else {
                                 actions_remove.insert( ACTION_MOVE_UP );
                             }
 
-                            if( can_interact_at( ACTION_MOVE_DOWN, pos ) ) {
+                            if( can_interact_at( ACTION_MOVE_DOWN, bub_pos ) ) {
                                 actions.insert( ACTION_MOVE_DOWN );
                             } else {
                                 actions_remove.insert( ACTION_MOVE_DOWN );
@@ -2920,7 +2920,7 @@ static void CheckMessages()
                         }
 
                         // Check for actions that work on nearby tiles and own tile
-                        if( can_interact_at( ACTION_PICKUP, pos ) ) {
+                        if( can_interact_at( ACTION_PICKUP, bub_pos ) ) {
                             actions.insert( ACTION_PICKUP );
                         }
                     }


### PR DESCRIPTION
#### Summary
Backport 74869 - Typify for android build

#### Purpose of change
Doesn't get the android build fixed, just makes it so something else I backported won't break it.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
