### PR TITLE
Update version.cpp

### DIFF
--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,18 +1,36 @@
-#include "get_version.h" // IWYU pragma: associated
+// #include "get_version.h" // IWYU pragma: associated
+#include <fstream>
+#include <string>
 
 //#if (defined(_WIN32) || defined(MINGW)) && !defined(GIT_VERSION) && !defined(CROSS_LINUX) && !defined(_MSC_VER)
 
 //#ifndef VERSION
-#define VERSION "1.0"
+// #define VERSION "1.0"
 //#endif
 
-//#else
-
-//#include "version.h"
-
-//#endif
+std::string getVersionFromFile()
+{
+    std::ifstream versionFile("VERSION.txt");
+    if (versionFile.is_open()) {
+        std::string line;
+        while (std::getline(versionFile, line)) {
+            if (line.rfind("build number:", 0) == 0) {
+                size_t colonPos = line.find(':');
+                if (colonPos != std::string::npos) {
+                    std::string buildNumber = line.substr(colonPos + 1);
+                    buildNumber.erase(0, buildNumber.find_first_not_of(" \t"));
+                    versionFile.close();
+                    return buildNumber;
+                }
+            }
+        }
+        versionFile.close();
+    }
+    return "unknown";
+}
 
 const char *getVersionString()
 {
-    return VERSION;
+    static std::string version = getVersionFromFile();
+    return version.c_str();
 }


### PR DESCRIPTION
#### Summary
Instead of version, this file now shows build number of compile (I commented the version part, in the future the version could return and the build number could just be a separated entirely).

#### Purpose of change
Too many bug reports that include json error logs don't include the exact build number, which is the closest we have to the release versions. This is for testing purposes.

#### Describe the solution
Extract the build number from VERSION.txt file in the root folder of the game and have the error logs show it on the version line.

#### Describe alternatives you've considered
Scraping the release page of the GitHub.

#### Testing
Tested with a past version and it worked. This change only depends on whether the file VERSION.txt exists, if it doesn't exist, the build number should be "unknown".

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![cataclysm-tlg-tiles_801rP6csFQ](https://github.com/user-attachments/assets/ddb819de-875a-4a9c-95c9-2b9e48170f0e)


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
