### PR TITLE
Melee attacks cannot target 0 hp parts

### DIFF
--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -213,14 +213,20 @@ bodypart_id anatomy::random_body_part() const
     return get_part_with_cumulative_hit_size( rng_float( 0.0f, size_sum ) ).id();
 }
 
-bodypart_id anatomy::select_body_part( int min_hit, int max_hit, bool can_attack_high,
+bodypart_id anatomy::select_body_part( const Creature *you, int min_hit, int max_hit, bool can_attack_high,
                                        int hit_roll ) const
 {
 
     weighted_float_list<bodypart_id> hit_weights;
     for( const bodypart_id &bp : cached_bps ) {
         float weight = bp->hit_size;
-        //Filter out too-large or too-small bodyparts
+
+        //Filter out too-large or too-small bodyparts, or damaged ones
+        if( you->get_part_hp_cur( bp ) <= 0 ) {
+            add_msg_debug( debugmode::DF_ANATOMY_BP, "BP %s discarded - no HP", body_part_name( bp ) );
+            continue;
+        }
+
         if( weight < min_hit || ( max_hit > -1 && weight > max_hit ) ) {
             add_msg_debug( debugmode::DF_ANATOMY_BP, "BP %s discarded - hitsize %.1f( min %d max %d )",
                            body_part_name( bp ), weight, min_hit, max_hit );

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -44,7 +44,7 @@ class anatomy
         /** Returns a random body_part token. main_parts_only will limit it to arms, legs, torso, and head. */
         bodypart_id random_body_part() const;
         // Returns a random bodypart determined by the attacks hitsize/limb restrictions
-        bodypart_id select_body_part( int min_hit, int max_hit, bool can_attack_high, int hit_roll ) const;
+        bodypart_id select_body_part( const Creature *you, int min_hit, int max_hit, bool can_attack_high, int hit_roll ) const;
         bodypart_id select_blocking_part( const Creature *blocker, bool arm, bool leg,
                                           bool nonstandard ) const;
         std::vector<bodypart_id> get_all_eligable_parts( int min_hit, int max_hit,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -939,7 +939,7 @@ void Creature::deal_melee_hit( Creature *source, int hit_spread, bool critical_h
         }
     }
     damage_instance d = dam; // copy, since we will mutate in block_hit
-    bodypart_id bp_hit = bp == nullptr ? select_body_part( -1, -1, source->can_attack_high(),
+    bodypart_id bp_hit = bp == nullptr ? select_body_part( this, -1, -1, source->can_attack_high(),
                          hit_spread ) : *bp;
     block_hit( source, bp_hit, d );
 
@@ -3277,7 +3277,7 @@ bodypart_id Creature::get_max_hitsize_bodypart() const
     return anatomy( get_all_body_parts() ).get_max_hitsize_bodypart();
 }
 
-bodypart_id Creature::select_body_part( int min_hit, int max_hit, bool can_attack_high,
+bodypart_id Creature::select_body_part( const Creature *you, int min_hit, int max_hit, bool can_attack_high,
                                         int hit_roll ) const
 {
     add_msg_debug( debugmode::DF_CREATURE, "hit roll = %d", hit_roll );
@@ -3285,7 +3285,7 @@ bodypart_id Creature::select_body_part( int min_hit, int max_hit, bool can_attac
         can_attack_high = as_character()->is_on_ground();
     }
 
-    return anatomy( get_all_body_parts() ).select_body_part( min_hit, max_hit, can_attack_high,
+    return anatomy( get_all_body_parts() ).select_body_part( you, min_hit, max_hit, can_attack_high,
             hit_roll );
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -1287,7 +1287,7 @@ class Creature : public viewer
         // Find the body part with the biggest hitsize - we will treat this as the center of mass for targeting
         bodypart_id get_max_hitsize_bodypart() const;
         // Select a bodypart depending on the attack's hitsize/limb restrictions
-        bodypart_id select_body_part( int min_hit, int max_hit, bool can_attack_high, int hit_roll ) const;
+        bodypart_id select_body_part( const Creature *you, int min_hit, int max_hit, bool can_attack_high, int hit_roll ) const;
         bodypart_id select_blocking_part( bool arm, bool leg, bool nonstandard ) const;
         bodypart_id random_body_part( bool main_parts_only = false ) const;
         std::vector<bodypart_id> get_all_eligable_parts( int min_hit, int max_hit,

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -708,7 +708,7 @@ bool melee_actor::call( monster &z ) const
 
     // Pick body part
     bodypart_str_id bp_hit = body_parts.empty() ?
-                             target->select_body_part( hitsize_min, hitsize_max, attack_upper, hitspread ).id() :
+                             target->select_body_part( target, hitsize_min, hitsize_max, attack_upper, hitspread ).id() :
                              *body_parts.pick();
 
     bodypart_id bp_id = bodypart_id( bp_hit );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -754,7 +754,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             melee::melee_stats.actual_crit_count += 1;
         }
         // select target body part
-        const bodypart_id &target_bp = t.select_body_part( -1, -1, can_attack_high(),
+        const bodypart_id &target_bp = t.select_body_part( &t, -1, -1, can_attack_high(),
                                        hit_spread );
 
         const bool has_force_technique = !force_technique.str().empty();


### PR DESCRIPTION
#### Summary
Melee attacks cannot target 0 hp parts

#### Purpose of change
NPCs in Cataclysm are unfairly durable: For performance/old code reasons, they don't experience a lot of the same debuffs as the player. This is compounded by the fact that like the player, they have (by default) five main bodyparts with five HP pools, and only two of those body parts will cause them to die if their HP reaches zero. This means that you can attack an NPC and do enough times to kill them many times over, only to get shot and killed because it turns out that in 10 attacks, you did 300 damage to their left leg, which only had 80 HP to begin with.

#### Describe the solution
- Melee attacks that target characters (both the player and NPCs) will now bypass body parts which have zero HP. This dramatically curtails the super-durability of NPCs by ensuring that every attack which does damage will do damage to a non-disabled part.
- Grabs can still target disabled parts. This is intended.
- Some special attacks may still target disabled parts. This is probably fine, but merits review at some point.
- This does not change the behavior of ranged attacks. Ranged attacks use a different and also broken bodypart selector which I don't want to disable until cover is introduced, as doing so would make enemy shooters much more dangerous.

#### Describe alternatives you've considered
None, this sucked for a long time.

#### Testing
- Created an NPC, disabled all their limbs, leaving only the head and torso. Attacked them many, many times, never hit a limb.
- Did the same to my character and let monsters attack them. This behaved as above.
- Tested grabs from monsters and by grabbing the disabled NPC. Grabs can still target broken limbs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
