### PR TITLE
Backport 75076 - Fix weather typo

### DIFF
--- a/data/json/weather_type.json
+++ b/data/json/weather_type.json
@@ -192,7 +192,7 @@
     "tiles_animation": "weather_snowflake",
     "weather_animation": { "factor": 0.01, "color": "white", "sym": "." },
     "sound_category": "flurries",
-    "required_weathers": [ "flurries" ],
+    "required_weathers": [ "drizzle" ],
     "priority": 90,
     "condition": { "math": [ "weather('temperature')", "<", "from_fahrenheit( 33 )" ] }
   },


### PR DESCRIPTION
#### Summary
Backport 75076 - Fix weather typo


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
