### PR TITLE
Fix missing teamster dialog

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -111,11 +111,6 @@
           ]
         },
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_Godco_Trader_Mission_Fail"
-      },
-      {
-        "text": "I wanted to tell you about a potential new trading partner I met recently.",
-        "topic": "TALK_FREE_MERCHANT_TEAMSTER_FACTION_INTRO",
-        "condition": { "u_has_var": "general_meeting_u_met_Rubik", "value": "yes" }
       }
     ]
   },
@@ -140,6 +135,24 @@
         "topic": "TALK_DONE",
         "effect": { "u_add_var": "general_meeting_u_met_teamster", "value": "yes" }
       }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_FREE_MERCHANT_TEAMSTER_Boris_Mission_1",
+    "dynamic_line": {
+      "gendered_line": "Alright, sure.  The mess is in my way, after all.  I'll let Boris know.",
+      "relevant_genders": [ "npc" ]
+    },
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "mission_Boris_mission_1_cleanup_asked", "value": "yes" },
+        { "math": [ "u_mission_cleanup_promises_Boris_mission_1", "++" ] }
+      ]
+    },
+    "responses": [
+      { "text": "Thanks!  <done_conversation_section>", "topic": "TALK_FREE_MERCHANT_TEAMSTER_CHAT" },
+      { "text": "Thanks!  I'll see you around.", "topic": "TALK_DONE" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix missing teamster dialog

#### Purpose of change
The Refugee Center teamster had a missing response for asking them to help with the cleanup effort.

#### Describe the solution
- Added a response. I didn't feel like tracking down the commit and doing a complicated revert, so for the sake of compliance with our license, I wrote a new one.
- Removed an orphaned bit of dialog relating to Rubik.

#### Testing
Game loads. That means it works, right??


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
