### PR TITLE
Fix bad Zui Quan vector

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -3510,7 +3510,7 @@
     "down_dur": 2,
     "messages": [ "You throw yourself down, dragging %s with you", "<npcname> falls, dragging %s down as well!" ],
     "description": "Down 2 turns, min 3 melee",
-    "attack_vectors": [ "GRAPPLE" ]
+    "attack_vectors": [ "vector_arm_grapple" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
#### Summary
Fix bad Zui Quan vector

#### Purpose of change
I backported some updates to attack vectors, but they missed a custom move I'd made. This caused it to throw an error when trying to use it.

#### Describe the solution
"GRAPPLE"->"vector_arm_grapple"

#### Testing
Did the move, no error

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
