### PR TITLE
Unify grapple release function

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -112,8 +112,6 @@ static const itype_id itype_guidebook( "guidebook" );
 static const itype_id itype_mut_longpull( "mut_longpull" );
 
 static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
-static const json_character_flag json_flag_GRAB( "GRAB" );
-static const json_character_flag json_flag_GRAB_FILTER( "GRAB_FILTER" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_WEBBED_HANDS( "WEBBED_HANDS" );
 
@@ -1469,27 +1467,6 @@ bool avatar::wield( item &target, const int obtain_cost )
     if( worn ) {
         target.on_takeoff( *this );
     }
-
-    // TODO: Standardize this as a single function in Character::
-    if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
-        if( as_character()->grab_1.victim ) {
-            for( const effect &eff : as_character()->grab_1.victim->get_effects_with_flag( json_flag_GRAB ) ) {
-                const efftype_id effid = eff.get_id();
-                if( eff.get_intensity() == as_character()->grab_1.grab_strength ) {
-                    add_msg( _( "You release %s." ), as_character()->grab_1.victim->disp_name() );
-                    as_character()->grab_1.victim->remove_effect( effid );
-                }
-            }
-        }
-        for( const effect &eff : get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
-            const efftype_id effid = eff.get_id();
-            if( eff.get_intensity() == as_character()->grab_1.grab_strength ) {
-                remove_effect( effid );
-            }
-        }
-
-    }
-
     add_msg_debug( debugmode::DF_AVATAR, "wielding took %d moves", mv );
     mod_moves( -mv );
 

--- a/src/character.h
+++ b/src/character.h
@@ -1487,6 +1487,8 @@ class Character : public Creature, public visitable
         void activate_mutation( const trait_id &mutation );
         void deactivate_mutation( const trait_id &mut );
 
+        void release_grapple();
+
         bool can_mount( const monster &critter ) const;
         void mount_creature( monster &z );
         bool cant_do_mounted( bool msg = true ) const;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -136,7 +136,6 @@ static const efftype_id effect_laserlocked( "laserlocked" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_stunned( "stunned" );
 
-static const flag_id json_flag_GRAB_FILTER( "GRAB_FILTER" );
 static const flag_id json_flag_MOP( "MOP" );
 static const flag_id json_flag_NO_GRAB( "NO_GRAB" );
 
@@ -716,18 +715,7 @@ static void grab()
         return;
     }
 
-    if( you.grab_1.victim != nullptr ) {
-        add_msg( _( "You release %s." ), you.grab_1.victim->disp_name() );
-        you.grab_1.victim->remove_effect( effect_grabbed );
-        for( const effect &eff : you.get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
-            const efftype_id effid = eff.get_id();
-            if( eff.get_intensity() == you.grab_1.grab_strength ) {
-                you.remove_effect( effid );
-            }
-        }
-        you.grab_1.clear();
-        return;
-    }
+    you.release_grapple();
 
     const std::optional<tripoint> grabp_ = choose_adjacent( _( "Grab where?" ) );
     if( !grabp_ ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6603,7 +6603,7 @@ void item::on_wield( Character &you )
 {
     int wield_cost = on_wield_cost( you );
     you.mod_moves( -wield_cost );
-
+    you.release_grapple();
     std::string msg;
 
     msg = _( "You wield your %s." );


### PR DESCRIPTION
#### Summary
Unify grapple release function

#### Purpose of change
There was a workaround allowing people to wield items while grappling if they used a sheath. The function also needed to be unified rather than redundantly typed out every time the game needed to make you let go of somebody.

#### Describe the solution
- Create a new function, Character::release_grapple(), which gets called in on_wield(), so you should let go of grapples any time something comes into your hand by any means.

#### Describe alternatives you've considered
Eventually I want to have some mutations allow you to maintain multiple grabs or wield stuff while grabbing. I think even baseliners should be able to hold a half-strength grapple with a small weapon in hand.

#### Testing
Spawned in, grappled, wielded stuff, used a sheath, all works as intended.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
