### PR TITLE
Try not to go insane while fixing corpses yet again

### DIFF
--- a/data/json/butchery_requirements.json
+++ b/data/json/butchery_requirements.json
@@ -27,7 +27,7 @@
           "QUARTER": "field_dress",
           "SKIN": "field_dress",
           "DISSECT": "dissect_small",
-          "FULL": "butchery_small",
+          "FULL": "full_butchery_large",
           "QUICK": "butchery_small",
           "BLEED": "bleed_small"
         },
@@ -74,7 +74,7 @@
           "QUARTER": "field_dress_no_surface",
           "SKIN": "field_dress_no_surface",
           "DISSECT": "dissect_small_no_surface",
-          "FULL": "butchery_small_no_surface",
+          "FULL": "full_butchery_large_no_surface",
           "QUICK": "butchery_small_no_surface",
           "BLEED": "bleed_small"
         },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1902,7 +1902,8 @@ void activity_handlers::pulp_do_turn( player_activity *act, Character *you )
             // Increase damage as we keep smashing ensuring we eventually smash the target.
             if( x_in_y( pulp_power, corpse.volume() / units::legacy_volume_factor ) ) {
                 corpse.inc_damage();
-                if( corpse.damage() == corpse.max_damage() ) {
+                if( corpse.damage() >= corpse.max_damage() && !corpse.has_flag( flag_PULPED ) ) {
+                    corpse.set_flag( flag_PULPED );
                     num_corpses++;
                 }
             }
@@ -1948,6 +1949,7 @@ void activity_handlers::pulp_do_turn( player_activity *act, Character *you )
                 return;
             }
         }
+        // This set_flag usually doesn't run, but I'll leave it here for corner cases.
         corpse.set_flag( flag_PULPED );
     }
     // If we reach this, all corpses have been pulped, finish the activity

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -983,8 +983,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( corpse_item->has_flag( flag_QUARTERED ) ) {
         monster_weight *= 0.95;
     }
-    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) ) {
-        monster_weight = std::round( 0.65 * monster_weight );
+    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) || corpse_item->damage() >= corpse_item->max_damage() ) {
+        monster_weight = std::round( 0.4 * monster_weight );
         if( action != butcher_type::FIELD_DRESS ) {
             you.add_msg_if_player( m_bad,
                                    _( "You salvage what you can from the corpse, but it is badly damaged." ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9315,6 +9315,7 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         if( dead_mon ) {
             for( const harvest_entry &entry : dead_mon->harvest.obj() ) {
                 if( entry.type == harvest_drop_skin && !( corpses[index]->has_flag( flag_SKINNED ) ||
+                        corpses[index]->damage() >= corpses[index]->max_damage() ||
                         ( corpses[index]->has_flag( flag_QUARTERED ) ) || ( corpses[index]->has_flag( flag_PULPED ) ) ||
                         ( corpses[index]->has_flag( flag_GIBBED ) ) ) ) {
                     has_skin = true;
@@ -9333,6 +9334,7 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                     has_blood = true;
                 }
                 if( !( corpses[index]->has_flag( flag_QUARTERED ) ||
+                       corpses[index]->damage() >= corpses[index]->max_damage() ||
                        corpses[index]->has_flag( flag_FIELD_DRESS ) ||
                        corpses[index]->has_flag( flag_FIELD_DRESS_FAILED ) ||
                        ( corpses[index]->has_flag( flag_SKINNED ) ) || ( corpses[index]->has_flag( flag_PULPED ) ) ||

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -558,8 +558,8 @@ bool mattack::eat_carrion( monster *z )
                 z->amount_eaten < z->stomach_size &&
                 ( item.made_of( material_flesh ) || item.made_of( material_iflesh ) ||
                   item.made_of( material_hflesh ) || item.made_of( material_veggy ) ) ) {
-                item.mod_damage( 700 );
-                if( item.damage() >= item.max_damage() && item.can_revive() ) {
+                item.mod_damage( 750 );
+                if( item.damage() >= item.max_damage() ) {
                     item.set_flag( flag_PULPED );
                 }
                 z->amount_eaten += 100;


### PR DESCRIPTION
#### Summary
Try not to go insane while fixing corpses yet again

#### Purpose of change
There was an existing DDA bug which was causing corpses to skip getting the PULPED flag applied to them during smashing sometimes. This threw my changes in the last few PRs into disarray, but we're all good now.

#### Describe the solution
- Properly apply the PULPED flag
- Add secondary checks for corpse damage, just in case
- Make human-sized corpses require a proper setup for full butchery (but not for bleeding)
- Dramatically reduce the meat yield from pulped corpses
- Slightly increase the damage done by monattack::eat_carrion() and verify that it's properly applying flags

#### Testing
- Smash corpses, attempt to butcher them

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
