### PR TITLE
Fix butchery segfault

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1396,6 +1396,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
         return;
     }
 
+    bool remove = false;
     //end messages and effects
     switch( action ) {
         case butcher_type::QUARTER:
@@ -1404,7 +1405,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
             add_msg( m_good, SNIPPET.random_from_category( "harvest_drop_default_quick_butcher" ).value_or(
                          translation() ).translated() );
             // Remove the target from the map
-            target.remove_item();
+            remove = true;
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1414,7 +1415,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                          translation() ).translated() );
 
             // Remove the target from the map
-            target.remove_item();
+            remove = true;
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1467,7 +1468,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                          translation() ).translated() );
 
             // Remove the target from the map
-            target.remove_item();
+            remove = true;
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1490,6 +1491,11 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
 
     get_event_bus().send<event_type::character_butchered_corpse>( you->getID(),
             corpse_item.get_mtype()->id, act->id().str() );
+
+    if( remove ) {
+        target.remove_item();
+    }
+
 
     // Ready to move on to the next item, if there is one (for example if multibutchering)
     act->index = true;


### PR DESCRIPTION
#### Summary
Fix butchery segfault

#### Purpose of change
Butchery was deleting the corpse in some cases before it could finish placing all the meat and blood on the ground, which seems to be the cause of some recently reported segfaults following #666 etc.

#### Describe the solution
Use a bool to indicate whether the corpse should be deleted, and delete it at the end of the process instead of doing it right away.

#### Testing
Spawned in and butchered some stuff. No issues, but it was a slippery bug so I'm not 100% sure it's fixed.

#### Additional context
The weird part is that I didn't change the code there, it was doing this for years in DDA with no issue. So why was it segfaulting now? Well, (confused Tim Allen grunting)

Special thanks to @doublescale and @Maepple for finding the potential issue and cooking this fix up.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
