### PR TITLE
Backport DDA 75047 - Camp storage meal abortion works properly

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1591,6 +1591,10 @@ void basecamp::player_eats_meal()
     smenu.addentry( i++, true, '2', _( "Meal" ) );
     smenu.addentry( i++, true, '3', _( "Just stuff your face.  You're hungry!" ) );
     smenu.query();
+    if( smenu.ret_act != "CONFIRM" ) {
+        popup( _( "You decide not to have anything after all." ) );
+        return;
+    }
     int kcal_to_eat = smenu.ret * 750 - 250; // 500, 1250, 2000 kcal
     Character &you = get_player_character();
     const int &food_available = fac()->food_supply.kcal();


### PR DESCRIPTION
#### Summary
Backport DDA 75047 - Camp storage meal abortion works properly


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
