### PR TITLE
Fix reach attacks some more

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10567,7 +10567,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
                 }
             }
         }
-        bool in_range = ( is_adjacent( &critter, true ) || std::round( trig_dist_z_adjust( pos(), critter.pos() ) < range ) );
+        bool in_range = ( is_adjacent( &critter, true ) ) || ( ( pos().z == critter.pos().z ) && ( std::round( trig_dist_z_adjust( pos(), critter.pos() ) ) <= range ) ) || ( std::ceil( trig_dist_z_adjust( pos(), critter.pos() ) ) <= range );
         // TODO: get rid of fake npcs (pos() check)
         bool valid_target = this != &critter && pos() != critter.pos() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1476,30 +1476,31 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
     const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
     const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
                             : input_context::allow_all_keys;
-  
-    while (true) {
+
+    while( true ) {
         query_popup qp;
-        qp.preferred_keyboard_mode(keyboard_mode::keycode)
-            .context("CANCEL_ACTIVITY_OR_IGNORE_QUERY")
-            .message(force_uc && !is_keycode_mode_supported() ?
-                pgettext("cancel_activity_or_ignore_query",
-                    "<color_light_red>%s %s (Case Sensitive)</color>") :
-                pgettext("cancel_activity_or_ignore_query",
-                    "<color_light_red>%s %s</color>"),
-                text, u.activity.get_stop_phrase())
-            .option("YES", allow_key)
-            .option("NO", allow_key)
-            .option("MANAGER", allow_key)
-            .option("IGNORE", allow_key);
+        qp.preferred_keyboard_mode( keyboard_mode::keycode )
+        .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
+        .message( force_uc && !is_keycode_mode_supported() ?
+                  pgettext( "cancel_activity_or_ignore_query",
+                            "<color_light_red>%s %s (Case Sensitive)</color>" ) :
+                  pgettext( "cancel_activity_or_ignore_query",
+                            "<color_light_red>%s %s</color>" ),
+                  text, u.activity.get_stop_phrase() )
+        .option( "YES", allow_key )
+        .option( "NO", allow_key )
+        .option( "MANAGER", allow_key )
+        .option( "IGNORE", allow_key );
 
         // Only show VIEW if the distraction is from a hostile enemy
-        if (type == distraction_type::hostile_spotted_near || type == distraction_type::hostile_spotted_far) {
-            qp.option("VIEW", allow_key);
+        if( type == distraction_type::hostile_spotted_near ||
+            type == distraction_type::hostile_spotted_far ) {
+            qp.option( "VIEW", allow_key );
         }
 
-        const std::string& action = qp.query().action;
+        const std::string &action = qp.query().action;
 
-        if (action == "YES") {
+        if( action == "YES" ) {
             u.cancel_activity();
             return true;
         }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -963,10 +963,12 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                                enchant_vals::mod::MELEE_STAMINA_CONSUMPTION,
                                get_total_melee_stamina_cost() );
 
-    // Train weapon proficiencies
-    for( const weapon_category_id &cat : wielded_weapon_categories( *this ) ) {
-        for( const proficiency_id &prof : cat->category_proficiencies() ) {
-            practice_proficiency( prof, 1_seconds );
+    // Train weapon proficiencies unless reach attacking
+    if( !reach_attacking ) {
+        for( const weapon_category_id &cat : wielded_weapon_categories( *this ) ) {
+            for( const proficiency_id &prof : cat->category_proficiencies() ) {
+                practice_proficiency( prof, 1_seconds );
+            }
         }
     }
 

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -242,7 +242,13 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
         debugmsg( "ERROR: npc tried to attack null critter" );
         return;
     }
-    int target_distance = rl_dist( source.pos(), location );
+    // TODO: Move this to line.h
+    int target_distance = static_cast<int>( std::round( trig_dist_z_adjust( source.pos(),
+                                            location ) ) );
+    if( source.pos().z != location.z ) {
+        // Always round up so that the Z adjustment actually matters.
+        target_distance = static_cast<int>( std::ceil( trig_dist_z_adjust( source.pos(), location ) ) );
+    }
     if( !source.is_adjacent( critter, true ) ) {
         if( target_distance <= weapon.reach_range( source ) ) {
             add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a reach attack",

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3328,8 +3328,12 @@ int target_ui::dist_fn( const tripoint &p )
             z_adjust = 100 * std::abs( src.z - p.z );
         }
     }
-    // Always round up so that the Z adjustment actually matters.
-    return static_cast<int>( z_adjust + std::ceil( trig_dist_z_adjust( src, p ) ) );
+    if( src.z == p.z ) {
+        return static_cast<int>( z_adjust + std::round( trig_dist_z_adjust( src, p ) ) );
+    } else {
+        // Always round up so that the Z adjustment actually matters.
+        return static_cast<int>( z_adjust + std::ceil( trig_dist_z_adjust( src, p ) ) );
+    }
 }
 
 void target_ui::set_last_target()


### PR DESCRIPTION
#### Summary
Fix reach attacks some more

#### Purpose of change
When I fixed different z-level reach attacks, I didn't realize that I'd inadvertantly broken kitty corner attacks on the same Z level.

#### Describe the solution
- Check the Z level of both the attacker and target and use std::round() when the levels are the same and std::ceil() when they are different. This ensures that Z-level attacks always round up while same-Z attacks do not.
- Ensure that this is implemented for NPCs and monsters as well, and that it works both with the (f)ire command and the tab key (autoattack).
- Disable proficiency learning during reach attacks.

#### Describe alternatives you've considered
- The option to disable circular distances needs to be removed as even prior to this change it wasn't really doing its job anymore, and there's no reason it should be there.
- I need to move the round/ceil thing to a single function so I don't have to repeat it in 3 places, but also *yawn*

#### Testing
Used a spear and a pike, let a grappler pull me off a roof, watched an NPC stab a guy kitty corner with a pike.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
