### PR TITLE
Backport DDA 75220 - Add stack calculation

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12029,8 +12029,9 @@ float item::simulate_burn( fire_data &frd ) const
         burn_added = 1;
     }
 
+    // Fire will depend on amount of fuel if stackable
     if( count_by_charges() ) {
-        int stack_burnt = rng( type->stack_size / 2, type->stack_size );
+        int stack_burnt = std::max( 1, count() / type->stack_size );
         time_added *= stack_burnt;
         smoke_added *= stack_burnt;
         burn_added *= stack_burnt;


### PR DESCRIPTION
#### Summary
Backport DDA 75220 - Add stack calculation

#### Purpose of change
Stackable items, like gasoline, weren't calculated correctly when burning, leading to puddles of gas burning for hours.

#### Describe the solution
Backport 75220, which causes the full stack to burn at once.

#### Testing
Poured a jerrycan of gas on the ground, lit it on fire, watched it burn up very quickly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
