### PR TITLE
Fix Arch Linux segmentation fault on startup

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -350,8 +350,15 @@ map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
     str_min_supported( -1 ), str_max_supported( -1 ),
     explosive( 0 ), sound_vol( -1 ), sound_fail_vol( -1 ),
     collapse_radius( 1 ), destroy_only( false ), bash_below( false ),
-    drop_group( Item_spawn_data_EMPTY_GROUP ),
-    ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
+    ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() )
+{
+    // NOTE: This got pulled out of the initializer list above
+    //       to fix a segmentation fault at startup on newer Arch Linux systems.
+    //       If/when C:DDA's commit 89657123e0124f1e75fd5d7fd6a1a85b74b5a98b from Nov 2024
+    //       gets backported, this divergence of the old versions should be safe to
+    //       ignore, as the new code of that commit stopped using initializer lists for this.
+    drop_group = Item_spawn_data_EMPTY_GROUP;
+}
 
 bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member,
                           map_object_type obj_type, const std::string &context )


### PR DESCRIPTION
Crashes started happening to Arch Linux users running on recently updated systems.
This crash was not happening on C:DDA.
All affected users seemed to have the same crash stacktrace, pointing at the initialization of map_bash_info.drop_group in an initialization list in src/mapdata.cpp .
It's possible that a change in the C/C++ runtime libraries caused some static initializations to happen in a wrong order.

#### Describe the solution
Pull the initialization of map_bash_info.drop_group from the initializer list into the body of the constructor.

#### Describe alternatives you've considered
Wait for November 2024 backports, and tell Linux users not to update their system ever.

#### Testing
Game crashed on startup before, it runs on my Arch Linux machine after the fix.  Can load existing games, save, and start new runs.

#### Additional context
While comparing the critical code with C:DDA, I came across this commit from Nov 2024:
https://github.com/CleverRaven/Cataclysm-DDA/commit/89657123e0124f1e75fd5d7fd6a1a85b74b5a98b
My suspicion is that that commit would have fixed this issue too, since that got rid of the initializer lists entirely for map_(common_)bash_info .
I left a comment in the code as a reminder, in case it comes up in a merge conflict during those backports.