### PR TITLE
Backport 74835

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6149,9 +6149,8 @@ int Character::throw_range( const item &it ) const
     if( ret < 1 ) {
         return 1;
     }
-    // Cap at double our strength + skill
-    /** @EFFECT_STR caps throwing range */
 
+    /** @EFFECT_STR caps throwing range */
     /** @EFFECT_THROW caps throwing range */
 
     int cap = round( str + get_skill_level( skill_throw ) );

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -198,7 +198,7 @@ bool game::grabbed_veh_move( const tripoint &dp )
         if( grabbed_vehicle->is_falling ) {
             add_msg( _( "You let go of the %1$s as it starts to fall." ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
-            m.drop_vehicle( final_dp_veh );
+            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub().raw() );
             return true;
         }
     } else {


### PR DESCRIPTION
#### Summary
Backport 74835 - Fix incorrect grabbed vehicle falling logic


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
