### PR TITLE
Reduce farm plants and drive-in cars

### DIFF
--- a/data/json/mapgen/drive-in_theater.json
+++ b/data/json/mapgen/drive-in_theater.json
@@ -156,17 +156,17 @@
       ],
       "palettes": [ { "distribution": [ [ "car_theater_full", 1 ], [ "car_theater", 1 ] ] } ],
       "place_vehicles": [
-        { "vehicle": "parking_garage", "chance": 20, "x": 105, "y": 39, "rotation": 0 },
-        { "vehicle": "parking_garage", "chance": 20, "x": 105, "y": 51, "rotation": 0 }
+        { "vehicle": "parking_garage", "chance": 10, "x": 105, "y": 39, "rotation": 0 },
+        { "vehicle": "parking_garage", "chance": 10, "x": 105, "y": 51, "rotation": 0 }
       ],
       "items": {
         "a": { "item": "trash", "chance": 60, "repeat": [ 1, 3 ] },
         "&": { "item": "trash", "chance": 60, "repeat": [ 1, 3 ] },
         "O": { "item": "SUS_oven", "chance": 100 },
-        "M": { "item": "fridgesnacks", "chance": 75, "repeat": [ 5, 10 ] },
-        "m": { "item": "groce_softdrink", "chance": 75, "repeat": [ 5, 10 ] },
-        "x": { "item": "groce_softdrink", "chance": 80, "repeat": [ 10, 15 ] },
-        "X": { "item": "salty_snacks", "chance": 80, "repeat": [ 10, 15 ] }
+        "M": { "item": "fridgesnacks", "chance": 55, "repeat": [ 0, 5 ] },
+        "m": { "item": "groce_softdrink", "chance": 55, "repeat": [ 0, 5 ] },
+        "x": { "item": "groce_softdrink", "chance": 60, "repeat": [ 0, 8 ] },
+        "X": { "item": "salty_snacks", "chance": 60, "repeat": [ 0, 15 ] }
       },
       "place_loot": [ { "group": "cash_register_random", "x": 85, "y": 50 }, { "item": "microwave", "x": 85, "y": 47 } ]
     }
@@ -314,8 +314,8 @@
     "type": "palette",
     "id": "car_theater_full",
     "palettes": [ "car_theater", "commercial" ],
-    "vehicles": { "1": { "vehicle": "cars_only", "chance": 80, "rotation": 270 } },
-    "monster": { "_": { "group": "GROUP_MALL", "chance": 1 } }
+    "vehicles": { "1": { "vehicle": "cars_only", "chance": 10, "rotation": 270 } },
+    "monster": { "_": { "group": "GROUP_MALL", "chance": 3 } }
   },
   {
     "type": "palette",

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -90,8 +90,8 @@
         { "item": "straw_pile", "x": [ 19, 19 ], "y": [ 10, 15 ], "amount": [ 2, 7 ] },
         { "item": "cattlefodder", "x": [ 19, 19 ], "y": [ 10, 15 ], "amount": [ 2, 7 ] }
       ],
-      "place_monster": [ { "group": "GROUP_DOMESTIC", "x": [ 10, 12 ], "y": [ 15, 17 ], "repeat": [ 1, 10 ] } ],
-      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 } }
+      "place_monster": [ { "group": "GROUP_DOMESTIC", "x": [ 10, 12 ], "y": [ 15, 17 ], "repeat": [ 1, 5 ] }, { "group": "GROUP_FARM_PESTS", "x": [ 4, 22 ], "y": [ 29, 39 ], "repeat": [ 1, 2 ] } ],
+      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 2 } }
     }
   },
   {
@@ -285,7 +285,7 @@
         "_": [ { "item": "straw_pile", "chance": 3 }, { "item": "cattlefodder", "chance": 2 } ],
         "f": { "item": "cattlefodder", "chance": 40, "repeat": 10 }
       },
-      "sealed_item": { "D": { "item": { "item": "seed_oats" }, "furniture": "f_plant_seedling", "chance": 20 } },
+      "sealed_item": { "D": { "item": { "item": "seed_oats" }, "furniture": "f_plant_seedling", "chance": 10 } },
       "palettes": [ "farm" ]
     }
   },
@@ -432,7 +432,7 @@
         " F                    F "
       ],
       "monster": { "7": { "monster": "mon_chicken" }, "8": { "monster": "mon_chicken_chick" } },
-      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 } },
+      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 6 } },
       "place_item": [
         { "item": "straw_pile", "x": 12, "y": 3, "chance": 75 },
         { "item": "straw_pile", "x": 14, "y": 3, "chance": 75 },
@@ -444,7 +444,7 @@
         { "item": "straw_pile", "x": 16, "y": 7, "chance": 75 },
         { "item": "straw_pile", "x": 18, "y": 7, "chance": 75 },
         { "item": "straw_pile", "x": 20, "y": 7, "chance": 75 },
-        { "item": "birdfood", "x": [ 3, 7 ], "y": [ 5, 11 ], "chance": 75, "repeat": [ 4, 7 ] },
+        { "item": "birdfood", "x": [ 3, 7 ], "y": [ 5, 11 ], "chance": 75, "repeat": [ 1, 4 ] },
         { "item": "straw_pile", "x": 20, "y": 7, "chance": 75 }
       ],
       "palettes": [ "farm" ]
@@ -533,15 +533,15 @@
         "%": "t_dirtfloor"
       },
       "sealed_item": {
-        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 20 },
-        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_planter_seedling", "chance": 20 },
-        "%": { "item": { "item": "seed_oats" }, "furniture": "f_planter_seedling", "chance": 20 }
+        "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 10 },
+        "♥": { "item": { "item": "seed_tomato" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "♠": { "item": { "item": "seed_lettuce" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "♦": { "item": { "item": "seed_cucumber" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "♣": { "item": { "item": "seed_carrot" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "Ʌ": { "item": { "item": "seed_zucchini" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "Δ": { "item": { "item": "seed_celery" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "‡": { "item": { "item": "seed_pumpkin" }, "furniture": "f_planter_seedling", "chance": 10 },
+        "%": { "item": { "item": "seed_oats" }, "furniture": "f_planter_seedling", "chance": 10 }
       },
       "palettes": [ "farm" ]
     }
@@ -625,7 +625,7 @@
         "r": { "item": "honey_market_stall", "repeat": [ 4, 12 ] }
       },
       "furniture": { "♥": "f_machinery_light", "♠": "f_locker", "♦": "f_woodchips" },
-      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 70 } },
+      "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 10 } },
       "palettes": [ "farm" ],
       "place_monster": [
         { "group": "GROUP_BEEKEEPER", "x": [ 6, 21 ], "y": [ 3, 10 ], "pack_size": 1, "chance": 10 },

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -90,7 +90,10 @@
         { "item": "straw_pile", "x": [ 19, 19 ], "y": [ 10, 15 ], "amount": [ 2, 7 ] },
         { "item": "cattlefodder", "x": [ 19, 19 ], "y": [ 10, 15 ], "amount": [ 2, 7 ] }
       ],
-      "place_monster": [ { "group": "GROUP_DOMESTIC", "x": [ 10, 12 ], "y": [ 15, 17 ], "repeat": [ 1, 5 ] }, { "group": "GROUP_FARM_PESTS", "x": [ 4, 22 ], "y": [ 29, 39 ], "repeat": [ 1, 2 ] } ],
+      "place_monster": [
+        { "group": "GROUP_DOMESTIC", "x": [ 10, 12 ], "y": [ 15, 17 ], "repeat": [ 1, 5 ] },
+        { "group": "GROUP_FARM_PESTS", "x": [ 4, 22 ], "y": [ 29, 39 ], "repeat": [ 1, 2 ] }
+      ],
       "sealed_item": { "D": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 2 } }
     }
   },

--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -34,16 +34,16 @@
       ],
       "palettes": [ "farm_dairy_palette" ],
       "place_monsters": [
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 12 ], "y": [ 1, 12 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 11 ], "y": [ 1, 10 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 9 ], "y": [ 1, 11 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 15 ], "y": [ 1, 14 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 34 ], "y": [ 1, 9 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 36 ], "y": [ 1, 12 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 35 ], "y": [ 1, 10 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 33 ], "y": [ 1, 11 ], "density": 0.5 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 39 ], "y": [ 1, 12 ], "density": 0.5 }
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 12 ], "y": [ 1, 12 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 11 ], "y": [ 1, 10 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 9 ], "y": [ 1, 11 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 15 ], "y": [ 1, 14 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 34 ], "y": [ 1, 9 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 36 ], "y": [ 1, 12 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 35 ], "y": [ 1, 10 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 33 ], "y": [ 1, 11 ], "density": 0.3 },
+        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 39 ], "y": [ 1, 12 ], "density": 0.3 }
       ]
     }
   },
@@ -81,7 +81,7 @@
         ",$............................................$,"
       ],
       "palettes": [ "farm_dairy_palette" ],
-      "monsters": { ".": { "monster": "GROUP_ZOMBIE_BOVINE", "chance": 1, "density": 0.0005 } }
+      "monsters": { ".": { "monster": "GROUP_ZOMBIE_BOVINE", "chance": 2, "density": 0.0005 } }
     }
   },
   {

--- a/data/json/mapgen/farm_dairy_2.json
+++ b/data/json/mapgen/farm_dairy_2.json
@@ -83,7 +83,7 @@
         "                                                @    ,,,  ,,, d                                 ",
         "                                                     ,,,  ,,,   @                               "
       ],
-      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 20 } },
+      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 5 } },
       "terrain": {
         "│": "t_hole",
         " ": [ [ "t_region_groundcover", 99 ], [ "t_region_shrub", 1 ] ],

--- a/data/json/mapgen/farm_horse.json
+++ b/data/json/mapgen/farm_horse.json
@@ -145,7 +145,7 @@
         "........................"
       ],
       "palettes": [ "farm_horse" ],
-      "sealed_item": { "Q": { "item": { "item": "seed_rose" }, "furniture": "f_planter_mature" } },
+      "sealed_item": { "Q": { "item": { "item": "seed_rose" }, "furniture": "f_planter_mature" }, "chance": 80 },
       "place_loot": [ { "group": "farming_seeds", "x": [ 13, 21 ], "y": [ 17, 21 ], "chance": 80, "repeat": [ 2, 4 ] } ],
       "place_nested": [ { "chunks": [ [ "null", 50 ], [ "shed_5x5_garden_E", 50 ] ], "x": 11, "y": [ 6, 9 ] } ]
     }

--- a/data/json/mapgen/farm_stills.json
+++ b/data/json/mapgen/farm_stills.json
@@ -143,7 +143,7 @@
         { "group": "GROUP_FARM_PESTS", "x": [ 75, 79 ], "y": [ 30, 35 ], "repeat": [ 1, 3 ] },
         { "group": "GROUP_FARM_PESTS", "x": [ 9, 12 ], "y": [ 66, 68 ], "repeat": [ 1, 2 ] }
       ],
-      "sealed_item": { "$": { "item": { "item": "seed_grapes" }, "furniture": "f_plant_seedling", "chance": 15 } }
+      "sealed_item": { "$": { "item": { "item": "seed_grapes" }, "furniture": "f_plant_seedling", "chance": 8 } }
     }
   },
   {

--- a/data/json/mapgen_palettes/farm_lots.json
+++ b/data/json/mapgen_palettes/farm_lots.json
@@ -6,7 +6,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "rows": [ "#" ],
-      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 15 } }
+      "sealed_item": { "#": { "item": { "item": "seed_corn" }, "furniture": "f_plant_seedling", "chance": 5 } }
     }
   },
   {
@@ -16,7 +16,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "rows": [ "#" ],
-      "sealed_item": { "#": { "item": { "item": "seed_wheat" }, "furniture": "f_plant_seedling", "chance": 15 } }
+      "sealed_item": { "#": { "item": { "item": "seed_wheat" }, "furniture": "f_plant_seedling", "chance": 5 } }
     }
   },
   {


### PR DESCRIPTION
#### Summary
Reduce farm plants and drive-in cars

#### Purpose of change
- Drive-ins could be empty or full. When full, they were completely stocked with like 30 near-pristine cars. This cuts that WAY down so you're lucky to get a couple.

- Traveling cross-country recently, I realized that a lot of farm fields still haven't been planted, and it's currently May. IRL, most American farms do their planting in June to maximize growth in the warmest part of the year. The game canonically starts in April, so there shouldn't be ANYTHING planted. Still, I think it'd be weird to have farms in the game with no crops ever, so I simply reduced the seeds some more. Maybe some early planting got done, or what's growing now are from seeds left in the fields last fall.

#### Describe the solution
- Reduce drive-in cars by a lot
- Cut farm plants by about half
- Reduced dairy cows, made zows a bit more likely

#### Describe alternatives you've considered
- A version of the drive-in that got used as an impromptu evac shelter where people were camping in their cars?

#### Testing
- Loads and runs, maps look fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
