### PR TITLE
Make lambs, goat kids and llama calves tamable like cow calves

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1816,6 +1816,7 @@
     "upgrades": { "age_grow": 240, "into": "mon_sheep" },
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CAN_BE_CULLED", "EATS" ]
   },
   {
@@ -1901,6 +1902,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "baby_flags": [ "SPRING" ],
     "special_attacks": [ [ "EAT_CROP", 100 ], [ "GRAZE", 60 ] ],
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "zombify_into": "mon_zombie_goat",
     "flags": [
       "SEES",
@@ -2135,6 +2137,7 @@
     "special_attacks": [ [ "EAT_CROP", 150 ], [ "GRAZE", 150 ] ],
     "//": "Puberty reached in 6-9 months, copied from lamb but it probably applies the same on llamas.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
+    "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS" ]
   },
   {


### PR DESCRIPTION
Makes lambs, goat kids, and llama calves tamable like cow calves are.

#### Summary
Cow calves are tamable with cattle food, but lambs, goat kids and llama calves are not.  This makes all of them tamable.

#### Purpose of change
Makes lambs, goat kids and llama calves tamable.

#### Describe the solution
Added the line:
	"petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
to each of the above, copied from cow calves.

#### Describe alternatives you've considered
Make cow calves untamable to be consistent.

#### Testing
Spawn cattle food and a lamb, goat kid and llama calf.  Confirm that each can now be tamed with cattle food.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
