### PR TITLE
Nerf learning from reach attacks

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10664,14 +10664,14 @@ bool Character::sees_with_infrared( const Creature &critter ) const
         // Return false if the critter is covered by something adjacent to it.
         if( critter.is_monster() && IR_concealment > critter.as_monster()->eye_level() ) {
             return false;
-        // Check ledge concealment as normal.
+            // Check ledge concealment as normal.
         } else if( !critter.is_monster() && IR_concealment > critter.as_character()->eye_level() ) {
             return false;
         } else {
             // If we can see over their coverage, let's make sure we can see over our own.
             const int viewer_IR_concealment = here.obstacle_coverage( critter.pos_bub(), viewer_pov );
             if( viewer_IR_concealment > eye_level() ) {
-            return false;
+                return false;
             }
         }
         return true;

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1915,8 +1915,8 @@ void map::monster_in_field( monster &z )
             mod_field_intensity( z.pos(), cur.get_field_type(), -1 );
         }
         if( cur_field_type == fd_sludge ) {
-                z.mod_moves( -cur.get_field_intensity() * 300 );
-                cur.set_field_intensity( 0 );
+            z.mod_moves( -cur.get_field_intensity() * 300 );
+            cur.set_field_intensity( 0 );
         }
         if( cur_field_type == fd_fire ) {
             // TODO: MATERIALS Use fire resistance
@@ -1988,7 +1988,8 @@ void map::monster_in_field( monster &z )
                     }
                 }
                 // Cyborg monsters ignore it because of the protective lenses CBM.
-                if( z.has_flag( mon_flag_SEES ) && z.made_of_any( Creature::cmat_flesh ) && !z.in_species( species_INSECT ) &&
+                if( z.has_flag( mon_flag_SEES ) && z.made_of_any( Creature::cmat_flesh ) &&
+                    !z.in_species( species_INSECT ) &&
                     !z.in_species( species_INSECT_FLYING ) && !z.in_species( species_CENTIPEDE ) &&
                     !z.in_species( species_SPIDER ) && !z.in_species( species_CYBORG ) &&
                     !z.has_effect( effect_blind ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -470,9 +470,16 @@ void Character::roll_all_damage( bool crit, damage_instance &di, bool average,
 }
 
 static void melee_train( Character &you, int lo, int hi, const item &weap,
-                         const attack_vector_id vector )
+                         const attack_vector_id vector, bool reach_attacking )
 {
-    you.practice( skill_melee, std::ceil( rng( lo, hi ) / 2.0 ), hi );
+    // 1/2 learning rate for reach attacks.
+    if( reach_attacking && one_in( 2 ) ) {
+        return;
+    }
+    // Don't train melee if we're not in melee.
+    if( !reach_attacking ) {
+        you.practice( skill_melee, std::ceil( rng( lo, hi ) / 2.0 ), hi );
+    }
 
     float total = 0.f;
 
@@ -732,7 +739,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
         // Practice melee and relevant weapon skill (if any) except when using CQB bionic
         if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() ) {
-            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null );
+            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null,
+                         reach_attacking );
         }
 
         // Cap stumble penalty, heavy weapons are quite weak already
@@ -914,7 +922,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
             // Practice melee and relevant weapon skill (if any) except when using CQB bionic
             if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() ) {
-                melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap, vector_id );
+                melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap, vector_id, reach_attacking );
             }
 
             // Treat monster as seen if we see it before or after the attack


### PR DESCRIPTION
#### Summary
Nerf learning from reach attacks

#### Purpose of change
- Players simply cannot help themselves from abusing reach attacks. This is a problem when they're often able to make these attacks against enemies who cannot reach them back.
- The melee skill represents up-close fighting, parrying, etc. and should not be learned from reach attacks anyway.

#### Describe the solution
- Reach attacks no longer teach melee.
- 1/2 the rate of learning from reach attacks in general. This will make it so that they don't teach bash/cut/stab "better" than melee attacks by virtue of not simultaneously teaching melee, and also make reach cheese a worse strategy in general.

#### Describe alternatives you've considered
- Remove all teaching from reach attacks: Doesn't super make sense.
- Remove teaching from reach attacks where the enemy can't hit back: Too many corner cases to code for.
- Remove teaching from monsters that have any kind of regeneration: Iffy, but still on the table.

#### Testing
Loaded in, reach attacked a debug monster, saw skill training went poorly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
