### PR TITLE
Backport DDA 74947 - Artificial Night Generator do[es] not grant invis

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1228,13 +1228,7 @@
     "description": "When active, this bionic eliminates all light within a 2 tile radius through destructive interference.",
     "occupied_bodyparts": [ [ "torso", 16 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "enchantments": [
-      {
-        "condition": "ACTIVE",
-        "ench_effects": [ { "effect": "invisibility", "intensity": 1 } ],
-        "emitter": "emit_shadow_field"
-      }
-    ],
+    "enchantments": [ { "condition": "ACTIVE", "emitter": "emit_shadow_field" } ],
     "act_cost": "9 kJ",
     "react_cost": "9 kJ",
     "time": "1 s"

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -693,7 +693,7 @@
     "type": "BIONIC_ITEM",
     "name": { "str": "Artificial Night Generator CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "When active, this bionic eliminates all light within a 15-tile radius of the user through destructive interference.",
+    "description": "When active, this bionic eliminates all light within a 2-tile radius of the user through destructive interference.",
     "price": "8500 USD",
     "price_postapoc": "80 USD",
     "difficulty": 5


### PR DESCRIPTION
#### Summary
Backport DDA 74947 - Artificial Night Generator do[es] not grant invis

#### Purpose of change
The CBM puts darkness on you, it doesn't need to also make you invisible, and it shouldn't be doing that anyway cause some monsters can see in the dark.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
