### PR TITLE
Tileset layering fixes

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -366,47 +366,23 @@
   {
     "id": "EXPLOSIVE_PG7VL",
     "type": "ammo_effect",
-    "explosion": {
-      "power": 3190,
-      "shrapnel": {
-        "casing_mass": 350,
-        "fragment_mass": 0.3
-      }
-    }
+    "explosion": { "power": 3190, "shrapnel": { "casing_mass": 350, "fragment_mass": 0.3 } }
   },
   {
     "id": "EXPLOSIVE_PG7VR",
     "type": "ammo_effect",
-    "explosion": {
-      "power": 5700,
-      "shrapnel": {
-        "casing_mass": 400,
-        "fragment_mass": 0.3
-      }
-    }
+    "explosion": { "power": 5700, "shrapnel": { "casing_mass": 400, "fragment_mass": 0.3 } }
   },
   {
     "id": "EXPLOSIVE_TBG7V",
     "type": "ammo_effect",
     "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 2, "radius": 5, "chance": 66 },
-    "explosion": {
-      "power": 6200,
-      "shrapnel": {
-        "casing_mass": 300,
-        "fragment_mass": 0.12
-      }
-    }
+    "explosion": { "power": 6200, "shrapnel": { "casing_mass": 300, "fragment_mass": 0.12 } }
   },
   {
     "id": "EXPLOSIVE_OG7V",
     "type": "ammo_effect",
-    "explosion": {
-      "power": 800,
-      "shrapnel": {
-        "casing_mass": 500,
-        "fragment_mass": 0.2
-      }
-    }
+    "explosion": { "power": 800, "shrapnel": { "casing_mass": 500, "fragment_mass": 0.2 } }
   },
   {
     "id": "FLASHBANG",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2304,7 +2304,18 @@
     "death_function": { "message": "The %s's body leaks acid.", "effect": { "id": "death_acid", "hit_self": true } },
     "harvest": "arachnid_acid",
     "dissect": "dissect_insect_sample_single",
-    "flags": [ "ACIDPROOF", "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "EATS", "CORNERED_FIGHTER" ],
+    "flags": [
+      "ACIDPROOF",
+      "CLIMBS",
+      "HEARS",
+      "POISON",
+      "SEES",
+      "SMELLS",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL",
+      "EATS",
+      "CORNERED_FIGHTER"
+    ],
     "armor": { "bash": 6, "cut": 10, "bullet": 8, "electric": 2 }
   },
   {
@@ -2361,7 +2372,18 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true },
-    "flags": [ "ACIDPROOF", "CLIMBS", "HEARS", "QUEEN", "SEES", "SMELLS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "BASHES", "CORNERED_FIGHTER" ],
+    "flags": [
+      "ACIDPROOF",
+      "CLIMBS",
+      "HEARS",
+      "QUEEN",
+      "SEES",
+      "SMELLS",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL",
+      "BASHES",
+      "CORNERED_FIGHTER"
+    ],
     "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1 }
   },
   {
@@ -2414,7 +2436,18 @@
     "dissect": "dissect_insect_sample_single",
     "upgrades": { "age_grow": 42, "into": "mon_ant_acid_soldier_mega" },
     "name": { "str": "oversized acidic soldier ant" },
-    "flags": [ "ACIDPROOF", "SHORTACIDTRAIL", "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "CORNERED_FIGHTER" ],
+    "flags": [
+      "ACIDPROOF",
+      "SHORTACIDTRAIL",
+      "CLIMBS",
+      "HEARS",
+      "POISON",
+      "SEES",
+      "SMELLS",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL",
+      "CORNERED_FIGHTER"
+    ],
     "armor": { "bash": 12, "cut": 14, "bullet": 11, "electric": 1 }
   },
   {
@@ -4016,7 +4049,10 @@
     ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true },
-    "death_function": { "message": "The %s's body hisses as gas escapes from its remains.", "effect": { "id": "death_fireball", "hit_self": true } },
+    "death_function": {
+      "message": "The %s's body hisses as gas escapes from its remains.",
+      "effect": { "id": "death_fireball", "hit_self": true }
+    },
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_single",
     "flags": [ "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_FIRE", "PATH_AVOID_FALL", "EATS", "CORNERED_FIGHTER" ],

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -13,57 +13,39 @@
           "WEB_SPINNER",
           "WEB_WALKER",
           "WEB_WEAVER",
-          "WINGS_BAT",
-          "WINGS_BIRD",
           "WINGS_BUTTERFLY",
-          "WINGS_INSECT"
+          "WINGS_INSECT",
+          "WINGS_INSECT_ACTIVE"
         ],
         "order": 500
       },
       {
-        "id": [
-          "bio_armor_arms",
-          "bio_armor_legs",
-          "bio_armor_torso",
-          "bio_armor_head",
-          "bio_armor_eyes",
-          "bio_sunglasses",
-          "bio_blindfold"
-        ],
-        "order": 500
-      },
-      {
-        "id": [
-          "BEAUTIFUL",
-          "BEAUTIFUL2",
-          "BEAUTIFUL3",
-          "LARGE",
-          "PRETTY",
-          "RADIOACTIVE1",
-          "RADIOACTIVE2",
-          "RADIOACTIVE3",
-          "REGEN",
-          "bio_deformity",
-          "bio_face_mask"
-        ],
+        "id": [ "BEAUTIFUL", "BEAUTIFUL2", "BEAUTIFUL3", "LARGE", "PRETTY", "RADIOACTIVE1", "RADIOACTIVE2", "RADIOACTIVE3", "REGEN" ],
         "order": 1000
       },
       { "id": [ "PALE", "SKIN_DARK", "SKIN_LIGHT", "SKIN_MEDIUM", "SKIN_PINK", "SKIN_TAN" ], "order": 1100 },
       {
         "id": [
+          "AMORPHOUS",
           "ALBINO",
-          "BARK",
+          "bio_deformity",
           "CHITIN",
+          "CHITIN_MOLTED",
           "CHITIN2",
+          "CHITIN2_MOLTED",
           "CHITIN3",
           "CHITIN_FUR",
           "CHITIN_FUR2",
           "CHITIN_FUR3",
+          "CHLOROMORPH",
           "FEATHERS",
           "FELINE_FUR",
           "FUR",
+          "HIRSUTE",
           "LIGHT_FUR",
           "LUPINE_FUR",
+          "LUPINE_FUR_SUMMER",
+          "URSINE_FUR_SUMMER",
           "M_SKIN",
           "M_SKIN2",
           "M_SKIN3",
@@ -72,11 +54,16 @@
           "PLANTSKIN",
           "RABBIT_FUR",
           "SCALES",
+          "SPARSE_SCALES",
           "SKIN_ROUGH",
+          "SKIN_SMOOTH",
+          "SKIN_PEELING",
+          "SKIN_RASHY",
           "SLEEK_SCALES",
           "SORES",
           "THICK_SCALES",
           "THORNS",
+          "TROGLO",
           "TROGLO2",
           "TROGLO3",
           "URSINE_FUR",
@@ -84,7 +71,27 @@
         ],
         "order": 1500
       },
-      { "id": [ "SHELL", "SHELL2", "SHELL3" ], "order": 1520 },
+      {
+        "id": [
+          "BARK",
+          "BARK_2a",
+          "BARK_2b",
+          "BARK_2c",
+          "SHELL",
+          "SHELL2",
+          "SHELL3",
+          "CRUSTACEAN_CARAPACE",
+          "CRUSTACEAN_CARAPACE_MOLTED",
+          "bio_armor_head",
+          "bio_armor_legs",
+          "bio_armor_torso",
+          "bio_armor_eyes",
+          "bio_sunglasses",
+          "bio_blindfold",
+          "bio_face_mask"
+        ],
+        "order": 1520
+      },
       {
         "id": [
           "FACIAL_HAIR_NONE",
@@ -144,17 +151,20 @@
         ],
         "order": 1600
       },
-      { "id": [ "LEAVES" ], "order": 1900 },
+      { "id": [ "LEAVES", "LEAVES_WINTER", "LEAVES2", "LEAVES2_FALL", "LEAVES3", "LEAVES3_FALL" ], "order": 1900 },
       {
         "id": [ "ARACHNID_ARMS", "ARACHNID_ARMS_OK", "ARM_FEATHERS", "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
         "order": 2000
       },
       { "id": [ "PAWS", "PAWS_LARGE", "SLIME_HANDS" ], "order": 2500 },
       {
-        "id": [ "CLAWS", "CLAWS_RAT", "CLAWS_RETRACT", "LONG_FINGERNAILS", "VINES1", "VINES2", "VINES3", "bio_claws" ],
+        "id": [ "CLAWS", "CLAWS_RAT", "CLAWS_RETRACT", "LONG_FINGERNAILS", "VINES1", "VINES2", "VINES3", "bio_claws", "CRAB_CLAW" ],
         "order": 3000
       },
-      { "id": [ "bio_blade", "bio_blaster", "bio_emp_armgun" ], "order": 3250 },
+      {
+        "id": [ "bio_blade", "bio_blaster", "bio_emp_armgun", "bio_dis_acid", "bio_evap", "bio_ads", "bio_armor_arms" ],
+        "order": 3250
+      },
       {
         "id": [
           "TAIL_CATTLE",
@@ -170,10 +180,13 @@
         ],
         "order": 3500
       },
-      { "id": [ "LEG_TENTACLES" ], "order": 4000 },
+      { "id": [ "LEG_TENTACLES", "GASTROPOD_FOOT", "CRAB_LEGS" ], "order": 4000 },
       { "id": [ "HOOVES", "ROOTS1", "ROOTS2", "ROOTS3", "TALONS" ], "order": 4500 },
-      { "id": [ "FLOWERS" ], "order": 5000 },
-      { "id": [ "ELFA_EARS", "FELINE_EARS", "LUPINE_EARS", "RABBIT_EARS", "URSINE_EARS" ], "order": 5500 },
+      {
+        "id": [ "FLOWERS", "ROSEBUDS", "ROSEBUDS_FALL", "ROSEBUDS_SUMMER", "SLIMY", "M_BLOSSOMS", "M_BLOOM", "M_PROVENANCE" ],
+        "order": 5000
+      },
+      { "id": [ "BATEARS", "ELFA_EARS", "FELINE_EARS", "LUPINE_EARS", "RABBIT_EARS", "URSINE_EARS" ], "order": 5500 },
       { "id": [ "ANTENNAE", "ANTLERS", "HORNS_CURLED", "HORNS", "HORNS_POINTED" ], "order": 6000 },
       { "id": [ "COMPOUND_EYES", "ELFAEYES", "FEL_EYE", "LIZ_EYE" ], "order": 6500 },
       {
@@ -186,6 +199,7 @@
           "MUZZLE_BEAR",
           "MUZZLE_LONG",
           "MUZZLE_RAT",
+          "LEAFNOSE",
           "MINOTAUR",
           "RABBIT_NOSE",
           "SLIT_NOSTRILS",
@@ -196,8 +210,11 @@
         "order": 7000
       },
       { "id": [ "FANGS", "MANDIBLES", "SABER_TEETH" ], "order": 7500 },
-      { "id": [ "FORKED_TONGUE" ], "order": 8000 },
-      { "id": [ "PROF_FED", "PROF_PD_DET", "PROF_POLICE", "PROF_SWAT", "PHEROMONE_INSECT" ], "order": 8500 }
+      { "id": [ "FORKED_TONGUE", "active_bio_ads", "active_bio_ods" ], "order": 8000 },
+      {
+        "id": [ "PROF_FED", "PROF_PD_DET", "PROF_POLICE", "PROF_SWAT", "PHEROMONE_INSECT", "WINGS_BAT", "WINGS_BIRD" ],
+        "order": 8500
+      }
     ]
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3867,7 +3867,9 @@
         ]
       },
       "male": { "entries": [ { "item": "jeans_skinny" }, { "item": "tank_top" }, { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "skirt" }, { "item": "corset" }, { "item": "panties" }, { "item": "stockings" }, { "item": "sockmitts" } ] }
+      "female": {
+        "entries": [ { "item": "skirt" }, { "item": "corset" }, { "item": "panties" }, { "item": "stockings" }, { "item": "sockmitts" } ]
+      }
     }
   },
   {


### PR DESCRIPTION
#### Summary
Tileset layering fixes

#### Purpose of change
Some mutations and bionics have been improperly layered for a very long time, even back in DDA.

#### Describe the solution
Move some things around in mutation_layering.json


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
