### PR TITLE
Nerf farm supply store

### DIFF
--- a/data/json/mapgen/farm_supply.json
+++ b/data/json/mapgen/farm_supply.json
@@ -64,10 +64,10 @@
         "à": {
           "item": {
             "subtype": "collection",
-            "entries": [ { "group": "guns_rifle_common_display", "prob": 40 }, { "group": "guns_shotgun_common_display", "prob": 60 } ]
+            "entries": [ { "group": "guns_rifle_common_display", "prob": 10 }, { "group": "guns_shotgun_common_display", "prob": 20 } ]
           },
-          "chance": 100,
-          "repeat": [ 0, 3 ]
+          "chance": 60,
+          "repeat": [ 0, 2 ]
         },
         "á": {
           "item": {
@@ -75,20 +75,20 @@
             "entries": [
               { "group": "ammo_rifle_common_collection", "prob": 25 },
               { "group": "ammo_shotgun_common_collection", "prob": 40 },
-              { "group": "mags_rifle_common_gunstore", "prob": 35 }
+              { "group": "mags_rifle_common_gunstore", "prob": 25 }
             ]
           },
-          "chance": 100,
-          "repeat": [ 0, 5 ]
+          "chance": 60,
+          "repeat": [ 0, 3 ]
         },
         "ç": { "item": "fishing_items", "chance": 100, "repeat": [ 0, 2 ] },
         "n": {
           "item": {
             "subtype": "collection",
-            "entries": [ { "item": "fishing_hook_basic", "prob": 70 }, { "item": "fish_bait", "prob": 30 } ]
+            "entries": [ { "item": "fishing_hook_basic", "prob": 40 }, { "item": "fish_bait", "prob": 30 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 3 ]
+          "chance": 50,
+          "repeat": [ 0, 1 ]
         },
         "1": { "item": "petstore_shelves", "chance": 80, "repeat": [ 0, 3 ] },
         "2": {
@@ -102,8 +102,8 @@
               { "group": "dinnerware", "prob": 15 }
             ]
           },
-          "chance": 70,
-          "repeat": [ 0, 3 ]
+          "chance": 50,
+          "repeat": [ 0, 2 ]
         },
         "3": {
           "item": {
@@ -117,18 +117,18 @@
               { "group": "book_survival", "prob": 5 }
             ]
           },
-          "chance": 100,
-          "repeat": [ 0, 3 ]
+          "chance": 50,
+          "repeat": [ 0, 2 ]
         },
-        "4": { "item": "sports", "chance": 50, "repeat": [ 0, 4 ] },
+        "4": { "item": "sports", "chance": 50, "repeat": [ 0, 3 ] },
         "5": {
           "item": { "subtype": "collection", "entries": [ { "group": "toy_store", "prob": 95 }, { "group": "child_hats", "prob": 5 } ] },
-          "chance": 70,
-          "repeat": [ 0, 3 ]
+          "chance": 50,
+          "repeat": [ 0, 2 ]
         },
         "6": { "item": "clothing_outdoor_shoes", "chance": 70, "repeat": [ 0, 2 ] },
-        "7": { "item": "clothing_watch", "chance": 60, "repeat": [ 1, 2 ] },
-        "8": { "item": "clothing_glasses", "chance": 60, "repeat": [ 1, 2 ] },
+        "7": { "item": "clothing_watch", "chance": 60, "repeat": [ 0, 2 ] },
+        "8": { "item": "clothing_glasses", "chance": 60, "repeat": [ 0, 2 ] },
         "9": {
           "item": {
             "subtype": "collection",
@@ -138,7 +138,7 @@
               { "group": "underwear", "prob": 10 }
             ]
           },
-          "chance": 70,
+          "chance": 50,
           "repeat": [ 0, 2 ]
         },
         "0": {
@@ -150,28 +150,28 @@
               { "group": "liquor_and_spirits", "prob": 5 }
             ]
           },
-          "chance": 70,
-          "repeat": [ 0, 4 ]
+          "chance": 40,
+          "repeat": [ 0, 2 ]
         },
         "É": {
           "item": {
             "subtype": "collection",
             "entries": [
-              { "group": "tools_common", "prob": 40 },
+              { "group": "tools_common", "prob": 30 },
               { "group": "tools_entry", "prob": 5 },
               { "group": "consumer_electronics", "prob": 25 },
               { "group": "ammo_any_batteries_full", "prob": 25 },
               { "group": "tools_lighting", "prob": 5 }
             ]
           },
-          "chance": 80,
-          "repeat": [ 0, 4 ]
+          "chance": 50,
+          "repeat": [ 0, 2 ]
         },
         "é": {
           "item": {
             "subtype": "collection",
             "entries": [
-              { "group": "tools_tailor", "prob": 50 },
+              { "group": "tools_tailor", "prob": 30 },
               { "item": "thread", "count": [ 5, 20 ], "prob": 10 },
               { "item": "cotton_patchwork", "count": [ 20, 50 ], "prob": 10 },
               { "item": "felt_patch", "count": [ 5, 25 ], "prob": 10 },
@@ -179,54 +179,54 @@
               { "group": "sewing_group", "prob": 10 }
             ]
           },
-          "chance": 80,
-          "repeat": [ 0, 6 ]
+          "chance": 30,
+          "repeat": [ 0, 2 ]
         },
         "ê": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_plumbing", "prob": 70 }, { "group": "plumbing_bulk", "prob": 30 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 5 ]
+          "chance": 40,
+          "repeat": [ 0, 3 ]
         },
         "ë": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_carpentry", "prob": 70 }, { "group": "supplies_woodcrafts", "prob": 30 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 5 ]
+          "chance": 40,
+          "repeat": [ 0, 2 ]
         },
         "È": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_mechanic", "prob": 70 }, { "group": "supplies_electronics", "prob": 30 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 5 ]
+          "chance": 30,
+          "repeat": [ 0, 2 ]
         },
         "Ë": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_earthworking", "prob": 90 }, { "group": "tools_entry", "prob": 10 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 3 ]
+          "chance": 60,
+          "repeat": [ 0, 2 ]
         },
         "æ": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "farming_tools", "prob": 50 }, { "group": "farm_supply_wire", "prob": 50 } ]
           },
-          "chance": 100,
-          "repeat": [ 0, 7 ]
+          "chance": 70,
+          "repeat": [ 0, 3 ]
         },
-        "÷": { "item": "farming_seeds", "chance": 100, "repeat": [ 3, 12 ] },
+        "÷": { "item": "farming_seeds", "chance": 40, "repeat": [ 1, 5 ] },
         "Î": {
           "item": { "subtype": "collection", "entries": [ { "group": "fertilizers", "prob": 80 }, { "item": "fungicide", "prob": 20 } ] },
           "chance": 100,
-          "repeat": [ 0, 6 ]
+          "repeat": [ 0, 3 ]
         },
         "ù": { "item": "farm_supply_soil_and_sand", "chance": 100, "repeat": [ 1, 6 ] },
         "ú": { "item": "farm_supply_rocks", "chance": 100, "repeat": [ 1, 6 ] },
@@ -237,12 +237,12 @@
             "entries": [ { "group": "farm_supply_animal_feed", "prob": 93 }, { "group": "farm_supply_riding_gear", "prob": 7 } ]
           },
           "chance": 80,
-          "repeat": [ 1, 4 ]
+          "repeat": [ 1, 3 ]
         },
         "Ø": {
           "item": { "subtype": "collection", "entries": [ { "group": "hardware_books", "prob": 80 }, { "group": "novels", "prob": 20 } ] },
-          "chance": 100,
-          "repeat": [ 0, 4 ]
+          "chance": 40,
+          "repeat": [ 0, 2 ]
         },
         "õ": {
           "item": {
@@ -253,8 +253,8 @@
               { "item": "stick", "prob": 20, "count": [ 5, 10 ] }
             ]
           },
-          "chance": 70,
-          "repeat": [ 0, 4 ]
+          "chance": 40,
+          "repeat": [ 0, 3 ]
         },
         "p": {
           "item": {
@@ -269,7 +269,7 @@
           "repeat": [ 1, 3 ]
         },
         "s": { "item": "coffee_bathroom", "chance": 40 },
-        "þ": { "item": "SUS_fridge_breakroom", "chance": 80 },
+        "þ": { "item": "SUS_fridge_breakroom", "chance": 30 },
         "q": { "item": "file_room", "chance": 100, "repeat": [ 1, 5 ] },
         ".": {
           "item": {
@@ -286,7 +286,7 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 600 },
+              { "item": "null", "prob": 700 },
               { "group": "floor_trash", "prob": 2 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
@@ -297,7 +297,7 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 300 },
+              { "item": "null", "prob": 400 },
               { "group": "trash", "prob": 1 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
@@ -308,7 +308,7 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 300 },
+              { "item": "null", "prob": 400 },
               { "group": "trash", "prob": 1 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
@@ -318,7 +318,7 @@
         "g": { "item": "trash", "chance": 70, "repeat": [ 0, 2 ] },
         "D": { "item": "trash", "chance": 70, "repeat": [ 0, 3 ] },
         "$": { "item": "cash_register_random", "chance": 100 },
-        "V": { "item": "vending_drink_items", "chance": 70, "repeat": [ 3, 10 ] },
+        "V": { "item": "vending_drink_items", "chance": 70, "repeat": [ 2, 6 ] },
         "c": {
           "item": {
             "subtype": "collection",
@@ -344,18 +344,18 @@
         "O": {
           "item": {
             "subtype": "collection",
-            "entries": [ { "item": "null", "prob": 400 }, { "group": "trash", "prob": 2 }, { "item": "football", "prob": 1 } ]
+            "entries": [ { "item": "null", "prob": 600 }, { "group": "trash", "prob": 2 }, { "item": "football", "prob": 1 } ]
           },
           "chance": 100
         }
       },
       "place_monster": [
         { "group": "GROUP_VANILLA", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 50, "repeat": [ 1, 3 ] },
-        { "group": "GROUP_POLICE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 0, 3 ] },
         { "group": "GROUP_VANILLA", "x": [ 24, 47 ], "y": [ 0, 23 ], "chance": 50, "repeat": [ 1, 4 ] },
         { "group": "GROUP_ZOMBIE", "x": [ 4, 23 ], "y": [ 26, 44 ], "chance": 80, "repeat": [ 0, 7 ] },
         { "group": "GROUP_ZOMBIE", "x": [ 24, 46 ], "y": [ 26, 44 ], "chance": 80, "repeat": [ 0, 7 ] },
-        { "group": "FERAL_HUMANS", "x": [ 32, 34 ], "y": [ 43, 44 ], "chance": 80 }
+        { "group": "FERAL_HUMANS", "x": [ 32, 34 ], "y": [ 43, 44 ], "chance": 30, "repeat": [ 1, 3 ] },
+        { "monster": "mon_feral_militia", "x": [ 30, 34 ], "y": [ 41, 44 ], "chance": 100, "repeat": [ 2, 3 ] }
       ],
       "vehicles": {
         "Ü": { "vehicle": "farm_vehicles", "chance": 50, "rotation": 180 },
@@ -451,7 +451,8 @@
           "x": [ 4, 9 ],
           "y": [ 26, 40 ]
         }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_CROWS", "x": [ 8, 10 ], "y": [ 24, 28 ], "chance": 60, "repeat": [ 1, 3 ] } ]
     }
   },
   {
@@ -522,7 +523,7 @@
             "entries": [ { "group": "guns_rifle_common_display", "prob": 40 }, { "group": "guns_shotgun_common_display", "prob": 60 } ]
           },
           "chance": 7,
-          "repeat": [ 0, 2 ]
+          "repeat": [ 0, 1 ]
         },
         "á": {
           "item": {
@@ -534,7 +535,7 @@
             ]
           },
           "chance": 7,
-          "repeat": [ 0, 4 ]
+          "repeat": [ 0, 1 ]
         },
         "ç": { "item": "fishing_items", "chance": 100, "repeat": [ 0, 2 ] },
         "n": {
@@ -543,9 +544,9 @@
             "entries": [ { "item": "fishing_hook_basic", "prob": 70 }, { "item": "fish_bait", "prob": 30 } ]
           },
           "chance": 100,
-          "repeat": [ 0, 2 ]
+          "repeat": [ 0, 1 ]
         },
-        "1": { "item": "petstore_shelves", "chance": 70, "repeat": [ 0, 3 ] },
+        "1": { "item": "petstore_shelves", "chance": 70, "repeat": [ 0, 1 ] },
         "2": {
           "item": {
             "subtype": "collection",
@@ -558,7 +559,7 @@
             ]
           },
           "chance": 70,
-          "repeat": [ 0, 3 ]
+          "repeat": [ 0, 1 ]
         },
         "3": {
           "item": {
@@ -573,17 +574,17 @@
             ]
           },
           "chance": 20,
-          "repeat": [ 0, 2 ]
+          "repeat": [ 0, 1 ]
         },
         "4": { "item": "sports", "chance": 50, "repeat": [ 0, 4 ] },
         "5": {
           "item": { "subtype": "collection", "entries": [ { "group": "toy_store", "prob": 95 }, { "group": "child_hats", "prob": 5 } ] },
           "chance": 70,
-          "repeat": [ 0, 3 ]
+          "repeat": [ 0, 1 ]
         },
-        "6": { "item": "clothing_outdoor_shoes", "chance": 40, "repeat": [ 0, 2 ] },
-        "7": { "item": "clothing_watch", "chance": 60, "repeat": [ 0, 2 ] },
-        "8": { "item": "clothing_glasses", "chance": 60, "repeat": [ 0, 2 ] },
+        "6": { "item": "clothing_outdoor_shoes", "chance": 40, "repeat": [ 0, 1 ] },
+        "7": { "item": "clothing_watch", "chance": 60, "repeat": [ 0, 1 ] },
+        "8": { "item": "clothing_glasses", "chance": 60, "repeat": [ 0, 1 ] },
         "9": {
           "item": {
             "subtype": "collection",
@@ -593,8 +594,8 @@
               { "group": "underwear", "prob": 10 }
             ]
           },
-          "chance": 60,
-          "repeat": [ 0, 2 ]
+          "chance": 40,
+          "repeat": [ 0, 1 ]
         },
         "0": {
           "item": {
@@ -605,8 +606,8 @@
               { "group": "liquor_and_spirits", "prob": 5 }
             ]
           },
-          "chance": 70,
-          "repeat": [ 0, 4 ]
+          "chance": 10,
+          "repeat": [ 0, 1 ]
         },
         "É": {
           "item": {
@@ -619,8 +620,8 @@
               { "group": "tools_lighting", "prob": 5 }
             ]
           },
-          "chance": 50,
-          "repeat": [ 0, 3 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "é": {
           "item": {
@@ -634,54 +635,54 @@
               { "group": "sewing_group", "prob": 10 }
             ]
           },
-          "chance": 80,
-          "repeat": [ 0, 6 ]
+          "chance": 10,
+          "repeat": [ 0, 2 ]
         },
         "ê": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_plumbing", "prob": 70 }, { "group": "plumbing_bulk", "prob": 30 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 5 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "ë": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_carpentry", "prob": 70 }, { "group": "supplies_woodcrafts", "prob": 30 } ]
           },
-          "chance": 60,
-          "repeat": [ 0, 5 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "È": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_mechanic", "prob": 70 }, { "group": "supplies_electronics", "prob": 30 } ]
           },
-          "chance": 60,
-          "repeat": [ 0, 5 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "Ë": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "tools_earthworking", "prob": 90 }, { "group": "tools_entry", "prob": 10 } ]
           },
-          "chance": 80,
-          "repeat": [ 0, 3 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "æ": {
           "item": {
             "subtype": "collection",
             "entries": [ { "group": "farming_tools", "prob": 50 }, { "group": "farm_supply_wire", "prob": 50 } ]
           },
-          "chance": 90,
-          "repeat": [ 0, 7 ]
+          "chance": 20,
+          "repeat": [ 0, 4 ]
         },
-        "÷": { "item": "farming_seeds", "chance": 100, "repeat": [ 3, 12 ] },
+        "÷": { "item": "farming_seeds", "chance": 60, "repeat": [ 3, 6 ] },
         "Î": {
           "item": { "subtype": "collection", "entries": [ { "group": "fertilizers", "prob": 80 }, { "item": "fungicide", "prob": 20 } ] },
-          "chance": 90,
-          "repeat": [ 0, 6 ]
+          "chance": 10,
+          "repeat": [ 0, 2 ]
         },
         "ù": { "item": "farm_supply_soil_and_sand", "chance": 100, "repeat": [ 1, 6 ] },
         "ú": { "item": "farm_supply_rocks", "chance": 100, "repeat": [ 1, 6 ] },
@@ -691,13 +692,13 @@
             "subtype": "collection",
             "entries": [ { "group": "farm_supply_animal_feed", "prob": 93 }, { "group": "farm_supply_riding_gear", "prob": 7 } ]
           },
-          "chance": 80,
-          "repeat": [ 1, 4 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "Ø": {
           "item": { "subtype": "collection", "entries": [ { "group": "hardware_books", "prob": 80 }, { "group": "novels", "prob": 20 } ] },
-          "chance": 100,
-          "repeat": [ 0, 4 ]
+          "chance": 20,
+          "repeat": [ 0, 2 ]
         },
         "õ": {
           "item": {
@@ -724,7 +725,7 @@
           "repeat": [ 1, 3 ]
         },
         "s": { "item": "coffee_bathroom", "chance": 40 },
-        "þ": { "item": "SUS_fridge_breakroom", "chance": 50 },
+        "þ": { "item": "SUS_fridge_breakroom", "chance": 5 },
         "q": { "item": "file_room", "chance": 100, "repeat": [ 1, 5 ] },
         ".": {
           "item": {
@@ -742,8 +743,8 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 500 },
-              { "group": "floor_trash", "prob": 2 },
+              { "item": "null", "prob": 600 },
+              { "group": "floor_trash", "prob": 4 },
               { "group": "ammo_casings", "prob": 1 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
@@ -754,8 +755,8 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 200 },
-              { "group": "trash", "prob": 1 },
+              { "item": "null", "prob": 600 },
+              { "group": "trash", "prob": 2 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
           },
@@ -765,8 +766,8 @@
           "item": {
             "subtype": "collection",
             "entries": [
-              { "item": "null", "prob": 200 },
-              { "group": "trash", "prob": 1 },
+              { "item": "null", "prob": 300 },
+              { "group": "trash", "prob": 2 },
               { "group": "farm_supply_floor_surprises", "prob": 1 }
             ]
           },
@@ -775,7 +776,7 @@
         "g": { "item": "trash", "chance": 70, "repeat": [ 0, 2 ] },
         "D": { "item": "trash", "chance": 70, "repeat": [ 0, 3 ] },
         "$": { "item": "cash_register_looted", "chance": 50 },
-        "V": { "item": "vending_drink_items", "chance": 20, "repeat": [ 0, 8 ] },
+        "V": { "item": "vending_drink_items", "chance": 20, "repeat": [ 0, 5 ] },
         "c": {
           "item": {
             "subtype": "collection",
@@ -808,11 +809,12 @@
       },
       "place_monster": [
         { "group": "GROUP_VANILLA", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 50, "repeat": [ 2, 5 ] },
-        { "group": "GROUP_POLICE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 1, 3 ] },
+        { "group": "GROUP_POLICE", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 50, "repeat": [ 1, 2 ] },
         { "group": "GROUP_VANILLA", "x": [ 24, 47 ], "y": [ 0, 23 ], "chance": 60, "repeat": [ 2, 4 ] },
         { "group": "GROUP_ZOMBIE", "x": [ 4, 23 ], "y": [ 26, 44 ], "chance": 60, "repeat": [ 3, 8 ] },
         { "group": "GROUP_ZOMBIE", "x": [ 24, 46 ], "y": [ 26, 44 ], "chance": 80, "repeat": [ 3, 8 ] },
-        { "group": "FERAL_HUMANS", "x": [ 32, 34 ], "y": [ 43, 44 ], "chance": 100 }
+        { "group": "FERAL_HUMANS", "x": [ 32, 34 ], "y": [ 43, 44 ], "chance": 100, "repeat": [ 1, 3 ] },
+        { "monster": "mon_feral_militia", "x": [ 30, 34 ], "y": [ 41, 44 ], "chance": 100, "repeat": [ 1, 2 ] }
       ],
       "place_corpses": [ { "group": "FERAL_HUMANS", "x": 7, "y": 42 } ],
       "vehicles": {


### PR DESCRIPTION
#### Summary
Nerf farm supply store

#### Purpose of change
The farm supply store was hugely overloaded with basically everything a survivor could want. Being outside of town, it was limited to having only the monsters that spawned inside of it, which posed little threat to even a modestly prepared character.

#### Describe the solution
- Severely reduce the spawns for all loot, going a bit easier on the actual farming tools and supplies - as a rule, a player should usually expect to be able to find at least some of the main sorts of things that a store supposedly sold, even if it's been picked over or looted.
- Add mad militia to both the regular and looted variants of the store. This location is remote, so these enemies aren't likely to break containment and wander around town sniping the player or anything.
- Add a bunch of evil crows to the roof.

#### Describe alternatives you've considered
- Even more monsters?
- A more rinky-dink version of the store might also be good. Something that was just like, some tractors, parts, a couple of bins of seed corn and fodder, and some hand tools.

#### Testing
- Spawned in and visited a couple of the stores. It all looks good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
