### PR TITLE
Ditch ursine eye mutation, improve mesopia

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -860,7 +860,6 @@
       "HYPEROPIC",
       "MYOPIC",
       "MESOPIC",
-      "URSINE_EYE",
       "FROG_EYES",
       "NIGHTVISION3",
       "NIGHTVISION2",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -344,7 +344,8 @@
     "id": "guns_pistol_improvised",
     "//": "Makeshift or otherwise poor quality pistols.",
     "items": [
-      { "item": "ashot", "prob": 100 }, { "item": "2_shot_special", "prob": 100 },
+      { "item": "ashot", "prob": 100 },
+      { "item": "2_shot_special", "prob": 100 },
       { "item": "surv_hand_cannon", "prob": 100, "charges": [ 0, 5 ] },
       { "item": "surv_six_shooter", "prob": 100, "charges": [ 0, 6 ] }
     ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -67,7 +67,7 @@
     "dummy": true,
     "category": [ "HUMAN" ],
     "types": [ "EYES", "VISION" ],
-    "cancels": [ "EAGLEEYED", "EYEBULGE", "INFRARED", "MEMBRANE", "MYOPIC", "SEESLEEP" ],
+    "cancels": [ "EAGLEEYED", "EYEBULGE", "INFRARED", "MEMBRANE", "MYOPIC", "SEESLEEP", "MESOPIC" ],
     "description": "You have human eyes."
   },
   {
@@ -754,6 +754,7 @@
     "changes_to": [ "NIGHTVISION2" ],
     "category": [
       "BIRD",
+      "BATRACHIAN",
       "CATTLE",
       "INSECT",
       "BATRACHIAN",
@@ -764,6 +765,7 @@
       "LUPINE",
       "MOUSE",
       "SPIDER",
+      "URSINE",
       "TROGLOBITE"
     ],
     "active": true,
@@ -1402,7 +1404,7 @@
     "points": -2,
     "description": "Without glasses, your seeing radius is severely reduced!  However, you are guaranteed to start with a pair of glasses.",
     "starting_trait": true,
-    "cancels": [ "URSINE_EYE" ],
+    "cancels": [ "MESOPIC" ],
     "category": [ "BEAST" ],
     "flags": [ "MYOPIC" ]
   },
@@ -2245,26 +2247,12 @@
   },
   {
     "type": "mutation",
-    "id": "URSINE_EYE",
-    "name": { "str": "Ursine Vision" },
-    "points": 1,
-    "description": "Your visual processing has shifted: though you can see better in the dark, you're nearsighted in the light.  Maybe glasses would help.  Activate to toggle NV-visible areas on or off.",
-    "types": [ "EYES", "VISION" ],
-    "cancels": [ "MYOPIC", "MESOPIC" ],
-    "category": [ "URSINE" ],
-    "flags": [ "MYOPIC_IN_LIGHT" ],
-    "active": true,
-    "starts_active": true
-  },
-  {
-    "type": "mutation",
     "id": "MESOPIC",
     "name": { "str": "Mesopic" },
     "points": -1,
     "description": "You find it difficult to see very far in bright light.  On its own, this doesn't necessarily make you any better in the dark.",
-    "types": [ "EYES", "VISION" ],
     "cancels": [ "MYOPIC" ],
-    "category": [ "CHIROPTERAN", "TROGLOBITE" ],
+    "category": [ "CHIROPTERAN", "TROGLOBITE", "URSINE" ],
     "flags": [ "MYOPIC_IN_LIGHT" ]
   },
   {
@@ -2431,7 +2419,6 @@
   {
     "type": "mutation",
     "id": "FROG_EYES",
-    "//": "Currently without the NV from URSINE_EYE",
     "name": { "str": "Frog Eyes" },
     "points": 1,
     "visibility": 8,
@@ -2440,8 +2427,8 @@
     "prereqs": [ "EYEBULGE" ],
     "category": [ "BATRACHIAN" ],
     "flags": [ "EYE_MEMBRANE", "SEESLEEP", "MYOPIC_IN_LIGHT" ],
-    "types": [ "EYES", "VISION" ],
-    "cancels": [ "MEMBRANE", "MYOPIC", "URSINE_EYE", "MESOPIC" ],
+    "types": [ "EYES" ],
+    "cancels": [ "MEMBRANE", "MYOPIC", "MESOPIC" ],
     "threshreq": [ "THRESH_BATRACHIAN" ],
     "wet_protection": [ { "part": "eyes", "neutral": 1 } ],
     "armor": [ { "parts": "eyes", "cut": 3, "bash": 1 } ],

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -55,5 +55,14 @@
     "active": true,
     "valid": false,
     "transform": { "target": "WINGS_INSECT_active", "msg_transform": "You begin buzzing your wings.", "active": true, "moves": 20 }
+  },
+  {
+    "type": "mutation",
+    "id": "URSINE_EYE",
+    "name": { "str": "Ursine Vision" },
+    "description": "Obsoleted Ursine Vision mutation.  Bears now get Mesopic and Night Vision.",
+    "points": 1,
+    "valid": false,
+    "player_display": false
   }
 ]

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -464,7 +464,7 @@
     "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
     "traits": [
       "ELFAEYES",
-      "URSINE_EYE",
+      "MESOPIC",
       "FANGS",
       "SPINES",
       "PLANTSKIN",
@@ -715,7 +715,7 @@
     "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "broken_cyborg", "bionic_patient" ],
     "traits": [
       "ELFAEYES",
-      "URSINE_EYE",
+      "MESOPIC",
       "FANGS",
       "SPINES",
       "PLANTSKIN",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12577,24 +12577,24 @@ void game::update_overmap_seen()
             continue;
         }
         if( can_see ) {
-        const auto set_seen = []( const tripoint_abs_omt & p, om_vision_level level ) {
-            tripoint_abs_omt seen( p );
-            do {
-                overmap_buffer.set_seen( seen, level );
-                --seen.z();
-            } while( seen.z() >= 0 );
-        };
-        int tiles_from = rl_dist( p, ompos );
-        if( tiles_from < std::floor( base_sight / 2 ) ) {
-            set_seen( p, om_vision_level::full );
-        } else if( tiles_from < base_sight ) {
-            set_seen( p, om_vision_level::details );
-        } else if( tiles_from < base_sight * 2 ) {
-            set_seen( p, om_vision_level::outlines );
-        } else {
-            set_seen( p, om_vision_level::vague );
+            const auto set_seen = []( const tripoint_abs_omt & p, om_vision_level level ) {
+                tripoint_abs_omt seen( p );
+                do {
+                    overmap_buffer.set_seen( seen, level );
+                    --seen.z();
+                } while( seen.z() >= 0 );
+            };
+            int tiles_from = rl_dist( p, ompos );
+            if( tiles_from < std::floor( base_sight / 2 ) ) {
+                set_seen( p, om_vision_level::full );
+            } else if( tiles_from < base_sight ) {
+                set_seen( p, om_vision_level::details );
+            } else if( tiles_from < base_sight * 2 ) {
+                set_seen( p, om_vision_level::outlines );
+            } else {
+                set_seen( p, om_vision_level::vague );
+            }
         }
-    }
     }
 }
 


### PR DESCRIPTION
#### Summary
Ditch ursine eye mutation, improve mesopia

#### Purpose of change
Mesopia was an EYE/VISION mutation, which made it conflict with night vision. This was done for some complicated reasons that don't matter anymore, so let's fix it.

#### Describe the solution
- Obsolete URSINE_EYE
- Give MESOPIC to URSINE
- Change MESOPIC to have no category, but be canceled by the dummy human eye mutation, as well as telescopic eyes
- Remove URSINE_EYE from mutant scenarios, replace with MESOPIC

#### Describe alternatives you've considered
- Remove MESOPIC from trog, but it makes too much sense.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
