### PR TITLE
Taser volume size balance

### DIFF
--- a/data/json/items/melee/misc.json
+++ b/data/json/items/melee/misc.json
@@ -76,7 +76,7 @@
     "charges_per_use": 2,
     "use_action": [ "TAZER" ],
     "pocket_data": [
-      { "pocket_type": "MAGAZINE_WELL", "flag_restriction": [ "BATTERY_MEDIUM" ], "default_magazine": "medium_battery_cell" }
+      { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "flag_restriction": [ "BATTERY_MEDIUM" ], "default_magazine": "medium_battery_cell" }
     ],
     "melee_damage": { "bash": 6 }
   }


### PR DESCRIPTION
#### Summary
Category "Brief description"
Tasers were too big for loot pools to spawn them,  they were missing similar flags in json that other pistols use to maintain a consistent size.

#### Purpose of change
Fix loot pools, allows tasers to spawn on zombie cops, and makes them similar to other pistol sizes.

#### Describe the solution
Added` "magazine_well": "250 ml",` to the pocket data

#### Describe alternatives you've considered

#### Testing
Game runs, checked in game for total stungun/taser size, and shows 0.45l
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
