### PR TITLE
Improve temperature warnings and reduce spam

### DIFF
--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -207,7 +207,11 @@
     "special_attacks": [ [ "SUICIDE", 20 ] ],
     "death_drops": { "subtype": "collection", "groups": [ "default_zombie_death_drops", "explode_gasbag" ] },
     "upgrades": { "half_life": 24, "into": "mon_zombie_gasbag_crawler" },
-    "death_function": { "message": "The %s explodes!", "effect": { "id": "death_gas", "hit_self": true, "min_level": 3 }, "corpse_type": "NO_CORPSE" },
+    "death_function": {
+      "message": "The %s explodes!",
+      "effect": { "id": "death_gas", "hit_self": true, "min_level": 3 },
+      "corpse_type": "NO_CORPSE"
+    },
     "flags": [ "SEES", "HEARS", "IMMOBILE", "WARM", "POISON", "NO_BREATHE", "FILTHY" ],
     "armor": { "electric": 1 }
   },
@@ -239,7 +243,11 @@
     "vision_night": 50,
     "harvest": "exempt",
     "special_attacks": [ { "type": "leap", "cooldown": 5, "max_range": 5, "allow_no_target": true }, [ "scratch", 5 ] ],
-    "death_function": { "message": "The %s explodes!", "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 }, "corpse_type": "NO_CORPSE" },
+    "death_function": {
+      "message": "The %s explodes!",
+      "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 },
+      "corpse_type": "NO_CORPSE"
+    },
     "death_drops": "explode_gasbag",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "POISON", "CLIMBS", "NO_BREATHE", "CLIMBS", "HARDTOSHOOT", "NEVER_WANDER" ],
     "armor": { "bash": 6, "cut": 6, "bullet": 5, "electric": 1 }
@@ -283,7 +291,11 @@
       { "type": "leap", "cooldown": 15, "max_range": 2, "allow_no_target": true },
       [ "scratch", 5 ]
     ],
-    "death_function": { "message": "The %s explodes!", "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 }, "corpse_type": "NO_CORPSE" },
+    "death_function": {
+      "message": "The %s explodes!",
+      "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 },
+      "corpse_type": "NO_CORPSE"
+    },
     "death_drops": "explode_gasbag",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "POISON", "CLIMBS", "NO_BREATHE", "CLIMBS", "HARDTOSHOOT" ],
     "armor": { "bash": 6, "cut": 6, "bullet": 5, "electric": 1 }
@@ -314,7 +326,11 @@
     "bleed_rate": 50,
     "vision_day": 1,
     "special_attacks": [ { "type": "leap", "cooldown": 5, "max_range": 3, "allow_no_target": true }, [ "scratch", 5 ] ],
-    "death_function": { "message": "The %s explodes!", "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 }, "corpse_type": "NO_CORPSE" },
+    "death_function": {
+      "message": "The %s explodes!",
+      "effect": { "id": "death_gas", "hit_self": true, "min_level": 2 },
+      "corpse_type": "NO_CORPSE"
+    },
     "death_drops": { "subtype": "collection", "groups": [ "explode_gasbag", "explode_gasbag" ] },
     "flags": [ "SEES", "HEARS", "GOODHEARING", "WARM", "POISON", "CLIMBS", "NO_BREATHE", "CLIMBS", "HARDTOSHOOT", "NEVER_WANDER" ],
     "armor": { "bash": 2, "cut": 10, "bullet": 10, "electric": 2 }
@@ -346,7 +362,11 @@
     "vision_day": 2,
     "vision_night": 2,
     "harvest": "exempt",
-    "death_function": { "message": "The %s explodes!", "effect": { "id": "death_gas", "hit_self": true, "min_level": 3 }, "corpse_type": "NO_CORPSE" },
+    "death_function": {
+      "message": "The %s explodes!",
+      "effect": { "id": "death_gas", "hit_self": true, "min_level": 3 },
+      "corpse_type": "NO_CORPSE"
+    },
     "death_drops": { "subtype": "collection", "groups": [ "explode_gasbag", "explode_innards" ] },
     "//grab": "High weight ratio since it's not *really* 81kg",
     "grab_strength": 35,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9181,9 +9181,9 @@ void Character::fall_asleep()
     std::string item_name = is_snuggling();
     if( item_name == "many" ) {
         if( one_in( 15 ) ) {
-            add_msg_if_player( _( "You nestle into your pile of clothes for warmth." ) );
+            add_msg_if_player( _( "You nestle into your pile of bedding for warmth." ) );
         } else {
-            add_msg_if_player( _( "You use your pile of clothes for warmth." ) );
+            add_msg_if_player( _( "You use your pile of bedding for warmth." ) );
         }
     } else if( item_name != "nothing" ) {
         if( one_in( 15 ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11935,7 +11935,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
                 pts.push_back( pt );
             }
         }
-        
+
         // TODO: Unify the tripoint types here.
         if( wall_cling && here.is_clingable_wall_adjacent( bub_stairs ) ) {
             pts.push_back( stairs );


### PR DESCRIPTION
#### Summary
Improve temperature warnings and reduce spam

#### Purpose of change
Simply put, temperature is a mess. Top to bottom the entire system is built on ancient hard code, characters lack actual body temperatures, stuff overlaps in weird ways that don't really work, and it's laggy as hell.

The most immediate and easy thing to fix is the message spam. So let's do that. Nobody needs to be told that their left foot is warm 50 times a minute.

#### Describe the solution
- Create a struct to house cooldowns for the different messages which can be set per-BP. Since this is only happening to the player character, it won't get out of hand.
- Have the temperature change, windchill, and frostnip messages respect these cooldowns.
- Adjust the messages to be a bit more generalized.
- Adjust the ordering of the messages to ensure that the most dangerous are always reported.
- Add a check for survival+health care. If your two skills sum to 5 or higher, you get told approximately how long you have before frostbite sets in. If not, you just feel achey and numb, unless you're pain immune.

#### Describe alternatives you've considered
- Intoxicated people, especially drunk people, ought to have a hard time knowing what temperature they really are.
- Rewrite all the hot/cold systems

#### Testing
- Runs, seems to work as intended, no slowdown here.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
