### PR TITLE
Fix grab not applying dodge penalties

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3625,7 +3625,7 @@
     "show_in_info": true,
     "show_intensity": true,
     "//mods": "No swimmin' or manipulatin' with a held limb, other scores start severly debilitated and reach useless at about 50 grab strength",
-    "base_mods": { "dodge_mod": [ -10 ] },
+    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "multiply": 0.0 } ] } ],
     "limb_score_mods": [
       { "limb_score": "manip", "modifier": 0.0 },
       { "limb_score": "grip", "modifier": 0.0 },
@@ -3647,7 +3647,7 @@
     "max_intensity": 1,
     "show_in_info": true,
     "//": "-dodge (can't really miss something holding you)",
-    "base_mods": { "dodge_mod": [ -8 ] },
+    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "add": -8.0 } ] } ],
     "flags": [ "GRAB_FILTER" ]
   },
   {
@@ -3658,7 +3658,7 @@
     "max_intensity": 1,
     "show_in_info": true,
     "//": "-dodge (can't really miss something holding you)",
-    "base_mods": { "dodge_mod": [ -8 ] },
+    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "add": -8.0 } ] } ],
     "flags": [ "GRAB_FILTER" ]
   },
   {
@@ -3669,7 +3669,7 @@
     "max_intensity": 1,
     "show_in_info": true,
     "//": "-dodge (can't really miss something holding you)",
-    "base_mods": { "dodge_mod": [ -8 ] },
+    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "add": -8.0 } ] } ],
     "flags": [ "GRAB_FILTER" ]
   },
   {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2570,6 +2570,14 @@ float monster::get_dodge() const
         ret /= 2;
     }
 
+    if( has_effect_with_flag( json_flag_GRAB ) ) {
+        ret *= 0;
+    }
+
+    if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+        ret -= 5;
+    }
+
     if( has_effect( effect_bouldering ) ) {
         ret /= 4;
     }


### PR DESCRIPTION
#### Summary
Fix grab not applying dodge penalties

#### Purpose of change
Grabbing was supposed to apply a -8 dodge penalty to the user (-5 for monsters, who have fewer sources of dodge bonus and cap out at 10) and prevent the victim from dodging at all, however this was found to be not working! The penalty seemed to apply to monsters, but not characters due to DODGE_CHANCE getting enchantified - the dodge_mod json object in effects.json was simply not affecting players.

#### Describe the solution
- Move dodge_mod for grab stuff to a DODGE_CHANCE enchantment. Hardcode (for now) the dodge penalty for grabbing or being grabbed to monsters, as they don't care about that enchantment.

#### Describe alternatives you've considered
DODGE_CHANCE could be made to work for monsters pretty easily, then that could be jsonized. Monsters with multigrab are currently sitting at -5 even with two grabs going. That seeeems fine?

#### Testing
- Did the shoebody bop to a couple of flesh raptors. Saw my dodge drop by 8.
- Got grabbed by a monster and saw my dodge go to 0.

#### Additional context
This might make grabs a lot deadlier for the player, we should keep an eye on this. Let me know if it's a problem, but for now we're just going to make it work like it was always intended.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
