### PR TITLE
Fix Cranberry's mission and Hub 01 map sale

### DIFF
--- a/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
@@ -93,7 +93,6 @@
       "terrain": { "@": "t_pavement" },
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
       "monster": {
-        "T": { "monster": "mon_zombie_necro" },
         "k": { "monster": "mon_zombie_electric" },
         "u": { "monster": "mon_zombie_plated" }
       }

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -583,7 +583,7 @@
       "effect": [ "follow_only", { "npc_add_var": "general_robofac_merc_1_temporal_follower", "value": "yes" } ],
       "assign_mission_target": { "om_terrain": "radio_tower_1", "om_special": "hub_01", "reveal_radius": 1, "random": true, "search_range": 10 },
       "update_mapgen": [
-        { "place_monster": [ { "monster": "mon_leech_radio", "x": 12, "y": 10, "target": true } ] },
+        { "place_monster": [ { "monster": "mon_zombie_necro", "x": 12, "y": 10, "target": true } ] },
         { "place_nested": [ { "chunks": [ "robofac_radio_leech" ], "x": 0, "y": 0 } ] }
       ]
     },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -34,7 +34,7 @@
         "text": "[1 HGC] Deal!",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 1 } },
         "effect": [
-          { "u_buy_item": "RobofacCoin", "count": 1 },
+          { "u_sell_item": "RobofacCoin", "count": 1 },
           { "mapgen_update": "robofachq_surface_entrance", "reveal_radius": 40, "random": true, "search_range": 70 },
           { "npc_add_var": "dialogue_intercom_sold_local_map", "value": "yes" }
         ],


### PR DESCRIPTION
#### Summary
Fix Cranberry's mission and Hub 01 map sale

#### Purpose of change
When I removed leech blossoms, I updated the map chunk they generate in robofac_locs to use a different set of enemies, however I missed that Cranberry's mission was still using a leech blossom as the kill target, so the mission was uncompletable.

There was an additional bug where Hub 01 was paying you a coin for their map, rather than the other way around.

#### Describe the solution
You are now meant to kill the zombie necromancer that spawns at the site, not a nonexistent leech blossom.

#### Testing
- Did the quest, killed the necromancer, which completed it.

#### Additional context
NPC following is bugged as hell. I smashed a corpse that Cranberry was smashing, which caused their AI to get stuck and decide to just stand there forever doing nothing. The quest was still completed, but Cranberry is supposed to go back to the Hub with you.

I will detail my problems with this in another issue so I can fix it later.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
