### PR TITLE
fix segfault when mobs drag mobs at edge of reality bubble

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -616,6 +616,9 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
             std::set<tripoint> intersect;
             std::set_intersection( neighbors.begin(), neighbors.end(), candidates.begin(), candidates.end(),
                                    std::inserter( intersect, intersect.begin() ) );
+            if( intersect.size() == 0 ) {
+                return 0;
+            }
             std::set<tripoint>::iterator intersect_iter = intersect.begin();
             std::advance( intersect_iter, rng( 0, intersect.size() - 1 ) );
             tripoint target_square = random_entry<std::set<tripoint>>( intersect );


### PR DESCRIPTION
#### Summary
The code for handling monster dragging sets up an intersection of two sets of tiles:
1. The square of neighboring tiles of the dragger
2. A square with variable radius around the tile which is on the opposite side of the dragger from the draggee

Both of these squares are clamped to the reality bubble by map::points_in_radius (more or less), which means that if the second set was just one tile that ended up outside the reality bubble, the intersection set would be empty.

The original code was assuming that this set would never be empty, trying to pick a random element from the intersection set unconditionally, but in this case, this was causing a segmentation fault crash.

#### Describe the solution
Return from melee_actor::do_grab if the intersection set is empty.

#### Describe alternatives you've considered
Allow the dragging mob to go out of the reality bubble when dragging, but I'm not sure if that'll break things.
It would be nice to handle the reality-bubble-edge transitions in one part of the code, instead of having individual updates like this take it into consideration and failing (when the player moves, a dragging pair of mobs would cross that edge anyways), but I am way not familiar with this codebase and the assumptions about this stuff.

#### Testing
Tested a provided reproducing save before and after this change, also with some debug-printf to make sure the early-return was triggering.
I tested mostly on the 2025-04-24-2034 codebase though, not on the up-to-date master.

#### Additional context
Fixes this bug reported on Discord:
https://discord.com/channels/1341953719889170594/1365801425132847114

The current C:DDA code for this got changed superficially, but it also seems to be doing the same basic thing, so I don't think there's a C:DDA change we can backport to fix this, and the same bug might occur there still.