### PR TITLE
Fix troglobite mutation layering

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -64,7 +64,7 @@
     "proportional": { "weight": 0.75, "volume": 0.75 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
-    {
+  {
     "type": "ARMOR",
     "id": "bagh_nakha",
     "name": { "str": "pair of bagh nakh", "str_pl": "pairs of bagh nakh" },

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1360,18 +1360,7 @@
       {
         "type": "repair_item",
         "item_action_type": "repair_metal",
-        "materials": [
-          "iron",
-          "steel",
-          "steel_chain",
-          "aluminum",
-          "copper",
-          "bronze",
-          "silver",
-          "gold",
-          "platinum",
-          "superalloy"
-        ],
+        "materials": [ "iron", "steel", "steel_chain", "aluminum", "copper", "bronze", "silver", "gold", "platinum", "superalloy" ],
         "skill": "fabrication",
         "tool_quality": 5,
         "cost_scaling": 0.1,

--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -26,9 +26,12 @@
       { "id": [ "PALE", "SKIN_DARK", "SKIN_LIGHT", "SKIN_MEDIUM", "SKIN_PINK", "SKIN_TAN" ], "order": 1100 },
       {
         "id": [
-          "AMORPHOUS",
+          "CHLOROMORPH",
           "ALBINO",
-          "bio_deformity",
+          "TROGLO",
+          "TROGLO2",
+          "TROGLO3",
+          "SUNBURN",
           "CHITIN",
           "CHITIN_MOLTED",
           "CHITIN2",
@@ -37,7 +40,6 @@
           "CHITIN_FUR",
           "CHITIN_FUR2",
           "CHITIN_FUR3",
-          "CHLOROMORPH",
           "FEATHERS",
           "FELINE_FUR",
           "FUR",
@@ -62,12 +64,10 @@
           "SLEEK_SCALES",
           "SORES",
           "THICK_SCALES",
-          "THORNS",
-          "TROGLO",
-          "TROGLO2",
-          "TROGLO3",
           "URSINE_FUR",
-          "VISCOUS"
+          "THORNS",
+          "VISCOUS",
+          "AMORPHOUS"
         ],
         "order": 1500
       },
@@ -82,6 +82,7 @@
           "SHELL3",
           "CRUSTACEAN_CARAPACE",
           "CRUSTACEAN_CARAPACE_MOLTED",
+          "bio_deformity",
           "bio_armor_head",
           "bio_armor_legs",
           "bio_armor_torso",

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -829,7 +829,7 @@
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
-    {
+  {
     "result": "bagh_nakha_xl",
     "type": "recipe",
     "copy-from": "bagh_nakha",


### PR DESCRIPTION
#### Summary
Fix troglobite mutation layering

#### Purpose of change
One of the trog mutations, Solar Sensitivity, was layering incorrectly because it wasn't included in mutation_ordering.json.

#### Describe the solution
Add it, shuffle some other stuff around.

#### Describe alternatives you've considered
This probably needs another pass, with fur and stuff on a layer above skin, and accessories like thorns on a layer above that.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
