### PR TITLE
Add button to activity cancel

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4165,6 +4165,17 @@
   },
   {
     "type": "keybinding",
+    "id": "VIEW",
+    "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
+    "name": "View enemy",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "v" }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "YES0",
     "category": "YES_QUERY",
     "name": "Yes, I will!",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1476,42 +1476,51 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
     const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
                             : input_context::allow_all_keys;
 
-    const std::string &action = query_popup()
-                                .preferred_keyboard_mode( keyboard_mode::keycode )
-                                .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
-                                .message( force_uc && !is_keycode_mode_supported() ?
-                                          pgettext( "cancel_activity_or_ignore_query",
-                                                  "<color_light_red>%s %s (Case Sensitive)</color>" ) :
-                                          pgettext( "cancel_activity_or_ignore_query",
-                                                  "<color_light_red>%s %s</color>" ),
-                                          text, u.activity.get_stop_phrase() )
-                                .option( "YES", allow_key )
-                                .option( "NO", allow_key )
-                                .option( "MANAGER", allow_key )
-                                .option( "IGNORE", allow_key )
-                                .query()
-                                .action;
+    while (true) {
+        const std::string& action = query_popup()
+            .preferred_keyboard_mode(keyboard_mode::keycode)
+            .context("CANCEL_ACTIVITY_OR_IGNORE_QUERY")
+            .message(force_uc && !is_keycode_mode_supported() ?
+                pgettext("cancel_activity_or_ignore_query",
+                    "<color_light_red>%s %s (Case Sensitive)</color>") :
+                pgettext("cancel_activity_or_ignore_query",
+                    "<color_light_red>%s %s</color>"),
+                text, u.activity.get_stop_phrase())
+            .option("YES", allow_key)
+            .option("NO", allow_key)
+            .option("MANAGER", allow_key)
+            .option("IGNORE", allow_key)
+            .option("VIEW", allow_key)
+            .query()
+            .action;
 
-    if( action == "YES" ) {
-        u.cancel_activity();
-        return true;
-    }
-    if( action == "IGNORE" ) {
-        u.activity.ignore_distraction( type );
-        for( player_activity &activity : u.backlog ) {
-            activity.ignore_distraction( type );
+        if (action == "YES") {
+            u.cancel_activity();
+            return true;
         }
-    }
-    if( action == "MANAGER" ) {
-        u.cancel_activity();
-        get_distraction_manager().show();
-        return true;
-    }
+        if (action == "IGNORE") {
+            u.activity.ignore_distraction(type);
+            for (player_activity& activity : u.backlog) {
+                activity.ignore_distraction(type);
+            }
+            return false;
+        }
+        if (action == "MANAGER") {
+            u.cancel_activity();
+            get_distraction_manager().show();
+            return true;
+        }
+        if (action == "VIEW") {
+            temp_exit_fullscreen();
+            list_items_monsters();
+            reenter_fullscreen();
+            continue;
+        }
 
-    ui_manager::redraw();
-    refresh_display();
-
-    return false;
+        ui_manager::redraw();
+        refresh_display();
+        return false;
+    }
 }
 
 bool game::portal_storm_query( const distraction_type type, const std::string &text )


### PR DESCRIPTION
#### Summary
Implemented a new action that lets you [V]iew the enemy interrupts an activity of the player.

#### Purpose of change
When an enemy triggers a distraction popup on long time-based activity, the menu doesn't give you enough information of it.

#### Describe the solution
Add a new button whenever a distraction happens [V]iew enemy.

#### Describe alternatives you've considered
Adding a more custom message similar to "Spotted a zombie 25 tiles to the north-east!" at the distraction popup.

#### Testing
Basic manual testing.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![Photos_Ef15Uw9Oed](https://github.com/user-attachments/assets/8a5fd52e-1c80-4edd-9f82-87db11ad9407)


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
