### PR TITLE
Backport DDA 76111 - Add indoor flagpole and use it for Hub01 American flags

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -350,5 +350,25 @@
       "sound_vol": 16,
       "items": [ { "item": "glass_shard", "count": [ 25, 50 ] }, { "item": "splinter", "count": [ 5, 15 ] } ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_indoor_flagpole",
+    "name": "indoor flagpole",
+    "description": "A 2.5-meter tall flagpole on a weighted stand.  You could hoist up a flag here.",
+    "symbol": "F",
+    "color": "light_gray",
+    "move_cost_mod": 2,
+    "coverage": 20,
+    "required_str": 1,
+    "flags": [ "TRANSPARENT", "PLACE_ITEM" ],
+    "max_volume": "2 L",
+    "bash": {
+      "str_min": 10,
+      "str_max": 30,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "items": [ { "item": "material_aluminium_ingot", "count": [ 4, 8 ] }, { "item": "scrap", "count": [ 2, 6 ] } ]
+    }
   }
 ]

--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -380,7 +380,7 @@
         "M": "t_ramp_up_high",
         "m": "t_ramp_up_low"
       },
-      "furniture": { "6": "f_console", ":": "f_server", "f": "f_filing_cabinet" },
+      "furniture": { "6": "f_console", ":": "f_server", "f": "f_filing_cabinet", "A": "f_indoor_flagpole" },
       "item": { "A": { "item": "american_flag" } },
       "items": { "f": { "item": "file_room", "chance": 100, "repeat": [ 10, 30 ] } },
       "monster": { "T": { "monster": "mon_robofac_laserturret_mk1" } },
@@ -459,7 +459,15 @@
         "R": "t_railing",
         "W": "t_water_dispenser"
       },
-      "furniture": { "6": "f_console", ":": "f_server", "K": "f_counter", "H": "f_armchair", "L": "f_locker", "f": "f_filing_cabinet" },
+      "furniture": {
+        "6": "f_console",
+        ":": "f_server",
+        "K": "f_counter",
+        "H": "f_armchair",
+        "L": "f_locker",
+        "f": "f_filing_cabinet",
+        "A": "f_indoor_flagpole"
+      },
       "item": { "A": { "item": "american_flag" } },
       "items": {
         "F": { "item": "fridge", "chance": 80 },


### PR DESCRIPTION
#### Summary
Backport DDA 76111 - Add indoor flagpole and use it for Hub01 American flags


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
