### PR TITLE
Switch from size == 0 to empty

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -616,7 +616,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
             std::set<tripoint> intersect;
             std::set_intersection( neighbors.begin(), neighbors.end(), candidates.begin(), candidates.end(),
                                    std::inserter( intersect, intersect.begin() ) );
-            if( intersect.size() == 0 ) {
+            if( intersect.empty() ) {
                 return 0;
             }
             std::set<tripoint>::iterator intersect_iter = intersect.begin();


### PR DESCRIPTION
#### Summary
Switch from size == 0 to empty

#### Purpose of change
#619 was throwing an error in one of the automated actions, so move it from using size == 0 to empty()


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
