### PR TITLE
Fixing Linux builds

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -82,7 +82,7 @@ jobs:
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-10
+          - compiler: clang++-13
             os: ubuntu-22.04
             tiles: 0
             sound: 0
@@ -94,12 +94,12 @@ jobs:
             pch: 1
             archive-success: basic-build
             dont_skip_data_only_changes: 1
-            title: Basic Build and Test (Clang 10, Ubuntu, Curses)
+            title: Basic Build and Test (Clang oldest supported, Ubuntu, Curses)
             # ~190MB in a clean build
             # ~30MB compressed
             # observed usage: 3.0GB -> 300MB
             ccache_limit: 2G
-            ccache_key: linux-llvm-10-break1
+            ccache_key: linux-llvm-13
 
           - compiler: clang++
             os: macos-13
@@ -241,7 +241,7 @@ jobs:
         CCACHE_FILECLONE: true
         CCACHE_HARDLINK: true
         CCACHE_NOCOMPRESS: true
-        SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
+        SKIP: ${{ ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 13, Ubuntu, Curses)' ) || ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) || ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' ) }}
         SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
     steps:
     - name: checkout repository


### PR DESCRIPTION
#### Summary
Bumped llvm from version 10 to 13, mostly took some changes from DDA, [here](https://github.com/CleverRaven/Cataclysm-DDA/pull/80524)

#### Purpose of change
Recently upgraded to Kubuntu 25.04 and immediatly got a segfault when running `cataclysm-tlg-tiles`. Then I checked if dda had the same issue and it doesn't. 

Thus I looked at tlg with `gdb` and got this:
```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff79709b8 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<true>(char const*, unsigned long) () from /lib/x86_64-linux-gnu/libstdc++.so.6
```
So I suspect fuckery with different versions of `libstdc++6`

#### Describe the solution
Newer versions of llvm/clang link against newer versions of libstdc++6, so I hope the segfault will go away.

#### Describe alternatives you've considered
:disappointed: 

#### Testing
I'm not really familiar with github and I failed to figure out how to run the githubworkflow to compile a test version, sorry if that's a dealbreaker

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
