### PR TITLE
Remove dead mod code

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -148,20 +148,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "SPEEDYDEX_MIN_DEX",
-    "info": "The minimum dex required for speedydex mod to add speed",
-    "stype": "int",
-    "value": 0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "SPEEDYDEX_DEX_SPEED",
-    "info": "The amount of moves gained per dex above SPEEDYDEX_MIN_DEX",
-    "stype": "int",
-    "value": 0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "DISABLE_ROBOT_RESPONSE",
     "info": "Disables robot spawning from alerts and from being wanted.",
     "stype": "bool",
@@ -169,22 +155,8 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "PORTAL_STORM_IGNORE_NPC",
-    "info": "Portal storm enemies will ignore NPCs no matter what.",
-    "stype": "bool",
-    "value": false
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "CRAZY",
     "info": "A boolean specifically for Crazy Cataclysm.",
-    "stype": "bool",
-    "value": false
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "STATS_THROUGH_KILLS",
-    "info": "Stats through Kills.  A mod that allows your stats to increase by killing zombies.",
     "stype": "bool",
     "value": false
   },
@@ -506,7 +478,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "ETERNAL_WEATHER",
-    "info": "Sets eternal weather.  Possible values are 'normal', 'clear', 'cloudy', 'light_drizzle', 'drizzle', 'rain', 'rainstorm', 'thunder', 'lightning', 'flurries', 'snowing', 'snowstorm', 'early_portal_storm', 'portal_storm'.  'normal' clears all eternal weather overrides and sets normal weather pattern.  Requires restart of the game after changing value to take effect.",
+    "info": "Sets eternal weather.  Possible values are 'normal', 'clear', 'cloudy', 'light_drizzle', 'drizzle', 'rain', 'rainstorm', 'thunder', 'lightning', 'flurries', 'snowing', 'snowstorm', 'normal' clears all eternal weather overrides and sets normal weather pattern.  Requires restart of the game after changing value to take effect.",
     "stype": "string_input",
     "value": "normal"
   },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4380,15 +4380,6 @@ int Character::get_int_bonus() const
     return int_bonus;
 }
 
-static int get_speedydex_bonus( const int dex )
-{
-    static const std::string speedydex_min_dex( "SPEEDYDEX_MIN_DEX" );
-    static const std::string speedydex_dex_speed( "SPEEDYDEX_DEX_SPEED" );
-    // this is the number to be multiplied by the increment
-    const int modified_dex = std::max( dex - get_option<int>( speedydex_min_dex ), 0 );
-    return modified_dex * get_option<int>( speedydex_dex_speed );
-}
-
 int Character::get_enchantment_speed_bonus() const
 {
     return enchantment_speed_bonus;
@@ -12552,8 +12543,6 @@ void Character::recalc_speed_bonus()
         carry_penalty = 25 * ( weight_carried() - weight_cap ) / weight_cap;
     }
     mod_speed_bonus( -carry_penalty, _( "Weight Carried" ) );
-
-    mod_speed_bonus( +get_speedydex_bonus( get_dex() ), _( "Dexterity" ) );
 
     mod_speed_bonus( -get_pain_penalty().speed, _( "Pain" ) );
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2211,9 +2211,6 @@ static void character_edit_menu()
     nmenu.addentry( D_HEALTHY, true, 'a', "%s", _( "Set health" ) );
     nmenu.addentry( D_NEEDS, true, 'n', "%s", _( "Set needs" ) );
     nmenu.addentry( D_NORMALIZE_BODY, true, 'N', "%s", _( "Normalize body stats" ) );
-    if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
-        nmenu.addentry( D_KILL_XP, true, 'X', "%s", _( "Set kill XP" ) );
-    }
     nmenu.addentry( D_MUTATE, true, 'u', "%s", _( "Mutate" ) );
     nmenu.addentry( D_BIONICS, true, 'b', "%s", _( "Edit [b]ionics" ) );
     nmenu.addentry( D_STATUS, true,

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -126,10 +126,6 @@ std::string kill_tracker::get_kills_text() const
         buffer = _( "You haven't killed any monsters yet!" );
     } else {
         buffer = string_format( _( "KILL COUNT: %d" ), totalkills );
-        if( get_option<bool>( "STATS_THROUGH_KILLS" ) ) {
-            buffer += string_format( _( "\nExperience: %d (%d points available)" ), get_avatar().kill_xp,
-                                     get_avatar().free_upgrade_points() );
-        }
         buffer += "\n";
     }
     for( const std::string &line : data ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1395,10 +1395,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
             case player_display_tab::stats:
                 if( header_clicked ) {
                     display_bodygraph( you );
-                } else if( line < 4 && get_option<bool>( "STATS_THROUGH_KILLS" ) && you.is_avatar() ) {
-                    you.as_avatar()->upgrade_stat_prompt( static_cast<character_stat>( line ) );
                 }
-
                 invalidate_tab( curtab );
                 break;
             case player_display_tab::skills: {


### PR DESCRIPTION
#### Summary
Remove dead mod code

#### Purpose of change
Removes some dead code related to mods we don't support, as well as a few references to portal storms.

#### Testing
Compiles and runs. Existing saves may experience error messages the first time they are loaded.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
