### PR TITLE
Backport DDA 75052 - Added deconstruction to deployed_items needing it

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -138,7 +138,6 @@
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "deployed_item": "mannequin",
-    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "examine_action": "deployed_furniture",
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -138,6 +138,7 @@
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "deployed_item": "mannequin",
+    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
     "examine_action": "deployed_furniture",
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -59,6 +59,7 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "brazier",
+    "deconstruct": { "items": [ { "item": "brazier", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -88,6 +89,7 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "makeshift_brazier",
+    "deconstruct": { "items": [ { "item": "makeshift_brazier", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -114,6 +116,7 @@
     "required_str": 4,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "hobo_stove",
+    "deconstruct": { "items": [ { "item": "hobo_stove", "count": 1 } ] },
     "examine_action": "fireplace",
     "max_volume": "680 ml",
     "bash": {
@@ -168,6 +171,7 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "55gal_firebarrel",
+    "deconstruct": { "items": [ { "item": "55gal_firebarrel", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,
@@ -195,6 +199,7 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "30gal_firebarrel",
+    "deconstruct": { "items": [ { "item": "30gal_firebarrel", "count": 1 } ] },
     "examine_action": "fireplace",
     "bash": {
       "str_min": 8,


### PR DESCRIPTION
#### Summary
Backport DDA 75052 - Added deconstruction to deployed_items needing it

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
