### PR TITLE
Backport 75038 - Improve fire behavior

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4439,8 +4439,13 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     const map_bash_info *bash = nullptr;
 
     tripoint_bub_ms below = p + tripoint_rel_ms_below;
-    const ter_str_id below_tile_roof = get_roof( below, false );
-    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
+    ter_str_id below_tile_roof = ter_t_dirt;
+    bool roof_of_below_tile = false;
+
+    if( zlevels ) {
+        below_tile_roof = get_roof( below, false );
+        roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
+    }
 
     bool success = false;
 
@@ -4677,8 +4682,8 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
     //regenerates roofs for tiles that should be walkable from above
-    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && ter( below )->has_flag( "WALL" ) &&
-        zlevels && !set_to_air ) {
+    if( zlevels && smash_ter && !set_to_air  && ter( p )->has_flag( "EMPTY_SPACE" ) &&
+        ter( below )->has_flag( "WALL" ) ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4437,10 +4437,10 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     bool smash_furn = false;
     bool smash_ter = false;
     const map_bash_info *bash = nullptr;
-    
+
     tripoint_bub_ms below = p + tripoint_rel_ms_below;
-    const ter_str_id below_tile_roof = get_roof(below, false);
-    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id());
+    const ter_str_id below_tile_roof = get_roof( below, false );
+    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id() );
 
     bool success = false;
 
@@ -4654,7 +4654,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         // If this terrain is being bashed from above and this terrain
         // has a valid post-destroy bashed-from-above terrain, set it
         ter_set( p, bash->ter_set_bashed_from_above );
-    } else if( bash->ter_set && !roof_of_below_tile) {
+    } else if( bash->ter_set && !roof_of_below_tile ) {
         // If the terrain has a valid post-destroy terrain, set it
         ter_set( p, bash->ter_set );
     } else {
@@ -4663,10 +4663,12 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
             // When bashing the tile below, don't allow bashing the floor
             bash_params params_below = params; // Make a copy
             params_below.bashing_from_above = true;
+            //the roof tile will be destroyed, so the below tile should also be destroyed
+            params_below.destroy = true;
             bash_ter_furn( below, params_below );
         }
 
-        set_to_air = roof_of_below_tile; //do not add a roof for the tile below if it was already removed
+        set_to_air = roof_of_below_tile; //do not add the roof for the tile below if it was already removed
         furn_set( p, furn_str_id::NULL_ID() );
         ter_set( p, ter_t_open_air );
     }
@@ -4674,8 +4676,9 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     if( !tent ) {
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
-
-    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels && !set_to_air ) {
+    //regenerates roofs for tiles that should be walkable from above
+    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && ter( below )->has_flag( "WALL" ) &&
+        zlevels && !set_to_air ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4437,6 +4437,10 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     bool smash_furn = false;
     bool smash_ter = false;
     const map_bash_info *bash = nullptr;
+    
+    tripoint_bub_ms below = p + tripoint_rel_ms_below;
+    const ter_str_id below_tile_roof = get_roof(below, false);
+    bool roof_of_below_tile = ( terid.id.id() == below_tile_roof.id());
 
     bool success = false;
 
@@ -4458,9 +4462,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         } else if( !bash->ter_set && zlevels ) {
             // HACK: A hack for destroy && !bash_floor
             // We have to check what would we create and cancel if it is what we have now
-            tripoint_bub_ms below = p + tripoint_rel_ms_below;
-            const ter_str_id roof = get_roof( below, false );
-            if( ter( p ) == roof ) {
+            if( roof_of_below_tile ) {
                 smash_ter = false;
                 bash = nullptr;
             }
@@ -4579,6 +4581,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
     const bool will_collapse = smash_ter &&
                                has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p ) && !has_flag( ter_furn_flag::TFLAG_INDOORS, p );
     const bool tent = smash_furn && !bash->tent_centers.empty();
+    bool set_to_air = false;
 
     // Special code to collapse the tent if destroyed
     if( tent ) {
@@ -4651,11 +4654,10 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         // If this terrain is being bashed from above and this terrain
         // has a valid post-destroy bashed-from-above terrain, set it
         ter_set( p, bash->ter_set_bashed_from_above );
-    } else if( bash->ter_set ) {
+    } else if( bash->ter_set && !roof_of_below_tile) {
         // If the terrain has a valid post-destroy terrain, set it
         ter_set( p, bash->ter_set );
     } else {
-        tripoint_bub_ms below = p + tripoint_rel_ms_below;
         const ter_t &ter_below = ter( below ).obj();
         if( bash->bash_below && ter_below.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ) {
             // When bashing the tile below, don't allow bashing the floor
@@ -4664,6 +4666,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
             bash_ter_furn( below, params_below );
         }
 
+        set_to_air = roof_of_below_tile; //do not add a roof for the tile below if it was already removed
         furn_set( p, furn_str_id::NULL_ID() );
         ter_set( p, ter_t_open_air );
     }
@@ -4672,8 +4675,7 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
 
-    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels ) {
-        tripoint_bub_ms below = p + tripoint_rel_ms_below;
+    if( smash_ter && ter( p )->has_flag( "EMPTY_SPACE" ) && zlevels && !set_to_air ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1110,8 +1110,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 175 - cur.get_field_intensity() * 50 ) ) {
-                here.furn_set( p, furn_str_id::NULL_ID() );
-                here.destroy( p, false );
+                here.bash(p, 999, false, true);
             }
 
         } else if( ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_FLAMMABLE_HARD ) &&
@@ -1122,8 +1121,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.furn_set( p, furn_str_id::NULL_ID() );
-                here.destroy( p, false );
+                here.bash(p, 999, false, true);
             }
 
         } else if( ter.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1110,7 +1110,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 175 - cur.get_field_intensity() * 50 ) ) {
-                here.bash(p, 999, false, true);
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter_furn_has_flag( ter, frn, ter_furn_flag::TFLAG_FLAMMABLE_HARD ) &&
@@ -1121,7 +1121,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             smoke += static_cast<int>( windpower / 5 );
             if( cur.get_field_intensity() > 1 &&
                 one_in( 200 - cur.get_field_intensity() * 50 ) ) {
-                here.bash(p, 999, false, true);
+                here.bash( p, 999, false, true, true );
             }
 
         } else if( ter.has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH ) ) {


### PR DESCRIPTION
#### Summary
Backport 75038 - Improve fire behavior

#### Purpose of change
Stop fire from throwing a bunch of warnings and burning forever

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
