### PR TITLE
Fix ballistic glass

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2677,8 +2677,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
-    "coverage": 30,
-    "concealment": 30,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
@@ -2692,7 +2691,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
+      "items": [ { "item": "glass_shard", "charges": [ 20, 44 ] }, { "item": "glass_shard_large", "count": [ 0, 3 ] } ]
     },
     "shoot": { "reduce_damage": [ 1, 8 ], "reduce_damage_laser": [ 0, 5 ], "destroy_damage": [ 2, 8 ], "no_laser_destroy": true }
   },
@@ -2706,8 +2705,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
-    "coverage": 30,
-    "concealment": 30,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
@@ -2721,7 +2719,7 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
+      "items": [ { "item": "glass_shard", "charges": [ 20, 44 ] }, { "item": "glass_shard_large", "count": [ 0, 3 ] } ]
     },
     "shoot": { "reduce_damage": [ 1, 8 ], "reduce_damage_laser": [ 0, 5 ], "destroy_damage": [ 2, 8 ], "no_laser_destroy": true }
   },
@@ -2735,6 +2733,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
@@ -2747,7 +2746,7 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
+      "items": [ { "item": "glass_shard", "charges": [ 20, 44 ] } ]
     },
     "shoot": { "reduce_damage": [ 2, 12 ], "reduce_damage_laser": [ 0, 7 ], "destroy_damage": [ 40, 120 ], "no_laser_destroy": true }
   },
@@ -2761,22 +2760,23 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "UNCLINGABLE" ],
     "bash": {
-      "str_min": 200,
-      "str_max": 400,
+      "str_min": 25,
+      "str_max": 90,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] } ]
+      "items": [ { "item": "glass_shard", "charges": [ 20, 44 ] } ]
     },
     "shoot": {
-      "reduce_damage": [ 30, 60 ],
+      "reduce_damage": [ 5, 20 ],
       "reduce_damage_laser": [ 0, 10 ],
       "destroy_damage": [ 80, 200 ],
       "no_laser_destroy": true
@@ -2791,22 +2791,23 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "UNCLINGABLE" ],
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "wire", "prob": 20 } ]
+      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] }, { "item": "wire", "prob": 20 } ]
     },
     "shoot": {
-      "reduce_damage": [ 15, 30 ],
+      "reduce_damage": [ 5, 10 ],
       "reduce_damage_laser": [ 0, 10 ],
       "destroy_damage": [ 60, 160 ],
       "no_laser_destroy": true
@@ -2821,6 +2822,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_gray",
     "move_cost": 0,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
@@ -2835,7 +2837,7 @@
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "count": [ 20, 44 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
@@ -2856,6 +2858,7 @@
     "symbol": "LINE_OXOX",
     "color": "light_cyan",
     "move_cost": 0,
+    "coverage": 100,
     "roof": "t_flat_roof",
     "connect_groups": "WALL",
     "connects_to": "WALL",
@@ -2872,21 +2875,21 @@
     ],
     "close": "t_reinforced_glass_shutter",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "charges": [ 20, 44 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
     },
     "shoot": {
-      "reduce_damage": [ 20, 40 ],
+      "reduce_damage": [ 5, 10 ],
       "reduce_damage_laser": [ 15, 25 ],
       "destroy_damage": [ 60, 160 ],
       "no_laser_destroy": true
@@ -2902,6 +2905,7 @@
     "color": "light_cyan",
     "move_cost": 0,
     "connect_groups": "WALL",
+    "coverage": 100,
     "connects_to": "WALL",
     "flags": [ "TRANSPARENT", "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
     "rotates_to": "INDOORFLOOR",
@@ -2913,7 +2917,11 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_null",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
+      "items": [
+        { "item": "glass_shard", "charges": [ 20, 44 ] },
+        { "item": "glass_shard_large", "count": [ 0, 3 ] },
+        { "item": "scrap", "count": [ 3, 6 ] }
+      ]
     }
   },
   {
@@ -2925,6 +2933,7 @@
     "symbol": "\"",
     "color": "light_gray",
     "move_cost": 0,
+    "coverage": 15,
     "hacksaw": {
       "result": "t_floor",
       "duration": "15 minutes",

--- a/data/json/recipes/food/brewing.json
+++ b/data/json/recipes/food/brewing.json
@@ -394,7 +394,7 @@
       [
         [ "chilly-p", 50 ],
         [ "chili_pepper", 1 ],
-		[ "chili_pepper_cut", 2 ],
+        [ "chili_pepper_cut", 2 ],
         [ "rehydrated_chili", 1 ],
         [ "cinnamon", 25 ],
         [ "pepper", 50 ],
@@ -587,7 +587,7 @@
       [
         [ "cabbage", 1 ],
         [ "chili_pepper", 1 ],
-		[ "chili_pepper_cut", 2 ],
+        [ "chili_pepper_cut", 2 ],
         [ "rehydrated_chili", 1 ],
         [ "yoghurt", 1 ],
         [ "yogurt_starter_culture", 1 ]

--- a/data/json/recipes/food/dry.json
+++ b/data/json/recipes/food/dry.json
@@ -455,7 +455,7 @@
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrating_heat", 12, "LIST" ] ] ],
     "//": "I pretty much made up all the relating numbers, feel free to change them",
-    "components": [ [ [ "chili_pepper", 1 ], [ "chili_pepper_cut", 2 ]  ] ]
+    "components": [ [ [ "chili_pepper", 1 ], [ "chili_pepper_cut", 2 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/milling.json
+++ b/data/json/recipes/food/milling.json
@@ -91,7 +91,7 @@
     "batch_time_factors": [ 83, 3 ],
     "charges": 50,
     "tools": [ [ [ "surface_heat", 3, "LIST" ] ], [ [ "rock_quern", -1 ], [ "clay_quern", -1 ] ] ],
-    "components": [ [ [ "chili_pepper", 1 ] , [ "chili_pepper_cut", 2 ] ] ]
+    "components": [ [ [ "chili_pepper", 1 ], [ "chili_pepper_cut", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -124,7 +124,7 @@
     "charges": 50,
     "batch_time_factors": [ 95, 10 ],
     "tools": [ [ [ "food_processor", 10 ] ] ],
-    "components": [ [ [ "chili_pepper", 1 ] , [ "chili_pepper_cut", 2 ] ] ]
+    "components": [ [ [ "chili_pepper", 1 ], [ "chili_pepper_cut", 2 ] ] ]
   },
   {
     "//": "For use by mills, so the only entries used are the charges and components.",

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5008,7 +5008,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
     * and "bad" shots, with 0.0f being perfect and 2000.0f being a pure gamble. See ranged.cpp
     * for more details on dispersion.
     */
-    if( coverage > 0 && dispersion < 1000.0f ) {
+    if( coverage > 0 && coverage < 100 && dispersion < 1000.0f ) {
         coverage *= dispersion / 1000.0f;
     }
     bool hit_something = false;
@@ -5057,7 +5057,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
                     }
                 } else if( furn_hit ) {
                     shoot_furn_ter( furniture.obj() );
-                    if( laser_passthrough == false ) {
+                    if( ( laser_passthrough == false && laser ) || !laser ) {
                         int damdown = std::min( static_cast<int>( dam ), rng( furniture->bash.str_min,
                                                 furniture->bash.str_max ) );
                         bash( p, modified_dam, false );
@@ -5065,7 +5065,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
                     }
                 } else if( ter_hit ) {
                     shoot_furn_ter( terrain.obj() );
-                    if( laser_passthrough == false ) {
+                    if( ( laser_passthrough == false && laser ) || !laser ) {
                         int damdown = std::min( static_cast<int>( dam ), rng( terrain->bash.str_min,
                                                 terrain->bash.str_max ) );
                         bash( p, modified_dam, false );


### PR DESCRIPTION
#### Summary
Fix ballistic glass

#### Purpose of change
Due to some backports, map::shoot() got broken again! The stats for balllistic and reinforced glass also needed some fixing.

#### Describe the solution
- Highly accurate shots cannot pass through solid objects. Third time should be the charm (until another backport ruins it!)
- Improved laser_passthrough logic
- Adjust bash yields for ballsitic and reinforced glass
- Adjust bash strength for ballistic and reinforced glass
- Adjust damage reduction for ballistic and reinforced glass
- Make damage < 1 destroy the projectile

#### Testing
Spawned in with a turret and some ballistic glass. Most of its bullets were stopped by the blast, some hit me for single digit or damage in the teens.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
