### PR TITLE
Reduce SLUDGETRAIL and fix pupa

### DIFF
--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -9,7 +9,6 @@
     "bleed_rate": 50,
     "regenerates": 5,
     "melee_skill": 0,
-    "dodge": 0,
     "harvest": "zombie_pupating",
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] },
     "upgrades": { "half_life": 4, "into": "mon_zombie_crawler_pupa" },
@@ -46,7 +45,6 @@
     "upgrades": { "half_life": 4, "into": "mon_zombie_pupa" },
     "regenerates": 5,
     "melee_skill": 0,
-    "dodge": 0,
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] },
     "armor": { "electric": 2, "bash": 8, "cut": 6, "bullet": 6 }
   },
@@ -234,7 +232,6 @@
     "vision_day": 8,
     "vision_night": 15,
     "melee_skill": 0,
-    "dodge": 0,
     "harvest": "zombie_humanoid_pupating_shadow",
     "upgrades": { "half_life": 4, "into": "mon_zombie_pupa_shady" },
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF", "NIGHT_INVISIBILITY" ] },

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2017,7 +2017,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     if( has_flag( mon_flag_SLUDGETRAIL ) ) {
         for( const tripoint &sludge_p : here.points_in_radius( pos(), 1 ) ) {
             const int fstr = 3 - ( std::abs( sludge_p.x - posx() ) + std::abs( sludge_p.y - posy() ) );
-            if( fstr >= 2 ) {
+            if( ( fstr >= 2 ) && ( rng( 0, 3 ) > 0 ) ) {
                 here.add_field( sludge_p, fd_sludge, fstr );
             }
         }


### PR DESCRIPTION
#### Summary
Reduce SLUDGETRAIL and fix pupa

#### Purpose of change
- SLUDGETRAIL was making a perfect 3 tile wide trail of sludge, which looked bad visually.
- The recent pupa changes accidentally redundantly defined 0 dodge, which caused an error message.

#### Describe the solution
- SLUDGETRAIL now checks if RNG 0,3 > 0, resulting in a 1/4 chance that it won't sludge a candidate tile.
- Delete the extraneous line in the pupating zombie jsons

#### Testing
![image](https://github.com/user-attachments/assets/e68a8f8d-4678-4567-b66e-66a1ced3bd31)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
