### PR TITLE
Backport DDA 75031 - Blocked negative part index from being used

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2759,6 +2759,10 @@ std::string optional_vpart_position::extended_description() const
 int vehicle::part_with_feature( int part, vpart_bitflags flag, bool unbroken,
                                 bool include_fake ) const
 {
+    if( part < 0 ) {
+        return -1;
+    }
+
     const vehicle_part &vp = this->part( part );
     if( vp.info().has_flag( flag ) && !( unbroken && vp.is_broken() ) ) {
         return part;


### PR DESCRIPTION
#### Summary
Backport DDA 75031 - Blocked negative part index from being used


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
