### PR TITLE
Remove fleet-footed from hobbies

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -803,7 +803,7 @@
     "name": "Marathon Running",
     "description": "You ran the Boston Marathon every year.  That conditioning should make you better equipped than most in avoiding the dead.",
     "points": 5,
-    "traits": [ "GOODCARDIO", "FLEET" ],
+    "traits": [ "GOODCARDIO" ],
     "skills": [ { "level": 2, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic" ]
   },
@@ -1019,7 +1019,7 @@
     "points": 5,
     "skills": [ { "level": 3, "name": "throw" }, { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic" ],
-    "traits": [ "TOUGH", "FLEET" ]
+    "traits": [ "TOUGH" ]
   },
   {
     "type": "profession",
@@ -1030,7 +1030,7 @@
     "points": 8,
     "skills": [ { "level": 4, "name": "throw" }, { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "TOUGH", "FLEET", "PAINRESIST" ]
+    "traits": [ "TOUGH", "PAINRESIST" ]
   },
   {
     "type": "profession",


### PR DESCRIPTION
#### Summary
Remove fleet-footed from hobbies

#### Purpose of change
Some hobbies still offered fleet-footed. That's not intended!

#### Describe alternatives you've considered
Removing fleet-footed entirely.

#### Testing
Game loads, runs, fleet-footed is no longer available.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
