### PR TITLE
Adjust integrated armor values

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -19,7 +19,7 @@
     "armor": [
       {
         "material": [
-          { "type": "veggy", "covered_by_mat": 100, "thickness": 2 },
+          { "type": "veggy", "covered_by_mat": 100, "thickness": 1.5 },
           { "type": "wood", "covered_by_mat": 100, "thickness": 0.5 }
         ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
@@ -44,13 +44,13 @@
     "color": "brown",
     "warmth": 8,
     "environmental_protection": 3,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "RAINPROOF", "PADDED", "TRANSPARENT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "SKINTIGHT", "RAINPROOF", "PADDED", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 4 }, { "type": "wood", "covered_by_mat": 75, "thickness": 6 } ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 75, "thickness": 1 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
         "coverage": 100,
-        "encumbrance": 9
+        "encumbrance": 14
       }
     ],
     "melee_damage": { "bash": 3 }
@@ -70,13 +70,13 @@
     "color": "brown",
     "warmth": 8,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "RAINPROOF", "PADDED", "TRANSPARENT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "SKINTIGHT", "RAINPROOF", "PADDED", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 6 }, { "type": "wood", "covered_by_mat": 75, "thickness": 7 } ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 75, "thickness": 2 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
         "coverage": 100,
-        "encumbrance": 10
+        "encumbrance": 16
       }
     ],
     "melee_damage": { "bash": 4 }
@@ -96,35 +96,35 @@
     "color": "brown",
     "warmth": 12,
     "environmental_protection": 4,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "RAINPROOF", "PADDED", "TRANSPARENT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "SKINTIGHT", "RAINPROOF", "PADDED", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 15 } ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "torso" ],
         "coverage": 100,
         "encumbrance": 20
       },
       {
         "material": [
-          { "type": "wood", "covered_by_mat": 100, "thickness": 4.5 },
-          { "type": "wood", "covered_by_mat": 50, "thickness": 5.5 }
+          { "type": "wood", "covered_by_mat": 100, "thickness": 2 },
+          { "type": "wood", "covered_by_mat": 50, "thickness": 1.5 }
         ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "head" ],
+        "coverage": 100,
+        "encumbrance": 10
+      },
+      {
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 50, "thickness": 1 } ],
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_palm_l", "hand_palm_r", "hand_wrist_l", "hand_wrist_r" ],
         "coverage": 100,
         "encumbrance": 8
       },
       {
-        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 3 }, { "type": "wood", "covered_by_mat": 40, "thickness": 4 } ],
-        "covers": [ "hand_l", "hand_r" ],
-        "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_palm_l", "hand_palm_r", "hand_wrist_l", "hand_wrist_r" ],
-        "coverage": 100,
-        "encumbrance": 6
-      },
-      {
-        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 3 }, { "type": "wood", "covered_by_mat": 40, "thickness": 4 } ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 50, "thickness": 1 } ],
         "covers": [ "foot_l", "foot_r" ],
         "coverage": 100,
-        "encumbrance": 6
+        "encumbrance": 8
       }
     ],
     "melee_damage": { "bash": 4 }
@@ -147,22 +147,16 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "OUTER", "PADDED", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [
-          { "type": "wood", "covered_by_mat": 100, "thickness": 9.5 },
-          { "type": "wood", "covered_by_mat": 60, "thickness": 7 }
-        ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 75, "thickness": 3 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
         "coverage": 100,
-        "encumbrance": 16
+        "encumbrance": 18
       },
       {
-        "material": [
-          { "type": "wood", "covered_by_mat": 100, "thickness": 9.5 },
-          { "type": "wood", "covered_by_mat": 60, "thickness": 7 }
-        ],
+        "material": [ { "type": "wood", "covered_by_mat": 100, "thickness": 2 }, { "type": "wood", "covered_by_mat": 75, "thickness": 3 } ],
         "covers": [ "mouth", "eyes" ],
         "coverage": 90,
-        "encumbrance": 8
+        "encumbrance": 18
       }
     ],
     "melee_damage": { "bash": 4 }
@@ -188,14 +182,14 @@
         "material": [ { "type": "feathers", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "arm_l", "arm_r", "torso", "head" ],
         "coverage": 100,
-        "encumbrance": 0
+        "encumbrance": 4
       },
       {
         "material": [ { "type": "feathers", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,
-        "encumbrance": 0
+        "encumbrance": 2
       }
     ]
   },
@@ -217,16 +211,10 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
-        "coverage": 100,
-        "encumbrance": 0
-      },
-      {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1 } ],
-        "covers": [ "mouth" ],
-        "coverage": 85,
-        "encumbrance": 0
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1.5 } ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
+        "coverage": 80,
+        "encumbrance": 2
       }
     ]
   },
@@ -248,16 +236,16 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
         "coverage": 100,
-        "encumbrance": 1
+        "encumbrance": 8
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-        "coverage": 100,
-        "encumbrance": 1
+        "coverage": 80,
+        "encumbrance": 6
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1 } ],
@@ -282,22 +270,22 @@
     "color": "black",
     "warmth": 45,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATER_FRIENDLY", "SOFT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "SKINTIGHT", "WATER_FRIENDLY", "SOFT" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 14 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 5 } ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
         "coverage": 100,
-        "encumbrance": 5
+        "encumbrance": 14
       },
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 9 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-        "coverage": 100,
-        "encumbrance": 6
+        "coverage": 90,
+        "encumbrance": 8
       },
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 5 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0
@@ -319,22 +307,22 @@
     "color": "black",
     "warmth": 32,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "WATER_FRIENDLY", "SOFT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "SKINTIGHT", "WATER_FRIENDLY", "SOFT" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
         "coverage": 100,
-        "encumbrance": 3
-      },
-      {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 6 } ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-        "coverage": 100,
-        "encumbrance": 4
+        "encumbrance": 12
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+        "coverage": 90,
+        "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0
@@ -359,19 +347,26 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 8 } ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
+        "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": 2
-      },
-      {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 6 } ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-        "coverage": 100,
-        "encumbrance": 1
+        "encumbrance": 14,
+        "layers": [ "SKINTIGHT", "NORMAL" ]
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "coverage": 90,
+        "encumbrance": 8
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+        "coverage": 80,
+        "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0
@@ -396,19 +391,26 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 6 } ],
-        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3.5 } ],
+        "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": 2
-      },
-      {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
-        "coverage": 100,
-        "encumbrance": 1
+        "encumbrance": 12,
+        "layers": [ "SKINTIGHT", "NORMAL" ]
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
+        "coverage": 90,
+        "encumbrance": 7
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+        "coverage": 80,
+        "encumbrance": 5
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0
@@ -433,10 +435,16 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
         "coverage": 100,
-        "encumbrance": 0
+        "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "head" ],
+        "coverage": 90,
+        "encumbrance": 6
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
@@ -464,7 +472,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "NORMAL", "COLLAR" ],
     "armor": [
       {
-        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "head" ],
         "coverage": 100,
         "cover_vitals": 65,
@@ -598,6 +606,7 @@
     "flags": [
       "INTEGRATED",
       "ALLOWS_NATURAL_ATTACKS",
+      "BLOCK_WHILE_WORN",
       "UNBREAKABLE",
       "SKINTIGHT",
       "NORMAL",
@@ -608,14 +617,14 @@
     "armor": [
       {
         "material": [
-          { "type": "bone", "covered_by_mat": 10, "thickness": 1 },
-          { "type": "keratin", "covered_by_mat": 10, "thickness": 1 },
-          { "type": "scales", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "fur", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "acidchitin", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "feathers", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "wool", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "leather_arthropod", "covered_by_mat": 33, "thickness": 1 },
+          { "type": "bone", "covered_by_mat": 20, "thickness": 1 },
+          { "type": "keratin", "covered_by_mat": 5, "thickness": 5 },
+          { "type": "scales", "covered_by_mat": 33, "thickness": 1.5 },
+          { "type": "fur", "covered_by_mat": 33, "thickness": 2 },
+          { "type": "acidchitin", "covered_by_mat": 33, "thickness": 1.5 },
+          { "type": "feathers", "covered_by_mat": 33, "thickness": 1.5 },
+          { "type": "wool", "covered_by_mat": 33, "thickness": 2 },
+          { "type": "leather_arthropod", "covered_by_mat": 33, "thickness": 1.5 },
           { "type": "flesh", "covered_by_mat": 33, "thickness": 1 },
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 1 }
         ],
@@ -626,10 +635,10 @@
       {
         "material": [
           { "type": "bone", "covered_by_mat": 10, "thickness": 1 },
-          { "type": "scales", "covered_by_mat": 33, "thickness": 1 },
+          { "type": "scales", "covered_by_mat": 33, "thickness": 1.5 },
           { "type": "fur", "covered_by_mat": 33, "thickness": 1 },
           { "type": "acidchitin", "covered_by_mat": 33, "thickness": 1 },
-          { "type": "leather_arthropod", "covered_by_mat": 33, "thickness": 1 },
+          { "type": "leather_arthropod", "covered_by_mat": 33, "thickness": 1.5 },
           { "type": "flesh", "covered_by_mat": 33, "thickness": 1 },
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 1 }
         ],
@@ -717,7 +726,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "epicuticle" },
-    "description": "Unnaturally smooth skin made of soft chitin.  Though pliable, it's tougher than human flesh.",
+    "description": "Unnaturally smooth skin made of soft chitin.  Though soft and pliable, it's tougher than human flesh.",
     "weight": "1 kg",
     "volume": "1500 ml",
     "price": "0 cent",
@@ -730,13 +739,13 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "SOFT", "TRANSPARENT" ],
     "armor": [
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head" ],
         "coverage": 100,
         "encumbrance": 2
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0
@@ -771,21 +780,21 @@
     ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.8 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "head" ],
         "coverage": 95,
         "encumbrance": 13,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 4.4 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 13,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3.2 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_upper_l", "arm_lower_l", "arm_upper_r", "arm_lower_r" ],
         "coverage": 95,
@@ -793,7 +802,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_shoulder_l", "arm_elbow_r", "arm_shoulder_r" ],
         "coverage": 95,
@@ -801,7 +810,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3.2 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_lower_l", "leg_upper_r", "leg_lower_r" ],
         "coverage": 95,
@@ -809,7 +818,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_knee_l", "leg_hip_r", "leg_knee_r" ],
         "coverage": 95,
@@ -838,7 +847,6 @@
     "flags": [
       "INTEGRATED",
       "ALLOWS_NATURAL_ATTACKS",
-      "BLOCK_WHILE_WORN",
       "UNBREAKABLE",
       "NORMAL",
       "SKINTIGHT",
@@ -848,21 +856,21 @@
     ],
     "armor": [
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.4 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "head" ],
         "coverage": 95,
         "encumbrance": 8,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.2 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 8,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.6 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_upper_l", "arm_lower_l", "arm_upper_r", "arm_lower_r" ],
         "coverage": 95,
@@ -870,7 +878,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_shoulder_l", "arm_elbow_r", "arm_shoulder_r" ],
         "coverage": 95,
@@ -878,7 +886,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.6 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.2 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_lower_l", "leg_upper_r", "leg_lower_r" ],
         "coverage": 98,
@@ -886,25 +894,11 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_knee_l", "leg_hip_r", "leg_knee_r" ],
         "coverage": 95,
         "encumbrance": 0,
-        "rigid_layer_only": true
-      },
-      {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.1 } ],
-        "covers": [ "hand_l", "hand_r" ],
-        "coverage": 85,
-        "encumbrance": 6,
-        "rigid_layer_only": true
-      },
-      {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.1 } ],
-        "covers": [ "foot_l", "foot_r" ],
-        "coverage": 90,
-        "encumbrance": 6,
         "rigid_layer_only": true
       }
     ]
@@ -924,24 +918,24 @@
     "color": "brown",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED", "BLOCK_WHILE_WORN" ],
     "armor": [
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3.4 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.8 } ],
         "covers": [ "head" ],
         "coverage": 95,
         "encumbrance": 24,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4.5 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.8 } ],
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 24,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3.9 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.8 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_upper_l", "arm_lower_l", "arm_upper_r", "arm_lower_r" ],
         "coverage": 100,
@@ -949,7 +943,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_shoulder_l", "arm_elbow_r", "arm_shoulder_r" ],
         "coverage": 95,
@@ -957,7 +951,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3.4 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.8 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_lower_l", "leg_upper_r", "leg_lower_r" ],
         "coverage": 98,
@@ -965,7 +959,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_knee_l", "leg_hip_r", "leg_knee_r" ],
         "coverage": 95,
@@ -973,14 +967,14 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 4.1 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "foot_l", "foot_r" ],
         "coverage": 98,
         "encumbrance": 20,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "hand_l", "hand_r" ],
         "coverage": 95,
         "encumbrance": 16,
@@ -1007,14 +1001,14 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED" ],
     "armor": [
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.2 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "head" ],
         "coverage": 95,
         "encumbrance": 18,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 18,
@@ -1029,7 +1023,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.4 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_shoulder_l", "arm_elbow_r", "arm_shoulder_r" ],
         "coverage": 90,
@@ -1037,7 +1031,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.6 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_lower_l", "leg_upper_r", "leg_lower_r" ],
         "coverage": 100,
@@ -1045,7 +1039,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_knee_l", "leg_hip_r", "leg_knee_r" ],
         "coverage": 90,
@@ -1053,7 +1047,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "foot_l", "foot_r" ],
         "coverage": 90,
         "encumbrance": 14,
@@ -1089,7 +1083,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "BELTED", "PADDED", "NATURAL_WEAPON", "PROVIDES_TECHNIQUES" ],
     "armor": [
       {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 5.2 } ],
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3.2 } ],
         "covers": [ "hand_r" ],
         "specifically_covers": [ "hand_fingers_r", "hand_back_r", "hand_palm_r" ],
         "coverage": 95,
@@ -1313,28 +1307,28 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY", "TOUGH_FEET" ],
     "armor": [
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.0 } ],
         "covers": [ "head" ],
         "coverage": 85,
-        "encumbrance": 3,
+        "encumbrance": 6,
         "breathability": "POOR"
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
         "coverage": 85,
-        "encumbrance": 4,
+        "encumbrance": 6,
         "breathability": "POOR"
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 0.5 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
         "coverage": 80,
         "encumbrance": 3,
         "breathability": "POOR"
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 0.5 } ],
         "covers": [ "mouth" ],
         "coverage": 80,
         "encumbrance": 0,
@@ -1361,25 +1355,25 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY", "TOUGH_FEET" ],
     "armor": [
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "head" ],
         "coverage": 95,
-        "encumbrance": 4
+        "encumbrance": 6
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
         "coverage": 95,
-        "encumbrance": 5
+        "encumbrance": 6
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
         "coverage": 90,
         "encumbrance": 4
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "mouth" ],
         "coverage": 95,
         "encumbrance": 0,
@@ -1417,39 +1411,39 @@
       {
         "material": [
           { "type": "bone", "covered_by_mat": 10, "thickness": 2.0 },
-          { "type": "scales", "covered_by_mat": 100, "thickness": 3.0 }
+          { "type": "scales", "covered_by_mat": 100, "thickness": 2.5 }
         ],
         "covers": [ "head" ],
-        "coverage": 100,
-        "encumbrance": 7
+        "coverage": 98,
+        "encumbrance": 16
       },
       {
         "material": [
-          { "type": "bone", "covered_by_mat": 30, "thickness": 3.0 },
-          { "type": "scales", "covered_by_mat": 100, "thickness": 4.0 }
+          { "type": "bone", "covered_by_mat": 30, "thickness": 2.0 },
+          { "type": "scales", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "torso" ],
         "coverage": 98,
-        "encumbrance": 9
+        "encumbrance": 16
       },
       {
         "//": "bone represents scutes or osteoderms",
         "material": [
-          { "type": "bone", "covered_by_mat": 30, "thickness": 3.0 },
-          { "type": "scales", "covered_by_mat": 100, "thickness": 4.0 }
+          { "type": "bone", "covered_by_mat": 30, "thickness": 2.0 },
+          { "type": "scales", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
         "coverage": 98,
-        "encumbrance": 9
+        "encumbrance": 16
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
         "coverage": 85,
-        "encumbrance": 7
+        "encumbrance": 8
       },
       {
-        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 3.0 } ],
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 1.5 } ],
         "covers": [ "mouth" ],
         "coverage": 85,
         "encumbrance": 0,

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -211,10 +211,8 @@
       },
       { "id": [ "FANGS", "MANDIBLES", "SABER_TEETH" ], "order": 7500 },
       { "id": [ "FORKED_TONGUE", "active_bio_ads", "active_bio_ods" ], "order": 8000 },
-      {
-        "id": [ "PROF_FED", "PROF_PD_DET", "PROF_POLICE", "PROF_SWAT", "PHEROMONE_INSECT", "WINGS_BAT", "WINGS_BIRD" ],
-        "order": 8500
-      }
+      { "id": [ "PROF_FED", "PROF_PD_DET", "PROF_POLICE", "PROF_SWAT", "PHEROMONE_INSECT" ], "order": 8500 },
+      { "id": [ "WINGS_BAT", "WINGS_BIRD" ], "order": 9000 }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Adjust integrated armor values

#### Purpose of change
Some integrated armor values were very out of whack. Phelloderm and epicuticle were still far too good, and the bark, scale, chitin, and most of the fur mutations were really out of control.

#### Describe the solution
Sharply reduce the thickness of all of these mutations and increase their encumbrance. Bring the fur mutations up to modern layering standards. Tweak them a bit so that they're more interesting and diverse.
GRAY FUR - Lupine fur is now NORMAL on the torso and SKINTIGHT everywhere else. It's moderately protective.
SLEEK FUR - Feline fur is weaker but only skintight, and has even coverage.
SHAGGY FUR - NORMAL and SKINTIGHT on all BPs, but has the best protection and is water-friendly.
FUR - Much worse protection and coverage for basic fur. It's still decent though!
LIGHTFUR - This has been scaled way back. It now has very poor coverage, per its description, and only offers a couple of points of protection. On the plus side, it's now PERSONAL rather than SKINTIGHT.

Patchwork Armor - Make the horn layer way thicker, but smaller. Thicken some of the more general layers.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
