### PR TITLE
Fix auto-generated itemgroup spam

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -242,7 +242,7 @@
     "//": "Medical consumables for emergency use excluding painkillers",
     "items": [
       [ "adrenaline_injector", 50 ],
-      { "item": "inhaler", "prob": 100, "charges": [ 10, 100 ] },
+      { "item": "inhaler", "prob": 70, "charges": [ 10, 100 ] },
       { "prob": 50, "group": "quikclot_bag_plastic_1_6" },
       { "item": "smoxygen_tank", "prob": 70, "charges": [ 0, 12 ] },
       { "distribution": [ { "group": "full_ifak" }, { "group": "used_ifak" } ], "prob": 40 }
@@ -255,8 +255,8 @@
     "subtype": "distribution",
     "entries": [
       { "group": "bfipowder_bottle_plastic_5_60", "prob": 100 },
-      { "item": "dayquil", "count": [ 1, 30 ], "container-item": "bottle_plastic", "prob": 50 },
-      { "item": "nyquil", "count": [ 1, 30 ], "container-item": "bottle_plastic", "prob": 50 }
+      { "item": "dayquil", "charges": [ 1, 10 ], "container-item": "bottle_plastic", "prob": 50 },
+      { "item": "nyquil", "charges": [ 1, 10 ], "container-item": "bottle_plastic", "prob": 50 }
     ]
   },
   {
@@ -338,8 +338,8 @@
       { "prob": 15, "group": "antihistamine_bottle_plastic_pill_supplement_1_30" },
       { "prob": 5, "group": "iodine_bottle_plastic_pill_supplement_1_10" },
       { "prob": 5, "group": "prussian_blue_bottle_plastic_pill_supplement_1_10" },
-      { "item": "dayquil", "prob": 70, "charges": [ 1, 5 ] },
-      { "item": "nyquil", "prob": 70, "charges": [ 1, 5 ] },
+      { "item": "dayquil", "prob": 70, "charges": [ 1, 10 ] },
+      { "item": "nyquil", "prob": 70, "charges": [ 1, 10 ] },
       { "group": "alcohol_wipes_box_used", "prob": 75 },
       { "group": "alcohol_wipes_box_full", "prob": 10 },
       { "item": "disinfectant", "prob": 35, "charges": [ 1, 10 ] },
@@ -358,7 +358,6 @@
     "type": "item_group",
     "id": "harddrugs",
     "items": [
-      { "item": "inhaler", "prob": 14, "charges": [ 10, 100 ] },
       { "prob": 15, "group": "codeine_bottle_plastic_pill_painkiller_1_10" },
       { "prob": 4, "group": "oxycodone_bottle_plastic_pill_prescription_1_10" },
       { "item": "morphine", "prob": 4, "count": [ 1, 4 ] },

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -7,7 +7,7 @@
       { "prob": 20, "group": "tobacco_bag_plastic_1_20" },
       { "prob": 20, "group": "chaw_wrapper_1_20" },
       { "item": "cigar", "prob": 10, "count": [ 1, 5 ] },
-      { "item": "ecig", "prob": 10, "count": [ 1, 40 ] },
+      { "item": "ecig", "prob": 10 },
       { "item": "advanced_ecig", "prob": 8, "charges": [ 1, 100 ] },
       [ "nicotine_liquid", 15 ],
       [ "pipe_tobacco", 10 ]

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -620,8 +620,8 @@
         ],
         "prob": 80
       },
-      { "count": [ 1, 10 ], "prob": 80, "group": "tea_raw_bag_plastic_33" },
-      { "count": [ 1, 10 ], "prob": 40, "group": "tea_green_raw_bag_plastic_33" },
+      { "prob": 30, "group": "tea_raw_bag_plastic_33" },
+      { "prob": 20, "group": "tea_green_raw_bag_plastic_33" },
       { "item": "teapot", "prob": 70 },
       { "item": "kettle", "prob": 50 },
       { "prob": 90, "sealed": false, "group": "sugar_jar_glass_sealed_10_140" },
@@ -629,10 +629,10 @@
         "distribution": [
           {
             "item": "milk_powder",
-            "count": [ 5, 20 ],
+            "count": [ 1, 20 ],
             "container-item": "null",
             "entry-wrapper": "jar_3l_glass_sealed",
-            "prob": 60,
+            "prob": 30,
             "sealed": false
           },
           { "item": "con_milk", "count": [ 1, 6 ], "prob": 10 },
@@ -647,7 +647,7 @@
       },
       { "item": "spoon", "count": [ 1, 6 ] },
       { "item": "ceramic_mug", "count": [ 1, 6 ] },
-      { "group": "teabag_box", "prob": 60 }
+      { "group": "teabag_box", "prob": 40 }
     ]
   },
   {
@@ -711,10 +711,10 @@
         "distribution": [
           {
             "item": "milk_powder",
-            "count": [ 5, 20 ],
+            "count": [ 1, 20 ],
             "container-item": "null",
             "entry-wrapper": "jar_3l_glass_sealed",
-            "prob": 40,
+            "prob": 20,
             "sealed": false
           },
           { "item": "milk_evap", "count": [ 1, 6 ], "prob": 10 },

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1745,7 +1745,7 @@
     "id": "milk_powder_various_full",
     "//": "This group was created by a fool and may contain errors.",
     "subtype": "distribution",
-    "entries": [ { "prob": 1, "group": "milk_powder_bag_paper_full", "container-item": "bag_paper_powder", "count": 40 } ]
+    "entries": [ { "prob": 1, "group": "milk_powder_bag_paper_full" } ]
   },
   {
     "type": "item_group",
@@ -1753,7 +1753,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
-    "entries": [ { "item": "milk_powder", "container-item": "null", "count": 40 } ]
+    "entries": [ { "item": "milk_powder", "count": 20 } ]
   },
   {
     "type": "item_group",
@@ -1797,7 +1797,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
-    "entries": [ { "item": "milk_powder", "container-item": "null", "count": [ 5, 40 ] } ]
+    "entries": [ { "item": "milk_powder", "container-item": "null", "count": [ 5, 20 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -753,7 +753,7 @@
       { "item": "milk_UHT", "prob": 15 },
       { "item": "milk_evap", "prob": 25 },
       { "item": "con_milk", "prob": 25 },
-      { "prob": 45, "group": "milk_powder_various_full" },
+      { "prob": 35, "group": "milk_powder_various_full" },
       { "prob": 50, "group": "salt_various_full" },
       { "item": "soysauce", "prob": 25 },
       { "item": "hot_sauce", "prob": 25 },


### PR DESCRIPTION
#### Summary
Fix auto-generated itemgroup spam

#### Purpose of change
The charge removal from solid comestibles a few years back left a lot of things in quite a state. Players noticed that several items were still spawning in comically huge piles thanks to bugs remaining in the automatically generated itemgroups that were done around that time.

#### Describe the solution
- Fix tea leaf spam
- Fix powdered milk spam
- Fix electronic cigarette spam
- Fix cough syrup spam

#### Describe alternatives you've considered
Electronic cigarettes don't appear to work properly, you just smoke the whole thing in one second and then it's gone. I assume these are just disposable ecigs - they ought to work like the advanced kind but have an internal battery and reservoir you can't take out (which can be salvaged if you deconstruct em!)

#### Testing
Spawned in, things seem OK so far.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
