### PR TITLE
Loosened hauberk is outer

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -773,7 +773,7 @@
     "looks_like": "boiled_leather_armor_suit",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY", "ALLOWS_TAIL" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -859,6 +859,7 @@
     "description": "A knee-length long-sleeved tunic made of interlocking steel rings.  It can be adjusted to fit closer to the body.",
     "copy-from": "chainmail_hauberk",
     "extend": { "flags": [ "OUTER" ] },
+    "delete": { "flags": [ "NORMAL" ] },
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a closer fit.",


### PR DESCRIPTION
#### Summary
Loosened hauberk is outer

#### Purpose of change
Chainmail hauberks fit on the NORMAL layer and are meant to become OUTER when loosened. This wasn't working because the flag wasn't actually set on the regular hauberk, and I guess just having NORMAL by default isn't removed when you extend the OUTER flag to a copy-from'd version.

#### Describe the solution
Manually set the flag on the regular hauberk and manually delete it from the loose version.

#### Testing
Spawned a hauberk, loosened it, saw its layers change.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
