### PR TITLE
Update baseball player weapon proficiencies

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1078,7 +1078,7 @@
       { "level": 4, "name": "throw" },
       { "level": 4, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_bludgeons_familiar", "prof_bludgeons_pro" ],
     "items": {
       "both": {
         "entries": [


### PR DESCRIPTION

#### Summary
Change the starting proficiencies of the baseball player profession to bludgeons instead of maces.

#### Purpose of change
Baseball players had the wrong weapon proficiency at character generation, since bats are bludgeons, not maces.

#### Testing
![image](https://github.com/user-attachments/assets/09784752-1aac-46dd-94a1-558d52c1ebfb)
Made a new character with the baseball player profession. They had the correct proficiencies


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
