### PR TITLE
Revert accidental reversion of reversion (im tired)

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -591,13 +591,8 @@ time_duration Character::vitamin_rate( const vitamin_id &vit ) const
     for( const auto &m : get_mutations() ) {
         const mutation_branch &mut = m.obj();
         auto iter = mut.vitamin_rates.find( vit );
-        if( iter != mut.vitamin_rates.end() && iter->second != 0_turns ) {
-            if( res != 0_turns ) {
-                const float recip_vit = 1 / to_turns<float>( res ) + 1 / to_turns<float>( iter->second );
-                res = recip_vit == 0 ? 0_turns : time_duration::from_turns( 1 / recip_vit );
-            } else {
-                res = iter->second;
-            }
+        if( iter != mut.vitamin_rates.end() ) {
+            res += iter->second;
         }
     }
 


### PR DESCRIPTION
#### Summary
Actually revert 55005 for real this time

#### Purpose of change
I was tired and distracted and github desktop is stupid so I accidentally reverted part of #640 

#### Describe the solution
un-revert, applying the code fix I wanted. See 640 for details.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
