### PR TITLE
Fix winged zombies and unstable flesh-raptors

### DIFF
--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -17,6 +17,7 @@
     "scents_tracked": [ "sc_human", "sc_fetid" ],
     "aggression": 100,
     "morale": 100,
+    "dodge": 2,
     "melee_skill": 2,
     "melee_dice": 2,
     "melee_dice_sides": 2,
@@ -84,6 +85,7 @@
     "scents_tracked": [ "sc_human", "sc_fetid" ],
     "aggression": 100,
     "morale": 100,
+    "dodge": 3,
     "melee_skill": 4,
     "melee_dice": 3,
     "melee_dice_sides": 6,
@@ -157,7 +159,7 @@
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_flying" ],
     "vision_night": 5,
     "harvest": "zombie_animal",
-    "special_attacks": [ { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] } ],
+    "special_attacks": [ { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 14, "armor_multiplier": 0.8 } ] } ],
     "upgrades": { "half_life": 42, "into_group": "GROUP_ZOMBIE_RAPTOR_UPGRADES" },
     "fungalize_into": "mon_fungal_raptor",
     "flags": [
@@ -198,13 +200,16 @@
     "color": "red",
     "description": "This small, winged predator darts through the air on three thinly-haired wings that look like stretched human hands.  A jagged spike juts out from the point where the wings meet, and a bloated, fleshy belly hangs beneath.  A sharp smell of rotten eggs hangs around it.",
     "special_attacks": [
-      [ "SUICIDE", 20 ],
-      { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] }
+    {
+      "type": "spell",
+      "spell_data": { "id": "boomer_claymore_initial", "min_level": 0 },
+      "monster_message": "An unstable flesh-raptor explodes!"
+    }
     ],
     "death_function": {
-      "effect": { "id": "death_explosion_mon_spawn_raptor_unstable", "hit_self": true },
-      "corpse_type": "NO_CORPSE",
-      "message": "The %s explodes!"
+      "effect": { "id": "death_boomer", "hit_self": true, "min_level": 3 },
+      "message": "A %s explodes!",
+      "corpse_type": "NO_CORPSE"
     },
     "death_drops": "explode_innards_small",
     "upgrades": false
@@ -223,10 +228,10 @@
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_electromagnetics" ],
     "special_attacks": [
       [ "SHOCKSTORM", 25 ],
-      { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] }
+      { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 14, "armor_multiplier": 0.8 } ] }
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
-    "upgrades": false,
+    "upgrades": { "half_life": 4, "into": "mon_spawn_raptor_unstable" },
     "extend": { "flags": [ "ELECTRIC" ] }
   }
 ]


### PR DESCRIPTION
#### Summary
Fix winged zombies and unstable flesh-raptors

#### Purpose of change
Unstable flesh-raptors weren't working, zaptors weren't burning out, flesh-raptors had damage and arpen designed for DDA armor values, and winged zombies were pretty unimpressive.

#### Describe the solution
Restore the self-destruct attack to unstable flesh-raptors, give winged zombies some dodge. reduce damage and arpen on flesh-raptor attacks, zaptors burn out into unstable flesh-raptors after a couple of days, similar to how shockers burn out.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
