### PR TITLE
Add Charge chance on feral security guards flashlights.

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -155,7 +155,7 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-      { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ] },
+      { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ], "charges": [ 0, 300 ] },
       { "item": "tazer", "prob": 100, "damage": [ 2, 4 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },
       { "group": "security_pants", "damage": [ 1, 4 ] },


### PR DESCRIPTION

#### Summary
Some feral security guards spawn with a heavy duty flashlight that doesn't roll for a battery charge chance unlike almost every other zombie.

#### Purpose of change
Make loot rolls more consistent between similar enemies.

#### Describe the solution
Added the charge chance roll to the loot drop in the json
#### Describe alternatives you've considered

#### Testing
Game runs, spawning feral secuirty guard flashlight and killing them now drop heavy duty flashlights with a battery that is not full.
#### Additional context
Inspired by the suggestion in discord.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
