### PR TITLE
Update armor protection and encumbrance

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -453,7 +453,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 14,
+        "encumbrance": 21,
         "coverage": 80,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_upper_r", "arm_upper_l" ],
         "rigid_layer_only": true
@@ -851,7 +851,7 @@
     "looks_like": "armguard_lightplate",
     "color": "yellow",
     "warmth": 15,
-    "material_thickness": 4,
+    "material_thickness": 2,
     "flags": [ "OUTER", "STURDY" ],
     "armor": [
       {
@@ -956,7 +956,7 @@
     "armor": [
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "leather", "covered_by_mat": 2, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
@@ -1006,7 +1006,7 @@
     "flags": [ "OUTER", "STURDY", "CONDUCTIVE" ],
     "armor": [
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_shoulder_r", "arm_shoulder_l" ],
         "coverage": 100,

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2152,7 +2152,7 @@
           "foot_arch_l"
         ],
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
         ],
         "encumbrance": 5,

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -126,7 +126,7 @@
     "looks_like": "leather_gauntlets",
     "color": "light_gray",
     "warmth": 5,
-    "material_thickness": 1.3,
+    "material_thickness": 2,
     "flags": [ "STURDY", "DURABLE_MELEE", "OUTER" ],
     "armor": [
       {

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1422,7 +1422,7 @@
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 95, "encumbrance": 40 }
     ],
     "warmth": 10,
-    "material_thickness": 5,
+    "material_thickness": 2.2,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "VARSIZE", "STURDY", "OUTER" ],
@@ -1468,7 +1468,7 @@
       }
     ],
     "warmth": 5,
-    "material_thickness": 4,
+    "material_thickness": 2,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "STURDY", "SUN_GLASSES", "RAINPROOF" ],
@@ -1508,7 +1508,7 @@
     "color": "light_gray",
     "warmth": 35,
     "flags": [ "OUTER" ],
-    "material_thickness": 6.5,
+    "material_thickness": 1.5,
     "techniques": [ "WBLOCK_1" ],
     "armor": [
       {
@@ -1540,7 +1540,7 @@
     "looks_like": "helmet_bike",
     "color": "dark_gray",
     "warmth": 10,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "flags": [ "PADDED", "OUTER" ],
     "techniques": [ "WBLOCK_1" ],
     "armor": [
@@ -1796,7 +1796,7 @@
     "armor": [
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 2 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "head" ],
@@ -1841,7 +1841,7 @@
     "armor": [
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 2 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.2 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 1.0 }
         ],
         "covers": [ "head" ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -550,7 +550,7 @@
     "looks_like": "platemail_leg_guards",
     "color": "yellow",
     "warmth": 15,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
@@ -752,7 +752,7 @@
     },
     "armor": [
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
         "coverage": 90,
@@ -760,7 +760,7 @@
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 70,
@@ -857,12 +857,11 @@
     "looks_like": "legguard_hard",
     "color": "light_gray",
     "warmth": 20,
-    "material_thickness": 1.3,
     "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "leather", "covered_by_mat": 2, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
@@ -872,7 +871,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "leather", "covered_by_mat": 2, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
@@ -947,7 +946,7 @@
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 6,
+        "encumbrance": 12,
         "coverage": 80,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
         "rigid_layer_only": true
@@ -981,6 +980,7 @@
     "price_postapoc": "7 USD 50 cent",
     "material": [ "kevlar", "denim", "plastic_pad" ],
     "symbol": "[",
+    "category": "armor",
     "looks_like": "jeans",
     "color": "dark_gray",
     "warmth": 15,
@@ -1056,6 +1056,7 @@
     "material": [ "steel", "denim" ],
     "symbol": "[",
     "looks_like": "motorbike_pants",
+    "category": "armor",
     "color": "light_blue",
     "warmth": 20,
     "environmental_protection": 1,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -323,21 +323,21 @@
     "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ONLY_ONE", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
     "armor": [
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 16,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
         "encumbrance": 16,
         "rigid_layer_only": true
       },
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
         "encumbrance": 16,
@@ -371,7 +371,7 @@
         ],
         "layers": [ "BELTED" ],
         "material": [
-          { "type": "steel", "covered_by_mat": 100, "thickness": 1.2 },
+          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
         ],
         "encumbrance": 5,
@@ -413,7 +413,6 @@
     "color": "light_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "material_thickness": 2,
     "flags": [ "STURDY", "GROUNDING", "ONLY_ONE", "BLOCK_WHILE_WORN" ],
     "armor": [
       {
@@ -449,7 +448,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 97, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 97, "thickness": 2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 0.4 }
         ],
         "covers": [ "torso" ],
@@ -459,7 +458,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 70, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 70, "thickness": 2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 2 }
         ],
         "encumbrance": 26,
@@ -469,7 +468,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 85, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 85, "thickness": 2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 0.4 }
         ],
         "covers": [ "arm_l", "arm_r" ],
@@ -479,7 +478,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 85, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 85, "thickness": 2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 0.4 }
         ],
         "covers": [ "leg_l", "leg_r" ],
@@ -489,7 +488,7 @@
       },
       {
         "material": [
-          { "type": "steel", "covered_by_mat": 90, "thickness": 1.3 },
+          { "type": "steel", "covered_by_mat": 90, "thickness": 2 },
           { "type": "soft_rubber", "covered_by_mat": 100, "thickness": 3 }
         ],
         "covers": [ "foot_l", "foot_r" ],
@@ -556,8 +555,8 @@
         "coverage": 95,
         "encumbrance": 40,
         "material": [
-          { "type": "iron", "covered_by_mat": 70, "thickness": 1.0 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
+          { "type": "iron", "covered_by_mat": 70, "thickness": 1.8 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.2 }
         ],
         "rigid_layer_only": true
       },
@@ -566,8 +565,8 @@
         "coverage": 90,
         "encumbrance": 40,
         "material": [
-          { "type": "iron", "covered_by_mat": 70, "thickness": 1.0 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
+          { "type": "iron", "covered_by_mat": 70, "thickness": 1.8 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.2 }
         ],
         "specifically_covers": [ "arm_lower_l", "arm_lower_r", "arm_upper_r", "arm_upper_l" ],
         "rigid_layer_only": true
@@ -576,7 +575,7 @@
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 90,
         "encumbrance": 0,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2.2 } ],
         "specifically_covers": [ "arm_elbow_l", "arm_elbow_r", "arm_shoulder_l", "arm_shoulder_r" ]
       },
       {
@@ -584,16 +583,17 @@
         "coverage": 85,
         "encumbrance": 40,
         "material": [
-          { "type": "iron", "covered_by_mat": 40, "thickness": 1.0 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 2 }
+          { "type": "iron", "covered_by_mat": 40, "thickness": 1.8 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 2.2 }
         ],
-        "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_upper_l", "leg_upper_r" ]
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_upper_l", "leg_upper_r" ],
+        "rigid_layer_only": true
       },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
         "encumbrance": 0,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 2.2 } ],
         "specifically_covers": [ "leg_hip_l", "leg_hip_r", "leg_knee_l", "leg_knee_r" ]
       }
     ],
@@ -616,7 +616,7 @@
     "copy-from": "armor_samurai",
     "name": { "str_sp": "ō-yoroi" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
     "id": "armor_riot",
@@ -715,7 +715,7 @@
     "flags": [ "OUTER", "NONCONDUCTIVE", "ALLOWS_TAIL" ],
     "armor": [
       {
-        "encumbrance": 18,
+        "encumbrance": 21,
         "coverage": 80,
         "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
         "rigid_layer_only": true

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -101,6 +101,7 @@
     "volume": "9250 ml",
     "price": "1 USD 20 cent",
     "price_postapoc": "50 cent",
+    "category": "armor",
     "material": [ "carpet_pilling", "plastic" ],
     "symbol": "[",
     "looks_like": "tunic_rag",
@@ -158,11 +159,24 @@
     "category": "armor",
     "color": "light_gray",
     "warmth": 15,
-    "material_thickness": 2,
     "flags": [ "VARSIZE", "OUTER", "STURDY" ],
     "armor": [
-      { "encumbrance": 30, "coverage": 90, "covers": [ "torso" ] },
       {
+        "material": [
+          { "type": "steel", "covered_by_mat": 80, "thickness": 1.3 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ],
+        "coverage": 90,
+        "encumbrance": 17,
+        "rigid_layer_only": true
+      },
+      {
+        "material": [
+          { "type": "steel", "covered_by_mat": 80, "thickness": 1.3 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "encumbrance": 4,
         "coverage": 90,
         "covers": [ "arm_l", "arm_r" ],
@@ -187,27 +201,6 @@
     "name": { "str_sp": "lorica segmentata" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
-  },
-  {
-    "id": "tireplate",
-    "type": "ARMOR",
-    "category": "armor",
-    "name": { "str": "tireplate" },
-    "description": "Armor fashioned from from overlapping chunks of tire and rolls of duct tape, covering the shoulders and torso.",
-    "weight": "5790 g",
-    "volume": "9500 ml",
-    "price": "42 USD",
-    "price_postapoc": "1 USD",
-    "to_hit": -1,
-    "material": [ "rubber" ],
-    "symbol": "O",
-    "looks_like": "armor_lorica",
-    "color": "light_gray",
-    "warmth": 10,
-    "longest_side": "40 cm",
-    "material_thickness": 4,
-    "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 22, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
   },
   {
     "id": "cloth_shirt_padded",
@@ -317,22 +310,13 @@
     "color": "light_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "material_thickness": 1.3,
     "flags": [ "OUTER", "STURDY", "RAINPROOF" ],
     "armor": [
       {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
+        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "torso" ],
-        "specifically_covers": [ "torso_upper" ],
-        "coverage": 90,
+        "coverage": 95,
         "encumbrance": 17,
-        "rigid_layer_only": true
-      },
-      {
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.3 } ],
-        "covers": [ "torso" ],
-        "specifically_covers": [ "torso_lower" ],
-        "coverage": 100,
         "rigid_layer_only": true
       }
     ]
@@ -372,7 +356,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "flags": [ "OUTER", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 22, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
+    "armor": [ { "encumbrance": 21, "coverage": 80, "covers": [ "torso" ], "rigid_layer_only": true } ]
   },
   {
     "id": "tire_cuirass_xl",
@@ -380,14 +364,14 @@
     "name": { "str": "tire cuirass", "str_pl": "tire cuirasses" },
     "copy-from": "tire_cuirass",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "flags": [ "OVERSIZE", "OUTER", "NONCONDUCTIVE", "PREFIX_XL" ]
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "tire_cuirass_xs",
     "type": "ARMOR",
     "copy-from": "tire_cuirass",
     "looks_like": "tire_cuirass",
-    "name": { "str": "tire cuirass", "str_pl": "XS tire cuirasses" },
+    "name": { "str": "tire cuirass", "str_pl": "tire cuirasses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
@@ -407,16 +391,17 @@
     "warmth": 20,
     "material_thickness": 3,
     "flags": [ "STURDY" ],
-    "armor": [ { "encumbrance": 9, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ] } ]
+    "armor": [ { "encumbrance": 14, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ] } ]
   },
   {
     "id": "jacket_leather_mod",
     "type": "ARMOR",
     "name": { "str": "armored riding jacket" },
-    "description": "A heavy-duty leather jacket with metal plates drilled onto various areas for increased protection.",
+    "description": "A heavy-duty leather jacket with sheet metal plates secured over it for increased protection.",
     "weight": "7500 g",
     "volume": "4500 ml",
     "price": "179 USD",
+    "category": "armor",
     "price_postapoc": "25 USD",
     "to_hit": -3,
     "material": [ "steel", "leather" ],
@@ -427,7 +412,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 28, 32 ],
+        "encumbrance": [ 34, 38 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -437,7 +422,7 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 28, 28 ],
+        "encumbrance": [ 36, 36 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -469,9 +454,10 @@
     "id": "jacket_jean_mod",
     "type": "ARMOR",
     "name": { "str": "armored jean jacket" },
-    "description": "A denim jacket reinforced with metal plates.  Adequately protective, but not very sturdy.",
+    "description": "A denim jacket reinforced with sheet metal plates.",
     "weight": "6350 g",
     "volume": "5750 ml",
+    "category": "armor",
     "price": "150 USD",
     "price_postapoc": "20 USD",
     "material": [ "steel", "denim" ],
@@ -482,7 +468,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 24, 28 ],
+        "encumbrance": [ 32, 36 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "denim", "covered_by_mat": 100, "thickness": 0.9 }
@@ -492,7 +478,7 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 24, 24 ],
+        "encumbrance": [ 34, 34 ],
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
           { "type": "denim", "covered_by_mat": 100, "thickness": 0.9 }
@@ -524,7 +510,7 @@
     "id": "vest_jean_mod",
     "type": "ARMOR",
     "name": { "str": "armored jean vest" },
-    "description": "A denim vest reinforced with metal plates.  Adequately protective, but not very sturdy.",
+    "description": "A denim vest reinforced with sheet metal plates.",
     "weight": "4100 g",
     "volume": "4100 ml",
     "price": "130 USD",
@@ -537,7 +523,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 24, 28 ],
+        "encumbrance": [ 32, 36 ],
         "material": [
           { "type": "steel", "covered_by_mat": 80, "thickness": 0.9 },
           { "type": "denim", "covered_by_mat": 100, "thickness": 0.9 }
@@ -568,7 +554,6 @@
   {
     "id": "jacket_leather_tire",
     "type": "ARMOR",
-    "category": "armor",
     "name": { "str_sp": "tire armor jacket" },
     "description": "A heavy leather jacket reinforced with chunks of thick rubber tire.  Thick and highly resistant to blunt force.",
     "weight": "5800 g",
@@ -582,7 +567,7 @@
       {
         "covers": [ "torso" ],
         "coverage": 100,
-        "encumbrance": [ 24, 28 ],
+        "encumbrance": [ 46, 48 ],
         "material": [
           { "type": "rubber", "covered_by_mat": 80, "thickness": 3.0 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -592,7 +577,7 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 100,
-        "encumbrance": [ 32, 32 ],
+        "encumbrance": [ 46, 48 ],
         "material": [
           { "type": "rubber", "covered_by_mat": 75, "thickness": 3.0 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
@@ -728,6 +713,7 @@
     "price": "179 USD",
     "price_postapoc": "12 USD",
     "to_hit": -3,
+    "category": "armor",
     "material": [ "steel", "leather" ],
     "symbol": "[",
     "looks_like": "vest_leather",
@@ -757,7 +743,7 @@
         "coverage": 90,
         "covers": [ "torso" ],
         "material": [
-          { "type": "steel", "covered_by_mat": 90, "thickness": 1.5 },
+          { "type": "steel", "covered_by_mat": 90, "thickness": 0.9 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
         ],
         "rigid_layer_only": true
@@ -838,7 +824,7 @@
         "covers": [ "torso" ],
         "coverage": 95,
         "encumbrance": 24,
-        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4.5 } ]
+        "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 4 } ]
       }
     ],
     "warmth": 25,

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -12,7 +12,7 @@
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
     "acid_dmg_verb": "burned",
-    "resist": { "bash": 4, "cut": 5, "acid": 10, "heat": 6, "bullet": 3 }
+    "resist": { "bash": 4, "cut": 4, "acid": 10, "heat": 6, "bullet": 2.5 }
   },
   {
     "type": "material",
@@ -1416,7 +1416,7 @@
       { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 1, "cut": 3, "acid": 4, "heat": 2, "bullet": 2 },
+    "resist": { "bash": 1.5, "cut": 2.5, "acid": 4, "heat": 2, "bullet": 2 },
     "repair_difficulty": 3
   },
   {
@@ -1432,6 +1432,7 @@
     "chip_resist": 10,
     "repaired_with": "leather",
     "salvaged_into": "leather",
+    "breathability": "IMPERMEABLE",
     "dmg_adj": [ "scratched", "cut", "shredded", "tattered" ],
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "sliced",
@@ -1442,12 +1443,13 @@
       { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 1, "cut": 3, "acid": 8, "heat": 2, "bullet": 2 },
+    "resist": { "bash": 1.2, "cut": 2.5, "acid": 8, "heat": 2.2, "bullet": 2 },
     "repair_difficulty": 3
   },
   {
     "type": "material",
     "id": "leather_arthropod",
+    "//": "More elastic and rubbery than leather, but less cut-resistant. Weak to heat and acid.",
     "name": "Soft Chitin",
     "density": 2,
     "specific_heat_liquid": 1.5,
@@ -1474,7 +1476,7 @@
     "id": "lycra",
     "name": "Lycra",
     "//": "AKA Spandex. These values assume there's another material blended in such as polyester.",
-    "//1": "This stuff should max out at 1mm in like a wetsuit, but is generally muuuuuch thinner, as in women's tights.",
+    "//1": "This stuff should max out at 1mm in a wetsuit, but is generally much thinner, as in women's tights.",
     "density": 1.2,
     "specific_heat_liquid": 1.7,
     "specific_heat_solid": 1.7,
@@ -1676,7 +1678,7 @@
       { "fuel": 3.3, "smoke": 1, "burn": 0.075 }
     ],
     "burn_products": [ [ "ash", 0.013 ] ],
-    "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
+    "resist": { "bash": 0.4, "cut": 0.5, "acid": 0, "heat": 0, "bullet": 1 }
   },
   {
     "type": "material",
@@ -1765,7 +1767,7 @@
       { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
       { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
-    "resist": { "bash": 1, "cut": 0.5, "acid": 8, "heat": 1, "bullet": 0.5 },
+    "resist": { "bash": 0.6, "cut": 0.3, "acid": 8, "heat": 1, "bullet": 0.3 },
     "repair_difficulty": 5
   },
   {

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -556,5 +556,10 @@
     "type": "MIGRATION",
     "id": "plated_leather_armor_suit_xl",
     "replace": "armor_samurai_xl"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "tireplate",
+    "replace": "tire_cuirass"
   }
 ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -791,7 +791,6 @@
     "using": [ [ "tailoring_kevlar_fabric", 3 ], [ "fastener_small", 1 ] ],
     "tools": [ [ [ "rubber_spray_can", 3 ] ] ],
     "components": [ [ [ "pants_army", 1 ], [ "pants_cargo", 1 ] ] ]
-    
   },
   {
     "result": "pants_survivor_xl",
@@ -801,7 +800,6 @@
     "using": [ [ "tailoring_kevlar_fabric", 6 ], [ "fastener_small", 1 ] ],
     "tools": [ [ [ "rubber_spray_can", 3 ] ] ],
     "components": [ [ [ "pants_army", 2 ], [ "pants_cargo", 2 ] ] ]
-    
   },
   {
     "result": "shorts",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -609,7 +609,7 @@
       ],
       [ [ "duct_tape", 135 ] ]
     ],
-    "tools": [ [ [ "rubber_spray_can", 10]]],
+    "tools": [ [ [ "rubber_spray_can", 10 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_closures" },
@@ -639,7 +639,6 @@
       ],
       [ [ "duct_tape", 101 ] ]
     ]
-  
   },
   {
     "result": "longcoat_survivor_xl",
@@ -2047,19 +2046,6 @@
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork", 4 ] ],
     "byproducts": [ [ "scrap_cotton", 22 ] ]
-  },
-  {
-    "result": "tireplate",
-    "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_TORSO",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "time": "2 h",
-    "autolearn": true,
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "rubber_tire_chunk", 16 ] ], [ [ "duct_tape", 16 ] ] ]
   },
   {
     "result": "thermal_shirt",


### PR DESCRIPTION
#### Summary
Update armor protection and encumbrance

#### Purpose of change
I have made a lot of sweeping armor changes which made the mechanics and coverage work more like I wanted, but several items still had improper protection values. This is one of those things that you never really finish tweaking, but now's as good a time as any to fix up a bunch of the more common sets and pieces.

#### Describe the solution
![image](https://github.com/user-attachments/assets/41e77297-3746-440c-971e-131637901729)
Ignore the acid and fire values here - this menu is currently incorrectly calculating some armor values. It's about right for the encumbrance, bash/cut/stab/bullet, and coverage averages though. The main thing is that plate mail is now as good as it's meant to be, instead of worse than leather.

I didn't change the plate carriers or longcoat, but everything else here got a review. I also haven't changed riot armor, which I know is popular (partly because the wear menu overestimates its physical protection values!)

This update also touched a few helmets, materials, and the accessories and suits made with the above torso armors.

Additionally, tireplate has been retired - it was just a copy of the tire cuirass anyway! You can still make tire arm guards, greaves, a tasset, and a full suit of the stuff if you're enough of a badass.

#### Testing
Looks good to me.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
