### PR TITLE
Block overmap sight through solid terrain

### DIFF
--- a/data/json/furniture_and_terrain/replace_concealment.sh
+++ b/data/json/furniture_and_terrain/replace_concealment.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-for file in *.json; do
-    sed 's/"concealment": 60,/"concealment": 38,/' "$file" > "tmp_$file"
-    mv "tmp_$file" "$file"
-done
-

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -983,7 +983,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( corpse_item->has_flag( flag_QUARTERED ) ) {
         monster_weight *= 0.95;
     }
-    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) || corpse_item->damage() >= corpse_item->max_damage() ) {
+    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) ||
+        corpse_item->damage() >= corpse_item->max_damage() ) {
         monster_weight = std::round( 0.4 * monster_weight );
         if( action != butcher_type::FIELD_DRESS ) {
             you.add_msg_if_player( m_bad,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -133,7 +133,8 @@ std::string get_ascii_tile_id( const uint32_t sym, const int FG, const int BG )
                         } );
 }
 
-auto simple_point_hash = []( const auto & p ) {
+auto simple_point_hash = []( const auto &p )
+{
     return p.x + p.y * 65536;
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12533,12 +12533,25 @@ void game::update_overmap_seen()
         const float multiplier = trigdist ? std::sqrt( h_squared ) / max_delta : 1;
         const std::vector<tripoint_abs_omt> line = line_to( ompos, p );
         float sight_points = dist;
-        for( auto it = line.begin();
-             it != line.end() && sight_points >= 0; ++it ) {
+        bool can_see = false;
+        for( auto it = line.begin(); it != line.end(); ++it ) {
             const oter_id &ter = overmap_buffer.ter( *it );
-            sight_points -= static_cast<int>( ter->get_see_cost() ) * multiplier;
+            const int see_cost = static_cast<int>( ter->get_see_cost() );
+
+            if( see_cost >= 5 ) {
+                break; // Solid wall blocks sight
+            }
+
+            sight_points -= see_cost * multiplier;
+            if( sight_points < 0 ) {
+                break;
+            }
+            if( *it == p ) {
+                can_see = true;
+                break;
+            }
         }
-        if( sight_points >= 0 ) {
+        if( can_see ) {
             tripoint_abs_omt seen( p );
             do {
                 overmap_buffer.set_seen( seen, true );


### PR DESCRIPTION
#### Summary
Block overmap sight through solid terrain

#### Purpose of change
Characters with sufficient overmap sight ability (IE Scout, high per) were sometimes able to see through solid earth/rock

![image](https://github.com/user-attachments/assets/e28cc8c3-ab1b-489d-a3a8-6bd8a8e0d53d)

#### Describe the solution
Terminate the overmap sight line the moment the viewer encounters a 5 view cost tile, no matter what.

#### Describe alternatives you've considered
This may need revisiting if the player ever gains a way to see through solid walls, but I assume that e.g. clairvoyance or quadcopters would use a different function, so it probably doesn't matter.

#### Testing
Spawned a character with Scout, gave him a telescope. Peeked into basements, walked into basements, could not see through solid earth on the map.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
