### PR TITLE
Remove Killer Drive and eye sweat

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -314,7 +314,7 @@
     "stylish_bonus": 2,
     "squeamish_penalty": 8,
     "base_hp": 60,
-    "drench_capacity": 100,
+    "drench_capacity": 0,
     "flags": [ "IGNORE_TEMP", "LIMB_UPPER" ],
     "smash_message": "You use your flippin' face to smash the %s.  EXTREME.",
     "smash_efficiency": 0.25,

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -2021,9 +2021,9 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 10 } ],
         "covers": [ "mouth" ],
-        "coverage": 0,
+        "coverage": 60,
         "encumbrance": 0
       }
     ],
@@ -2047,9 +2047,9 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 10 } ],
         "covers": [ "mouth" ],
-        "coverage": 0,
+        "coverage": 60,
         "encumbrance": 0
       }
     ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1886,7 +1886,7 @@
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3.2 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
-        "coverage": 100,
+        "coverage": 0,
         "encumbrance": 0
       }
     ],
@@ -1913,7 +1913,7 @@
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 3.2 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
-        "coverage": 100,
+        "coverage": 20,
         "encumbrance": 0
       }
     ],
@@ -1937,7 +1937,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
         "coverage": 20,
@@ -1969,7 +1969,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 8 } ],
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
         "coverage": 10,
@@ -1995,7 +1995,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "mouth" ],
         "coverage": 0,
         "encumbrance": 0
@@ -2021,7 +2021,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "mouth" ],
         "coverage": 60,
         "encumbrance": 0
@@ -2047,7 +2047,7 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 7 } ],
         "covers": [ "mouth" ],
         "coverage": 60,
         "encumbrance": 0

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1590,7 +1590,7 @@
     "techniques": [ "TEC_CLAW" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 2 } ],
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 2,
@@ -1666,7 +1666,7 @@
     "techniques": [ "TEC_CLAW" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 10,
@@ -1704,7 +1704,7 @@
     "techniques": [ "TEC_CLAW" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 20,
@@ -1742,7 +1742,7 @@
     "techniques": [ "TEC_CLAW" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 40,
@@ -1782,7 +1782,7 @@
     "techniques": [ "TEC_CLAW" ],
     "armor": [
       {
-        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],
+        "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ],
         "coverage": 10,
@@ -1924,7 +1924,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str_sp": "saber teeth" },
-    "description": "A pair of enormous fangs, strong enough to punch through bone.",
+    "description": "A pair of enormous protruding fangs, strong enough to punch through bone.",
     "weight": "200 g",
     "volume": "250 ml",
     "price": "0 cent",
@@ -1940,7 +1940,7 @@
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 10 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
-        "coverage": 0,
+        "coverage": 20,
         "encumbrance": 0
       }
     ],
@@ -1969,10 +1969,10 @@
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PADDED", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
     "armor": [
       {
-        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 10 } ],
+        "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 8 } ],
         "covers": [ "mouth" ],
         "specifically_covers": [ "mouth_lips" ],
-        "coverage": 0,
+        "coverage": 10,
         "encumbrance": 0
       }
     ],

--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -360,16 +360,6 @@
     "text": "Craving fire"
   },
   {
-    "id": "morale_killer_has_killed",
-    "type": "morale_type",
-    "text": "Killed recently"
-  },
-  {
-    "id": "morale_killer_need_to_kill",
-    "type": "morale_type",
-    "text": "Longing to kill"
-  },
-  {
     "id": "morale_perm_filthy",
     "type": "morale_type",
     "text": "Filthy gear"

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1234,17 +1234,6 @@
   },
   {
     "type": "mutation",
-    "id": "KILLER",
-    "name": { "str": "Killer Drive" },
-    "points": 2,
-    "description": "You derive enjoyment from killing things.  Putting end to life seem to spark some dark satisfaction and thrill, and you crave it every moment.",
-    "starting_trait": true,
-    "valid": false,
-    "social_modifiers": { "intimidate": 5 },
-    "prereqs": [ "PSYCHOPATH" ]
-  },
-  {
-    "type": "mutation",
     "id": "MARTIAL_ARTS",
     "name": { "str": "Martial Arts Training" },
     "points": 2,

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -61,7 +61,16 @@
     "id": "URSINE_EYE",
     "name": { "str": "Ursine Vision" },
     "description": "Obsoleted Ursine Vision mutation.  Bears now get Mesopic and Night Vision.",
-    "points": 1,
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "KILLER",
+    "name": { "str": "Killer Drive" },
+    "description": "Obsoleted Killer Drive mutation.",
+    "points": 0,
     "valid": false,
     "player_display": false
   }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3976,29 +3976,6 @@
   },
   {
     "type": "profession",
-    "id": "death_row_convict",
-    "name": "Death Row Convict",
-    "description": "You were a serial killer, ready to walk the green mile, but in a twist of fate you're one of the few still alive.  True death comes only from your hands, so you're in for a job.",
-    "points": 1,
-    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar", "prof_shivs_familiar" ],
-    "skills": [ { "level": 3, "name": "melee" }, { "level": 3, "name": "stabbing" }, { "level": 2, "name": "unarmed" } ],
-    "traits": [ "KILLER" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt_costume", "variant": "shirt_striped" },
-          { "item": "pants_costume", "variant": "pants_striped" },
-          { "item": "sneakers" },
-          { "item": "socks" },
-          { "item": "glass_shiv" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "convict_assassin",
     "name": "Undercover Assassin Convict",
     "description": "You were given a target, a mission, but killing your mark seems to have become much more difficult now.  Your employer cut contact with you and now you have to make do with what you have.",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -654,7 +654,6 @@
     "start_name": "Prison",
     "professions": [
       "convict",
-      "death_row_convict",
       "convict_assassin",
       "convict_embezzler",
       "convict_drugs",
@@ -675,7 +674,6 @@
     "start_name": "Island prison",
     "professions": [
       "convict",
-      "death_row_convict",
       "convict_assassin",
       "convict_embezzler",
       "convict_drugs",

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -92,7 +92,6 @@ static const mtype_id mon_generator( "mon_generator" );
 static const species_id species_HALLUCINATION( "HALLUCINATION" );
 static const species_id species_SLIME( "SLIME" );
 
-static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_PACIFIST( "PACIFIST" );
 static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
@@ -1691,7 +1690,7 @@ void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &tar
         guilt_thresholds[max_kills] = _( "You feel uneasy about killing %s." );
 
         Character &guy = *guilt_target;
-        if( guy.has_trait( trait_PSYCHOPATH ) || guy.has_trait( trait_KILLER ) ||
+        if( guy.has_trait( trait_PSYCHOPATH ) ||
             guy.has_flag( json_flag_PRED3 ) || guy.has_flag( json_flag_PRED4 ) ) {
             // specially immune.
             return;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -195,7 +195,6 @@ static const trait_id trait_ANIMALEMPATH2( "ANIMALEMPATH2" );
 static const trait_id trait_BEE( "BEE" );
 static const trait_id trait_FLOWERS( "FLOWERS" );
 static const trait_id trait_INATTENTIVE( "INATTENTIVE" );
-static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_MYCUS_FRIEND( "MYCUS_FRIEND" );
 static const trait_id trait_PHEROMONE_AMPHIBIAN( "PHEROMONE_AMPHIBIAN" );
 static const trait_id trait_PHEROMONE_INSECT( "PHEROMONE_INSECT" );
@@ -2863,14 +2862,6 @@ void monster::die( Creature *nkiller )
             cata::event e = cata::event::make<event_type::character_kills_monster>( ch->getID(), type->id,
                             compute_kill_xp( type->id ) );
             get_event_bus().send_with_talker( ch, this, e );
-            if( ch->is_avatar() && ch->has_trait( trait_KILLER ) ) {
-                if( one_in( 4 ) ) {
-                    const translation snip = SNIPPET.random_from_category( "killer_on_kill" ).value_or( translation() );
-                    ch->add_msg_if_player( m_good, "%s", snip );
-                }
-                ch->add_morale( morale_killer_has_killed, 5, 10, 6_hours, 4_hours );
-                ch->rem_morale( morale_killer_need_to_kill );
-            }
         }
     }
     map &here = get_map();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -161,7 +161,6 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_BEE( "BEE" );
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
 static const trait_id trait_HALLUCINATION( "HALLUCINATION" );
-static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_NO_BASH( "NO_BASH" );
 static const trait_id trait_PACIFIST( "PACIFIST" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
@@ -2899,14 +2898,10 @@ void npc::die( Creature *nkiller )
             if( player_character.has_flag( json_flag_PSYCHOPATH ) ||
                 player_character.has_flag( json_flag_SAPIOVORE ) ) {
                 morale_effect = 0;
-            } // Killer has the psychopath flag, so we're at +5 total. Whee!
-            if( player_character.has_trait( trait_KILLER ) ) {
-                morale_effect += 5;
-            } // only god can juge me
+            }
             if( player_character.has_flag( json_flag_SPIRITUAL ) &&
                 ( !player_character.has_flag( json_flag_PSYCHOPATH ) ||
-                  ( player_character.has_flag( json_flag_PSYCHOPATH ) &&
-                    player_character.has_trait( trait_KILLER ) ) ) &&
+                  player_character.has_flag( json_flag_PSYCHOPATH ) ) &&
                 !player_character.has_flag( json_flag_SAPIOVORE ) ) {
                 if( morale_effect < 0 ) {
                     add_msg( _( "You feel ashamed of your actions." ) );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -131,8 +131,6 @@ static const json_character_flag json_flag_SUNBURN( "SUNBURN" );
 static const limb_score_id limb_score_breathing( "breathing" );
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
-static const morale_type morale_killer_has_killed( "morale_killer_has_killed" );
-static const morale_type morale_killer_need_to_kill( "morale_killer_need_to_kill" );
 static const morale_type morale_moodswing( "morale_moodswing" );
 static const morale_type morale_pyromania_nearfire( "morale_pyromania_nearfire" );
 static const morale_type morale_pyromania_nofire( "morale_pyromania_nofire" );
@@ -150,7 +148,6 @@ static const trait_id trait_FRESHWATEROSMOSIS( "FRESHWATEROSMOSIS" );
 static const trait_id trait_HAS_NEMESIS( "HAS_NEMESIS" );
 static const trait_id trait_JAUNDICE( "JAUNDICE" );
 static const trait_id trait_JITTERY( "JITTERY" );
-static const trait_id trait_KILLER( "KILLER" );
 static const trait_id trait_LEAVES( "LEAVES" );
 static const trait_id trait_LEAVES2( "LEAVES2" );
 static const trait_id trait_LEAVES2_FALL( "LEAVES2_FALL" );
@@ -1249,15 +1246,6 @@ void suffer::from_other_mutations( Character &you )
             const translation smokin_hot_fiyah =
                 SNIPPET.random_from_category( "pyromania_withdrawal" ).value_or( translation() );
             you.add_msg_if_player( m_bad, "%s", smokin_hot_fiyah );
-        }
-    }
-    if( you.has_trait( trait_KILLER ) && !you.has_morale( morale_killer_has_killed ) &&
-        calendar::once_every( 2_hours ) ) {
-        you.add_morale( morale_killer_need_to_kill, -1, -30, 24_hours, 24_hours );
-        if( calendar::once_every( 4_hours ) ) {
-            const translation snip = SNIPPET.random_from_category( "killer_withdrawal" ).value_or(
-                                         translation() );
-            you.add_msg_if_player( m_bad, "%s", snip );
         }
     }
 }


### PR DESCRIPTION
#### Summary
Remove Killer Drive and eye sweat

#### Purpose of change
- Eyes were able to become wet, which didn't do anything because they're unaffected by temperature. This was causing weirdness with the protective lens cbms and probably some integrated mutations as water would get trapped on the BP, unable to evaporate(???).
- Killer Drive was buggy, annoying, and ridiculous.

#### Describe the solution
- Set drench_capacity on eyes to 0. They simply cannot get wet and do not interact with that system.
- Removed killer drive.
- Removed the death row convict profession. If you want to play as a serial killer on death row, just...play as a convict?
- Added some coverage to beaks, switched their material to keratin.
- Moved claws over to keratin.
- Added some coverage to saber teeth and incisors.
- Adjusted thickness to make protection values less weird.

#### Testing
Loads, runs, bps look good. Set temperature to 90 degrees, my eyes did not get sweaty.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
