### PR TITLE
Backport 75077 for typification (and fix cover)

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -733,7 +733,7 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p )
     tripoint_bub_ms player_pos = get_player_character().pos_bub();
     switch( action ) {
         case ACTION_OPEN:
-            return here.open_door( get_avatar(), p.raw(), !here.is_outside( player_pos ), true );
+            return here.open_door( get_avatar(), p, !here.is_outside( player_pos ), true );
         case ACTION_CLOSE: {
             const optional_vpart_position vp = here.veh_at( p );
             return ( vp &&

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4872,7 +4872,7 @@ void reload_activity_actor::finish( player_activity &act, Character &who )
             loc.carrier()->add_msg_if_player( m_neutral,
                                               _( "The %s no longer fits in your inventory so you drop it instead." ),
                                               reloadable_name );
-            get_map().add_item_or_charges( loc.position(), reloadable );
+            get_map().add_item_or_charges( loc.pos_bub(), reloadable );
             loc.remove_item();
             break;
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -983,7 +983,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( corpse_item->has_flag( flag_QUARTERED ) ) {
         monster_weight *= 0.95;
     }
-    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) || corpse_item->damage() >= corpse_item->max_damage() ) {
+    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) ||
+        corpse_item->damage() >= corpse_item->max_damage() ) {
         monster_weight = std::round( 0.4 * monster_weight );
         if( action != butcher_type::FIELD_DRESS ) {
             you.add_msg_if_player( m_bad,
@@ -1211,7 +1212,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, corpse_item, you );
                 for( item &obj : objs ) {
-                    here.add_item_or_charges( you.pos(), obj );
+                    here.add_item_or_charges( you.pos_bub(), obj );
                 }
             } else {
                 item obj( drop, calendar::turn );
@@ -1232,7 +1233,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                     obj.set_var( "activity_var", you.name );
                 }
                 for( int i = 0; i != roll; ++i ) {
-                    here.add_item_or_charges( you.pos(), obj );
+                    here.add_item_or_charges( you.pos_bub(), obj );
                 }
             }
             you.add_msg_if_player( m_good, _( "You harvest: %s" ), drop->nname( roll ) );
@@ -1273,7 +1274,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 ruined_parts.set_var( "activity_var", you.name );
             }
             for( int i = 0; i < item_charges; ++i ) {
-                here.add_item_or_charges( you.pos(), ruined_parts );
+                here.add_item_or_charges( you.pos_bub(), ruined_parts );
             }
         }
     }
@@ -1298,9 +1299,9 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 //~ %1$s - item name, %2$s - monster name
                 you.add_msg_if_player( m_good, _( "You discover a %1$s in the %2$s!" ), content->tname(),
                                        corpse_item->get_mtype()->nname() );
-                here.add_item_or_charges( you.pos(), *content );
+                here.add_item_or_charges( you.pos_bub(), *content );
             } else if( content->is_bionic() ) {
-                here.spawn_item( you.pos(), itype_burnt_out_bionic, 1, 0, calendar::turn );
+                here.spawn_item( you.pos_bub(), itype_burnt_out_bionic, 1, 0, calendar::turn );
             }
         }
     }
@@ -1316,7 +1317,7 @@ static void butchery_quarter( item *corpse_item, const Character &you )
                            _( "You roughly slice the corpse of %s into four parts and set them aside." ),
                            corpse_item->get_mtype()->nname() );
     map &here = get_map();
-    tripoint pos = you.pos();
+    tripoint_bub_ms pos = you.pos_bub();
 
     // 4 quarters (one exists, add 3, flag does the rest)
     for( int i = 1; i <= 3; i++ ) {
@@ -1818,7 +1819,7 @@ void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    const tripoint pos( here.getlocal( act->placement ) );
+    const tripoint_bub_ms pos( here.bub_from_abs( act->placement ) );
     // Invalidate the activity early to prevent a query from mod_pain()
     act->set_to_null();
     if( you->is_avatar() ) {
@@ -1854,7 +1855,7 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
 void activity_handlers::pulp_do_turn( player_activity *act, Character *you )
 {
     map &here = get_map();
-    const tripoint &pos = here.getlocal( act->placement );
+    const tripoint_bub_ms &pos = here.bub_from_abs( act->placement );
 
     const item_location weapon = you->get_wielded_item();
     int weap_cut = 0;
@@ -1912,18 +1913,18 @@ void activity_handlers::pulp_do_turn( player_activity *act, Character *you )
                 // Splatter some blood around
                 // Splatter a bit more randomly, so that it looks cooler
                 const int radius = mess_radius + x_in_y( pulp_power, 500 ) + x_in_y( pulp_power, 1000 );
-                const tripoint dest( pos + point( rng( -radius, radius ), rng( -radius, radius ) ) );
+                const tripoint_bub_ms dest( pos + point( rng( -radius, radius ), rng( -radius, radius ) ) );
 
                 if( !corpse.has_flag( flag_BLED ) ) {
                     const field_type_id type_blood = ( mess_radius > 1 && x_in_y( pulp_power, 10000 ) ) ?
                                                      corpse.get_mtype()->gibType() :
                                                      corpse.get_mtype()->bloodType();
-                    here.add_splatter_trail( type_blood, pos, dest );
+                    here.add_splatter_trail( type_blood, pos.raw(), dest.raw() );
                 } else {
                     const field_type_id type_blood = ( mess_radius > 1 && x_in_y( pulp_power, 10000 ) ) ?
                                                      corpse.get_mtype()->gibType() :
                                                      fd_null;
-                    here.add_splatter_trail( type_blood, pos, dest );
+                    here.add_splatter_trail( type_blood, pos.raw(), dest.raw() );
                 }
             }
 
@@ -2008,15 +2009,14 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
 void activity_handlers::start_fire_do_turn( player_activity *act, Character *you )
 {
     map &here = get_map();
-    // TODO: fix point types
-    tripoint where = here.getlocal( act->placement );
+    tripoint_bub_ms where = here.bub_from_abs( act->placement );
     if( !here.is_flammable( where ) ) {
         try_fuel_fire( *act, *you, true );
         if( !here.is_flammable( where ) ) {
             if( here.has_field_at( where, fd_fire ) ||
                 here.has_flag_ter( ter_furn_flag::TFLAG_USABLE_FIRE, where ) ) {
                 you->add_msg_if_player( m_info, _( "It's already burning hot there." ) );
-            } else if( !here.is_dry( where ) ) {
+            } else if( !here.is_dry( where.raw() ) ) {
                 you->add_msg_if_player( m_info, _( "You need dry ground to light a fire." ) );
             } else if( here.has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, where ) ) {
                 you->add_msg_if_player( m_info, _( "You can't light a fire in midair." ) );
@@ -3058,8 +3058,9 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                     GROUP_FISH, true );
         const mtype_id fish_mon = random_entry_ref( fish_group );
-        here.add_item_or_charges( you->pos(), item::make_corpse( fish_mon, calendar::turn + rng( 0_turns,
-                                  3_hours ) ) );
+        here.add_item_or_charges( you->pos_bub(), item::make_corpse( fish_mon,
+                                  calendar::turn + rng( 0_turns,
+                                          3_hours ) ) );
         you->add_msg_if_player( m_good, _( "You caught a %s." ), fish_mon.obj().nname() );
     } else {
         monster *chosen_fish = random_entry( fishables );
@@ -3067,13 +3068,13 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         if( chosen_fish->fish_population <= 0 ) {
             g->catch_a_monster( chosen_fish, you->pos(), you, 50_hours );
         } else {
-            here.add_item_or_charges( you->pos(), item::make_corpse( chosen_fish->type->id,
+            here.add_item_or_charges( you->pos_bub(), item::make_corpse( chosen_fish->type->id,
                                       calendar::turn + rng( 0_turns,
                                               3_hours ) ) );
             you->add_msg_if_player( m_good, _( "You caught a %s." ), chosen_fish->type->nname() );
         }
     }
-    for( item &elem : here.i_at( you->pos() ) ) {
+    for( item &elem : here.i_at( you->pos_bub() ) ) {
         if( elem.is_corpse() && !elem.has_var( "activity_var" ) ) {
             elem.set_var( "activity_var", you->name );
         }
@@ -3452,7 +3453,7 @@ void activity_handlers::operation_finish( player_activity *act, Character *you )
 void activity_handlers::plant_seed_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    tripoint examp = here.getlocal( act->placement );
+    tripoint_bub_ms examp = here.bub_from_abs( act->placement );
     const itype_id seed_id( act->str_values[0] );
     std::list<item> used_seed;
     if( item::count_by_charges( seed_id ) ) {
@@ -3653,7 +3654,7 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 void activity_handlers::jackhammer_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
-    const tripoint &pos = here.getlocal( act->placement );
+    const tripoint_bub_ms &pos = here.bub_from_abs( act->placement );
 
     here.destroy( pos, true );
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -203,9 +203,9 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
             c.add_msg_player_or_npc(
                 _( "To avoid spilling its contents, you set your %1$s on the %2$s." ),
                 _( "To avoid spilling its contents, <npcname> sets their %1$s on the %2$s." ),
-                it.display_name(), m.name( c.pos() )
+                it.display_name(), m.name( c.pos_bub() )
             );
-            m.add_item_or_charges( c.pos(), it );
+            m.add_item_or_charges( c.pos_bub(), it );
             return true;
         }
     }
@@ -222,7 +222,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     c.invalidate_weight_carried_cache();
     vehicle_part &vp = vpr.part();
     vehicle &veh = vpr.vehicle();
-    const tripoint where = veh.global_part_pos3( vp );
+    const tripoint_bub_ms where = veh.bub_part_pos( vp );
     map &here = get_map();
     int items_did_not_fit_count = 0;
     int into_vehicle_count = 0;
@@ -235,7 +235,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
         }
 
         if( it.made_of( phase_id::LIQUID ) ) {
-            here.add_item_or_charges( c.pos(), it );
+            here.add_item_or_charges( c.pos_bub(), it );
             it.charges = 0;
         }
 
@@ -3531,7 +3531,7 @@ int get_auto_consume_moves( Character &you, const bool food )
                 }
             }
         } else {
-            for( item &it : here.i_at( here.getlocal( loc ) ) ) {
+            for( item &it : here.i_at( here.bub_from_abs( loc ) ) ) {
                 item_location i_loc( map_cursor( here.bub_from_abs( loc ) ), &it );
                 visit_item_contents( i_loc, visit );
             }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -207,27 +207,27 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     }
 
     const bool is_riding = you.is_mounted();
-    tripoint dest_loc;
+    tripoint_bub_ms dest_loc;
     if( d.z == 0 && ( you.has_effect( effect_stunned ) || you.has_effect( effect_psi_stunned ) ) ) {
-        dest_loc.x = rng( you.posx() - 1, you.posx() + 1 );
-        dest_loc.y = rng( you.posy() - 1, you.posy() + 1 );
-        dest_loc.z = you.posz();
+        dest_loc.x() = rng( you.posx() - 1, you.posx() + 1 );
+        dest_loc.y() = rng( you.posy() - 1, you.posy() + 1 );
+        dest_loc.z() = you.posz();
     } else {
-        dest_loc.x = you.posx() + d.x;
-        dest_loc.y = you.posy() + d.y;
-        dest_loc.z = you.posz() + d.z;
+        dest_loc.x() = you.posx() + d.x;
+        dest_loc.y() = you.posy() + d.y;
+        dest_loc.z() = you.posz() + d.z;
     }
 
-    if( dest_loc == you.pos() ) {
+    if( dest_loc == you.pos_bub() ) {
         // Well that sure was easy
         return true;
     }
     bool via_ramp = false;
     if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
-        dest_loc.z += 1;
+        dest_loc.z() += 1;
         via_ramp = true;
     } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest_loc ) ) {
-        dest_loc.z -= 1;
+        dest_loc.z() -= 1;
         via_ramp = true;
     }
 
@@ -239,14 +239,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         if( weapon && weapon->has_flag( flag_DIG_TOOL ) ) {
             if( weapon->type->can_use( "JACKHAMMER" ) &&
                 weapon->ammo_sufficient( &you ) ) {
-                you.invoke_item( &*weapon, "JACKHAMMER", dest_loc );
+                you.invoke_item( &*weapon, "JACKHAMMER", dest_loc.raw() );
                 // don't move into the tile until done mining
-                you.defer_move( dest_loc );
+                you.defer_move( dest_loc.raw() );
                 return true;
             } else if( weapon->type->can_use( "PICKAXE" ) ) {
-                you.invoke_item( &*weapon, "PICKAXE", dest_loc );
+                you.invoke_item( &*weapon, "PICKAXE", dest_loc.raw() );
                 // don't move into the tile until done mining
-                you.defer_move( dest_loc );
+                you.defer_move( dest_loc.raw() );
                 return true;
             }
         }
@@ -259,15 +259,15 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     }
 
     // If the player is *attempting to* move on the X axis, update facing direction of their sprite to match.
-    point new_d( dest_loc.xy() + point( -you.posx(), -you.posy() ) );
+    point_rel_ms new_d( dest_loc.xy().raw() + point_rel_ms( -you.posx(), -you.posy() ) );
 
     if( !g->is_tileset_isometric() ) {
-        if( new_d.x > 0 ) {
+        if( new_d.x() > 0 ) {
             you.facing = FacingDirection::RIGHT;
             if( is_riding ) {
                 you.mounted_creature->facing = FacingDirection::RIGHT;
             }
-        } else if( new_d.x < 0 ) {
+        } else if( new_d.x() < 0 ) {
             you.facing = FacingDirection::LEFT;
             if( is_riding ) {
                 you.mounted_creature->facing = FacingDirection::LEFT;
@@ -304,14 +304,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         // y: left-up key       =>  __ -y       FacingDirection::LEFT
         // down key             =>  -x +y       ______
         //
-        if( new_d.x >= 0 && new_d.y >= 0 ) {
+        if( new_d.x() >= 0 && new_d.y() >= 0 ) {
             you.facing = FacingDirection::RIGHT;
             if( is_riding ) {
                 auto *mons = you.mounted_creature.get();
                 mons->facing = FacingDirection::RIGHT;
             }
         }
-        if( new_d.y <= 0 && new_d.x <= 0 ) {
+        if( new_d.y() <= 0 && new_d.x() <= 0 ) {
             you.facing = FacingDirection::LEFT;
             if( is_riding ) {
                 auto *mons = you.mounted_creature.get();
@@ -327,11 +327,11 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         const tripoint maxp = tripoint( MAPSIZE_X, MAPSIZE_Y, you.posz() );
         for( const tripoint &pt : m.points_in_rectangle( minp, maxp ) ) {
             if( m.ter( pt ) == ter_t_fault ) {
-                int dist = rl_dist( pt, you.pos() );
+                int dist = rl_dist( pt, you.pos_bub().raw() );
                 if( dist < curdist ) {
                     curdist = dist;
                 }
-                dist = rl_dist( pt, dest_loc );
+                dist = rl_dist( pt, dest_loc.raw() );
                 if( dist < newdist ) {
                     newdist = dist;
                 }
@@ -345,7 +345,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
 
     dbg( D_PEDANTIC_INFO ) << "game:plmove: From (" <<
                            you.posx() << "," << you.posy() << "," << you.posz() << ") to (" <<
-                           dest_loc.x << "," << dest_loc.y << "," << dest_loc.z << ")";
+                           dest_loc.x() << "," << dest_loc.y() << "," << dest_loc.z() << ")";
 
     if( g->disable_robot( dest_loc ) ) {
         return false;
@@ -448,7 +448,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     if( veh0 != nullptr && std::abs( veh0->velocity ) > 100 ) {
         if( veh1 == nullptr ) {
             if( query_yn( _( "Dive from moving vehicle?" ) ) ) {
-                g->moving_vehicle_dismount( dest_loc );
+                g->moving_vehicle_dismount( dest_loc.raw() );
             }
             return false;
         } else if( veh1 != veh0 ) {
@@ -468,7 +468,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
     bool fromBoat = veh0 != nullptr;
     bool toBoat = veh1 != nullptr;
     if( is_riding ) {
-        if( !you.check_mount_will_move( dest_loc ) ) {
+        if( !you.check_mount_will_move( dest_loc.raw() ) ) {
             if( you.is_auto_moving() ) {
                 you.clear_destination();
             }
@@ -493,7 +493,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
                 add_msg( m_info, _( "%s to dive underwater." ),
                          press_x( ACTION_MOVE_DOWN ) );
             }
-            avatar_action::swim( get_map(), get_avatar(), dest_loc );
+            avatar_action::swim( get_map(), get_avatar(), dest_loc.raw() );
         }
 
         g->on_move_effects();
@@ -512,14 +512,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         you.add_msg_if_player( _( "You open the %s." ), door_name );
         // if auto move is on, continue moving next turn
         if( you.is_auto_moving() ) {
-            you.defer_move( dest_loc );
+            you.defer_move( dest_loc.raw() );
         }
         return true;
     }
     if( g->walk_move( dest_loc, via_ramp ) ) {
         return true;
     }
-    if( g->phasing_move( dest_loc ) ) {
+    if( g->phasing_move( dest_loc.raw() ) ) {
         return true;
     }
     if( veh_closed_door ) {
@@ -538,7 +538,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         you.mod_moves( -you.get_speed() );
         // if auto move is on, continue moving next turn
         if( you.is_auto_moving() ) {
-            you.defer_move( dest_loc );
+            you.defer_move( dest_loc.raw() );
         }
         return true;
     }
@@ -554,14 +554,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint &d )
         }
         // if auto move is on, continue moving next turn
         if( you.is_auto_moving() ) {
-            you.defer_move( dest_loc );
+            you.defer_move( dest_loc.raw() );
         }
         return true;
     }
 
     // Invalid move
     const bool waste_moves = you.is_blind() || you.has_effect( effect_stunned );
-    if( waste_moves || dest_loc.z != you.posz() ) {
+    if( waste_moves || dest_loc.z() != you.posz() ) {
         add_msg( _( "You bump into the %s!" ), m.obstacle_name( dest_loc ) );
         // Only lose movement if we're blind
         if( waste_moves ) {

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -71,7 +71,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
         return;
     }
 
-    const tripoint &pt = attack.end_point;
+    const tripoint_bub_ms &pt = tripoint_bub_ms( attack.end_point );
 
     if( effects.count( ammo_effect_SHATTER_SELF ) ) {
         // Drop the contents, not the thrown item
@@ -173,7 +173,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
 
         const trap &tr = here.tr_at( pt );
         if( tr.triggered_by_item( dropped_item ) ) {
-            tr.trigger( pt, dropped_item );
+            tr.trigger( pt.raw(), dropped_item );
         }
     }
 }

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -759,7 +759,7 @@ void basecamp::form_crafting_inventory( map &target_map )
     // find available fuel
 
     for( const tripoint_abs_ms &abs_ms_pt : src_set ) {
-        const tripoint &pt = target_map.getlocal( abs_ms_pt );
+        const tripoint_bub_ms &pt = target_map.bub_from_abs( abs_ms_pt );
         if( target_map.accessible_items( pt ) ) {
             for( const item &i : target_map.i_at( pt ) ) {
                 for( basecamp_fuel &bcp_f : fuels ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -899,7 +899,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         //~Sound of a bionic sonic-resonator shaking the area
         sounds::sound( pos(), 30, sounds::sound_t::combat, _( "VRRRRMP!" ), false, "bionic",
                        static_cast<std::string>( bio_resonator ) );
-        for( const tripoint &bashpoint : here.points_in_radius( pos(), 1 ) ) {
+        for( const tripoint_bub_ms &bashpoint : here.points_in_radius( pos_bub(), 1 ) ) {
             here.bash( bashpoint, 110 );
             // Multibash effect, so that doors &c will fall
             here.bash( bashpoint, 110 );
@@ -964,7 +964,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
     } else if( bio.id == bio_water_extractor ) {
         bool no_target = true;
         bool extracted = false;
-        for( item &it : here.i_at( pos() ) ) {
+        for( item &it : here.i_at( pos_bub() ) ) {
             static const units::volume volume_per_water_charge = 500_ml;
             if( it.is_corpse() ) {
                 const int avail = it.get_var( "remaining_water", it.volume() / volume_per_water_charge );
@@ -999,8 +999,8 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         // Don't "snowball" by affecting some items multiple times
         std::vector<std::pair<item, tripoint>> affected;
         const units::mass weight_cap = weight_capacity();
-        for( const tripoint &p : here.points_in_radius( pos(), 10 ) ) {
-            if( p == pos() || !here.has_items( p ) || here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) ) {
+        for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 10 ) ) {
+            if( p == pos_bub() || !here.has_items( p ) || here.has_flag( ter_furn_flag::TFLAG_SEALED, p ) ) {
                 continue;
             }
 
@@ -1008,7 +1008,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             for( auto it = stack.begin(); it != stack.end(); it++ ) {
                 if( it->weight() < weight_cap &&
                     it->made_of_any( affected_materials ) ) {
-                    affected.emplace_back( *it, p );
+                    affected.emplace_back( *it, p.raw() );
                     stack.erase( it );
                     break;
                 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7487,7 +7487,7 @@ bool Character::consume_charges( item &used, int qty )
         if( has_item( used ) ) {
             i_rem( &used );
         } else {
-            map_stack items = get_map().i_at( pos() );
+            map_stack items = get_map().i_at( pos_bub() );
             for( item_stack::iterator iter = items.begin(); iter != items.end(); iter++ ) {
                 if( &( *iter ) == &used ) {
                     iter = items.erase( iter );
@@ -7498,7 +7498,7 @@ bool Character::consume_charges( item &used, int qty )
         return true;
     }
 
-    used.ammo_consume( qty, pos(), this );
+    used.ammo_consume( qty, pos_bub(), this );
     return false;
 }
 
@@ -10325,7 +10325,7 @@ bool Character::crush_frozen_liquid( item_location loc )
                                        hammering_item.tname() );
                     // FIXME: Hardcoded damage type
                     const int smashskill = get_arm_str() + hammering_item.damage_melee( damage_bash );
-                    get_map().bash( loc.position(), smashskill );
+                    get_map().bash( loc.pos_bub(), smashskill );
                 }
             } else {
                 done_crush = false;
@@ -10608,14 +10608,14 @@ void Character::place_corpse()
         }
     }
 
-    here.add_item_or_charges( pos(), body );
+    here.add_item_or_charges( pos_bub(), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
 {
     tinymap bay;
     bay.load( om_target, false );
-    point fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
+    point_omt_ms fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map
     // and essentially select the last one that has no furniture.
@@ -10625,8 +10625,8 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     if( bay.furn( fin ) != furn_str_id::NULL_ID() ) {
         for( const tripoint &p : bay.points_on_zlevel() ) {
             if( bay.furn( p ) == furn_str_id::NULL_ID() ) {
-                fin.x = p.x;
-                fin.y = p.y;
+                fin.x() = p.x;
+                fin.y() = p.y;
             }
         }
     }
@@ -13049,7 +13049,7 @@ void Character::leak_items()
         }
     } else if( weapon.made_of( phase_id::LIQUID ) ) {
         if( weapon.leak( get_map(), this, pos() ) ) {
-            get_map().add_item_or_charges( pos(), weapon );
+            get_map().add_item_or_charges( pos_bub(), weapon );
             removed_items.emplace_back( *this, &weapon );
             add_msg_if_player( m_warning, _( "%s spilled from your hand." ), weapon.tname() );
         }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -251,7 +251,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
     }
     map &here = get_map();
     for( item &remain : worn_remains ) {
-        here.add_item_or_charges( pos(), remain );
+        here.add_item_or_charges( pos_bub(), remain );
     }
     if( armor_destroyed ) {
         drop_invalid_inventory();

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -148,8 +148,8 @@ void Character::try_remove_heavysnare()
             if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 32 ) ) {
                 mon->remove_effect( effect_heavysnare );
                 remove_effect( effect_heavysnare );
-                here.spawn_item( pos(), itype_rope_6 );
-                here.spawn_item( pos(), itype_snare_trigger );
+                here.spawn_item( pos_bub(), itype_rope_6 );
+                here.spawn_item( pos_bub(), itype_snare_trigger );
                 add_msg( _( "The %s escapes the heavy snare!" ), mon->get_name() );
             }
         }
@@ -160,8 +160,8 @@ void Character::try_remove_heavysnare()
                                    _( "<npcname> frees themselves from the heavy snare!" ) );
             item rope( "rope_6", calendar::turn );
             item snare( "snare_trigger", calendar::turn );
-            here.add_item_or_charges( pos(), rope );
-            here.add_item_or_charges( pos(), snare );
+            here.add_item_or_charges( pos_bub(), rope );
+            here.add_item_or_charges( pos_bub(), snare );
         } else {
             add_msg_if_player( m_bad,
                                _( "You try to free yourself from the heavy snare, but can't get loose!" ) );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -147,12 +147,12 @@ void Character::handle_contents_changed( const std::vector<item_location> &conta
             add_msg_player_or_npc(
                 _( "To avoid spilling its contents, you set your %1$s on the %2$s." ),
                 _( "To avoid spilling its contents, <npcname> sets their %1$s on the %2$s." ),
-                loc->display_name(), m.name( pos() )
+                loc->display_name(), m.name( pos_bub() )
             );
             item it_copy( *loc );
             loc.remove_item();
             // target item of `loc` is invalidated and should not be used from now on
-            m.add_item_or_charges( pos(), it_copy );
+            m.add_item_or_charges( pos_bub(), it_copy );
         }
     }
 }
@@ -334,7 +334,7 @@ item_location Character::i_add( item it, bool /* should_stack */, const item *av
     if( added == item_location::nowhere ) {
         if( !allow_wield || !wield( it ) ) {
             if( allow_drop ) {
-                return item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos(), it ) );
+                return item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos_bub(), it ) );
             } else {
                 return added;
             }
@@ -394,7 +394,7 @@ ret_val<item_location> Character::i_add_or_fill( item &it, bool should_stack, co
         if( new_charge >= 1 ) {
             if( !allow_wield || !wield( it ) ) {
                 if( allow_drop ) {
-                    loc = item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos(), it ) );
+                    loc = item_location( map_cursor( pos_bub() ), &get_map().add_item_or_charges( pos_bub(), it ) );
                 }
             } else {
                 loc = item_location( *this, &weapon );
@@ -459,7 +459,7 @@ bool Character::i_add_or_drop( item &it, int qty, const item *avoid,
     for( int i = 0; i < qty; ++i ) {
         drop |= !can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) || !can_pickVolume( it );
         if( drop ) {
-            retval &= !here.add_item_or_charges( pos(), it ).is_null();
+            retval &= !here.add_item_or_charges( pos_bub(), it ).is_null();
             if( !retval ) {
                 // No need to loop now, we already knew that there isn't enough room for the item.
                 break;
@@ -481,7 +481,7 @@ bool Character::i_drop_at( item &it, int qty )
     bool retval = true;
     map &here = get_map();
     for( int i = 0; i < qty; ++i ) {
-        retval &= !here.add_item_or_charges( pos(), it ).is_null();
+        retval &= !here.add_item_or_charges( pos_bub(), it ).is_null();
     }
 
     return retval;
@@ -670,7 +670,7 @@ void Character::drop_invalid_inventory()
         const item &it = stack->front();
         if( it.made_of( phase_id::LIQUID ) ) {
             dropped_liquid = true;
-            get_map().add_item_or_charges( pos(), it );
+            get_map().add_item_or_charges( pos_bub(), it );
             // must be last
             i_rem( &it );
         }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -310,7 +310,7 @@ plot_options::query_seed_result plot_options::query_seed()
     const std::unordered_set<tripoint_abs_ms> zone_src_set =
         mgr.get_near( zone_type_LOOT_SEEDS, here.getglobal( player_character.pos() ), 60 );
     for( const tripoint_abs_ms &elem : zone_src_set ) {
-        tripoint elem_loc = here.getlocal( elem );
+        tripoint_bub_ms elem_loc = here.bub_from_abs( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
                 seed_inv.push_back( &it );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -438,21 +438,23 @@ void computer_session::action_open_disarm()
 void computer_session::action_open()
 {
     get_map().translate_radius( ter_t_door_metal_locked, ter_t_floor, 25.0,
-                                get_player_character().pos(),
+                                get_player_character().pos_bub(),
                                 true );
     query_any( _( "Doors opened.  Press any key…" ) );
 }
 
 void computer_session::action_open_gate()
 {
-    get_map().translate_radius( ter_t_wall_metal, ter_t_metal_floor, 8.0, get_player_character().pos(),
+    get_map().translate_radius( ter_t_wall_metal, ter_t_metal_floor, 8.0,
+                                get_player_character().pos_bub(),
                                 true );
     query_any( _( "Gates opened.  Press any key…" ) );
 }
 
 void computer_session::action_close_gate()
 {
-    get_map().translate_radius( ter_t_metal_floor, ter_t_wall_metal, 8.0, get_player_character().pos(),
+    get_map().translate_radius( ter_t_metal_floor, ter_t_wall_metal, 8.0,
+                                get_player_character().pos_bub(),
                                 true );
     query_any( _( "Gates closed.  Press any key…" ) );
 }
@@ -465,7 +467,7 @@ void computer_session::action_close_gate()
 void computer_session::action_lock()
 {
     get_map().translate_radius( ter_t_door_metal_c, ter_t_door_metal_locked, 8.0,
-                                get_player_character().pos(),
+                                get_player_character().pos_bub(),
                                 true );
     query_any( _( "Lock enabled.  Press any key…" ) );
 }
@@ -479,7 +481,7 @@ void computer_session::action_unlock_disarm()
 void computer_session::action_unlock()
 {
     get_map().translate_radius( ter_t_door_metal_locked, ter_t_door_metal_c, 8.0,
-                                get_player_character().pos(),
+                                get_player_character().pos_bub(),
                                 true );
     query_any( _( "Lock disabled.  Press any key…" ) );
 }
@@ -505,11 +507,11 @@ void computer_session::action_sample()
 {
     get_player_character().mod_moves( -to_moves<int>( 1_seconds ) * 0.3 );
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
         if( here.ter( p ) != ter_t_sewage_pump ) {
             continue;
         }
-        for( const tripoint &n : here.points_in_radius( p, 1 ) ) {
+        for( const tripoint_bub_ms &n : here.points_in_radius( p, 1 ) ) {
             if( here.furn( n ) != furn_f_counter ) {
                 continue;
             }
@@ -542,7 +544,7 @@ void computer_session::action_release()
                    "environment",
                    "alarm" );
     get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 25.0,
-                                player_character.pos(),
+                                player_character.pos_bub(),
                                 true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
 }
@@ -559,7 +561,8 @@ void computer_session::action_release_bionics()
     sounds::sound( player_character.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
                    "environment",
                    "alarm" );
-    get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 3.0, player_character.pos(),
+    get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 3.0,
+                                player_character.pos_bub(),
                                 true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
 }
@@ -795,7 +798,7 @@ void computer_session::action_list_bionics()
     std::vector<std::string> names;
     int more = 0;
     map &here = get_map();
-    for( const tripoint &p : here.points_on_zlevel() ) {
+    for( const tripoint_bub_ms &p : here.bub_points_on_zlevel() ) {
         for( item &elem : here.i_at( p ) ) {
             if( elem.is_bionic() ) {
                 if( static_cast<int>( names.size() ) < TERMY - 8 ) {
@@ -985,7 +988,7 @@ void computer_session::action_blood_anal()
     Character &player_character = get_player_character();
     player_character.mod_moves( -to_moves<int>( 1_seconds ) * 0.7 );
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( player_character.pos(), 2 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 2 ) ) {
         if( here.furn( dest ) == furn_f_centrifuge ) {
             map_stack items = here.i_at( dest );
             if( items.empty() ) {
@@ -1033,7 +1036,7 @@ void computer_session::action_data_anal()
     Character &player_character = get_player_character();
     player_character.mod_moves( -to_moves<int>( 1_seconds ) * 0.3 );
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( player_character.pos(), 2 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 2 ) ) {
         if( here.ter( dest ) == ter_t_floor_blue ) {
             print_error( _( "PROCESSING DATA" ) );
             map_stack items = here.i_at( dest );
@@ -1051,7 +1054,7 @@ void computer_session::action_data_anal()
                 if( items.only_item().typeId() == itype_black_box ) {
                     print_line( _( "Memory Bank: Military Hexron Encryption\nPrinting Transcript\n" ) );
                     item transcript( "black_box_transcript", calendar::turn );
-                    here.add_item_or_charges( player_character.pos(), transcript );
+                    here.add_item_or_charges( player_character.pos_bub(), transcript );
                 } else {
                     print_line( _( "Memory Bank: Unencrypted\nNothing of interest.\n" ) );
                 }
@@ -1263,7 +1266,7 @@ void computer_session::action_irradiator()
     bool error = false;
     bool platform_exists = false;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( player_character.pos(), 10 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 10 ) ) {
         if( here.ter( dest ) == ter_t_rad_platform ) {
             platform_exists = true;
             if( here.i_at( dest ).empty() ) {
@@ -1278,7 +1281,7 @@ void computer_session::action_irradiator()
                     // critical failure - radiation spike sets off electronic detonators
                     if( it->typeId() == itype_mininuke || it->typeId() == itype_mininuke_act ||
                         it->typeId() == itype_c4 ) {
-                        explosion_handler::explosion( &get_player_character(), dest, 40 );
+                        explosion_handler::explosion( &get_player_character(), dest.raw(), 40 );
                         reset_terminal();
                         print_error( _( "WARNING [409]: Primary sensors offline!" ) );
                         print_error( _( "  >> Initialize secondary sensors: Geiger profiling…" ) );
@@ -1290,17 +1293,17 @@ void computer_session::action_irradiator()
                                        "alarm" );
                         here.i_rem( dest, it );
                         here.make_rubble( dest );
-                        here.propagate_field( dest, fd_nuke_gas, 100, 3 );
+                        here.propagate_field( dest.raw(), fd_nuke_gas, 100, 3 );
                         here.translate_radius( ter_t_water_pool, ter_t_sewage, 8.0, dest, true );
                         here.adjust_radiation( dest, rng( 50, 500 ) );
-                        for( const tripoint &radorigin : here.points_in_radius( dest, 5 ) ) {
+                        for( const tripoint_bub_ms &radorigin : here.points_in_radius( dest, 5 ) ) {
                             here.adjust_radiation( radorigin, rng( 50, 500 ) / ( rl_dist( radorigin,
                                                    dest ) > 0 ? rl_dist( radorigin, dest ) : 1 ) );
                         }
                         if( here.pl_sees( dest, 10 ) ) {
-                            player_character.irradiate( rng_float( 50, 250 ) / rl_dist( player_character.pos(), dest ) );
+                            player_character.irradiate( rng_float( 50, 250 ) / rl_dist( player_character.pos_bub(), dest ) );
                         } else {
-                            player_character.irradiate( rng_float( 20, 100 ) / rl_dist( player_character.pos(), dest ) );
+                            player_character.irradiate( rng_float( 20, 100 ) / rl_dist( player_character.pos_bub(), dest ) );
                         }
                         query_any( _( "EMERGENCY SHUTDOWN!  Press any key…" ) );
                         error = true;
@@ -1309,13 +1312,13 @@ void computer_session::action_irradiator()
                         break;
                     }
                     here.adjust_radiation( dest, rng( 20, 50 ) );
-                    for( const tripoint &radorigin : here.points_in_radius( dest, 5 ) ) {
+                    for( const tripoint_bub_ms &radorigin : here.points_in_radius( dest, 5 ) ) {
                         here.adjust_radiation( radorigin, rng( 20, 50 ) / ( rl_dist( radorigin,
                                                dest ) > 0 ? rl_dist( radorigin, dest ) : 1 ) );
                     }
                     // if unshielded, rad source irradiates player directly, reduced by distance to source
                     if( here.pl_sees( dest, 10 ) ) {
-                        player_character.irradiate( rng_float( 5, 25 ) / rl_dist( player_character.pos(), dest ) );
+                        player_character.irradiate( rng_float( 5, 25 ) / rl_dist( player_character.pos_bub(), dest ) );
                     }
                 }
                 if( !error && platform_exists ) {
@@ -1339,21 +1342,21 @@ void computer_session::action_geiger()
 {
     Character &player_character = get_player_character();
     player_character.mod_moves( -to_moves<int>( 1_seconds ) * 0.3 );
-    tripoint platform;
+    tripoint_bub_ms platform;
     bool source_exists = false;
     int sum_rads = 0;
     int peak_rad = 0;
     int tiles_counted = 0;
     map &here = get_map();
     print_error( _( "RADIATION MEASUREMENTS:" ) );
-    for( const tripoint &dest : here.points_in_radius( player_character.pos(), 10 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 10 ) ) {
         if( here.ter( dest ) == ter_t_rad_platform ) {
             source_exists = true;
             platform = dest;
         }
     }
     if( source_exists ) {
-        for( const tripoint &dest : here.points_in_radius( platform, 3 ) ) {
+        for( const tripoint_bub_ms &dest : here.points_in_radius( platform, 3 ) ) {
             sum_rads += here.get_radiation( dest );
             tiles_counted ++;
             if( here.get_radiation( dest ) > peak_rad ) {
@@ -1370,7 +1373,7 @@ void computer_session::action_geiger()
         print_newline();
     }
     print_error( _( "GEIGER COUNTER @ CONSOLE:… %s mSv/h." ),
-                 here.get_radiation( player_character.pos() ) );
+                 here.get_radiation( player_character.pos_bub() ) );
     print_error( _( "PERSONAL DOSIMETRY:… %s mSv." ), player_character.get_rad() );
     print_newline();
     query_any( _( "Press any key…" ) );
@@ -1382,14 +1385,14 @@ void computer_session::action_conveyor()
 {
     Character &player_character = get_player_character();
     player_character.mod_moves( -to_moves<int>( 3_seconds ) );
-    tripoint loading; // red tile = loading bay
-    tripoint unloading; // green tile = unloading bay
-    tripoint platform; // radiation platform = middle point
+    tripoint_bub_ms loading; // red tile = loading bay
+    tripoint_bub_ms unloading; // green tile = unloading bay
+    tripoint_bub_ms platform; // radiation platform = middle point
     bool l_exists = false;
     bool u_exists = false;
     bool p_exists = false;
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( player_character.pos(), 10 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 10 ) ) {
         if( here.ter( dest ) == ter_t_rad_platform ) {
             platform = dest;
             p_exists = true;
@@ -1438,7 +1441,7 @@ void computer_session::action_shutters()
     player_character.mod_moves( -to_moves<int>( 3_seconds ) );
     get_map().translate_radius( ter_t_reinforced_glass_shutter_open, ter_t_reinforced_glass_shutter,
                                 8.0,
-                                player_character.pos(),
+                                player_character.pos_bub(),
                                 true, true );
     query_any( _( "Toggling shutters.  Press any key…" ) );
 }
@@ -1449,10 +1452,10 @@ void computer_session::action_extract_rad_source()
     Character &player_character = get_player_character();
     if( query_yn( _( "Operation irreversible.  Extract radioactive material?" ) ) ) {
         player_character.mod_moves( -to_moves<int>( 3_seconds ) );
-        tripoint platform;
+        tripoint_bub_ms platform;
         bool p_exists = false;
         map &here = get_map();
-        for( const tripoint &dest : here.points_in_radius( player_character.pos(), 10 ) ) {
+        for( const tripoint_bub_ms &dest : here.points_in_radius( player_character.pos_bub(), 10 ) ) {
             if( here.ter( dest ) == ter_t_rad_platform ) {
                 platform = dest;
                 p_exists = true;
@@ -1460,7 +1463,7 @@ void computer_session::action_extract_rad_source()
         }
         if( p_exists ) {
             here.spawn_item( platform, itype_cobalt_60, rng( 8, 15 ) );
-            here.translate_radius( ter_t_rad_platform, ter_t_concrete, 8.0, player_character.pos(), true );
+            here.translate_radius( ter_t_rad_platform, ter_t_concrete, 8.0, player_character.pos_bub(), true );
             comp.remove_option( COMPACT_IRRADIATOR );
             comp.remove_option( COMPACT_EXTRACT_RAD_SOURCE );
             query_any( _( "Extraction sequence complete…  Press any key." ) );
@@ -1654,7 +1657,7 @@ void computer_session::failure_destroy_blood()
 {
     print_error( _( "ERROR: Disruptive Spin" ) );
     map &here = get_map();
-    for( const tripoint &dest : here.points_in_radius( get_player_character().pos(), 2 ) ) {
+    for( const tripoint_bub_ms &dest : here.points_in_radius( get_player_character().pos_bub(), 2 ) ) {
         if( here.furn( dest ) == furn_f_centrifuge ) {
             map_stack items = here.i_at( dest );
             if( items.empty() ) {
@@ -1681,7 +1684,7 @@ void computer_session::failure_destroy_data()
 {
     print_error( _( "ERROR: ACCESSING DATA MALFUNCTION" ) );
     map &here = get_map();
-    for( const tripoint &p : here.points_in_radius( get_player_character().pos(), 2 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( get_player_character().pos_bub(), 2 ) ) {
         if( here.ter( p ) == ter_t_floor_blue ) {
             map_stack items = here.i_at( p );
             if( items.empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1822,7 +1822,7 @@ static void unroll_digging( const int numer_of_2x4s )
     // refund components!
     item rope( "rope_30" );
     map &here = get_map();
-    tripoint avatar_pos = get_player_character().pos();
+    tripoint_bub_ms avatar_pos = get_player_character().pos_bub();
     here.add_item_or_charges( avatar_pos, rope );
     // presuming 2x4 to conserve lumber.
     here.spawn_item( avatar_pos, itype_2x4, numer_of_2x4s );
@@ -1877,13 +1877,11 @@ void construct::done_dig_grave( const tripoint_bub_ms &p, Character &who )
             { mon_zombie, mon_zombie_fat, mon_zombie_rot, mon_skeleton, mon_zombie_crawler }
         };
 
-        // TODO: fix point types
-        g->place_critter_at( random_entry( monids ), p.raw() );
+        g->place_critter_at( random_entry( monids ), p );
         here.furn_set( p, furn_f_coffin_o );
         who.add_msg_if_player( m_warning, _( "Something crawls out of the coffin!" ) );
     } else {
-        // TODO: fix point types
-        here.spawn_item( p.raw(), itype_bone_human, rng( 5, 15 ) );
+        here.spawn_item( p, itype_bone_human, rng( 5, 15 ) );
         here.furn_set( p, furn_f_coffin_c );
     }
     std::vector<item *> dropped =
@@ -1958,7 +1956,7 @@ void construct::done_wood_stairs( const tripoint_bub_ms &p, Character &/*who*/ )
 void construct::done_window_curtains( const tripoint_bub_ms &, Character &who )
 {
     map &here = get_map();
-    tripoint avatar_pos = who.pos();
+    tripoint_bub_ms avatar_pos = who.pos_bub();
     // copied from iexamine::curtains
     here.spawn_item( avatar_pos, itype_nail, 1, 4 );
     here.spawn_item( avatar_pos, itype_sheet, 2 );

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -90,3 +90,8 @@ tripoint_bub_ms rebase_bub( tripoint_omt_ms p )
 {
     return tripoint_bub_ms( p.raw() );
 }
+
+tripoint_omt_ms rebase_omt( tripoint_bub_ms p )
+{
+    return tripoint_omt_ms( p.raw() );
+}

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -674,6 +674,7 @@ tripoint_bub_ms rebase_bub( tripoint_rel_ms p );
 // as the reference remains the same location regardless, and the map operation still knows how large the map is.
 point_bub_ms rebase_bub( point_omt_ms p );
 tripoint_bub_ms rebase_bub( tripoint_omt_ms p );
+tripoint_omt_ms rebase_omt( tripoint_bub_ms p );
 
 template<typename Point, coords::origin Origin, coords::scale Scale, bool LhsInBounds, bool RhsInBounds>
 inline int square_dist( const coords::coord_point<Point, Origin, Scale, LhsInBounds> &loc1,

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -287,7 +287,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         };
 
         const char *liq_cont_msg = _( "%1$s is not empty.  Continue anyway?" );
-        std::vector<std::pair<const tripoint, item>> map_items;
+        std::vector<std::pair<const tripoint_bub_ms, item>> map_items;
         std::vector<std::pair<const vpart_reference, item>> veh_items;
         std::vector<item> inv_items;
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -784,7 +784,7 @@ static item_location set_item_inventory( Character &p, item &newit )
 static item_location set_item_map( const tripoint &loc, item &newit )
 {
     // Includes loc
-    for( const tripoint &tile : closest_points_first( loc, 2 ) ) {
+    for( const tripoint_bub_ms &tile : closest_points_first( tripoint_bub_ms( loc ), 2 ) ) {
         // Pass false to disallow overflow, null_item_reference indicates failure.
         item *it_on_map = &get_map().add_item_or_charges( tile, newit, false );
         if( it_on_map != &null_item_reference() ) {
@@ -2743,7 +2743,7 @@ void Character::disassemble_all( bool one_pass )
 
     bool found_any = false;
     std::vector<item_location> to_disassemble;
-    for( item &it : get_map().i_at( pos() ) ) {
+    for( item &it : get_map().i_at( pos_bub() ) ) {
         to_disassemble.emplace_back( map_cursor( pos_bub() ), &it );
     }
     for( item_location &it_loc : to_disassemble ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1578,7 +1578,8 @@ static void spawn_artifact()
                 if( query_yn( _( "Is the artifact resonant?" ) ) ) {
                     artifact_is_resonant = true;
                 }
-                here.spawn_artifact( *center, relic_list[relic_menu.ret], artifact_max_attributes,
+                here.spawn_artifact( tripoint_bub_ms( *center ), relic_list[relic_menu.ret],
+                                     artifact_max_attributes,
                                      artifact_power_level, artifact_max_negative_value, artifact_is_resonant );
             }
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2574,7 +2574,7 @@ void basecamp::start_setup_hide_site( const mission_id &miss_id, float exertion_
     }
 }
 
-static const tripoint relay_site_stash = tripoint( 11, 10, 0 );
+static const tripoint_omt_ms relay_site_stash{ 11, 10, 0 };
 
 void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_level )
 {
@@ -2603,7 +2603,7 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
         units::volume total_import_volume;
         units::mass total_import_mass;
 
-        drop_locations gaining_equipment = get_equipment( &target_bay, relay_site_stash, pc, preset,
+        drop_locations gaining_equipment = get_equipment( &target_bay, relay_site_stash.raw(), pc, preset,
                                            _( "These are the items you've selected so far." ), _( "Select items to bring back" ),
                                            total_import_volume, total_import_mass );
 
@@ -3465,12 +3465,12 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
     farm_map.load( omt_tgt, false );
     // farm_json is what the area should look like according to jsons (loaded on demand)
     std::unique_ptr<small_fake_map> farm_json;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
+    tripoint_omt_ms mapmin{ 0, 0, omt_tgt.z() };
+    tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() };
     bool done_planting = false;
     Character &player_character = get_player_character();
     map &here = get_map();
-    for( const tripoint &pos : farm_map.points_in_rectangle( mapmin, mapmax ) ) {
+    for( const tripoint_omt_ms &pos : farm_map.points_in_rectangle( mapmin, mapmax ) ) {
         if( done_planting ) {
             break;
         }
@@ -3517,7 +3517,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                     }
                 }
                 // Needs to be plowed to match json
-                if( is_dirtmound( pos, *farm_json, farm_map ) && is_unplowed( pos, farm_map ) ) {
+                if( is_dirtmound( pos.raw(), *farm_json, farm_map ) && is_unplowed( pos.raw(), farm_map ) ) {
                     plots_cnt += 1;
                     if( comp ) {
                         farm_map.ter_set( pos, ter_t_dirtmound );
@@ -3526,7 +3526,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                 break;
             }
             case farm_ops::plant:
-                if( is_dirtmound( pos, farm_map, farm_map ) ) {
+                if( is_dirtmound( pos.raw(), farm_map, farm_map ) ) {
                     plots_cnt += 1;
                     if( comp ) {
                         if( seed_inv.empty() ) {
@@ -3570,7 +3570,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point &dir, farm_ops
                             int seed_cnt = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
                             for( item &i : iexamine::get_harvest_items( *seed->type, plant_count,
                                     seed_cnt, true ) ) {
-                                here.add_item_or_charges( player_character.pos(), i );
+                                here.add_item_or_charges( player_character.pos_bub(), i );
                             }
                             farm_map.i_clear( pos );
                             farm_map.furn_set( pos, furn_str_id::NULL_ID() );
@@ -4752,9 +4752,9 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
     target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() + 1 );
-    for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
+    tripoint_omt_ms mapmin{ 0, 0, omt_tgt.z() };
+    tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() + 1 };
+    for( const tripoint_omt_ms &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.ter( p ).obj().has_flag( ter_furn_flag::TFLAG_TREE ) && rng( 0, 100 ) < chance ) {
             total++;
             if( estimate ) {
@@ -4776,7 +4776,7 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
         return harvested;
     }
     // having cut down the trees, cut the trunks into logs
-    for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
+    for( const tripoint_omt_ms &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         if( target_bay.ter( p ) == ter_t_trunk || target_bay.ter( p ) == ter_t_stump ) {
             target_bay.ter_set( p, ter_t_dirt );
             target_bay.spawn_item( p, itype_log, rng( 2, 3 ), 0, calendar::turn );
@@ -4798,9 +4798,10 @@ mass_volume om_harvest_itm( const npc_ptr &comp, const tripoint_abs_omt &omt_tgt
     units::volume total_v = 0_ml;
     int total_num = 0;
     int harvested_num = 0;
-    tripoint mapmin = tripoint( 0, 0, omt_tgt.z() );
-    tripoint mapmax = tripoint( 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() );
-    for( const tripoint &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
+    tripoint_omt_ms mapmin{ 0, 0, omt_tgt.z() };
+    tripoint_omt_ms mapmax{ 2 * SEEX - 1, 2 * SEEY - 1, omt_tgt.z() };
+    tripoint_range<tripoint_omt_ms> xxx = target_bay.points_in_rectangle( mapmin, mapmax );
+    for( const tripoint_omt_ms &p : target_bay.points_in_rectangle( mapmin, mapmax ) ) {
         for( const item &i : target_bay.i_at( p ) ) {
             if( !i.made_of_from_type( phase_id::LIQUID ) ) {
                 total_m += i.weight( true );
@@ -5643,7 +5644,7 @@ bool basecamp::distribute_food()
     };
     for( const tripoint_abs_ms &p_food_stock_abs : z_food ) {
         // @FIXME: this will not handle zones in vehicle
-        const tripoint p_food_stock = here.getlocal( p_food_stock_abs );
+        const tripoint_bub_ms p_food_stock = here.bub_from_abs( p_food_stock_abs );
         map_stack items = here.i_at( p_food_stock );
         for( auto iter = items.begin(); iter != items.end(); ) {
             if( consume( *iter, nullptr ) ) {
@@ -5837,7 +5838,7 @@ void basecamp::place_results( const item &result )
 {
     map &target_bay = get_camp_map();
     form_storage_zones( target_bay, bb_pos );
-    tripoint new_spot = target_bay.getlocal( get_dumping_spot() );
+    tripoint_bub_ms new_spot = target_bay.bub_from_abs( get_dumping_spot() );
     // Special handling for liquids
     // find any storage-zoned LIQUIDCONT we can dump them in, set that as the item's destination instead
     if( result.made_of( phase_id::LIQUID ) ) {
@@ -5845,8 +5846,8 @@ void basecamp::place_results( const item &result )
             // No items at a potential spot? Set the destination there and stop checking.
             // We could check if the item at the tile are the same as the item we're placing, but liquids of the same typeid
             // don't always mix depending on their components...
-            if( target_bay.i_at( target_bay.getlocal( potential_spot ) ).empty() ) {
-                new_spot = target_bay.getlocal( potential_spot );
+            if( target_bay.i_at( target_bay.bub_from_abs( potential_spot ) ).empty() ) {
+                new_spot = target_bay.bub_from_abs( potential_spot );
                 break;
             }
             // We've processed the last spot and haven't found anywhere to put it, we'll end up using dumping_spot.
@@ -5857,14 +5858,15 @@ void basecamp::place_results( const item &result )
         }
     }
     target_bay.add_item_or_charges( new_spot, result, true );
-    apply_camp_ownership( target_bay, new_spot, 10 );
+    apply_camp_ownership( target_bay, new_spot.raw(), 10 );
     target_bay.save();
 }
 
 void apply_camp_ownership( map &here, const tripoint &camp_pos, int radius )
 {
-    for( const tripoint &p : here.points_in_rectangle( camp_pos + point( -radius, -radius ),
-            camp_pos + point( radius, radius ) ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_rectangle( tripoint_bub_ms( camp_pos ) + point(
+                -radius, -radius ),
+            tripoint_bub_ms( camp_pos ) + point( radius, radius ) ) ) {
         map_stack items = here.i_at( p.xy() );
         for( item &elem : items ) {
             elem.set_owner( get_player_character() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7776,15 +7776,15 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
         return ret;
     }
 
-    for( tripoint &points_p_it : closest_points_first( u.pos(), iRadius ) ) {
-        if( points_p_it.y >= u.posy() - iRadius && points_p_it.y <= u.posy() + iRadius &&
+    for( tripoint_bub_ms &points_p_it : closest_points_first( u.pos_bub(), iRadius ) ) {
+        if( points_p_it.y() >= u.posy() - iRadius && points_p_it.y() <= u.posy() + iRadius &&
             u.sees( points_p_it ) &&
             m.sees_some_items( points_p_it, u ) ) {
 
             for( item &elem : m.i_at( points_p_it ) ) {
-                const tripoint relative_pos = points_p_it - u.pos();
+                const tripoint_rel_ms relative_pos = points_p_it - u.pos_bub();
 
-                add_item_recursive( item_order, temp_items, &elem, relative_pos );
+                add_item_recursive( item_order, temp_items, &elem, relative_pos.raw() );
             }
         }
     }
@@ -9430,7 +9430,7 @@ void game::butcher()
     std::vector<map_stack::iterator> corpses;
     std::vector<map_stack::iterator> disassembles;
     std::vector<map_stack::iterator> salvageables;
-    map_stack items = m.i_at( u.pos() );
+    map_stack items = m.i_at( u.pos_bub() );
     const inventory &crafting_inv = u.crafting_inventory();
 
     // TODO: Properly handle different material whitelists
@@ -10872,7 +10872,7 @@ point game::place_player( const tripoint &dest_loc, bool quick )
             u.max_quality( qual_BUTCHER, PICKUP_RANGE ) > INT_MIN ) {
             std::vector<item *> corpses;
 
-            for( item &it : m.i_at( u.pos() ) ) {
+            for( item &it : m.i_at( u.pos_bub() ) ) {
                 corpses.push_back( &it );
             }
 
@@ -10885,7 +10885,7 @@ point game::place_player( const tripoint &dest_loc, bool quick )
         } else if( pulp_butcher == "pulp" || pulp_butcher == "pulp_adjacent" ||
                    pulp_butcher == "pulp_zombie_only" || pulp_butcher == "pulp_adjacent_zombie_only" ) {
             const bool acid_immune = u.is_immune_damage( damage_acid ) || u.is_immune_field( fd_acid );
-            const auto pulp = [&]( const tripoint & pos ) {
+            const auto pulp = [&]( const tripoint_bub_ms & pos ) {
                 for( const item &maybe_corpse : m.i_at( pos ) ) {
                     if( maybe_corpse.is_corpse() && maybe_corpse.can_revive() &&
                         ( !maybe_corpse.get_mtype()->bloodType().obj().has_acid || acid_immune ) ) {
@@ -10907,10 +10907,10 @@ point game::place_player( const tripoint &dest_loc, bool quick )
 
             if( pulp_butcher == "pulp_adjacent" || pulp_butcher == "pulp_adjacent_zombie_only" ) {
                 for( const direction &elem : adjacentDir ) {
-                    pulp( u.pos() + displace_XY( elem ) );
+                    pulp( u.pos_bub() + displace_XY( elem ) );
                 }
             } else {
-                pulp( u.pos() );
+                pulp( u.pos_bub() );
             }
         }
     }
@@ -11236,7 +11236,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
 {
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
-    tripoint fpos = ( u.pos_bub() + u.grab_point ).raw();
+    tripoint_bub_ms fpos = ( u.pos_bub() + u.grab_point );
     // supposed position of grabbed furniture
     if( !m.has_furn( fpos ) ) {
         // Where did it go? We're grabbing thin air so reset.
@@ -11258,11 +11258,11 @@ bool game::grabbed_furn_move( const tripoint &dp )
     const bool shifting_furniture = !pushing_furniture && !pulling_furniture;
 
     // Intended destination of furniture.
-    const tripoint fdest = fpos + tripoint( dp.xy(), ramp_z_offset );
+    const tripoint_bub_ms fdest = fpos + tripoint( dp.xy(), ramp_z_offset );
 
     // Unfortunately, game::is_empty fails for tiles we're standing on,
     // which will forbid pulling, so:
-    const bool canmove = can_move_furniture( fdest, dp );
+    const bool canmove = can_move_furniture( fdest.raw(), dp );
     // @TODO: it should be possible to move over invisible traps. This should probably
     // trigger the trap.
     // The current check (no move if trap) allows a player to detect invisible traps by
@@ -11362,7 +11362,7 @@ bool game::grabbed_furn_move( const tripoint &dp )
     if( fire_intensity == 1 && !pulling_furniture ) {
         m.remove_field( fpos, fd_fire );
         m.set_field_intensity( fdest, fd_fire, fire_intensity );
-        m.set_field_age( fdest, fd_fire, fire_age );
+        m.set_field_age( fdest.raw(), fd_fire, fire_age );
     }
 
     // Is there is only liquids on the ground, remove them after moving furniture.
@@ -11391,10 +11391,10 @@ bool game::grabbed_furn_move( const tripoint &dp )
     }
 
     if( !m.has_floor_or_water( fdest ) && !m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ) {
-        std::string danger_tile = enumerate_as_string( get_dangerous_tile( fdest ) );
+        std::string danger_tile = enumerate_as_string( get_dangerous_tile( fdest.raw() ) );
         add_msg( _( "You let go of the %1$s as it falls down the %2$s." ), furntype.name(), danger_tile );
         u.grab( object_type::NONE );
-        m.drop_furniture( fdest );
+        m.drop_furniture( fdest.raw() );
         return true;
     }
 
@@ -11780,9 +11780,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     bool climbing = false;
     climbing_aid_id climbing_aid = climbing_aid_default;
     int move_cost = 100;
-    tripoint stairs( u.posx(), u.posy(), u.posz() + movez );
-    // TODO: Clean up/finish this typification.
-    tripoint_bub_ms bub_stairs = here.bub_from_abs( stairs );
+    tripoint_bub_ms stairs( u.posx(), u.posy(), u.posz() + movez );
     bool wall_cling = u.has_flag( json_flag_WALL_CLING );
     bool adjacent_climb = false;
     if( !force && movez == 1 && !here.has_flag( ter_furn_flag::TFLAG_GOES_UP, u.pos_bub() ) &&
@@ -11793,7 +11791,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
                 adjacent_climb = true;
             }
         }
-        if( here.has_floor_or_support( stairs ) ) {
+        if( here.has_floor_or_support( stairs.raw() ) ) {
             add_msg( m_info, _( "You can't climb here - there's a ceiling above your head." ) );
             return;
         }
@@ -11803,7 +11801,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             return;
         }
 
-        const int cost = u.climbing_cost( u.pos(), stairs );
+        const int cost = u.climbing_cost( u.pos_bub().raw(), stairs.raw() );
         add_msg_debug( debugmode::DF_GAME, "Climb cost %d", cost );
         const bool can_climb_here = cost > 0 ||
                                     u.has_flag( json_flag_CLIMB_NO_LADDER ) || wall_cling;
@@ -11827,16 +11825,15 @@ void game::vertical_move( int movez, bool force, bool peeking )
         }
 
         std::vector<tripoint> pts;
-        for( const tripoint &pt : here.points_in_radius( stairs, 1 ) ) {
+        for( const tripoint_bub_ms &pt : here.points_in_radius( stairs, 1 ) ) {
             if( here.passable( pt ) &&
-                here.has_floor_or_support( pt ) ) {
-                pts.push_back( pt );
+                here.has_floor_or_support( pt.raw() ) ) {
+                pts.push_back( pt.raw() );
             }
         }
 
-        // TODO: Unify the tripoint types here.
-        if( wall_cling && here.is_clingable_wall_adjacent( bub_stairs ) ) {
-            pts.push_back( stairs );
+        if( wall_cling && here.is_clingable_wall_adjacent( stairs ) ) {
+            pts.push_back( stairs.raw() );
         }
 
         if( pts.empty() ) {
@@ -11854,7 +11851,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             if( !pnt ) {
                 return;
             }
-            stairs = *pnt;
+            stairs = tripoint_bub_ms( *pnt );
         }
     }
 
@@ -12004,7 +12001,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         if( !pnt ) {
             return;
         }
-        stairs = *pnt;
+        stairs = tripoint_bub_ms( *pnt );
     }
 
     std::vector<monster *> monsters_following;
@@ -12045,7 +12042,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     point submap_shift;
     const bool z_level_changed = vertical_shift( z_after );
     if( !force ) {
-        submap_shift = update_map( stairs.x, stairs.y, z_level_changed );
+        submap_shift = update_map( stairs.x(), stairs.y(), z_level_changed );
     }
 
     // if an NPC or monster is on the stairs when player ascends/descends

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -210,7 +210,7 @@ void tutorial_game::per_turn()
 
     map &here = get_map();
     if( !tutorials_seen[tut_lesson::LESSON_BUTCHER] ) {
-        for( const item &it : here.i_at( player_character.pos().xy() ) ) {
+        for( const item &it : here.i_at( player_character.pos_bub().xy() ) ) {
             if( it.is_corpse() ) {
                 add_message( tut_lesson::LESSON_BUTCHER );
                 break;
@@ -246,7 +246,7 @@ void tutorial_game::per_turn()
         }
     }
 
-    if( !here.i_at( point( player_character.posx(), player_character.posy() ) ).empty() ) {
+    if( !here.i_at( point_bub_ms( player_character.posx(), player_character.posy() ) ).empty() ) {
         add_message( tut_lesson::LESSON_PICKUP );
     }
 

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -445,11 +445,11 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
             return false;
         }
     }
-    if( bash_dmg < 0 && !m.i_at( point( x, y ) ).empty() ) {
+    if( bash_dmg < 0 && !m.i_at( point_bub_ms( x, y ) ).empty() ) {
         return false;
     }
     if( bash_dmg == 0 ) {
-        for( item &elem : m.i_at( point( x, y ) ) ) {
+        for( item &elem : m.i_at( point_bub_ms( x, y ) ) ) {
             if( elem.made_of( phase_id::LIQUID ) ) {
                 // Liquids are OK, will be destroyed later
                 continue;
@@ -465,7 +465,7 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
 
     m.ter_set( point( x, y ), door_type );
     if( m.has_flag( ter_furn_flag::TFLAG_NOITEM, point( x, y ) ) ) {
-        map_stack items = m.i_at( point( x, y ) );
+        map_stack items = m.i_at( point_bub_ms( x, y ) );
         for( map_stack::iterator it = items.begin(); it != items.end(); ) {
             if( it->made_of( phase_id::LIQUID ) ) {
                 it = items.erase( it );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -477,20 +477,20 @@ static void rcdrive( const point &d )
     }
     item *rc_car = rc_pair->second;
 
-    tripoint dest( c + d );
+    tripoint_bub_ms dest( c + d );
     if( here.impassable( dest ) || !here.can_put_items_ter_furn( dest ) ||
         here.has_furn( dest ) ) {
         sounds::sound( dest, 7, sounds::sound_t::combat,
                        _( "sound of a collision with an obstacle." ), true, "misc", "rc_car_hits_obstacle" );
         return;
     } else if( !here.add_item_or_charges( dest, *rc_car ).is_null() ) {
-        tripoint src( c );
+        tripoint_bub_ms src( c );
         //~ Sound of moving a remote controlled car
         sounds::sound( src, 6, sounds::sound_t::movement, _( "zzz…" ), true, "misc", "rc_car_drives" );
         player_character.mod_moves( -to_moves<int>( 1_seconds ) * 0.5 );
         here.i_rem( src, rc_car );
         car_location_string.clear();
-        car_location_string << dest.x << ' ' << dest.y << ' ' << dest.z;
+        car_location_string << dest.x() << ' ' << dest.y() << ' ' << dest.z();
         player_character.set_value( "remote_controlling", car_location_string.str() );
         return;
     }
@@ -591,7 +591,7 @@ static void open()
     if( !openp_ ) {
         return;
     }
-    const tripoint openp = *openp_;
+    const tripoint_bub_ms openp = tripoint_bub_ms( *openp_ );
     map &here = get_map();
 
     player_character.mod_moves( -to_moves<int>( 1_seconds ) );
@@ -1027,16 +1027,16 @@ static void smash()
     if( !smashp_ ) {
         return;
     }
-    tripoint smashp = *smashp_;
+    tripoint_bub_ms smashp = tripoint_bub_ms( *smashp_ );
 
     bool smash_floor = false;
-    if( smashp.z != player_character.posz() ) {
-        if( smashp.z > player_character.posz() ) {
+    if( smashp.z() != player_character.posz() ) {
+        if( smashp.z() > player_character.posz() ) {
             // TODO: Knock on the ceiling
             return;
         }
 
-        smashp.z = player_character.posz();
+        smashp.z() = player_character.posz();
         smash_floor = true;
     }
     get_event_bus().send<event_type::character_smashes_tile>(

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -405,14 +405,15 @@ void iexamine::nanofab( Character &you, const tripoint &examp )
     bool table_exists = false;
     std::list<item_location> on_table;
     item_location nanofab_template;
-    tripoint spawn_point;
+    tripoint_bub_ms spawn_point;
     map &here = get_map();
     std::set<itype_id> allowed_template = here.ter( examp )->allowed_template_id;
-    for( const tripoint &valid_location : here.points_in_radius( examp, 1 ) ) {
+    for( const tripoint_bub_ms &valid_location : here.points_in_radius( tripoint_bub_ms( examp ),
+            1 ) ) {
         if( here.has_flag( ter_furn_flag::TFLAG_NANOFAB_TABLE, valid_location ) ) {
             spawn_point = valid_location;
             table_exists = true;
-            on_table = here.items_with( valid_location, [&]( const item & it ) {
+            on_table = here.items_with( valid_location.raw(), [&]( const item & it ) {
                 return it.has_flag( flag_NANOFAB_REPAIR );
             } );
             break;
@@ -550,10 +551,10 @@ void iexamine::gaspump( Character &you, const tripoint &examp )
 
                 item spill = item_it->split( qty );
                 if( spill.is_null() ) {
-                    here.add_item_or_charges( you.pos(), *item_it );
+                    here.add_item_or_charges( you.pos_bub(), *item_it );
                     items.erase( item_it );
                 } else {
-                    here.add_item_or_charges( you.pos(), spill );
+                    here.add_item_or_charges( you.pos_bub(), spill );
                 }
 
             } else {
@@ -1340,7 +1341,8 @@ void iexamine::elevator( Character &you, const tripoint &examp )
         }
     }
 
-    const auto move_item = [&]( map_stack & items, const tripoint & src, const tripoint & dest ) {
+    const auto move_item = [&]( map_stack & items, const tripoint_bub_ms & src,
+    const tripoint_bub_ms & dest ) {
         for( auto it = items.begin(); it != items.end(); ) {
             here.add_item_or_charges( dest, *it );
             it = here.i_rem( src, it );
@@ -1349,9 +1351,9 @@ void iexamine::elevator( Character &you, const tripoint &examp )
 
     // move along every item in the elevator
     for( decltype( this_elevator )::size_type i = 0; i < this_elevator.size(); i++ ) {
-        tripoint const &src = this_elevator[i];
+        tripoint_bub_ms const &src = tripoint_bub_ms( this_elevator[i] );
         map_stack items = here.i_at( src );
-        move_item( items, src, that_elevator[i] );
+        move_item( items, src, tripoint_bub_ms( that_elevator[i] ) );
     }
 
     // move along all creatures on the elevator
@@ -1635,10 +1637,10 @@ void iexamine::deployed_furniture( Character &you, const tripoint &pos )
 {
     map &here = get_map();
 
-    tripoint drop_pos = pos;
+    tripoint_bub_ms drop_pos = tripoint_bub_ms( pos );
 
     if( you.pos().z != pos.z ) {
-        drop_pos = you.pos();
+        drop_pos = you.pos_bub();
         if( !you.query_yn( _( "Pull up the %s?" ), here.furn( pos ).obj().name() ) ) {
             return;
         }
@@ -1762,7 +1764,7 @@ void iexamine::pit_covered( Character &you, const tripoint &examp )
     map &here = get_map();
     item plank( "2x4", calendar::turn );
     add_msg( _( "You remove the plank." ) );
-    here.add_item_or_charges( you.pos(), plank );
+    here.add_item_or_charges( you.pos_bub(), plank );
     const ter_id &ter_pit = here.ter( examp );
     if( ter_pit == ter_t_pit_covered ) {
         here.ter_set( examp, ter_t_pit );
@@ -2162,7 +2164,7 @@ void iexamine_helper::handle_harvest( Character &you, const std::string &itemid,
         you.i_add( harvest );
         you.add_msg_if_player( _( "You harvest: %s." ), harvest.tname() );
     } else {
-        get_map().add_item_or_charges( you.pos(), harvest );
+        get_map().add_item_or_charges( you.pos_bub(), harvest );
         you.add_msg_if_player( _( "You harvest and drop: %s." ), harvest.tname() );
     }
 }
@@ -2400,7 +2402,7 @@ void iexamine::flower_marloss( Character &you, const tripoint &examp )
         return;
     }
     here.furn_set( examp, furn_str_id::NULL_ID() );
-    here.spawn_item( you.pos(), itype_marloss_seed, 1, 3, calendar::turn );
+    here.spawn_item( you.pos_bub(), itype_marloss_seed, 1, 3, calendar::turn );
     iexamine_helper::handle_harvest( you, "withered", false );
 }
 
@@ -2680,7 +2682,7 @@ void iexamine::harvest_plant( Character &you, const tripoint &examp, bool from_a
                 if( from_activity ) {
                     i.set_var( "activity_var", you.name );
                 }
-                here.add_item_or_charges( you.pos(), i );
+                here.add_item_or_charges( you.pos_bub(), i );
             }
             here.furn_set( examp, furn_str_id( here.furn( examp )->plant->base ) );
             you.add_msg_if_player( m_neutral, _( "You harvest the plant." ) );
@@ -3609,7 +3611,7 @@ void iexamine::fvat_full( Character &you, const tripoint &examp )
     for( item &it : items_here ) {
         if( !it.made_of_from_type( phase_id::LIQUID ) ) {
             add_msg( _( "You remove %s from the vat." ), it.tname() );
-            here.add_item_or_charges( you.pos(), it );
+            here.add_item_or_charges( you.pos_bub(), it );
             here.i_rem( examp, &it );
         }
     }
@@ -3841,7 +3843,7 @@ void iexamine::compost_full( Character &you, const tripoint &examp )
     for( item &it : items_here ) {
         if( !it.made_of_from_type( phase_id::LIQUID ) ) {
             add_msg( _( "You remove %s from the tank." ), it.tname() );
-            here.add_item_or_charges( you.pos(), it );
+            here.add_item_or_charges( you.pos_bub(), it );
             here.i_rem( examp, &it );
         }
     }
@@ -4218,11 +4220,11 @@ static void pick_plant( Character &you, const tripoint &examp,
     int plantCount = rng( plantBase, round( plantBase + survival / 2 ) );
     plantCount = std::min( plantCount, 12 );
 
-    here.spawn_item( you.pos(), itemType, plantCount, 0, calendar::turn );
+    here.spawn_item( you.pos_bub(), itemType, plantCount, 0, calendar::turn );
 
     if( seeds ) {
         // FIXME: shouldn't derive seed type by string manipulation
-        here.spawn_item( you.pos(), itype_id( "seed_" + itemType.str() ), 1,
+        here.spawn_item( you.pos_bub(), itype_id( "seed_" + itemType.str() ), 1,
                          rng( plantCount / 4, plantCount / 2 ), calendar::turn );
     }
 
@@ -4242,7 +4244,7 @@ void iexamine::tree_hickory( Character &you, const tripoint &examp )
         query_yn( _( "Dig up %s?  This kills the tree!" ), here.tername( examp ) ) ) {
         digging_up = true;
         /** @EFFECT_SURVIVAL increases hickory root number per tree */
-        here.spawn_item( you.pos(), itype_hickory_root, rng( 1,
+        here.spawn_item( you.pos_bub(), itype_hickory_root, rng( 1,
                          round( 3 + you.get_skill_level( skill_survival ) ) ),
                          0,
                          calendar::turn );
@@ -4376,10 +4378,10 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
             }
 
             add_msg( _( "You remove the %s." ), spile->tname() );
-            here.add_item_or_charges( you.pos(), *spile );
+            here.add_item_or_charges( you.pos_bub(), *spile );
 
             if( container ) {
-                here.add_item_or_charges( you.pos(), *container );
+                here.add_item_or_charges( you.pos_bub(), *container );
             }
             here.i_clear( examp );
 
@@ -4411,7 +4413,7 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint &examp )
         }
 
         case REMOVE_CONTAINER: {
-            here.add_item_or_charges( you.pos(), *container );
+            here.add_item_or_charges( you.pos_bub(), *container );
             you.mod_moves( -you.item_handling_cost( *container ) );
             here.i_rem( examp, container );
             return;
@@ -4428,7 +4430,7 @@ void iexamine::shrub_marloss( Character &you, const tripoint &examp )
         pick_plant( you, examp, itype_mycus_fruit, ter_t_shrub_fungal );
     } else if( you.has_trait( trait_THRESH_MARLOSS ) ) {
         map &here = get_map();
-        here.spawn_item( you.pos(), itype_mycus_fruit, 1, 0, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_mycus_fruit, 1, 0, calendar::turn );
         here.ter_set( examp, ter_t_fungus );
         add_msg( m_info, _( "The shrub offers up a fruit, then crumbles into a fungal bed." ) );
     } else {
@@ -4449,7 +4451,7 @@ void iexamine::tree_marloss( Character &you, const tripoint &examp )
             here.ter_set( examp, ter_t_marloss_tree );
         }
     } else if( you.has_trait( trait_THRESH_MARLOSS ) ) {
-        here.spawn_item( you.pos(), itype_mycus_fruit, 1, 0, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_mycus_fruit, 1, 0, calendar::turn );
         here.ter_set( examp, ter_t_tree_fungal );
         add_msg( m_info, _( "The tree offers up a fruit, then shrivels into a fungal tree." ) );
     } else {
@@ -4737,7 +4739,7 @@ static void reload_furniture( Character &you, const tripoint &examp, bool allow_
                             const int handling_cost = -you.item_handling_cost( *itm );
 
                             add_msg( _( "You remove %1$s from the %2$s." ), itm->tname(), f.name() );
-                            here.add_item_or_charges( you.pos(), *itm );
+                            here.add_item_or_charges( you.pos_bub(), *itm );
                             itm = items.erase( itm );
                             you.mod_moves( handling_cost );
                             return;
@@ -4857,10 +4859,10 @@ void iexamine::curtains( Character &you, const tripoint &examp )
             here.ter_set( examp, here.ter( examp )->curtain_transform );
         }
 
-        here.spawn_item( you.pos(), itype_nail, 1, 4, calendar::turn );
-        here.spawn_item( you.pos(), itype_sheet, 2, 0, calendar::turn );
-        here.spawn_item( you.pos(), itype_stick, 1, 0, calendar::turn );
-        here.spawn_item( you.pos(), itype_string_36, 1, 0, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_nail, 1, 4, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_sheet, 2, 0, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_stick, 1, 0, calendar::turn );
+        here.spawn_item( you.pos_bub(), itype_string_36, 1, 0, calendar::turn );
         you.mod_moves( -to_moves<int>( 10_seconds ) );
         you.add_msg_if_player( _( "You tear the curtains and curtain rod off the windowframe." ) );
     } else {
@@ -6111,7 +6113,7 @@ static void mill_activate( Character &you, const tripoint &examp )
             add_msg( _( "You remove the %s from the mill." ), source.tname() );
 
             for( int i = 0; i < mill_type_count.second; i++ ) {
-                here.add_item_or_charges( you.pos(), source );
+                here.add_item_or_charges( you.pos_bub(), source );
                 you.mod_moves( -you.item_handling_cost( source ) );
                 for( item &iter : items ) {
                     if( iter.typeId() == source.typeId() ) {
@@ -6148,7 +6150,7 @@ static void mill_activate( Character &you, const tripoint &examp )
                 add_msg( _( "You remove the %s from the mill." ), source.tname() );
 
                 for( int i = 0; i < mill_type_count.second; i++ ) {
-                    here.add_item_or_charges( you.pos(), source );
+                    here.add_item_or_charges( you.pos_bub(), source );
                     you.mod_moves( -you.item_handling_cost( source ) );
                     for( item &iter : items ) {
                         if( iter.typeId() == source.typeId() ) {
@@ -6166,7 +6168,7 @@ static void mill_activate( Character &you, const tripoint &examp )
                              source.tname( 1, false ), lot_size );
                     add_msg( _( "You remove the %s from the mill." ), source.tname() );
                     for( int i = 0; i < mill_type_count.second; i++ ) {
-                        here.add_item_or_charges( you.pos(), source );
+                        here.add_item_or_charges( you.pos_bub(), source );
                         you.mod_moves( -you.item_handling_cost( source ) );
                         for( item &iter : items ) {
                             if( iter.typeId() == source.typeId() ) {
@@ -6181,7 +6183,7 @@ static void mill_activate( Character &you, const tripoint &examp )
                              source.tname( 1, false ), lot_size );
                     add_msg( _( "You remove the excess %s from the mill." ), source.tname() );
                     for( int i = 0; i < mill_type_count.second - process_count; i++ ) {
-                        here.add_item_or_charges( you.pos(), source );
+                        here.add_item_or_charges( you.pos_bub(), source );
                         you.mod_moves( -you.item_handling_cost( source ) );
                         for( item &iter : items ) {
                             if( iter.typeId() == source.typeId() ) {
@@ -6203,7 +6205,7 @@ static void mill_activate( Character &you, const tripoint &examp )
         } else {
             add_msg( m_bad, _( "This mill contains %s, which can't be milled!" ), it.tname( 1, false ) );
             add_msg( _( "You remove the %s from the mill." ), it.tname() );
-            here.add_item_or_charges( you.pos(), it );
+            here.add_item_or_charges( you.pos_bub(), it );
             you.mod_moves( -you.item_handling_cost( it ) );
             here.i_rem( examp, &it );
             return;
@@ -6277,7 +6279,7 @@ static void smoker_activate( Character &you, const tripoint &examp )
             add_msg( m_bad, _( "This rack contains %s, which can't be smoked!" ), it.tname( 1,
                      false ) );
             add_msg( _( "You remove %s from the rack." ), it.tname() );
-            here.add_item_or_charges( you.pos(), it );
+            here.add_item_or_charges( you.pos_bub(), it );
             you.mod_moves( -you.item_handling_cost( it ) );
             here.i_rem( examp, &it );
             return;
@@ -6855,7 +6857,7 @@ void iexamine::quern_examine( Character &you, const tripoint &examp )
                     const int handling_cost = -you.item_handling_cost( *it );
 
                     add_msg( _( "You remove %s from the mill." ), it->tname() );
-                    here.add_item_or_charges( you.pos(), *it );
+                    here.add_item_or_charges( you.pos_bub(), *it );
                     it = items_here.erase( it );
                     you.mod_moves( handling_cost );
                 } else {
@@ -7086,7 +7088,7 @@ void iexamine::smoker_options( Character &you, const tripoint &examp )
                     const int handling_cost = -you.item_handling_cost( *it );
 
                     add_msg( _( "You remove %s from the rack." ), it->tname() );
-                    here.add_item_or_charges( you.pos(), *it );
+                    here.add_item_or_charges( you.pos_bub(), *it );
                     it = items_here.erase( it );
                     you.mod_moves( handling_cost );
                 } else {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -866,7 +866,7 @@ void inventory::rust_iron_items()
                                     elem_stack_iter.base_volume().value() ) / 250 ) ) ) ) &&
                 //                       ^season length   ^14/5*0.75/pi (from volume of sphere)
                 //Freshwater without oxygen rusts slower than air
-                here.water_from( player_character.pos() ).typeId() == itype_salt_water ) {
+                here.water_from( player_character.pos_bub() ).typeId() == itype_salt_water ) {
                 // rusting never completely destroys an item, so no need to handle return value
                 elem_stack_iter.inc_damage();
                 add_msg( m_bad, _( "Your %s is damaged by rust." ), elem_stack_iter.tname() );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -496,7 +496,7 @@ std::optional<int> iuse::sewage( Character *p, item *, const tripoint & )
 
 std::optional<int> iuse::honeycomb( Character *p, item *, const tripoint & )
 {
-    get_map().spawn_item( p->pos(), itype_wax, 2 );
+    get_map().spawn_item( p->pos_bub(), itype_wax, 2 );
     return 1;
 }
 
@@ -1823,13 +1823,13 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint & )
     if( !pnt_ ) {
         return std::nullopt;
     }
-    const tripoint pnt = *pnt_;
+    const tripoint_bub_ms pnt = tripoint_bub_ms( *pnt_ );
 
     if( !here.has_flag( ter_furn_flag::TFLAG_FISHABLE, pnt ) ) {
         p->add_msg_if_player( m_info, _( "You can't fish there!" ) );
         return std::nullopt;
     }
-    if( !good_fishing_spot( pnt, p ) ) {
+    if( !good_fishing_spot( pnt.raw(), p ) ) {
         return std::nullopt;
     }
     it->active = true;
@@ -2231,7 +2231,7 @@ class exosuit_interact
                 } else if( ret == 0 ) {
                     // Unload existing module
                     pkt->remove_items_if( [&c, &here]( const item & i ) {
-                        here.add_item_or_charges( c.pos(), i );
+                        here.add_item_or_charges( c.pos_bub(), i );
                         return true;
                     } );
                     return to_moves<int>( 5_seconds );
@@ -2292,7 +2292,7 @@ class exosuit_interact
             // Unload existing module
             if( not_empty ) {
                 pkt->remove_items_if( [&c, &here]( const item & i ) {
-                    here.add_item_or_charges( c.pos(), i );
+                    here.add_item_or_charges( c.pos_bub(), i );
                     return true;
                 } );
                 moves += to_moves<int>( 5_seconds );
@@ -3168,7 +3168,7 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint & )
         }
         case 1:
             p->add_msg_if_player( m_info, _( "The ground's radiation level: %d mSv/h" ),
-                                  get_map().get_radiation( p->pos() ) );
+                                  get_map().get_radiation( p->pos_bub() ) );
             break;
         case 2:
             p->add_msg_if_player( _( "The geiger counter's scan LED turns on." ) );
@@ -4415,7 +4415,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint & )
     bool acid_blood = false;
     bool vampire = false;
     units::temperature blood_temp = units::from_kelvin( -1.0f ); //kelvins
-    for( item &map_it : get_map().i_at( point( p->posx(), p->posy() ) ) ) {
+    for( item &map_it : get_map().i_at( point_bub_ms( p->posx(), p->posy() ) ) ) {
         if( map_it.is_corpse() &&
             query_yn( _( "Draw blood from %s?" ),
                       colorize( map_it.tname(), map_it.color_in_inventory() ) ) ) {
@@ -4496,7 +4496,7 @@ void iuse::cut_log_into_planks( Character &p )
     p.add_msg_if_player( _( "You cut the log into planks." ) );
 
     p.assign_activity( chop_planks_activity_actor( moves ) );
-    p.activity.placement = get_map().getglobal( p.pos() );
+    p.activity.placement = get_map().getglobal( p.pos_bub() );
 }
 
 std::optional<int> iuse::lumber( Character *p, item *it, const tripoint & )
@@ -4511,9 +4511,9 @@ std::optional<int> iuse::lumber( Character *p, item *it, const tripoint & )
     }
     map &here = get_map();
     // Check if player is standing on any lumber
-    for( item &i : here.i_at( p->pos() ) ) {
+    for( item &i : here.i_at( p->pos_bub() ) ) {
         if( i.typeId() == itype_log ) {
-            here.i_rem( p->pos(), &i );
+            here.i_rem( p->pos_bub(), &i );
             cut_log_into_planks( *p );
             return 1;
         }
@@ -8577,16 +8577,16 @@ std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint & )
     map &here = get_map();
     if( chance <= 20 ) {
         p->add_msg_if_player( _( "You try to break the stick in two, but it shatters into splinters." ) );
-        here.spawn_item( p->pos(), "splinter", 2 );
+        here.spawn_item( p->pos_bub(), "splinter", 2 );
         return 1;
     } else if( chance <= 40 ) {
         p->add_msg_if_player( _( "The stick breaks clean into two parts." ) );
-        here.spawn_item( p->pos(), "stick", 2 );
+        here.spawn_item( p->pos_bub(), "stick", 2 );
         return 1;
     } else if( chance <= 100 ) {
         p->add_msg_if_player( _( "You break the stick, but one half shatters into splinters." ) );
-        here.spawn_item( p->pos(), "stick", 1 );
-        here.spawn_item( p->pos(), "splinter", 1 );
+        here.spawn_item( p->pos_bub(), "stick", 1 );
+        here.spawn_item( p->pos_bub(), "splinter", 1 );
         return 1;
     }
     return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -517,7 +517,7 @@ std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint & )
             content.set_flag( flag_FILTHY );
         }
 
-        here.add_item_or_charges( p->pos(), content );
+        here.add_item_or_charges( p->pos_bub(), content );
     }
 
     p->i_rem( &it );
@@ -1745,7 +1745,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
              cut.get_item()->tname() );
 
     const item_location::type cut_type = cut.where();
-    const tripoint pos = cut.position();
+    const tripoint_bub_ms pos = cut.pos_bub();
     const bool filthy = cut.get_item()->is_filthy();
 
     // Clean up before removing the item.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3022,18 +3022,18 @@ void map::drop_furniture( const tripoint &p )
         return SS_NO_SUPPORT;
     };
 
-    tripoint current( p.xy(), p.z + 1 );
+    tripoint_bub_ms current( point_bub_ms( p.xy() ), p.z + 1 );
     support_state last_state = SS_NO_SUPPORT;
     while( last_state == SS_NO_SUPPORT ) {
-        current.z--;
+        current.z()--;
         // Check current tile
-        last_state = check_tile( current );
+        last_state = check_tile( current.raw() );
     }
 
-    if( current == p ) {
+    if( current.raw() == p ) {
         // Nothing happened
         if( last_state != SS_FLOOR ) {
-            support_dirty( current );
+            support_dirty( current.raw() );
         }
 
         return;
@@ -3069,7 +3069,7 @@ void map::drop_furniture( const tripoint &p )
     }
 
     // TODO: Balance this.
-    int dmg = weight * ( p.z - current.z );
+    int dmg = weight * ( p.z - current.z() );
 
     if( last_state == SS_FLOOR ) {
         // Bash the same tile twice - once for furniture, once for the floor
@@ -3077,16 +3077,16 @@ void map::drop_furniture( const tripoint &p )
         bash( current, dmg, false, false, true );
     } else if( last_state == SS_BAD_SUPPORT || last_state == SS_GOOD_SUPPORT ) {
         bash( current, dmg, false, false, false );
-        tripoint below( current.xy(), current.z - 1 );
+        tripoint_bub_ms below{ current + tripoint_rel_ms_below };
         bash( below, dmg, false, false, false );
     } else if( last_state == SS_CREATURE ) {
         const std::string &furn_name = frn_obj.name();
         bash( current, dmg, false, false, false );
-        tripoint below( current.xy(), current.z - 1 );
+        tripoint_bub_ms below{ current + tripoint_rel_ms_below };
         Creature *critter = get_creature_tracker().creature_at( below );
         if( critter == nullptr ) {
             debugmsg( "drop_furniture couldn't find creature at %d,%d,%d",
-                      below.x, below.y, below.z );
+                      below.x(), below.y(), below.z() );
             return;
         }
 
@@ -3117,7 +3117,7 @@ void map::drop_furniture( const tripoint &p )
     }
 
     // Re-queue for another check, in case bash destroyed something
-    support_dirty( current );
+    support_dirty( current.raw() );
 }
 
 void map::drop_items( const tripoint &p )
@@ -3130,14 +3130,14 @@ void map::drop_items( const tripoint &p )
     // TODO: Make items check the volume tile below can accept
     // rather than disappearing if it would be overloaded
 
-    tripoint below( p );
+    tripoint_bub_ms below( p );
     int max_height_fallen = 0;
     while( !has_floor_or_water( below ) ) {
-        below.z--;
+        below.z()--;
         max_height_fallen++;
     }
 
-    if( below == p ) {
+    if( below.raw() == p ) {
         return;
     }
 
@@ -3973,10 +3973,10 @@ point_bub_ms map::random_outdoor_tile() const
     return random_entry( options, point_bub_ms( point_north_west ) );
 }
 
-bool map::has_adjacent_furniture_with( const tripoint &p,
+bool map::has_adjacent_furniture_with( const tripoint_bub_ms &p,
                                        const std::function<bool( const furn_t & )> &filter ) const
 {
-    for( const tripoint &adj : points_in_radius( p, 1 ) ) {
+    for( const tripoint_bub_ms &adj : points_in_radius( p, 1 ) ) {
         if( has_furn( adj ) && filter( furn( adj ).obj() ) ) {
             return true;
         }
@@ -4823,6 +4823,11 @@ void map::bash_field( const tripoint_bub_ms &p, bash_params &params )
 
 void map::destroy( const tripoint &p, const bool silent )
 {
+    map::destroy( tripoint_bub_ms( p ), silent );
+}
+
+void map::destroy( const tripoint_bub_ms &p, const bool silent )
+{
     // Break if it takes more than 25 destructions to remove to prevent infinite loops
     // Example: A bashes to B, B bashes to A leads to A->B->A->...
     int count = 0;
@@ -4831,12 +4836,7 @@ void map::destroy( const tripoint &p, const bool silent )
     }
 }
 
-void map::destroy( const tripoint_bub_ms &p, const bool silent )
-{
-    map::destroy( p.raw(), silent );
-}
-
-void map::destroy_furn( const tripoint &p, const bool silent )
+void map::destroy_furn( const tripoint_bub_ms &p, const bool silent )
 {
     // Break if it takes more than 25 destructions to remove to prevent infinite loops
     // Example: A bashes to B, B bashes to A leads to A->B->A->...
@@ -4847,12 +4847,7 @@ void map::destroy_furn( const tripoint &p, const bool silent )
     }
 }
 
-void map::destroy_furn( const tripoint_bub_ms &p, const bool silent )
-{
-    destroy_furn( p.raw(), silent );
-}
-
-void map::batter( const tripoint &p, int power, int tries, const bool silent )
+void map::batter( const tripoint_bub_ms &p, int power, int tries, const bool silent )
 {
     int count = 0;
     while( count < tries && bash( p, power, silent ).success ) {
@@ -4915,12 +4910,16 @@ void map::crush( const tripoint_bub_ms &p )
         vp->vehicle().damage( *this, vp->part_index(), rng( 100, 1000 ), damage_bash, false );
     }
 }
-
-
 void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, const bool hit_items,
                  double dispersion )
 {
-    // TODO: make bashing better at destroying, worse at penetrating
+    map::shoot( tripoint_bub_ms( p ), tripoint( source ), proj, hit_items, dispersion );
+}
+
+void map::shoot( const tripoint_bub_ms &p, const tripoint &source, projectile &proj,
+                 const bool hit_items, double dispersion )
+{
+    // TODO: make bashing better a destroying, worse at penetrating
     std::map<damage_type_id, float> dmg_by_type {};
     for( const damage_unit &dam : proj.impact ) {
         dmg_by_type[dam.type] +=
@@ -4949,7 +4948,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
     const bool ignite = ammo_effects.count( ammo_effect_IGNITE );
     const bool laser = ammo_effects.count( ammo_effect_LASER );
 
-    int dist = rl_dist( source, p );
+    int dist = rl_dist( source, p.raw() );
     // Manually check coverage sources as coverage() isn't smart enough.
     int furn_coverage = 0;
     if( furn( p ) != f_null ) {
@@ -5008,13 +5007,14 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
     * and "bad" shots, with 0.0f being perfect and 2000.0f being a pure gamble. See ranged.cpp
     * for more details on dispersion.
     */
-    if( coverage > 0 && dispersion < 1000.0f ) {
-        coverage *= dispersion / 1000.0f;
+    if( coverage > 0 && coverage < 100 && dispersion < 1000.0 ) {
+        float factor = std::sqrt( std::max( 0.0, dispersion ) / 1000.0f );
+        coverage *= factor;
     }
     bool hit_something = false;
     // Check again so we can skip if the result was zero.
     if( coverage > 0 || ter( p )->has_flag( ter_furn_flag::TFLAG_HIT_WITHOUT_COVER ) ) {
-        int coverage_roll = rng( 1, 100 );
+        int coverage_roll = rng( 1, 99 );
         if( ( coverage > 0 && coverage_roll < coverage ) ||
             ter( p )->has_flag( ter_furn_flag::TFLAG_HIT_WITHOUT_COVER ) ) {
             furn_id furniture = furn( p );
@@ -5143,7 +5143,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
     smash_items( p, dam / 3, damage_message );
 }
 
-bool map::hit_with_acid( const tripoint &p )
+bool map::hit_with_acid( const tripoint_bub_ms &p )
 {
     if( passable( p ) ) {
         return false;    // Didn't hit the tile!
@@ -5161,7 +5161,7 @@ bool map::hit_with_acid( const tripoint &p )
                t == ter_t_bars ||
                t == ter_t_reb_cage ) {
         ter_set( p, ter_t_floor );
-        add_msg_if_player_sees( p, m_warning, _( "The metal bars melt!" ) );
+        add_msg_if_player_sees( p.raw(), m_warning, _( "The metal bars melt!" ) );
     } else if( t == ter_t_door_b ) {
         if( one_in( 4 ) ) {
             ter_set( p, ter_t_door_frame );
@@ -5181,7 +5181,7 @@ bool map::hit_with_acid( const tripoint &p )
 }
 
 // Returns true if terrain stops fire. TODO: Old hardcoded monattack, defunct?
-bool map::hit_with_fire( const tripoint &p )
+bool map::hit_with_fire( const tripoint_bub_ms &p )
 {
     if( passable( p ) ) {
         return false;    // Didn't hit the tile!
@@ -5194,7 +5194,14 @@ bool map::hit_with_fire( const tripoint &p )
     }
     return true;
 }
+
 bool map::open_door( Creature const &u, const tripoint &p, const bool inside,
+                     const bool check_only )
+{
+    return map::open_door( u, tripoint_bub_ms( p ), inside, check_only );
+}
+
+bool map::open_door( Creature const &u, const tripoint_bub_ms &p, const bool inside,
                      const bool check_only )
 {
     if( u.has_effect( effect_incorporeal ) ) {
@@ -5214,8 +5221,8 @@ bool map::open_door( Creature const &u, const tripoint &p, const bool inside,
 
             if( u.has_trait( trait_SCHIZOPHRENIC ) && u.is_avatar() &&
                 one_in( 50 ) && !ter.has_flag( ter_furn_flag::TFLAG_TRANSPARENT ) ) {
-                tripoint mp = p + -2 * u.pos().xy() + tripoint( 2 * p.x, 2 * p.y, p.z );
-                g->spawn_hallucination( mp );
+                tripoint_bub_ms mp = p + point_rel_ms( -2 * u.pos_bub().xy().raw() ) + tripoint_rel_ms{ 2 * p.x(), 2 * p.y(), p.z() };
+                g->spawn_hallucination( mp.raw() );
             }
         }
 
@@ -5272,7 +5279,8 @@ void map::translate( const ter_id &from, const ter_id &to )
 }
 
 //This function performs the translate function within a given radius of the player.
-void map::translate_radius( const ter_id &from, const ter_id &to, float radi, const tripoint &p,
+void map::translate_radius( const ter_id &from, const ter_id &to, float radi,
+                            const tripoint_bub_ms &p,
                             const bool same_submap, const bool toggle_between )
 {
     if( from == to ) {
@@ -5280,10 +5288,10 @@ void map::translate_radius( const ter_id &from, const ter_id &to, float radi, co
         return;
     }
 
-    const tripoint abs_omt_p = ms_to_omt_copy( getabs( p ) );
+    const tripoint_abs_omt abs_omt_p = tripoint_abs_omt( ms_to_omt_copy( getglobal( p ).raw() ) );
     for( const tripoint &t : points_on_zlevel() ) {
-        const tripoint abs_omt_t = ms_to_omt_copy( getabs( t ) );
-        const float radiX = trig_dist( p, t );
+        const tripoint_abs_omt abs_omt_t = tripoint_abs_omt( ms_to_omt_copy( getabs( t ) ) );
+        const float radiX = trig_dist( p.raw(), t );
         if( ter( t ) == from ) {
             // within distance, and either no submap limitation or same overmap coords.
             if( radiX <= radi && ( !same_submap || abs_omt_t == abs_omt_p ) ) {
@@ -5323,7 +5331,7 @@ void map::transform_line( const ter_furn_transform_id &transform, const tripoint
     }
 }
 
-bool map::close_door( const tripoint &p, const bool inside, const bool check_only )
+bool map::close_door( const tripoint_bub_ms &p, const bool inside, const bool check_only )
 {
     if( has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, p ) && !inside ) {
         return false;
@@ -5349,19 +5357,19 @@ bool map::close_door( const tripoint &p, const bool inside, const bool check_onl
     return false;
 }
 
-bool map::close_door( const tripoint_bub_ms &p, const bool inside, const bool check_only )
+std::string map::get_signage( const tripoint &p ) const
 {
-    return close_door( p.raw(), inside, check_only );
+    return map::get_signage( tripoint_bub_ms( p ) );
 }
 
-std::string map::get_signage( const tripoint &p ) const
+std::string map::get_signage( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
         return "";
     }
 
     point_sm_ms l;
-    const submap *const current_submap = unsafe_get_submap_at( tripoint_bub_ms( p ), l );
+    const submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to get signage at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return std::string();
@@ -5369,14 +5377,20 @@ std::string map::get_signage( const tripoint &p ) const
 
     return current_submap->get_signage( l );
 }
+
 void map::set_signage( const tripoint &p, const std::string &message )
+{
+    map::set_signage( tripoint_bub_ms( p ), message );
+}
+
+void map::set_signage( const tripoint_bub_ms &p, const std::string &message )
 {
     if( !inbounds( p ) ) {
         return;
     }
 
     point_sm_ms l;
-    submap *const current_submap = unsafe_get_submap_at( tripoint_bub_ms( p ), l );
+    submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried set signage at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -5384,10 +5398,7 @@ void map::set_signage( const tripoint &p, const std::string &message )
 
     current_submap->set_signage( l, message );
 }
-void map::delete_signage( const tripoint &p )
-{
-    delete_signage( tripoint_bub_ms( p ) );
-}
+
 void map::delete_signage( const tripoint_bub_ms &p )
 {
     if( !inbounds( p ) ) {
@@ -5427,12 +5438,17 @@ int map::get_radiation( const tripoint_bub_ms &p ) const
 
 void map::set_radiation( const tripoint &p, const int value )
 {
+    map::set_radiation( tripoint_bub_ms( p ), value );
+}
+
+void map::set_radiation( const tripoint_bub_ms &p, const int value )
+{
     if( !inbounds( p ) ) {
         return;
     }
 
     point_sm_ms l;
-    submap *const current_submap = unsafe_get_submap_at( tripoint_bub_ms( p ), l );
+    submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to set radiation at (%d,%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -5441,14 +5457,14 @@ void map::set_radiation( const tripoint &p, const int value )
     current_submap->set_radiation( l, value );
 }
 
-void map::adjust_radiation( const tripoint &p, const int delta )
+void map::adjust_radiation( const tripoint_bub_ms &p, const int delta )
 {
     if( !inbounds( p ) ) {
         return;
     }
 
     point_sm_ms l;
-    submap *const current_submap = unsafe_get_submap_at( tripoint_bub_ms( p ), l );
+    submap *const current_submap = unsafe_get_submap_at( p, l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to adjust radiation at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -5460,27 +5476,35 @@ void map::adjust_radiation( const tripoint &p, const int delta )
 
 units::temperature_delta map::get_temperature_mod( const tripoint &p ) const
 {
+    return map::get_temperature_mod( tripoint_bub_ms( p ) );
+}
+
+units::temperature_delta map::get_temperature_mod( const tripoint_bub_ms &p ) const
+{
     if( !inbounds( p ) ) {
         return units::from_kelvin_delta( 0 );
     }
 
     const submap *const current_submap = unsafe_get_submap_at( p );
     if( current_submap == nullptr ) {
-        debugmsg( "Tried to get temperature at (%d,%d,%d) but the submap is not loaded", p.x, p.y, p.z );
+        debugmsg( "Tried to get temperature at (%d,%d,%d) but the submap is not loaded", p.x(), p.y(),
+                  p.z() );
         return units::from_kelvin_delta( 0 );
     }
 
     return current_submap->get_temperature_mod();
 }
 
-void map::set_temperature_mod( const tripoint &p, units::temperature_delta new_temperature_mod )
+void map::set_temperature_mod( const tripoint_bub_ms &p,
+                               units::temperature_delta new_temperature_mod )
 {
     if( !inbounds( p ) ) {
         return;
     }
     submap *const current_submap = unsafe_get_submap_at( p );
     if( current_submap == nullptr ) {
-        debugmsg( "Tried to set temperature at (%d,%d,%d) but the submap is not loaded", p.x, p.y, p.z );
+        debugmsg( "Tried to set temperature at (%d,%d,%d) but the submap is not loaded", p.x(), p.y(),
+                  p.z() );
         return;
     }
 
@@ -5534,16 +5558,16 @@ map_stack::iterator map::i_rem( const tripoint_bub_ms &p, const map_stack::const
 
 void map::i_rem( const tripoint &p, item *it )
 {
+    return i_rem( tripoint_bub_ms( p ), it );
+}
+
+void map::i_rem( const tripoint_bub_ms &p, item *it )
+{
     map_stack map_items = i_at( p );
     map_stack::const_iterator iter = map_items.get_iterator_from_pointer( it );
     if( iter != map_items.end() ) {
         i_rem( p, iter );
     }
-}
-
-void map::i_rem( const tripoint_bub_ms &p, item *it )
-{
-    return i_rem( p.raw(), it );
 }
 
 void map::i_clear( const tripoint &p )
@@ -5590,19 +5614,6 @@ std::vector<item *> map::spawn_items( const tripoint_bub_ms &p, const std::vecto
     return spawn_items( p.raw(), new_items );
 }
 
-void map::spawn_artifact( const tripoint &p, const relic_procgen_id &id,
-                          const int max_attributes,
-                          const int power_level, const int max_negative_power, const bool is_resonant )
-{
-    relic_procgen_data::generation_rules rules;
-    rules.max_attributes = max_attributes;
-    rules.power_level = power_level;
-    rules.max_negative_power = max_negative_power;
-    rules.resonant = is_resonant;
-
-    add_item_or_charges( p, id->create_item( rules ) );
-}
-
 void map::spawn_artifact( const tripoint_bub_ms &p, const relic_procgen_id &id,
                           const int max_attributes,
                           const int power_level, const int max_negative_power, const bool is_resonant )
@@ -5617,6 +5628,14 @@ void map::spawn_artifact( const tripoint_bub_ms &p, const relic_procgen_id &id,
 }
 
 void map::spawn_item( const tripoint &p, const itype_id &type_id, const unsigned quantity,
+                      const int charges, const time_point &birthday, const int damlevel, const std::set<flag_id> &flags,
+                      const std::string &variant, const std::string &faction )
+{
+    map::spawn_item( tripoint_bub_ms( p ), type_id, quantity, charges, birthday, damlevel, flags,
+                     variant, faction );
+}
+
+void map::spawn_item( const tripoint_bub_ms &p, const itype_id &type_id, const unsigned quantity,
                       const int charges, const time_point &birthday, const int damlevel, const std::set<flag_id> &flags,
                       const std::string &variant, const std::string &faction )
 {
@@ -5660,20 +5679,13 @@ void map::spawn_item( const tripoint &p, const itype_id &type_id, const unsigned
     add_item_or_charges( p, new_item );
 }
 
-void map::spawn_item( const tripoint_bub_ms &p, const itype_id &type_id, const unsigned quantity,
-                      const int charges, const time_point &birthday, const int damlevel, const std::set<flag_id> &flags,
-                      const std::string &variant, const std::string &faction )
-{
-    map::spawn_item( p.raw(), type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
-}
-
 units::volume map::max_volume( const tripoint_bub_ms &p )
 {
     return i_at( p ).max_volume();
 }
 
 // total volume of all the things
-units::volume map::stored_volume( const tripoint &p )
+units::volume map::stored_volume( const tripoint_bub_ms &p )
 {
     return i_at( p ).stored_volume();
 }
@@ -5681,17 +5693,12 @@ units::volume map::stored_volume( const tripoint &p )
 // free space
 units::volume map::free_volume( const tripoint &p )
 {
-    return i_at( p ).free_volume();
+    return free_volume( tripoint_bub_ms( p ) );
 }
 
 units::volume map::free_volume( const tripoint_bub_ms &p )
 {
-    return free_volume( p.raw() );
-}
-
-item_location map::add_item_ret_loc( const tripoint &pos, item obj, bool overflow )
-{
-    return map::add_item_ret_loc( tripoint_bub_ms( pos ), std::move( obj ), overflow );
+    return i_at( p ).free_volume();
 }
 
 item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
@@ -5958,10 +5965,15 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
 // NOLINTNEXTLINE(readability-make-member-function-const)
 item map::water_from( const tripoint &p )
 {
+    return map::water_from( tripoint_bub_ms( p ) );
+}
+
+item map::water_from( const tripoint_bub_ms &p )
+{
     weather_manager &weather = get_weather();
     if( has_flag( ter_furn_flag::TFLAG_SALT_WATER, p ) ) {
         item ret( "salt_water", calendar::turn, item::INFINITE_CHARGES );
-        ret.set_item_temperature( std::max( weather.get_temperature( p ),
+        ret.set_item_temperature( std::max( weather.get_temperature( p.raw() ),
                                             temperatures::cold ) );
         return ret;
     }
@@ -5969,7 +5981,7 @@ item map::water_from( const tripoint &p )
     const ter_id terrain_id = ter( p );
     if( terrain_id == ter_t_sewage ) {
         item ret( "water_sewage", calendar::turn, item::INFINITE_CHARGES );
-        ret.set_item_temperature( std::max( weather.get_temperature( p ),
+        ret.set_item_temperature( std::max( weather.get_temperature( p.raw() ),
                                             temperatures::cold ) );
         return ret;
     }
@@ -5979,7 +5991,7 @@ item map::water_from( const tripoint &p )
         furn( p )->has_examine( iexamine::water_source ) ) {
         itype_id liquid_id = has_flag( ter_furn_flag::TFLAG_MURKY, p ) ? itype_water_murky : itype_water;
         item ret( liquid_id, calendar::turn, item::INFINITE_CHARGES );
-        ret.set_item_temperature( std::max( weather.get_temperature( p ),
+        ret.set_item_temperature( std::max( weather.get_temperature( p.raw() ),
                                             temperatures::cold ) );
         return ret;
     }
@@ -9267,8 +9279,8 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     tripoint_bub_ms to = p + 3 * dir + point( rng( -1, 1 ), rng( -1, 1 ) );
 
     // TODO: make line_to type aware.
-    std::vector<tripoint> tree = line_to( p.raw(), to.raw(), rng( 1, 8 ) );
-    for( tripoint &elem : tree ) {
+    std::vector<tripoint_bub_ms> tree = line_to( p, to, rng( 1, 8 ) );
+    for( tripoint_bub_ms &elem : tree ) {
         batter( elem, 300, 5 );
         ter_set( elem, ter_t_trunk );
     }
@@ -9798,6 +9810,13 @@ bool map::inbounds( const tripoint_abs_omt &p ) const
 tripoint_range<tripoint> tinymap::points_on_zlevel() const
 {
     return map::points_on_zlevel();
+}
+
+tripoint_range<tripoint_omt_ms> tinymap::omt_points_on_zlevel() const
+{
+
+    const tripoint_range <tripoint_bub_ms> temp = map::bub_points_on_zlevel();
+    return tripoint_range <tripoint_omt_ms>( rebase_omt( temp.min() ), rebase_omt( temp.max() ) );
 }
 
 tripoint_range<tripoint> tinymap::points_on_zlevel( int z ) const
@@ -10532,59 +10551,64 @@ void map::draw_fill_background( const ter_id &type )
 
 void map::draw_fill_background( ter_id( *f )() )
 {
-    draw_square_ter( f, point_zero, point( SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1 ) );
+    draw_square_ter( f, point_bub_ms_zero, point_bub_ms( SEEX * my_MAPSIZE - 1,
+                     SEEY * my_MAPSIZE - 1 ) );
 }
 void map::draw_fill_background( const weighted_int_list<ter_id> &f )
 {
-    draw_square_ter( f, point_zero, point( SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1 ) );
+    draw_square_ter( f, point_bub_ms_zero, point_bub_ms( SEEX * my_MAPSIZE - 1,
+                     SEEY * my_MAPSIZE - 1 ) );
 }
 
-void map::draw_square_ter( const ter_id &type, const point &p1, const point &p2, const int z,
+void map::draw_square_ter( const ter_id &type, const point_bub_ms &p1, const point_bub_ms &p2,
+                           const int z,
                            bool avoid_creatures )
 {
     draw_square( [this, type, avoid_creatures, z]( const point & p ) {
         this->ter_set( tripoint_bub_ms( p.x, p.y, z ), type, avoid_creatures );
-    }, p1, p2 );
+    }, p1.raw(), p2.raw() );
 }
 
-void map::draw_square_furn( const furn_id &type, const point &p1, const point &p2, const int z,
+void map::draw_square_furn( const furn_id &type, const point_bub_ms &p1, const point_bub_ms &p2,
+                            const int z,
                             bool avoid_creatures )
 {
     draw_square( [this, type, avoid_creatures, z]( const point & p ) {
         this->furn_set( tripoint_bub_ms( p.x, p.y, z ), type, avoid_creatures );
-    }, p1, p2 );
+    }, p1.raw(), p2.raw() );
 }
 
-void map::draw_square_ter( ter_id( *f )(), const point &p1, const point &p2, bool avoid_creatures )
+void map::draw_square_ter( ter_id( *f )(), const point_bub_ms &p1, const point_bub_ms &p2,
+                           bool avoid_creatures )
 {
     draw_square( [this, f, avoid_creatures]( const point & p ) {
         this->ter_set( p, f(), avoid_creatures );
-    }, p1, p2 );
+    }, p1.raw(), p2.raw() );
 }
 
-void map::draw_square_ter( const weighted_int_list<ter_id> &f, const point &p1,
-                           const point &p2, bool avoid_creatures )
+void map::draw_square_ter( const weighted_int_list<ter_id> &f, const point_bub_ms &p1,
+                           const point_bub_ms &p2, bool avoid_creatures )
 {
     draw_square( [this, f, avoid_creatures]( const point & p ) {
         const ter_id *tid = f.pick();
         this->ter_set( p, tid != nullptr ? *tid : ter_str_id::NULL_ID(), avoid_creatures );
-    }, p1, p2 );
+    }, p1.raw(), p2.raw() );
 }
 
-void map::draw_rough_circle_ter( const ter_id &type, const point &p, int rad )
+void map::draw_rough_circle_ter( const ter_id &type, const point_bub_ms &p, int rad )
 {
     draw_rough_circle( [this, type]( const point & q ) {
         this->ter_set( q, type );
-    }, p, rad );
+    }, p.raw(), rad );
 }
 
-void map::draw_rough_circle_furn( const furn_id &type, const point &p, int rad )
+void map::draw_rough_circle_furn( const furn_id &type, const point_bub_ms &p, int rad )
 {
     draw_rough_circle( [this, type]( const point & q ) {
         if( !is_open_air( tripoint( q, abs_sub.z() ) ) ) {
             this->furn_set( q, type );
         }
-    }, p, rad );
+    }, p.raw(), rad );
 }
 
 void map::draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad )
@@ -10594,21 +10618,21 @@ void map::draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad )
     }, p, rad );
 }
 
-void map::draw_circle_ter( const ter_id &type, const point &p, int rad )
+void map::draw_circle_ter( const ter_id &type, const point_bub_ms &p, int rad )
 {
     draw_circle( [this, type]( const point & q ) {
         this->ter_set( q, type );
-    }, p, rad );
+    }, p.raw(), rad );
 }
 
-void map::draw_circle_furn( const furn_id &type, const point &p, int rad )
+void map::draw_circle_furn( const furn_id &type, const point_bub_ms &p, int rad )
 {
     draw_circle( [this, type]( const point & q ) {
         this->furn_set( q, type );
-    }, p, rad );
+    }, p.raw(), rad );
 }
 
-void map::add_corpse( const tripoint &p )
+void map::add_corpse( const tripoint_bub_ms &p )
 {
     item body;
 
@@ -10899,17 +10923,30 @@ tripoint_range<tripoint_bub_ms> map::points_in_radius(
 
 tripoint_range<tripoint> map::points_on_zlevel( const int z ) const
 {
+    const tripoint_range<tripoint_bub_ms> temp = map::bub_points_on_zlevel( z );
+    return tripoint_range<tripoint>( temp.min().raw(), temp.max().raw() );
+}
+
+tripoint_range<tripoint_bub_ms> map::bub_points_on_zlevel( const int z ) const
+{
     if( z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
         // TODO: need a default constructor that creates an empty range.
-        return tripoint_range<tripoint>( tripoint_zero, tripoint_zero - tripoint_above );
+        return tripoint_range<tripoint_bub_ms>( tripoint_bub_ms_zero,
+                                                tripoint_bub_ms_zero - tripoint_rel_ms_above );
     }
-    return tripoint_range<tripoint>(
-               tripoint( 0, 0, z ), tripoint( SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1, z ) );
+    return tripoint_range<tripoint_bub_ms>(
+    { 0, 0, z }, { SEEX * my_MAPSIZE - 1, SEEY * my_MAPSIZE - 1, z } );
 }
 
 tripoint_range<tripoint> map::points_on_zlevel() const
 {
     return points_on_zlevel( abs_sub.z() );
+}
+
+tripoint_range<tripoint_bub_ms> map::bub_points_on_zlevel() const
+{
+    return bub_points_on_zlevel( abs_sub.z() );
+
 }
 
 std::list<item_location> map::get_active_items_in_radius(

--- a/src/map.h
+++ b/src/map.h
@@ -1367,51 +1367,51 @@ class map
         void draw_fill_background( ter_id( *f )() );
         void draw_fill_background( const weighted_int_list<ter_id> &f );
 
-        void draw_square_ter( const ter_id &type, const point &p1, const point &p2, int z,
+        void draw_square_ter( const ter_id &type, const point_bub_ms &p1, const point_bub_ms &p2, int z,
                               bool avoid_creature = false );
-        void draw_square_furn( const furn_id &type, const point &p1, const point &p2, int z,
+        void draw_square_furn( const furn_id &type, const point_bub_ms &p1, const point_bub_ms &p2, int z,
                                bool avoid_creatures = false );
-        void draw_square_ter( ter_id( *f )(), const point &p1, const point &p2,
+        void draw_square_ter( ter_id( *f )(), const point_bub_ms &p1, const point_bub_ms &p2,
                               bool avoid_creatures = false );
-        void draw_square_ter( const weighted_int_list<ter_id> &f, const point &p1,
-                              const point &p2, bool avoid_creatures = false );
-        void draw_rough_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_rough_circle_furn( const furn_id &type, const point &p, int rad );
+        void draw_square_ter( const weighted_int_list<ter_id> &f, const point_bub_ms &p1,
+                              const point_bub_ms &p2, bool avoid_creatures = false );
+        void draw_rough_circle_ter( const ter_id &type, const point_bub_ms &p, int rad );
+        void draw_rough_circle_furn( const furn_id &type, const point_bub_ms &p, int rad );
         void draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad );
-        void draw_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_circle_furn( const furn_id &type, const point &p, int rad );
+        void draw_circle_ter( const ter_id &type, const point_bub_ms &p, int rad );
+        void draw_circle_furn( const furn_id &type, const point_bub_ms &p, int rad );
 
-        void add_corpse( const tripoint &p );
+        void add_corpse( const tripoint_bub_ms &p );
 
         // Terrain changing functions
         // Change all instances of $from->$to
         void translate( const ter_id &from, const ter_id &to );
         // Change all instances $from->$to within this radius, optionally limited to locations in the same submap.
         // Optionally toggles instances $from->$to & $to->$from
-        void translate_radius( const ter_id &from, const ter_id &to, float radi, const tripoint &p,
+        void translate_radius( const ter_id &from, const ter_id &to, float radi, const tripoint_bub_ms &p,
                                bool same_submap = false, bool toggle_between = false );
         void transform_radius( const ter_furn_transform_id &transform, int radi,
                                const tripoint_abs_ms &p );
         void transform_line( const ter_furn_transform_id &transform, const tripoint_abs_ms &first,
                              const tripoint_abs_ms &second );
-        // TODO: fix point types (remove the first overload)
-        bool close_door( const tripoint &p, bool inside, bool check_only );
         bool close_door( const tripoint_bub_ms &p, bool inside, bool check_only );
+        // TODO: Get rid of untyped overload.
         bool open_door( Creature const &u, const tripoint &p, bool inside, bool check_only = false );
+        bool open_door( Creature const &u, const tripoint_bub_ms &p, bool inside, bool check_only = false );
         // Destruction
         /** bash a square for a set number of times at set power.  Does not destroy */
-        void batter( const tripoint &p, int power, int tries = 1, bool silent = false );
+        void batter( const tripoint_bub_ms &p, int power, int tries = 1, bool silent = false );
         /** Keeps bashing a square until it can't be bashed anymore */
         // TODO: Get rid of untyped overload
         void destroy( const tripoint &p, bool silent = false );
         void destroy( const tripoint_bub_ms &p, bool silent = false );
         /** Keeps bashing a square until there is no more furniture */
-        // TODO: fix point types (remove the first overload)
-        void destroy_furn( const tripoint &p, bool silent = false );
         void destroy_furn( const tripoint_bub_ms &, bool silent = false );
         void crush( const tripoint_bub_ms &p );
-        /** Track a projectile as it travels and roll for cover etc. */
+        // TODO: Get rid of untyped overload.
         void shoot( const tripoint &p, const tripoint &source, projectile &proj, bool hit_items,
+                    double dispersion );
+        void shoot( const tripoint_bub_ms &p, const tripoint &source, projectile &proj, bool hit_items,
                     double dispersion );
         /** Checks if a square should collapse, returns the X for the one_in(X) collapse chance */
         int collapse_check( const tripoint_bub_ms &p ) const;
@@ -1441,8 +1441,8 @@ class map
                           const vehicle *bashing_vehicle = nullptr );
 
         // Effects of attacks/items
-        bool hit_with_acid( const tripoint &p );
-        bool hit_with_fire( const tripoint &p );
+        bool hit_with_acid( const tripoint_bub_ms &p );
+        bool hit_with_fire( const tripoint_bub_ms &p );
 
         /**
          * Returns true if there is furniture for which filter returns true in a 1 tile radius of p.
@@ -1450,7 +1450,7 @@ class map
          * @param p the location to check at
          * @param filter what to filter the furniture by.
          */
-        bool has_adjacent_furniture_with( const tripoint &p,
+        bool has_adjacent_furniture_with( const tripoint_bub_ms &p,
                                           const std::function<bool( const furn_t & )> &filter ) const;
         /**
          * Check for moppable fields/items at this location
@@ -1471,35 +1471,41 @@ class map
         void decay_fields_and_scent( const time_duration &amount );
 
         // Signs
+        // TODO: Get rid of untyped overload.
         std::string get_signage( const tripoint &p ) const;
+        std::string get_signage( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         void set_signage( const tripoint &p, const std::string &message );
-        // TODO: fix point types (remove the first overload)
-        void delete_signage( const tripoint &p );
+        void set_signage( const tripoint_bub_ms &p, const std::string &message );
         void delete_signage( const tripoint_bub_ms &p );
 
         // Radiation
-        // TODO: Get rid of untyped overload
+        // TODO: Get rid of untyped overload.
         int get_radiation( const tripoint &p ) const;
         int get_radiation( const tripoint_bub_ms &p ) const;
+        // TODO: Get rid of untyped overload.
         void set_radiation( const tripoint &p, int value );
-        void set_radiation( const point &p, const int value ) {
-            set_radiation( tripoint( p, abs_sub.z() ), value );
+        void set_radiation( const tripoint_bub_ms &p, int value );
+        void set_radiation( const point_bub_ms &p, const int value ) {
+            set_radiation( tripoint_bub_ms( p, abs_sub.z() ), value );
         }
 
         /** Increment the radiation in the given tile by the given delta
         *  (decrement it if delta is negative)
         */
-        void adjust_radiation( const tripoint &p, int delta );
-        void adjust_radiation( const point &p, const int delta ) {
-            adjust_radiation( tripoint( p, abs_sub.z() ), delta );
+        void adjust_radiation( const tripoint_bub_ms &p, int delta );
+        void adjust_radiation( const point_bub_ms &p, const int delta ) {
+            adjust_radiation( tripoint_bub_ms( p, abs_sub.z() ), delta );
         }
 
         // Temperature modifier for submap
+        // TODO: Get rid of untyped overload.
         units::temperature_delta get_temperature_mod( const tripoint &p ) const;
+        units::temperature_delta get_temperature_mod( const tripoint_bub_ms &p ) const;
         // Set temperature modifier for all four submap quadrants
-        void set_temperature_mod( const tripoint &p, units::temperature_delta temperature_mod );
-        void set_temperature_mod( const point &p, units::temperature_delta new_temperature_mod ) {
-            set_temperature_mod( tripoint( p, abs_sub.z() ), new_temperature_mod );
+        void set_temperature_mod( const tripoint_bub_ms &p, units::temperature_delta temperature_mod );
+        void set_temperature_mod( const point_bub_ms &p, units::temperature_delta new_temperature_mod ) {
+            set_temperature_mod( tripoint_bub_ms( p, abs_sub.z() ), new_temperature_mod );
         }
 
         // Returns points for all submaps with inconsistent state relative to
@@ -1509,33 +1515,26 @@ class map
         // TODO: fix point types (remove the first overload)
         map_stack i_at( const tripoint &p );
         map_stack i_at( const tripoint_bub_ms &p );
-        map_stack i_at( const point &p ) {
-            return i_at( tripoint( p, abs_sub.z() ) );
+        map_stack i_at( const point_bub_ms &p ) {
+            return i_at( tripoint_bub_ms( p, abs_sub.z() ) );
         }
+        // TODO: Get rid of untyped overload.
         item water_from( const tripoint &p );
+        item water_from( const tripoint_bub_ms &p );
         // TODO: Get rid of untyped overload.
         void i_clear( const tripoint &p );
         void i_clear( const tripoint_bub_ms &p );
-        void i_clear( const point &p ) {
-            i_clear( tripoint( p, abs_sub.z() ) );
+        void i_clear( const point_bub_ms &p ) {
+            i_clear( tripoint_bub_ms( p, abs_sub.z() ) );
         }
         // i_rem() methods that return values act like container::erase(),
         // returning an iterator to the next item after removal.
         // TODO: Get rid of untyped overload.
         map_stack::iterator i_rem( const tripoint &p, const map_stack::const_iterator &it );
         map_stack::iterator i_rem( const tripoint_bub_ms &p, const map_stack::const_iterator &it );
-        map_stack::iterator i_rem( const point &location, const map_stack::const_iterator &it ) {
-            return i_rem( tripoint( location, abs_sub.z() ), it );
-        }
         // TODO: fix point types (remove the first overload)
         void i_rem( const tripoint &p, item *it );
         void i_rem( const tripoint_bub_ms &p, item *it );
-        void i_rem( const point &p, item *it ) {
-            i_rem( tripoint( p, abs_sub.z() ), it );
-        }
-        void spawn_artifact( const tripoint &p, const relic_procgen_id &id,
-                             int max_attributes = 5,  // TODO: Get rid of untyped version
-                             int power_level = 1000, int max_negative_power = -2000, bool is_resonant = false );
         void spawn_artifact( const tripoint_bub_ms &p, const relic_procgen_id &id, int max_attributes = 5,
                              int power_level = 1000, int max_negative_power = -2000, bool is_resonant = false );
         // TODO: Get rid of untyped overload
@@ -1549,12 +1548,23 @@ class map
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" );
+        // TODO: Get rid of untyped overload.
         void spawn_item( const point &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" ) {
-            spawn_item( tripoint( p, abs_sub.z() ), type_id, quantity, charges, birthday, damlevel, flags,
+            spawn_item( tripoint_bub_ms( p.x, p.y, abs_sub.z() ), type_id, quantity, charges, birthday,
+                        damlevel, flags,
+                        variant, faction );
+        }
+        void spawn_item( const point_bub_ms &p, const itype_id &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            spawn_item( tripoint_bub_ms( p, abs_sub.z() ), type_id, quantity, charges, birthday, damlevel,
+                        flags,
                         variant, faction );
         }
 
@@ -1565,22 +1575,32 @@ class map
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" ) {
-            spawn_item( p, itype_id( type_id ), quantity, charges, birthday, damlevel, flags, variant,
+            spawn_item( tripoint_bub_ms( p ), itype_id( type_id ), quantity, charges, birthday, damlevel, flags,
+                        variant,
                         faction );
         }
-        void spawn_item( const point &p, const std::string &type_id,
+        void spawn_item( const tripoint_bub_ms &p, const std::string &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" ) {
-            spawn_item( tripoint( p, abs_sub.z() ), type_id, quantity, charges, birthday, damlevel, flags,
+            spawn_item( p, itype_id( type_id ), quantity, charges, birthday, damlevel, flags, variant,
+                        faction );
+        }
+        void spawn_item( const point_bub_ms &p, const std::string &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            spawn_item( tripoint_bub_ms( p, abs_sub.z() ), type_id, quantity, charges, birthday, damlevel,
+                        flags,
                         variant, faction );
         }
         units::volume max_volume( const tripoint_bub_ms &p );
         // TODO: fix point types (remove the first overload)
         units::volume free_volume( const tripoint &p );
         units::volume free_volume( const tripoint_bub_ms &p );
-        units::volume stored_volume( const tripoint &p );
+        units::volume stored_volume( const tripoint_bub_ms &p );
 
         /**
          *  Adds an item to map tile or stacks charges
@@ -1591,8 +1611,6 @@ class map
          *  @return reference to dropped (and possibly stacked) item or null item on failure
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
-        // TODO: fix point types (remove the first overload)
-        item_location add_item_ret_loc( const tripoint &pos, item obj, bool overflow = true );
         item_location add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         // TODO: fix point types (remove the first overload)
         item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true );
@@ -1602,7 +1620,7 @@ class map
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, int &copies_remaining,
                                    bool overflow = true );
         item &add_item_or_charges( const point &p, const item &obj, bool overflow = true ) {
-            return add_item_or_charges( tripoint( p, abs_sub.z() ), obj, overflow );
+            return add_item_or_charges( tripoint_bub_ms( point_bub_ms( p ), abs_sub.z() ), obj, overflow );
         }
 
         /**
@@ -2677,10 +2695,14 @@ class map
          * Yields a range of all points that are contained in the map and have the z-level of
          * this map (@ref abs_sub).
          */
+        // TODO: Get rid of untyped "overload"
         tripoint_range<tripoint> points_on_zlevel() const;
+        tripoint_range<tripoint_bub_ms> bub_points_on_zlevel() const;
         /// Same as above, but uses the specific z-level. If the given z-level is invalid, it
         /// returns an empty range.
+        /// TODO: Get rid of untyped "overload".
         tripoint_range<tripoint> points_on_zlevel( int z ) const;
+        tripoint_range<tripoint_bub_ms> bub_points_on_zlevel( int z ) const;
 
         std::list<item_location> get_active_items_in_radius( const tripoint &center, int radius );
         std::list<item_location> get_active_items_in_radius( const tripoint &center, int radius,
@@ -2792,8 +2814,12 @@ class tinymap : private map
         ter_id ter( const tripoint_omt_ms &p ) const {
             return map::ter( p.raw() );
         }
+        // TODO: Get rid of untyped overload.
         bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
             return map::ter_set( p, new_terrain, avoid_creatures );    // TODO: Make it typed
+        }
+        bool ter_set( const tripoint_omt_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
+            return map::ter_set( rebase_bub( p ), new_terrain, avoid_creatures );
         }
         bool has_flag_ter( ter_furn_flag flag,
                            const tripoint &p ) const { // TODO: remove when usages converted
@@ -2815,8 +2841,12 @@ class tinymap : private map
                                const point_omt_ms &max, direction dir ) const {
             return map::is_last_ter_wall( no_furn, rebase_bub( p ), rebase_bub( max ), dir );
         }
+        // TODO: Get rid of untyped overload.
         furn_id furn( const point &p ) const {
-            return map::furn( p );    // TODO: Make it typed
+            return map::furn( p );
+        }
+        furn_id furn( const point_omt_ms &p ) const {
+            return map::furn( rebase_bub( p ) );
         }
         furn_id furn( const tripoint &p ) const {
             return map::furn( p );    // TODO: Make it typed
@@ -2824,19 +2854,35 @@ class tinymap : private map
         furn_id furn( const tripoint_omt_ms &p ) const {
             return map::furn( p.raw() );
         }
+        // TODO: Get rid of untyped overload.
         bool has_furn( const tripoint &p ) const {
-            return map::has_furn( p );    // TODO: Make it typed
+            return map::has_furn( p );
         }
+        bool has_furn( const tripoint_omt_ms &p ) const {
+            return map::has_furn( rebase_bub( p ) );
+        }
+        bool has_furn( const point_omt_ms &p ) const {
+            return map::has_furn( rebase_bub( p ) );
+        }
+        // TODO: Get rid of untyped overload.
         void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
-            map::set( p, new_terrain, new_furniture );    // TODO: Make it typed
+            map::set( p, new_terrain, new_furniture );
+        }
+        void set( const tripoint_omt_ms &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+            map::set( rebase_bub( p ), new_terrain, new_furniture );
         }
         bool furn_set( const point &p, const furn_id &new_furniture,
                        bool avoid_creatures = false ) { // TODO: Make it typed
             return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
         }
+        // TODO: Get rid of untyped overload.
         bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false ) {
-            return map::furn_set( p, new_furniture, furn_reset, avoid_creatures ); // TODO: Make it typed
+            return map::furn_set( p, new_furniture, furn_reset, avoid_creatures );
+        }
+        bool furn_set( const tripoint_omt_ms &p, const furn_id &new_furniture, bool furn_reset = false,
+                       bool avoid_creatures = false ) {
+            return map::furn_set( rebase_bub( p ), new_furniture, furn_reset, avoid_creatures );
         }
         // TODO: Get rid of untyped overload.
         void draw_line_furn( const furn_id &type, const point &p1, const point &p2,
@@ -2847,9 +2893,9 @@ class tinymap : private map
                              bool avoid_creatures = false ) {
             map::draw_line_furn( type, rebase_bub( p1 ), rebase_bub( p2 ), avoid_creatures );
         }
-        void draw_square_furn( const furn_id &type, const point &p1, const point &p2, // TODO: Make it typed
+        void draw_square_furn( const furn_id &type, const point_omt_ms &p1, const point_omt_ms &p2,
                                bool avoid_creatures = false ) {
-            map::draw_square_furn( type, p1, p2, avoid_creatures );
+            map::draw_square_furn( type, rebase_bub( p1 ), rebase_bub( p2 ), avoid_creatures );
         }
         bool has_flag_furn( ter_furn_flag flag, const tripoint &p ) const {
             return map::has_flag_furn( flag, p );    // TODO: Make it typed
@@ -2863,7 +2909,9 @@ class tinymap : private map
         bool impassable( const tripoint &p ) const {
             return map::impassable( p );    // TODO: Make it typed
         }
-        tripoint_range<tripoint> points_on_zlevel() const; // TODO: Make it typed
+        // TODO: Get rid of untyped overload.
+        tripoint_range<tripoint> points_on_zlevel() const;
+        tripoint_range<tripoint_omt_ms> omt_points_on_zlevel() const;
         tripoint_range<tripoint> points_on_zlevel( int z ) const; // TODO: Make it typed
         tripoint_range<tripoint> points_in_rectangle(
             const tripoint &from, const tripoint &to ) const; // TODO: Make it typed
@@ -2874,16 +2922,30 @@ class tinymap : private map
             size_t radiusz = 0 ) const; // TODO: remove when usages converted.
         tripoint_range<tripoint_omt_ms> points_in_radius(
             const tripoint_omt_ms &center, size_t radius, size_t radiusz = 0 ) const;
+        // TODO: Get rid of untyped overload.
         map_stack i_at( const tripoint &p ) {
-            return map::i_at( p );    // TODO: Make it typed
+            return map::i_at( tripoint_bub_ms( p ) );
         }
+        map_stack i_at( const tripoint_omt_ms &p ) {
+            return map::i_at( rebase_bub( p ) );
+        }
+        // TODO: Get rid of untyped overload.
         void spawn_item( const tripoint &p, const itype_id &type_id,
                          unsigned quantity = 1, int charges = 0,
                          const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
                          const std::set<flag_id> &flags = {}, const std::string &variant = "",
                          const std::string &faction = "" ) {
-            map::spawn_item( p, type_id, quantity, charges, birthday, damlevel, flags, variant,
-                             faction ); // TODO: Make it typed
+            map::spawn_item( tripoint_bub_ms( p ), type_id, quantity, charges, birthday, damlevel, flags,
+                             variant,
+                             faction );
+        }
+        void spawn_item( const tripoint_omt_ms &p, const itype_id &type_id,
+                         unsigned quantity = 1, int charges = 0,
+                         const time_point &birthday = calendar::start_of_cataclysm, int damlevel = 0,
+                         const std::set<flag_id> &flags = {}, const std::string &variant = "",
+                         const std::string &faction = "" ) {
+            map::spawn_item( rebase_bub( p ), type_id, quantity, charges, birthday, damlevel, flags, variant,
+                             faction );
         }
         void spawn_item( const tripoint &p, const std::string &type_id, // TODO: Make it typed
                          unsigned quantity = 1, int charges = 0,
@@ -2892,23 +2954,27 @@ class tinymap : private map
                          const std::string &faction = "" ) {
             map::spawn_item( p, type_id, quantity, charges, birthday, damlevel, flags, variant, faction );
         }
+        // TODO: Get rid of untyped overload.
         std::vector<item *> spawn_items( const tripoint &p, const std::vector<item> &new_items ) {
-            return map::spawn_items( p, new_items );    // TODO: Make it typed
+            return map::spawn_items( p, new_items );
+        }
+        std::vector<item *> spawn_items( const tripoint_omt_ms &p, const std::vector<item> &new_items ) {
+            return map::spawn_items( rebase_bub( p ), new_items );
         }
         item &add_item( const tripoint &p, item new_item ) {
             return map::add_item( p, std::move( new_item ) );  // TODO: Make it typed
         }
-        item &add_item_or_charges( const point &p, const item &obj,
+        item &add_item_or_charges( const point_omt_ms &p, const item &obj,
                                    bool overflow = true ) { // TODO: Make it typed
-            return map::add_item_or_charges( tripoint( p, abs_sub.z() ), obj, overflow );
+            return map::add_item_or_charges( tripoint_bub_ms( rebase_bub( p ), abs_sub.z() ), obj, overflow );
         }
         std::vector<item *> put_items_from_loc(
             const item_group_id &group_id, const tripoint &p,
             const time_point &turn = calendar::start_of_cataclysm ) {
             return map::put_items_from_loc( group_id, p, turn ); // TODO: Make it typed
         }
-        item &add_item_or_charges( const tripoint &pos, item obj, bool overflow = true ) {
-            return map::add_item_or_charges( pos, std::move( obj ), overflow );  // TODO: Make it typed
+        item &add_item_or_charges( const tripoint_omt_ms &pos, item obj, bool overflow = true ) {
+            return map::add_item_or_charges( rebase_bub( pos ), std::move( obj ), overflow );
         }
         std::vector<item *> place_items( // TODO: Make it typed
             const item_group_id &group_id, int chance, const tripoint &p1, const tripoint &p2,
@@ -2916,14 +2982,18 @@ class tinymap : private map
             const std::string &faction = "" ) {
             return map::place_items( group_id, chance, p1, p2, ongrass, turn, magazine, ammo, faction );
         }
-        void add_corpse( const tripoint &p ) {
-            map::add_corpse( p );
+        void add_corpse( const tripoint_omt_ms &p ) {
+            map::add_corpse( rebase_bub( p ) );
         }
-        void i_rem( const tripoint &p, item *it ) {
-            map::i_rem( p, it );    // TODO: Make it typed
+        void i_rem( const tripoint_omt_ms &p, item *it ) {
+            map::i_rem( rebase_bub( p ), it );
         }
+        // TODO: Get rid of untyped overload.
         void i_clear( const tripoint &p ) {
-            return map::i_clear( p );    //TODO: Make it typed
+            return map::i_clear( p );
+        }
+        void i_clear( const tripoint_omt_ms &p ) {
+            return map::i_clear( rebase_bub( p ) );
         }
         bool add_field( const tripoint &p, const field_type_id &type_id, int intensity = INT_MAX,
                         const time_duration &age = 0_turns, bool hit_player = true ) {
@@ -2949,8 +3019,8 @@ class tinymap : private map
         bool has_flag( ter_furn_flag flag, const point &p ) const { // TODO: Make it typed
             return map::has_flag( flag, p );
         }
-        void destroy( const tripoint &p, bool silent = false ) {
-            return map::destroy( p, silent );    // TODO: Make it typed
+        void destroy( const tripoint_omt_ms &p, bool silent = false ) {
+            return map::destroy( rebase_bub( p ), silent );
         }
         const trap &tr_at( const tripoint &p ) const {
             return map::tr_at( p );    // TODO: Make it typed
@@ -2964,11 +3034,11 @@ class tinymap : private map
         void trap_set( const tripoint_omt_ms &p, const trap_id &type ) {
             map::trap_set( p.raw(), type );
         }
-        void set_signage( const tripoint &p, const std::string &message ) {
-            map::set_signage( p, message );    // TODO: Make it typed
+        void set_signage( const tripoint_omt_ms &p, const std::string &message ) {
+            map::set_signage( rebase_bub( p ), message );  // TODO: Make it typed
         }
-        void delete_signage( const tripoint &p ) {
-            map::delete_signage( p );    // TODO: Make it typed
+        void delete_signage( const tripoint_omt_ms &p ) {
+            map::delete_signage( rebase_bub( p ) );
         }
         VehicleList get_vehicles() {
             return map::get_vehicles();
@@ -2987,10 +3057,16 @@ class tinymap : private map
         void add_splatter_trail( const field_type_id &type, const tripoint &from, const tripoint &to ) {
             return map::add_splatter_trail( type, from, to );    // TODO: Make it typed
         }
+        // TODO: Get rid of untyped overload.
         void collapse_at( const tripoint &p, bool silent,
-                          bool was_supporting = false, // TODO: Make it typed
+                          bool was_supporting = false,
                           bool destroy_pos = true ) {
             map::collapse_at( tripoint_bub_ms( p ), silent, was_supporting, destroy_pos );
+        }
+        void collapse_at( const tripoint_omt_ms &p, bool silent,
+                          bool was_supporting = false,
+                          bool destroy_pos = true ) {
+            map::collapse_at( rebase_bub( p ), silent, was_supporting, destroy_pos );
         }
         tripoint getlocal( const tripoint &p ) const {
             return map::getlocal( tripoint_abs_ms( p ) );  // TODO: Make it typed
@@ -3001,9 +3077,13 @@ class tinymap : private map
         tripoint getabs( const tripoint &p ) const {
             return map::getabs( p );    // TODO: Make it typed
         }
+        // TODO: Get rid of untyped overload.
         tripoint getlocal( const tripoint_abs_ms &p ) const {
             return map::getlocal( p );
-        }; // TODO: Get rid of untyped overload.
+        };
+        tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
+            return rebase_omt( map::bub_from_abs( p ) );
+        };
         bool is_outside( const tripoint &p ) const {
             return map::is_outside( p );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -531,7 +531,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             item body = item::make_corpse();
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 17, 5, abs_sub.z } );
-            m.add_item_or_charges( tripoint{ 17, 5, abs_sub.z }, body );
+            m.add_item_or_charges( tripoint_omt_ms{ 17, 5, abs_sub.z }, body );
         }
 
         //33% chance to spawn empty magazines used by soldiers
@@ -545,8 +545,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Horizontal line of barbed wire fence
         line( &m, ter_t_fence_barbed, point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
 
-        std::vector<point> barbed_wire = line_to( point( 3, 9 ), point( SEEX * 2 - 4, 9 ) );
-        for( point &i : barbed_wire ) {
+        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 3, 9 ), point_omt_ms( SEEX * 2 - 4,
+                                                9 ) );
+        for( point_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
                 m.add_corpse( { i, abs_sub.z } );
@@ -567,13 +568,13 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point p2( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ) );
+            const point_omt_ms p2( rng( 3, SEEX * 2 - 4 ), rng( SEEY, SEEY * 2 - 2 ) );
             if( m.tr_at( { p2, abs_sub.z } ).is_null() ) {
                 m.add_field( { p2, abs_sub.z }, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
                     m.add_corpse( { p2, abs_sub.z } );
-                    for( const tripoint &loc : m.points_in_radius( { p2, abs_sub.z }, 1 ) ) {
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p2, abs_sub.z }, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
                             m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -587,9 +588,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         const int x = rng( 3, SEEX );
         const int x1 = rng( SEEX + 1, SEEX * 2 - 4 );
         m.furn_set( point( x, SEEY * 2 - 1 ), furn_f_sign_warning );
-        m.set_signage( tripoint( x, SEEY * 2 - 1, abs_sub.z ), text );
+        m.set_signage( { x, SEEY * 2 - 1, abs_sub.z }, text );
         m.furn_set( point( x1, SEEY * 2 - 1 ), furn_f_sign_warning );
-        m.set_signage( tripoint( x1, SEEY * 2 - 1, abs_sub.z ), text );
+        m.set_signage( { x1, SEEY * 2 - 1, abs_sub.z }, text );
 
         did_something = true;
     }
@@ -603,8 +604,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         //Section of barbed wire fence
         line( &m, ter_t_fence_barbed, point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
 
-        std::vector<point> barbed_wire = line_to( point( 3, 13 ), point( SEEX * 2 - 4, 13 ) );
-        for( point &i : barbed_wire ) {
+        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 3, 13 ), point_omt_ms( SEEX * 2 - 4,
+                                                13 ) );
+        for( point_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
                 m.add_corpse( { i, abs_sub.z } );
@@ -626,7 +628,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             item body = item::make_corpse();
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 11, 21, abs_sub.z } );
-            m.add_item_or_charges( tripoint{ 11, 21, abs_sub.z }, body );
+            m.add_item_or_charges( tripoint_omt_ms{ 11, 21, abs_sub.z }, body );
         }
 
         //5.56x45mm casings left from a soldier
@@ -670,13 +672,13 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point p4( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ) );
+            const point_omt_ms p4( rng( 3, SEEX * 2 - 4 ), rng( 1, SEEY ) );
             if( m.tr_at( { p4, abs_sub.z } ).is_null() ) {
                 m.add_field( { p4, abs_sub.z }, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
                     m.add_corpse( { p4, abs_sub.z } );
-                    for( const tripoint &loc : m.points_in_radius( { p4, abs_sub.z }, 1 ) ) {
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p4, abs_sub.z }, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
                             m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -690,9 +692,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         const int x = rng( 3, SEEX );
         const int x1 = rng( SEEX + 1, SEEX * 2 - 4 );
         m.furn_set( point( x, 0 ), furn_f_sign_warning );
-        m.set_signage( tripoint( x, 0, abs_sub.z ), text );
+        m.set_signage( { x, 0, abs_sub.z }, text );
         m.furn_set( point( x1, 0 ), furn_f_sign_warning );
-        m.set_signage( tripoint( x1, 0, abs_sub.z ), text );
+        m.set_signage( { x1, 0, abs_sub.z }, text );
 
         did_something = true;
     }
@@ -700,14 +702,14 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
     if( bridge_at_west && road_at_east ) {
         m.load( abs_omt + point_east, false );
         //Draw walls of first tent
-        square_furn( &m, furn_f_canvas_wall, point( 0, 3 ), point( 4, 13 ) );
+        square_furn( &m, furn_f_canvas_wall, point_omt_ms( 0, 3 ), point_omt_ms( 4, 13 ) );
 
         //Add first tent doors
         m.furn_set( tripoint{ 4, 5, abs_sub.z }, furn_f_canvas_door );
         m.furn_set( tripoint{ 4, 11, abs_sub.z }, furn_f_canvas_door );
 
         //Fill empty space with groundsheets
-        square_furn( &m, furn_f_fema_groundsheet, point( 1, 4 ), point( 3, 12 ) );
+        square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 1, 4 ), point_omt_ms( 3, 12 ) );
 
         //Place makeshift beds in the first tent and place loot
         m.furn_set( tripoint{ 1, 4, abs_sub.z }, furn_f_makeshift_bed );
@@ -732,7 +734,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             m.add_vehicle( vehicle_prototype_car_fbi, tripoint( 7, 7, abs_sub.z ), 0_degrees, 70, 1 );
 
             //Remove tent parts after drive-through
-            square_furn( &m, furn_str_id::NULL_ID(), point( 0, 6 ), point( 8, 9 ) );
+            square_furn( &m, furn_str_id::NULL_ID(), point_omt_ms( 0, 6 ), point_omt_ms( 8, 9 ) );
 
             //Add sandbag barricade and then destroy few sections where car smashed it
             line_furn( &m, furn_f_sandbag_half, point( 10, 3 ), point( 10, 13 ) );
@@ -772,8 +774,8 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         line( &m, ter_t_fence_barbed, point( 12, 16 ), point( 12, 20 ) );
 
         //Place second tent
-        square_furn( &m, furn_f_canvas_wall, point( 0, 16 ), point( 4, 20 ) );
-        square_furn( &m, furn_f_fema_groundsheet, point( 1, 17 ), point( 3, 19 ) );
+        square_furn( &m, furn_f_canvas_wall, point_omt_ms( 0, 16 ), point_omt_ms( 4, 20 ) );
+        square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 1, 17 ), point_omt_ms( 3, 19 ) );
         m.furn_set( tripoint{ 4, 18, abs_sub.z }, furn_f_canvas_door );
 
         //Place desk and chair in the second tent
@@ -795,8 +797,8 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             }
         }
 
-        std::vector<point> barbed_wire = line_to( point( 12, 3 ), point( 12, 20 ) );
-        for( point &i : barbed_wire ) {
+        std::vector<point_omt_ms> barbed_wire = line_to( point_omt_ms( 12, 3 ), point_omt_ms( 12, 20 ) );
+        for( point_omt_ms &i : barbed_wire ) {
             //10% chance to spawn corpses of bloody people/zombies on every tile of barbed wire fence
             if( one_in( 10 ) ) {
                 m.add_corpse( { i, abs_sub.z } );
@@ -817,13 +819,13 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point p6( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ) );
+            const point_omt_ms p6( rng( SEEX + 1, SEEX * 2 - 2 ), rng( 3, SEEY * 2 - 4 ) );
             if( m.tr_at( { p6, abs_sub.z } ).is_null() ) {
                 m.add_field( { p6, abs_sub.z }, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
                     m.add_corpse( { p6, abs_sub.z } );
-                    for( const tripoint &loc : m.points_in_radius( { p6, abs_sub.z }, 1 ) ) {
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p6, abs_sub.z }, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
                             m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -837,9 +839,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         const int y = rng( 3, SEEY );
         const int y1 = rng( SEEY + 1, SEEY * 2 - 4 );
         m.furn_set( point( SEEX * 2 - 1, y ), furn_f_sign_warning );
-        m.set_signage( tripoint( SEEX * 2 - 1, y, abs_sub.z ), text );
+        m.set_signage( { SEEX * 2 - 1, y, abs_sub.z }, text );
         m.furn_set( point( SEEX * 2 - 1, y1 ), furn_f_sign_warning );
-        m.set_signage( tripoint( SEEX * 2 - 1, y1, abs_sub.z ), text );
+        m.set_signage( { SEEX * 2 - 1, y1, abs_sub.z }, text );
 
         did_something = true;
     }
@@ -860,7 +862,7 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             item body = item::make_corpse();
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 15, 5, abs_sub.z } );
-            m.add_item_or_charges( tripoint{ 15, 5, abs_sub.z }, body );
+            m.add_item_or_charges( tripoint_omt_ms{ 15, 5, abs_sub.z }, body );
         }
 
         //5.56x45mm casings left from soldiers
@@ -884,8 +886,8 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         m.furn_set( tripoint{ 17, 18, abs_sub.z }, furn_f_crate_o );
 
         //...and fill them with mines
-        m.spawn_item( { 16, 18, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
-        m.spawn_item( { 16, 19, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
+        m.spawn_item( tripoint_omt_ms{ 16, 18, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
+        m.spawn_item( tripoint_omt_ms{ 16, 19, abs_sub.z }, itype_landmine, rng( 0, 5 ) );
 
         // Set some resting place with fire ring, camp chairs, folding table, and benches.
         m.furn_set( tripoint{ 20, 12, abs_sub.z }, furn_f_crate_o );
@@ -894,26 +896,27 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         line_furn( &m, furn_f_bench, point( 23, 11 ), point( 23, 13 ) );
         line_furn( &m, furn_f_camp_chair, point( 20, 14 ), point( 21, 14 ) );
 
-        m.spawn_item( { 21, 12, abs_sub.z }, itype_splinter, rng( 5, 10 ) );
+        m.spawn_item( tripoint_omt_ms{ 21, 12, abs_sub.z }, itype_splinter, rng( 5, 10 ) );
 
         //33% chance for an argument between drunk soldiers gone terribly wrong
         if( one_in( 3 ) ) {
-            m.spawn_item( { 22, 12, abs_sub.z }, itype_bottle_glass );
-            m.spawn_item( { 23, 11, abs_sub.z }, itype_hatchet );
+            m.spawn_item( tripoint_omt_ms{ 22, 12, abs_sub.z }, itype_bottle_glass );
+            m.spawn_item( tripoint_omt_ms{ 23, 11, abs_sub.z }, itype_hatchet );
 
             //Spawn chopped soldier corpse
             item body = item::make_corpse();
             m.put_items_from_loc( Item_spawn_data_mon_zombie_soldier_death_drops,
             { 23, 12, abs_sub.z } );
-            m.add_item_or_charges( tripoint{ 23, 12, abs_sub.z }, body );
+            m.add_item_or_charges( tripoint_omt_ms{ 23, 12, abs_sub.z }, body );
             m.add_field( tripoint{ 23, 12, abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
 
             //Spawn broken bench and splintered wood
             m.furn_set( tripoint{ 23, 13, abs_sub.z }, furn_str_id::NULL_ID() );
-            m.spawn_item( { 23, 13, abs_sub.z }, itype_splinter, rng( 5, 10 ) );
+            m.spawn_item( tripoint_omt_ms{ 23, 13, abs_sub.z }, itype_splinter, rng( 5, 10 ) );
 
             //Spawn blood
-            for( const tripoint &loc : m.points_in_radius( tripoint{ 23, 12, abs_sub.z }, 1, 0 ) ) {
+            for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 23, 12, abs_sub.z }, 1,
+                    0 ) ) {
                 if( one_in( 2 ) ) {
                     m.add_field( { loc.xy(), abs_sub.z }, fd_blood, rng( 1, 3 ) );
                 }
@@ -922,9 +925,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
             m.place_items( Item_spawn_data_trash_cart, 80, tripoint{ 19, 11, abs_sub.z },
             { 21, 13, abs_sub.z }, false, calendar::start_of_cataclysm );
         } else {
-            m.spawn_item( { 20, 11, abs_sub.z }, itype_hatchet );
-            m.spawn_item( { 22, 12, abs_sub.z }, itype_vodka );
-            m.spawn_item( { 20, 14, abs_sub.z }, itype_acoustic_guitar );
+            m.spawn_item( tripoint_omt_ms{ 20, 11, abs_sub.z }, itype_hatchet );
+            m.spawn_item( tripoint_omt_ms{ 22, 12, abs_sub.z }, itype_vodka );
+            m.spawn_item( tripoint_omt_ms{ 20, 14, abs_sub.z }, itype_acoustic_guitar );
 
             //Spawn trash in a crate
             m.place_items( Item_spawn_data_trash_cart, 80, tripoint{ 20, 12, abs_sub.z },
@@ -932,8 +935,8 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         }
 
         //Place a tent
-        square_furn( &m, furn_f_canvas_wall, point( 20, 4 ), point( 23, 7 ) );
-        square_furn( &m, furn_f_fema_groundsheet, point( 21, 5 ), point( 22, 6 ) );
+        square_furn( &m, furn_f_canvas_wall, point_omt_ms( 20, 4 ), point_omt_ms( 23, 7 ) );
+        square_furn( &m, furn_f_fema_groundsheet, point_omt_ms( 21, 5 ), point_omt_ms( 22, 6 ) );
         m.furn_set( tripoint{ 21, 7, abs_sub.z }, furn_f_canvas_door );
 
         //Place beds in a tent
@@ -957,13 +960,13 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
 
         //Spawn 6-20 puddles of blood on tiles without mines
         for( int i = 0; i < num_mines; i++ ) {
-            const point p8( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ) );
+            const point_omt_ms p8( rng( 1, SEEX ), rng( 3, SEEY * 2 - 4 ) );
             if( m.tr_at( { p8, abs_sub.z } ).is_null() ) {
                 m.add_field( { p8, abs_sub.z }, fd_blood, rng( 1, 3 ) );
                 //10% chance to spawn a corpse of dead people/zombie on a tile with blood
                 if( one_in( 10 ) ) {
                     m.add_corpse( { p8, abs_sub.z } );
-                    for( const tripoint &loc : m.points_in_radius( { p8, abs_sub.z }, 1 ) ) {
+                    for( const tripoint_omt_ms &loc : m.points_in_radius( { p8, abs_sub.z }, 1 ) ) {
                         //50% chance to spawn gibs in every tile around corpse in 1-tile radius
                         if( one_in( 2 ) ) {
                             m.add_field( { loc.xy(), abs_sub.z }, fd_gibs_flesh, rng( 1, 3 ) );
@@ -977,9 +980,9 @@ static bool mx_minefield( map &, const tripoint &abs_sub )
         const int y = rng( 3, SEEY );
         const int y1 = rng( SEEY + 1, SEEY * 2 - 4 );
         m.furn_set( point( 0, y ), furn_f_sign_warning );
-        m.set_signage( tripoint( 0, y, abs_sub.z ), text );
+        m.set_signage( { 0, y, abs_sub.z }, text );
         m.furn_set( point( 0, y1 ), furn_f_sign_warning );
-        m.set_signage( tripoint( 0, y1, abs_sub.z ), text );
+        m.set_signage( { 0, y1, abs_sub.z }, text );
 
         did_something = true;
     }
@@ -992,20 +995,20 @@ static void place_fumarole( map &m, const point &p1, const point &p2, std::set<p
     // Tracks points nearby for ignition after the lava is placed
     //std::set<point> ignited;
 
-    std::vector<point> fumarole = line_to( p1, p2, 0 );
-    for( point &i : fumarole ) {
+    std::vector<point_bub_ms> fumarole = line_to( point_bub_ms( p1 ), point_bub_ms( p2 ), 0 );
+    for( point_bub_ms &i : fumarole ) {
         m.ter_set( i, ter_t_lava );
 
         // Add all adjacent tiles (even on diagonals) for possible ignition
         // Since they're being added to a set, duplicates won't occur
-        ignited.insert( i + point_north_west );
-        ignited.insert( i + point_north );
-        ignited.insert( i + point_north_east );
-        ignited.insert( i + point_west );
-        ignited.insert( i + point_east );
-        ignited.insert( i + point_south_west );
-        ignited.insert( i + point_south );
-        ignited.insert( i + point_south_east );
+        ignited.insert( ( i + point_north_west ).raw() );
+        ignited.insert( ( i + point_north ).raw() );
+        ignited.insert( ( i + point_north_east ).raw() );
+        ignited.insert( ( i + point_west ).raw() );
+        ignited.insert( ( i + point_east ).raw() );
+        ignited.insert( ( i + point_south_west ).raw() );
+        ignited.insert( ( i + point_south ).raw() );
+        ignited.insert( ( i + point_south_east ).raw() );
 
         if( one_in( 6 ) ) {
             m.spawn_item( i + point_north_west, itype_chunk_sulfur );
@@ -1069,8 +1072,8 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
             for( int i = p.x() - rad; i <= p.x() + rad; i++ ) {
                 for( int j = p.y() - rad; j <= p.y() + rad; j++ ) {
                     if( trig_dist( p.raw(), point( i, j ) ) + rng( 0, 3 ) <= rad ) {
-                        const tripoint loc( i, j, abs_sub.z );
-                        dead_vegetation_parser( m, loc );
+                        const tripoint_bub_ms loc( i, j, abs_sub.z );
+                        dead_vegetation_parser( m, loc.raw() );
                         m.adjust_radiation( loc.xy(), rng( 20, 40 ) );
                     }
                 }
@@ -1578,9 +1581,9 @@ static bool mx_roadworks( map &m, const tripoint &abs_sub )
     const weighted_int_list<ter_id> defects = road_defects;
 
     // location holders
-    point defects_from; // road defects square start
-    point defects_to; // road defects square end
-    point defects_centered; //  road defects centered
+    point_bub_ms defects_from; // road defects square start
+    point_bub_ms defects_to; // road defects square end
+    point_bub_ms defects_centered; //  road defects centered
     tripoint veh( 0, 0, abs_sub.z ); // vehicle
     point equipment; // equipment
 
@@ -1828,8 +1831,8 @@ static bool mx_roadworks( map &m, const tripoint &abs_sub )
     }
     // soil generator
     for( int i = 1; i <= 10; i++ ) {
-        m.spawn_item( point( rng( defects_from.x, defects_to.x ),
-                             rng( defects_from.y, defects_to.y ) ), itype_material_soil );
+        m.spawn_item( point_bub_ms( rng( defects_from.x(), defects_to.x() ),
+                                    rng( defects_from.y(), defects_to.y() ) ), itype_material_soil );
     }
     // vehicle placer
     switch( rng( 1, 6 ) ) {
@@ -2016,7 +2019,7 @@ static bool mx_casings( map &m, const tripoint &abs_sub )
 
 static bool mx_looters( map &m, const tripoint &abs_sub )
 {
-    const tripoint center( rng( 5, SEEX * 2 - 5 ), rng( 5, SEEY * 2 - 5 ), abs_sub.z );
+    const tripoint_bub_ms center( rng( 5, SEEX * 2 - 5 ), rng( 5, SEEY * 2 - 5 ), abs_sub.z );
     //25% chance to spawn a corpse with some blood around it
     if( one_in( 4 ) && m.passable( center ) ) {
         m.add_corpse( center );
@@ -2028,11 +2031,12 @@ static bool mx_looters( map &m, const tripoint &abs_sub )
     //Spawn up to 5 hostile bandits with equal chance to be ranged or melee type
     const int num_looters = rng( 1, 5 );
     for( int i = 0; i < num_looters; i++ ) {
-        if( const std::optional<tripoint> pos_ = random_point( m.points_in_radius( center, rng( 1,
-        4 ) ), [&]( const tripoint & p ) {
+        if( const std::optional<tripoint_bub_ms> pos_ = random_point( m.points_in_radius( center, rng( 1,
+        4 ) ), [&]( const tripoint_bub_ms & p ) {
         return m.passable( p );
         } ) ) {
-            m.place_npc( pos_->xy(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
+            m.place_npc( pos_->xy().raw(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
+            m.place_npc( pos_->xy().raw(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
         }
     }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -634,7 +634,7 @@ static void field_processor_extra_radiation( const tripoint &p, field_entry &cur
     const field_intensity_level &ilevel = cur.get_intensity_level();
     if( ilevel.extra_radiation_max > 0 ) {
         int extra_radiation = rng( ilevel.extra_radiation_min, ilevel.extra_radiation_max );
-        pd.here.adjust_radiation( p, extra_radiation );
+        pd.here.adjust_radiation( tripoint_bub_ms( p ), extra_radiation );
     }
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2108,7 +2108,7 @@ class jmapgen_sign : public jmapgen_piece
                 }
                 signtext = apply_all_tags( signtext, cityname );
             }
-            dat.m.set_signage( r.raw(), signtext );
+            dat.m.set_signage( r, signtext );
         }
         std::string apply_all_tags( std::string signtext, const std::string &cityname ) const {
             signtext = SNIPPET.expand( signtext );
@@ -2326,7 +2326,7 @@ class jmapgen_liquid_item : public jmapgen_piece
                 }
                 if( newliquid.charges > 0 ) {
                     dat.m.add_item_or_charges(
-                        tripoint( x.get(), y.get(), dat.zlevel() + z.get() ), newliquid );
+                        tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), newliquid );
                 }
             }
         }
@@ -2360,7 +2360,7 @@ class jmapgen_corpse : public jmapgen_piece
             const mtype_id &corpse_type = random_entry_ref( monster_group );
             item corpse = item::make_corpse( corpse_type,
                                              std::max( calendar::turn - age, calendar::fall_of_civilization ) );
-            dat.m.add_item_or_charges( tripoint( x.get(), y.get(), dat.zlevel() + z.get() ),
+            dat.m.add_item_or_charges( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ),
                                        corpse );
         }
 };
@@ -2907,7 +2907,8 @@ class jmapgen_spawn_item : public jmapgen_piece
             const float spawn_rate = get_option<float>( "ITEM_SPAWNRATE" );
             int spawn_count = ( c == 100 ) ? 1 : roll_remainder( c * spawn_rate / 100.0f );
             for( int i = 0; i < spawn_count; i++ ) {
-                dat.m.spawn_item( tripoint( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_id, amount.get(),
+                dat.m.spawn_item( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_id,
+                                  amount.get(),
                                   0, calendar::start_of_cataclysm, 0, flags, variant, faction );
             }
         }
@@ -3034,7 +3035,7 @@ class jmapgen_terrain : public jmapgen_piece
             if( chosen_id.id().is_null() ) {
                 return;
             }
-            tripoint p( x.get(), y.get(), dat.zlevel() + z.get() );
+            tripoint_bub_ms p( x.get(), y.get(), dat.zlevel() + z.get() );
 
             ter_id terrain_here = dat.m.ter( p );
             const ter_t &chosen_ter = *chosen_id;
@@ -3129,7 +3130,7 @@ class jmapgen_terrain : public jmapgen_piece
             if( is_boring_wall || act_trap == apply_action::act_erase ) {
                 dat.m.remove_trap( p );
             } else if( act_trap == apply_action::act_dismantle ) {
-                dat.m.tr_at( p ).on_disarmed( dat.m, p );
+                dat.m.tr_at( p ).on_disarmed( dat.m, p.raw() );
             }
 
             if( is_boring_wall || act_item == apply_action::act_erase ) {
@@ -5014,7 +5015,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_RADIATION: {
-                m.set_radiation( target_pos.raw(), val.get() );
+                m.set_radiation( target_pos, val.get() );
             }
             break;
             case JMAPGEN_SETMAP_TRAP_REMOVE: {
@@ -5038,7 +5039,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
             }
             break;
             case JMAPGEN_SETMAP_BASH: {
-                m.bash( target_pos.raw(), 9999 );
+                m.bash( target_pos, 9999 );
             }
             break;
             case JMAPGEN_SETMAP_VARIABLE: {
@@ -5112,20 +5113,22 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                 const std::vector<point> line = line_to( point( x_get(), y_get() ), point( x2_get(), y2_get() ),
                                                 0 );
                 for( const point &i : line ) {
-                    m.set_radiation( tripoint( i, z_level ), static_cast<int>( val.get() ) );
+                    m.set_radiation( tripoint_bub_ms( i.x, i.y, z_level ), static_cast<int>( val.get() ) );
                 }
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_TER: {
                 // TODO: the ter_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_square_ter( ter_id( val.get() ), point( x_get(), y_get() ), point( x2_get(), y2_get() ),
+                m.draw_square_ter( ter_id( val.get() ), point_bub_ms( x_get(), y_get() ), point_bub_ms( x2_get(),
+                                   y2_get() ),
                                    z_level,
                                    dat.has_flag( jmapgen_flags::avoid_creatures ) );
             }
             break;
             case JMAPGEN_SETMAP_SQUARE_FURN: {
                 // TODO: the furn_id should be stored separately and not be wrapped in an jmapgen_int
-                m.draw_square_furn( furn_id( val.get() ), point( x_get(), y_get() ), point( x2_get(), y2_get() ),
+                m.draw_square_furn( furn_id( val.get() ), point_bub_ms( x_get(), y_get() ), point_bub_ms( x2_get(),
+                                    y2_get() ),
                                     z_level,
                                     dat.has_flag( jmapgen_flags::avoid_creatures ) );
             }
@@ -5198,7 +5201,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                 const int cy2 = y2_get();
                 for( int tx = c2.x; tx <= cx2; tx++ ) {
                     for( int ty = c2.y; ty <= cy2; ty++ ) {
-                        m.set_radiation( tripoint( tx, ty, z_level ), static_cast<int>( val.get() ) );
+                        m.set_radiation( tripoint_bub_ms( tx, ty, z_level ), static_cast<int>( val.get() ) );
                     }
                 }
             }
@@ -5505,7 +5508,7 @@ void map::draw_lab( mapgendata &dat )
     bool central_lab = false;
     bool tower_lab = false;
 
-    point p2;
+    point_bub_ms p2;
 
     int lw = 0;
     int rw = 0;
@@ -6293,7 +6296,7 @@ void map::draw_lab( mapgendata &dat )
                                   point_bub_ms( 6, SEEY * 2 - 7 ), abs_sub.z(), 1, true );
                     place_spawns( GROUP_ROBOT_SECUBOT, 1, point_bub_ms( SEEX * 2 - 7, SEEY * 2 - 7 ),
                                   point_bub_ms( SEEX * 2 - 7, SEEY * 2 - 7 ), abs_sub.z(), 1, true );
-                    spawn_item( point( SEEX - 4, SEEY - 2 ), "id_science" );
+                    spawn_item( point_bub_ms( SEEX - 4, SEEY - 2 ), "id_science" );
                     if( loot_variant <= 96 ) {
                         mtrap_set( this, tripoint_bub_ms( SEEX - 3, SEEY - 3, dat.zlevel() ), tr_dissector );
                         mtrap_set( this, tripoint_bub_ms( SEEX + 2, SEEY - 3, dat.zlevel() ), tr_dissector );
@@ -6312,22 +6315,22 @@ void map::draw_lab( mapgendata &dat )
                         furn_set( point( SEEX - 1, SEEY ), furn_f_table );
                         furn_set( point( SEEX, SEEY ), furn_f_table );
                         if( loot_variant <= 67 ) {
-                            spawn_item( point( SEEX, SEEY - 1 ), "UPS_off" );
-                            spawn_item( point( SEEX, SEEY - 1 ), "heavy_battery_cell" );
-                            spawn_item( point( SEEX - 1, SEEY ), "v29" );
-                            spawn_item( point( SEEX - 1, SEEY ), "laser_rifle", dice( 1, 0 ) );
-                            spawn_item( point( SEEX, SEEY ), "plasma_gun" );
-                            spawn_item( point( SEEX, SEEY ), "plasma" );
-                            spawn_item( point( SEEX - 1, SEEY ), "recipe_atomic_battery" );
-                            spawn_item( point( SEEX + 1, SEEY ), "plut_cell", rng( 8, 20 ) );
+                            spawn_item( point_bub_ms( SEEX, SEEY - 1 ), "UPS_off" );
+                            spawn_item( point_bub_ms( SEEX, SEEY - 1 ), "heavy_battery_cell" );
+                            spawn_item( point_bub_ms( SEEX - 1, SEEY ), "v29" );
+                            spawn_item( point_bub_ms( SEEX - 1, SEEY ), "laser_rifle", dice( 1, 0 ) );
+                            spawn_item( point_bub_ms( SEEX, SEEY ), "plasma_gun" );
+                            spawn_item( point_bub_ms( SEEX, SEEY ), "plasma" );
+                            spawn_item( point_bub_ms( SEEX - 1, SEEY ), "recipe_atomic_battery" );
+                            spawn_item( point_bub_ms( SEEX + 1, SEEY ), "plut_cell", rng( 8, 20 ) );
                         } else if( loot_variant < 89 ) {
-                            spawn_item( point( SEEX, SEEY ), "recipe_atomic_battery" );
-                            spawn_item( point( SEEX + 1, SEEY ), "plut_cell", rng( 8, 20 ) );
+                            spawn_item( point_bub_ms( SEEX, SEEY ), "recipe_atomic_battery" );
+                            spawn_item( point_bub_ms( SEEX + 1, SEEY ), "plut_cell", rng( 8, 20 ) );
                         }  else { // loot_variant between 90 and 96.
-                            spawn_item( point( SEEX - 1, SEEY - 1 ), "rm13_armor" );
-                            spawn_item( point( SEEX, SEEY - 1 ), "plut_cell" );
-                            spawn_item( point( SEEX - 1, SEEY ), "plut_cell" );
-                            spawn_item( point( SEEX, SEEY ), "recipe_caseless" );
+                            spawn_item( point_bub_ms( SEEX - 1, SEEY - 1 ), "rm13_armor" );
+                            spawn_item( point_bub_ms( SEEX, SEEY - 1 ), "plut_cell" );
+                            spawn_item( point_bub_ms( SEEX - 1, SEEY ), "plut_cell" );
+                            spawn_item( point_bub_ms( SEEX, SEEY ), "recipe_caseless" );
                         }
                     } else { // 4% of the lab ends will be this weapons testing end.
                         mtrap_set( this, tripoint_bub_ms( SEEX - 4, SEEY - 3, dat.zlevel() ), tr_dissector );
@@ -6358,7 +6361,7 @@ void map::draw_lab( mapgendata &dat )
                         place_items( Item_spawn_data_guns_rare, 96, point( SEEX - 2, SEEY ),
                                      point( SEEX + 1, SEEY ), abs_sub.z(), false,
                                      calendar::start_of_cataclysm );
-                        spawn_item( point( SEEX + 1, SEEY ), "plut_cell", rng( 1, 10 ) );
+                        spawn_item( point_bub_ms( SEEX + 1, SEEY ), "plut_cell", rng( 1, 10 ) );
                     }
                     break;
                 // Netherworld access
@@ -6387,7 +6390,7 @@ void map::draw_lab( mapgendata &dat )
                         }
                     }
 
-                    spawn_item( point( SEEX - 1, 8 ), "id_science" );
+                    spawn_item( point_bub_ms( SEEX - 1, 8 ), "id_science" );
                     tmpcomp = add_computer( tripoint( SEEX,  8, abs_sub.z() ),
                                             _( "Sub-prime contact console" ), 7 );
                     if( monsters_end ) { //only add these options when there are monsters.
@@ -6421,7 +6424,7 @@ void map::draw_lab( mapgendata &dat )
                     mtrap_set( this, tripoint_bub_ms( SEEX + 1, SEEY - 2, dat.zlevel() ), tr_dissector );
                     mtrap_set( this, tripoint_bub_ms( SEEX - 2, SEEY + 1, dat.zlevel() ), tr_dissector );
                     mtrap_set( this, tripoint_bub_ms( SEEX + 1, SEEY + 1, dat.zlevel() ), tr_dissector );
-                    square_furn( this, furn_f_counter, point( SEEX - 1, SEEY - 1 ), point( SEEX, SEEY ) );
+                    square_furn( this, furn_f_counter, point_bub_ms( SEEX - 1, SEEY - 1 ), point_bub_ms( SEEX, SEEY ) );
                     int item_count = 0;
                     while( item_count < 5 ) {
                         item_count +=
@@ -6437,8 +6440,8 @@ void map::draw_lab( mapgendata &dat )
                           dat.zlevel() );
                     line( this, ter_t_reinforced_glass, point( SEEX + 1, SEEY - 1 ), point( SEEX + 1, SEEY ),
                           dat.zlevel() );
-                    spawn_item( point( SEEX - 4, SEEY - 3 ), "id_science" );
-                    furn_set( point( SEEX - 3, SEEY - 3 ), furn_f_console );
+                    spawn_item( point_bub_ms( SEEX - 4, SEEY - 3 ), "id_science" );
+                    furn_set( point_bub_ms( SEEX - 3, SEEY - 3 ), furn_f_console );
                     tmpcomp = add_computer( tripoint( SEEX - 3,  SEEY - 3, abs_sub.z() ),
                                             _( "Bionic access" ), 3 );
                     tmpcomp->add_option( _( "Manifest" ), COMPACT_LIST_BIONICS, 0 );
@@ -6465,7 +6468,7 @@ void map::draw_lab( mapgendata &dat )
                     line( this, ter_t_cvdbody, point( SEEX, SEEY - 1 ), point( SEEX, SEEY + 1 ), dat.zlevel() );
                     line( this, ter_t_cvdbody, point( SEEX + 1, SEEY - 2 ), point( SEEX + 1, SEEY + 1 ), dat.zlevel() );
                     ter_set( point( SEEX, SEEY - 2 ), ter_t_cvdmachine );
-                    spawn_item( point( SEEX, SEEY - 3 ), "id_science" );
+                    spawn_item( point_bub_ms( SEEX, SEEY - 3 ), "id_science" );
                     break;
             }
         } // end use_hardcoded_lab_finale
@@ -6648,7 +6651,7 @@ void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bo
         if( lootable &&
             !one_in( std::max( to_days<int>( calendar::turn - calendar::start_of_cataclysm ), 0 ) + 4 ) ) {
             furn_set( p, furn_f_vending_o );
-            for( const tripoint &loc : points_in_radius( p.raw(), 1 ) ) {
+            for( const tripoint_bub_ms &loc : points_in_radius( p, 1 ) ) {
                 if( one_in( 4 ) ) {
                     spawn_item( loc, "glass_shard", rng( 1, 25 ) );
                 }
@@ -6675,7 +6678,7 @@ void map::apply_faction_ownership( const point &p1, const point &p2, const facti
 {
     for( const tripoint &p : points_in_rectangle( tripoint( p1, abs_sub.z() ), tripoint( p2,
             abs_sub.z() ) ) ) {
-        map_stack items = i_at( p.xy() );
+        map_stack items = i_at( point_bub_ms( p.xy() ) );
         for( item &elem : items ) {
             elem.set_owner( id );
         }
@@ -6723,13 +6726,13 @@ std::vector<item *> map::place_items(
                    !terrain.has_flag( ter_furn_flag::TFLAG_FLAT );
         };
 
-        tripoint p;
+        tripoint_bub_ms p;
         do {
-            p.x = rng( p1.x, p2.x );
-            p.y = rng( p1.y, p2.y );
-            p.z = rng( p1.z, p2.z );
+            p.x() = rng( p1.x, p2.x );
+            p.y() = rng( p1.y, p2.y );
+            p.z() = rng( p1.z, p2.z );
             tries++;
-        } while( is_valid_terrain( p ) && tries < 20 );
+        } while( is_valid_terrain( p.raw() ) && tries < 20 );
         if( tries < 20 ) {
             auto add_res_itm = [this, &p, &res]( const item & itm ) {
                 item &it = add_item_or_charges( p, itm );
@@ -7721,7 +7724,7 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 {
     // TODO: Z
     const int z = cp.z;
-    point c( cp.xy() );
+    point_bub_ms c( cp.xy() );
     if( create_rubble ) {
         rough_circle( this, ter_t_dirt, c, 11 );
         rough_circle_furn( this, furn_f_rubble, c, 5 );
@@ -7730,12 +7733,12 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
     switch( prop ) {
         case ARTPROP_WRIGGLING:
         case ARTPROP_MOVING:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble ) {
                         add_field( tripoint_bub_ms{i, j, z}, fd_push_items, 1 );
                         if( one_in( 3 ) ) {
-                            spawn_item( point( i, j ), "rock" );
+                            spawn_item( point_bub_ms( i, j ), "rock" );
                         }
                     }
                 }
@@ -7744,9 +7747,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_GLOWING:
         case ARTPROP_GLITTERING:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble && one_in( 2 ) ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble && one_in( 2 ) ) {
                         mtrap_set( this, tripoint_bub_ms( i, j, z ), tr_glow );
                     }
                 }
@@ -7755,9 +7758,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_HUMMING:
         case ARTPROP_RATTLING:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble && one_in( 2 ) ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble && one_in( 2 ) ) {
                         mtrap_set( this, tripoint_bub_ms( i, j, z ), tr_hum );
                     }
                 }
@@ -7766,9 +7769,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
 
         case ARTPROP_WHISPERING:
         case ARTPROP_ENGRAVED:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble && one_in( 3 ) ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble && one_in( 3 ) ) {
                         mtrap_set( this, tripoint_bub_ms( i, j, z ), tr_shadow );
                     }
                 }
@@ -7776,9 +7779,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_BREATHING:
-            for( int i = c.x - 1; i <= c.x + 1; i++ ) {
-                for( int j = c.y - 1; j <= c.y + 1; j++ ) {
-                    if( i == c.x && j == c.y ) {
+            for( int i = c.x() - 1; i <= c.x() + 1; i++ ) {
+                for( int j = c.y() - 1; j <= c.y() + 1; j++ ) {
+                    if( i == c.x() && j == c.y() ) {
                         place_spawns( GROUP_BREATHER_HUB, 1, point_bub_ms( i, j ), point_bub_ms( i, j ), z, 1,
                                       true );
                     } else {
@@ -7789,9 +7792,9 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_DEAD:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble ) {
                         mtrap_set( this, tripoint_bub_ms( i, j, z ), tr_drain );
                     }
                 }
@@ -7799,10 +7802,10 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_ITCHY:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble ) {
-                        set_radiation( point( i, j ), rng( 0, 10 ) );
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble ) {
+                        set_radiation( point_bub_ms( i, j ), rng( 0, 10 ) );
                     }
                 }
             }
@@ -7818,20 +7821,20 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
             break;
 
         case ARTPROP_WARM:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble ) {
                         add_field( tripoint_bub_ms{i, j, abs_sub.z()}, fd_fire_vent,
-                                   1 + ( rl_dist( c, point( i, j ) ) % 3 ) );
+                                   1 + ( rl_dist( c, point_bub_ms( i, j ) ) % 3 ) );
                     }
                 }
             }
             break;
 
         case ARTPROP_SCALED:
-            for( int i = c.x - 5; i <= c.x + 5; i++ ) {
-                for( int j = c.y - 5; j <= c.y + 5; j++ ) {
-                    if( furn( point( i, j ) ) == furn_f_rubble ) {
+            for( int i = c.x() - 5; i <= c.x() + 5; i++ ) {
+                for( int j = c.y() - 5; j <= c.y() + 5; j++ ) {
+                    if( furn( point_bub_ms( i, j ) ) == furn_f_rubble ) {
                         mtrap_set( this, tripoint_bub_ms( i, j, z ), tr_snake );
                     }
                 }
@@ -7851,10 +7854,10 @@ void map::create_anomaly( const tripoint &cp, artifact_natural_property prop, bo
                 return static_cast<artifact_natural_property>(
                            rng( ARTPROP_NULL + 1, ARTPROP_FRACTAL - 1 ) );
             };
-            create_anomaly( c + point( -4, -4 ), random_type() );
-            create_anomaly( c + point( 4, -4 ), random_type() );
-            create_anomaly( c + point( -4, 4 ), random_type() );
-            create_anomaly( c + point( 4, 4 ), random_type() );
+            create_anomaly( c.raw() + point( -4, -4 ), random_type() );
+            create_anomaly( c.raw() + point( 4, -4 ), random_type() );
+            create_anomaly( c.raw() + point( -4, 4 ), random_type() );
+            create_anomaly( c.raw() + point( 4, 4 ), random_type() );
             break;
         }
         default:
@@ -7908,31 +7911,32 @@ void fill_background( map *m, ter_id( *f )() )
 {
     m->draw_fill_background( f );
 }
-void square( map *m, const ter_id &type, const point &p1, const point &p2 )
+void square( map *m, const ter_id &type, const point_bub_ms &p1, const point_bub_ms &p2 )
 {
     m->draw_square_ter( type, p1, p2, m->get_abs_sub().z() );
 }
-void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 )
+void square_furn( map *m, const furn_id &type, const point_bub_ms &p1, const point_bub_ms &p2 )
 {
     m->draw_square_furn( type, p1, p2, m->get_abs_sub().z() );
 }
-void square_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 )
+void square_furn( tinymap *m, const furn_id &type, const point_omt_ms &p1, const point_omt_ms &p2 )
 {
     m->draw_square_furn( type, p1, p2 );
 }
-void square( map *m, ter_id( *f )(), const point &p1, const point &p2 )
+void square( map *m, ter_id( *f )(), const point_bub_ms &p1, const point_bub_ms &p2 )
 {
     m->draw_square_ter( f, p1, p2 );
 }
-void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 )
+void square( map *m, const weighted_int_list<ter_id> &f, const point_bub_ms &p1,
+             const point_bub_ms &p2 )
 {
     m->draw_square_ter( f, p1, p2 );
 }
-void rough_circle( map *m, const ter_id &type, const point &p, int rad )
+void rough_circle( map *m, const ter_id &type, const point_bub_ms &p, int rad )
 {
     m->draw_rough_circle_ter( type, p, rad );
 }
-void rough_circle_furn( map *m, const furn_id &type, const point &p, int rad )
+void rough_circle_furn( map *m, const furn_id &type, const point_bub_ms &p, int rad )
 {
     m->draw_rough_circle_furn( type, p, rad );
 }
@@ -7940,17 +7944,17 @@ void circle( map *m, const ter_id &type, double x, double y, double rad )
 {
     m->draw_circle_ter( type, rl_vec2d( x, y ), rad );
 }
-void circle( map *m, const ter_id &type, const point &p, int rad )
+void circle( map *m, const ter_id &type, const point_bub_ms &p, int rad )
 {
     m->draw_circle_ter( type, p, rad );
 }
-void circle_furn( map *m, const furn_id &type, const point &p, int rad )
+void circle_furn( map *m, const furn_id &type, const point_bub_ms &p, int rad )
 {
     m->draw_circle_furn( type, p, rad );
 }
-void add_corpse( map *m, const point &p )
+void add_corpse( map *m, const point_bub_ms &p )
 {
-    m->add_corpse( tripoint( p, m->get_abs_sub().z() ) );
+    m->add_corpse( { p, m->get_abs_sub().z() } );
 }
 
 //////////////////// mapgen update

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -663,17 +663,18 @@ void line_furn( tinymap *m, const furn_id &type, const point &p1, const point &p
 void line_furn( tinymap *m, const furn_id &type, const point_omt_ms &p1, const point_omt_ms &p2 );
 void fill_background( map *m, const ter_id &type );
 void fill_background( map *m, ter_id( *f )() );
-void square( map *m, const ter_id &type, const point &p1, const point &p2 );
-void square( map *m, ter_id( *f )(), const point &p1, const point &p2 );
-void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 );
-void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
-void square_furn( tinymap *m, const furn_id &type, const point &p1, const point &p2 );
-void rough_circle( map *m, const ter_id &type, const point &, int rad );
-void rough_circle_furn( map *m, const furn_id &type, const point &, int rad );
+void square( map *m, const ter_id &type, const point_bub_ms &p1, const point_bub_ms &p2 );
+void square( map *m, ter_id( *f )(), const point_bub_ms &p1, const point_bub_ms &p2 );
+void square( map *m, const weighted_int_list<ter_id> &f, const point_bub_ms &p1,
+             const point_bub_ms &p2 );
+void square_furn( map *m, const furn_id &type, const point_bub_ms &p1, const point_bub_ms &p2 );
+void square_furn( tinymap *m, const furn_id &type, const point_omt_ms &p1, const point_omt_ms &p2 );
+void rough_circle( map *m, const ter_id &type, const point_bub_ms &, int rad );
+void rough_circle_furn( map *m, const furn_id &type, const point_bub_ms &, int rad );
 void circle( map *m, const ter_id &type, double x, double y, double rad );
-void circle( map *m, const ter_id &type, const point &, int rad );
-void circle_furn( map *m, const furn_id &type, const point &, int rad );
-void add_corpse( map *m, const point & );
+void circle( map *m, const ter_id &type, const point_bub_ms &, int rad );
+void circle_furn( map *m, const furn_id &type, const point_bub_ms &, int rad );
+void add_corpse( map *m, const point_bub_ms & );
 
 extern std::map<nested_mapgen_id, nested_mapgen> nested_mapgens;
 extern std::map<update_mapgen_id, update_mapgen> update_mapgens;

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1216,7 +1216,7 @@ void mapgen_lake_shore( mapgendata &dat )
             if( did_extend_adjacent_terrain ) {
                 for( int x = 0; x < SEEX * 2; x++ ) {
                     for( int y = 0; y < SEEY * 2; y++ ) {
-                        m->i_clear( point( x, y ) );
+                        m->i_clear( point_bub_ms( x, y ) );
                     }
                 }
             }
@@ -1668,7 +1668,7 @@ void mapgen_ocean_shore( mapgendata &dat )
             if( did_extend_adjacent_terrain ) {
                 for( int x = 0; x < SEEX * 2; x++ ) {
                     for( int y = 0; y < SEEY * 2; y++ ) {
-                        m->i_clear( point( x, y ) );
+                        m->i_clear( point_bub_ms( x, y ) );
                     }
                 }
             }

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -218,7 +218,7 @@ int &mapgendata::dir( int dir_in )
     }
 }
 
-void mapgendata::square_groundcover( const point &p1, const point &p2 ) const
+void mapgendata::square_groundcover( const point_bub_ms &p1, const point_bub_ms &p2 ) const
 {
     m.draw_square_ter( default_groundcover, p1, p2 );
 }

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -225,7 +225,7 @@ class mapgendata
         const oter_id &neighbor_at( om_direction::type dir ) const;
         const oter_id &neighbor_at( direction ) const;
         void fill_groundcover() const;
-        void square_groundcover( const point &p1, const point &p2 ) const;
+        void square_groundcover( const point_bub_ms &p1, const point_bub_ms &p2 ) const;
         ter_id groundcover() const;
         bool is_groundcover( const ter_id &iid ) const;
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -317,7 +317,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
                 if( comp.typeId() == big_comp && !has_wield_conflicts( comp ) ) {
                     wield( comp );
                 } else {
-                    get_map().add_item_or_charges( pos(), comp );
+                    get_map().add_item_or_charges( pos_bub(), comp );
                 }
             }
         }
@@ -1973,7 +1973,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
 
     if( technique.disarms && you != nullptr && you->is_armed() && !you->is_hallucination() ) {
         item weap = you->remove_weapon();
-        here.add_item_or_charges( you->pos(), weap );
+        here.add_item_or_charges( you->pos_bub(), weap );
         if( you->is_avatar() ) {
             add_msg_if_npc( _( "<npcname> disarms you!" ) );
         } else {
@@ -2887,7 +2887,7 @@ void avatar::disarm( npc &target )
         } else if( my_roll >= their_roll / 2 ) {
             add_msg( _( "You grab at %s and pull with all your force, but it drops nearby!" ),
                      it->tname() );
-            const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+            const tripoint_bub_ms tp = target.pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
             here.add_item_or_charges( tp, target.i_rem( &*it ) );
             mod_moves( -100 );
         } else {
@@ -2902,7 +2902,7 @@ void avatar::disarm( npc &target )
         if( my_roll >= their_roll ) {
             add_msg( _( "You smash %s with all your might forcing their %s to drop down nearby!" ),
                      target.get_name(), it->tname() );
-            const tripoint tp = target.pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+            const tripoint_bub_ms tp = target.pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
             here.add_item_or_charges( tp, target.i_rem( &*it ) );
         } else {
             add_msg( _( "You smash %s with all your might but %s remains in their hands!" ),

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1630,7 +1630,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
     player_character.use_amount( itype_FMCNote, limiting_number );
 
     //Plant the actual seeds
-    for( const tripoint &plot : bay.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &plot : bay.omt_points_on_zlevel() ) {
         if( bay.ter( plot ) == ter_t_dirtmound && limiting_number > 0 ) {
             std::list<item> used_seed;
             if( item::count_by_charges( seed_id ) ) {
@@ -2480,7 +2480,7 @@ void talk_function::companion_return( npc &comp )
     for( size_t i = 0; i < comp.companion_mission_inv.size(); i++ ) {
         for( const item &it : comp.companion_mission_inv.const_stack( i ) ) {
             if( !it.count_by_charges() || it.charges > 0 ) {
-                here.add_item_or_charges( player_character.pos(), it );
+                here.add_item_or_charges( player_character.pos_bub(), it );
             }
         }
     }
@@ -2807,7 +2807,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
     bay.load( site, false );
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
-    for( const tripoint &p : bay.points_on_zlevel() ) {
+    for( const tripoint_omt_ms &p : bay.omt_points_on_zlevel() ) {
         const ter_id t = bay.ter( p );
         //Open all the doors, doesn't need to be exhaustive
         const std::unordered_set<ter_str_id> openable_doors = {ter_t_door_c, ter_t_door_c_peep, ter_t_door_b, ter_t_door_boarded, ter_t_door_boarded_damaged, ter_t_rdoor_boarded, ter_t_rdoor_boarded_damaged, ter_t_door_boarded_peep, ter_t_door_boarded_damaged_peep };
@@ -2849,7 +2849,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
             bay.spawn_items( p, item_group::items_from( bash.drop_group, calendar::turn ) );
         }
         //Kill zombies!  Only works against pre-spawned enemies at the moment...
-        Creature *critter = creatures.creature_at( p );
+        Creature *critter = creatures.creature_at( rebase_bub( p ) );
         if( critter != nullptr ) {
             critter->die( nullptr );
         }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -497,7 +497,7 @@ bool mattack::absorb_items( monster *z )
         if( it->is_container() && !absorb_material.empty() ) {
             it->spill_contents( z->pos() );
         }
-        here.i_rem( z->pos(), it );
+        here.i_rem( z->pos_bub(), it );
     }
 
     return !consumed_items.empty();
@@ -690,11 +690,11 @@ bool mattack::shriek_stun( monster *z )
     units::angle cone_angle = 20_degrees;
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint &cone : here.points_in_radius( z->pos(), 4 ) ) {
-        units::angle tile_angle = coord_to_angle( z->pos(), cone );
+    for( const tripoint_bub_ms &cone : here.points_in_radius( z->pos_bub(), 4 ) ) {
+        units::angle tile_angle = coord_to_angle( z->pos_bub().raw(), cone.raw() );
         units::angle diff = units::fabs( target_angle - tile_angle );
         // Skip the target, because it's outside cone or it's the source
-        if( diff + cone_angle > 360_degrees || diff > cone_angle || cone == z->pos() ) {
+        if( diff + cone_angle > 360_degrees || diff > cone_angle || cone == z->pos_bub() ) {
             continue;
         }
         // Affect the target
@@ -796,7 +796,7 @@ bool mattack::acid( monster *z )
     proj.proj_effects.insert( ammo_effect_NO_OVERSHOOT );
     dealt_projectile_attack dealt = projectile_attack( proj, z->pos(), target->pos(), dispersion_sources{ 5400 },
                                     z );
-    const tripoint &hitp = dealt.end_point;
+    const tripoint_bub_ms &hitp = tripoint_bub_ms( dealt.end_point );
     const Creature *hit_critter = dealt.hit_critter;
     if( hit_critter == nullptr && here.hit_with_acid( hitp ) ) {
         add_msg_if_player_sees( hitp,  _( "A glob of acid hits the %s!" ), here.tername( hitp ) );
@@ -808,7 +808,7 @@ bool mattack::acid( monster *z )
 
     for( int i = -3; i <= 3; i++ ) {
         for( int j = -3; j <= 3; j++ ) {
-            tripoint dest = hitp + tripoint( i, j, 0 );
+            tripoint_bub_ms dest = hitp + tripoint_rel_ms( i, j, 0 );
             if( here.passable( dest ) &&
                 here.clear_path( dest, hitp, 6, 1, 100 ) &&
                 ( ( one_in( std::abs( j ) ) && one_in( std::abs( i ) ) ) || ( i == 0 && j == 0 ) ) ) {
@@ -2888,7 +2888,7 @@ bool mattack::check_money_left( monster *z )
                     if( it.has_var( "DESTROY_ITEM_ON_MON_DEATH" ) ) {
                         continue;
                     }
-                    get_map().add_item_or_charges( z->pos(), it );
+                    get_map().add_item_or_charges( z->pos_bub(), it );
                 }
                 z->inv.clear();
                 z->remove_effect( effect_has_bag );
@@ -3526,7 +3526,7 @@ void mattack::flame( monster *z, Creature *target )
         for( tripoint &i : traj ) {
             // break out of attack if flame hits a wall
             // TODO: Z
-            if( here.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
+            if( here.hit_with_fire( { i.x, i.y, z->posz() } ) ) {
                 add_msg_if_player_sees( i, _( "The tongue of flame hits the %s!" ),
                                         here.tername( i.xy() ) );
                 return;
@@ -3548,7 +3548,7 @@ void mattack::flame( monster *z, Creature *target )
 
     for( tripoint &i : traj ) {
         // break out of attack if flame hits a wall
-        if( here.hit_with_fire( tripoint( i.xy(), z->posz() ) ) ) {
+        if( here.hit_with_fire( { i.x, i.y, z->posz() } ) ) {
             add_msg_if_player_sees( i,  _( "The tongue of flame hits the %s!" ),
                                     here.tername( i.xy() ) );
             return;
@@ -4887,7 +4887,7 @@ bool mattack::bio_op_disarm( monster *z )
 
     if( my_roll >= their_roll && !it->has_flag( flag_NO_UNWIELD ) ) {
         target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
-        const tripoint tp = foe->pos() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        const tripoint_bub_ms tp = foe->pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
         get_map().add_item_or_charges( tp, foe->i_rem( &*it ) );
     } else {
         target->add_msg_if_player( m_good, _( "but you break its grip!" ) );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -101,8 +101,9 @@ static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint tarp( z.pos() + point( rng( -distance, distance ), rng( -distance, distance ) ) );
-        const auto traj = line_to( z.pos(), tarp );
+        tripoint_bub_ms tarp( z.pos_bub() + point( rng( -distance, distance ), rng( -distance,
+                              distance ) ) );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub(), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -204,7 +205,7 @@ item_location mdeath::splatter( monster &z )
         if( z.has_effect( effect_critter_underfed ) ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here.add_item_ret_loc( z.pos(), corpse );
+        return here.add_item_ret_loc( z.pos_bub(), corpse );
     }
     return {};
 }
@@ -235,7 +236,7 @@ void mdeath::broken( monster &z )
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
     map &here = get_map();
-    here.add_item_or_charges( z.pos(), broken_mon );
+    here.add_item_or_charges( z.pos_bub(), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -265,7 +266,7 @@ void mdeath::broken( monster &z )
                     }
                 }
                 if( !spawned ) {
-                    here.spawn_item( z.pos(), ammo_entry.first, ammo_entry.second, 1,
+                    here.spawn_item( z.pos_bub(), ammo_entry.first, ammo_entry.second, 1,
                                      calendar::turn );
                 }
             }
@@ -295,5 +296,5 @@ item_location make_mon_corpse( monster &z, int damageLvl )
     if( z.has_effect( effect_critter_underfed ) ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return get_map().add_item_ret_loc( z.pos(), corpse );
+    return get_map().add_item_ret_loc( z.pos_bub(), corpse );
 }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -213,7 +213,7 @@ void dump_items( monster &z )
         if( it.has_var( "DESTROY_ITEM_ON_MON_DEATH" ) ) {
             continue;
         }
-        here.add_item_or_charges( player_character.pos(), it );
+        here.add_item_or_charges( player_character.pos_bub(), it );
     }
     z.inv.clear();
     add_msg( _( "You dump the contents of the %s's bag on the ground." ), pet_name );
@@ -228,7 +228,7 @@ void remove_bag_from( monster &z )
             dump_items( z );
         }
         Character &player_character = get_player_character();
-        get_map().add_item_or_charges( player_character.pos(), *z.storage_item );
+        get_map().add_item_or_charges( player_character.pos_bub(), *z.storage_item );
         add_msg( _( "You remove the %1$s from %2$s." ), z.storage_item->display_name(), pet_name );
         z.storage_item.reset();
         player_character.mod_moves( -to_moves<int>( 2_seconds ) );
@@ -345,7 +345,7 @@ void remove_armor( monster &z )
     std::string pet_name = z.get_name();
     if( z.armor_item ) {
         z.armor_item->erase_var( "pet_armor" );
-        get_map().add_item_or_charges( z.pos(), *z.armor_item );
+        get_map().add_item_or_charges( z.pos_bub(), *z.armor_item );
         add_msg( pgettext( "pet armor", "You remove the %1$s from %2$s." ), z.armor_item->display_name(),
                  pet_name );
         z.armor_item.reset();
@@ -523,7 +523,7 @@ void shear_animal( monster &z )
 
 void remove_battery( monster &z )
 {
-    get_map().add_item_or_charges( get_player_character().pos(), *z.battery_item );
+    get_map().add_item_or_charges( get_player_character().pos_bub(), *z.battery_item );
     z.battery_item.reset();
 }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -985,7 +985,7 @@ void monster::move()
     }
 
     bool moved = false;
-    tripoint destination;
+    tripoint_bub_ms destination;
 
     bool try_to_move = false;
     creature_tracker &creatures = get_creature_tracker();
@@ -1001,15 +1001,15 @@ void monster::move()
 
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
-    tripoint local_dest = here.getlocal( get_dest() );
+    tripoint_bub_ms local_dest = here.bub_from_abs( get_dest() );
     if( try_to_move ) {
         // Move using vision by follow smells and sounds
         bool move_without_target = false;
         if( is_wandering() && has_intelligence() && can_see() ) {
             if( has_flag( mon_flag_SMELLS ) ) {
                 unset_dest();
-                tripoint tmp = scent_move();
-                if( tmp.x != -1 ) {
+                tripoint_bub_ms tmp = tripoint_bub_ms( scent_move() );
+                if( tmp.x() != -1 ) {
                     local_dest = tmp;
                     move_without_target = true;
                     add_msg_debug( debugmode::DF_MONMOVE, "%s follows smell using vision", name() );
@@ -1018,7 +1018,7 @@ void monster::move()
             if( !move_without_target && wandf > 0 && friendly == 0 ) {
                 unset_dest();
                 if( wander_pos != get_location() ) {
-                    local_dest = here.getlocal( wander_pos );
+                    local_dest = here.bub_from_abs( wander_pos );
                     move_without_target = true;
                     add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound using vision", name() );
                 }
@@ -1032,15 +1032,15 @@ void monster::move()
 
             const pathfinding_settings &pf_settings = get_pathfinding_settings();
             if( pf_settings.max_dist >= rl_dist( get_location(), get_dest() ) &&
-                ( path.empty() || rl_dist( pos(), path.front() ) >= 2 || path.back() != local_dest ) ) {
+                ( path.empty() || rl_dist( pos(), path.front() ) >= 2 || path.back() != local_dest.raw() ) ) {
                 // We need a new path
                 if( can_pathfind() ) {
-                    path = here.route( pos(), local_dest, pf_settings, get_path_avoid() );
+                    path = here.route( pos(), local_dest.raw(), pf_settings, get_path_avoid() );
                     if( path.empty() ) {
                         increment_pathfinding_cd();
                     }
                 } else {
-                    path = here.straight_route( pos(), local_dest );
+                    path = here.straight_route( pos(), local_dest.raw() );
                     if( !path.empty() ) {
                         if( std::any_of( path.begin(), path.end(), get_path_avoid() ) ) {
                             path.clear();
@@ -1053,8 +1053,8 @@ void monster::move()
             }
 
             // Try to respect old paths, even if we can't pathfind at the moment
-            if( !path.empty() && path.back() == local_dest ) {
-                destination = path.front();
+            if( !path.empty() && path.back() == local_dest.raw() ) {
+                destination = tripoint_bub_ms( path.front() );
                 moved = true;
                 pathed = true;
             } else {
@@ -1068,8 +1068,8 @@ void monster::move()
         // No sight... or our plans are invalid (e.g. moving through a transparent, but
         //  solid, square of terrain).  Fall back to smell if we have it.
         unset_dest();
-        tripoint tmp = scent_move();
-        if( tmp.x != -1 ) {
+        tripoint_bub_ms tmp = tripoint_bub_ms( scent_move() );
+        if( tmp.x() != -1 ) {
             destination = tmp;
             moved = true;
             add_msg_debug( debugmode::DF_MONMOVE, "%s follows smell to not use vision", name() );
@@ -1078,26 +1078,26 @@ void monster::move()
     if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
         unset_dest();
         if( wander_pos != get_location() ) {
-            destination = here.getlocal( wander_pos );
+            destination = here.bub_from_abs( wander_pos );
             moved = true;
             add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound to not use vision", name() );
         }
     }
 
-    point new_d( destination.xy() - pos().xy() );
+    point_rel_ms new_d( destination.xy() - pos_bub().xy() );
 
     // toggle facing direction for sdl flip
     if( !g->is_tileset_isometric() ) {
-        if( new_d.x < 0 ) {
+        if( new_d.x() < 0 ) {
             facing = FacingDirection::LEFT;
-        } else if( new_d.x > 0 ) {
+        } else if( new_d.x() > 0 ) {
             facing = FacingDirection::RIGHT;
         }
     } else {
-        if( new_d.y <= 0 && new_d.x <= 0 ) {
+        if( new_d.y() <= 0 && new_d.x() <= 0 ) {
             facing = FacingDirection::LEFT;
         }
-        if( new_d.x >= 0 && new_d.y >= 0 ) {
+        if( new_d.x() >= 0 && new_d.y() >= 0 ) {
             facing = FacingDirection::RIGHT;
         }
     }
@@ -1112,8 +1112,8 @@ void monster::move()
         const bool can_bash = bash_skill() > 0;
         // This is a float and using trig_dist() because that Does the Right Thing(tm)
         // in both circular and roguelike distance modes.
-        const float distance_to_target = trig_dist( pos(), destination );
-        for( tripoint &candidate : squares_closer_to( pos(), destination ) ) {
+        const float distance_to_target = trig_dist( pos_bub(), destination );
+        for( tripoint &candidate : squares_closer_to( pos_bub().raw(), destination.raw() ) ) {
             // rare scenario when monster is on the border of the map and it's goal is outside of the map
             if( !here.inbounds( candidate ) ) {
                 continue;
@@ -1208,14 +1208,14 @@ void monster::move()
             }
 
             // Try to shove vehicle out of the way
-            shove_vehicle( destination, candidate );
+            shove_vehicle( destination.raw(), candidate );
             // Bail out if we can't move there and we can't bash.
             if( !pathed && !can_move_to( candidate ) ) {
                 if( !can_bash ) {
                     continue;
                 }
                 // Don't bash if we're just tracking a noise.
-                if( !provocative_sound && is_wandering() && destination == here.getlocal( wander_pos ) ) {
+                if( !provocative_sound && is_wandering() && destination == here.bub_from_abs( wander_pos ) ) {
                     continue;
                 }
                 const int estimate = here.bash_rating( bash_estimate(), candidate );
@@ -1229,7 +1229,7 @@ void monster::move()
             }
 
             const float progress = distance_to_target - trig_dist( tripoint( candidate.xy(),
-                                   candidate.z + rampPos ), destination );
+                                   candidate.z + rampPos ), destination.raw() );
             // The x2 makes the first (and most direct) path twice as likely,
             // since the chance of switching is 1/1, 1/4, 1/6, 1/8
             switch_chance += progress * 2;
@@ -1257,7 +1257,8 @@ void monster::move()
               here.open_door( *this, local_next_step, !here.is_outside( pos_bub() ) ) ) ||
             ( !pacified && bash_at( local_next_step ) ) ||
             ( !pacified && push_to( local_next_step, 0, 0 ) ) ||
-            move_to( local_next_step, false, false, get_stagger_adjust( pos(), destination, local_next_step ) );
+            move_to( local_next_step, false, false, get_stagger_adjust( pos(), destination.raw(),
+                     local_next_step ) );
 
         if( !did_something ) {
             mod_moves( -get_speed() ); // If we don't do this, we'll get infinite loops.
@@ -2025,7 +2026,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
 
     if( has_flag( mon_flag_SMALLSLUDGETRAIL ) ) {
         if( one_in( 2 ) ) {
-            here.add_field( pos(), fd_sludge, 1 );
+            here.add_field( pos_bub(), fd_sludge, 1 );
         }
     }
 
@@ -2035,7 +2036,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
             if( one_in( 10 ) ) {
                 // if it has more napalm, drop some and reduce ammo in tank
                 if( ammo[itype_pressurized_tank] > 0 ) {
-                    here.add_item_or_charges( pos(), item( "napalm", calendar::turn, 50 ) );
+                    here.add_item_or_charges( pos_bub(), item( "napalm", calendar::turn, 50 ) );
                     ammo[itype_pressurized_tank] -= 50;
                 } else {
                     // TODO: remove mon_flag_DRIPS_NAPALM flag since no more napalm in tank
@@ -2046,7 +2047,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         if( has_flag( mon_flag_DRIPS_GASOLINE ) ) {
             if( one_in( 5 ) ) {
                 // TODO: use same idea that limits napalm dripping
-                here.add_item_or_charges( pos(), item( "gasoline" ) );
+                here.add_item_or_charges( pos_bub(), item( "gasoline" ) );
             }
         }
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -610,7 +610,7 @@ void monster::try_reproduce()
             } else {
                 const item egg( type->baby_egg, *baby_timer );
                 for( int i = 0; i < spawn_cnt; i++ ) {
-                    here.add_item_or_charges( pos(), egg, true );
+                    here.add_item_or_charges( pos_bub(), egg, true );
                 }
             }
         }
@@ -704,7 +704,7 @@ void monster::try_biosignature()
         if( *biosig_timer > calendar::turn || counter > 50 ) {
             return;
         }
-        here.add_item_or_charges( pos(), item( type->biosig_item, *biosig_timer, 1 ), true );
+        here.add_item_or_charges( pos_bub(), item( type->biosig_item, *biosig_timer, 1 ), true );
         *biosig_timer += *type->biosig_timer;
         counter += 1;
     }
@@ -2286,7 +2286,7 @@ bool monster::move_effects( bool )
                 if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                     add_msg( _( "The %s easily slips out of its bonds." ), name() );
                 }
-                here.add_item_or_charges( pos(), *tied_item );
+                here.add_item_or_charges( pos_bub(), *tied_item );
                 tied_item.reset();
             }
         } else {
@@ -2294,7 +2294,7 @@ bool monster::move_effects( bool )
                 const bool broken = rng( type->melee_dice * type->melee_sides, std::min( 10000,
                                          type->melee_dice * type->melee_sides * 250 ) ) > 800;
                 if( !broken ) {
-                    here.add_item_or_charges( pos(), *tied_item );
+                    here.add_item_or_charges( pos_bub(), *tied_item );
                 }
                 tied_item.reset();
                 if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
@@ -2344,8 +2344,8 @@ bool monster::move_effects( bool )
         if( type->melee_dice * type->melee_sides >= 7 ) {
             if( x_in_y( type->melee_dice * type->melee_sides, 32 ) ) {
                 remove_effect( effect_heavysnare );
-                here.spawn_item( pos(), "rope_6" );
-                here.spawn_item( pos(), "snare_trigger" );
+                here.spawn_item( pos_bub(), "rope_6" );
+                here.spawn_item( pos_bub(), "snare_trigger" );
                 if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                     add_msg( _( "The %s escapes the heavy snare!" ), name() );
                 }
@@ -3032,7 +3032,7 @@ void monster::die( Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                get_map().add_item_or_charges( pos(), it );
+                get_map().add_item_or_charges( pos_bub(), it );
             }
         }
         for( const item &it : dissectable_inv ) {
@@ -3159,7 +3159,7 @@ void monster::drop_items_on_death( item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            get_map().add_item_or_charges( pos(), it );
+            get_map().add_item_or_charges( pos_bub(), it );
         }
         return;
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -537,7 +537,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
                                    _( "Your %s is pushed off!" ),
                                    _( "<npcname>'s %s is pushed off!" ),
                                    armor.tname() );
-            get_map().add_item_or_charges( pos(), armor );
+            get_map().add_item_or_charges( pos_bub(), armor );
             return true;
         }
         if( armor.has_flag( STATIC( flag_id( "OVERSIZE" ) ) ) ) {
@@ -577,7 +577,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
                                    _( "Your %s is pushed off!" ),
                                    _( "<npcname>'s %s is pushed off!" ),
                                    armor.tname() );
-            get_map().add_item_or_charges( pos(), armor );
+            get_map().add_item_or_charges( pos_bub(), armor );
         }
         return true;
     } );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1339,7 +1339,7 @@ void npc::stow_item( item &it )
         if( avatar_sees ) {
             add_msg_if_npc( m_info, _( "<npcname> drops the %s." ), it.tname() );
         }
-        get_map().add_item_or_charges( pos(), remove_item( it ) );
+        get_map().add_item_or_charges( pos_bub(), remove_item( it ) );
     }
 }
 
@@ -3349,8 +3349,9 @@ std::function<bool( const tripoint & )> npc::get_path_avoid() const
             doors::can_unlock_door( here, *this, tripoint_bub_ms( p ) ) ) {
             return true;
         }
-        if( rules.has_flag( ally_rule::hold_the_line ) && ( here.close_door( p, true, true ) ||
-                here.move_cost( p ) > 2 ) ) {
+        if( rules.has_flag( ally_rule::hold_the_line ) &&
+            ( here.close_door( tripoint_bub_ms( p ), true, true ) ||
+              here.move_cost( p ) > 2 ) ) {
             return true;
         }
         if( sees_dangerous_field( p ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2888,16 +2888,16 @@ bool npc::can_move_to( const tripoint &p, bool no_bashing ) const
 
 void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomove )
 {
-    tripoint p = pt;
+    tripoint_bub_ms p = tripoint_bub_ms( pt );
     map &here = get_map();
-    if( sees_dangerous_field( p )
-        || ( nomove != nullptr && nomove->find( p ) != nomove->end() ) ) {
+    if( sees_dangerous_field( p.raw() )
+        || ( nomove != nullptr && nomove->find( p.raw() ) != nomove->end() ) ) {
         // Move to a neighbor field instead, if possible.
         // Maybe this code already exists somewhere?
-        auto other_points = here.get_dir_circle( pos(), p );
-        for( const tripoint &ot : other_points ) {
+        std::vector<tripoint_bub_ms> other_points = here.get_dir_circle( pos_bub(), p );
+        for( const tripoint_bub_ms &ot : other_points ) {
             if( could_move_onto( ot )
-                && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {
+                && ( nomove == nullptr || nomove->find( ot.raw() ) == nomove->end() ) ) {
 
                 p = ot;
                 break;
@@ -2906,9 +2906,9 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     }
 
     if( !can_move_to_vehicle_tile( here.getglobal( p ) ) ) {
-        auto other_points = here.get_dir_circle( pos(), p );
-        for( const tripoint &ot : other_points ) {
-            if( could_move_onto( ot ) && ( nomove == nullptr || nomove->find( ot ) == nomove->end() ) ) {
+        auto other_points = here.get_dir_circle( pos_bub(), p );
+        for( const tripoint_bub_ms &ot : other_points ) {
+            if( could_move_onto( ot ) && ( nomove == nullptr || nomove->find( ot.raw() ) == nomove->end() ) ) {
                 p = ot;
                 break;
             } else {
@@ -2922,20 +2922,20 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     recoil = MAX_RECOIL;
 
     if( has_effect( effect_stunned ) || has_effect( effect_psi_stunned ) ) {
-        p.x = rng( posx() - 1, posx() + 1 );
-        p.y = rng( posy() - 1, posy() + 1 );
-        p.z = posz();
+        p.x() = rng( posx() - 1, posx() + 1 );
+        p.y() = rng( posy() - 1, posy() + 1 );
+        p.z() = posz();
     }
 
     // nomove is used to resolve recursive invocation, so reset destination no
     // matter it was changed by stunned effect or not.
-    if( nomove != nullptr && nomove->find( p ) != nomove->end() ) {
-        p = pos();
+    if( nomove != nullptr && nomove->find( p.raw() ) != nomove->end() ) {
+        p = pos_bub();
     }
 
     // "Long steps" are allowed when crossing z-levels
     // Stairs teleport the player too
-    if( rl_dist( pos(), p ) > 1 && p.z == posz() ) {
+    if( rl_dist( pos_bub(), p ) > 1 && p.z() == posz() ) {
         // On the same level? Not so much. Something weird happened
         path.clear();
         move_pause();
@@ -3010,7 +3010,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
             }
         }
 
-        if( critter->pos() == p ) {
+        if( critter->pos_bub() == p ) {
             move_pause();
             return;
         }
@@ -3029,7 +3029,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     }
 
     Character &player_character = get_player_character();
-    if( p.z != posz() ) {
+    if( p.z() != posz() ) {
         // Z-level move
         // For now just teleport to the destination
         // TODO: Make it properly find the tile to move to
@@ -3042,12 +3042,12 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
     } else if( has_effect( effect_stumbled_into_invisible ) &&
                here.has_field_at( p, field_fd_last_known ) && !sees( player_character ) &&
                attitude_to( player_character ) == Attitude::HOSTILE ) {
-        attack_air( p );
+        attack_air( p.raw() );
         move_pause();
     } else if( here.passable( p ) && !here.has_flag( ter_furn_flag::TFLAG_DOOR, p ) ) {
-        bool diag = trigdist && posx() != p.x && posy() != p.y;
+        bool diag = trigdist && posx() != p.x() && posy() != p.y();
         if( is_mounted() ) {
-            const double base_moves = run_cost( here.combined_movecost( pos(), p ),
+            const double base_moves = run_cost( here.combined_movecost( pos_bub(), p ),
                                                 diag ) * 100.0 / mounted_creature->get_speed();
             const double encumb_moves = get_weight() / 4800.0_gram;
             mod_moves( -static_cast<int>( std::ceil( base_moves + encumb_moves ) ) );
@@ -3055,7 +3055,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
                 mounted_creature->use_mech_power( 1_kJ );
             }
         } else {
-            mod_moves( -run_cost( here.combined_movecost( pos(), p ), diag ) );
+            mod_moves( -run_cost( here.combined_movecost( pos_bub(), p ), diag ) );
         }
         moved = true;
     } else if( here.open_door( *this, p, !here.is_outside( pos_bub() ), true ) ) {
@@ -3101,9 +3101,9 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
 
     if( moved ) {
         make_footstep_noise();
-        const tripoint old_pos = pos();
+        const tripoint_bub_ms old_pos = pos_bub();
         setpos( p );
-        if( old_pos.x - p.x < 0 ) {
+        if( old_pos.x() - p.x() < 0 ) {
             facing = FacingDirection::RIGHT;
         } else {
             facing = FacingDirection::LEFT;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3116,11 +3116,11 @@ talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view mem
 void map_add_item( item &it, tripoint_abs_ms target_pos )
 {
     if( get_map().inbounds( target_pos ) ) {
-        get_map().add_item_or_charges( get_map().getlocal( target_pos ), it );
+        get_map().add_item_or_charges( get_map().bub_from_abs( target_pos ), it );
     } else {
         tinymap target_bay;
         target_bay.load( project_to<coords::omt>( target_pos ), false );
-        target_bay.add_item_or_charges( target_bay.getlocal( target_pos ), it );
+        target_bay.add_item_or_charges( target_bay.omt_from_abs( target_pos ), it );
     }
 }
 

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -984,7 +984,7 @@ bool talk_function::drop_stolen_item( item &cur_item, npc &p )
         item to_drop = player_character.i_rem( &cur_item );
         to_drop.remove_old_owner();
         to_drop.set_owner( p );
-        here.add_item_or_charges( player_character.pos(), to_drop );
+        here.add_item_or_charges( player_character.pos_bub(), to_drop );
         dropped = true;
     } else if( cur_item.is_container() ) {
         bool changed = false;
@@ -1046,7 +1046,7 @@ void talk_function::drop_weapon( npc &p )
         return;
     }
     item weap = p.remove_weapon();
-    get_map().add_item_or_charges( p.pos(), weap );
+    get_map().add_item_or_charges( p.pos_bub(), weap );
 }
 
 void talk_function::player_weapon_away( npc &/*p*/ )

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1169,7 +1169,7 @@ void suffer::from_item_dropping( Character &you )
 void suffer::from_other_mutations( Character &you )
 {
     map &here = get_map();
-    const tripoint position = you.pos();
+    const tripoint_bub_ms position = you.pos_bub();
 
     if( you.has_trait( trait_WINGS_INSECT_active ) ) {
         //~Sound of buzzing Insect Wings
@@ -1276,7 +1276,7 @@ void suffer::from_radiation( Character &you )
     map &here = get_map();
     // get radioactive leak level of your inventory
     float item_radiation = you.get_leak_level();
-    const int map_radiation = here.get_radiation( you.pos() );
+    const int map_radiation = here.get_radiation( you.pos_bub() );
     float rads = map_radiation / 100.0f + item_radiation / 10.0f;
 
     int rad_mut = 0;
@@ -1307,7 +1307,7 @@ void suffer::from_radiation( Character &you )
         if( rad_mut_proc && !kept_in ) {
             // Irradiate a random nearby point
             // If you can't, irradiate the player instead
-            tripoint rad_point = you.pos() + point( rng( -3, 3 ), rng( -3, 3 ) );
+            tripoint_bub_ms rad_point = you.pos_bub() + point( rng( -3, 3 ), rng( -3, 3 ) );
             // TODO: Radioactive vehicles?
             if( here.get_radiation( rad_point ) < rad_mut ) {
                 here.adjust_radiation( rad_point, 1 );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1206,7 +1206,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( roll < diff ) {
         you.add_msg_if_player( m_bad, _( "You fail to attach it…" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( random_neighbor( you.pos() ), itemname );
+        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
         return false;
     }
 
@@ -1219,7 +1219,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( safe.empty() ) {
         you.add_msg_if_player( m_bad, _( "There's nowhere to pull yourself to, and you sink!" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( random_neighbor( you.pos() ), itemname );
+        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
         return false;
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1832,8 +1832,8 @@ bool vehicle::merge_vehicle_parts( vehicle *veh )
             item drop = veh->part_to_item( part );
             if( drop.link().t_veh.get() == this ) {
                 if( !veh->magic && part.info().id != vpart_power_cord ) {
-                    const tripoint drop_pos = veh->global_part_pos3( part );
-                    drop.reset_link( false, nullptr, -1, true, drop_pos );
+                    const tripoint_bub_ms drop_pos = veh->bub_part_pos( part );
+                    drop.reset_link( false, nullptr, -1, true, drop_pos.raw() );
                     here.add_item_or_charges( drop_pos, drop );
                 }
                 veh->remove_remote_part( part );
@@ -5814,7 +5814,7 @@ void vehicle::slow_leak()
         itype_id fuel = p.ammo_current();
         int qty = std::max( ( 0.5 - health ) * ( 0.5 - health ) * p.ammo_remaining() / 10, 1.0 );
         point q = coord_translate( p.mount );
-        const tripoint dest = global_pos3() + tripoint( q, 0 );
+        const tripoint_bub_ms dest = pos_bub() + tripoint( q, 0 );
 
         // damaged batteries self-discharge without leaking, plutonium leaks slurry
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
@@ -6900,7 +6900,7 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             vehicle_part &vp = parts[tow_cable_idx];
             item drop = part_to_item( vp );
             drop.set_damage( 0 );
-            tripoint drop_pos = global_part_pos3( vp );
+            tripoint_bub_ms drop_pos = bub_part_pos( vp );
             remove_part( vp );
             if( other_tow_cable_idx > -1 ) {
                 drop.reset_link( false );
@@ -7067,7 +7067,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
         }
         const item drop = part_to_item( vp_loose );
         if( !magic ) {
-            here.add_item_or_charges( global_part_pos3( vp_loose ), drop );
+            here.add_item_or_charges( bub_part_pos( vp_loose ), drop );
         }
 
         if( remove_remote ) {
@@ -7372,12 +7372,12 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
     if( rng( 0, vpi.durability / 10 ) >= dmg ) {
         return dmg;
     }
-    const tripoint pos = global_part_pos3( vp );
+    const tripoint_bub_ms pos = bub_part_pos( vp );
     const auto scatter_parts = [&]( const vehicle_part & pt ) {
         for( const item &piece : pt.pieces_for_broken_part() ) {
             // inside the loop, so each piece goes to a different place
             // TODO: this may spawn items behind a wall
-            const tripoint where = random_entry( here.points_in_radius( pos, SCATTER_DISTANCE ) );
+            const tripoint_bub_ms where = random_entry( here.points_in_radius( pos, SCATTER_DISTANCE ) );
             // TODO: balance audit, ensure that less pieces are generated than one would need
             // to build the component (smash a vehicle box that took 10 lumps of steel,
             // find 12 steel lumps scattered after atom-smashing it with a tree trunk)
@@ -7402,20 +7402,24 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
                 continue; // Ignore the frame being destroyed
             } else if( vpi_here.has_flag( "TOW_CABLE" ) ) {
                 // Tow cables - remove it in one piece, remove remote part, and remove towing data
-                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name, vp_here.name() );
+                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                                        vp_here.name() );
                 invalidate_towing( true );
             } else if( vpi_here.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 // Electrical cables - remove it in one piece and remove remote part
-                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name, vp_here.name() );
+                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                                        vp_here.name() );
                 here.add_item_or_charges( pos, part_to_item( vp_here ) );
                 remove_remote_part( vp_here );
             } else if( vp_here.is_broken() ) {
                 // Tearing off a broken part - break it up
-                add_msg_if_player_sees( pos, m_bad, _( "The %s's %s breaks into pieces!" ), name, vp_here.name() );
+                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s's %s breaks into pieces!" ), name,
+                                        vp_here.name() );
                 scatter_parts( vp_here );
             } else {
                 // Intact (but possibly damaged) part - remove it in one piece
-                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is torn off!" ), name, vp_here.name() );
+                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is torn off!" ), name,
+                                        vp_here.name() );
                 if( !magic ) {
                     here.add_item_or_charges( pos, part_to_item( vp_here ) );
                 }
@@ -7423,23 +7427,25 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
             remove_part( vp_here, *handler_ptr );
         }
         // After clearing the frame, remove it.
-        add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+        add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
         scatter_parts( vp );
         remove_part( vp, *handler_ptr );
         find_and_split_vehicles( here, { index_of_part( &vp, /* include_removed = */ true ) } );
     } else {
         if( vpi.has_flag( "TOW_CABLE" ) ) {
             // Tow cables - remove it in one piece, remove remote part, and remove towing data
-            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name, vp.name() );
+            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                                    vp.name() );
             invalidate_towing( true );
         } else if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
             // Electrical cables - remove it in one piece and remove remote part
-            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name, vp.name() );
+            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                                    vp.name() );
             here.add_item_or_charges( pos, part_to_item( vp ) );
             remove_remote_part( vp );
         } else {
             //Just break it off
-            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
             scatter_parts( vp );
         }
         const point position = vp.mount;
@@ -7515,7 +7521,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         return dmg; // part is already dead
     }
     const vpart_info &vpi = vp.info();
-    const tripoint vppos = global_part_pos3( vp );
+    const tripoint_bub_ms vppos = bub_part_pos( vp );
     // If auto-driving and damage happens, bail out
     if( is_autodriving ) {
         stop_autodriving();
@@ -7580,9 +7586,10 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         } else {
             item part_as_item = part_to_item( vp );
             if( vpi.has_flag( "INITIAL_PART" ) ) {
-                add_msg_if_player_sees( vppos, m_bad, _( "The %s falls over!" ), name );
+                add_msg_if_player_sees( vppos.raw(), m_bad, _( "The %s falls over!" ), name );
             } else {
-                add_msg_if_player_sees( vppos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name, vp.name() );
+                add_msg_if_player_sees( vppos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                                        vp.name() );
             }
             if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 remove_remote_part( vp );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1030,7 +1030,7 @@ void vehicle::operate_reaper()
 {
     map &here = get_map();
     for( const vpart_reference &vp : get_enabled_parts( "REAPER" ) ) {
-        const tripoint reaper_pos = vp.pos();
+        const tripoint_bub_ms reaper_pos = vp.pos_bub();
         const int plant_produced = rng( 1, vp.info().bonus );
         const int seed_produced = rng( 1, 3 );
         const units::volume max_pickup_volume = vp.info().size / 20;

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -39,7 +39,7 @@ static void test_projectile_hitting_wall( const std::string &target_type, bool s
         projectile projectile_copy = attack.proj;
         here.set( target_point, ter_id( target_type ), furn_id( "f_null" ) );
         CAPTURE( projectile_copy.impact.total_damage() );
-        here.shoot( target_point.raw(), projectile_copy, false );
+        here.shoot( target_point, projectile_copy, false );
         CAPTURE( target_type );
         CAPTURE( weapon_type );
         CAPTURE( ter_id( target_type ).obj().name() );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -97,7 +97,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
         if( in_vehicle ) {
             vp->vehicle().add_item( vp->part(), ammo_belt );
         } else {
-            here.add_item_or_charges( tripoint_east, ammo_belt );
+            here.add_item_or_charges( tripoint_bub_ms( tripoint_east ), ammo_belt );
         }
         if( move_act ) {
             dummy.assign_activity( player_activity( ACT_MOVE_LOOT ) );

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -30,7 +30,7 @@ static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_tailor( "tailor" );
 
 static constexpr int max_iters = 4000;
-static constexpr tripoint spawn_pos( HALF_MAPSIZE_X - 1, HALF_MAPSIZE_Y, 0 );
+static constexpr tripoint_bub_ms spawn_pos( HALF_MAPSIZE_X - 1, HALF_MAPSIZE_Y, 0 );
 
 static float get_avg_degradation( const itype_id &it, int count, int damage )
 {
@@ -258,7 +258,7 @@ TEST_CASE( "Repairing_degraded_items", "[item][degradation]" )
     // Setup map
     clear_map();
     set_time_to_day();
-    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
+    REQUIRE( static_cast<int>( get_map().light_at( spawn_pos.raw() ) ) > 2 );
 
     GIVEN( "Item with normal degradation" ) {
         Character &u = get_player_character();

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -355,7 +355,7 @@ TEST_CASE( "radioactive_field", "[field]" )
     fields_test_setup();
     clear_radiation();
 
-    const tripoint p{ 33, 33, 0 };
+    const tripoint_bub_ms p{ 33, 33, 0 };
     map &m = get_map();
 
     REQUIRE( fd_nuke_gas->get_intensity_level().extra_radiation_max > 0 );

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "doors_should_be_able_to_open_and_close", "[gates]" )
     map &here = get_map();
     clear_map();
 
-    tripoint pos = get_avatar().pos() + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east;
 
     WHEN( "the door is unlocked" ) {
         // create closed door on tile next to player
@@ -53,7 +53,7 @@ TEST_CASE( "windows_should_be_able_to_open_and_close", "[gates]" )
     map &here = get_map();
     clear_map();
 
-    tripoint pos = get_avatar().pos() + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east;
 
     // create closed window on tile next to player
     REQUIRE( here.ter_set( pos, ter_t_window_no_curtains ) );
@@ -83,7 +83,7 @@ TEST_CASE( "doors_and_windows_should_make_whoosh_sound", "[gates]" )
     clear_avatar();
     sounds::reset_sounds();
 
-    tripoint pos = get_avatar().pos() + point_east;
+    tripoint_bub_ms pos = get_avatar().pos_bub() + point_east;
 
     WHEN( "the door is opened" ) {
         REQUIRE( here.ter_set( pos, ter_t_door_c ) );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -266,28 +266,28 @@ static void pick_up_from_feet( Character &you, const std::string &id )
 
 static void wear_from_feet( Character &you, const std::string &id )
 {
-    map_stack items = get_map().i_at( you.pos() );
+    map_stack items = get_map().i_at( you.pos_bub() );
     size_t size_before = items.size();
 
     item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
     REQUIRE( found );
 
     you.wear_item( *found, false );
-    get_map().i_rem( you.pos(), found );
+    get_map().i_rem( you.pos_bub(), found );
 
     REQUIRE( items.size() == size_before - 1 );
 }
 
 static void wield_from_feet( Character &you, const std::string &id )
 {
-    map_stack items = get_map().i_at( you.pos() );
+    map_stack items = get_map().i_at( you.pos_bub() );
     size_t size_before = items.size();
 
     item *found = retrieve_item( map_cursor( you.pos_bub() ), id );
     REQUIRE( found );
 
     you.wield( *found );
-    get_map().i_rem( you.pos(), found );
+    get_map().i_rem( you.pos_bub(), found );
 
     REQUIRE( items.size() == size_before - 1 );
 }

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -24,15 +24,14 @@ TEST_CASE( "item_location_can_maintain_reference_despite_item_removal", "[item][
 {
     clear_map();
     map &m = get_map();
-    tripoint pos( 60, 60, 0 );
+    tripoint_bub_ms pos( 60, 60, 0 );
     m.i_clear( pos );
     m.add_item( pos, item( "jeans" ) );
     m.add_item( pos, item( "jeans" ) );
     m.add_item( pos, item( "tshirt" ) );
     m.add_item( pos, item( "jeans" ) );
     m.add_item( pos, item( "jeans" ) );
-    const tripoint_bub_ms bub = tripoint_bub_ms( pos );
-    map_cursor cursor( bub );
+    map_cursor cursor( pos );
     item *tshirt = nullptr;
     cursor.visit_items( [&tshirt]( item * i, item * ) {
         if( i->typeId() == itype_tshirt ) {
@@ -62,10 +61,10 @@ TEST_CASE( "item_location_doesnt_return_stale_map_item", "[item][item_location]"
 {
     clear_map();
     map &m = get_map();
-    tripoint pos( 60, 60, 0 );
+    tripoint_bub_ms pos( 60, 60, 0 );
     m.i_clear( pos );
     m.add_item( pos, item( "tshirt" ) );
-    item_location item_loc( map_cursor( tripoint_bub_ms( pos ) ), &m.i_at( pos ).only_item() );
+    item_location item_loc( map_cursor( pos ), &m.i_at( pos ).only_item() );
     REQUIRE( item_loc->typeId() == itype_tshirt );
     m.i_rem( pos, &*item_loc );
     m.add_item( pos, item( "jeans" ) );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -1829,11 +1829,12 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
     Character &u = get_player_character();
     clear_map();
     clear_character( u, true );
-    item_location cont1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(),
+    item_location cont1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
                          cont_nest_rigid ) );
-    item_location cont2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(), cont_nest_soft ) );
-    item_location obj1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(), rigid_obj ) );
-    item_location obj2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(), soft_obj ) );
+    item_location cont2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
+                         cont_nest_soft ) );
+    item_location obj1( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), rigid_obj ) );
+    item_location obj2( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), soft_obj ) );
     pickup_activity_actor act_actor( { obj1, obj2 }, { 1, 1 }, u.pos_bub(), autopickup );
     u.assign_activity( act_actor );
 
@@ -2060,7 +2061,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
         item_location c = give_item_to_char( u, soft_nested ? cont2 : cont1 );
         WHEN( "item stack too large to fit in top-level container" ) {
             stack.charges = 300;
-            item_location obj3( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(), stack ) );
+            item_location obj3( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(), stack ) );
             REQUIRE( obj3->charges == 300 );
             u.cancel_activity();
             pickup_activity_actor new_actor( { obj3 }, { 300 }, u.pos_bub(), autopickup );
@@ -2255,7 +2256,8 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
     item cont_suit( "test_robofac_armor_rig" );
 
     // Place a container at the character's feet
-    item_location jug_w_water( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos(), cont_jug ) );
+    item_location jug_w_water( map_cursor( u.pos_bub() ), &m.add_item_or_charges( u.pos_bub(),
+                               cont_jug ) );
 
     GIVEN( "character wearing a multipocket liquid container" ) {
         item_location suit( u, & **u.wear_item( cont_suit, false ) );

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -78,8 +78,8 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                         case spawn_type::map: {
                             clear_map();
                             map &here = get_map();
-                            here.spawn_item( tripoint_zero, cs_data.item, 1, cs_data.charges );
-                            for( item &it : here.i_at( tripoint_zero ) ) {
+                            here.spawn_item( tripoint_bub_ms_zero, cs_data.item, 1, cs_data.charges );
+                            for( item &it : here.i_at( tripoint_bub_ms_zero ) ) {
                                 items.push_back( it );
                             }
                             break;

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -150,14 +150,14 @@ static void cut_up_yields( const std::string &target )
     REQUIRE( smallest_yield_mass != units::mass_max );
 
     units::mass cut_up_target_mass = cut_up_target.weight();
-    item &spawned_item = here.add_item_or_charges( guy.pos(), cut_up_target );
+    item &spawned_item = here.add_item_or_charges( guy.pos_bub(), cut_up_target );
     item_location item_loc( map_cursor( guy.pos_bub() ), &spawned_item );
 
     REQUIRE( smallest_yield_mass <= cut_up_target_mass );
 
     test_actor.try_to_cut_up( guy, tool, item_loc );
 
-    map_stack salvaged_items = here.i_at( guy.pos() );
+    map_stack salvaged_items = here.i_at( guy.pos_bub() );
     units::mass salvaged_mass = 0_gram;
     for( const item &salvage : salvaged_items ) {
         salvaged_mass += salvage.weight();

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -52,7 +52,7 @@ static void test_bash_set( const bash_test_set &set )
             int tries = 0;
             while( here.furn( test_pt ) == furn && tries < max_tries ) {
                 ++tries;
-                here.bash( test_pt.raw(), guy.smash_ability() );
+                here.bash( test_pt, guy.smash_ability() );
             }
             auto it = test.furn_tries.find( furn );
             if( it == test.furn_tries.end() ) {
@@ -69,7 +69,7 @@ static void test_bash_set( const bash_test_set &set )
             int tries = 0;
             while( here.ter( test_pt ) == ter && tries < max_tries ) {
                 ++tries;
-                here.bash( test_pt.raw(), guy.smash_ability() );
+                here.bash( test_pt, guy.smash_ability() );
             }
             auto it = test.ter_tries.find( ter );
             if( it == test.ter_tries.end() ) {
@@ -110,13 +110,13 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
         REQUIRE( here.furn( test_pt ) == furn_test_f_bash_persist );
         REQUIRE( here.get_map_damage( test_pt ) == 0 );
         // One above str_min, but well below str_max
-        here.bash( test_pt.raw(), 5 );
+        here.bash( test_pt, 5 );
         // Does not destroy it
         CHECK( here.furn( test_pt ) == furn_test_f_bash_persist );
         // There is any map damage
         CHECK( here.get_map_damage( test_pt ) > 0 );
         // Bash it again to destroy it
-        here.bash( test_pt.raw(), 999 );
+        here.bash( test_pt, 999 );
         CHECK( here.furn( test_pt ) != furn_test_f_bash_persist );
         // Then, it is gone and there is no map damage
         CHECK( here.furn( test_pt ) != furn_test_f_bash_persist );
@@ -128,13 +128,13 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
         REQUIRE( here.ter( test_pt ) == ter_test_t_bash_persist );
         REQUIRE( here.get_map_damage( test_pt ) == 0 );
         // One above str_min, but well below str_max
-        here.bash( test_pt.raw(), 5 );
+        here.bash( test_pt, 5 );
         // Does not destroy the terrain
         CHECK( here.ter( test_pt ) == ter_test_t_bash_persist );
         // There is any map damage
         CHECK( here.get_map_damage( test_pt ) > 0 );
         // Bash it again to destroy it
-        here.bash( test_pt.raw(), 999 );
+        here.bash( test_pt, 999 );
         CHECK( here.ter( test_pt ) != ter_test_t_bash_persist );
         // Then, it is gone and there is no map damage
         CHECK( here.ter( test_pt ) != ter_test_t_bash_persist );
@@ -146,7 +146,7 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
         REQUIRE( here.ter( test_pt ) == ter_test_t_bash_persist );
         REQUIRE( here.get_map_damage( test_pt ) == 0 );
         // One above str_min, but well below str_max
-        here.bash( test_pt.raw(), 5 );
+        here.bash( test_pt, 5 );
         // Does not destroy the terrain
         CHECK( here.ter( test_pt ) == ter_test_t_bash_persist );
         // There is any map damage
@@ -162,7 +162,7 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
         REQUIRE( here.furn( test_pt ) == furn_test_f_bash_persist );
         REQUIRE( here.get_map_damage( test_pt ) == 0 );
         // One above str_min, but well below str_max
-        here.bash( test_pt.raw(), 5 );
+        here.bash( test_pt, 5 );
         // Does not destroy the terrain
         CHECK( here.furn( test_pt ) == furn_test_f_bash_persist );
         // There is any map damage

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -48,7 +48,7 @@ void clear_radiation()
     for( int z = -1; z <= OVERMAP_HEIGHT; ++z ) {
         for( int x = 0; x < mapsize; ++x ) {
             for( int y = 0; y < mapsize; ++y ) {
-                here.set_radiation( { x, y, z}, 0 );
+                here.set_radiation( tripoint_bub_ms{ x, y, z}, 0 );
             }
         }
     }

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -101,9 +101,9 @@ TEST_CASE( "crater_crash", "[vehicle]" )
     tripoint_abs_omt map_location( 30, 30, 0 );
     here.load( map_location, true );
     here.add_vehicle( vehicle_prototype_car, { 14, 11, here.get_abs_sub().z() }, 45_degrees );
-    const tripoint end{ 20, 20, 0 };
-    for( tripoint cursor = { 14, 4, 0 }; cursor.y < end.y; cursor.y++ ) {
-        for( cursor.x = 4; cursor.x < end.x; cursor.x++ ) {
+    const tripoint_omt_ms end{ 20, 20, 0 };
+    for( tripoint_omt_ms cursor = { 14, 4, 0 }; cursor.y() < end.y(); cursor.y()++ ) {
+        for( cursor.x() = 4; cursor.x() < end.x(); cursor.x()++ ) {
             here.destroy( cursor, true );
         }
     }
@@ -121,9 +121,9 @@ TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
     tm.load( project_to<coords::omt>( here.get_abs_sub() ) + tripoint_rel_omt( 10, 10, 0 ), false );
     wipe_map_terrain( tm.cast_to_map() );
     REQUIRE( tm.get_vehicles().empty() );
-    tripoint vehicle_origin{ 14, 14, 0 };
+    tripoint_omt_ms vehicle_origin{ 14, 14, 0 };
     vehicle *veh_ptr = tm.add_vehicle( vehicle_prototype_cross_split_test,
-                                       vehicle_origin, 0_degrees, 0, 0 );
+                                       vehicle_origin.raw(), 0_degrees, 0, 0 );
     REQUIRE( veh_ptr != nullptr );
     REQUIRE( !tm.get_vehicles().empty() );
     tm.destroy( vehicle_origin );

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -47,7 +47,7 @@ static void wield_check_from_inv( avatar &guy, const itype_id &item_name, const 
 static void wield_check_from_ground( avatar &guy, const itype_id &item_name,
                                      const int expected_moves )
 {
-    item &spawned_item = get_map().add_item_or_charges( guy.pos(), item( item_name, calendar::turn,
+    item &spawned_item = get_map().add_item_or_charges( guy.pos_bub(), item( item_name, calendar::turn,
                          1 ) );
     item_location item_loc( map_cursor( guy.pos_bub() ), &spawned_item );
     CHECK( item_loc.obtain_cost( guy ) == Approx( expected_moves ).epsilon( 0.1f ) );


### PR DESCRIPTION
#### Summary
Backport 75077 for typification (and fix cover)

#### Purpose of change
Another huge backport PR. This one is a monster due to touching a ton of files and some of them are ones I've worked extensively on.

While working on this, I discovered a couple of bugs with coverage.

#### Describe the solution
- Backport. Manually adjust the stuff that needed adjusting.
- For coverage: Dispersion < 1000 no longer linearly reduces coverage, it's now based on sqrt, so accurate shots are still substantially better, but not guaranteed in most cases.

#### Testing
shootan

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
