### PR TITLE
Add dashboards to golf carts

### DIFF
--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -339,7 +339,7 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "5 h 40 m",
-    "book_learn": [ [ "textbook_weapeast", 2 ], [ "textbook_weapwast", 2 ] ],
+    "book_learn": [ [ "textbook_weapeast", 2 ], [ "textbook_weapwest", 2 ] ],
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "max_experience": "100 m" } ],
     "qualities": [
@@ -369,7 +369,7 @@
     "subcategory": "CSC_WEAPON_BASHING",
     "skill_used": "fabrication",
     "difficulty": 3,
-    "book_learn": [ [ "textbook_weapeast", 2 ], [ "textbook_weapwast", 2 ] ],
+    "book_learn": [ [ "textbook_weapeast", 2 ], [ "textbook_weapwest", 2 ] ],
     "time": "5 h 40 m",
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "max_experience": "100 m" } ],

--- a/data/json/vehicles/carts.json
+++ b/data/json/vehicles/carts.json
@@ -36,7 +36,7 @@
     ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame#vertical_T_left", "seat_back#left", "roof", "engine_electric" ] },
-      { "x": 0, "y": 0, "parts": [ "controls" ] },
+      { "x": 0, "y": 0, "parts": [ "controls", "dashboard" ] },
       { "x": 0, "y": 1, "parts": [ "frame#vertical_T_right", "seat_back#right", "roof" ] },
       { "x": 0, "y": 1, "parts": [ "storage_battery" ] },
       { "x": 1, "y": 0, "parts": [ "frame#nw", "halfboard#nw", "wheel_mount_light_steerable" ] },
@@ -61,7 +61,7 @@
     ],
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame#vertical_T_left", "seat_back#left", "roof", "engine_electric" ] },
-      { "x": 0, "y": 0, "parts": [ "controls" ] },
+      { "x": 0, "y": 0, "parts": [ "controls", "dashboard" ] },
       { "x": 0, "y": 1, "parts": [ "frame#vertical_T_right", "seat_back#right", "roof" ] },
       { "x": 0, "y": 1, "parts": [ "storage_battery" ] },
       { "x": 1, "y": 0, "parts": [ "frame#nw", "halfboard#nw", "wheel_mount_light_steerable" ] },


### PR DESCRIPTION
#### Summary
Add dashboards to golf carts

#### Purpose of change
Golf carts weren't chargeable because they lacked electronics controls or dashboards to plug into.

#### Describe the solution
- Give them dashboards
- Fix a random typo

#### Describe alternatives you've considered
Add a charging port part that allows power cables to plug in.

#### Testing
Spawned both golf carts, observed dashboards.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
