### PR TITLE
Revert 55005 and fix RDA & vitamin rates

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3054,7 +3054,8 @@
       { "part": "hand_l", "ignored": 9 },
       { "part": "hand_r", "ignored": 9 },
       { "part": "torso", "ignored": 34 }
-    ]
+    ],
+    "vitamin_rates": [ [ "calcium", -150 ] ]
   },
   {
     "type": "mutation",
@@ -7361,11 +7362,11 @@
     "id": "CARNIVORE",
     "name": { "str": "Carnivore" },
     "points": -4,
-    "description": "Your body's ability to digest fruits, vegetables, grains and nuts is severely hampered.  You cannot eat anything besides meat.  While your vitamin C needs are lowered, it's still needed and can be found often in organ meat.",
+    "description": "Your body's ability to digest fruits, vegetables, grains and nuts is severely hampered.  You've largely lost your taste for everything but meat, but your nutritional needs have largely adjusted to suit your new lifestyle.",
     "types": [ "DIET" ],
     "cancels": [ "VEGAN" ],
     "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "FELINE", "BATRACHIAN", "BEAST", "LUPINE" ],
-    "vitamin_rates": [ [ "vitC", 1200 ] ]
+    "vitamin_rates": [ [ "vitC", 600 ] ]
   },
   {
     "type": "mutation",
@@ -7378,7 +7379,7 @@
     "cancels": [ "VEGAN" ],
     "category": [ "CHIROPTERAN" ],
     "changes_to": [ "BLOODFEEDER" ],
-    "vitamin_rates": [ [ "iron", -2000 ], [ "vitC", 300 ] ]
+    "vitamin_rates": [ [ "iron", -450 ], [ "vitC", 450 ] ]
   },
   {
     "type": "mutation",
@@ -7394,7 +7395,7 @@
     "vitamins_absorb_multi": [ [ "blood", [ [ "mutant_toxin", 0.25 ] ] ], [ "flesh", [ [ "mutant_toxin", 0.75 ] ] ] ],
     "category": [ "CHIROPTERAN" ],
     "threshreq": [ "THRESH_CHIROPTERAN" ],
-    "vitamin_rates": [ [ "iron", -4000 ], [ "vitC", 600 ] ]
+    "vitamin_rates": [ [ "iron", -600 ], [ "vitC", 600 ] ]
   },
   {
     "type": "mutation",
@@ -8043,7 +8044,8 @@
     "category": [ "CEPHALOPOD", "GASTROPOD" ],
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "integrated_armor": [ "integrated_shell" ],
-    "restricts_gear": [ "torso" ]
+    "restricts_gear": [ "torso" ],
+    "vitamin_rates": [ [ "calcium", -200 ] ]
   },
   {
     "type": "mutation",
@@ -8064,7 +8066,8 @@
     "wet_protection": [ { "part": "torso", "ignored": 26 } ],
     "active": true,
     "integrated_armor": [ "integrated_shell2" ],
-    "restricts_gear": [ "torso" ]
+    "restricts_gear": [ "torso" ],
+    "vitamin_rates": [ [ "calcium", -250 ] ]
   },
   {
     "type": "mutation",
@@ -8082,7 +8085,8 @@
     "wet_protection": [ { "part": "torso", "ignored": 45 } ],
     "active": true,
     "integrated_armor": [ "integrated_shell3" ],
-    "restricts_gear": [ "torso" ]
+    "restricts_gear": [ "torso" ],
+    "vitamin_rates": [ [ "calcium", -300 ] ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7366,7 +7366,7 @@
     "types": [ "DIET" ],
     "cancels": [ "VEGAN" ],
     "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "FELINE", "BATRACHIAN", "BEAST", "LUPINE" ],
-    "vitamin_rates": [ [ "vitC", 600 ] ]
+    "vitamin_rates": [ [ "vitC", 900 ] ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2029,11 +2029,10 @@
     "name": { "str": "Genetic Downward Spiral" },
     "points": -8,
     "purifiable": false,
-    "description": "The events of the Cataclysm have damaged your DNA beyond repair.  You mutate frequently, all mutations you receive (from any source) are negative, and your instability is rapidly growing out of control.",
+    "description": "The events of the Cataclysm have damaged your DNA beyond repair.  You mutate frequently, all mutations you receive (from any source) are negative.",
     "starting_trait": true,
     "cancels": [ "ROBUST", "RESTRICTED" ],
-    "valid": false,
-    "vitamin_rates": [ [ "instability", -60 ] ]
+    "valid": false
   },
   {
     "type": "mutation",
@@ -7366,7 +7365,7 @@
     "types": [ "DIET" ],
     "cancels": [ "VEGAN" ],
     "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "FELINE", "BATRACHIAN", "BEAST", "LUPINE" ],
-    "vitamin_rates": [ [ "vitC", -1200 ] ]
+    "vitamin_rates": [ [ "vitC", 1200 ] ]
   },
   {
     "type": "mutation",
@@ -7379,7 +7378,7 @@
     "cancels": [ "VEGAN" ],
     "category": [ "CHIROPTERAN" ],
     "changes_to": [ "BLOODFEEDER" ],
-    "vitamin_rates": [ [ "iron", 1000 ], [ "vitC", -300 ] ]
+    "vitamin_rates": [ [ "iron", -2000 ], [ "vitC", 300 ] ]
   },
   {
     "type": "mutation",
@@ -7395,7 +7394,7 @@
     "vitamins_absorb_multi": [ [ "blood", [ [ "mutant_toxin", 0.25 ] ] ], [ "flesh", [ [ "mutant_toxin", 0.75 ] ] ] ],
     "category": [ "CHIROPTERAN" ],
     "threshreq": [ "THRESH_CHIROPTERAN" ],
-    "vitamin_rates": [ [ "iron", 800 ], [ "vitC", -600 ] ]
+    "vitamin_rates": [ [ "iron", -4000 ], [ "vitC", 600 ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Revert DDA 55005 and fix RDA & vitamin rates

#### Purpose of change
Carnivores and hemovores were experiencing weird RDA readouts and other unintended behavior. Looking into this, I discovered that https://github.com/CleverRaven/Cataclysm-DDA/pull/55005 had made some changes to how vitamin_rates from mutations worked, using reciprocal addition to try to model multiple simultaneous sources of absorption. This made everything way more confusing than it was supposed to be, and was only capable of speeding the decay time up, not slowing it down, as the function only dealt with positives.

#### Describe the solution
- Revert DDA 55005. vitamin_tates are now simple addition or subtraction in seconds to the vitamin's base rate of loss or gain. We are not adding fractions, we are just adding to or subtracting from the denominator of one fraction.
- Adjust the vitamin_rates in mutations.json to properly work under the new values. The base decay of iron, vitC, and calcium are one per 900, or 1 every 15 minutes each.
- CARNIVORE: Adds 600 to vitC, changing the rate of decay to 1 every 45 minutes. This means carnivores now require about 1/4 of the vitamin C that standard humans need.
- HEMOVORE: Subtracts 450 from iron and adds 450 to vitC. This changes their respective needs to 2x and 1/2x that of a standard human.
- BLOODFEEDER: Subtracts 600 from iron and adds 600 to vitC. 3x and 1/3x as much as a human needs, respectively.
- SHELL, ROOMY SHELL, NACREOUS SHELL, CRUSTACEAN CARAPACE: I subtracted a small amount from the calcium timer on these mutations to reflect the fact that these mutations are essentially made of huge amounts of the stuff. This is mostly just for fun, but I plan on really taxing the body's calcium reserves once I add shell damage - fixing that thing is gonna be a pain!

#### Describe alternatives you've considered
It's possible that I just don't see the way 55005 is supposed to work, and that it actually is better for some reason, but I really suspect its contributor somehow misunderstood what vitamin_rates was supposed to be doing or something.

#### Testing
Spawned in, became a hemovore, watched my nutrient decay rates. Ate vitamins, saw my phone properly tracked my adjusted RDA.

#### Additional context
Knowing your mutant RDA should be a health care/cooking thing, but right now I want to sleep.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
