### PR TITLE
Fix gloves and finish removing survivor machete

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3216,7 +3216,7 @@
       { "distribution": [ { "group": "full_survival_kit" }, { "group": "used_survival_kit" } ], "prob": 3 },
       { "group": "tools_toolbox", "prob": 1 },
       [ "survivor_belt_notools", 2 ],
-      [ "survivor_machete", 2 ],
+      [ "machete", 2 ],
       [ "survivor_mess_kit", 6 ],
       [ "acetylene_cooker", 12 ],
       [ "survivor_shavingkit", 3 ],

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -182,7 +182,7 @@
     "flags": [ "STURDY", "DURABLE_MELEE", "NORMAL", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
     "armor": [
       {
-        "encumbrance": 12,
+        "encumbrance": 16,
         "coverage": 95,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_back_l", "hand_back_r", "hand_wrist_l", "hand_wrist_r", "hand_palm_l", "hand_palm_r" ],
@@ -317,7 +317,7 @@
     "flags": [ "VARSIZE", "STURDY", "ALLOWS_NATURAL_ATTACKS", "DURABLE_MELEE", "NORMAL" ],
     "armor": [
       {
-        "encumbrance": 8,
+        "encumbrance": 18,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r", "hand_back_l", "hand_back_r" ],
@@ -393,6 +393,7 @@
     "flags": [ "VARSIZE", "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS" ],
     "armor": [
       {
+        "encumbrance": 8,
         "coverage": 90,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r", "hand_back_l", "hand_back_r" ]
@@ -435,14 +436,14 @@
         "rigid_layer_only": true
       },
       {
-        "encumbrance": 3,
+        "encumbrance": 18,
         "coverage": 95,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ],
         "material": [ { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 } ]
       },
       {
-        "encumbrance": 3,
+        "encumbrance": 0,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_palm_l", "hand_palm_r" ],

--- a/data/json/npcs/EOC_talkers/xedra_merc.json
+++ b/data/json/npcs/EOC_talkers/xedra_merc.json
@@ -49,7 +49,7 @@
       { "group": "clothing_watch" },
       { "item": "phase_immersion_suit" },
       { "item": "id_science_security_black" },
-      { "item": "survivor_machete", "container-item": "scabbard" },
+      { "item": "machete", "container-item": "scabbard" },
       {
         "collection": [
           { "item": "rm103a_pistol", "prob": 100, "charges": 6, "container-item": "holster" },

--- a/data/json/npcs/Kindred/NPC_Darren_Cooper.json
+++ b/data/json/npcs/Kindred/NPC_Darren_Cooper.json
@@ -62,7 +62,7 @@
     "type": "item_group",
     "id": "KINDRED_COOPER_wield",
     "subtype": "collection",
-    "entries": [ { "item": "survivor_machete" } ]
+    "entries": [ { "item": "machete" } ]
   },
   {
     "type": "item_group",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ANCILLA_GRUNT.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ANCILLA_GRUNT.json
@@ -36,7 +36,7 @@
       { "item": "under_armor" },
       { "item": "under_armor_shorts" },
       { "item": "holster" },
-      { "item": "survivor_machete", "container-item": "scabbard" },
+      { "item": "machete", "container-item": "scabbard" },
       { "item": "gloves_fingerless_mod" }
     ]
   },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -561,5 +561,10 @@
     "type": "MIGRATION",
     "id": "tireplate",
     "replace": "tire_cuirass"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "survivor_machete",
+    "replace": "machete"
   }
 ]

--- a/data/json/requirements/melee.json
+++ b/data/json/requirements/melee.json
@@ -177,8 +177,7 @@
         [ "sword_bronze", -1 ],
         [ "sword_bayonet", -1 ],
         [ "butterfly_swords", -1 ],
-        [ "arisaka_bayonet", -1 ],
-        [ "survivor_machete", -1 ]
+        [ "arisaka_bayonet", -1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Fix gloves and finish removing survivor machete

#### Purpose of change
- A bunch of gloves had missing or too little encumbrance. This bumps them up.
- I forgot to remove survivor machetes from a few places.

#### Describe the solution
- Add encumbrance.
- Remove references to the survivor machete.
- Migrate the survivor machete.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
