### PR TITLE
Backport DDA 75103 & 75270 for performance

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -234,7 +234,10 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
-                if( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) {
+                // For some reason 'emplace' doesn't work. emplacing data later overwrote data...
+                generated[grid_pos] = MAPBUFFER.submap_exists( p_sm_base.xy() + pos );
+
+                if( !generated.at( grid_pos ) || !save_results ) {
                     setsubmap( grid_pos, new submap() );
 
                     // Generate uniform submaps immediately and cheaply.
@@ -272,7 +275,8 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridy = 0; gridy <= 1; gridy++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
-                if( ( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) &&
+
+                if( ( !generated.at( grid_pos ) || !save_results ) &&
                     !getsubmap( grid_pos )->is_uniform() &&
                     uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
                     saved_overlay[gridx + gridy * 2] = getsubmap( grid_pos );
@@ -300,7 +304,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                                  MAPBUFFER.lookup_submap( p_sm + point_south ) == nullptr;
 
         mapgendata dat( { p.xy(), gridz}, *this, density, when, nullptr );
-        if( ( !save_results || any_missing ) &&
+        if( ( any_missing || !save_results ) &&
             uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
             draw_map( dat );
         }
@@ -319,7 +323,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             }
         }
 
-        if( !save_results || any_missing ) {
+        if( any_missing || !save_results ) {
 
             // At some point, we should add region information so we can grab the appropriate extras
             map_extras &this_ex = region_settings_map["default"].region_extras[terrain_type->get_extras()];

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -234,10 +234,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
-                // For some reason 'emplace' doesn't work. emplacing data later overwrote data...
-                generated[grid_pos] = MAPBUFFER.submap_exists( p_sm_base.xy() + pos );
-
-                if( !generated.at( grid_pos ) || !save_results ) {
+                if( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) {
                     setsubmap( grid_pos, new submap() );
 
                     // Generate uniform submaps immediately and cheaply.
@@ -275,8 +272,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             for( int gridy = 0; gridy <= 1; gridy++ ) {
                 const tripoint_rel_sm pos( gridx, gridy, gridz );
                 const size_t grid_pos = get_nonant( pos );
-
-                if( ( !generated.at( grid_pos ) || !save_results ) &&
+                if( ( !save_results || MAPBUFFER.lookup_submap( p_sm_base.xy() + pos ) == nullptr ) &&
                     !getsubmap( grid_pos )->is_uniform() &&
                     uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
                     saved_overlay[gridx + gridy * 2] = getsubmap( grid_pos );
@@ -304,7 +300,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                                  MAPBUFFER.lookup_submap( p_sm + point_south ) == nullptr;
 
         mapgendata dat( { p.xy(), gridz}, *this, density, when, nullptr );
-        if( ( any_missing || !save_results ) &&
+        if( ( !save_results || any_missing ) &&
             uniform_terrain( overmap_buffer.ter( { p.xy(), gridz } ) ) == t_null.id() ) {
             draw_map( dat );
         }
@@ -323,7 +319,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             }
         }
 
-        if( any_missing || !save_results ) {
+        if( !save_results || any_missing ) {
 
             // At some point, we should add region information so we can grab the appropriate extras
             map_extras &this_ex = region_settings_map["default"].region_extras[terrain_type->get_extras()];


### PR DESCRIPTION
#### Summary
Backport DDA 75103 & 75188 for performance

#### Purpose of change
It looks like #582 which was intended to fix some bugs/lag/etc introduced a new lag issue. 75103 and/or 75188 ought to clean that all up.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
