### PR TITLE
Update samurai armor, survivor masks, and various dialog

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -16,7 +16,7 @@
     "color": "brown",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "OUTER", "WATER_FRIENDLY" ],
+    "flags": [ "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -47,7 +47,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "NO_REPAIR" ],
+    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -80,7 +80,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "NO_REPAIR" ],
+    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -112,7 +112,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -238,7 +238,7 @@
     "looks_like": "legguard_hard",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -303,7 +303,7 @@
     "looks_like": "skirt_leather",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -446,7 +446,7 @@
     "color": "dark_gray",
     "warmth": 10,
     "material_thickness": 3,
-    "flags": [ "OUTER" ],
+    "flags": [ "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": 3,
@@ -493,7 +493,7 @@
     ],
     "warmth": 25,
     "material_thickness": 2.5,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": [ 7, 9 ],
@@ -986,7 +986,7 @@
     "warmth": 15,
     "material_thickness": 2,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "NORMAL" ],
+    "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "NORMAL", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -1059,7 +1059,7 @@
     "color": "light_blue",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS" ],
+    "flags": [ "VARSIZE", "POCKETS", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": [ 12, 16 ],
@@ -1194,7 +1194,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "40 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -1235,7 +1235,7 @@
     "color": "brown",
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [ { "covers": [ "leg_l", "leg_r" ], "encumbrance": 7, "coverage": 90 } ]
   },
   {

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -28,7 +28,7 @@
     ],
     "warmth": 20,
     "material_thickness": 6,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -49,7 +49,7 @@
     "warmth": 10,
     "longest_side": "60 cm",
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER" ],
+    "flags": [ "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 90, "encumbrance": 10 },
       {
@@ -147,7 +147,7 @@
     ],
     "warmth": 45,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -206,7 +206,7 @@
     ],
     "warmth": 40,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -254,7 +254,7 @@
     ],
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -292,7 +292,7 @@
     "warmth": 25,
     "longest_side": "60 cm",
     "material_thickness": 1.6,
-    "flags": [ "VARSIZE", "OUTER", "STURDY" ],
+    "flags": [ "VARSIZE", "OUTER", "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": 34,
@@ -320,7 +320,7 @@
     "warmth": 20,
     "longest_side": "60 cm",
     "material_thickness": 2,
-    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ONLY_ONE", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ONLY_ONE", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
@@ -536,39 +536,38 @@
     "extend": { "flags": [ "UNDERSIZE" ] }
   },
   {
-    "id": "plated_leather_armor_suit",
+    "id": "armor_samurai",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "suit of plated leather armor", "str_pl": "suits of plated leather armor" },
-    "description": "Thick leather body armor reinforced by the addition of sheet metal plates.",
-    "weight": "9500 g",
-    "volume": "11 L",
-    "price": "1100 USD",
-    "price_postapoc": "30 USD",
+    "name": { "str_sp": "ō-yoroi" },
+    "description": "An ornamental suit of Japanese samurai armor.",
+    "weight": "20000 g",
+    "volume": "17000 ml",
+    "price": "900 USD",
+    "price_postapoc": "80 USD",
     "to_hit": -5,
-    "material": [ "steel", "leather" ],
+    "material": [ "iron", "leather" ],
     "symbol": "[",
     "color": "brown",
     "longest_side": "60 cm",
-    "looks_like": "leather_armor_suit",
     "armor": [
       {
         "covers": [ "torso" ],
         "coverage": 95,
-        "encumbrance": 22,
+        "encumbrance": 40,
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 85, "thickness": 0.9 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 4 }
+          { "type": "iron", "covered_by_mat": 70, "thickness": 1.0 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
         ],
         "rigid_layer_only": true
       },
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 90,
-        "encumbrance": 22,
+        "encumbrance": 40,
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 0.9 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 4 }
+          { "type": "iron", "covered_by_mat": 70, "thickness": 1.0 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
         ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_upper_r", "arm_upper_l" ],
         "rigid_layer_only": true
@@ -577,16 +576,16 @@
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 90,
         "encumbrance": 0,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2 } ],
         "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r" ]
       },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
-        "encumbrance": 22,
+        "encumbrance": 40,
         "material": [
-          { "type": "leather", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 }
+          { "type": "iron", "covered_by_mat": 40, "thickness": 1.0 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
         ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_upper_l", "leg_upper_r" ]
       },
@@ -594,28 +593,28 @@
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
         "encumbrance": 0,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2 } ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ]
       }
     ],
-    "warmth": 25,
+    "warmth": 35,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
-    "id": "plated_leather_armor_suit_xl",
+    "id": "armor_samurai_xl",
     "type": "ARMOR",
-    "name": { "str": "suit of plated leather armor", "str_pl": "suits of plated leather armor" },
-    "copy-from": "plated_leather_armor_suit",
+    "name": { "str_sp": "ō-yoroi" },
+    "copy-from": "armor_samurai",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
-    "id": "plated_leather_armor_suit_xs",
+    "id": "armor_samurai_xs",
     "type": "ARMOR",
-    "copy-from": "plated_leather_armor_suit",
-    "name": { "str": "suit of plated leather armor", "str_pl": "suits of plated leather armor" },
+    "copy-from": "armor_samurai",
+    "name": { "str_sp": "ō-yoroi" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE" ] }
   },
@@ -636,7 +635,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
     "use_action": [ { "type": "attach_molle", "size": 6 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -696,34 +695,6 @@
     ]
   },
   {
-    "id": "armor_samurai",
-    "type": "ARMOR",
-    "category": "armor",
-    "name": { "str_sp": "ō-yoroi" },
-    "description": "An ornamental suit of Japanese samurai armor.",
-    "weight": "20000 g",
-    "volume": "17000 ml",
-    "price": "900 USD",
-    "price_postapoc": "80 USD",
-    "material": [ "iron", "leather" ],
-    "symbol": "[",
-    "looks_like": "armor_lightplate",
-    "color": "dark_gray",
-    "warmth": 25,
-    "longest_side": "60 cm",
-    "material_thickness": 4,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
-    "armor": [
-      {
-        "encumbrance": 15,
-        "coverage": 85,
-        "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r", "hand_l", "hand_r" ],
-        "rigid_layer_only": true
-      }
-    ],
-    "melee_damage": { "bash": 8 }
-  },
-  {
     "id": "armor_tiresuit",
     "type": "ARMOR",
     "category": "armor",
@@ -741,7 +712,7 @@
     "warmth": 10,
     "longest_side": "40 cm",
     "material_thickness": 4,
-    "flags": [ "OUTER", "NONCONDUCTIVE" ],
+    "flags": [ "OUTER", "NONCONDUCTIVE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": 18,
@@ -802,7 +773,7 @@
     "looks_like": "boiled_leather_armor_suit",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -967,7 +938,7 @@
     "looks_like": "touring_suit",
     "color": "light_red",
     "warmth": 15,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -218,9 +218,9 @@
     "looks_like": "blindfold",
     "color": "dark_gray",
     "warmth": 0,
-    "material_thickness": 1,
+    "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "BLIND", "SKINTIGHT" ],
+    "flags": [ "BLIND", "SKINTIGHT", "SOFT" ],
     "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
@@ -238,9 +238,8 @@
     "looks_like": "blindfold",
     "color": "dark_gray",
     "warmth": 0,
-    "material_thickness": 1,
-    "environmental_protection": 1,
-    "flags": [ "SKINTIGHT" ],
+    "material_thickness": 0.2,
+    "flags": [ "SKINTIGHT", "SOFT" ],
     "armor": [ { "encumbrance": 10, "coverage": 95, "covers": [ "head" ], "rigid_layer_only": true } ]
   },
   {
@@ -1329,7 +1328,7 @@
       "need_charges": 1,
       "need_charges_msg": "\"Illumination disabled, low power.\""
     },
-    "flags": [ "STURDY", "OUTER", "RAINPROOF", "PADDED", "TWO_WAY_RADIO", "WATCH", "ALARMCLOCK" ]
+    "flags": [ "STURDY", "RAINPROOF", "PADDED", "TWO_WAY_RADIO", "WATCH", "ALARMCLOCK" ]
   },
   {
     "id": "helmet_eod_on",
@@ -1658,8 +1657,9 @@
         "encumbrance": 10,
         "coverage": 100,
         "covers": [ "mouth", "eyes" ],
-        "layers": [ "OUTER" ],
-        "volume_encumber_modifier": 0
+        "layers": [ "BELTED" ],
+        "volume_encumber_modifier": 0,
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -1671,8 +1671,9 @@
         "encumbrance": 0,
         "coverage": 100,
         "covers": [ "head" ],
-        "layers": [ "OUTER" ],
-        "volume_encumber_modifier": 0
+        "layers": [ "OUTER", "BELTED" ],
+        "volume_encumber_modifier": 0,
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -1684,7 +1685,9 @@
         "encumbrance": 10,
         "coverage": 100,
         "covers": [ "torso" ],
-        "volume_encumber_modifier": 0
+        "volume_encumber_modifier": 0,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -1695,7 +1698,9 @@
         "encumbrance": 5,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
-        "volume_encumber_modifier": 0
+        "volume_encumber_modifier": 0,
+        "layers": [ "NORMAL", "OUTER" ],
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -1707,7 +1712,8 @@
         "coverage": 100,
         "covers": [ "foot_l", "foot_r" ],
         "layers": [ "NORMAL", "OUTER" ],
-        "volume_encumber_modifier": 0
+        "volume_encumber_modifier": 0,
+        "rigid_layer_only": true
       },
       {
         "material": [
@@ -1716,11 +1722,13 @@
           { "type": "superalloy", "covered_by_mat": 40, "thickness": 0.5 },
           { "type": "superalloy", "covered_by_mat": 40, "thickness": 0.5 }
         ],
-        "//": "limbs are lighter armored than torso but still strongly armored this is the non joints so extra hardsteel",
+        "//": "limbs are lighter armored than torso but still strongly armored",
         "encumbrance": 10,
         "coverage": 100,
         "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
-        "volume_encumber_modifier": 0
+        "volume_encumber_modifier": 0,
+        "layers": [ "OUTER" ],
+        "rigid_layer_only": true
       }
     ]
   },
@@ -1798,7 +1806,9 @@
     "warmth": 10,
     "environmental_protection": 3,
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "rebreather_on",
@@ -1812,7 +1822,9 @@
     "revert_to": "rebreather",
     "use_action": { "ammo_scale": 0, "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "rebreather" },
     "environmental_protection": 15,
-    "armor": [ { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "rebreather_xl",
@@ -1850,7 +1862,9 @@
     "warmth": 10,
     "environmental_protection": 3,
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "rebreather_xl_on",
@@ -1870,7 +1884,9 @@
       "target": "rebreather_xl"
     },
     "environmental_protection": 15,
-    "armor": [ { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "rebreather_xs",
@@ -1909,7 +1925,9 @@
     "warmth": 10,
     "environmental_protection": 3,
     "material_thickness": 1,
-    "armor": [ { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 30, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "rebreather_xs_on",
@@ -1923,7 +1941,9 @@
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "rebreather_xs" },
     "covers": [ "mouth" ],
     "environmental_protection": 15,
-    "armor": [ { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ] } ]
+    "armor": [
+      { "encumbrance": 20, "coverage": 75, "covers": [ "mouth" ], "layers": [ "NORMAL", "OUTER" ], "rigid_layer_only": true }
+    ]
   },
   {
     "id": "mask_filter",
@@ -1956,7 +1976,15 @@
     "ammo": "gasfilter_s",
     "use_action": [ "GASMASK_ACTIVATE" ],
     "tick_action": [ "GASMASK" ],
-    "armor": [ { "encumbrance": 15, "rigid_layer_only": true, "coverage": 100, "covers": [ "mouth" ] } ]
+    "armor": [
+      {
+        "encumbrance": 15,
+        "coverage": 100,
+        "covers": [ "mouth" ],
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
+      }
+    ]
   },
   {
     "id": "mask_gas",
@@ -1975,7 +2003,13 @@
     "color": "dark_gray",
     "armor": [
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 25 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 35 }
+      {
+        "covers": [ "mouth" ],
+        "rigid_layer_only": true,
+        "coverage": 100,
+        "encumbrance": 35,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ]
+      }
     ],
     "warmth": 20,
     "material_thickness": 2,
@@ -2009,7 +2043,13 @@
     "color": "dark_gray",
     "armor": [
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 25 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 35 }
+      {
+        "covers": [ "mouth" ],
+        "rigid_layer_only": true,
+        "coverage": 100,
+        "encumbrance": 35,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ]
+      }
     ],
     "warmth": 20,
     "material_thickness": 2,
@@ -2044,7 +2084,13 @@
     "color": "dark_gray",
     "armor": [
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 25 },
-      { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 35 }
+      {
+        "covers": [ "mouth" ],
+        "rigid_layer_only": true,
+        "coverage": 100,
+        "encumbrance": 35,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ]
+      }
     ],
     "warmth": 20,
     "material_thickness": 2,
@@ -2093,7 +2139,15 @@
     "ammo": "gasfilter_m",
     "use_action": [ "GASMASK_ACTIVATE" ],
     "tick_action": [ "GASMASK" ],
-    "armor": [ { "encumbrance": 35, "rigid_layer_only": true, "coverage": 100, "covers": [ "mouth" ] } ]
+    "armor": [
+      {
+        "encumbrance": 35,
+        "rigid_layer_only": true,
+        "coverage": 100,
+        "covers": [ "mouth" ],
+        "layers": [ "NORMAL", "OUTER", "BELTED" ]
+      }
+    ]
   },
   {
     "id": "mask_fsurvivor",
@@ -2124,17 +2178,20 @@
       {
         "material": [
           { "type": "nomex", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "leather_treated", "covered_by_mat": 100, "thickness": 4 }
+          { "type": "leather_treated", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "mouth" ],
         "coverage": 100,
-        "encumbrance": 37
+        "encumbrance": 37,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 } ],
+        "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 25
+        "encumbrance": 25,
+        "rigid_layer_only": true
       }
     ],
     "warmth": 25,
@@ -2193,17 +2250,20 @@
       {
         "material": [
           { "type": "nomex", "covered_by_mat": 100, "thickness": 3 },
-          { "type": "plastic", "covered_by_mat": 100, "thickness": 3 }
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "mouth" ],
         "coverage": 100,
-        "encumbrance": 25
+        "encumbrance": 25,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 12
+        "encumbrance": 12,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -2229,27 +2289,30 @@
     "ammo": "gasfilter_m",
     "use_action": [ "GASMASK_ACTIVATE" ],
     "tick_action": [ "GASMASK" ],
-    "material": [ "leather_treated", "hard_plastic_transp", "steel" ],
+    "material": [ "steel", "hard_plastic_transp", "leather_treated" ],
     "symbol": "[",
     "color": "brown",
     "armor": [
       {
         "material": [
-          { "type": "leather_treated", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "steel", "covered_by_mat": 90, "thickness": 1 }
+          { "type": "steel", "covered_by_mat": 90, "thickness": 1 },
+          { "type": "leather_treated", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "mouth" ],
         "coverage": 100,
-        "encumbrance": 38
+        "encumbrance": 38,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
       },
       {
         "material": [
-          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 },
-          { "type": "steel", "covered_by_mat": 15, "thickness": 1 }
+          { "type": "steel", "covered_by_mat": 15, "thickness": 1 },
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 28
+        "encumbrance": 28,
+        "rigid_layer_only": true
       }
     ],
     "warmth": 28,
@@ -2305,7 +2368,9 @@
         "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "mouth" ],
         "coverage": 100,
-        "encumbrance": 35
+        "encumbrance": 35,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
       }
     ],
     "warmth": 15,
@@ -2358,16 +2423,19 @@
     "color": "brown",
     "armor": [
       {
-        "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 4 } ],
+        "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "mouth" ],
         "coverage": 100,
-        "encumbrance": 35
+        "encumbrance": 35,
+        "layers": [ "NORMAL", "OUTER", "BELTED" ],
+        "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 5 } ],
+        "material": [ { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 25
+        "encumbrance": 25,
+        "rigid_layer_only": true
       }
     ],
     "warmth": 20,
@@ -2549,7 +2617,7 @@
     "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "UNRESTRICTED" ],
     "price": "400 USD",
     "price_postapoc": "20 USD",
-    "material": [ "kevlar_layered", "plastic" ],
+    "material": [ "kevlar_layered", "hard_plastic_transp" ],
     "weight": "982 g",
     "volume": "1500 ml",
     "to_hit": -3,
@@ -2576,8 +2644,8 @@
     "armor": [
       {
         "material": [
-          { "type": "plastic", "covered_by_mat": 100, "thickness": 3.0 },
-          { "type": "neoprene", "covered_by_mat": 25, "thickness": 1.0 }
+          { "type": "neoprene", "covered_by_mat": 25, "thickness": 1.0 },
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "eyes" ],
         "rigid_layer_only": true,
@@ -2587,7 +2655,7 @@
       {
         "material": [
           { "type": "kevlar_layered", "covered_by_mat": 100, "thickness": 1.1, "ignore_sheet_thickness": true },
-          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 1.0 },
           { "type": "aluminum", "covered_by_mat": 75, "thickness": 0.5 },
           { "type": "neoprene", "covered_by_mat": 50, "thickness": 1.0 }
         ],
@@ -3250,8 +3318,8 @@
       },
       {
         "material": [
-          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
-          { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.0 }
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "thermo_resin", "covered_by_mat": 30, "thickness": 1.0 }
         ],
         "covers": [ "eyes" ],
         "rigid_layer_only": true,
@@ -3261,8 +3329,8 @@
       },
       {
         "material": [
-          { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
-          { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.0 }
+          { "type": "hard_plastic_transp", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "thermo_resin", "covered_by_mat": 20, "thickness": 1.0 }
         ],
         "covers": [ "mouth" ],
         "rigid_layer_only": true,

--- a/data/json/npcs/talk_tags_chat.json
+++ b/data/json/npcs/talk_tags_chat.json
@@ -33,7 +33,8 @@
       "Gotta say, I'm not minding the snow.",
       "Not quite like the winters from before, huh?",
       "Can't wait for this winter to be over.",
-      "It's weird the zombies don't freeze."
+      "The weather's definitely getting worse, right?",
+      "Sometimes it almost seems peaceful this time of year."
     ]
   },
   {
@@ -99,8 +100,9 @@
     "text": [
       "I can't stop wondering who fucked up to make all this happen.  Obviously we can't trust the news, they claimed the zombies were \"rioters\" for weeks.  Why?  Where did this come from?",
       "If what they told us about the Chinese was even partly true, do you think it's like this in China?  Or maybe the US is some kind of quarantine zone, and at least some of the world is still out there.",
-      "Have you noticed injuries aren't healing the same as usual?  I started spotting it before the world ended, but it's become more pronounced.  There's hardly even a granulation step after a cut closes.",
-      "I still don't understand how these zombies are powered.  They're like perpetual motion machines.",
+      "Looking back, it seems kind of obvious that something was wrong for a long time.  The wars, the environment, all of it.  Like the world was rotting before it died.",
+      "Most of the zombies don't eat, and I've never seen one breathe.  How are they getting energy to move their muscles?",
+      "We just have to remember that we're smarter than they are.  Whatever happens, that's something we can count on.",
       "So many parts of this still don't fit together.  Who created the zombies?  What powers them?  Maybe the rumors of mind control drugs were true all along, and someone found a way to bioengineer living dead."
     ]
   },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -541,5 +541,20 @@
     "id": "bee_dress",
     "replace": "dress_costume_skimpy",
     "variant": "bee_dress"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "plated_leather_armor_suit",
+    "replace": "armor_samurai"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "plated_leather_armor_suit_xs",
+    "replace": "armor_samurai_xs"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "plated_leather_armor_suit_xl",
+    "replace": "armor_samurai_xl"
   }
 ]

--- a/data/json/recipes/armor/pets_cow.json
+++ b/data/json/recipes/armor/pets_cow.json
@@ -233,7 +233,7 @@
     "result": "iron_armor_cow",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
-    "copy-from": "plated_leather_armor_suit",
+    "copy-from": "jacket_leather_mod",
     "category": "CC_ANIMALS",
     "subcategory": "CSC_ANIMALS_BOVINE ARMOR",
     "skills_required": [ "tailor", 3 ],

--- a/data/json/recipes/armor/pets_horse.json
+++ b/data/json/recipes/armor/pets_horse.json
@@ -233,7 +233,7 @@
     "result": "iron_armor_horse",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
-    "copy-from": "plated_leather_armor_suit",
+    "copy-from": "jacket_leather_mod",
     "category": "CC_ANIMALS",
     "subcategory": "CSC_ANIMALS_EQUINE ARMOR",
     "skills_required": [ "tailor", 3 ],

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -257,47 +257,6 @@
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
-    "result": "plated_leather_armor_suit",
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_SUIT",
-    "skill_used": "fabrication",
-    "difficulty": 2,
-    "skills_required": [ "tailor", 3 ],
-    "time": "2 h",
-    "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ], [ "textbook_armwest", 4 ], [ "textbook_armschina", 4 ] ],
-    "using": [ [ "sewing_standard", 26 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic", "time_multiplier": 1.1, "skill_penalty": 0.15 },
-      { "proficiency": "prof_closures", "time_multiplier": 1.1 },
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_armorsmithing" },
-      { "proficiency": "prof_articulation" }
-    ],
-    "components": [ [ [ "sheet_metal_small", 18 ] ], [ [ "leather_armor_suit", 1 ] ] ]
-  },
-  {
-    "result": "plated_leather_armor_suit_xs",
-    "type": "recipe",
-    "copy-from": "plated_leather_armor_suit",
-    "time": "2 h",
-    "using": [ [ "sewing_standard", 19 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "components": [ [ [ "sheet_metal_small", 14 ] ], [ [ "leather_armor_suit_xs", 1 ] ] ]
-  },
-  {
-    "result": "plated_leather_armor_suit_xl",
-    "type": "recipe",
-    "copy-from": "plated_leather_armor_suit",
-    "time": "2 h 15 m",
-    "using": [ [ "sewing_standard", 38 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "components": [ [ [ "sheet_metal_small", 24 ] ], [ [ "leather_armor_suit_xl", 1 ] ] ]
-  },
-  {
     "result": "armor_samurai",
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
@@ -323,6 +282,24 @@
       { "proficiency": "prof_armorsmithing" },
       { "proficiency": "prof_articulation" }
     ]
+  },
+  {
+    "result": "armor_samurai_xs",
+    "type": "recipe",
+    "copy-from": "armor_samurai",
+    "time": "2 h",
+    "using": [ [ "sewing_standard", 19 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 } ],
+    "components": [ [ [ "sheet_metal_small", 14 ] ], [ [ "leather_armor_suit_xs", 1 ] ] ]
+  },
+  {
+    "result": "armor_samurai_xl",
+    "type": "recipe",
+    "copy-from": "armor_samurai",
+    "time": "2 h 15 m",
+    "using": [ [ "sewing_standard", 38 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 3 } ],
+    "components": [ [ [ "sheet_metal_small", 24 ] ], [ [ "leather_armor_suit_xl", 1 ] ] ]
   },
   {
     "result": "platemail_suit",


### PR DESCRIPTION
#### Summary
Update samurai armor, survivor masks, and various dialog

#### Purpose of change
- The o-yoroi was super outdated
- The plated leather armor was too strong and sort of redundant with brigandine+o-yoroi
- Some gas masks didn't have proper layers, materials and thicknesses
- A lot of greaves and pants didn't allow tails
- A couple bits of dialog were outdated

#### Describe the solution
- Delete plated leather armor and migrate it to o-yoroi
- Update and modernize o-yoroi
- Update cow and horse plated leather barding to use a different copy-from
- Add xl and xs o-yoroi
- All gas masks should be compatible with NVG helmet attachments
- Allow most greaves, riot armor, plate and chain mail (but not faraday), and some other odds and ends to be work with tails
- Rewrite a couple bits of random dialog to remove outdated references to blob healing

#### Testing
Seems good. The new o-yoroi is slightly stronger than platemail and a bit easier to make, but a lot less reliable.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
