### PR TITLE
Pauldrons aren't sided

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -1001,7 +1001,6 @@
     "color": "light_gray",
     "warmth": 10,
     "longest_side": "60 cm",
-    "sided": true,
     "material_thickness": 1.3,
     "flags": [ "OUTER", "STURDY", "CONDUCTIVE" ],
     "armor": [
@@ -1049,7 +1048,6 @@
     "color": "brown",
     "warmth": 10,
     "longest_side": "60 cm",
-    "sided": true,
     "material_thickness": 4,
     "flags": [ "OUTER", "STURDY" ],
     "armor": [


### PR DESCRIPTION
#### Summary
Pauldrons aren't sided

#### Purpose of change
Leather and plate mail pauldrons had the "sided" object set to true, meaning despite being a pair they'd only go on one shoulder.

#### Describe the solution
Delete that line. Now they're a pair.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
