### PR TITLE
Update torso.json to fix weird paper breastplate recipes

### DIFF
--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -192,7 +192,7 @@
     "components": [ [ [ "paper", 1200 ] ], [ [ "duct_tape", 150 ] ] ]
   },
   {
-    "result": "paper_breastplate_xl",
+    "result": "paper_breastplate_xs",
     "type": "recipe",
     "copy-from": "paper_breastplate",
     "time": "3 h",
@@ -200,7 +200,7 @@
     "components": [ [ [ "paper", 900 ] ], [ [ "duct_tape", 100 ] ] ]
   },
   {
-    "result": "paper_breastplate_xs",
+    "result": "paper_breastplate_xl",
     "type": "recipe",
     "copy-from": "paper_breastplate",
     "qualities": [ { "id": "CUT", "level": 2 } ],


### PR DESCRIPTION
#### Summary
Switches over the result ID to fix the overly small consumption on the XL paper breastplate and vise versa

#### Purpose of change
Fixes a bug posted in the discord
#### Describe the solution
Switched the ids of the recipes
#### Describe alternatives you've considered
I suppose I could retype the whole thing but I just switched the IDs
#### Testing
Booted it up on my PC, checked recipes, seemed all good 
#### Additional context
was being foolish trying to figure out this issue on discord. Thanks Worm Girl for clarifying!

![image](https://github.com/user-attachments/assets/8bca010c-fec6-45e3-a897-a9eae03dcd53)

![image](https://github.com/user-attachments/assets/f7f04ad5-dc46-45c2-9f8b-0241830c05f8)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
