### PR TITLE
Fix crash while approaching certain vehicles

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1034,20 +1034,21 @@ static recipe_subset filter_recipes( const recipe_subset &available_recipes,
                     // Filter by category e.g. armor
                     std::string user_cat = qry_filter_str.substr( 2 );
                     if( !user_cat.empty() ) {
-                        for (std::string::size_type i = 0; i < user_cat.size(); ++i) {
-                            user_cat[i] = std::toupper(static_cast<unsigned char>(user_cat[i]));
+                        for( std::string::size_type i = 0; i < user_cat.size(); ++i ) {
+                            user_cat[i] = std::toupper( static_cast<unsigned char>( user_cat[i] ) );
                         }
                     }
                     std::string cat_id = "CC_" + user_cat;
-                    filtered_recipes = recipe_subset( filtered_recipes, filtered_recipes.in_category( crafting_category_id( cat_id ) ) );
+                    filtered_recipes = recipe_subset( filtered_recipes,
+                                                      filtered_recipes.in_category( crafting_category_id( cat_id ) ) );
                     break;
                 }
                 case 'S': {
                     // Filter by subcategory e.g. food_snack
                     std::string user_subcat = qry_filter_str.substr( 2 );
                     if( !user_subcat.empty() ) {
-                        for (std::string::size_type i = 0; i < user_subcat.size(); ++i) {
-                            user_subcat[i] = std::toupper(static_cast<unsigned char>(user_subcat[i]));
+                        for( std::string::size_type i = 0; i < user_subcat.size(); ++i ) {
+                            user_subcat[i] = std::toupper( static_cast<unsigned char>( user_subcat[i] ) );
                         }
                     }
                     std::string subcat_id = "CSC_" + user_subcat;

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -14,15 +14,15 @@ const char *getVersionString();
 
 std::string getVersionFromFile()
 {
-    std::ifstream versionFile("VERSION.txt");
-    if (versionFile.is_open()) {
+    std::ifstream versionFile( "VERSION.txt" );
+    if( versionFile.is_open() ) {
         std::string line;
-        while (std::getline(versionFile, line)) {
-            if (line.rfind("build number:", 0) == 0) {
-                size_t colonPos = line.find(':');
-                if (colonPos != std::string::npos) {
-                    std::string buildNumber = line.substr(colonPos + 1);
-                    buildNumber.erase(0, buildNumber.find_first_not_of(" \t"));
+        while( std::getline( versionFile, line ) ) {
+            if( line.rfind( "build number:", 0 ) == 0 ) {
+                size_t colonPos = line.find( ':' );
+                if( colonPos != std::string::npos ) {
+                    std::string buildNumber = line.substr( colonPos + 1 );
+                    buildNumber.erase( 0, buildNumber.find_first_not_of( " \t" ) );
                     versionFile.close();
                     return buildNumber;
                 }


### PR DESCRIPTION
#### Summary
Fix crash while approaching certain vehicles

#### Purpose of change
Something got lost in the shuffle while doing typification backports, and vehicle memory was crashing the game when the player entered certain areas.

#### Describe the solution
Re-add two deleted lines to an iterator in map.cpp, make sure they're done at the end of it so they don't trip a segfault

#### Testing
Was able to load a map where the crash was occurring and enter the area without issue.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
