### PR TITLE
Fix chainmail and snares

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -669,7 +669,7 @@
     "looks_like": "armguard_metal",
     "color": "light_red",
     "warmth": 10,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -747,7 +747,8 @@
       "msg": "You adjust your mail for a looser fit.",
       "target": "chainmail_junk_sleeves_loose",
       "menu_text": "Loosen"
-    }
+    },
+    "delete": { "flags": [ "STURDY" ] }
   },
   {
     "id": "chainmail_sleeves_loose",
@@ -761,6 +762,7 @@
       "target": "chainmail_junk_sleeves",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -775,6 +777,7 @@
       "target": "chainmail_sleeves_xs",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -789,6 +792,7 @@
       "target": "chainmail_sleeves_xl",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -802,6 +806,7 @@
       "target": "chainmail_junk_sleeves",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL", "STURDY" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {

--- a/data/json/items/armor/hoods.json
+++ b/data/json/items/armor/hoods.json
@@ -166,6 +166,7 @@
     "copy-from": "chainmail_coif",
     "replace_materials": { "steel_chain": "budget_steel_chain" },
     "name": { "str": "chainmail coif" },
-    "description": "A protective hood made of interlocking steel rings that drape down to cover the neck.  It is of poor quality."
+    "description": "A protective hood made of interlocking steel rings that drape down to cover the neck.  It is of poor quality.",
+    "delete": { "flags": [ "STURDY" ] }
   }
 ]

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -284,7 +284,8 @@
     "copy-from": "chainmail_chausses",
     "name": { "str": "chainmail chausses", "str_pl": "pairs of chainmail chausses" },
     "description": "Protective leggings made of interlocking links of low-quality steel wire, covering from the thighs to the tops of the feet.",
-    "replace_materials": { "steel_chain": "budget_steel_chain" }
+    "replace_materials": { "steel_chain": "budget_steel_chain" },
+    "delete": { "flags": [ "STURDY" ] }
   },
   {
     "id": "chainmail_skirt",
@@ -303,7 +304,7 @@
     "looks_like": "skirt_leather",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY", "ALLOWS_TAIL" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -373,7 +374,8 @@
       "msg": "You adjust your mail for a looser fit.",
       "target": "chainmail_skirt_budget_loose",
       "menu_text": "Loosen"
-    }
+    },
+    "delete": { "flags": [ "STURDY" ] }
   },
   {
     "id": "chainmail_skirt_loose",
@@ -387,6 +389,7 @@
       "target": "chainmail_skirt",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -401,6 +404,7 @@
       "target": "chainmail_skirt_xs",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -415,6 +419,7 @@
       "target": "chainmail_skirt_xl",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {
@@ -428,6 +433,7 @@
       "target": "chainmail_skirt_budget",
       "menu_text": "Tighten"
     },
+    "delete": { "flags": [ "NORMAL", "STURDY" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -279,7 +279,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "full plate armor" },
-    "description": "A suit of medieval plate armor.  The metal shows signs of rust and corrosion, and the leather straps are tattered.",
+    "description": "A suit of medieval plate armor, covering everything but the head and neck.  It's made of low-quality steel that doesn't look like it'll hold together long.  This would likely be uncomfortable without something soft underneath.",
     "weight": "11 kg",
     "volume": "17500 ml",
     "price": "600 USD",
@@ -292,7 +292,7 @@
     "warmth": 25,
     "longest_side": "60 cm",
     "material_thickness": 1.6,
-    "flags": [ "VARSIZE", "OUTER", "STURDY", "ALLOWS_TAIL" ],
+    "flags": [ "VARSIZE", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": 34,
@@ -308,7 +308,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "full plate armor" },
-    "description": "A suit of medieval full plate armor, covering everything but the head and neck.  This would likely be uncomfortable without something soft underneath.",
+    "description": "A suit of medieval plate armor, covering everything but the head and neck.  This would likely be uncomfortable without something soft underneath.",
     "weight": "15 kg",
     "volume": "17500 ml",
     "price": "600 USD",
@@ -907,11 +907,13 @@
       "msg": "You adjust your mail for a looser fit.",
       "target": "chainmail_junk_hauberk_loose",
       "menu_text": "Loosen"
-    }
+    },
+    "delete": { "flags": [ "STURDY" ] }
   },
   {
     "id": "chainmail_junk_hauberk_loose",
-    "copy-from": "chainmail_junk_hauberk",
+    "copy-from": "chainmail_hauberk",
+    "replace_materials": { "steel_chain": "budget_steel_chain" },
     "type": "ARMOR",
     "name": { "str": "chainmail hauberk (loose)" },
     "description": "A knee-length long-sleeved tunic made of interlocking low-quality steel rings.  It can be adjusted to fit closer to the body.",
@@ -920,7 +922,9 @@
       "msg": "You adjust your mail for a closer fit.",
       "target": "chainmail_junk_hauberk",
       "menu_text": "Tighten"
-    }
+    },
+    "extend": { "flags": [ "OUTER" ] },
+    "delete": { "flags": [ "STURDY", "NORMAL" ] }
   },
   {
     "id": "chainmail_suit",

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -1019,7 +1019,8 @@
       "msg": "You adjust your mail for a looser fit.",
       "target": "chainmail_junk_vest_loose",
       "menu_text": "Loosen"
-    }
+    },
+    "delete": { "flags": [ "STURDY" ] }
   },
   {
     "id": "chainmail_junk_vest_loose",
@@ -1031,6 +1032,7 @@
       "msg": "You adjust your mail for a closer fit.",
       "target": "chainmail_junk_vest",
       "menu_text": "Tighten"
-    }
+    },
+    "delete": { "flags": [ "STURDY" ] }
   }
 ]

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3017,7 +3017,12 @@ void monster::die( Creature *nkiller )
         move_special_item_to_inv( armor_item );
         move_special_item_to_inv( storage_item );
         move_special_item_to_inv( tied_item );
-
+        if( has_effect( effect_beartrap ) ) {
+            add_item( item( "beartrap", calendar::turn_zero ) );
+        }
+        if( has_effect( effect_lightsnare ) ) {
+            add_item( item( "light_snare_kit", calendar::turn_zero ) );
+        }
         if( has_effect( effect_heavysnare ) ) {
             add_item( item( "rope_6", calendar::turn_zero ) );
             add_item( item( "snare_trigger", calendar::turn_zero ) );


### PR DESCRIPTION
#### Summary
Fix chainmail and snares

#### Purpose of change
I forgot to make snares/beartraps drop when a trapped monster died, and also some chainmail pieces were still not properly switching their layer when loosened.

#### Describe the solution
- Traps now go to the monster's inventory when it dies, if it's still stuck.
- Chainmail should work better, and also budget chain/plate lost their STURDY flag.

#### Testing
Seems good

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
