### PR TITLE
Change tupperware containers to reduce spoilage inline with zipper bags.

### DIFF
--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -583,7 +583,8 @@
         "rigid": true,
         "max_contains_volume": "750 ml",
         "max_contains_weight": "1 kg",
-        "max_item_length": "239 mm"
+        "max_item_length": "239 mm",
+        "spoil_multiplier": 0.8
       }
     ],
     "qualities": [ [ "CONTAIN", 1 ] ],


### PR DESCRIPTION
#### Summary
Changes Tupperware containers to slow spoilage of food inside

#### Purpose of change
Make tupperware containers inline with zipperbags.

#### Describe the solution
Changed tupperware containers to have 80% of standard spoilage rate.

#### Testing
Game loads, tupperware containers in game show they spoil at 80% original rate



<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
