### PR TITLE
More fun with corpses

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -590,7 +590,9 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
         return;
     }
 
-    if( action == butcher_type::SKIN && ( corpse_item.has_flag( flag_SKINNED ) || corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) || corpse_item.has_flag( flag_GIBBED ) ) ) {
+    if( action == butcher_type::SKIN && ( corpse_item.has_flag( flag_SKINNED ) ||
+                                          corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) ||
+                                          corpse_item.has_flag( flag_GIBBED ) ) ) {
         you.add_msg_if_player( m_info, _( "The corpse no longer has a salvageable skin." ) );
         act.targets.pop_back();
         return;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8671,7 +8671,7 @@ bool item::ready_to_revive( map &here, const tripoint &pos ) const
     if( here.veh_at( pos ) ) {
         return false;
     }
-    if( !calendar::once_every( 361_seconds ) ) {
+    if( !calendar::once_every( 1_seconds ) ) {
         return false;
     }
     int age_in_hours = to_hours<int>( age() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8659,7 +8659,8 @@ bool item::can_revive() const
            damage() < max_damage() &&
            !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
               has_flag( flag_QUARTERED ) ||
-              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) );
+              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) || has_flag( flag_GIBBED ) ||
+              has_flag( flag_FROZEN ) );
 }
 
 bool item::ready_to_revive( map &here, const tripoint &pos ) const
@@ -8670,7 +8671,7 @@ bool item::ready_to_revive( map &here, const tripoint &pos ) const
     if( here.veh_at( pos ) ) {
         return false;
     }
-    if( !calendar::once_every( 1_seconds ) ) {
+    if( !calendar::once_every( 361_seconds ) ) {
         return false;
     }
     int age_in_hours = to_hours<int>( age() );


### PR DESCRIPTION
#### Summary
Frozen zombies can't revive, actually prevent dissecting pulped corpses

#### Purpose of change
I tried to make it impossible to dissect pulped or otherwise catastrophically damaged corpses, but I only disabled the activity, not selecting it from the menu. This led to some issues! Also I thought it would be funny if frozen corpses would not revive.

#### Describe the solution
- Prevent frozen corpses from reviving
- Create an "intact" condition and have it negated by skinning, field dressing, quartering, gibbing, or pulping the corpse. Bleeding is OK.

#### Describe alternatives you've considered
HE HAS NO ORGANS
HE HAS NO SKIN
THIS KONG
IS A SKELETON

#### Testing
![image](https://github.com/user-attachments/assets/a6a0b8ee-749f-4b92-aae3-4113cdd0e82c)
![image](https://github.com/user-attachments/assets/e1e4fa3c-054a-4acd-9b14-23e0cf2ca63e)

#### Additional context
It's possible that if you leave a corpse in deep freeze for more than a day it will wake up the split second it thaws because its timer keeps running. This is funny and inconsequential enough that I don't care about it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
