### PR TITLE
Nerf pet store and car trunk loot

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1370,8 +1370,8 @@
     "items": [
       { "item": "dogfood", "prob": 20, "container-item": "can_medium" },
       { "item": "catfood", "prob": 20, "container-item": "can_food" },
-      { "prob": 5, "group": "dogfood_dry_bag_plastic_24" },
-      { "prob": 5, "group": "catfood_dry_bag_plastic_24" },
+      { "prob": 5, "group": "dogfood_dry_bag_plastic_6" },
+      { "prob": 5, "group": "catfood_dry_bag_plastic_6" },
       [ "birdfood", 15 ],
       [ "dog_whistle", 15 ],
       { "item": "flashlight", "prob": 5, "charges": [ 0, 300 ] }
@@ -1381,10 +1381,10 @@
     "id": "petstore_shelves",
     "type": "item_group",
     "items": [
-      { "item": "dogfood", "prob": 10, "container-item": "can_medium" },
-      { "item": "catfood", "prob": 10, "container-item": "can_food" },
-      { "prob": 10, "group": "dogfood_dry_bag_plastic_24" },
-      { "prob": 10, "group": "catfood_dry_bag_plastic_24" },
+      { "item": "dogfood", "prob": 5, "container-item": "can_medium" },
+      { "item": "catfood", "prob": 5, "container-item": "can_food" },
+      { "prob": 2, "group": "dogfood_dry_bag_plastic_6" },
+      { "prob": 2, "group": "catfood_dry_bag_plastic_6" },
       { "item": "salt_water", "prob": 10, "container-item": "aquarium_medium" },
       { "item": "water", "prob": 10, "container-item": "aquarium_medium" },
       { "item": "salt_water", "prob": 10, "container-item": "aquarium_small" },
@@ -1955,8 +1955,8 @@
       [ "dog_whistle", 10 ],
       [ "pet_carrier", 30 ],
       [ "petpack", 3 ],
-      { "item": "dogfood", "prob": 20, "container-item": "can_medium" },
-      { "item": "catfood", "prob": 20, "container-item": "can_food" },
+      { "item": "dogfood", "prob": 10, "container-item": "can_medium" },
+      { "item": "catfood", "prob": 10, "container-item": "can_food" },
       [ "birdfood", 10 ],
       [ "towel", 20 ],
       { "item": "soap", "prob": 10, "charges": [ 1, 10 ] },
@@ -2186,19 +2186,19 @@
   },
   {
     "type": "item_group",
-    "id": "dogfood_dry_bag_plastic_24",
+    "id": "dogfood_dry_bag_plastic_6",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
-    "entries": [ { "item": "dogfood_dry", "container-item": "null", "count": 24 } ]
+    "entries": [ { "item": "dogfood_dry", "container-item": "null", "count": 6 } ]
   },
   {
     "type": "item_group",
-    "id": "catfood_dry_bag_plastic_24",
+    "id": "catfood_dry_bag_plastic_6",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
-    "entries": [ { "item": "catfood_dry", "container-item": "null", "count": 24 } ]
+    "entries": [ { "item": "catfood_dry", "container-item": "null", "count": 6 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/vehicles_fuel_related.json
+++ b/data/json/itemgroups/vehicles_fuel_related.json
@@ -110,8 +110,8 @@
     "id": "car_kit",
     "subtype": "collection",
     "items": [
-      { "group": "tools_car_kit", "prob": 70 },
-      { "distribution": [ { "item": "jerrycan" }, { "item": "jerrycan_big" } ], "prob": 12 },
+      { "group": "tools_car_kit", "prob": 20 },
+      { "distribution": [ { "item": "jerrycan" }, { "item": "jerrycan_big" } ], "prob": 8 },
       {
         "distribution": [ { "item": "sm_extinguisher", "charges": 10 }, { "item": "extinguisher", "charges": 100 } ],
         "prob": 20
@@ -127,9 +127,11 @@
       [ "plastic_sheet", 12 ],
       [ "hd_tow_cable", 5 ],
       [ "hose", 10 ],
+      [ "blanket", 2 ],
+      [ "towel", 3 ],
       [ "funnel", 10 ],
       [ "jumper_cable", 30 ],
-      [ "hand_pump", 30 ],
+      [ "hand_pump", 15 ],
       [ "folding_solar_panel_v2", 1 ],
       { "group": "bugout_bag", "prob": 1 }
     ]

--- a/data/json/mapgen/petstore.json
+++ b/data/json/mapgen/petstore.json
@@ -68,11 +68,11 @@
       },
       "toilets": { "B": {  } },
       "items": {
-        "A": { "item": "petstore_shelves", "chance": 70, "repeat": [ 2, 8 ] },
-        "L": { "item": "petstore_shelves", "chance": 70, "repeat": [ 2, 8 ] },
-        "G": { "item": "cleaning", "chance": 70, "repeat": [ 1, 4 ] },
-        "C": { "item": "petstore_misc", "chance": 70, "repeat": [ 2, 8 ] },
-        "K": { "item": "petstore_misc", "chance": 70, "repeat": [ 2, 8 ] },
+        "A": { "item": "petstore_shelves", "chance": 40, "repeat": [ 0, 3 ] },
+        "L": { "item": "petstore_shelves", "chance": 40, "repeat": [ 0, 3 ] },
+        "G": { "item": "cleaning", "chance": 50, "repeat": [ 0, 4 ] },
+        "C": { "item": "petstore_misc", "chance": 40, "repeat": [ 0, 4 ] },
+        "K": { "item": "petstore_misc", "chance": 40, "repeat": [ 0, 4 ] },
         "d": { "item": "office", "chance": 50, "repeat": [ 2, 4 ] },
         "U": { "item": "trash", "chance": 20, "repeat": [ 2, 4 ] }
       },
@@ -164,7 +164,7 @@
       "items": {
         "l": { "item": "cleaning", "chance": 30 },
         "T": { "item": "softdrugs", "chance": 30 },
-        "{": { "item": "petstore_shelves", "chance": 70, "repeat": [ 2, 8 ] }
+        "{": { "item": "petstore_shelves", "chance": 40, "repeat": [ 0, 4 ] }
       },
       "place_monster": [
         { "group": "GROUP_PET_CATS", "x": 2, "y": 3 },
@@ -307,9 +307,9 @@
         { "item": "cash_register_random", "x": 7, "y": [ 7, 11 ], "chance": 100 }
       ],
       "items": {
-        "{": { "item": "petstore_shelves", "chance": 70, "repeat": [ 1, 4 ] },
-        "G": { "item": "cleaning", "chance": 70, "repeat": [ 1, 4 ] },
-        "l": { "item": "petstore_misc", "chance": 70, "repeat": [ 1, 4 ] },
+        "{": { "item": "petstore_shelves", "chance": 40, "repeat": [ 0, 3 ] },
+        "G": { "item": "cleaning", "chance": 60, "repeat": [ 1, 4 ] },
+        "l": { "item": "petstore_misc", "chance": 60, "repeat": [ 0, 4 ] },
         "Y": [ { "item": "jackets", "chance": 10 }, { "item": "bags", "chance": 10 } ]
       },
       "place_monster": [


### PR DESCRIPTION
#### Summary
Nerf pet store and car trunk loot

#### Purpose of change
Pet stores had an obnoxious amount of pet food in them due to auto-generated itemgroups and charge removal. Car trunks had a ridiculously high chance of having a toolbox.

#### Describe the solution
- Drastically cut the chances of a toobox being in a car trunk
- Add a tiny chance for a towel or blanket to be in a car trunk
- Drastically cut the pet food in pet stores

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
