### PR TITLE
Reduce fun and max fun from reading

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1953,9 +1953,8 @@ bool read_activity_actor::player_read( avatar &you )
 
         const int book_fun = learner->book_fun_for( *book, *learner );
         if( book_fun != 0 ) {
-            // Fun bonus is no longer calculated here.
             learner->add_morale( morale_book,
-                                 book_fun * 5, book_fun * 15,
+                                 book_fun, book_fun * 10,
                                  2_hours, 1_hours, true,
                                  book->type );
         }
@@ -2109,9 +2108,8 @@ bool read_activity_actor::npc_read( npc &learner )
 
     const int book_fun = learner.book_fun_for( *book, learner );
     if( book_fun != 0 ) {
-        // Fun bonus is no longer calculated here.
         learner.add_morale( morale_book,
-                            book_fun * 5, book_fun * 15,
+                            book_fun, book_fun * 10,
                             2_hours, 1_hours, true,
                             book->type );
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5606,12 +5606,12 @@ void play_with_pet_activity_actor::start( player_activity &act, Character & )
 void play_with_pet_activity_actor::finish( player_activity &act, Character &who )
 {
     if( !who.has_trait( trait_PSYCHOPATH ) && !who.has_trait( trait_NUMB ) ) {
-    who.add_morale( morale_play_with_pet, 10, 10, 5_hours, 25_minutes );
-    if( !playstr.empty() ) {
-        who.add_msg_if_player( m_good, playstr, pet_name );
-    }
-    who.add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
-                           pet_name );
+        who.add_morale( morale_play_with_pet, 10, 10, 5_hours, 25_minutes );
+        if( !playstr.empty() ) {
+            who.add_msg_if_player( m_good, playstr, pet_name );
+        }
+        who.add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
+                               pet_name );
     } else {
         if( !playstr.empty() ) {
             who.add_msg_if_player( m_good, playstr, pet_name );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2325,18 +2325,15 @@ void activity_handlers::vibe_do_turn( player_activity *act, Character *you )
                 add_msg( m_info, _( "The %s runs out of batteries." ), vibrator_item.tname() );
             }
         } else {
-            //twenty minutes to fill
+            // Twenty minutes to fill
             you->add_morale( morale_feeling_good, 1, 40 );
         }
     }
     // Dead Tired: different kind of relaxation needed
     if( you->get_fatigue() >= fatigue_levels::DEAD_TIRED ) {
         act->moves_left = 0;
-        add_msg( m_info, _( "You're too tired to continue." ) );
+        add_msg( m_info, _( "You're too drowsy to continue." ) );
     }
-
-    // Vibrator requires that you be able to move around, stretch, etc, so doesn't play
-    // well with roots.  Sorry.  :-(
 }
 
 void activity_handlers::start_engines_finish( player_activity *act, Character *you )


### PR DESCRIPTION
#### Summary
Reduce fun and max fun from reading

#### Purpose of change
Books used to have such a short morale boost that it wasn't really worth reading them. I made it last longer in #695 but this made us discover that book morale is for some reason capped at fun * 15. A book lover could potentially get 90 morale by reading a book 3 times! What the heck! Nobody ever noticed I guess because it wasn't ever worth doing.

#### Describe the solution
- Book base and max fun were fun * 5 and fun * 15. They are now fun and fun * 10. If you want to try and read a playboy 10 times as a book lover to get 60 morale for the 20 remaining minutes your buff lasts, then that is between you and the Lord.

#### Testing
readan books

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
