### PR TITLE
Update meteorologist.json so meteorologist can give mission

### DIFF
--- a/data/json/npcs/other/meteorologist.json
+++ b/data/json/npcs/other/meteorologist.json
@@ -88,8 +88,8 @@
         "text": "Do you need any help?",
         "switch": true,
         "trial": {
-          "type": "CONDITION",
-          "condition": { "math": [ "time_since(n_time_mission_meteorologist_wait)", ">=", "time('2 d')" ] }
+        "type": "CONDITION",
+		    "condition": { "math": [ "time_since( value_or(n_time_mission_meteorologist_wait, time('cataclysm') ) )", ">=", "time('2 d')" ] }
         },
         "success": { "effect": [ { "npc_lose_var": "time_mission_meteorologist_wait" } ], "topic": "TALK_MISSION_LIST" },
         "failure": { "topic": "TALK_meteorologist_wait" }


### PR DESCRIPTION
Fixed it so the meteorologist will give mission

#### Summary
Category "Brief description"
Update meteorologist.json so meteorologist can give mission

#### Purpose of change
To fix meteorologist mission

#### Describe the solution
Took proposed fix from https://github.com/CleverRaven/Cataclysm-DDA/issues/75960
and changed
          "condition": { "math": [ "time_since(n_time_mission_meteorologist_wait)", ">=", "time('2 d')" ] }

to
		"condition": { "math": [ "time_since( value_or(n_time_mission_meteorologist_wait, time('cataclysm') ) )", ">=", "time('2 d')" ] }

#### Describe alternatives you've considered

#### Testing
Spawn meteorologist
Wait 2 days
Confirm that they can give their mission now

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
