### PR TITLE
Update game.cpp

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1477,8 +1477,8 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
                             : input_context::allow_all_keys;
 
     while (true) {
-        const std::string& action = query_popup()
-            .preferred_keyboard_mode(keyboard_mode::keycode)
+        query_popup qp;
+        qp.preferred_keyboard_mode(keyboard_mode::keycode)
             .context("CANCEL_ACTIVITY_OR_IGNORE_QUERY")
             .message(force_uc && !is_keycode_mode_supported() ?
                 pgettext("cancel_activity_or_ignore_query",
@@ -1489,10 +1489,14 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
             .option("YES", allow_key)
             .option("NO", allow_key)
             .option("MANAGER", allow_key)
-            .option("IGNORE", allow_key)
-            .option("VIEW", allow_key)
-            .query()
-            .action;
+            .option("IGNORE", allow_key);
+
+        // Only show VIEW if the distraction is from a hostile enemy
+        if (type == distraction_type::hostile_spotted_near || type == distraction_type::hostile_spotted_far) {
+            qp.option("VIEW", allow_key);
+        }
+
+        const std::string& action = qp.query().action;
 
         if (action == "YES") {
             u.cancel_activity();


### PR DESCRIPTION


#### Summary
Now the activity distraction popup shows button "VIEW" when an enemy triggers the distraction.

#### Purpose of change
The "VIEW" button was visible when any distraction happened.

#### Describe the solution
Only show the said button when hostiles are dangerously close to you or simply spotted.

#### Testing
Might need some additional testing.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
