### PR TITLE
Proper plural for bunnies

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1683,7 +1683,7 @@
   {
     "id": "mon_rabbit_baby",
     "type": "MONSTER",
-    "name": { "str": "wild bunny" },
+    "name": { "str": "wild bunny", "str_pl": "wild bunnies" },
     "copy-from": "mon_rabbit",
     "description": "A baby rabbit with a cute wiggling nose and long ears.  It is extremely skittish.",
     "volume": "150 ml",
@@ -1709,7 +1709,7 @@
   {
     "id": "mon_rabbit_domestic_baby",
     "type": "MONSTER",
-    "name": { "str": "bunny" },
+    "name": { "str": "bunny", "str_pl": "bunnies" },
     "description": "A baby rabbit with a cute wiggling nose and long ears.  This one is of the domesticated variety, commonly kept as a pet, a research subject, or a source of food.",
     "copy-from": "mon_rabbit_baby",
     "upgrades": { "age_grow": 45, "into": "mon_rabbit_domestic" },


### PR DESCRIPTION
Changes to be committed:
	modified:   data/json/monsters/mammal.json

#### Summary
Wild and domestic bunnies were called "bunnys". Fixed this.

#### Purpose of change
Grammar

#### Describe the solution

#### Describe alternatives you've considered
None

#### Testing
Created a new world. Spawned some wild and domestic bunnies. They were properly called "wild bunnies" and "bunnies".
#### Additional context
Noticed when my tame rabbit had babies that "bunnys" stabbed me in the eye.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
