### PR TITLE
Mannequins aren't plastic

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -144,7 +144,7 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "plastic_chunk", "count": [ 9, 12 ] } ]
+      "items": [ { "item": "epoxy_chunk", "count": [ 9, 12 ] } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Mannequins aren't plastic

#### Purpose of change
Accidentally left the bash results as epoxy chunks.

#### Describe the solution
Bashed mannequins drop epoxy chunks, not plastic. They're made of fiberglass.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
