### PR TITLE
Reduce apple orchard and grape farm food spawns

### DIFF
--- a/data/json/mapgen/farm_stills.json
+++ b/data/json/mapgen/farm_stills.json
@@ -91,7 +91,7 @@
         "`": { "param": "linoleum_color_kitchen", "fallback": "t_linoleum_gray" },
         "?": "t_region_groundcover",
         "#": "t_wall_wood",
-        "$": "t_shrub_grape",
+        "$": "t_dirtmound",
         "&": "t_water_pump",
         "=": "t_dirtfloor",
         ",": "t_region_soil",
@@ -138,7 +138,9 @@
         { "item": "still", "x": 29, "y": 33, "amount": 1 },
         { "item": "fruit_wine", "x": [ 25, 25 ], "y": [ 30, 33 ], "repeat": [ 1, 4 ], "amount": [ 0, 3 ] }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 28, 38 ], "y": [ 5, 19 ], "repeat": [ 2, 10 ] } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 28, 38 ], "y": [ 5, 19 ], "repeat": [ 2, 10 ] },
+      { "group": "GROUP_FARM_PESTS", "x": [ 75, 79 ], "y": [ 30, 35 ], "repeat": [ 1, 3 ] }, { "group": "GROUP_FARM_PESTS", "x": [ 9, 12 ], "y": [ 66, 68 ], "repeat": [ 1, 2 ] } ],
+      "sealed_item": { "$": { "item": { "item": "seed_grapes" }, "furniture": "f_plant_seedling", "chance": 15 } }
     }
   },
   {
@@ -207,8 +209,8 @@
       },
       "furniture": { "}": "f_glass_fridge" },
       "items": {
-        "}": { "item": "wines_worthy", "chance": 70, "repeat": [ 1, 2 ] },
-        "0": { "item": "keg_wine_intact", "chance": 70 },
+        "}": { "item": "wines_worthy", "chance": 60, "repeat": [ 0, 2 ] },
+        "0": { "item": "keg_wine_intact", "chance": 60 },
         "?": { "item": "barrels", "chance": 100 }
       }
     }
@@ -296,18 +298,18 @@
         "X": "f_wood_keg",
         "W": "f_wood_keg"
       },
-      "place_vehicles": [ { "vehicle": "bikeshop", "x": 22, "y": 19, "chance": 100, "rotation": 90 } ],
-      "liquids": { "X": { "liquid": "hb_beer", "amount": [ 100, 500 ] }, "W": { "liquid": "dandelion_wine", "amount": [ 100, 500 ] } },
+      "place_vehicles": [ { "vehicle": "bikeshop", "x": 22, "y": 19, "chance": 80, "rotation": 90 } ],
+      "liquids": { "X": { "liquid": "hb_beer", "amount": [ 50, 300 ] }, "W": { "liquid": "dandelion_wine", "amount": [ 20, 300 ] } },
       "items": {
         "%": { "item": "wines_worthy", "chance": 70, "repeat": [ 1, 2 ] },
         "0": { "item": "keg_wine_intact", "chance": 70 },
         "3": { "item": "barrels", "chance": 100 },
         "1": { "item": "keg_wine_intact", "chance": 70 },
-        "a": { "item": "dry_goods", "chance": 50, "repeat": [ 2, 8 ] },
-        "r": { "item": "preserved_food", "chance": 50, "repeat": [ 2, 8 ] },
-        "c": { "item": "condiments", "chance": 50, "repeat": [ 2, 8 ] },
-        "e": { "item": "pantry_liquids", "chance": 50, "repeat": [ 2, 8 ] },
-        "l": { "item": "farming_seeds", "chance": 50, "repeat": [ 2, 8 ] },
+        "a": { "item": "dry_goods", "chance": 50, "repeat": [ 0, 5 ] },
+        "r": { "item": "preserved_food", "chance": 50, "repeat": [ 0, 5 ] },
+        "c": { "item": "condiments", "chance": 50, "repeat": [ 0, 5 ] },
+        "e": { "item": "pantry_liquids", "chance": 50, "repeat": [ 0, 5 ] },
+        "l": { "item": "farming_seeds", "chance": 50, "repeat": [ 1, 5 ] },
         "b": [
           { "item": "supplies_farming", "chance": 30, "repeat": [ 1, 2 ] },
           { "item": "tools_earthworking", "chance": 40, "repeat": [ 1, 2 ] }

--- a/data/json/mapgen_palettes/orchard_apple.json
+++ b/data/json/mapgen_palettes/orchard_apple.json
@@ -60,7 +60,7 @@
     "terrain": {
       " ": "t_region_groundcover_forest",
       "*": "t_region_soil",
-      "7": [ [ "t_tree_apple", 7 ], [ "t_tree_young", 2 ], "t_tree_dead" ]
+      "7": [ [ "t_tree_apple", 3 ], [ "t_tree_young", 3 ], [ "t_tree_dead", 4 ], "t_stump" ]
     }
   }
 ]


### PR DESCRIPTION
#### Summary
Reduce apple orchard and grape farm food spawns

#### Purpose of change
- Grape farms and apple orchards had preposterous amounts of pickable fruit available despite ripening six months into a full blown apocalypse.
- Grape farms had wild grape bushes and not cultivated ones, meaning they never overgrew and would come back year after year.
- Some corn farms still had way too much food.

#### Describe the solution
- Change grape farms to use crop furniture instead of wild grape bush terrain.
- Dramatically reduce the pickable fruit terrain/furniture.
- Add farm pests to the grape farm

#### Testing
Spawned in and visited both locations. Seems good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
