### PR TITLE
Adjust bad back and light/hollow bones

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1507,11 +1507,11 @@
     "id": "BADBACK",
     "name": { "str": "Bad Back" },
     "points": -3,
-    "description": "You simply cannot carry as much as people with a similar strength could.  Your maximum weight carried is reduced by 35%.",
+    "description": "You simply cannot carry as much as people with a similar strength could.  Your maximum weight carried is reduced by 20%.",
     "starting_trait": true,
     "category": [ "BIRD", "ELFA" ],
     "cancels": [ "STRONGBACK" ],
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.35 } ] } ]
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] } ]
   },
   {
     "type": "mutation",
@@ -2677,7 +2677,7 @@
     "name": { "str": "Light Bones" },
     "points": 2,
     "mixed_effect": true,
-    "description": "Your bones are very light.  This enables you to move and attack 10% faster, but also reduces your carrying weight by 20% and makes bashing attacks hurt a little more.",
+    "description": "Your bones are very light.  This enables you to move and attack more quickly, but limits your weight capacity and makes you vulnerable to bashing damage.",
     "types": [ "BONES" ],
     "category": [ "MOUSE", "RABBIT", "BIRD", "SLIME", "ELFA", "SPIDER", "CHIROPTERAN" ],
     "changes_to": [ "HOLLOW_BONES" ],
@@ -2688,7 +2688,7 @@
           { "value": "EXTRA_BASH", "multiply": 0.4 },
           { "value": "MOVE_COST", "multiply": -0.1 },
           { "value": "ATTACK_SPEED", "multiply": -0.1 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
+          { "value": "CARRY_WEIGHT", "multiply": -0.1 }
         ]
       }
     ]
@@ -6712,7 +6712,7 @@
     "name": { "str": "Hollow Bones" },
     "points": 1,
     "mixed_effect": true,
-    "description": "You have Avian Bone Syndrome--your bones are nearly hollow.  Your body is very light as a result, enabling you to move and attack 20% faster, but also frail; you can carry 40% less, and bashing attacks injure you more.",
+    "description": "Your bones are very light, hollow and partially supported by a network of air sacs connected to your lungs.  You are faster and recover stamina more efficiently as a result, but are vulnerable to blunt force trauma and cannot carry as much.",
     "types": [ "BONES" ],
     "prereqs": [ "LIGHT_BONES" ],
     "category": [ "BIRD", "SLIME", "ELFA" ],
@@ -6720,9 +6720,10 @@
       {
         "values": [
           { "value": "EXTRA_BASH", "multiply": 0.8 },
-          { "value": "MOVE_COST", "multiply": -0.2 },
-          { "value": "ATTACK_SPEED", "multiply": -0.2 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.4 }
+          { "value": "MOVE_COST", "multiply": -0.15 },
+          { "value": "ATTACK_SPEED", "multiply": -0.15 },
+          { "value": "STAMINA_REGEN_MOD", "add": 0.1 },
+          { "value": "CARRY_WEIGHT", "multiply": -0.25 }
         ]
       }
     ]


### PR DESCRIPTION
#### Summary
Adjust bad back and light/hollow bones

#### Purpose of change
Sylvan, Slime, and Avian were getting shafted bad by the carry weight reduction on hollow bones, which was a whopping 40%. Birds and slimes in particular were also getting hit by bad back, which was making even reasonably strong characters unable to really carry anything. This got into "unplayably bad" territory. It can be offset with titanium skeletal bracing, but that shouldn't be a requirement to play these mutations at all!

#### Describe the solution
- Bad Back was a 30% reduction, it is now 20%..
- Light Bones was a 20% reduction, it is now 10%.
- Hollow Bones was a 40% reduction(!), it is now 25%.
- Light and Hollow Bones have had their speed bonuses nerfed to 10% and 15% respectively.
- Hollow Bones now confers a 10% stamina regen buff. This is something birds are specifically very good at IRL thanks to their air sacs and wasn't reflected by any mutations except Rapid Metabolism. In fact, they were WORSE at it than humans because of light eater slowing their metabolism.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
