### PR TITLE
Fix barred window frame

### DIFF
--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -1269,7 +1269,7 @@
     "symbol": "#",
     "color": "light_gray",
     "move_cost": 0,
-    "coverage": 100,
+    "coverage": 15,
     "concealment": 38,
     "roof": "t_flat_roof",
     "hacksaw": {


### PR DESCRIPTION
#### Summary
Fix barred window frame

#### Purpose of change
The empty window frame with bars accidentally had 100 coverage, as if it still had glass, but it had bash stats for the metal bars, so it became an impenetrable steel wall basically.

#### Describe the solution
Coverage 100 -> 15

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
