### PR TITLE
Backport DDA 74959 - add missing threshes to NECC blacklist

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -30,7 +30,9 @@
             "THRESH_MOUSE",
             "THRESH_MARLOSS",
             "THRESH_MYCUS",
-            "THRESH_CRUSTACEAN"
+            "THRESH_CRUSTACEAN",
+            "THRESH_CHIROPTERAN",
+            "THRESH_RABBIT"
           ]
         }
       ]


### PR DESCRIPTION
#### Summary
Backport DDA 74959 - add missing threshes to NECC blacklist

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
