### PR TITLE
Nerf frog mothers, stop pupating zombie cheese

### DIFF
--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -7,9 +7,12 @@
     "copy-from": "mon_zombie_crawler",
     "delete": { "categories": [ "CLASSIC" ] },
     "bleed_rate": 50,
-    "regenerates": 10,
+    "regenerates": 5,
+    "melee_skill": 0,
+    "dodge": 0,
     "harvest": "zombie_pupating",
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] },
+    "upgrades": { "half_life": 4, "into": "mon_zombie_crawler_pupa" },
     "armor": { "electric": 1, "bash": 7, "cut": 5, "bullet": 5 }
   },
   {
@@ -40,7 +43,10 @@
     "delete": { "categories": [ "CLASSIC" ] },
     "bleed_rate": 50,
     "special_attacks": [ { "type": "bite", "cooldown": 3 } ],
-    "regenerates": 10,
+    "upgrades": { "half_life": 4, "into": "mon_zombie_pupa" },
+    "regenerates": 5,
+    "melee_skill": 0,
+    "dodge": 0,
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] },
     "armor": { "electric": 2, "bash": 8, "cut": 6, "bullet": 6 }
   },
@@ -71,7 +77,7 @@
     "delete": { "categories": [ "CLASSIC" ] },
     "harvest": "zombie_pupating",
     "speed": 95,
-    "regenerates": 10,
+    "regenerates": 5,
     "upgrades": { "half_life": 42, "into_group": "GROUP_BRUTE_PUPA" },
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] }
   },
@@ -118,6 +124,7 @@
     "melee_dice_sides": 7,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
+    "upgrades": { "half_life": 4, "into": "mon_hulk_pupa" },
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_hulk" ],
     "vision_day": 83,
     "vision_night": 4,
@@ -130,7 +137,7 @@
       { "id": "smash", "cooldown": 30 }
     ],
     "death_drops": "mon_zombie_hulk_death_drops",
-    "regenerates": 10,
+    "regenerates": 8,
     "flags": [
       "SEES",
       "HEARS",
@@ -193,7 +200,7 @@
       }
     ],
     "death_drops": "mon_zombie_hulk_death_drops",
-    "regenerates": 10,
+    "regenerates": 8,
     "flags": [
       "SEES",
       "HEARS",
@@ -226,7 +233,10 @@
     "bleed_rate": 0,
     "vision_day": 8,
     "vision_night": 15,
+    "melee_skill": 0,
+    "dodge": 0,
     "harvest": "zombie_humanoid_pupating_shadow",
+    "upgrades": { "half_life": 4, "into": "mon_zombie_pupa_shady" },
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF", "NIGHT_INVISIBILITY" ] },
     "armor": { "electric": 2, "bash": 8, "cut": 6, "bullet": 6 }
   },

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -109,7 +109,7 @@
         "monster_message": "Some of the pustules pop, and the frog mother opens her mouth and vomits tadpoles!"
       }
     ],
-    "regenerates": 40,
+    "regenerates": 12,
     "armor": { "bash": 12, "cut": 2, "bullet": 1, "electric": 2 }
   },
   {


### PR DESCRIPTION
#### Summary
Nerf frog mothers, stop pupating zombie cheese

#### Purpose of change
![image](https://github.com/user-attachments/assets/1955ce95-4947-45af-ae92-ebb0f8c7e8d2)

#### Describe the solution
- Decoy pupating zombies now always eventually evolve into real ones. They're not decoys, they're just not finished cooking.
- Decoy pupating zombies have reduced skill to prevent being used for training exploits.
- Reduced the regen on decoy pupating zombies.
- Reduced the regen on frog mothers. They had fucking 40. For reference, a relentless hulk feels almost unkillable with just 15.

#### Describe alternatives you've considered
A DOES_NOT_TRAIN flag would be nice.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
