### PR TITLE
Domestic rabbits at Lapin's

### DIFF
--- a/data/json/mapgen/cabin.json
+++ b/data/json/mapgen/cabin.json
@@ -813,7 +813,7 @@
       "palettes": [ "cabin_palette" ],
       "terrain": { ".": "t_region_groundcover", "_": "t_region_soil", "x": "t_floor" },
       "furniture": { "x": "f_firefly_terrarium" },
-      "place_monster": [ { "monster": "mon_rabbit", "x": 8, "y": 21, "repeat": [ 3, 6 ] } ],
+      "place_monster": [ { "monster": "mon_rabbit_domestic", "x": 8, "y": 21, "repeat": [ 3, 6 ] } ],
       "place_npcs": [ { "class": "warrener", "x": 9, "y": 17 } ]
     }
   },


### PR DESCRIPTION
Changes to be committed:
	modified:   data/json/mapgen/cabin.json

#### Summary
Changed the wild rabbits at Lapin's cottage to tameable domestic ones.

#### Purpose of change
Able to get rabbits as a reward for doing missions for Mr. Lapin.

#### Describe the solution
Changed mon_rabbit in mapgen/cabin.json to mon_rabbit_domestic

#### Describe alternatives you've considered
None

#### Testing
Spawned the cabin. Rabbits are the correct type. Tamed a rabbit using cattle fodder.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
