### PR TITLE
Wielding an item releases your grab

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -112,6 +112,8 @@ static const itype_id itype_guidebook( "guidebook" );
 static const itype_id itype_mut_longpull( "mut_longpull" );
 
 static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
+static const json_character_flag json_flag_GRAB( "GRAB" );
+static const json_character_flag json_flag_GRAB_FILTER( "GRAB_FILTER" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_WEBBED_HANDS( "WEBBED_HANDS" );
 
@@ -1466,6 +1468,26 @@ bool avatar::wield( item &target, const int obtain_cost )
 
     if( worn ) {
         target.on_takeoff( *this );
+    }
+
+    // TODO: Standardize this as a single function in Character::
+    if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+        if( as_character()->grab_1.victim ) {
+            for( const effect &eff : as_character()->grab_1.victim->get_effects_with_flag( json_flag_GRAB ) ) {
+                const efftype_id effid = eff.get_id();
+                if( eff.get_intensity() == as_character()->grab_1.grab_strength ) {
+                    add_msg( _( "You release %s." ), as_character()->grab_1.victim->disp_name() );
+                    as_character()->grab_1.victim->remove_effect( effid );
+                }
+            }
+        }
+        for( const effect &eff : get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
+            const efftype_id effid = eff.get_id();
+            if( eff.get_intensity() == as_character()->grab_1.grab_strength ) {
+                remove_effect( effid );
+            }
+        }
+
     }
 
     add_msg_debug( debugmode::DF_AVATAR, "wielding took %d moves", mv );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1476,41 +1476,41 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
     const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
                             : input_context::allow_all_keys;
 
-    while (true) {
-        const std::string& action = query_popup()
-            .preferred_keyboard_mode(keyboard_mode::keycode)
-            .context("CANCEL_ACTIVITY_OR_IGNORE_QUERY")
-            .message(force_uc && !is_keycode_mode_supported() ?
-                pgettext("cancel_activity_or_ignore_query",
-                    "<color_light_red>%s %s (Case Sensitive)</color>") :
-                pgettext("cancel_activity_or_ignore_query",
-                    "<color_light_red>%s %s</color>"),
-                text, u.activity.get_stop_phrase())
-            .option("YES", allow_key)
-            .option("NO", allow_key)
-            .option("MANAGER", allow_key)
-            .option("IGNORE", allow_key)
-            .option("VIEW", allow_key)
-            .query()
-            .action;
+    while( true ) {
+        const std::string &action = query_popup()
+                                    .preferred_keyboard_mode( keyboard_mode::keycode )
+                                    .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
+                                    .message( force_uc && !is_keycode_mode_supported() ?
+                                              pgettext( "cancel_activity_or_ignore_query",
+                                                      "<color_light_red>%s %s (Case Sensitive)</color>" ) :
+                                              pgettext( "cancel_activity_or_ignore_query",
+                                                      "<color_light_red>%s %s</color>" ),
+                                              text, u.activity.get_stop_phrase() )
+                                    .option( "YES", allow_key )
+                                    .option( "NO", allow_key )
+                                    .option( "MANAGER", allow_key )
+                                    .option( "IGNORE", allow_key )
+                                    .option( "VIEW", allow_key )
+                                    .query()
+                                    .action;
 
-        if (action == "YES") {
+        if( action == "YES" ) {
             u.cancel_activity();
             return true;
         }
-        if (action == "IGNORE") {
-            u.activity.ignore_distraction(type);
-            for (player_activity& activity : u.backlog) {
-                activity.ignore_distraction(type);
+        if( action == "IGNORE" ) {
+            u.activity.ignore_distraction( type );
+            for( player_activity &activity : u.backlog ) {
+                activity.ignore_distraction( type );
             }
             return false;
         }
-        if (action == "MANAGER") {
+        if( action == "MANAGER" ) {
             u.cancel_activity();
             get_distraction_manager().show();
             return true;
         }
-        if (action == "VIEW") {
+        if( action == "VIEW" ) {
             temp_exit_fullscreen();
             list_items_monsters();
             reenter_fullscreen();


### PR DESCRIPTION
#### Summary
Wielding an item releases your grab

#### Purpose of change
It was previously possible to grab an enemy, wield a weapon, and then hit them with it while grabbing them. This was unintentional.

#### Describe the solution
Wielding an item while grabbing will now release your grab.

#### Describe alternatives you've considered
It is eventually planned that certain characters (IE cephalopods) will be able to wield things while grabbing, and that one-handed items will be wieldable but apply a penalty to your grab_strength.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
