### PR TITLE
Fix mannequin deconstruct bug

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -136,6 +136,7 @@
     "concealment": 40,
     "required_str": 5,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
+    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "deployed_item": "mannequin",
     "examine_action": "deployed_furniture",
     "bash": {
@@ -143,7 +144,7 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 9, 12 ] } ]
+      "items": [ { "item": "plastic_chunk", "count": [ 9, 12 ] } ]
     }
   },
   {

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -289,12 +289,12 @@
     "description": "A figure of an adult human, as seen in the display case at the mall.  It might be able to fool some zombies if it could attract their attention.",
     "price": "150 USD",
     "price_postapoc": "5 USD",
-    "material": [ "wood" ],
-    "weight": "81500 g",
+    "material": [ "fiberglass" ],
+    "weight": "13600 g",
     "volume": "62500 ml",
     "longest_side": "180 cm",
     "to_hit": -2,
-    "melee_damage": { "bash": 18 },
+    "melee_damage": { "bash": 4 },
     "use_action": [ { "type": "deploy_furn", "furn_type": "f_mannequin" } ]
   },
   {
@@ -307,8 +307,8 @@
     "description": "A figure of an adult human, as seen in the display case at the mall.  This one is cradling a talking doll.  It can make sound when powered by batteries and can be used to distract some zombies.",
     "price": "150 USD",
     "price_postapoc": "5 USD",
-    "material": [ "wood" ],
-    "weight": "81500 g",
+    "material": [ "fiberglass" ],
+    "weight": "13600 g",
     "volume": "62500 ml",
     "longest_side": "180 cm",
     "to_hit": -2,
@@ -331,6 +331,6 @@
       "need_charges": 100,
       "moves": 20
     },
-    "melee_damage": { "bash": 18 }
+    "melee_damage": { "bash": 4 }
   }
 ]

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -46,7 +46,7 @@
   {
     "type": "material",
     "id": "fiberglass",
-    "name": "Fiberglass Laminate",
+    "name": "Fiberglass",
     "//": "Fiberglass laminates, consisting of sheets of fiberglass and epoxy resin.  Includes FR-4, G-10, G-11 laminates.",
     "density": 1.8,
     "copy-from": "generic_polymer_resin",


### PR DESCRIPTION
#### Summary
Fix mannequin deconstruct bug

#### Purpose of change
Deconstructing a mannequin via * was causing a segfault because it had no deconstruction values defined. I also noticed that mannequins were made of wood. IRL mannequins are generally fiberglass.

#### Describe the solution
- Add a deconstruct object in the json
- Swap the material over to fiberglass
- Change the bash result to epoxy chunks (we don't have fiberglass chunks yet, and I don't think we need them)
- Reduce the bash damage and weight on the mannequin item

#### Testing
- Spawned a mannequin, placed, examined, placed, deconstructed, made a decoy mannequin, killed it, got a damaged mannequin item. All good!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
