### PR TITLE
Fix Vagabond equipment

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -664,10 +664,8 @@
           { "item": "gloves_light" },
           { "item": "hat_ball" },
           { "item": "duffelbag" },
-          { "item": "backpack" },
           { "item": "long_underpants" },
           { "item": "boots" },
-          { "item": "socks_wool" },
           { "item": "socks" },
           { "item": "hoodie" },
           { "item": "folding_poncho" },
@@ -679,9 +677,7 @@
           { "group": "charged_matches" },
           { "item": "tshirt" }
         ]
-      },
-      "male": { "entries": [ { "item": "boxer_briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
+      }
     }
   },
   {


### PR DESCRIPTION
#### Summary
Fix Vagabond equipment

#### Purpose of change
The vagabond profession had some weird conflicts with its starting equipment.

#### Describe the solution
- Remove the gendered underwear, backpack, and wool socks.

#### Testing
Loaded it up. Looks good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
