### PR TITLE
Climbing is an explosive activity

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11962,7 +11962,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             // TODO: Make it an extended action
             climbing = true;
             climbing_aid = climbing_aid_furn_CLIMBABLE;
-            u.set_activity_level( EXTRA_EXERCISE );
+            u.set_activity_level( EXPLOSIVE_EXERCISE );
             move_cost = cost == 0 ? 1000 : cost + 500;
 
             const std::optional<tripoint> pnt = point_selection_menu( pts );
@@ -11979,7 +11979,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         if( wall_cling && !here.has_floor_or_support( u.pos() ) ) {
             climbing = true;
             climbing_aid = climbing_aid_ability_WALL_CLING;
-            u.set_activity_level( EXTRA_EXERCISE );
+            u.set_activity_level( EXPLOSIVE_EXERCISE );
             u.burn_energy_all( -750 );
             move_cost += 500;
         } else {
@@ -13608,8 +13608,8 @@ void game::climb_down_using( const tripoint &examp, climbing_aid_id aid_id, bool
         }
     }
 
-    you.set_activity_level( ACTIVE_EXERCISE );
-    float weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( ACTIVE_EXERCISE );
+    you.set_activity_level( EXPLOSIVE_EXERCISE );
+    float weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( EXPLOSIVE_EXERCISE );
 
     you.mod_moves( -to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult );
     you.setpos( examp );


### PR DESCRIPTION
#### Summary
Climbing is an explosive activity

#### Purpose of change
Climbing was an extreme activity. It's something that is extremely strenuous IRL, and in-game only takes a couple of seconds to do, which means that like melee it qualifies as an explosive activity. This includes climbing up and down trees, drainpipes, ledges, ropes, and (for mutants) scaling walls. This makes this kind of movement a liiiittle less OP, but shouldn't really throw the brakes on anybody's gameplay.

#### Describe the solution
EXTRA->EXPLOSIVE

#### Testing
![image](https://github.com/user-attachments/assets/7d3faf54-859c-4b1f-a29e-f3bef486d96b)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
