### PR TITLE
Fix IR vision, improve fields, adjust itemgroups

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -47,37 +47,37 @@
     "type": "enchantment",
     "id": "nvg_great",
     "name": { "str": "Night Vision Goggles" },
-    "description": "You are wearing night vision goggles which allow you to see really well in the dark.",
+    "description": "You are wearing night vision goggles which allow you to see very well in the dark, though at the cost of some detail.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 19 } ]
+    "values": [ { "value": "PERCEPTION", "add": -1 }, { "value": "NIGHT_VIS", "add": 18 } ]
   },
   {
     "type": "enchantment",
     "id": "nvg_good",
     "name": { "str": "Night Vision Goggles" },
-    "description": "You are wearing night vision goggles which allow you to see quite well in the dark.",
+    "description": "You are wearing night vision goggles which allow you to see quite well in the dark, though at the cost of some detail.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 17 } ]
+    "values": [ { "value": "PERCEPTION", "add": -1 }, { "value": "NIGHT_VIS", "add": 16 } ]
   },
   {
     "type": "enchantment",
     "id": "nvg_normal",
     "name": { "str": "Night Vision Goggles" },
-    "description": "You are wearing night vision goggles which allow you to see in the dark.",
+    "description": "You are wearing night vision goggles which allow you to see in the dark, though at the cost of some detail.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 13 } ]
+    "values": [ { "value": "PERCEPTION", "add": -1 }, { "value": "NIGHT_VIS", "add": 12 } ]
   },
   {
     "type": "enchantment",
     "id": "nvg_bad",
     "name": { "str": "Night Vision Goggles" },
-    "description": "You are wearing night vision goggles which allow you to poorly see in the dark.",
+    "description": "You are wearing night vision goggles which allow you to see poorly in the dark, though at the cost of some detail.",
     "condition": "ACTIVE",
     "has": "WORN",
-    "values": [ { "value": "NIGHT_VIS", "add": 11 } ]
+    "values": [ { "value": "PERCEPTION", "add": -1 }, { "value": "NIGHT_VIS", "add": 10 } ]
   },
   {
     "id": "ench_climate_control_warm",

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -312,8 +312,8 @@
       { "item": "elbow_pads", "prob": 10 },
       { "item": "knee_pads", "prob": 85 },
       {
-        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 99 } ],
-        "prob": 70
+        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 199 } ],
+        "prob": 50
       },
       { "item": "gloves_tactical", "prob": 60 },
       { "group": "military_ballistic_vest", "prob": 90 },
@@ -336,8 +336,8 @@
       { "item": "elbow_pads", "prob": 10 },
       { "item": "knee_pads", "prob": 85 },
       {
-        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 99 } ],
-        "prob": 70
+        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 199 } ],
+        "prob": 50
       },
       { "item": "gloves_tactical", "prob": 60 },
       { "group": "military_ballistic_vest_pristine", "prob": 90 },
@@ -359,8 +359,8 @@
       { "item": "elbow_pads", "prob": 10 },
       { "item": "knee_pads", "prob": 85 },
       {
-        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 99 } ],
-        "prob": 70
+        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 199 } ],
+        "prob": 40
       },
       { "item": "gloves_tactical", "prob": 60 },
       { "group": "military_ballistic_vest", "prob": 100 },
@@ -383,8 +383,8 @@
       { "item": "elbow_pads", "prob": 10 },
       { "item": "knee_pads", "prob": 85 },
       {
-        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 99 } ],
-        "prob": 70
+        "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 199 } ],
+        "prob": 50
       },
       { "item": "gloves_tactical", "prob": 60 },
       { "group": "military_ballistic_vest_heavy", "prob": 90 },
@@ -408,10 +408,10 @@
       { "item": "knee_pads", "prob": 85 },
       {
         "collection": [
-          { "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 99 } ] },
+          { "distribution": [ { "group": "army_helmet_nvg", "prob": 1 }, { "item": "helmet_army", "prob": 199 } ] },
           { "item": "helmet_liner" }
         ],
-        "prob": 70
+        "prob": 50
       },
       { "collection": [ { "item": "gloves_liner", "prob": 60 }, { "item": "winter_gloves_army" } ], "prob": 80 },
       { "group": "military_ballistic_vest", "prob": 90 },
@@ -2224,7 +2224,8 @@
       { "item": "peacoat", "prob": 30 },
       { "item": "greatcoat", "prob": 15 },
       { "item": "gloves_light", "prob": 35 },
-      { "item": "mittens", "prob": 30 },
+      { "item": "mittens", "prob": 25 },
+      { "item": "mittens_nylon", "prob": 12 },
       { "item": "gloves_wool", "prob": 33 },
       { "item": "gloves_wool_fingerless", "prob": 10 },
       { "item": "thermal_socks", "prob": 2 },
@@ -2760,18 +2761,17 @@
       [ "under_armor", 20 ],
       [ "boots", 70 ],
       [ "boots_combat", 70 ],
-      [ "gloves_tactical", 30 ],
-      [ "glasses_bal", 40 ],
-      [ "chestguard_hard", 20 ],
-      [ "armguard_hard", 20 ],
-      [ "legguard_hard", 15 ],
-      { "group": "army_helmet_nvg", "prob": 1 },
-      [ "helmet_army", 40 ],
+      [ "gloves_tactical", 60 ],
+      [ "glasses_bal", 45 ],
+      [ "chestguard_hard", 25 ],
+      [ "armguard_hard", 25 ],
+      [ "legguard_hard", 20 ],
+      [ "helmet_army", 60 ],
       [ "helmet_liner", 10 ],
       [ "beret", 50 ],
-      [ "beret_wool", 40 ],
-      [ "elbow_pads", 50 ],
-      [ "knee_pads", 50 ],
+      [ "beret_wool", 60 ],
+      [ "elbow_pads", 80 ],
+      [ "knee_pads", 80 ],
       [ "solarpack", 5 ]
     ]
   },

--- a/data/json/itemgroups/Clothing_Gear/gear.json
+++ b/data/json/itemgroups/Clothing_Gear/gear.json
@@ -12,8 +12,8 @@
       [ "bootstrap", 5 ],
       [ "chestpouch", 5 ],
       [ "flashbang", 30 ],
-      { "item": "goggles_ir", "prob": 10, "charges": [ 0, 100 ] },
-      { "item": "goggles_nv", "prob": 10, "charges": [ 0, 100 ] },
+      { "item": "goggles_ir", "prob": 1, "charges": [ 0, 100 ] },
+      { "item": "goggles_nv", "prob": 1, "charges": [ 0, 100 ] },
       [ "helmet_riot", 5 ],
       [ "holo_sight", 20 ],
       [ "balaclava", 10 ],
@@ -33,7 +33,7 @@
       [ "suppressor_compact", 20 ],
       [ "tac_fullhelmet", 5 ],
       [ "tac_helmet", 10 ],
-      { "item": "teargas_sprayer", "prob": 25, "charges": [ 1, 10 ] }
+      { "item": "teargas_sprayer", "prob": 15, "charges": [ 1, 10 ] }
     ]
   },
   {
@@ -55,8 +55,8 @@
       {
         "distribution": [
           { "item": "military_nvg", "prob": 60, "charges": [ 0, 100 ] },
-          { "item": "advanced_gpnvg", "prob": 30, "charges": [ 0, 100 ] },
-          { "item": "enhanced_nvg", "prob": 10, "charges": [ 0, 100 ] }
+          { "item": "advanced_gpnvg", "prob": 35, "charges": [ 0, 100 ] },
+          { "item": "enhanced_nvg", "prob": 5, "charges": [ 0, 100 ] }
         ]
       }
     ]

--- a/data/json/itemgroups/Clothing_Gear/gear_civilian.json
+++ b/data/json/itemgroups/Clothing_Gear/gear_civilian.json
@@ -61,7 +61,7 @@
       [ "comb_pocket", 50 ],
       [ "ankle_wallet_pouch", 1 ],
       { "group": "lunchbox_with_contents", "prob": 50 },
-      { "item": "teargas_sprayer", "prob": 10, "charges": [ 1, 10 ] }
+      { "item": "teargas_sprayer", "prob": 2, "charges": [ 1, 10 ] }
     ]
   },
   {
@@ -408,7 +408,7 @@
       [ "flint_steel", 5 ],
       [ "bottle_metal", 5 ],
       [ "wallet_travel", 10 ],
-      { "item": "teargas_sprayer", "prob": 5, "charges": [ 0, 10 ] }
+      { "item": "teargas_sprayer", "prob": 1, "charges": [ 0, 10 ] }
     ]
   },
   {

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -434,7 +434,7 @@
       { "item": "elbow_pads", "prob": 80 },
       { "item": "knee_pads", "prob": 85 },
       {
-        "distribution": [ { "group": "tac_helmet_nvg", "prob": 60 }, { "item": "tac_helmet", "prob": 40 } ],
+        "distribution": [ { "group": "tac_helmet_nvg", "prob": 10 }, { "item": "tac_helmet", "prob": 90 } ],
         "prob": 100
       },
       { "item": "mask_gas", "prob": 100 },

--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -17,7 +17,7 @@
     "environmental_protection": 1,
     "qualities": [ [ "GLARE", 1 ] ],
     "flags": [ "SUN_GLASSES" ],
-    "armor": [ { "encumbrance": 10, "coverage": 80, "covers": [ "eyes" ], "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 40, "coverage": 80, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
     "id": "eyepatch_leather",

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -263,7 +263,7 @@
       "msg": "Your %s deactivates.",
       "target": "military_nvg"
     },
-    "armor": [ { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 20, "rigid_layer_only": true } ]
+    "armor": [ { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 30, "rigid_layer_only": true } ]
   },
   {
     "id": "advanced_gpnvg",
@@ -328,7 +328,7 @@
       "target": "advanced_gpnvg"
     },
     "armor": [
-      { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 15, "rigid_layer_only": true },
+      { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 30, "rigid_layer_only": true },
       { "covers": [ "head" ], "encumbrance": 3, "coverage": 80, "specifically_covers": [ "head_crown" ] }
     ]
   },
@@ -395,7 +395,7 @@
       "target": "enhanced_nvg"
     },
     "armor": [
-      { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 10, "rigid_layer_only": true },
+      { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 30, "rigid_layer_only": true },
       { "covers": [ "head" ], "encumbrance": 3, "coverage": 80, "specifically_covers": [ "head_crown" ] }
     ]
   },

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1520,14 +1520,52 @@
     "armor": [
       {
         "material": [
-          { "type": "chitin", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "sclerotin", "covered_by_mat": 70, "thickness": 1.0 }
+          { "type": "sclerotin", "covered_by_mat": 70, "thickness": 1.0 },
+          { "type": "chitin", "covered_by_mat": 100, "thickness": 0.5 }
         ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 1,
-        "rigid_layer_only": true,
-        "cover_vitals": 90
+        "rigid_layer_only": true
+      }
+    ]
+  },
+  {
+    "id": "integrated_compound_eyes",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "compound eyes" },
+    "description": "Thousands of ommatidea tesselate into a pair of eyes.  Each jewel-hard hexagonal lens picks up the dominant color in its field of view, rendering a single pixel to the image composited by the viewer's brain.",
+    "weight": "180 g",
+    "volume": "250 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "to_hit": -2,
+    "material": [ "sclerotin", "chitin" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "warmth": 0,
+    "material_thickness": 1.5,
+    "environmental_protection": 10,
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "SKINTIGHT",
+      "NORMAL",
+      "SOFT",
+      "WATER_FRIENDLY",
+      "NO_REPAIR",
+      "SWIM_GOGGLES",
+      "NO_SALVAGE"
+    ],
+    "armor": [
+      {
+        "material": [
+          { "type": "sclerotin", "covered_by_mat": 70, "thickness": 0.6 },
+          { "type": "chitin", "covered_by_mat": 100, "thickness": 0.5 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "rigid_layer_only": true
       }
     ]
   },

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -9,7 +9,7 @@
     "price": "25 USD",
     "price_postapoc": "10 cent",
     "to_hit": -3,
-    "material": [ "cotton" ],
+    "material": [ "nylon" ],
     "symbol": "[",
     "color": "pink",
     "warmth": 20,

--- a/data/json/monsterdrops/mutant_experimental.json
+++ b/data/json/monsterdrops/mutant_experimental.json
@@ -9,7 +9,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "mon_mutant_evolved_death_drops",
-    "entries": [ { "item": "cotton_patchwork", "damage": [ 1, 4 ], "count": [ 1, 4 ] }, { "item": "pants", "damage": [ 2, 3 ] } ]
+    "entries": [ { "item": "cotton_patchwork", "damage": [ 1, 4 ], "count": [ 1, 4 ] }, { "item": "shorts", "damage": [ 2, 3 ] } ]
   },
   {
     "type": "item_group",
@@ -18,9 +18,9 @@
     "entries": [
       { "item": "id_science_mutagen_green" },
       { "item": "coat_lab", "damage": [ 0, 2 ] },
+      { "item": "leather_journal", "prob": 80, "contents-item": "note_mutant_alpha_boss" },
       {
         "collection": [
-          { "item": "leather_journal", "prob": 80, "contents-item": "note_mutant_alpha_boss" },
           { "item": "recipe_alpha", "prob": 5 },
           { "item": "recipe_animal", "prob": 10 },
           { "item": "recipe_chimera", "prob": 5 },
@@ -28,11 +28,10 @@
           { "item": "recipe_labchem", "prob": 10 },
           { "item": "recipe_maiar", "prob": 10 },
           { "item": "recipe_medicalmut", "prob": 5 },
-          { "item": "recipe_raptor", "prob": 5 },
-          { "group": "lab_files_biology", "prob": 5 }
+          { "item": "recipe_raptor", "prob": 5 }
         ]
       },
-      { "item": "jumpsuit" }
+      { "item": "subsuit_xl" }
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -122,10 +122,10 @@
     "entries": [
       { "group": "default_zombie_items_bags_small", "prob": 100 },
       { "group": "homebooks", "prob": 30 },
-      { "group": "alcohol_bottled_canned", "prob": 10 },
+      { "group": "alcohol_bottled_canned", "prob": 8 },
       { "group": "vending_drink_items", "prob": 10 },
-      { "item": "laptop", "prob": 10, "charges": [ 0, 500 ] },
-      { "item": "eink_tablet_pc", "prob": 10, "charges": [ 0, 50 ] },
+      { "item": "laptop", "prob": 5, "charges": [ 0, 500 ] },
+      { "item": "eink_tablet_pc", "prob": 3, "charges": [ 0, 50 ] },
       { "item": "teleumbrella", "prob": 10 },
       { "item": "thermos", "prob": 10 },
       { "item": "spray_can", "prob": 10 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1191,16 +1191,16 @@
     "name": { "str": "Scout" },
     "points": 1,
     "description": "You're an excellent navigator and your ability to recognize distant landmarks is unmatched.  Your sight radius on the overmap extends beyond the normal range.",
-    "category": [ "BIRD", "MOUSE", "CEPHALOPOD" ],
+    "category": [ "BIRD", "CEPHALOPOD" ],
     "cancels": [ "UNOBSERVANT" ],
     "enchantments": [ { "condition": "is_day", "values": [ { "value": "OVERMAP_SIGHT", "add": 5 } ] } ]
   },
   {
     "type": "mutation",
     "id": "UNOBSERVANT",
-    "name": { "str": "Topographagnosia" },
+    "name": { "str": "Directionally Challenged" },
     "points": -1,
-    "description": "Focal brain damage has rendered you incapable of recognizing landmarks and orienting yourself in your surroundings, severely crippling your sight radius on the overmap.",
+    "description": "You get lost easily.  Even in good conditions, you will uncover much less of your overmap while exploring.",
     "valid": false,
     "starting_trait": true,
     "cancels": [ "EAGLEEYED" ],
@@ -1211,7 +1211,6 @@
     "id": "CANNIBAL",
     "name": { "str": "Cannibal" },
     "points": 2,
-    "//": "Feral humans vastly increase the cannibal meat supply, therefore this trait needs to increase in cost.",
     "description": "For your whole life you've been forbidden from indulging in your peculiar tastes.  Now the world's ended, and you'll be damned if anyone is going to tell you that you can't eat people.",
     "starting_trait": true,
     "valid": false,
@@ -1223,7 +1222,7 @@
     "id": "PSYCHOPATH",
     "name": { "str": "Psychopath" },
     "points": 2,
-    "description": "You have a diminished capacity for empathy and feel little remorse for your actions.  This does not necessarily make you predisposed to using, harming, or lying to others, but your superficial charm and lack of guilt make it all too easy.",
+    "description": "You have a diminished capacity for empathy and feel little remorse for your actions.  This does not necessarily make you predisposed to harming or exploiting others, but your superficial charm and lack of guilt make lying all too easy.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "lie": 10, "persuade": 5 },
@@ -4131,7 +4130,9 @@
     "description": "Your eyes are compound, like those of an insect.  This increases your Perception by 2 whenever you aren't wearing eyewear.",
     "types": [ "EYES" ],
     "prereqs": [ "EYEBULGE" ],
-    "category": [ "INSECT" ]
+    "cancels": [ "MYOPIC", "HYPEROPIC" ],
+    "category": [ "INSECT" ],
+    "integrated_armor": [ "integrated_compound_eyes" ]
   },
   {
     "type": "mutation",
@@ -4498,6 +4499,7 @@
     "prereqs": [ "HERBIVORE" ],
     "changes_to": [ "GRAZER" ],
     "category": [ "CATTLE", "RABBIT" ],
+    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 } ] } ],
     "active": true,
     "cost": 0
   },
@@ -4620,7 +4622,7 @@
     "description": "You're burning calories like crazy to heal your wounds.",
     "copy-from": "EATHEALTH",
     "valid": false,
-    "cost": 9,
+    "cost": 33,
     "time": "1 s",
     "kcal": true,
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 349 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.85 } ] } ],
@@ -6180,7 +6182,7 @@
     "points": 0,
     "visibility": 8,
     "mixed_effect": true,
-    "description": "You're the size of a toddler!  The weight of things you once found easy to carry is now unbearable, clothes are now twice as encumbering for you unless you refit them, and your hit points are heavily reduced.  However, your movement is silent, and your dodge skill is a little higher.",
+    "description": "You're the size of a toddler!  You can't carry much, most clothes won't fit, and your hit points are heavily reduced, but your stature confers a number of advantages: you're harder to hit, quieter, less injured by falls, and too light to set off certain traps.",
     "types": [ "SIZE" ],
     "prereqs": [ "SMALL" ],
     "changes_to": [ "SMALL_OK" ],
@@ -7151,11 +7153,7 @@
         }
       ]
     ],
-    "enchantments": [ "ench_quadruped_movement_half", {
-      "values": [
-        { "value": "MOVECOST_SWIM_MOD", "multiply": -0.02 }
-      ]
-    } ],
+    "enchantments": [ "ench_quadruped_movement_half", { "values": [ { "value": "MOVECOST_SWIM_MOD", "multiply": -0.02 } ] } ],
     "category": [ "BEAST", "URSINE" ]
   },
   {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -136,6 +136,7 @@ static const json_character_flag json_flag_LIMB_UPPER( "LIMB_UPPER" );
 
 static const material_id material_cotton( "cotton" );
 static const material_id material_flesh( "flesh" );
+static const material_id material_hflesh( "hflesh" );
 static const material_id material_iflesh( "iflesh" );
 static const material_id material_kevlar( "kevlar" );
 static const material_id material_paper( "paper" );
@@ -163,13 +164,13 @@ const std::map<std::string, creature_size> Creature::size_map = {
 };
 
 const std::set<material_id> Creature::cmat_flesh{
-    material_flesh, material_iflesh
+    material_flesh, material_iflesh, material_hflesh,
 };
 const std::set<material_id> Creature::cmat_fleshnveg{
-    material_flesh,  material_iflesh, material_veggy
+    material_flesh, material_iflesh, material_hflesh, material_veggy
 };
 const std::set<material_id> Creature::cmat_flammable{
-    material_paper, material_powder, material_wood,
+    material_paper, material_powder,
     material_cotton, material_wool
 };
 const std::set<material_id> Creature::cmat_flameres{

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -866,7 +866,7 @@ static void grab()
             }
         }
         you.grab( object_type::VEHICLE, grabp - you.pos_bub() );
-        add_msg( _( "You grab the %s. btw %2s" ), veh_name, you.eye_level() );
+        add_msg( _( "You grab the %s." ), veh_name );
     } else if( here.has_furn( grabp ) ) {
         if( !here.furn( grabp ).obj().is_movable() ) {
             add_msg( _( "You can not grab the %s." ), here.furnname( grabp ) );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8103,7 +8103,7 @@ int map::obstacle_coverage( const tripoint_bub_ms &loc1, const tripoint_bub_ms &
     int offset = std::min( a.x, a.y ) - ( std::max( a.x, a.y ) / 2 );
     tripoint obstaclepos;
     bresenham( loc2.raw(), loc1.raw(), offset, 0, [&obstaclepos]( const tripoint & new_point ) {
-        // Only adjacent tile between you and enemy is checked for cover.
+        // Only adjacent tile between viewer and enemy is checked for cover.
         obstaclepos = new_point;
         return false;
     } );
@@ -8204,8 +8204,9 @@ int map::coverage( const tripoint &p ) const
 
 int map::coverage( const tripoint_bub_ms &p ) const
 {
-    if( furn( p )->coverage > 0 ) {
-        return furn( p )->coverage;
+    const furn_id obstacle_f = furn( p );
+    if( obstacle_f != f_null && obstacle_f->coverage > 0 ) {
+        return obstacle_f->coverage;
     }
     if( const optional_vpart_position vp = veh_at( p ) ) {
         const bool is_obstacle = vp->obstacle_at_part().has_value();


### PR DESCRIPTION
#### Summary
Fix IR vision, improve fields, adjust itemgroups

#### Purpose of change
- IR vision was broken
- A bunch of fields were using outdated checks in map_field()
- I wanted to make some game balance adjustments

#### Describe the solution
- Fixed some issues with IR vision. As far as I can tell, it now works as intended.
- Added a simple range limitation to IR. Previously it used your unimpaired_range(), which was generally 60 tiles. This was kind of nutty. While some sources of IR can see quite far IRL, others, such as vampire bat or pit viper senses, are mostly for close range. A temporary compromise has been struck: The range is now one plus (60 * perception / 20), with 60 being the hard cap as it is with normal vision. I intend to revisit this later and have different sources of IR (heat smision, bad IR goggles, good IR goggles) giving different ranges, but this will do for now.
- Reduced the abundance of night-vision/IR goggles in military itemgroups.
- Nerfed NVGs somewhat - they now reduce your perception by 1 as detail gets lost and you are not as good at making out details in unnatural NVG coloration. Also added some eye encumbrance to them when they're active. I may revisit this and change it to -2, the idea being the goggles make it easier to see your target from farther away, but harder to actually hit them compared to day vision.
- Made tear gas sprayers a bit less common.
- Gave compound eyes an integrated item so that they can properly protect from tear gas. They also add quite a bit of armor to your eyes, and make it difficult to wear eyewear, however the mutation cures your myopia and/or hyperopia, so there's that.
- Clown wig is now nylon instead of cotton. I guess I could have made it keratin, but a human hair clown wig is perhaps a bridge too far.
- Fixed the mutant child's itemgroups so he's likely to drop both his diary and a random mutagen recipe book, rather than one or the other.
- Made minor adjustments to zombie loot, giving them less booze and computers.
- Took Scout away from Mouse. Mice have HORRIBLE vision IRL and while they are skilled navigators in their home area, they don't actually travel very far.
- Re-named and re-described Topographagnosia. It is now Directionally Challenged and makes it clear that it just reduces your scouting range and doesn't necessarily include any brain damage.
- Removed a stray debug message in the vehicle grab messaging.

FIELD UPDATES
- Tear gas no longer works on plant monsters like Triffids.
- Tear gas no longer gives a guaranteed 5 round stun/blind at high intensity: it is now RNG 1-5 per turn spent in the gas.
- Fields that were looking for flesh and blood monsters to target now appropriately inclue human flesh in that check.
- Reduced and randomized the duration on pacification gas.
- Reduced and randomized the duration on flashbang blindness/stun.
- Reduced the damage from fireburst fields to be more in line with how normal fire works.
- Added size-based resistance to fungal clouds, fungicide, and insecticide. Larger creatures will be less hindered and harmed by these fields, but not exempt. Consequently, small and tiny creatures will actually be hurt MORE by them.

#### Describe alternatives you've considered
- human hair clown wig

#### Testing
IR and NV seem to be working fine with cover now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
