### PR TITLE
Remove survivor machete+Backport DDA 72536 - Remove rapid strike from knives

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -215,7 +215,7 @@
     "material": [ "budget_steel" ],
     "symbol": "/",
     "color": "light_gray",
-    "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
+    "techniques": [ "RAPID", "WBLOCK_1", "PRECISE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -8 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
     "weapon_category": [ "FENCING_WEAPONRY" ],
@@ -238,7 +238,6 @@
     "symbol": ";",
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 14 ] ],
-    "techniques": [ "RAPID" ],
     "flags": [ "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
     "weapon_category": [ "SHIVS" ],
     "melee_damage": { "stab": 15 }
@@ -259,7 +258,6 @@
     "symbol": ";",
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 14 ] ],
-    "techniques": [ "RAPID" ],
     "flags": [ "ALLOWS_BODY_BLOCK", "CONDUCTIVE", "DURABLE_MELEE" ],
     "weapon_category": [ "SHIVS" ],
     "melee_damage": { "stab": 11 }
@@ -733,20 +731,6 @@
     "melee_damage": { "cut": 21 }
   },
   {
-    "id": "survivor_machete",
-    "copy-from": "machete",
-    "type": "TOOL",
-    "name": { "str": "combat machete" },
-    "description": "This common gardening tool has been customized and rebalanced to improve its performance as a weapon.",
-    "extend": { "techniques": [ "RAPID" ] },
-    "relative": {
-      "melee_damage": { "bash": 1, "cut": 2 },
-      "qualities": [ [ "BUTCHER", -5 ] ],
-      "price_postapoc": "10 USD",
-      "weight": "27 g"
-    }
-  },
-  {
     "id": "machete_gimmick",
     "name": { "str": "machete multitool" },
     "type": "TOOL",
@@ -785,7 +769,7 @@
     "techniques": [ "WBLOCK_2", "RAPID" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 7 ] ],
     "flags": [ "SHEATH_SWORD", "CONDUCTIVE", "DURABLE_MELEE" ],
-    "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 23 }
   },
   {
@@ -1006,7 +990,7 @@
     "material": [ { "type": "leather", "portion": 1.1 }, { "type": "steel", "portion": 112 } ],
     "repairs_with": [ "steel" ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
-    "techniques": [ "WBLOCK_2", "BRUTAL", "RAPID" ],
+    "techniques": [ "WBLOCK_2", "BRUTAL" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 7 ] ],
     "weapon_category": [ "LONG_SWORDS", "LONG_THRUSTING_SWORDS" ],
@@ -2256,7 +2240,7 @@
     "to_hit": { "grip": "solid", "length": "short", "surface": "line", "balance": "neutral" },
     "material": [ { "type": "leather", "portion": 1.1 }, { "type": "steel", "portion": 144 } ],
     "repairs_with": [ "steel" ],
-    "techniques": [ "WBLOCK_2", "RAPID", "BRUTAL" ],
+    "techniques": [ "WBLOCK_2", "BRUTAL" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 6 ] ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
     "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
@@ -2279,7 +2263,7 @@
     "to_hit": { "grip": "solid", "length": "short", "surface": "line", "balance": "neutral" },
     "material": [ { "type": "leather", "portion": 1.1 }, { "type": "steel", "portion": 144 } ],
     "repairs_with": [ "steel" ],
-    "techniques": [ "WBLOCK_2", "RAPID" ],
+    "techniques": [ "WBLOCK_2" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 6 ] ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
     "weapon_category": [ "MEDIUM_SWORDS" ],

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -361,11 +361,10 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving", "time_multiplier": 1.5, "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 20 ], [ "steel_standard", 5 ] ],
+    "using": [ [ "blacksmithing_standard", 10 ], [ "steel_standard", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
-    "//": "basically 2.5x the resources of a single machete to cover the fact that it's two weapons, each with a hand guard",
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "components": [ [ [ "2x4", 2 ], [ "stick", 4 ] ], [ [ "fur", 4 ], [ "leather", 4 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -934,28 +933,6 @@
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "katana", 1 ], [ "wakizashi", 1 ] ], [ [ "stick_long", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "survivor_machete",
-    "category": "CC_WEAPON",
-    "subcategory": "CSC_WEAPON_CUTTING",
-    "skill_used": "fabrication",
-    "difficulty": 6,
-    "skills_required": [ "melee", 5 ],
-    "time": "25 m",
-    "autolearn": true,
-    "using": [ [ "soldering_standard", 20 ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
-    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SAW_M", "level": 1 }, { "id": "GRIND", "level": 2 } ],
-    "components": [
-      [ [ "machete", 1 ] ],
-      [ [ "duct_tape", 150 ] ],
-      [ [ "filament_durable", 20, "LIST" ] ],
-      [ [ "leather", 2 ], [ "chunk_rubber", 1 ] ],
-      [ [ "rubber_cement", 1 ], [ "superglue", 1 ] ]
-    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Remove survivor machete+Backport DDA 72536 - Remove rapid strike from knives

#### Purpose of change
A few of our knives still had Rapid Strike. I noticed a few other issues during this backport that I wanted to fix too.

#### Describe the solution
- Remove rapid strike from most knives.
- Once again, cavalry sabers are not fencing weapons.
- Reduce the blocking ability of a few shitty swords.
- Remove the survivor machete and its recipe.

#### Testing
Loads and runs, wee

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
