### PR TITLE
Prevent 0 damage hits from trying to apply damage

### DIFF
--- a/data/json/recipes/food/vegetable_dishes.json
+++ b/data/json/recipes/food/vegetable_dishes.json
@@ -174,7 +174,7 @@
     "qualities": [ { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
     "//": "2u for roasting a veggy",
-    "components": [ [ [ "chili_pepper", 1 ], [ "rehydrated_chili", 1 ] , [ "chili_pepper_cut", 2 ] ] ]
+    "components": [ [ [ "chili_pepper", 1 ], [ "rehydrated_chili", 1 ], [ "chili_pepper_cut", 2 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -6059,7 +6059,7 @@
       [ [ "tomato", 1 ], [ "can_tomato", 1 ] ],
       [ [ "meat_cooked", 1, "LIST" ], [ "dry_meat", 1 ], [ "can_chicken", 1 ] ],
       [ [ "can_beans", 1 ], [ "raw_beans", 1 ], [ "dry_beans", 1 ] ],
-      [ [ "chilly-p", 2 ], [ "chili_pepper", 1 ], [ "rehydrated_chili", 1 ] , [ "chili_pepper_cut", 2 ] ]
+      [ [ "chilly-p", 2 ], [ "chili_pepper", 1 ], [ "rehydrated_chili", 1 ], [ "chili_pepper_cut", 2 ] ]
     ]
   },
   {
@@ -9689,7 +9689,7 @@
         [ "rehydrated_garlic", 1 ],
         [ "garlic_powder", 20 ],
         [ "chili_pepper", 2 ],
-		[ "chili_pepper_cut", 4 ],
+        [ "chili_pepper_cut", 4 ],
         [ "rehydrated_chili", 2 ]
       ]
     ]

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5114,7 +5114,7 @@ void map::shoot( const tripoint &p, const tripoint &source, projectile &proj, co
     }
 
     // Rescale the damage
-    if( dam <= 0 ) {
+    if( dam < 1 ) {
         proj.impact.damage_units.clear();
         return;
     } else if( dam < initial_damage ) {


### PR DESCRIPTION
#### Summary
Prevent 0 damage hits from trying to apply damage

#### Purpose of change
Ranged hits reduced to fractional amounts of damage by hitting cover get rounded to 0, but were still being passed to the hit function. This was occasionally damaging the player's equipment, which is not appropriate.

#### Describe the solution
If damage is reduced to less than 1, cancel the attack.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
