### PR TITLE
RubberSealant

### DIFF
--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -774,7 +774,8 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "14 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 4 ], [ "fastener_small", 1 ], [ "liquid_rubber", 4 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 4 ], [ "fastener_small", 1 ] ],
+    "tools": [ [ [ "rubber_spray_can, 4" ] ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -787,16 +788,20 @@
     "type": "recipe",
     "copy-from": "pants_survivor",
     "time": "14 h",
-    "using": [ [ "tailoring_kevlar_fabric", 3 ], [ "fastener_small", 1 ], [ "liquid_rubber", 3 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 3 ], [ "fastener_small", 1 ] ],
+    "tools": [ [ [ "rubber_spray_can", 3 ] ] ],
     "components": [ [ [ "pants_army", 1 ], [ "pants_cargo", 1 ] ] ]
+    
   },
   {
     "result": "pants_survivor_xl",
     "type": "recipe",
     "copy-from": "pants_survivor",
     "time": "15 h 45 m",
-    "using": [ [ "tailoring_kevlar_fabric", 6 ], [ "fastener_small", 1 ], [ "liquid_rubber", 6 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 6 ], [ "fastener_small", 1 ] ],
+    "tools": [ [ [ "rubber_spray_can", 3 ] ] ],
     "components": [ [ [ "pants_army", 2 ], [ "pants_cargo", 2 ] ] ]
+    
   },
   {
     "result": "shorts",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -775,7 +775,7 @@
     "time": "14 h",
     "autolearn": true,
     "using": [ [ "tailoring_kevlar_fabric", 4 ], [ "fastener_small", 1 ] ],
-    "tools": [ [ [ "rubber_spray_can, 4" ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 4 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -609,7 +609,7 @@
       ],
       [ [ "duct_tape", 135 ] ]
     ],
-    "tools": [ [ [ rubber_spray_can", 10]]],
+    "tools": [ [ [ "rubber_spray_can", 10]]],
     "proficiencies": [
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_closures" },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1558,7 +1558,7 @@
     "time": "10 h 20 m",
     "autolearn": true,
     "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 20 ] ],
-    "tools": [ [ [ "liquid_rubber_spray", 8 ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 8 ] ] ],
     "components": [
       [ [ "longcoat", 1 ], [ "sleeveless_longcoat", 1 ] ],
       [ [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
@@ -1609,7 +1609,7 @@
     "time": "10 h 20 m",
     "autolearn": true,
     "using": [ [ "sewing_kevlar", 65 ], [ "tailoring_kevlar_fabric", 12 ] ],
-    "tools": [ [ [ "liquid_rubber_spray", 5 ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 5 ] ] ],
     "components": [
       [ [ "longcoat_xs", 1 ], [ "sleeveless_longcoat_xs", 1 ] ],
       [ [ "sheet_kevlar", 60 ], [ "sheet_kevlar_patchwork", 60 ] ],
@@ -1660,7 +1660,7 @@
     "time": "11 h 20 m",
     "autolearn": true,
     "using": [ [ "sewing_kevlar", 100 ], [ "tailoring_kevlar_fabric", 20 ] ],
-    "tools": [ [ [ "liquid_rubber_spray", 12 ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 12 ] ] ],
     "components": [
       [ [ "longcoat_xl", 1 ], [ "sleeveless_longcoat_xl", 1 ] ],
       [ [ "sheet_kevlar", 100 ], [ "sheet_kevlar_patchwork", 100 ] ],

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -609,7 +609,7 @@
       ],
       [ [ "duct_tape", 135 ] ]
     ],
-    "tools": [ [ [ "liquid_rubber_spray", 10]]],
+    "tools": [ [ [ rubber_spray_can", 10]]],
     "proficiencies": [
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_closures" },
@@ -622,7 +622,7 @@
     "copy-from": "longcoat_survivor",
     "time": "12 h 10 m",
     "using": [ [ "sewing_kevlar", 101 ], [ "tailoring_kevlar_fabric", 40 ] ],
-    "tools": [ [ [ "liquid_rubber_spray", 6 ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 6 ] ] ],
     "components": [
       [ [ "longcoat_xs", 1 ] ],
       [ [ "sheet_kevlar", 70 ], [ "sheet_kevlar_patchwork", 70 ] ],
@@ -647,7 +647,7 @@
     "copy-from": "longcoat_survivor",
     "time": "13 h 40 m",
     "using": [ [ "sewing_kevlar", 175 ], [ "tailoring_kevlar_fabric", 75 ] ],
-    "tools": [ [ [ "liquid_rubber_spray", 14 ] ] ],
+    "tools": [ [ [ "rubber_spray_can", 14 ] ] ],
     "components": [
       [ [ "longcoat_xl", 1 ] ],
       [ [ "sheet_kevlar", 80 ], [ "sheet_kevlar_patchwork", 80 ] ],

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -592,7 +592,7 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "12 h 10 m",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 135 ], [ "tailoring_kevlar_fabric", 50 ], [ "liquid_rubber", 10 ] ],
+    "using": [ [ "sewing_kevlar", 135 ], [ "tailoring_kevlar_fabric", 50 ] ],
     "components": [
       [ [ "longcoat", 1 ] ],
       [ [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
@@ -609,6 +609,7 @@
       ],
       [ [ "duct_tape", 135 ] ]
     ],
+    "tools": [ [ [ "liquid_rubber_spray", 10]]],
     "proficiencies": [
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_closures" },
@@ -620,7 +621,8 @@
     "type": "recipe",
     "copy-from": "longcoat_survivor",
     "time": "12 h 10 m",
-    "using": [ [ "sewing_kevlar", 101 ], [ "tailoring_kevlar_fabric", 40 ], [ "liquid_rubber", 6 ] ],
+    "using": [ [ "sewing_kevlar", 101 ], [ "tailoring_kevlar_fabric", 40 ] ],
+    "tools": [ [ [ "liquid_rubber_spray", 6 ] ] ],
     "components": [
       [ [ "longcoat_xs", 1 ] ],
       [ [ "sheet_kevlar", 70 ], [ "sheet_kevlar_patchwork", 70 ] ],
@@ -637,13 +639,15 @@
       ],
       [ [ "duct_tape", 101 ] ]
     ]
+  
   },
   {
     "result": "longcoat_survivor_xl",
     "type": "recipe",
     "copy-from": "longcoat_survivor",
     "time": "13 h 40 m",
-    "using": [ [ "sewing_kevlar", 175 ], [ "tailoring_kevlar_fabric", 75 ], [ "liquid_rubber", 14 ] ],
+    "using": [ [ "sewing_kevlar", 175 ], [ "tailoring_kevlar_fabric", 75 ] ],
+    "tools": [ [ [ "liquid_rubber_spray", 14 ] ] ],
     "components": [
       [ [ "longcoat_xl", 1 ] ],
       [ [ "sheet_kevlar", 80 ], [ "sheet_kevlar_patchwork", 80 ] ],
@@ -1553,7 +1557,8 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "10 h 20 m",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 20 ], [ "liquid_rubber", 8 ] ],
+    "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 20 ] ],
+    "tools": [ [ [ "liquid_rubber_spray", 8 ] ] ],
     "components": [
       [ [ "longcoat", 1 ], [ "sleeveless_longcoat", 1 ] ],
       [ [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
@@ -1603,7 +1608,8 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "10 h 20 m",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 65 ], [ "tailoring_kevlar_fabric", 12 ], [ "liquid_rubber", 5 ] ],
+    "using": [ [ "sewing_kevlar", 65 ], [ "tailoring_kevlar_fabric", 12 ] ],
+    "tools": [ [ [ "liquid_rubber_spray", 5 ] ] ],
     "components": [
       [ [ "longcoat_xs", 1 ], [ "sleeveless_longcoat_xs", 1 ] ],
       [ [ "sheet_kevlar", 60 ], [ "sheet_kevlar_patchwork", 60 ] ],
@@ -1653,7 +1659,8 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "11 h 20 m",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 100 ], [ "tailoring_kevlar_fabric", 20 ], [ "liquid_rubber", 12 ] ],
+    "using": [ [ "sewing_kevlar", 100 ], [ "tailoring_kevlar_fabric", 20 ] ],
+    "tools": [ [ [ "liquid_rubber_spray", 12 ] ] ],
     "components": [
       [ [ "longcoat_xl", 1 ], [ "sleeveless_longcoat_xl", 1 ] ],
       [ [ "sheet_kevlar", 100 ], [ "sheet_kevlar_patchwork", 100 ] ],


### PR DESCRIPTION
Changes to be committed:
	modified:   data/json/recipes/armor/legs.json
	modified:   data/json/recipes/armor/torso.json


#### Summary
Made Survivor Cargo Pants and Survivor Longcoat properly use the rubber sealant spray tool.

#### Purpose of change
Crafting survivor gear has been changed to use rubber sealant spray as a tool instead of using rubber sealant as a component. Survivor cargo pants and longcoat were missed in that update.

#### Describe the solution
Change requirement of rubber sealant to requirement of charges of rubber sealant spray.

#### Describe alternatives you've considered
Console spawn in the clothes.

#### Testing
Started the game, made a pair of pants, seems to work.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
