### PR TITLE
Double Z for aim and attack

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10567,7 +10567,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
                 }
             }
         }
-        bool in_range = std::round( rl_dist_exact( pos(), critter.pos() ) ) <= range;
+        bool in_range = ( is_adjacent( &critter, true ) || std::round( trig_dist_z_adjust( pos(), critter.pos() ) < range ) );
         // TODO: get rid of fake npcs (pos() check)
         bool valid_target = this != &critter && pos() != critter.pos() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -884,6 +884,11 @@ bool Creature::is_adjacent( const Creature *target, const bool allow_z_levels ) 
         return false;
     }
 
+    // Diagonally offset targets are not adjacent.
+    if( pos().z != target->pos().z && pos().xy() != target->pos().xy() ) {
+        return false;
+    }
+
     map &here = get_map();
     if( posz() == target->posz() ) {
         return

--- a/src/line.h
+++ b/src/line.h
@@ -165,6 +165,18 @@ inline float trig_dist( const point &loc1, const point &loc2 )
     return trig_dist( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
 }
 
+inline float trig_dist_z_adjust( const tripoint &loc1, const tripoint &loc2 )
+{
+    return std::sqrt( static_cast<double>( ( loc1.x - loc2.x ) * ( loc1.x - loc2.x ) ) +
+                      ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
+                      ( ( 2 * ( loc1.z - loc2.z ) ) * ( 2 * ( loc1.z - loc2.z ) ) ) );
+}
+inline float trig_dist_z_adjust( const point &loc1, const point &loc2 )
+{
+    return trig_dist_z_adjust( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
+}
+
+
 // Roguelike distance; maximum of dX and dY
 inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
 {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -472,10 +472,6 @@ void Character::roll_all_damage( bool crit, damage_instance &di, bool average,
 static void melee_train( Character &you, int lo, int hi, const item &weap,
                          const attack_vector_id vector, bool reach_attacking )
 {
-    // 1/2 learning rate for reach attacks.
-    if( reach_attacking && one_in( 2 ) ) {
-        return;
-    }
     // Don't train melee if we're not in melee.
     if( !reach_attacking ) {
         you.practice( skill_melee, std::ceil( rng( lo, hi ) / 2.0 ), hi );
@@ -501,11 +497,11 @@ static void melee_train( Character &you, int lo, int hi, const item &weap,
     total = std::max( total, 1.f );
 
     // Unarmed may deal cut, stab, and bash damage depending on the weapon
-    if( !vector->weapon ) {
+    if( !vector->weapon && !reach_attacking ) {
         you.practice( skill_unarmed, std::ceil( 1 * rng( lo, hi ) ), hi );
     } else {
         for( const std::pair<const damage_type_id, int> &dmg : dmg_vals ) {
-            if( !dmg.first->skill.is_null() ) {
+            if( !dmg.first->skill.is_null() && !reach_attacking ) {
                 you.practice( dmg.first->skill, std::ceil( dmg.second / total * rng( lo, hi ) ), hi );
             }
         }
@@ -806,17 +802,13 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         damage_instance d;
         roll_all_damage( critical_hit, d, false, cur_weap, vector_id, contact_area, &t, target_bp );
 
-        // polearms and pikes (but not spears) do less damage to adjacent targets
-        // In the case of a weapon like a glaive or a naginata, the wielder
-        // lacks the room to build up momentum on a slash.
-        // In the case of a pike, the mass of the pole behind the wielder
-        // should they choose to employ it up close will unbalance them.
+        // Most reach weapons are less effective in melee.
         if( cur_weap.reach_range( *this ) > 1 && !reach_attacking &&
             cur_weap.has_flag( flag_POLEARM ) ) {
             d.mult_damage( 0.7 );
         }
-        // being prone affects how much leverage you can use to deal damage
-        // quadrupeds don't mind as much, tentacles and goo-limbs even less
+        // Being prone affects how much leverage you can use to deal damage.
+        // Quadrupeds don't mind as much, tentacles and goo-limbs even less.
         if( is_on_ground() )  {
             if( has_flag( json_flag_PSEUDOPOD_GRASP ) ) {
                 d.mult_damage( 0.8 );
@@ -1045,6 +1037,7 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
     Creature *critter = creatures.creature_at( p );
     // Original target size, used when there are monsters in front of our target
     const int target_size = critter != nullptr ? static_cast<int>( critter->get_size() ) : 2;
+
     // Reset last target pos
     last_target_pos = std::nullopt;
     // Max out recoil

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -250,7 +250,7 @@ static bool within_visual_range( monster *z, int max_range )
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
     return target != nullptr &&
-           rl_dist( z->pos(), target->pos() ) <= range &&
+           trig_dist_z_adjust( z->pos(), target->pos() ) <= range &&
            z->sees( *target );
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1346,8 +1346,7 @@ int Character::throwing_dispersion( const item &to_throw, Creature *critter,
     ///\EFFECT_PER decreases throwing accuracy penalty from eye encumbrance
     dispersion += std::max( 0, ( encumb( bodypart_id( "eyes" ) ) - get_per() ) * 10 );
 
-    // If throwing blind, we're assuming they mechanically can't achieve the
-    // accuracy of a normal throw.
+    // Blind throws are less accurate
     if( is_blind_throw ) {
         dispersion *= 4;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -549,10 +549,12 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
         tripoint pos = veh.global_part_pos3( *t );
 
         int res = 0;
-        res = std::max( res, rl_dist( you.pos(), pos + point( range, 0 ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( -range, 0 ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( 0, range ) ) );
-        res = std::max( res, rl_dist( you.pos(), pos + point( 0, -range ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos + point( range, 0 ) ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos + point( -range,
+                                               0 ) ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos + point( 0, range ) ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos + point( 0,
+                                               -range ) ) ) );
         range_total = std::max( range_total, res );
     }
 
@@ -1270,7 +1272,7 @@ double calculate_aim_cap( const Character &you, const tripoint &target )
     // No p.sees_with_specials() here because special senses are not precise enough
     // to give creature's exact size & position, only which tile it occupies
     if( victim == nullptr || ( !you.sees( *victim ) && !you.sees_with_infrared( *victim ) ) ) {
-        const int range = rl_dist( you.pos(), target );
+        const int range = trig_dist_z_adjust( you.pos(), target );
         // Get angle of triangle that spans the target square.
         const double angle = 2 * atan2( 0.5, range );
         // Convert from radians to arcmin.
@@ -1335,8 +1337,9 @@ int Character::throwing_dispersion( const item &to_throw, Creature *critter,
     if( critter != nullptr ) {
         // It's easier to dodge at close range (thrower needs to adjust more)
         // Dodge x10 at point blank, x5 at 1 dist, then flat
-        float effective_dodge = critter->get_dodge() * std::max( 1, 10 - 5 * rl_dist( pos(),
-                                critter->pos() ) );
+        float effective_dodge = critter->get_dodge() * std::max( 1,
+                                10 - 5 * static_cast<int>( trig_dist_z_adjust( pos(),
+                                        critter->pos() ) ) );
         dispersion += throw_dispersion_per_dodge( true ) * effective_dodge;
     }
     // 1 perception per 1 eye encumbrance
@@ -1544,7 +1547,7 @@ dealt_projectile_attack Character::throw_item( const tripoint &target, const ite
     // throw from the the blind throw position instead.
     const tripoint throw_from = blind_throw_from_pos ? *blind_throw_from_pos : pos();
 
-    float range = rl_dist( throw_from, target );
+    float range = trig_dist_z_adjust( throw_from, target );
     proj.range = range;
     float skill_lvl = get_skill_level( skill_throw );
     // Avoid awarding tons of xp for lucky throws against hard to hit targets
@@ -1736,7 +1739,7 @@ Target_attributes::Target_attributes( tripoint src, tripoint target )
 {
     Creature *target_critter = get_creature_tracker().creature_at( target );
     Creature *shooter = get_creature_tracker().creature_at( src );
-    range = rl_dist( src, target );
+    range = trig_dist_z_adjust( src, target );
     size = target_critter != nullptr ?
            target_critter->ranged_target_size() :
            get_map().ranged_target_size( target );
@@ -2116,7 +2119,7 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
     }
 
     const dispersion_sources dispersion( you.throwing_dispersion( weapon, target, is_blind_throw ) );
-    const double range = rl_dist( you.pos(), target_pos );
+    const double range = trig_dist_z_adjust( you.pos(), target_pos );
 
     const double target_size = target != nullptr ? target->ranged_target_size() : 1.0f;
 
@@ -2158,7 +2161,7 @@ static void draw_throwcreature_aim( const target_ui &ui, const Character &you,
     item weapon = null_item_reference();
 
     const dispersion_sources dispersion( you.throwing_dispersion( weapon, target, false ) );
-    const double range = rl_dist( you.pos(), target_pos );
+    const double range = trig_dist_z_adjust( you.pos(), target_pos );
 
     const double target_size = target != nullptr ? target->ranged_target_size() : 1.0f;
 
@@ -3097,21 +3100,26 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
             if( square_dist( src, valid_pos ) > 1 ) {
                 valid_pos = new_traj[0];
             }
-        } else if( trigdist ) {
             if( dist_fn( valid_pos ) > range ) {
-                // Find the farthest point that is still in range
+                auto dist_fn_unrounded = [this]( const tripoint & p ) {
+                    return trig_dist_z_adjust( src, p );
+                };
+
+                bool found = false;
                 for( size_t i = new_traj.size(); i > 0; i-- ) {
-                    if( dist_fn( new_traj[i - 1] ) <= range ) {
-                        valid_pos = new_traj[i - 1];
+                    const tripoint &test_pt = new_traj[i - 1];
+                    double raw_dist = dist_fn_unrounded( test_pt );
+                    if( std::ceil( raw_dist ) <= range || raw_dist <= range + 0.001 ) {
+                        valid_pos = test_pt;
+                        found = true;
                         break;
                     }
                 }
-
                 // FIXME: due to a bug in map::find_clear_path (DDA #39693),
                 //        returned trajectory is invalid in some cases.
                 //        This bandaid stops us from exceeding range,
                 //        but does not fix the issue.
-                if( dist_fn( valid_pos ) > range ) {
+                if( !found ) {
                     debugmsg( "Exceeded allowed range!" );
                     valid_pos = src;
                 }
@@ -3222,7 +3230,7 @@ void target_ui::update_target_list()
     // Get targets in range and sort them by distance (targets[0] is the closest)
     targets = you->get_targetable_creatures( range, mode == TargetMode::Reach );
     std::sort( targets.begin(), targets.end(), [&]( const Creature * lhs, const Creature * rhs ) {
-        return rl_dist_exact( lhs->pos(), you->pos() ) < rl_dist_exact( rhs->pos(), you->pos() );
+        return trig_dist_z_adjust( lhs->pos(), you->pos() ) < trig_dist_z_adjust( rhs->pos(), you->pos() );
     } );
 }
 
@@ -3316,14 +3324,13 @@ int target_ui::dist_fn( const tripoint &p )
 {
     int z_adjust = 0;
     if( casting && casting->effect() == "dash" ) {
-        if( casting->has_flag( spell_flag::AIRBORNE ) ) {
-            z_adjust = 2 * std::abs( src.z - p.z );
-        } else {
+        if( !casting->has_flag( spell_flag::AIRBORNE ) ) {
             // Arbitrarily high number to prevent ascending or descending.
             z_adjust = 100 * std::abs( src.z - p.z );
         }
     }
-    return static_cast<int>( z_adjust + std::round( rl_dist_exact( src, p ) ) );
+    // Always round up so that the Z adjustment actually matters.
+    return static_cast<int>( z_adjust + std::ceil( trig_dist_z_adjust( src, p ) ) );
 }
 
 void target_ui::set_last_target()


### PR DESCRIPTION
#### Summary
Double Z for aim and attack

#### Purpose of change
Tiles are not cubes, they're rectangular prisms - a Z level is roughly twice as a tile is wide or long. As such, ranged attacks should consider Z levels 2 steps, not one. 

#### Describe the solution
- Adds a new function, trig_dist_z_adjust, that multiplies Z distances by 2. Apply this function to all targeting, aiming, and in-range checks. This makes it harder to shoot up or down and makes diagonal attacks across Z levels impossible without something like a pike.
- Gives monster special attacks the same treatment.
- Removes the ability to learn anything from reach attacks entirely, as apparently heavily nerfing it was not enough to dissuade people from abusing it.
- Adjusts is_adjacent() to reject vertical diagonals.
- You can still attack enemies below you on stairs, that's fine.

#### Describe alternatives you've considered
- Z level sight range needs to work the same way.
- Aiming needs to uncover the Z levels above the player - for some reason they don't get shown unless you use x to look up there first.
- Reach attacks also need to make you fall, drop your weapon, etc if you're up above.

#### Testing
Aiming and shooting etc seem to work fine.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
