### PR TITLE
Backport 74888 - Audit Carnivore for items with volumes indivisible by 50ml

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -883,7 +883,10 @@
     "price_postapoc": "2 USD 50 cent",
     "quench": -5,
     "fun": 4,
-    "proportional": { "price": 2.0, "volume": 0.345, "weight": 0.345 },
+    "volume": "50 ml",
+    "proportional": { "price": 2.0, "weight": 0.345 },
+    "vitamins": [ [ "vitC", 1 ], [ "calcium", 3 ], [ "iron", 7 ] ],
+    "calories": 130,
     "delete": { "flags": [ "RAW" ] }
   },
   {
@@ -900,7 +903,7 @@
     "price_postapoc": "2 USD 50 cent",
     "quench": -5,
     "fun": 4,
-    "proportional": { "price": 2.0, "volume": 0.345, "weight": 0.345 },
+    "proportional": { "price": 2.0, "weight": 0.345 },
     "delete": { "flags": [ "RAW" ] }
   },
   {
@@ -966,14 +969,14 @@
     "looks_like": "offal",
     "name": { "str": "piece of raw lung", "str_pl": "pieces of raw lung" },
     "description": "A portion of lung from an animal.  It's spongy and pink, and spoils very quickly.  It can be a delicacy if properly prepared - but if improperly prepared, it's a chewy lump of flavorless connective tissue.",
-    "weight": "56 g",
-    "volume": "62 ml",
+    "weight": "45 g",
+    "volume": "50 ml",
     "color": "pink",
     "spoils_in": "1 day",
     "price_postapoc": "6 cent",
     "quench": 2,
     "fun": -10,
-    "calories": 50,
+    "calories": 40,
     "vitamins": [ [ "vitC", 9 ], [ "calcium", 0 ], [ "iron", 14 ] ],
     "extend": { "flags": [ "PREDATOR_FUN" ] }
   },

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -3489,6 +3489,7 @@
     "time": "30 m",
     "batch_time_factors": [ 83, 5 ],
     "autolearn": true,
+    "charges": 2,
     "tools": [ [ [ "surface_heat", 13, "LIST" ] ] ],
     "//": "150g meat + 25%",
     "components": [ [ [ "salt_preservation", 1, "LIST" ] ], [ [ "fish", 1 ] ] ]
@@ -6474,7 +6475,7 @@
     "subcategory": "CSC_FOOD_MEAT",
     "skill_used": "cooking",
     "difficulty": 4,
-    "charges": 5,
+    "charges": 10,
     "time": "5 m",
     "batch_time_factors": [ 10, 3 ],
     "autolearn": true,


### PR DESCRIPTION
#### Summary
Backport 74888 - Audit Carnivore for items with volumes indivisible by 50ml

#### Purpose of change
Fix behavior of small meat items, which were in some cases not counting as meat or human flesh.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
