### PR TITLE
Adding charges to feral security guard items

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -155,7 +155,7 @@
     "magazine": 100,
     "ammo": 20,
     "entries": [
-      { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ] },
+      { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ], "charges": [ 0, 300 ] },
       { "item": "tazer", "prob": 100, "damage": [ 2, 4 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },
       { "group": "security_pants", "damage": [ 1, 4 ] },

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -156,7 +156,7 @@
     "ammo": 20,
     "entries": [
       { "item": "heavy_flashlight", "prob": 100, "damage": [ 2, 4 ], "charges": [ 0, 300 ] },
-      { "item": "tazer", "prob": 100, "damage": [ 2, 4 ] },
+      { "item": "tazer", "prob": 100, "damage": [ 2, 4 ], "charges": [ 0, 500 ] },
       { "group": "cop_gloves", "prob": 30, "damage": [ 1, 4 ] },
       { "group": "security_pants", "damage": [ 1, 4 ] },
       { "group": "security_shoes", "prob": 70, "damage": [ 1, 4 ] },


### PR DESCRIPTION
#### Summary
Category "Brief description"
Add charge settings to the feral security guards that would be spawning with either max or empty charge in their stunguns and flashlights.


#### Purpose of change
Make loot more uniform and not consistent as well as make cross platform charges more uniform.

#### Describe the solution
Adding charge rolls in the loot pool for feral security guards

#### Describe alternatives you've considered

#### Testing
Game loads, testing for loot drops, shows that flashlight variant feral security guards drop random charge amounts in their items. 

#### Additional context
Based on the suggestion in discord.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
