### PR TITLE
Simplify superglue and reduce spawn amount

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -76,14 +76,14 @@
     "type": "item_group",
     "//": "Portable tools used for luthier",
     "items": [
-      { "item": "luthier_toolset", "prob": 100 },
-      { "item": "tonewood", "prob": 100, "count": [ 1, 6 ] },
-      { "item": "tuning_pegs", "prob": 100, "count": [ 5, 15 ] },
-      { "item": "piano_wire", "prob": 100, "count": [ 1, 3 ] },
+      { "item": "luthier_toolset", "prob": 90 },
+      { "item": "tonewood", "prob": 90, "count": [ 1, 6 ] },
+      { "item": "tuning_pegs", "prob": 90, "count": [ 1, 15 ] },
+      { "item": "piano_wire", "prob": 90, "count": [ 1, 3 ] },
       [ "hand_drill", 20 ],
-      { "item": "super_glue", "prob": 100, "count": [ 1, 3 ] },
+      { "group": "superglue", "prob": 90, "count": [ 0, 2 ] },
       [ "chisel", 10 ],
-      [ "sandpaper", 100 ]
+      [ "sandpaper", 90 ]
     ]
   },
   {
@@ -330,7 +330,7 @@
       [ "shovel", 40 ],
       [ "hammer_sledge", 10 ],
       [ "hammer_sledge_engineer", 20 ],
-      { "item": "spray_can", "prob": 100, "charges": [ 0, 10 ] },
+      { "item": "spray_can", "prob": 90, "charges": [ 0, 10 ] },
       { "item": "rubber_spray_can", "prob": 20, "charges": [ 0, 10 ] },
       { "item": "permanent_marker", "prob": 50, "charges": [ 0, 500 ] },
       [ "funnel", 200 ],
@@ -345,7 +345,7 @@
       { "item": "soldering_iron", "prob": 150 },
       { "item": "soldering_iron_portable", "prob": 150, "charges": [ 0, 50 ] },
       { "item": "reciprocating_saw", "prob": 50, "charges": [ 0, 500 ] },
-      { "item": "cordless_drill", "prob": 100, "charges": [ 0, 500 ] },
+      { "item": "cordless_drill", "prob": 80, "charges": [ 0, 500 ] },
       [ "pin_reamer", 30 ],
       [ "clamp", 10 ],
       [ "sandpaper", 90 ],
@@ -357,12 +357,12 @@
     "type": "item_group",
     "//": "Portable tools used by electricians and for electronics repair",
     "items": [
-      { "group": "tools_common_small", "prob": 100 },
-      { "item": "soldering_iron", "prob": 100 },
-      { "item": "soldering_iron_portable", "prob": 100, "charges": [ 0, 50 ] },
+      { "group": "tools_common_small", "prob": 90 },
+      { "item": "soldering_iron", "prob": 90 },
+      { "item": "soldering_iron_portable", "prob":70, "charges": [ 0, 50 ] },
       [ "magnifying_glass", 100 ],
       { "item": "voltmeter", "prob": 10, "charges": [ 0, 100 ] },
-      { "item": "multimeter", "prob": 100, "charges": [ 0, 100 ] },
+      { "item": "multimeter", "prob": 90, "charges": [ 0, 100 ] },
       [ "recharge_station", 10 ],
       [ "vac_mold", 10 ],
       [ "polycarbonate_sheet", 50 ],
@@ -389,7 +389,7 @@
     "type": "item_group",
     "//": "Tools commonly found in the home or other domestic settings",
     "items": [
-      { "group": "tools_common", "prob": 100 },
+      { "group": "tools_common", "prob": 90 },
       { "group": "tools_lighting", "prob": 50 },
       { "group": "tools_tailor", "prob": 50 },
       { "group": "tools_toolbox", "prob": 4 },
@@ -409,7 +409,7 @@
       [ "polycarbonate_sheet", 50 ],
       {
         "collection": [
-          { "item": "oxy_torch", "prob": 100 },
+          { "item": "oxy_torch", "prob": 90 },
           {
             "distribution": [ { "item": "weldtank", "prob": 100, "count": [ 1, 2 ] }, { "item": "tinyweldtank", "prob": 100, "count": [ 1, 3 ] } ],
             "prob": 100
@@ -1072,15 +1072,6 @@
     "type": "item_group",
     "subtype": "distribution",
     "id": "superglue",
-    "items": [ { "item": "super_glue", "charges-min": 0, "charges-max": 600, "container-group": "superglue_bottles" } ]
-  },
-  {
-    "type": "item_group",
-    "subtype": "distribution",
-    "id": "superglue_bottles",
-    "items": [
-      { "item": "small_squeeze_tube", "variant": "small_squeeze_tube_superglue", "prob": 90 },
-      { "item": "bottle_plastic_tiny_glue", "variant": "bottle_plastic_tiny_superglue", "prob": 10 }
-    ]
+    "items": [ { "item": "super_glue", "charges-min": 0, "charges-max": 10, "container-item": "bottle_plastic_tiny" } ]
   }
 ]

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -359,7 +359,7 @@
     "items": [
       { "group": "tools_common_small", "prob": 90 },
       { "item": "soldering_iron", "prob": 90 },
-      { "item": "soldering_iron_portable", "prob":70, "charges": [ 0, 50 ] },
+      { "item": "soldering_iron_portable", "prob": 70, "charges": [ 0, 50 ] },
       [ "magnifying_glass", 100 ],
       { "item": "voltmeter", "prob": 10, "charges": [ 0, 100 ] },
       { "item": "multimeter", "prob": 90, "charges": [ 0, 100 ] },
@@ -1072,6 +1072,6 @@
     "type": "item_group",
     "subtype": "distribution",
     "id": "superglue",
-    "items": [ { "item": "super_glue", "charges-min": 0, "charges-max": 10, "container-item": "bottle_plastic_tiny" } ]
+    "items": [ { "item": "super_glue", "charges-min": 0, "charges-max": 10, "container-item": "bottle_plastic_superglue" } ]
   }
 ]

--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -481,8 +481,8 @@
   },
   {
     "type": "ammunition_type",
-    "id": "superglue",
-    "name": "super glue",
+    "id": "super_glue",
+    "name": "superglue",
     "default": "super_glue"
   },
   {

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -680,64 +680,6 @@
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
   {
-    "id": "bottle_plastic_tiny_glue",
-    "type": "GENERIC",
-    "copy-from": "bottle_plastic_tiny",
-    "name": { "str": "tiny plastic glue bottle" },
-    "description": "A watertight plastic bottle, holds 30 mL of liquid.  Due to the design of the tip, it cannot be refilled.",
-    "longest_side": "120 mm",
-    "extend": { "flags": [ "NO_RELOAD", "NO_UNLOAD" ] },
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "bottle_plastic_tiny_superglue",
-        "name": { "str": "large superglue bottle" },
-        "description": "This one reads \"Super Glue - All Purpose!\", with directions and cautions below.",
-        "weight": 1,
-        "append": true
-      }
-    ]
-  },
-  {
-    "id": "small_squeeze_tube",
-    "type": "GENERIC",
-    "category": "container",
-    "name": { "str": "small squeeze tube" },
-    "description": "A small squeeze tube, holds 3 mL of liquid.  It cannot be refilled after it's empty.",
-    "ascii_picture": "bottle_plastic_small",
-    "weight": "2 g",
-    "volume": "11 ml",
-    "longest_side": "3 cm",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "watertight": true,
-        "rigid": true,
-        "max_contains_volume": "4 ml",
-        "max_item_volume": "4 ml",
-        "max_contains_weight": "50 g",
-        "moves": 400
-      }
-    ],
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
-    "material": [ "plastic" ],
-    "symbol": ")",
-    "color": "white",
-    "flags": [ "NO_RELOAD", "NO_UNLOAD", "COLLAPSE_CONTENTS" ],
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "small_squeeze_tube_superglue",
-        "name": { "str": "superglue tube" },
-        "description": "This one reads \"Super Glue - All Purpose!\", with directions and cautions below.",
-        "weight": 1,
-        "append": true
-      }
-    ]
-  },
-  {
     "id": "bottle_plastic_pill_prescription",
     "type": "GENERIC",
     "category": "container",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -326,7 +326,7 @@
     "material": [ "plastic" ],
     "weight": "26 mg",
     "volume": "1 ml",
-    "ammo_type": "superglue",
+    "ammo_type": "super_glue",
     "//": "1 charge of superglue should cover an area of 5mm^2",
     "count": 10,
     "flags": [ "UNRECOVERABLE" ]

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -328,7 +328,7 @@
     "volume": "1 ml",
     "ammo_type": "superglue",
     "//": "1 charge of superglue should cover an area of 5mm^2",
-    "count": 40,
+    "count": 10,
     "flags": [ "UNRECOVERABLE" ]
   },
   {

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -665,6 +665,33 @@
     "flags": [ "NO_RELOAD", "NO_UNLOAD" ]
   },
   {
+    "id": "bottle_plastic_superglue",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "superglue bottle" },
+    "looks_like": "bottle_plastic_tiny",
+    "weight": "2 g",
+    "volume": "20 ml",
+    "longest_side": "4 cm",
+    "price_postapoc": "50 cent",
+    "material": [ "plastic" ],
+    "color": "white",
+    "symbol": ")",
+    "description": "A little plastic bottle with a narrow tip, designed to store and dispense superglue.  It's gunked up with the stuff and wouldn't be good for much else.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": true,
+        "rigid": true,
+        "max_contains_volume": "10 ml",
+        "max_item_volume": "10 ml",
+        "max_contains_weight": "300 g",
+        "moves": 400
+      }
+    ],
+    "flags": [ "NO_RELOAD", "NO_UNLOAD" ]
+  },
+  {
     "id": "stepladder",
     "type": "TOOL",
     "name": { "str": "wooden stepladder" },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -780,8 +780,8 @@
   {
     "id": "superglue",
     "type": "MIGRATION",
-    "replace": "small_squeeze_tube",
-    "contents": [ { "id": "super_glue", "count": 40 } ]
+    "replace": "bottle_plastic_tiny",
+    "contents": [ { "id": "super_glue", "count": 10 } ]
   },
   {
     "id": "stabilizer",
@@ -802,5 +802,15 @@
     "id": "miner_hat",
     "type": "MIGRATION",
     "replace": "hat_hard"
+  },
+  {
+    "id": "small_squeeze_tube",
+    "type": "MIGRATION",
+    "replace": "bottle_plastic_small"
+  },
+  {
+    "id": "bottle_plastic_tiny_glue",
+    "type": "MIGRATION",
+    "replace": "bottle_plastic_tiny"
   }
 ]

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -780,7 +780,7 @@
   {
     "id": "superglue",
     "type": "MIGRATION",
-    "replace": "bottle_plastic_tiny",
+    "replace": "bottle_plastic_superglue",
     "contents": [ { "id": "super_glue", "count": 10 } ]
   },
   {
@@ -806,11 +806,11 @@
   {
     "id": "small_squeeze_tube",
     "type": "MIGRATION",
-    "replace": "bottle_plastic_small"
+    "replace": "bottle_plastic_superglue"
   },
   {
     "id": "bottle_plastic_tiny_glue",
     "type": "MIGRATION",
-    "replace": "bottle_plastic_tiny"
+    "replace": "bottle_plastic_superglue"
   }
 ]

--- a/data/json/recipes/recipe_traps.json
+++ b/data/json/recipes/recipe_traps.json
@@ -228,7 +228,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_traps" }, { "proficiency": "prof_trapsetting" } ],
     "components": [
-      [ [ "super_glue", 150 ], [ "duct_tape", 75 ] ],
+      [ [ "super_glue", 3 ], [ "duct_tape", 75 ] ],
       [ [ "scrap", 3 ], [ "steel_chunk", 1 ], [ "canister_empty", 1 ], [ "clay_canister", 1 ], [ "can_food", 1 ] ],
       [ [ "bb", 200 ], [ "nails", 100, "LIST" ] ],
       [

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -1535,7 +1535,7 @@
       [ [ "ruger_1022", 1 ] ],
       [ [ "wire", 1 ], [ "piano_wire", 1 ] ],
       [ [ "sheet_metal_small", 2 ] ],
-      [ [ "super_glue", 5 ] ]
+      [ [ "super_glue", 2 ] ]
     ]
   },
   {
@@ -1563,7 +1563,7 @@
       [ [ "ruger_charger", 1 ] ],
       [ [ "wire", 1 ], [ "piano_wire", 1 ] ],
       [ [ "sheet_metal_small", 2 ] ],
-      [ [ "super_glue", 5 ] ]
+      [ [ "super_glue", 2 ] ]
     ]
   }
 ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -3,19 +3,19 @@
     "id": "adhesive",
     "type": "requirement",
     "//": "Materials used for joining (typically non-metallic) parts",
-    "components": [ [ [ "duct_tape", 25 ], [ "super_glue", 10 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "duct_tape", 25 ], [ "super_glue", 1 ], [ "bone_glue", 1 ] ] ]
   },
   {
     "id": "glue_any",
     "type": "requirement",
     "//": "Any type of all-surface glue.  Each unit is 1cm^2 of coverage",
-    "components": [ [ [ "super_glue", 4 ], [ "bone_glue", 1 ] ] ]
+    "components": [ [ [ "super_glue", 1 ], [ "bone_glue", 1 ] ] ]
   },
   {
     "id": "glue_waterproof",
     "type": "requirement",
     "//": "Any type of waterproof glue, which is just about everything except bone/hide glue.  Each unit is 1cm^2 of coverage",
-    "components": [ [ [ "super_glue", 4 ] ] ]
+    "components": [ [ [ "super_glue", 1 ] ] ]
   },
   {
     "id": "glue_strong",

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -195,7 +195,7 @@
       [ [ "camera", 1 ], [ "camera_pro", 1 ], [ "wearable_camera", 1 ], [ "wearable_camera_pro", 1 ], [ "omnicamera", 1 ] ],
       [ [ "warptoken", 5 ] ],
       [ [ "scrap_aluminum", 12 ] ],
-      [ [ "super_glue", 10 ], [ "bone_glue", 1 ] ],
+      [ [ "super_glue", 1 ], [ "bone_glue", 1 ] ],
       [ [ "medium_battery_cell", 2 ], [ "medium_plus_battery_cell", 4 ], [ "medium_disposable_cell", 6 ] ],
       [ [ "extension_cable", 1 ], [ "long_extension_cable", 1 ], [ "jumper_cable", 1 ] ]
     ]
@@ -2348,7 +2348,7 @@
       [ [ "2x4", 4 ] ],
       [ [ "glass_shard", 150 ] ],
       [ [ "chunk_rubber", 5 ] ],
-      [ [ "super_glue", 20 ] ],
+      [ [ "super_glue", 2 ] ],
       [ [ "cordage", 5, "LIST" ] ]
     ]
   },
@@ -2411,7 +2411,7 @@
       [ [ "aquamarine", 4 ], [ "citrine", 4 ], [ "garnet", 4 ], [ "peridot", 4 ], [ "tourmaline", 4 ], [ "blue_topaz", 4 ] ],
       [ [ "glass_sheet", 3 ] ],
       [ [ "mirror", 1 ] ],
-      [ [ "super_glue", 40 ] ],
+      [ [ "super_glue", 4 ] ],
       [ [ "frame_wood", 2 ] ],
       [ [ "cordage", 1, "LIST" ] ]
     ]

--- a/data/mods/innawood/migration_items.json
+++ b/data/mods/innawood/migration_items.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "small_squeeze_tube",
+    "id": "bottle_plastic_tiny",
     "type": "MIGRATION",
     "replace": "clay_canister"
   }


### PR DESCRIPTION
#### Summary
Simplify superglue and reduce spawn amount

#### Purpose of change
I backported some changes to superglue that came with a little more granularity than I wanted. Superglue amounts also seemed kinda off in the requirements jsons.

#### Describe the solution
- Simplify superglue bottles so there's just one kind.
- Reduce superglue spawns to 1-10 per bottle.
- Reduce superglue requirements so people don't need dozens of units for stuff.
- Obsolete the two unique superglue bottle types.
- Update sky islands and innawood to reflect this change.

#### Describe alternatives you've considered
- Make superglue spawn in a single bespoke sealed container that can't store anything else.
- Make it charge-based like rubber sealant.

#### Testing
- Spawned glue, looks good
- Used glue to make stuff, looks good

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
