### PR TITLE
Restore RPG-7 effects

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -364,6 +364,51 @@
     "explosion": { "power": 7980, "shrapnel": { "casing_mass": 8725, "fragment_mass": 0.5 } }
   },
   {
+    "id": "EXPLOSIVE_PG7VL",
+    "type": "ammo_effect",
+    "explosion": {
+      "power": 3190,
+      "shrapnel": {
+        "casing_mass": 350,
+        "fragment_mass": 0.3
+      }
+    }
+  },
+  {
+    "id": "EXPLOSIVE_PG7VR",
+    "type": "ammo_effect",
+    "explosion": {
+      "power": 5700,
+      "shrapnel": {
+        "casing_mass": 400,
+        "fragment_mass": 0.3
+      }
+    }
+  },
+  {
+    "id": "EXPLOSIVE_TBG7V",
+    "type": "ammo_effect",
+    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 2, "radius": 5, "chance": 66 },
+    "explosion": {
+      "power": 6200,
+      "shrapnel": {
+        "casing_mass": 300,
+        "fragment_mass": 0.12
+      }
+    }
+  },
+  {
+    "id": "EXPLOSIVE_OG7V",
+    "type": "ammo_effect",
+    "explosion": {
+      "power": 800,
+      "shrapnel": {
+        "casing_mass": 500,
+        "fragment_mass": 0.2
+      }
+    }
+  },
+  {
     "id": "FLASHBANG",
     "type": "ammo_effect",
     "//": "Blinds and deafens nearby targets",

--- a/data/json/items/ammo/rpg.json
+++ b/data/json/items/ammo/rpg.json
@@ -35,7 +35,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "weight": "4500 g",
     "ammo_type": "RPG-7",
-    "damage": { "damage_type": "stab", "amount": 3250, "armor_penetration": 1450 },
+    "damage": { "damage_type": "stab", "amount": 325, "armor_penetration": 1450 },
     "range": 60,
     "dispersion": 75,
     "recoil": 450,
@@ -60,7 +60,7 @@
     "range": 60,
     "dispersion": 50,
     "recoil": 450,
-    "effects": [ "COOKOFF", "EXPLOSIVE_TBG7V", "TRAIL", "NEVER_MISFIRES", "NAPALM_TBG7V" ]
+    "effects": [ "COOKOFF", "EXPLOSIVE_TBG7V", "TRAIL", "NEVER_MISFIRES" ]
   },
   {
     "type": "AMMO",


### PR DESCRIPTION
#### Summary
Restore RPG-7 effects

#### Purpose of change
When I de-obsoleted RPG-7s from DDA, I didn't realize that their ammo effects were missing.

#### Describe the solution
I couldn't find the old ones, so I cooked up some new ones using the existing high explosive grenades and rockets as a rough guide.

#### Testing
![image](https://github.com/user-attachments/assets/1ec96bd0-b2c1-414a-a6f8-e9c61ec1ad64)
I hit this crowd of zombies with a PG-7VL on the right, a PG-7VR on top, an OG-7V on the left, and of course the TBG-7V on the bottom. The OG-7V doesn't look super impressive as it's an antipersonnel round that just throws shrapnel all over instead of thermobarics or whatnot, but it scored 19 kills in one shot.

#### Additional context
I also reduced the base damage on the PG-7VL (the rocket, not its explosion). It was so high that it was overpenetrating walls and not exploding. You'd fire and it would just vanish into the distance.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
