### PR TITLE
Fix artifact varsity jacket copy-from

### DIFF
--- a/data/json/items/relics/altered_items.json
+++ b/data/json/items/relics/altered_items.json
@@ -137,7 +137,7 @@
   },
   {
     "id": "altered_jacket",
-    "copy-from": "jacket_leather",
+    "copy-from": "jacket_varsity",
     "type": "ARMOR",
     "name": { "str": "varsity jacket" },
     "description": "A jacket traditionally worn by school athletes.  The logo of the school has an oddly detailed fractal pattern that draws your eye in whenever you look at it."


### PR DESCRIPTION
#### Summary
Fix artifact varsity jacket copy-from

#### Purpose of change
The artifact varsity jacket was using the stats and materials of a leather jacket.

#### Describe the solution
Now it's a varsity jacket

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
