### PR TITLE
Apply a soft cap to pain from damage

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8399,7 +8399,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
         const int cur_pain = get_perceived_pain();
         const int max_pain = max_injury_pain( hurt );
         if( dam / 2 + cur_pain < max_pain ) {
-            const float pain_ratio = static_cast<float>(cur_pain) / max_pain;
+            const float pain_ratio = static_cast<float>( cur_pain ) / max_pain;
             mod_pain( static_cast<int>( ( dam / 2 ) * ( 1.0f - pain_ratio * pain_ratio ) ) );
         } else if( dam / 2 + cur_pain > max_pain && cur_pain < max_pain ) {
             mod_pain( max_pain - cur_pain );
@@ -12740,7 +12740,6 @@ void Character::mod_pain( int npain )
 
 int Character::max_injury_pain( bodypart_id part )
 {
-    // Always return at least 5 so chip damage still matters.
     return 300 - ( 300 * ( get_part_hp_cur( part ) / get_part_hp_max( part ) ) );
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -2643,7 +2643,10 @@ class Character : public Creature, public visitable
 
         /** Modifies a pain value by player traits before passing it to Creature::mod_pain() */
         void mod_pain( int npain ) override;
-        /** Sets new intensity of pain an reacts to it */
+        /** Returns a value used to cap pain from injury to this body part. 300 is a magic
+         * number for now, but should eventually become the cap for pain overall. */
+        int max_injury_pain( bodypart_id part );
+        /** Sets new intensity of pain and reacts to it */
         void set_pain( int npain ) override;
         /** Returns perceived pain (reduced with painkillers)*/
         int get_perceived_pain() const override;


### PR DESCRIPTION
#### Summary
Apply a soft cap to pain from damage

#### Purpose of change
Pain was always just adding damage/2 to the pile, and while that gets run through some stuff, it wasn't really doing much to account for repeated chip damage leading to out of control pain levels.

There was also an issue where a character getting injured down to 50% would receive more pain if they had higher max HP. Given that HP is supposed to be toughness and pain is so dangerous, that feels really odd.

#### Describe the solution
- Soft cap incoming damage based on how much pain we already have and how badly injured the body part is after damage is applied. 
- Healthy body parts trigger less pain. Punching someone in a perfectly healthy arm is less painful than punching them in an arm that is already very badly injured.
- Lessen incoming pain as we approach the cap.

#### Testing
Ongoing. I'll probably need to just merge this and get player feedback.

#### Additional context
- I think 300 pain probably ought to become the hard cap. That's a hard number to get to, and it ought to be totally incapacitating. 200 pain is usually about where a very bad beatodown winds up leaving you.
- It may be necessary to adjust the pain penalty thresholds a bit to better fit these numbers.
- We also need more pain descriptors. Severe starts at like 100 and I think that's it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
