### PR TITLE
Beartraps drop properly and don't prevent attack

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4713,7 +4713,8 @@
     "rating": "bad",
     "show_intensity": false,
     "//": "Don't multiply speed by 0 or else the effect will never be removed for creatures with 0 damage(e.g. rabbits)",
-    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": 0.01 } ] } ]
+    "enchantments": [ { "values": [ { "value": "SPEED", "multiply": 0.01 } ] } ],
+    "show_in_info": true
   },
   {
     "id": "Shadow_Reveal",

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -128,15 +128,19 @@ void Character::try_remove_lightsnare()
     if( is_mounted() ) {
         auto *mon = mounted_creature.get();
         if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 12 ) ) {
+            map &here = get_map();
             mon->remove_effect( effect_lightsnare );
             remove_effect( effect_lightsnare );
             add_msg( _( "The %s escapes the light snare!" ), mon->get_name() );
+            here.spawn_item( pos(), "light_snare_kit" );
         }
     } else {
         if( can_escape_trap( 12 ) ) {
+            map &here = get_map();
             remove_effect( effect_lightsnare );
             add_msg_player_or_npc( m_good, _( "You free yourself from the light snare!" ),
                                    _( "<npcname> frees themselves from the light snare!" ) );
+            here.spawn_item( pos(), "light_snare_kit" );
         } else {
             add_msg_if_player( m_bad,
                                _( "You try to free yourself from the light snare, but can't get loose!" ) );
@@ -476,15 +480,15 @@ void Character::wait_effects( bool attacking )
         try_remove_downed();
         return;
     }
-    if( has_effect( effect_beartrap ) && !attacking ) {
+    if( has_effect( effect_beartrap ) ) {
         try_remove_bear_trap();
         return;
     }
-    if( has_effect( effect_lightsnare ) && !attacking ) {
+    if( has_effect( effect_lightsnare ) ) {
         try_remove_lightsnare();
         return;
     }
-    if( has_effect( effect_heavysnare ) && !attacking ) {
+    if( has_effect( effect_heavysnare ) ) {
         try_remove_heavysnare();
         return;
     }

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -98,9 +98,12 @@ void Character::try_remove_bear_trap()
         auto *mon = mounted_creature.get();
         if( mon->type->melee_dice * mon->type->melee_sides >= 18 ) {
             if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 200 ) ) {
+                map &here = get_map();
                 mon->remove_effect( effect_beartrap );
                 remove_effect( effect_beartrap );
                 add_msg( _( "The %s escapes the bear trap!" ), mon->get_name() );
+
+                here.spawn_item( mon->pos(), "beartrap" );
             } else {
                 add_msg_if_player( m_bad,
                                    _( "Your %s tries to free itself from the bear trap, but can't get loose!" ), mon->get_name() );
@@ -111,6 +114,8 @@ void Character::try_remove_bear_trap()
             remove_effect( effect_beartrap );
             add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
                                    _( "<npcname> frees themselves from the bear trap!" ) );
+            map &here = get_map();
+            here.spawn_item( pos(), "beartrap" );
         } else {
             add_msg_if_player( m_bad,
                                _( "You try to free yourself from the bear trap, but can't get loose!" ) );
@@ -413,7 +418,7 @@ void Character::try_remove_impeding_effect()
 
 bool Character::move_effects( bool attacking )
 {
-    if( has_effect( effect_downed ) ) {
+    if( has_effect( effect_downed ) && !attacking ) {
         try_remove_downed();
         return false;
     }
@@ -421,16 +426,16 @@ bool Character::move_effects( bool attacking )
         try_remove_webs();
         return false;
     }
-    if( has_effect( effect_lightsnare ) ) {
+    if( has_effect( effect_lightsnare ) && !attacking ) {
         try_remove_lightsnare();
         return false;
 
     }
-    if( has_effect( effect_heavysnare ) ) {
+    if( has_effect( effect_heavysnare ) && !attacking ) {
         try_remove_heavysnare();
         return false;
     }
-    if( has_effect( effect_beartrap ) ) {
+    if( has_effect( effect_beartrap ) && !attacking ) {
         try_remove_bear_trap();
         return false;
     }
@@ -471,15 +476,15 @@ void Character::wait_effects( bool attacking )
         try_remove_downed();
         return;
     }
-    if( has_effect( effect_beartrap ) ) {
+    if( has_effect( effect_beartrap ) && !attacking ) {
         try_remove_bear_trap();
         return;
     }
-    if( has_effect( effect_lightsnare ) ) {
+    if( has_effect( effect_lightsnare ) && !attacking ) {
         try_remove_lightsnare();
         return;
     }
-    if( has_effect( effect_heavysnare ) ) {
+    if( has_effect( effect_heavysnare ) && !attacking ) {
         try_remove_heavysnare();
         return;
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2379,7 +2379,8 @@ std::string Character::melee_special_effects( Creature &t, damage_instance &d, i
             //redeclare shatter_dam because deal_damage mutates it
             deal_damage( nullptr, bodypart_id( "arm_l" ), di );
         }
-        d.add_damage( damage_cut, rng( 0, 5 + std::min( 5, static_cast<int>( vol * 1.5 ) ) ) ); // Hurt the monster extra
+        d.add_damage( damage_cut, rng( 0, 5 + std::min( 5,
+                                       static_cast<int>( vol * 1.5 ) ) ) ); // Hurt the monster extra
         remove_weapon();
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2362,6 +2362,7 @@ bool monster::move_effects( bool )
                 if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                     add_msg( _( "The %s escapes the bear trap!" ), name() );
                 }
+                here.spawn_item( pos(), "beartrap" );
             }
         }
         return false;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2339,6 +2339,7 @@ bool monster::move_effects( bool )
             if( u_see_me && get_option<bool>( "LOG_MONSTER_MOVE_EFFECTS" ) ) {
                 add_msg( _( "The %s escapes the light snare!" ), name() );
             }
+            here.spawn_item( pos(), "light_snare_kit" );
         }
         return false;
     }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -221,8 +221,6 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         }
         c->check_dead_state();
     }
-
-    here.spawn_item( p, "beartrap" );
     return true;
 }
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -197,12 +197,16 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         const bodypart_id hit = random_entry( c->get_ground_contact_bodyparts( true ) );
 
         // Messages
-        c->add_msg_player_or_npc( m_bad,
-                                  string_format( _( "A bear trap closes on your %s" ), body_part_name_accusative( hit ) ),
-                                  string_format( _( "A bear trap closes on <npcname>'s %s" ), body_part_name( hit ) ) );
-
-        if( c->has_effect( effect_ridden ) ) {
-            add_msg( m_warning, _( "Your %s is caught by a beartrap!" ), c->get_name() );
+        if( c->is_monster() ) {
+            if( c->has_effect( effect_ridden ) ) {
+                add_msg( m_warning, _( "Your %s is caught by a beartrap!" ), c->get_name() );
+            } else {
+                add_msg_if_player_sees( c->pos(), _( "%s gets caught in a beartrap!" ), c->get_name() );
+            }
+        } else {
+            c->add_msg_player_or_npc( m_bad,
+                                      string_format( _( "A bear trap closes on your %s" ), body_part_name_accusative( hit ) ),
+                                      string_format( _( "A bear trap closes on <npcname>'s %s" ), body_part_name( hit ) ) );
         }
         // Actual effects
         c->add_effect( effect_beartrap, 1_turns, hit, true );
@@ -210,6 +214,8 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
         d.add_damage( damage_bash, 12 );
         d.add_damage( damage_cut, 18 );
         dealt_damage_instance dealt_dmg = c->deal_damage( nullptr, hit, d );
+
+        sounds::sound( p, 8, sounds::sound_t::activity, _( "Clank!" ), false, "trap", "snare" );
 
         Character *you = dynamic_cast<Character *>( c );
         if( you != nullptr && !you->has_flag( json_flag_INFECTION_IMMUNE ) &&
@@ -635,15 +641,17 @@ bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
         // The lightsnare effect multiplies speed by 0.01 so on average this is actually 10,000 turns duration.
         // Creatures can still escape earlier (possibly much earlier) based on their melee dice(for creatures) or strength/limb scores (character)
         c->add_effect( effect_lightsnare, 100_turns, true );
-        if( c->has_effect( effect_ridden ) ) {
-            add_msg( m_bad, _( "A snare closes on your %s's leg!" ), c->get_name() );
+        if( c->is_monster() ) {
+            if( c->has_effect( effect_ridden ) ) {
+                add_msg( m_warning, _( "Your %s is caught in a snare!" ), c->get_name() );
+            } else {
+                add_msg_if_player_sees( c->pos(), _( "%s gets caught in a snare!" ), c->get_name() );
+            }
+        } else {
+            c->add_msg_player_or_npc( m_bad, _( "A snare closes on your leg." ),
+                                      _( "A snare closes on <npcname>s leg." ) );
         }
-        c->add_msg_player_or_npc( m_bad, _( "A snare closes on your leg." ),
-                                  _( "A snare closes on <npcname>s leg." ) );
     }
-
-    // Always get trap components back on triggering tile
-    here.spawn_item( p, "light_snare_kit" );
     return true;
 }
 
@@ -656,12 +664,17 @@ bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
     }
     // Determine what got hit
     const bodypart_id hit = one_in( 2 ) ? bodypart_id( "leg_l" ) : bodypart_id( "leg_r" );
-    if( c->has_effect( effect_ridden ) ) {
-        add_msg( m_bad, _( "A snare closes on your %s's leg!" ), c->get_name() );
+    if( c->is_monster() ) {
+        if( c->has_effect( effect_ridden ) ) {
+            add_msg( m_warning, _( "Your %s is caught in a snare!" ), c->get_name() );
+        } else {
+            add_msg_if_player_sees( c->pos(), _( "%s gets caught in a snare!" ), c->get_name() );
+        }
+    } else {
+        //~ %s is bodypart name in accusative.
+        c->add_msg_player_or_npc( m_bad, _( "A snare closes on your %s." ),
+                                  _( "A snare closes on <npcname>s %s." ), body_part_name_accusative( hit ) );
     }
-    //~ %s is bodypart name in accusative.
-    c->add_msg_player_or_npc( m_bad, _( "A snare closes on your %s." ),
-                              _( "A snare closes on <npcname>s %s." ), body_part_name_accusative( hit ) );
 
     // Actual effects
     c->add_effect( effect_heavysnare, 1_turns, hit, true );


### PR DESCRIPTION
#### Summary
Beartraps drop properly and don't prevent attack

#### Purpose of change
- It was impossible to attack an enemy while downed or stuck in a beartrap or snare, even if you wanted to
- Beartraps were dropping at the point where you set them off, even if you had been moved

#### Describe the solution
- Move the beartrap dropping code to the character or monster escape functions
- Make it so that when downed, snared, or beartrapped, walking into a monster will attack it
- Pressing tab or pausing will still prioritize trying to remove the bad effect. Generally a downed player will want to get up before trying to attack again, so this is the better solution there, and we apply that across the board for consistency
- Fix messaging to stop the trap from closing on monster appendices
- Apply the same fixes to snares
- Add a sound to beartraps

#### Describe alternatives you've considered
Tab could maybe also attack? idk

#### Testing
- Spawned, stepped on a trap, attacked a debug monster, the trap didn't drop until I got free
- Let a zombie hulk get stuck in a beartrap, it played a sound, the trap didn't drop until he got free
- Chased a rabbit into a snare, saw it still worked

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
