### PR TITLE
Remove some xedra references

### DIFF
--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -314,8 +314,6 @@
     "name": { "str": "disconnected advanced Stirling radioisotope generator" },
     "looks_like": "t_plut_generator",
     "description": "A rather heavy brick of metal housing an ASRG, formerly designed by NASA and repurposed for terrestrial use.  Will provide about 130 W, basically forever as far as you're concerned.  Even though the alpha radiation these run off of isn't very dangerous in case of a breach, this unit appears to be armored to take a beating and is a good deal heavier owing to its composite plating.",
-    "//0": "the base unit is 39x46x76cm (136 liters) and weighs 32 kg. I am assuming that XEDRA or another org added a lot of armor as a hedge against portal fuckery",
-    "//1": "being enclosed in a solid box of milcomp plating I'm assuming about another 68 kg (3 armor platings' worth + shocks etc)",
     "weight": "100 kg",
     "to_hit": -10,
     "material": [ "lead", "steel" ],

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -1392,7 +1392,7 @@
     "id": "xedra_seismograph",
     "type": "ARMOR",
     "name": { "str": "portable seismograph" },
-    "description": "A sturdy steel briefcase, containing what appears to be an old-fashioned drum seismograph.  The stenciled acronyms of its outer case imply it was used by XEDRA as some sort of recording device.\n\nThin parallel lines cover both ends of the drum, but as they approach the middle their vibrations intensify, until the ink fuses into a thick red stain.",
+    "description": "A sturdy steel briefcase, containing what appears to be an old-fashioned drum seismograph.  The stenciled acronyms of its outer case imply it was used as some sort of recording device.\n\nThin parallel lines cover both ends of the drum, but as they approach the middle their vibrations intensify, until the ink fuses into a thick red stain.",
     "weight": "5000 g",
     "volume": "15750 ml",
     "price": "240 USD",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -139,7 +139,7 @@
     "id": "log_immersion27",
     "copy-from": "file",
     "name": { "str": "INCIDENT REPORT: IMMERSION-27A" },
-    "description": "A white piece of paper, with the logo of XEDRA printed on its upper left corner.  It seems to be an internal report of some kind.",
+    "description": "A white piece of paper on official-looking stationary.  It seems to be an internal report of some kind.",
     "snippet_category": "log_immersion27"
   },
   {
@@ -160,7 +160,7 @@
     "type": "GENERIC",
     "id": "monitoring_equipment_doc",
     "copy-from": "log_immersion27",
-    "name": { "str": "XEDRA document" },
+    "name": { "str": "lab document" },
     "snippet_category": "monitoring_equipment"
   },
   {
@@ -2235,8 +2235,8 @@
     "type": "GENERIC",
     "id": "memory_card_science",
     "copy-from": "memory_card",
-    "name": { "str": "memory card (XEDRA)", "str_pl": "memory cards (XEDRA)" },
-    "description": "A memory card, can be used to store data.  This one has a label on which is written 'XEDRA' followed by a long string of numbers.",
+    "name": { "str": "memory card (CLASSIFIED)", "str_pl": "memory cards (CLASSIFIED)" },
+    "description": "A memory card, can be used to store data.  This one has an ominous label warning that it contains classified information.",
     "memory_card": {
       "data_chance": 1.0,
       "on_read_convert_to": "memory_card",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -343,7 +343,6 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_2_ADVICE_DARPA",
     "type": "talk_topic",
-    "//": "This is a lie.  The researcher was XEDRA; DARPA is just the organization being used as a front.",
     "dynamic_line": "Officially speaking, they were a senior DARPA researcher.  Their corpse should stick out; it's likely the only one not wearing camouflage.  That's all you need to know."
   },
   {

--- a/data/json/snippets/newspapers.json
+++ b/data/json/snippets/newspapers.json
@@ -232,7 +232,7 @@
       },
       {
         "id": "months_old_news_5",
-        "text": "TIME TRAVEL: TRUTH OR FICTION?  Leaked federal documents describe the formation of a new federal agency called XEDRA, to oversee \"4th Axis technology\" already in use.  Our expert's opinion suggests time-travel or parallel worlds.  The meaning of the acronym is currently unknown."
+        "text": "TIME TRAVEL: TRUTH OR FICTION?  A collection of shocking photographs depicting people and technology years before they should have existed!"
       },
       {
         "id": "months_old_news_6",
@@ -315,7 +315,7 @@
       },
       {
         "id": "weeks_old_news_5",
-        "text": "SUPERSOLDIER EXPERIMENTS GONE WRONG.  Recently leaked documents from an inside source in a hitherto unknown government agency abbreviated 'XEDRA' confirm that violent riots across the country are the result of an accidentally released self-replicating supersoldier serum.  The serum gives people unprecedented strength and durability, even regenerative capacity, but has the dangerous side effect of causing uncontrolled anger.  Although the leak suggests that the effect should wear off, it may take weeks or even months to reach a stable state."
+        "text": "SUPERSOLDIER EXPERIMENTS GONE WRONG.  Recently leaked documents from an inside source confirm that violent riots across the country are the result of an accidentally released self-replicating supersoldier serum.  The serum gives people unprecedented strength and durability, even regenerative capacity, but also triggers violent outbursts.  Although the leak suggests that the effect should wear off, it may take weeks or even months to reach a stable state."
       },
       {
         "id": "weeks_old_news_6",

--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -391,7 +391,7 @@
       },
       {
         "id": "lost_note_4",
-        "text": "This note has a chemical smell and a bloody thumbprint on it.  You see directions to nearby isolated sites, mainly forests and fields.  The name of the company(?) who printed this, XEDRA, sounds ominous."
+        "text": "This note has a chemical smell and a bloody thumbprint on it.  You see directions to nearby isolated sites, mainly forests and fields."
       }
     ]
   },


### PR DESCRIPTION
#### Summary
Remove some xedra references

#### Purpose of change
There were some lingering references to XEDRA in snippets and item descriptions.

#### Describe the solution
Remove, genericize, obscure

#### Testing
Loads and runs

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
