### PR TITLE
Stop Hub 01 doc from trading HGC for 1% of their value

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -25,7 +25,7 @@
     "shopkeeper_price_rules": [
       { "group": "NC_ANCILLA_DOCTOR_stock", "premium": 2.0 },
       { "group": "NC_ANCILLA_DOCTOR_EXPENSIVE_ITEMS", "premium": 6.0 },
-      { "item": "RobofacCoin", "price": 50, "fixed_adj": 0 }
+      { "item": "RobofacCoin", "price": 5000, "fixed_adj": 0 }
     ],
     "skills": [
       {
@@ -52,12 +52,12 @@
     "id": "NC_ANCILLA_DOCTOR_stock",
     "subtype": "collection",
     "entries": [
-      { "item": "RobofacCoin", "prob": 100, "count": [ 8, 10 ] },
-      { "item": "disinfectant", "prob": 100, "count": [ 2, 10 ] },
+      { "item": "RobofacCoin", "prob": 100, "count": [ 2, 4 ] },
+      { "item": "disinfectant", "prob": 70, "count": [ 2, 10 ] },
       { "item": "bandages", "prob": 100, "count": [ 3, 10 ] },
       { "item": "saline", "prob": 100, "count": [ 1, 2 ] },
-      { "group": "drugs_emergency", "prob": 100, "count": [ 4, 6 ] },
-      { "group": "drugs_analgesic", "prob": 100, "count": [ 2, 4 ] }
+      { "group": "drugs_emergency", "prob": 70, "count": [ 1, 4 ] },
+      { "group": "drugs_analgesic", "prob": 70, "count": [ 2, 4 ] }
     ]
   },
   {
@@ -65,12 +65,12 @@
     "id": "NC_ANCILLA_DOCTOR_EXPENSIVE_ITEMS",
     "subtype": "collection",
     "entries": [
-      { "item": "morphine", "prob": 100, "count": 4 },
-      { "prob": 100, "group": "antibiotics_bottle_plastic_pill_prescription_15" },
-      { "prob": 100, "group": "strong_antibiotic_bottle_plastic_pill_prescription_5" },
-      { "item": "anesthetic", "prob": 100 },
-      { "prob": 100, "group": "oxycodone_bottle_plastic_pill_prescription_10" },
-      { "prob": 100, "group": "codeine_bottle_plastic_pill_painkiller_10" }
+      { "item": "morphine", "prob": 80, "count": 4 },
+      { "prob": 80, "group": "antibiotics_bottle_plastic_pill_prescription_15" },
+      { "prob": 80, "group": "strong_antibiotic_bottle_plastic_pill_prescription_5" },
+      { "item": "anesthetic", "prob": 90 },
+      { "prob": 80, "group": "oxycodone_bottle_plastic_pill_prescription_10" },
+      { "prob": 80, "group": "codeine_bottle_plastic_pill_painkiller_10" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Stop Hub 01 doc from trading HGC for 1% of their value

#### Purpose of change
The Hub 01 doctor was selling HGC for 50 cents. They're supposed to be fifty dollars!

#### Describe the solution
- 50->5000
- Reduce some of his vendor stock.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
