### PR TITLE
Fix rot timers

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7915,25 +7915,11 @@ void item::randomize_rot()
                                     rng_float( 0.2, 1.2 );
         set_rot( loot_adjust );
     }
-    for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
-        if( pocket->spoil_multiplier() > 0.0f ) {
-            time_duration pocket_loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm )
-                                               * rng_float( 0.2, 1.2 );
-            // Apply the same adjustment to all items in this pocket
-            for( item *subitem : pocket->all_items_top() ) {
-                if( subitem->is_comestible() && subitem->get_comestible()->spoils > 0_turns ) {
-                    subitem->set_rot( pocket_loot_adjust );
-                }
-            }
-        }
-    }
 
     for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
         if( pocket->spoil_multiplier() > 0.0f ) {
             for( item *subitem : pocket->all_items_top() ) {
-                if( !subitem->contents.empty() ) {
-                    subitem->randomize_rot();
-                }
+                subitem->randomize_rot();
             }
         }
     }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2061,7 +2061,7 @@ static bool mx_corpses( map &m, const tripoint &abs_sub )
         const tripoint_bub_ms corpse_location = { rng( 1, SEEX * 2 - 1 ), rng( 1, SEEY * 2 - 1 ), abs_sub.z };
         const std::vector<item> gibs =
             item_group::items_from( Item_spawn_data_remains_human_generic,
-                                    calendar::start_of_cataclysm );
+                                    calendar::fall_of_civilization );
         m.spawn_items( corpse_location, gibs );
         m.add_field( corpse_location, fd_gibs_flesh, rng( 1, 3 ) );
         //50% chance to spawn gibs and dogs in every tile around what's left of human corpse in 1-tile radius


### PR DESCRIPTION
#### Summary
Fix rot timers

#### Purpose of change
- One of the hardcoded map extras was spawning some corpses. These were 20 days old, which is probably not a big deal but could have been causing a couple of super-evolved zombies to show up.
- Food in houses was sometimes still spawning fresh, even weeks into the game. This shouldn't be the case for anything that isn't sealed!

#### Describe the solution
- Change the date to spawn the corpses in that one map extra, so they spawn on the usual game start date instead.
- Adjust the logic in randomize_rot() to better handle things in pockets.

#### Testing
Ran around in summer, didn't find any fresh food at all.

#### Additional context
This is not likely to be the cause of some of you seeing evolved bad guys on day one. That's almost certainly just normal outliers and selection bias.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
