### PR TITLE
Make 5-point anchors wearable for all

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1568,7 +1568,7 @@
     },
     "warmth": 10,
     "material_thickness": 2,
-    "flags": [ "OVERSIZE", "BELTED", "SOFT" ],
+    "flags": [ "UNRESTRICTED", "BELTED", "SOFT" ],
     "armor": [ { "encumbrance": 2, "coverage": 50, "covers": [ "torso" ] } ]
   },
   {
@@ -1586,7 +1586,7 @@
       "msg": "The %s LED light flickers off.",
       "target": "dimensional_anchor"
     },
-    "flags": [ "DIMENSIONAL_ANCHOR", "OVERSIZE", "BELTED", "PORTAL_PROOF", "SOFT" ]
+    "flags": [ "DIMENSIONAL_ANCHOR", "UNRESTRICTED", "BELTED", "PORTAL_PROOF", "SOFT" ]
   },
   {
     "id": "broken_dimensional_anchor",


### PR DESCRIPTION
#### Summary
Make 5-point anchors wearable for all

#### Purpose of change
5-point anchors are important items, but they weren't wearable by tiny characters. This was due to an oversight in how sizes were implemented. Since the item is simply a device strapped around the wearer's torso, it should be trivial to fit on pretty much anyone.

#### Describe the solution
Remove the OVERSIZE flag and replace with UNRESTRICTED. These items will still indicate that they are too large or too small for tiny/huge characters, but are still quite usable. Tiny characters get 2 extra encumbrance from them, but that's no big deal.

#### Describe alternatives you've considered
Equipment sizes need to be entirely redone, but (exhausted sigh)

#### Testing
Tried wearing an anchor as a tiny character, a huge character, and a character with a roomy shell (which restricts torso gear but should still allow OVERTOP items like the anchor. It all worked.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
