### PR TITLE
Hobby and Profession cleanup

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -32,16 +32,16 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "high_school_graduate",
-    "name": "High School Graduate",
-    "description": "You've graduated from high school and thus know a little bit about applied science and electronics.",
+    "id": "basic_education",
+    "name": "Basic Education",
+    "description": "You have received the equivalent of a K-12 education and know the basics of science and computer literacy.",
     "points": 0,
-    "skills": [ { "level": 1, "name": "chemistry" }, { "level": 1, "name": "electronics" } ]
+    "skills": [ { "level": 1, "name": "chemistry" }, { "level": 1, "name": "electronics" }, { "level": 1, "name": "computer" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "mundane_survival",
+    "id": "everyday_skills",
     "name": "Everyday Skills",
     "description": "You've managed to survive modern life in a first world country.  Through your ordeals you've learned how to treat scrapes and bruises, and how to assemble basic furniture.",
     "points": 0,
@@ -253,13 +253,8 @@
     "name": "Metalworking",
     "description": "You know quite a bit about crafting things with metal, whether hot or cold.",
     "points": 5,
-    "proficiencies": [
-      "prof_metalworking",
-      "prof_welding_basic"
-    ],
-    "skills": [
-      { "level": 5, "name": "fabrication" }
-    ]
+    "proficiencies": [ "prof_metalworking", "prof_welding_basic" ],
+    "skills": [ { "level": 5, "name": "fabrication" } ]
   },
   {
     "type": "profession",
@@ -268,12 +263,7 @@
     "name": "Baking",
     "description": "Hours in the kitchen have taught you the ins and outs of making bread and pastries.",
     "points": 2,
-    "proficiencies": [
-      "prof_baking",
-      "prof_baking_bread",
-      "prof_baking_desserts_1",
-      "prof_food_prep"
-    ],
+    "proficiencies": [ "prof_baking", "prof_baking_bread", "prof_baking_desserts_1", "prof_food_prep" ],
     "skills": [ { "level": 3, "name": "cooking" }, { "level": 1, "name": "chemistry" } ]
   },
   {
@@ -286,7 +276,7 @@
     "proficiencies": [ "prof_food_prep", "prof_cheesemaking_1", "prof_cheesemaking_2" ],
     "skills": [ { "level": 3, "name": "cooking" } ]
   },
-    {
+  {
     "type": "profession",
     "id": "homebrewer",
     "subtype": "hobby",
@@ -365,7 +355,7 @@
     "skills": [ { "level": 2, "name": "firstaid" } ],
     "proficiencies": [ "prof_field_medic" ]
   },
-    {
+  {
     "type": "profession",
     "subtype": "hobby",
     "id": "martial_training",
@@ -383,11 +373,7 @@
     "name": "Melee Style",
     "description": "Whether for school, ren faires, or fitness, you've learned how to handle some kind of medieval weapon.  You start with a weapon-based martial arts style of your choosing.",
     "points": 5,
-    "skills": [
-      { "level": 2, "name": "melee" },
-      { "level": 1, "name": "cutting" },
-      { "level": 1, "name": "stabbing" }
-    ],
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 1, "name": "cutting" }, { "level": 1, "name": "stabbing" } ],
     "traits": [ "MARTIAL_ARTS_MELEE" ]
   },
   {
@@ -398,6 +384,12 @@
     "description": "You figured you could save money on ammo by learning to make your own.  Now that the factories are shut down, your abilities just went from handy to lifesaving.",
     "points": 3,
     "proficiencies": [ "prof_handloading", "prof_gun_cleaning" ],
-    "skills": [ { "level": 3, "name": "fabrication" }, { "level": 2, "name": "gun" }, { "level": 1, "name": "pistols" }, { "level": 1, "name": "rifles" }, { "level": 1, "name": "shotguns" } ]
+    "skills": [
+      { "level": 3, "name": "fabrication" },
+      { "level": 2, "name": "gun" },
+      { "level": 1, "name": "pistol" },
+      { "level": 1, "name": "rifle" },
+      { "level": 1, "name": "shotgun" }
+    ]
   }
 ]

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -32,24 +32,6 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "computer_literate",
-    "name": "Computer Literate",
-    "description": "Either through school, your job, or from your family, you've learned the basics of how to use a computer.",
-    "points": 0,
-    "skills": [ { "level": 1, "name": "computer" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "social_skills",
-    "name": "Social Skills",
-    "description": "You've spent a significant portion of your life living among other people and are familiar with social norms.  You know how to talk with other people, and how to convey your emotions and understand those of others.",
-    "points": 0,
-    "skills": [ { "level": 1, "name": "speech" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
     "id": "high_school_graduate",
     "name": "High School Graduate",
     "description": "You've graduated from high school and thus know a little bit about applied science and electronics.",
@@ -60,7 +42,7 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "mundane_survival",
-    "name": "Mundane Survival",
+    "name": "Everyday Skills",
     "description": "You've managed to survive modern life in a first world country.  Through your ordeals you've learned how to treat scrapes and bruises, and how to assemble basic furniture.",
     "points": 0,
     "skills": [ { "level": 1, "name": "fabrication" }, { "level": 1, "name": "firstaid" } ]
@@ -90,7 +72,6 @@
     "name": "Crack Cocaine Dependence",
     "description": "Cocaine.  It is, indeed, a helluva drug.  You blew your money on some rocks, and before you knew it you were turning tricks behind the local pharmacy just to score a little more.  Where are you going to get your fix now?",
     "points": -2,
-    "traits": [ "STIMBOOST" ],
     "addictions": [ { "intensity": 20, "type": "crack" } ]
   },
   {
@@ -100,7 +81,6 @@
     "name": "Amphetamine Dependence",
     "description": "You're not entirely sure what happened last night, but you woke up on the floor and everything has completely gone to shit.  The only thing running through your head, though, is where you're gonna find your next hit.",
     "points": -2,
-    "traits": [ "STIMBOOST" ],
     "addictions": [ { "intensity": 30, "type": "amphetamine" } ]
   },
   {
@@ -119,7 +99,6 @@
     "name": "Alcohol Dependence",
     "description": "One drink became two, two became too many, and before long you were only able to find solace at the bottom of a bottle.  God-damn, you need a drink.",
     "points": -2,
-    "traits": [ "DISORGANIZED" ],
     "addictions": [ { "intensity": 20, "type": "alcohol" } ]
   },
   {
@@ -128,8 +107,7 @@
     "id": "sleepingpillhead",
     "name": "Sleeping Pill Dependence",
     "description": "You'd been having trouble falling asleep, so you started taking prescription sleep meds.  Now you can hardly seem to fall asleep at all without them, and you'll need plenty of rest to face the days ahead.",
-    "points": -3,
-    "traits": [ "INSOMNIA" ],
+    "points": -2,
     "addictions": [ { "intensity": 20, "type": "sleeping pill" } ]
   },
   {
@@ -137,29 +115,9 @@
     "subtype": "hobby",
     "id": "caffiend",
     "name": "Caffeine Fiend",
-    "description": "Caffeine gave you life and without it you are nothing.  Your dependence upon it was so extreme that you can barely function in its absence and you've done lasting psychological harm to yourself.  You'd better find a steady supply, and fast.",
+    "description": "Caffeine gave you life and without it you are nothing.  You'd better find a steady supply, and fast.",
     "points": -1,
-    "traits": [ "STIMBOOST", "SLEEPY" ],
-    "addictions": [ { "intensity": 50, "type": "caffeine" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "caffeine_junkie",
-    "name": "Caffeine Dependence",
-    "description": "Coffee was your faithful companion every morning, and without it you feel like a zombie.  Thanks to all the actual zombies shambling about, getting your caffeine fix will be much harder now.",
-    "points": -1,
-    "addictions": [ { "intensity": 10, "type": "caffeine" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "cosplay",
-    "name": "Cosplay",
-    "description": "You liked to make your own costumes and wear them to various conventions.  Now that everyone is dead or dying, maybe this will be useful for something else.",
-    "points": 1,
-    "skills": [ { "level": 1, "name": "tailor" } ],
-    "proficiencies": [ "prof_closures", "prof_leatherworking_basic" ]
+    "addictions": [ { "intensity": 30, "type": "caffeine" } ]
   },
   {
     "type": "profession",
@@ -187,30 +145,9 @@
     "id": "parkour",
     "name": "Parkour",
     "description": "You've practiced parkour for many years, and made the world your playground.  It wouldn't be a lie to say that running is your life.  Which is good, because now that the end has come, you're running for your life.",
-    "points": 2,
+    "points": 3,
     "proficiencies": [ "prof_parkour", "prof_athlete_basic" ],
     "skills": [ { "level": 1, "name": "swimming" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "camping",
-    "name": "Camping",
-    "description": "You enjoyed camping in the vast wilderness as a means of escaping the pace of modern life.  The wilderness isn't filled with people, so it must be safe.  Right?  It must be.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 1, "name": "firstaid" }, { "level": 1, "name": "cooking" } ],
-    "traits": [ "OUTDOORSMAN" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "bushcraft",
-    "name": "Bushcraft",
-    "description": "You take camping to a whole new level.  You have spent nights and weekends surviving in the wild with just a knife to aid you.  Maybe this skill for self-sufficiency can keep you safe.",
-    "points": 4,
-    "skills": [ { "level": 3, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "cooking" } ],
-    "proficiencies": [ "prof_fibers", "prof_leatherworking_basic", "prof_fibers_rope", "prof_traps", "prof_knapping", "prof_carving" ],
-    "traits": [ "OUTDOORSMAN" ]
   },
   {
     "type": "profession",
@@ -225,18 +162,9 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "loves_books",
-    "name": "Reading",
-    "description": "You love reading, but you never seemed to have enough time.  Maybe the Cataclysm is a blessing in disguise.",
-    "points": 1,
-    "traits": [ "LOVES_BOOKS" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
     "id": "chem_cooking",
-    "name": "Chemical Cooking",
-    "description": "Perhaps you produced illicit chemicals for your own consumption, or to sell to others.  Or maybe you're just a real nerd about chemistry.  In any case, you know your way around a Periodic Table.",
+    "name": "Chemistry",
+    "description": "You're acquainted with the basics of chemistry.",
     "points": 3,
     "proficiencies": [ "prof_intro_chemistry", "prof_intro_chem_synth" ],
     "skills": [ { "level": 3, "name": "chemistry" }, { "level": 1, "name": "cooking" } ]
@@ -245,8 +173,8 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "archery",
-    "name": "Archery (Beginner)",
-    "description": "You've used a bow before and maybe taken a class or two.  You won't be pulling off any trick shots but at least you can usually get an arrow to fly forward instead of spinning off to the side.",
+    "name": "Archery",
+    "description": "You've used a bow before and maybe taken a class or two.",
     "points": 2,
     "skills": [ { "level": 2, "name": "archery" }, { "level": 2, "name": "gun" } ],
     "proficiencies": [ "prof_bow_basic" ]
@@ -254,162 +182,49 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "archery_expert",
-    "name": "Archery (Intermediate)",
-    "description": "You enjoy nocking back an arrow and hearing it whistle through the air.  If you can get the proper gear together and stay on-target, you'll have a good, quiet alternative to using guns.",
-    "points": 4,
-    "skills": [ { "level": 4, "name": "archery" }, { "level": 3, "name": "gun" } ],
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "archery_master",
-    "name": "Archery (Expert)",
-    "description": "You're a modern day Robin Hood and probably have hella back muscles.  Perhaps you're an Olympic archer in training or maybe you're descended from the longbowmen of old.  In either case, sniping zombie heads should be as easy as pinning apples to trees for you.",
-    "points": 8,
-    "skills": [ { "level": 8, "name": "archery" }, { "level": 5, "name": "gun" } ],
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_bow_master" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "swimming_beginner",
-    "name": "Swimming (Beginner)",
-    "description": "You can swim.  Probably not very well, and you won't break any speed records, but, you CAN swim.",
-    "points": 1,
-    "skills": [ { "level": 2, "name": "swimming" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "swimming",
-    "name": "Swimming (Intermediate)",
-    "description": "You're a strong swimmer, and you're pretty sure zombies aren't.  You can't swim forever, but it's certainly an advantage over the undead.",
+    "id": "athlete",
+    "name": "Athlete",
+    "description": "You've spent a good deal of time practicing physical fitness and are well acquainted with exercise routines.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ],
-    "traits": [ "OUTDOORSMAN" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "swimming_expert",
-    "name": "Swimming (Expert)",
-    "description": "You're an excellent swimmer and may be part fish.  Plus, all that swimming has left you in great shape.  There aren't any zombie sharks in the water, right?",
-    "points": 5,
-    "skills": [ { "level": 6, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "OUTDOORSMAN", "GOODCARDIO" ]
+    "skills": [ { "level": 3, "name": "swimming" } ],
+    "proficiencies": [ "prof_athlete_basic" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "baseball_beginner",
-    "name": "Baseball (Beginner)",
-    "description": "You used to play baseball, occasionally.  Maybe you were on your school team growing up, but it was never a focus of yours.  Hopefully you can still remember how to use a bat when your life depends on it.",
+    "name": "Baseball",
+    "description": "You used to play baseball.  Hopefully you can still remember how to use a bat when your life depends on it.",
     "points": 2,
     "skills": [ { "level": 2, "name": "bashing" }, { "level": 2, "name": "throw" } ],
-    "proficiencies": [ "prof_maces_familiar" ]
+    "proficiencies": [ "prof_bludgeons_familiar" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "baseball",
-    "name": "Baseball (Intermediate)",
-    "description": "You got the stance, you got the grip, you got the game.  Swinging at a zombie's head is close enough to swinging at a baseball… right?",
-    "points": 4,
-    "skills": [ { "level": 4, "name": "bashing" }, { "level": 4, "name": "throw" }, { "level": 1, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "baseball_pitcher",
-    "name": "Baseball Pitcher (Expert)",
-    "description": "You're accustomed to striking out poor batters at the plate and can probably throw a mean knuckleball.  Now you get to practice your fastball, but perhaps with rocks or grenades this time.",
-    "points": 6,
-    "skills": [ { "level": 4, "name": "bashing" }, { "level": 7, "name": "throw" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "baseball_expert",
-    "name": "Baseball (Expert)",
-    "description": "You didn't quite make it into the big leagues, but you were close.  Now it's time to go for the grand slam or you'll be dealing with worse than a strike out.",
-    "points": 6,
-    "skills": [ { "level": 6, "name": "bashing" }, { "level": 5, "name": "throw" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_maces_familiar", "prof_maces_pro", "prof_maces_master" ],
-    "traits": [ "GOODCARDIO" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "wrestling_beginner",
-    "name": "Wrestling (Beginner)",
-    "description": "Maybe you've taken a few classes at a gym somewhere, or used to be on the youth team, or maybe you just liked to rough-house with your friends or family growing up.  You're not entirely unused to grappling, but you're hardly an expert.",
+    "id": "unarmed",
+    "name": "Fist Fighting",
+    "description": "Whether at the gym or on the streets, you've had some experience with unarmed combat.",
     "points": 2,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" } ],
     "proficiencies": [ "prof_unarmed_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "wrestling",
-    "name": "Wrestling (Intermediate)",
-    "description": "While not the type of wrestler to use folding chairs as weapons, you have experience wrasslin' and tusslin' with others out on the mat.  There's no referees around to see, but hopefully your skills will help you avoid getting pinned by the undead.",
-    "points": 5,
-    "skills": [ { "level": 3, "name": "melee" }, { "level": 4, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar", "prof_unarmed_pro" ],
-    "traits": [ "FAST_REFLEXES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "wrestling_expert",
-    "name": "Wrestling (Expert)",
-    "description": "You were likely on the 100+ wins list back in school and maybe you're a collegiate wrestler or you're using it as part of something like MMA.  Considering how grabby those zombies are, you should get plenty of use out of your skills.",
-    "points": 8,
-    "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 6, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ],
-    "traits": [ "FAST_REFLEXES", "GOODCARDIO" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "vid_games",
-    "name": "Video Gaming",
-    "description": "You loved immersing yourself in virtual worlds through video games.  Now you're faced with real survival horror, and no extra lives.",
-    "points": 1,
-    "skills": [ { "level": 1, "name": "computer" } ],
-    "traits": [ "WAKEFUL" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "trapping",
     "name": "Trapping",
-    "description": "You liked to trap little wild animals such as mice and other rodents.  This skill could be useful for working with more deadly devices, if you're creative enough.",
-    "points": 2,
+    "description": "You're experienced with setting traps and snares for small game or pests.",
+    "points": 3,
     "proficiencies": [ "prof_traps", "prof_disarming" ],
     "skills": [ { "level": 3, "name": "traps" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "dodgeball",
-    "name": "Dodgeball",
-    "description": "Dodging fast-moving balls as though your life depended on it was fun.  Dodging zombies isn't as fun, but your life certainly depends on it.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "dodge" }, { "level": 2, "name": "throw" }, { "level": 1, "name": "swimming" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "amateur_electronics",
-    "name": "Electronic Tinkering",
-    "description": "You found unexpected solace while soldering components to circuit boards.",
+    "id": "electronics",
+    "name": "Electronics",
+    "description": "You know a thing or two about working on electronics.",
     "points": 3,
     "proficiencies": [ "prof_elec_soldering" ],
     "skills": [ { "level": 3, "name": "electronics" }, { "level": 2, "name": "computer" } ]
@@ -418,8 +233,8 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "diy_crafts",
-    "name": "DIY Crafting (Intermediate)",
-    "description": "You spent much of your time making useful things out of bits and bobbles.",
+    "name": "Arts and Crafts",
+    "description": "You've got a fair bit of experience making odds and ends out of basic materials.",
     "points": 3,
     "proficiencies": [
       "prof_pottery",
@@ -434,762 +249,44 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "diy_crafts_expert",
-    "name": "DIY Crafting (Expert)",
-    "description": "Whether due to circumstances forcing ingenuity or just an unhealthy fascination with tinkering you're a certified MacGyver with a very wide range of fabrication knowledge.  You could probably make a functioning cannon out of a paper clip and some bubble gum.",
-    "points": 8,
+    "id": "metalworking",
+    "name": "Metalworking",
+    "description": "You know quite a bit about crafting things with metal, whether hot or cold.",
+    "points": 5,
     "proficiencies": [
-      "prof_pottery",
-      "prof_carving",
-      "prof_basketweaving",
-      "prof_elastics",
-      "prof_leatherworking_basic",
-      "prof_plasticworking",
-      "prof_elec_soldering",
       "prof_metalworking",
-      "prof_welding_basic",
-      "prof_carpentry_basic"
+      "prof_welding_basic"
     ],
     "skills": [
-      { "level": 6, "name": "fabrication" },
-      { "level": 2, "name": "tailor" },
-      { "level": 2, "name": "electronics" },
-      { "level": 2, "name": "mechanics" }
+      { "level": 5, "name": "fabrication" }
     ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "cooking_beginner",
-    "name": "Cooking (Beginner)",
-    "description": "You can cook well enough that you didn't have to live on instant noodles and takeout, but you've only really learned the bare minimum.",
-    "points": 1,
-    "proficiencies": [ "prof_food_prep" ],
-    "skills": [ { "level": 2, "name": "cooking" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
     "id": "cooking",
-    "name": "Cooking (Intermediate)",
-    "description": "You enjoyed cooking for yourself and others.  The grocery stores are closed for good, so you might need to start getting creative with your recipes.",
+    "name": "Baking",
+    "description": "Hours in the kitchen have taught you the ins and outs of making bread and pastries.",
     "points": 2,
     "proficiencies": [
       "prof_baking",
       "prof_baking_bread",
       "prof_baking_desserts_1",
-      "prof_food_prep",
-      "prof_knife_skills",
-      "prof_knives_familiar"
+      "prof_food_prep"
     ],
-    "skills": [ { "level": 4, "name": "cooking" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "cooking_expert",
-    "name": "Cooking (Expert)",
-    "description": "You're an excellent chef capable of making delicious meals out of almost anything and have a wide array of culinary knowledge.  Sadly, the undead would rather eat you than your meals.",
-    "points": 6,
-    "proficiencies": [
-      "prof_baking",
-      "prof_baking_bread",
-      "prof_baking_desserts_1",
-      "prof_food_prep",
-      "prof_knife_skills",
-      "prof_frying_dessert",
-      "prof_frying",
-      "prof_preservation",
-      "prof_scav_cooking",
-      "prof_knives_familiar"
-    ],
-    "skills": [ { "level": 7, "name": "cooking" } ]
+    "skills": [ { "level": 3, "name": "cooking" }, { "level": 1, "name": "chemistry" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "cheesemaking",
     "name": "Cheesemaking",
-    "description": "The art of producing the finest quality cheeses has been passed down through your family for generations.  How useful these skills will be in the apocalypse remains to *brie* seen.",
+    "description": "Making cheese is a delicate, difficult process, and you're one of the few left alive with the skills to do it.",
     "points": 2,
     "proficiencies": [ "prof_food_prep", "prof_cheesemaking_1", "prof_cheesemaking_2" ],
     "skills": [ { "level": 3, "name": "cooking" } ]
   },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "paintball",
-    "name": "Paintball",
-    "description": "Pretending to shoot at your friends has always been fun.  Now you can do it for real.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "rifle" }, { "level": 2, "name": "gun" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "plinking",
-    "name": "Plinking",
-    "description": "You enjoyed target plinking with your airsoft pistol.  You're a good shot, but you'll need a real gun for it to matter.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "pistol" }, { "level": 2, "name": "gun" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "skeet_shooting",
-    "name": "Skeet Shooting",
-    "description": "Where the skeet go, your shot follows.  Throw enough pellets downrange, and you'll at least hit something.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "shotgun" }, { "level": 2, "name": "gun" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "public_speaking",
-    "name": "Public Speaking",
-    "description": "You are an incredibly social individual, with the projection and vocabulary to make people listen.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "speech" } ],
-    "traits": [ "BOOMING_VOICE" ],
-    "missions": [ "MISSION_SOCIAL_BUTTERFLY" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "street_fighting",
-    "name": "Street Fighting (Intermediate)",
-    "description": "You've been in quite a few fights in the street.  You can throw and dodge a punch better than most.",
-    "points": 3,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "street_fighting_expert",
-    "name": "Street Fighting (Expert)",
-    "description": "Maybe you're the muscle of some criminal gang, maybe you're a bouncer at a club, or maybe you're just a huge asshole.  You've constantly been getting into fights with strangers on the streets for most of your life, and somehow you ain't dead yet, so you must be doing something right.",
-    "points": 6,
-    "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
-    "traits": [ "PAINRESIST" ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "knife_throwing",
-    "name": "Knife Throwing",
-    "description": "You learned how to throw knives before the world ended, a skill that can be deadly in the right situation.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "throw" } ],
-    "proficiencies": [ "prof_knives_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "sewing",
-    "name": "Sewing (Intermediate)",
-    "description": "You are quite good at sewing torn clothes back together, and have even made your own clothes a few times.",
-    "points": 3,
-    "proficiencies": [ "prof_closures", "prof_elastics", "prof_knitting" ],
-    "skills": [ { "level": 3, "name": "tailor" }, { "level": 1, "name": "fabrication" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "sewing_expert",
-    "name": "Sewing (Expert)",
-    "description": "Despite modern technology making career tailors obsolete you've spent much of your life hand-making clothing of all sorts, whether for historical purposes or to sell as artisanal goods.  Too bad you can't stitch the holes in reality closed.",
-    "points": 8,
-    "proficiencies": [
-      "prof_closures",
-      "prof_elastics",
-      "prof_knitting",
-      "prof_knitting_speed",
-      "prof_quilting",
-      "prof_closures_waterproofing",
-      "prof_leatherworking_basic",
-      "prof_furriery",
-      "prof_spinning",
-      "prof_weaving"
-    ],
-    "skills": [ { "level": 7, "name": "tailor" }, { "level": 2, "name": "fabrication" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "fencing",
-    "name": "Fencing (Intermediate)",
-    "description": "You were in a fencing club, and you weren't too shabby with a saber.  If you can get your hands on a real sword, you'll be a formidable fighter.",
-    "points": 6,
-    "skills": [ { "level": 3, "name": "stabbing" }, { "level": 3, "name": "melee" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_FENCING" ],
-    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "fencing_expert",
-    "name": "Fencing (Expert)",
-    "description": "You've spent so long practicing your fencing you wouldn't look out of place in the Renaissance dueling with ne'er-do-wells and rapscallions.  En Garde!",
-    "points": 10,
-    "skills": [ { "level": 6, "name": "stabbing" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "dodge" } ],
-    "traits": [ "MARTIAL_FENCING" ],
-    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_fencing_weapons_master" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "car_fan",
-    "name": "Motorsports",
-    "description": "You're a big fan of cars and other things that go vroom, whether it's fixing them or driving them.  You may not be a professional, but you know your way around an engine.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
-    "proficiencies": [ "prof_driver" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "racing",
-    "name": "Racing",
-    "description": "You're a real speed demon in anything with an engine!  Pulling off hairpin turns at high speeds is a difficult skill to master but you can drift with the best of them.",
-    "points": 5,
-    "skills": [ { "level": 8, "name": "driving" }, { "level": 2, "name": "mechanics" } ],
-    "proficiencies": [ "prof_driver" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "kickboxing_beginner",
-    "name": "Cardio Kickboxing",
-    "description": "You've trained in non-combat kickboxing at a gym as a way to exercise.  While you were taught the moves, you've never sparred or fought anything more dangerous than a falling punching bag.  Whether you can remember your training when push kick comes to jab is up to you.",
-    "points": 5,
-    "skills": [
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "unarmed" },
-      { "level": 2, "name": "swimming" },
-      { "level": 1, "name": "dodge" }
-    ],
-    "traits": [ "PROF_KICKBOXER" ],
-    "proficiencies": [ "prof_unarmed_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "martial_training",
-    "name": "Martial Arts",
-    "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
-    "points": 5,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS" ],
-    "proficiencies": [ "prof_unarmed_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "self_defense",
-    "name": "Self-Defense",
-    "description": "You have taken some self-defense classes at a local gym.  You start with your choice of Boxing, Kickboxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
-    "points": 5,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS2" ],
-    "proficiencies": [ "prof_unarmed_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "shaolin",
-    "name": "Shaolin Kung Fu",
-    "description": "You have studied the arts of the Shaolin monks.  You start with one of the five animal fighting styles: Tiger, Crane, Leopard, Snake, or Dragon.",
-    "points": 5,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS3" ],
-    "proficiencies": [ "prof_unarmed_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "blackbelt_hobby",
-    "name": "Black Belt",
-    "description": "You've been doing martial arts for years and have earned the coveted black belt in a martial art of your choice.",
-    "points": 10,
-    "skills": [
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "unarmed" },
-      { "level": 5, "name": "dodge" },
-      { "level": 3, "name": "swimming" }
-    ],
-    "traits": [ "PROF_MA_BLACK" ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "melee_training",
-    "name": "Melee Training (Intermediate)",
-    "description": "You have practiced fighting with weapons.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
-    "points": 7,
-    "skills": [
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "cutting" }
-    ],
-    "traits": [ "MARTIAL_ARTS5" ],
-    "proficiencies": [
-      "prof_quarterstaves_familiar",
-      "prof_maces_familiar",
-      "prof_knives_familiar",
-      "prof_long_swords_familiar",
-      "prof_hooking_familiar",
-      "prof_fencing_weapons_familiar",
-      "prof_spears_familiar"
-    ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "melee_training_expert",
-    "name": "Melee Training (Expert)",
-    "description": "Despite firearms making traditional melee weapons largely obsolete, you have extensive experience fighting in hand-to-hand combat with tools of war.  Maybe it was full-contact HEMA or SCA sparring, or maybe you're just a badass commando with a machete.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
-    "points": 14,
-    "skills": [
-      { "level": 6, "name": "melee" },
-      { "level": 5, "name": "bashing" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "cutting" }
-    ],
-    "traits": [ "MARTIAL_ARTS5" ],
-    "proficiencies": [
-      "prof_quarterstaves_familiar",
-      "prof_quarterstaves_pro",
-      "prof_maces_familiar",
-      "prof_maces_pro",
-      "prof_knives_familiar",
-      "prof_knives_pro",
-      "prof_long_swords_familiar",
-      "prof_long_swords_pro",
-      "prof_hooking_familiar",
-      "prof_hooking_pro",
-      "prof_fencing_weapons_familiar",
-      "prof_fencing_weapons_pro",
-      "prof_spears_familiar",
-      "prof_spears_pro"
-    ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "gourmand",
-    "name": "Fine Dining",
-    "description": "You loved going to all kinds of restaurants and experiencing everything the world of culinary arts had to offer.  Nowadays, those chefs are all dead, so it'll be up to you to recreate the joys of your past.",
-    "points": 2,
-    "traits": [ "GOURMAND", "TABLEMANNERS" ],
-    "skills": [ { "level": 2, "name": "cooking" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "gourmand_alt",
-    "name": "Competitive Eating",
-    "description": "You were a professional eater before the Cataclysm and frequently participated in eating contests.  Thanks to your training, you can eat huge amounts of food without getting sick, and while eating forty hot dogs in ten minutes might not be too useful in the apocalypse, your fortitude might help you survive off food other survivors would pass over.",
-    "points": 3,
-    "traits": [ "GOURMAND", "STRONGSTOMACH" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "marathon_runner",
-    "name": "Marathon Running",
-    "description": "You ran the Boston Marathon every year.  That conditioning should make you better equipped than most in avoiding the dead.",
-    "points": 5,
-    "traits": [ "GOODCARDIO" ],
-    "skills": [ { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "hates_books",
-    "name": "Book Hating",
-    "description": "Reading is for nerds!  You've managed to make hatred of the written word a central part of your identity.  Or, perhaps, you have a barrier that makes books additionally challenging and frustrating for you.  Whatever the reason, boring books are more boring, and you can't have fun by reading books.",
-    "points": -1,
-    "traits": [ "HATES_BOOKS" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "meatarian",
-    "name": "Butchering",
-    "description": "You absolutely love meat, and dislike eating fruits and vegetables.  Your particular tastes have turned you into a decent amateur butcher.",
-    "points": -3,
-    "traits": [ "ANTIFRUIT", "MEATARIAN" ],
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "cooking" } ],
-    "proficiencies": [ "prof_knives_familiar", "prof_knife_skills" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "vegetarian",
-    "name": "Vegetarian Foraging",
-    "description": "You have been a vegetarian for so long that eating meat makes you feel sick.  You like to supplement your diet with wild plants and mushrooms foraged in the woods.",
-    "points": -1,
-    "traits": [ "VEGETARIAN" ],
-    "skills": [ { "level": 2, "name": "cooking" }, { "level": 2, "name": "survival" } ],
-    "proficiencies": [ "prof_food_prep", "prof_forage_cooking" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "skating",
-    "name": "Skating",
-    "description": "You are skilled in maneuvering on skates.  You suffer lower penalties to dodging and are less likely to fall down if hit in melee combat while you're wearing rollerskates or rollerblades.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "dodge" } ],
-    "traits": [ "PROF_SKATER" ],
-    "missions": [ "MISSION_SKATES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "arts_and_crafts",
-    "name": "Arts and Crafts",
-    "description": "You loved doing crafts at home.  Now, you might want to channel those skills into making more practical things.",
-    "points": 1,
-    "skills": [ { "level": 1, "name": "fabrication" }, { "level": 2, "name": "tailor" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "car_rebuilding",
-    "name": "Car Restoration",
-    "description": "Spending time every weekend in your garage working on an old classic car was your favorite pastime.  You never finished the car, but at least you learned a little over the years.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "mechanics" }, { "level": 1, "name": "driving" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "trickster",
-    "name": "Practical Jokes",
-    "description": "Pranks and physical jokes are a passion of yours, from the setup right through to playing innocent at the end.",
-    "points": 1,
-    "skills": [ { "level": 1, "name": "traps" }, { "level": 1, "name": "speech" } ],
-    "traits": [ "LIAR" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "modelling",
-    "name": "Modelling",
-    "description": "You were deep into the fashion scene, keeping up on the latest trends and even modelling clothes yourself.  Having style and good looks is just as, if not more, important to you than practicality.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "tailor" } ],
-    "traits": [ "STYLISH" ],
-    "missions": [ "MISSION_STYLISH" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "pottery",
-    "name": "Pottery",
-    "description": "You're a master of throwing on the potter's wheel, able to shape clay into whatever shape you need.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 1, "name": "survival" } ],
-    "proficiencies": [ "prof_pottery", "prof_pottery_glazing" ]
-  },
-  {
-    "subtype": "hobby",
-    "name": "Handloading",
-    "type": "profession",
-    "id": "handloading",
-    "description": "You figured you could save money on ammo by learning to make your own.  Now that the factories are shut down, your abilities just went from handy to lifesaving.",
-    "points": 3,
-    "proficiencies": [ "prof_handloading", "prof_gun_cleaning" ],
-    "skills": [ { "level": 3, "name": "fabrication" }, { "level": 2, "name": "gun" } ]
-  },
-  {
-    "subtype": "hobby",
-    "type": "profession",
-    "name": "Tabletop Gaming",
-    "id": "game_mastering",
-    "description": "As the Game Master, you've guided players' journeys through dungeons and fortresses.  Now, you're the last member of your party.",
-    "points": 2,
-    "traits": [ "PROF_DICEMASTER" ],
-    "skills": [ { "level": 2, "name": "speech" } ],
-    "missions": [ "MISSION_GAME_MASTER" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "ham_radio_operator",
-    "name": "Ham Radio",
-    "description": "You whiled your nights away using, building, and repairing old ham radios.  Now you have no one to talk to. But you won't give up hope, and maybe your electronics knowledge can help you somehow.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "electronics" } ],
-    "proficiencies": [ "prof_elec_soldering", "prof_elec_circuits" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "golfing",
-    "name": "Golf",
-    "points": 2,
-    "description": "The backswing's a breeze, and your drive could get skulls into the green if you tried.",
-    "skills": [ { "level": 2, "name": "bashing" }, { "level": 1, "name": "melee" }, { "level": 1, "name": "driving" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "cyclist_beginner",
-    "name": "Cyclist (Beginner)",
-    "description": "Whether through regular commuting, or just riding for the joy of it, you're no stranger to bicycles.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "driving" }, { "level": 1, "name": "swimming" } ],
-    "proficiencies": [ "prof_driver", "prof_athlete_basic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "cyclist_intermediate",
-    "name": "Cyclist (Intermediate)",
-    "description": "You've shed gallons of sweat, and more than a little blood, riding the streets and trails as a cyclist.",
-    "points": 4,
-    "skills": [ { "level": 4, "name": "driving" }, { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_driver", "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "GOODCARDIO" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "cyclist_expert",
-    "name": "Cyclist (Expert)",
-    "description": "You've honed the fitness and form of a professional bicycle racer.  When you're riding, your wheels are like an extension of your body.",
-    "points": 7,
-    "skills": [ { "level": 6, "name": "driving" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_driver", "prof_athlete_basic", "prof_athlete_expert", "prof_athlete_master" ],
-    "traits": [ "GOODCARDIO", "DEFT" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "basketball_beginner",
-    "name": "Basketball (Beginner)",
-    "description": "You used to shoot some b-ball outside of the school… at least, until a couple of corpses who were up to no good started making trouble in your neighborhood.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "throw" }, { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "basketball",
-    "name": "Basketball (Intermediate)",
-    "description": "Your ability to play point or post will beat the undead in overtime.",
-    "points": 4,
-    "skills": [ { "level": 4, "name": "throw" }, { "level": 3, "name": "dodge" }, { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ],
-    "traits": [ "FAST_REFLEXES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "basketball_expert",
-    "name": "Basketball (Expert)",
-    "description": "You can sink 3-pointers all day, and dribble around the most determined defenders.",
-    "points": 7,
-    "skills": [ { "level": 6, "name": "throw" }, { "level": 4, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "GOODCARDIO", "FAST_REFLEXES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "football_beginner",
-    "name": "Football (Beginner)",
-    "description": "You'd occasionally play touch or flag football at the park, but never got too serious about it.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "throw" }, { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "football",
-    "name": "Football (Intermediate)",
-    "description": "You're no stranger to throwing the ol' pigskin and taking a few tackles.  Hopefully your skills in dodging defenders will help you charge through the hordes of undead.",
-    "points": 5,
-    "skills": [ { "level": 3, "name": "throw" }, { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ],
-    "traits": [ "TOUGH" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "football_expert",
-    "name": "Football (Expert)",
-    "description": "You played college ball, ya know.  You could have gone pro if the world hadn't ended.",
-    "points": 8,
-    "skills": [ { "level": 4, "name": "throw" }, { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "TOUGH", "PAINRESIST" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "shooter_beginner",
-    "name": "Shooting (Beginner)",
-    "description": "You've been to a gun range once or twice and maybe took a firearm safety class.  At the very least, you're confident you can point the gun in the correct direction.",
-    "points": 2,
-    "skills": [
-      { "level": 1, "name": "shotgun" },
-      { "level": 1, "name": "pistol" },
-      { "level": 1, "name": "rifle" },
-      { "level": 2, "name": "gun" }
-    ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "shooter",
-    "name": "Shooting (Intermediate)",
-    "description": "You liked going to the local gun range and shooting at some targets or blasting cans off of fence posts with a variety of firearms.  Maybe if you just imagine targets on those undead, this could help.",
-    "points": 2,
-    "proficiencies": [ "prof_gun_cleaning", "prof_auto_pistols_familiar", "prof_auto_rifles_familiar" ],
-    "skills": [
-      { "level": 1, "name": "smg" },
-      { "level": 2, "name": "shotgun" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "rifle" },
-      { "level": 4, "name": "gun" }
-    ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "name": "First Aid",
-    "id": "redcross",
-    "description": "You've got training and some experience in dealing with urgent injuries.  In the absence of any medical professionals, that'll have to do.",
-    "points": 1,
-    "skills": [ { "level": 2, "name": "firstaid" } ],
-    "proficiencies": [ "prof_field_medic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "trap_shooting",
-    "name": "Trap Shooting",
-    "description": "You loved the smell of gunsmoke and blowing ceramic discs out of the sky.  Your future will likely involve shooting things a little fleshier than clay pigeons.",
-    "points": 2,
-    "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 2, "name": "gun" }, { "level": 2, "name": "shotgun" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "back_yard_grilling",
-    "name": "Backyard Grilling",
-    "description": "You enjoyed inviting the neighborhood to a backyard cookout on the weekends.  You, of course, were the grill master.",
-    "points": 1,
-    "skills": [ { "level": 2, "name": "cooking" } ],
-    "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_knives_familiar" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "carpentry",
-    "name": "Carpentry",
-    "points": 2,
-    "description": "With enough time and materials, you could make a boat from scratch.  These undead can't swim, right?",
-    "skills": [ { "level": 3, "name": "fabrication" } ],
-    "proficiencies": [ "prof_carving", "prof_carpentry_basic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "luthier",
-    "name": "Woodworking - Luthier",
-    "description": "You've learned woodworking in the field of making musical instruments.  You'll be able to create musical instruments in the Cataclysm.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "fabrication" } ],
-    "proficiencies": [ "prof_luthier_basic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "home_improvement",
-    "name": "Home Improvement",
-    "points": 4,
-    "description": "You'd fix up any holes and appliances in your own home with nothing but your two hands and some elbow grease.  You did it to save money on repairmen, but now it seems you'll do it to save your life.",
-    "skills": [ { "level": 4, "name": "fabrication" }, { "level": 2, "name": "mechanics" }, { "level": 1, "name": "electronics" } ],
-    "proficiencies": [ "prof_carpentry_basic", "prof_appliance_repair" ]
-  },
-  {
-    "type": "profession",
-    "id": "fishing",
-    "subtype": "hobby",
-    "name": "Fishing",
-    "points": 1,
-    "description": "A quiet day at the lake would be a welcome break from the hordes.  Though, now that you think about it, the fish have been acting strangely vicious lately too.",
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 1, "name": "swimming" } ],
-    "traits": [ "OUTDOORSMAN" ]
-  },
-  {
-    "subtype": "hobby",
-    "type": "profession",
-    "id": "gunsmithing",
-    "name": "Home Gunsmithing",
-    "description": "You could have been the next Browning, if not for the those pesky corpses walking around.  It's time to test for accuracy.",
-    "points": 3,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gunsmithing_improv", "prof_gun_cleaning" ],
-    "skills": [ { "level": 3, "name": "fabrication" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "traps" } ]
-  },
-  {
-    "subtype": "hobby",
-    "type": "profession",
-    "id": "roller_derby",
-    "description": "Being able to body your way through the pack is always useful, whether your opponent is living or rotting.",
-    "name": "Roller Derby",
-    "points": 3,
-    "skills": [
-      { "level": 1, "name": "unarmed" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "swimming" },
-      { "level": 1, "name": "dodge" }
-    ],
-    "traits": [ "PROF_SKATER" ],
-    "proficiencies": [ "prof_athlete_basic" ],
-    "missions": [ "MISSION_SKATES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "hockey",
-    "name": "Roller Hockey",
-    "description": "Your time in the rink has taught you that sometimes the best way forward is straight through whoever's trying to block you.",
-    "points": 3,
-    "skills": [ { "level": 2, "name": "bashing" }, { "level": 2, "name": "swimming" }, { "level": 1, "name": "melee" } ],
-    "traits": [ "PROF_SKATER" ],
-    "proficiencies": [ "prof_athlete_basic" ],
-    "missions": [ "MISSION_SKATES" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "frying",
-    "name": "Deep Frying",
-    "points": 2,
-    "description": "You'd have been a hit at the county fair, but you're cooking for one now.",
-    "proficiencies": [
-      "prof_frying",
-      "prof_frying_bread",
-      "prof_baking_desserts_1",
-      "prof_frying_dessert",
-      "prof_food_prep",
-      "prof_knife_skills",
-      "prof_knives_familiar"
-    ],
-    "skills": [ { "level": 3, "name": "cooking" } ]
-  },
-  {
+    {
     "type": "profession",
     "id": "homebrewer",
     "subtype": "hobby",
@@ -1207,90 +304,100 @@
     ]
   },
   {
-    "subtype": "hobby",
     "type": "profession",
-    "id": "coaching",
-    "name": "Sports Coaching",
-    "description": "They tore apart your team, but you're determined to keep the team spirit alive.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "speech" }, { "level": 1, "name": "swimming" } ]
+    "subtype": "hobby",
+    "id": "bushcraft",
+    "name": "Bushcraft",
+    "description": "You take camping to a whole new level.  You have spent nights and weekends surviving in the wild with just a knife to aid you.  Maybe this skill for self-sufficiency can keep you safe.",
+    "points": 5,
+    "skills": [ { "level": 3, "name": "survival" }, { "level": 1, "name": "fabrication" }, { "level": 1, "name": "cooking" } ],
+    "proficiencies": [ "prof_fibers", "prof_leatherworking_basic", "prof_fibers_rope", "prof_traps", "prof_knapping", "prof_carving" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "gardening",
-    "name": "Gardening",
-    "description": "Your green thumb will come in handy when the grocery stores are overrun.",
-    "points": 1,
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 1, "name": "cooking" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "ropemaking",
-    "name": "Ropemaking",
-    "description": "Your knots are strong, whether they're made from cloth or natural cordage.",
-    "points": 1,
-    "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "tailor" } ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "backpacking",
-    "name": "Backpacking",
-    "description": "You enjoyed trekking on long trails in nature with all your necessities strapped to your back.",
+    "id": "sewing",
+    "name": "Sewing",
+    "description": "You are quite good at sewing torn clothes back together, and have even made your own clothes a few times.",
     "points": 3,
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "firstaid" } ],
-    "traits": [ "OUTDOORSMAN", "GOODCARDIO", "NOMAD" ]
+    "proficiencies": [ "prof_closures", "prof_elastics", "prof_knitting", "prof_leatherworking_basic" ],
+    "skills": [ { "level": 3, "name": "tailor" }, { "level": 1, "name": "fabrication" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "scrapart",
-    "name": "Scrap Art",
-    "description": "You spent hours welding discarded scrap into large and intricate designs.  Some said you were just welding junk into bigger junk.  You call it art.",
-    "points": 2,
-    "skills": [ { "level": 2, "name": "fabrication" } ],
-    "proficiencies": [ "prof_metalworking", "prof_welding_basic" ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "moshing",
-    "name": "Moshing",
-    "description": "You went to loud concerts and spent your time in the mosh pits.  Now that everything's gone to hell, the whole world is your mosh pit.",
+    "id": "car_fan",
+    "name": "Motorsports",
+    "description": "You're a big fan of cars and other things that go vroom, whether it's fixing them or driving them.",
     "points": 1,
-    "skills": [ { "level": 1, "name": "unarmed" } ],
-    "traits": [ "BADHEARING", "MASOCHIST", "PAINRESIST" ]
+    "skills": [ { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
+    "proficiencies": [ "prof_driver" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "fireperformance",
-    "name": "Fire Performing",
-    "description": "Whether you twirled, spun, juggled, or ate it, your manipulation of flaming objects was impressive and terrifying to behold.",
+    "id": "skating",
+    "name": "Skating",
+    "description": "You are skilled in maneuvering on skates.  You suffer lower penalties to dodging and are less likely to fall down if hit in melee combat while you're wearing rollerskates or rollerblades.",
     "points": 2,
-    "traits": [ "PYROMANIA", "DEFT" ],
-    "skills": [ { "level": 1, "name": "throw" }, { "level": 1, "name": "dodge" } ]
+    "skills": [ { "level": 2, "name": "dodge" } ],
+    "traits": [ "PROF_SKATER" ],
+    "missions": [ "MISSION_SKATES" ]
   },
   {
-    "type": "profession",
     "subtype": "hobby",
-    "id": "socialdance",
-    "name": "Social Dancing",
-    "description": "You loved meeting new people on the dance floor.  These zombies aren't terribly friendly, but they're ready to tango!",
+    "type": "profession",
+    "name": "Tabletop Gaming",
+    "id": "game_mastering",
+    "description": "As the Game Master, you've guided players' journeys through dungeons and fortresses.  Now, you're the last member of your party.",
     "points": 2,
-    "skills": [ { "level": 1, "name": "dodge" }, { "level": 2, "name": "speech" } ],
-    "traits": [ "LIGHTSTEP" ]
+    "traits": [ "PROF_DICEMASTER" ],
+    "skills": [ { "level": 2, "name": "speech" } ],
+    "missions": [ "MISSION_GAME_MASTER" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "meditation",
-    "name": "Meditation",
-    "description": "You make a habit of clearing your thoughts and finding your center, even amidst the chaos of the world.",
+    "name": "First Aid",
+    "id": "redcross",
+    "description": "You've got training and some experience in dealing with urgent injuries.  In the absence of any medical professionals, that'll have to do.",
+    "points": 1,
+    "skills": [ { "level": 2, "name": "firstaid" } ],
+    "proficiencies": [ "prof_field_medic" ]
+  },
+    {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "martial_training",
+    "name": "Martial Arts",
+    "description": "You have received some martial arts training.  You start with an unarmed martial arts style of your choosing.",
+    "points": 5,
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" } ],
+    "traits": [ "MARTIAL_ARTS" ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "melee_training",
+    "name": "Melee Style",
+    "description": "Whether for school, ren faires, or fitness, you've learned how to handle some kind of medieval weapon.  You start with a weapon-based martial arts style of your choosing.",
+    "points": 5,
+    "skills": [
+      { "level": 2, "name": "melee" },
+      { "level": 1, "name": "cutting" },
+      { "level": 1, "name": "stabbing" }
+    ],
+    "traits": [ "MARTIAL_ARTS_MELEE" ]
+  },
+  {
+    "subtype": "hobby",
+    "name": "Handloading",
+    "type": "profession",
+    "id": "handloading",
+    "description": "You figured you could save money on ammo by learning to make your own.  Now that the factories are shut down, your abilities just went from handy to lifesaving.",
     "points": 3,
-    "traits": [ "OPTIMISTIC", "SPIRITUAL" ]
+    "proficiencies": [ "prof_handloading", "prof_gun_cleaning" ],
+    "skills": [ { "level": 3, "name": "fabrication" }, { "level": 2, "name": "gun" }, { "level": 1, "name": "pistols" }, { "level": 1, "name": "rifles" }, { "level": 1, "name": "shotguns" } ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -568,6 +568,7 @@
     "points": 1,
     "description": "You are accustomed to being exposed to the elements.  This decreases morale penalties for being wet.",
     "valid": false,
+    "starting_trait": true,
     "wet_protection": [
       { "part": "head", "neutral": 6 },
       { "part": "leg_l", "neutral": 8 },
@@ -1012,7 +1013,7 @@
     "name": { "str": "Gourmand" },
     "points": 2,
     "description": "You eat faster, and can eat and drink more, than anyone else!  You also enjoy food more; delicious food is better for your morale, and you don't mind unsavory meals as much.  Activate to skip prompt for overeating.",
-    "category": [ "MOUSE", "LUPINE" ],
+    "category": [ "MOUSE", "LUPINE", "RAT" ],
     "cancels": [ "PICKYEATER" ],
     "starting_trait": true,
     "active": true,
@@ -1024,21 +1025,12 @@
   },
   {
     "type": "mutation",
-    "id": "TINYSTOMACH",
-    "name": { "str": "Tiny Stomach" },
-    "points": -3,
-    "description": "Either as the result of a lifesaving surgery, or as a congenital defect, your stomach is much smaller than usual.  You'll have to eat your food in small servings during the day, rather than one or two large daily meals.",
-    "starting_trait": true,
-    "active": false,
-    "enchantments": [ { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.7 } ] } ]
-  },
-  {
-    "type": "mutation",
     "id": "LOVES_BOOKS",
     "name": { "str": "Bookworm" },
     "points": 1,
     "description": "There's nothing quite like the smell of a good book!  Books are more fun (or less boring) for you!",
     "valid": false,
+    "starting_trait": true,
     "cancels": [ "ILLITERATE", "HATES_BOOKS" ]
   },
   {
@@ -1188,7 +1180,6 @@
     "id": "RESTRICTED",
     "name": { "str": "Restricted Genetics" },
     "points": 3,
-    "vitamin_cost": 160,
     "description": "Your genome has become an impregnable fortress to lesser genetic deviations.  You are no longer able to mutate traits that are outside of the Alpha category.  Any that you previously developed are safe, for now.",
     "allowed_category": [ "ALPHA", "HUMAN" ],
     "cancels": [ "CHAOTIC_BAD", "ROBUST" ],
@@ -1197,7 +1188,6 @@
   {
     "type": "mutation",
     "id": "EAGLEEYED",
-    "//": "Can't change the ID as that breaks save-compatibility.",
     "name": { "str": "Scout" },
     "points": 1,
     "description": "You're an excellent navigator and your ability to recognize distant landmarks is unmatched.  Your sight radius on the overmap extends beyond the normal range.",
@@ -1241,46 +1231,7 @@
   },
   {
     "type": "mutation",
-    "id": "MARTIAL_ARTS",
-    "name": { "str": "Martial Arts Training" },
-    "points": 2,
-    "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
-    "player_display": false,
-    "initial_ma_styles": [ "style_karate", "style_judo", "style_aikido", "style_tai_chi", "style_taekwondo", "style_pankration" ],
-    "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "MARTIAL_ARTS2",
-    "name": { "str": "Self-Defense Classes" },
-    "points": 2,
-    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Kickboxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
-    "player_display": false,
-    "initial_ma_styles": [
-      "style_krav_maga",
-      "style_muay_thai",
-      "style_ninjutsu",
-      "style_capoeira",
-      "style_zui_quan",
-      "style_wingchun",
-      "style_kickboxing",
-      "style_boxing"
-    ],
-    "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "MARTIAL_ARTS3",
-    "name": { "str": "Shaolin Adept" },
-    "points": 2,
-    "description": "You have studied the arts of the Shaolin monks.  You start with one of the five animal fighting styles: Tiger, Crane, Leopard, Snake, or Dragon.",
-    "player_display": false,
-    "initial_ma_styles": [ "style_tiger", "style_crane", "style_leopard", "style_snake", "style_dragon" ],
-    "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "MARTIAL_ARTS5",
+    "id": "MARTIAL_ARTS_MELEE",
     "name": { "str": "Melee Weapon Training" },
     "points": 3,
     "description": "You have practiced fighting with weapons.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
@@ -1296,15 +1247,6 @@
       "style_swordsmanship",
       "style_medievalpole"
     ],
-    "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "MARTIAL_FENCING",
-    "name": { "str": "Competitive Fencer" },
-    "points": 0,
-    "description": "You were an avid fencer, starting with foil and moving onto saber, then épée.  You competed nationally and dabbled with some of the historical fencing weapons afforded by HEMA's popularity.",
-    "initial_ma_styles": [ "style_fencing" ],
     "valid": false
   },
   {
@@ -1325,6 +1267,7 @@
     "points": 1,
     "description": "You have no qualms about bending the truth, and have practically no tells.  Telling lies and otherwise bluffing will be much easier for you.",
     "cancels": [ "TRUTHTELLER" ],
+    "starting_trait": true,
     "social_modifiers": { "lie": 40 }
   },
   {
@@ -1631,6 +1574,7 @@
     "points": -1,
     "description": "Reading is for nerds!  Boring books are more boring, and you can't have fun by reading books.",
     "valid": false,
+    "starting_trait": true,
     "cancels": [ "ILLITERATE", "LOVES_BOOKS" ]
   },
   {
@@ -6294,17 +6238,6 @@
   },
   {
     "type": "mutation",
-    "id": "MUT_JUNKIE",
-    "name": { "str": "Metallassomaiphile" },
-    "//": "name courtesy of wiktionary's Greek for 'mutate'.  Greek-speakers, feel free to correct the term",
-    "points": -1,
-    "mixed_effect": true,
-    "description": "Just thinking of mutagen (such a lovely word!  'Mutagen'.  Perfect!) makes you thirsty.  And you so love your new parts.  You simply must have more mutagen!",
-    "threshreq": [ "THRESH_MEDICAL", "THRESH_CHIMERA" ],
-    "category": [ "MEDICAL", "CHIMERA" ]
-  },
-  {
-    "type": "mutation",
     "id": "HEADBUMPS",
     "name": { "str": "Head Bumps" },
     "points": 0,
@@ -6456,7 +6389,7 @@
     "description": "You have a pair of stubby little wings projecting from your shoulderblades.  They can be wiggled at will, but are useless.",
     "types": [ "WINGS" ],
     "changes_to": [ "WINGS_INSECT" ],
-    "category": [ "INSECT" ]
+    "category": [ "INSECT", "CHIMERA" ]
   },
   {
     "type": "mutation",
@@ -8750,46 +8683,19 @@
   },
   {
     "type": "mutation",
-    "id": "PROF_MA_ORANGE",
+    "id": "MARTIAL_ARTS",
     "name": { "str": "Martial Artist" },
     "points": 0,
-    "description": "You were shaping up to be a pretty decent student of the martial arts before the Cataclysm struck.  Time to see just how good you really are.",
-    "valid": false,
+    "description": "You are trained in a hand-to-hand fighting style.",
     "initial_ma_styles": [
       "style_aikido",
+      "style_boxing",
       "style_capoeira",
       "style_crane",
       "style_dragon",
       "style_judo",
       "style_karate",
-      "style_krav_maga",
-      "style_leopard",
-      "style_muay_thai",
-      "style_ninjutsu",
-      "style_pankration",
-      "style_snake",
-      "style_taekwondo",
-      "style_tai_chi",
-      "style_tiger",
-      "style_wingchun",
-      "style_zui_quan"
-    ],
-    "purifiable": false,
-    "profession": true
-  },
-  {
-    "type": "mutation",
-    "id": "PROF_MA_BLACK",
-    "name": { "str": "Black Belt" },
-    "points": 0,
-    "description": "You were competitive at national levels, and had considered teaching your art.  Defending against the entire town may still be a challenge, though.",
-    "initial_ma_styles": [
-      "style_aikido",
-      "style_capoeira",
-      "style_crane",
-      "style_dragon",
-      "style_judo",
-      "style_karate",
+      "style_kickboxing",
       "style_krav_maga",
       "style_leopard",
       "style_muay_thai",
@@ -8804,28 +8710,7 @@
     ],
     "valid": false,
     "purifiable": false,
-    "profession": true
-  },
-  {
-    "type": "mutation",
-    "id": "PROF_BOXER",
-    "name": { "str": "Pugilist" },
-    "points": 0,
-    "description": "You are experienced in the Sweet Science of boxing.  You could've had a shot at a local boxing tournament, if the Cataclysm hadn't screwed that up.",
-    "valid": false,
-    "initial_ma_styles": [ "style_boxing" ],
-    "purifiable": false,
-    "profession": true
-  },
-  {
-    "type": "mutation",
-    "id": "PROF_KICKBOXER",
-    "name": { "str": "Kickboxer" },
-    "points": 0,
-    "description": "You have some training in the art of kickboxing.  It's just boxing with kicks, right?",
-    "valid": false,
-    "initial_ma_styles": [ "style_kickboxing" ],
-    "purifiable": false,
+    "player_display": false,
     "profession": true
   },
   {

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -92,7 +92,7 @@
     "valid": false,
     "player_display": false
   },
-    {
+  {
     "type": "mutation",
     "id": "MARTIAL_ARTS2",
     "name": { "str": "Self Defense" },
@@ -110,7 +110,7 @@
     "valid": false,
     "player_display": false
   },
-    {
+  {
     "type": "mutation",
     "id": "MARTIAL_ARTS3",
     "name": { "str": "Melee Training" },
@@ -146,7 +146,7 @@
     "valid": false,
     "player_display": false
   },
-    {
+  {
     "type": "mutation",
     "id": "PROF_BOXER",
     "name": { "str": "Boxer" },
@@ -163,5 +163,33 @@
     "points": 0,
     "valid": false,
     "player_display": false
+  },
+  {
+    "type": "profession",
+    "id": "computer_literate",
+    "name": "Computer Literate",
+    "description": "You are computer literate.",
+    "points": 0
+  },
+  {
+    "type": "profession",
+    "id": "social_skills",
+    "name": "Social Skills",
+    "description": "You possess basic social skills.",
+    "points": 0
+  },
+  {
+    "type": "profession",
+    "id": "high_school_graduate",
+    "name": "High School Graduate",
+    "description": "You're a high school graduate, for all that's worth.",
+    "points": 0
+  },
+  {
+    "type": "profession",
+    "id": "mundane_survial",
+    "name": "Mundane Survival",
+    "description": "You survived the mundane world, but that's all over now.",
+    "points": 0
   }
 ]

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -73,5 +73,95 @@
     "points": 0,
     "valid": false,
     "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "MARTIAL_FENCING",
+    "name": { "str": "Competitive Fencer" },
+    "description": "Obsoleted Competitive Fencer mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "TINYSTOMACH",
+    "name": { "str": "Tiny Stomach" },
+    "description": "Obsoleted Tiny Stomach mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+    {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS2",
+    "name": { "str": "Self Defense" },
+    "description": "Obsoleted Self Defense mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS5",
+    "name": { "str": "Melee Training" },
+    "description": "Obsoleted Melee Martial Arts mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+    {
+    "type": "mutation",
+    "id": "MARTIAL_ARTS3",
+    "name": { "str": "Melee Training" },
+    "description": "Obsoleted Melee Martial Arts mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "PROF_MA_ORANGE",
+    "name": { "str": "Orange Belt" },
+    "description": "Obsoleted Orange Belt mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "PROF_MA_BLACK",
+    "name": { "str": "Black Belt" },
+    "description": "Obsoleted Black Belt mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "MUT_JUNKIE",
+    "name": { "str": "Metallassimophile" },
+    "description": "Obsoleted mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+    {
+    "type": "mutation",
+    "id": "PROF_BOXER",
+    "name": { "str": "Boxer" },
+    "description": "Obsoleted mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "PROF_KICKBOXER",
+    "name": { "str": "Kickboxer" },
+    "description": "Obsoleted mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
   }
 ]

--- a/data/json/profession_groups.json
+++ b/data/json/profession_groups.json
@@ -2,13 +2,6 @@
   {
     "type": "profession_group",
     "id": "adult_basic_background",
-    "professions": [
-      "driving_license",
-      "simple_home_cooking",
-      "computer_literate",
-      "social_skills",
-      "high_school_graduate",
-      "mundane_survival"
-    ]
+    "professions": [ "driving_license", "simple_home_cooking", "basic_education", "everyday_skills" ]
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2523,62 +2523,6 @@
   },
   {
     "type": "profession",
-    "id": "swat_heavy",
-    "name": "SWAT CQC Specialist",
-    "description": "As a member of the police force's most elite division, you were given special training and became an expert in close-quarters combat.  Unfortunately, the chain of command has broken down; your only mission now is to stay alive.",
-    "points": 6,
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 5, "name": "shotgun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 1, "name": "stabbing" },
-      { "level": 4, "name": "unarmed" },
-      { "level": 4, "name": "dodge" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
-    ],
-    "traits": [ "PROF_SWAT" ],
-    "proficiencies": [
-      "prof_spotting",
-      "prof_gun_cleaning",
-      "prof_batons_familiar",
-      "prof_batons_pro",
-      "prof_unarmed_familiar",
-      "prof_unarmed_pro",
-      "prof_auto_pistols_familiar"
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "socks" },
-          { "item": "tac_fullhelmet" },
-          { "item": "boots_combat" },
-          { "item": "gloves_tactical" },
-          { "item": "badge_swat" },
-          { "item": "wristwatch" },
-          { "item": "pants_tactical" },
-          { "item": "elbow_pads" },
-          { "item": "knee_pads" },
-          { "group": "swat_ballistic_vest_pristine" },
-          { "group": "charged_two_way_radio" },
-          { "item": "sheriffshirt" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc2" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp9" },
-          { "item": "usp_9mm", "ammo-item": "9mmfmj", "charges": 15, "container-item": "holster" },
-          { "item": "baton-extended", "container-item": "police_belt" },
-          { "item": "ksg", "ammo-item": "shot_00", "charges": 7, "contents-item": [ "shoulder_strap" ] }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "sniper_police",
     "name": "Police Sniper",
     "description": "Your skill as a sharpshooter served you well in the line of duty, protecting the innocent with a single, well-placed bullet.  Now your own life is on the line, and you can't afford to miss if you don't want to end up as something's dinner.",
@@ -2688,6 +2632,7 @@
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
+    "vehicle": "motorcycle",
     "items": {
       "both": {
         "entries": [
@@ -2712,29 +2657,6 @@
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "salesman",
-    "name": { "male": "Used Car Salesman", "female": "Used Car Saleswoman" },
-    "description": "They said you'd sell your own mother for a dollar.  How dare they!  You've been around the block a few times, and you'd charge way more than a dollar - and get it, too!",
-    "points": 1,
-    "skills": [ { "level": 5, "name": "speech" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "suit" },
-          { "item": "knit_scarf" },
-          { "item": "socks" },
-          { "item": "dress_shoes" },
-          { "item": "gold_watch" },
-          { "item": "money_strap_fifty" },
-          { "group": "charged_smart_phone" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" }, { "item": "citrine_gold_cufflinks" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "gold_ear" } ] }
     }
   },
   {
@@ -2959,40 +2881,6 @@
       "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
-  },
-  {
-    "type": "profession",
-    "id": "hillbilly",
-    "name": { "male": "Hillbilly", "female": "Hillbilly Girl" },
-    "description": "You n' yer kin always figured shit would hit the fan some day, but never like this!  When they turned on you, you grabbed yer gun and a six pack, and hauled ass in the family truck.",
-    "points": 4,
-    "proficiencies": [ "prof_driver" ],
-    "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "shotgun" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "driving" }
-    ],
-    "vehicle": "extended_pickup",
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "hoodie" },
-          { "item": "socks" },
-          { "item": "boots_steel" },
-          { "item": "jeans" },
-          { "item": "multitool" },
-          { "item": "jacket_flannel" },
-          { "item": "slingpack" },
-          { "group": "charged_smart_phone" },
-          { "item": "shot_00", "charges": 25 },
-          { "item": "beer", "count": 6 },
-          { "item": "remington_870", "ammo-item": "shot_00", "charges": 5, "contents-item": "shoulder_strap_simple" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
   },
   {
     "type": "profession",
@@ -4006,75 +3894,6 @@
   },
   {
     "type": "profession",
-    "id": "convict_embezzler",
-    "name": "Embezzler",
-    "description": "You had a genius plan to skim fractions of cents out of your company's accounts.  This plan immediately failed and got you arrested.  They said you were too soft for prison, but guess what?  They're dead, and you're not.",
-    "points": 0,
-    "skills": [ { "level": 4, "name": "speech" }, { "level": 3, "name": "computer" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt_costume", "variant": "shirt_striped" },
-          { "item": "pants_costume", "variant": "pants_striped" },
-          { "item": "sneakers" },
-          { "item": "socks" },
-          { "item": "rock_sock" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    },
-    "flags": [ "SCEN_ONLY" ]
-  },
-  {
-    "type": "profession",
-    "id": "convict_drugs",
-    "name": "Meth Cook",
-    "description": "You clawed your way out of poverty by selling products everyone wanted, and they had the nerve to put you in jail for it.  Too bad you can't sell drugs to zombies.",
-    "points": 2,
-    "skills": [ { "level": 6, "name": "chemistry" }, { "level": 2, "name": "firstaid" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt_costume", "variant": "shirt_striped" },
-          { "item": "pants_costume", "variant": "pants_striped" },
-          { "item": "sneakers" },
-          { "item": "socks" },
-          { "item": "adderall" },
-          { "item": "condom", "contents-item": "dayquil" },
-          { "group": "charged_matches" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    },
-    "flags": [ "SCEN_ONLY" ]
-  },
-  {
-    "type": "profession",
-    "id": "convict_political",
-    "name": "Political Prisoner",
-    "description": "You did your best to expose what was going on in those labs, but they caught you and threw you in prison on trumped-up charges to silence you.  Clearly, they should have listened.",
-    "points": 1,
-    "skills": [ { "level": 6, "name": "speech" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt_costume", "variant": "shirt_striped" },
-          { "item": "pants_costume", "variant": "pants_striped" },
-          { "item": "sneakers" },
-          { "item": "socks" },
-          { "item": "gum" },
-          { "group": "charged_cell_phone" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    },
-    "flags": [ "SCEN_ONLY" ]
-  },
-  {
-    "type": "profession",
     "id": "convict_ratman",
     "name": { "male": "Rat Prince", "female": "Rat Princess" },
     "description": "You probably needed psychiatric help instead of a prison sentence.  At least your loyal subjects have agreed to hold the line as you make your daring escape.",
@@ -4472,74 +4291,6 @@
           { "item": "mbag" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "archaeologist",
-    "name": "Archaeologist",
-    "description": "Following a clue from your dead grandfather's journal, you made your way to a long-lost temple, but then the ground started to shake uncontrollably.  You had a bad feeling about that, so you got out of there quickly.",
-    "points": 2,
-    "skills": [
-      { "level": 4, "name": "survival" },
-      { "level": 2, "name": "gun" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "bashing" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "undershirt" },
-          { "item": "leather_belt" },
-          { "item": "socks" },
-          { "item": "boots" },
-          { "item": "jacket_leather" },
-          { "item": "knit_scarf" },
-          { "item": "bullwhip" },
-          { "item": "mbag" },
-          { "item": "fedora" },
-          { "item": "wristwatch" },
-          { "item": "spiral_stone" },
-          { "group": "charged_smart_phone" },
-          { "group": "speedloaders_s&w619_special" },
-          { "item": "sw_619", "ammo-item": "38_special", "charges": 7, "container-item": "holster" },
-          { "item": "pants" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "paperboy",
-    "name": { "male": "Paperboy", "female": "Papergirl" },
-    "description": "You set out this morning to deliver the news of the apocalypse.  The undead hordes don't seem to value the latest news, but at least your trusty bicycle is still in working order.",
-    "points": 2,
-    "skills": [ { "level": 4, "name": "driving" }, { "level": 3, "name": "throw" }, { "level": 1, "name": "speech" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_driver" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "hat_newsboy" },
-          { "item": "sweatshirt" },
-          { "item": "peacoat" },
-          { "item": "socks" },
-          { "item": "boots_winter" },
-          { "item": "gloves_wool" },
-          { "item": "knit_scarf" },
-          { "item": "mbag" },
-          { "item": "dog_whistle" },
-          { "item": "wristwatch" },
-          { "item": "newest_newspaper", "count": [ 5, 10 ] },
-          { "item": "folded_bicycle" },
-          { "group": "charged_smart_phone" },
-          { "item": "pants" }
         ]
       },
       "male": { "entries": [ { "item": "briefs" } ] },
@@ -5523,137 +5274,6 @@
   },
   {
     "type": "profession",
-    "id": "roadie",
-    "name": "Roadie",
-    "description": "You've always worked just outside of the limelight, carrying and fixing the equipment and ensuring that the performers got what they needed.  The show must go on.",
-    "points": 2,
-    "skills": [
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "electronics" },
-      { "level": 3, "name": "driving" }
-    ],
-    "proficiencies": [ "prof_appliance_repair" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "jacket_jean" },
-          { "item": "tshirt" },
-          { "item": "socks" },
-          { "item": "boots_steel" },
-          { "item": "multitool" },
-          { "item": "wristwatch" },
-          { "item": "gloves_work" },
-          { "item": "mbag" },
-          { "group": "charged_smart_phone" },
-          { "group": "charged_matches" },
-          { "group": "charged_soldering_iron" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "jeans" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" }, { "item": "jeans_skinny" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "musician",
-    "name": "Musician",
-    "description": "You nailed your solo, but the audience erupted into screams instead of applause.  You weren't able to grab much during the panic, but at least you have your loaded six string on your back.",
-    "points": 1,
-    "skills": [ { "level": 5, "name": "speech" } ],
-    "items": {
-      "both": {
-        "ammo": 100,
-        "magazine": 100,
-        "entries": [
-          { "item": "mbag" },
-          { "item": "tshirt" },
-          { "item": "shorts_cargo" },
-          { "item": "socks" },
-          { "item": "sneakers" },
-          { "item": "wristwatch" },
-          { "item": "water_clean" },
-          { "item": "guitar_electric" },
-          { "item": "cable_instrument" },
-          { "item": "plectrum" },
-          { "item": "plectrum" },
-          { "item": "plectrum" },
-          { "item": "joint" },
-          { "item": "towel", "custom-flags": [ "no_auto_equip" ] },
-          { "group": "charged_smart_phone" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "kit_survivor",
-    "name": "Kitted Survivor",
-    "description": "You saw a sign at the local mall advertising a discount on survival kits.  You bought one, more for show than for actual use.  Now it's all you have.",
-    "points": 1,
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "sneakers" },
-          { "item": "socks" },
-          { "item": "jeans" },
-          { "item": "longshirt" },
-          { "item": "wristwatch" },
-          { "item": "mbag" },
-          { "group": "full_survival_kit" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "gunslinger",
-    "name": "Wild West Gunslinger",
-    "description": "You made your living on Wild West exhibitions and shows, impressing tourists with your displays of marksmanship.  But that world has ended, so you took your trusty six-shooter and wandered into a world where it's always high noon.",
-    "points": 4,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "shotgun" },
-      { "level": 2, "name": "survival" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "under_armor" },
-          { "item": "under_armor_shorts" },
-          { "item": "cowboy_hat" },
-          { "item": "socks" },
-          { "item": "jeans" },
-          { "item": "chaps_leather" },
-          { "item": "gloves_leather" },
-          { "item": "boots_western" },
-          { "item": "longcoat_leather" },
-          { "item": "badge_deputy" },
-          { "item": "novel_western" },
-          { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "whiskey", "container-item": "bottle_glass" },
-          {
-            "item": "colt_saa",
-            "ammo-item": "45colt_jhp",
-            "charges": 6,
-            "container-item": "western_holster",
-            "contents-group": "bandolier_ww_gunslinger"
-          },
-          { "item": "sheriffshirt" }
-        ]
-      }
-    }
-  },
-  {
-    "type": "profession",
     "id": "frat",
     "name": { "male": "Frat Boy", "female": "Sorority Girl" },
     "description": "You were living the high life, spending your parents' money without a care in the world.  At one of your usual crazy parties, the guests became hungry for more than drugs and booze, but you still have a chance to use the last symbol of your luxurious life - your sports car - and get far away.",
@@ -5701,60 +5321,6 @@
       }
     },
     "age_upper": 25
-  },
-  {
-    "type": "profession",
-    "id": "mil_marksman",
-    "name": "Military Marksman",
-    "description": "You like to think of yourself as a sniper, but really you're just infantry with a bigger gun.  That said, a big gun is a definite advantage now.",
-    "points": 5,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "pants_army" },
-          { "item": "undershirt" },
-          { "item": "combat_shirt" },
-          { "item": "helmet_army" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "wristwatch" },
-          { "item": "molle_pack" },
-          { "group": "charged_two_way_radio" },
-          { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m110" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
-          { "item": "m110a1", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap" ] },
-          { "item": "m17", "ammo-item": "9mmfmj", "charges": 17, "container-item": "holster" },
-          { "group": "army_mags_m17" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
   },
   {
     "type": "profession",
@@ -5815,295 +5381,6 @@
   },
   {
     "type": "profession",
-    "id": "mil_grenadier",
-    "name": "Military Grenadier",
-    "description": "There's no kill like overkill, and not many people in this world can boast that they have a grenade launcher and know how to use it.  Just try not to blow yourself up, that would be really embarrassing.",
-    "points": 4,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "launcher" },
-      { "level": 3, "name": "rifle" },
-      { "level": 1, "name": "pistol" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "pants_army" },
-          { "item": "undershirt" },
-          { "item": "combat_shirt" },
-          { "item": "helmet_army" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "pockknife" },
-          { "item": "wristwatch" },
-          { "item": "molle_pack" },
-          { "group": "charged_two_way_radio" },
-          { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          {
-            "item": "m320",
-            "ammo-item": "40x46mm_m433",
-            "charges": 1,
-            "contents-item": [ "shoulder_strap_simple", "holo_sight" ]
-          },
-          {
-            "group": "modular_m4a1",
-            "ammo-item": "556_mk318",
-            "charges": 30,
-            "contents-item": [ "shoulder_strap", "holo_sight" ]
-          },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "grenade_pouch", "contents-group": [ "army_grenades_40x46" ] },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "mil_breacher",
-    "name": "Military Breacher",
-    "description": "Doors and windows everywhere dare not speak your name.  You're going to be breaking into buildings for supplies rather than combat operations now, but the principle is about the same.",
-    "points": 5,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "shotgun" },
-      { "level": 3, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 2, "name": "rifle" },
-      { "level": 1, "name": "pistol" },
-      { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 2, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "pants_army" },
-          { "item": "undershirt" },
-          { "item": "combat_shirt" },
-          { "item": "tac_fullhelmet" },
-          { "item": "armguard_hard" },
-          { "item": "legguard_hard" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "wristwatch" },
-          { "item": "molle_pack" },
-          { "item": "hammer_sledge" },
-          { "group": "charged_two_way_radio" },
-          { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "mossberg_500", "ammo-item": "shot_00", "charges": 6, "contents-item": [ "shoulder_strap" ] },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "grenadebandolier", "contents-item": [ "flashbang", "flashbang" ] },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "mil_sniper",
-    "name": "Military Sniper",
-    "description": "You're a crack shot with a rifle, and the farther you can stay away from zombies, the better.  The only thing stopping you is limited ammo, so you should try to find a place to restock sooner or later.",
-    "points": 5,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "pants_army" },
-          { "item": "undershirt" },
-          { "item": "combat_shirt" },
-          { "item": "helmet_army" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "wristwatch" },
-          { "item": "molle_pack" },
-          { "item": "cloak" },
-          { "group": "charged_two_way_radio" },
-          { "group": "us_ballistic_vest_pristine" },
-          { "group": "army_mags_m2010" },
-          { "item": "water_clean", "container-item": "canteen" },
-          {
-            "item": "m2010",
-            "ammo-item": "300_winmag",
-            "charges": 5,
-            "contents-item": [ "shoulder_strap", "rifle_scope" ]
-          },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mmfmj", "container-item": "holster", "charges": 17 },
-          { "item": "legpouch_large", "contents-group": "army_mags_m17" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "mil_hacker",
-    "name": "Military Hacker",
-    "description": "'Hacker' is a silly pop-culture name, popularized by Hollywood and people with little to no knowledge of what your job entails.  You prefer 'Electronic Warfare Specialist,' though nobody's really left to make the distinction.",
-    "points": 7,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_elec_soldering",
-      "prof_appliance_repair",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 7, "name": "computer" },
-      { "level": 6, "name": "electronics" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "smg" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "rifle" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "stabbing" },
-      { "level": 1, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 2, "name": "throw" },
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "pants_army" },
-          { "item": "undershirt" },
-          { "item": "combat_shirt" },
-          { "item": "helmet_army" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "diving_watch" },
-          { "item": "molle_pack" },
-          { "item": "multitool" },
-          { "item": "single_sling" },
-          { "group": "charged_two_way_radio" },
-          { "group": "us_ballistic_vest_pristine" },
-          { "group": "army_mags_mp7" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "hk_mp7", "ammo-item": "46mm", "charges": 20, "contents-item": [ "holo_sight", "suppressor" ] },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_marine", "container-item": "sheath" },
-          { "item": "XL_holster", "contents-group": "holster_supp_MEU" },
-          { "item": "legpouch_large", "contents-group": "army_mags_1911" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "mil_undercover",
-    "name": "Undercover Operative",
-    "description": "You've been tailing your target for months, and now he's a zombie.  So much for that lead.  Command isn't responding to your calls for an evac, so you'll have to make do with what you have on you.",
-    "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning", "prof_knives_familiar", "prof_auto_pistols_familiar" ],
-    "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "speech" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 2, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "scarf" },
-          { "item": "dress_shirt" },
-          { "item": "jeans" },
-          { "item": "longshirt" },
-          { "item": "kevlar" },
-          { "item": "mbag" },
-          { "item": "fancy_sunglasses" },
-          { "item": "socks" },
-          { "item": "lowtops" },
-          { "item": "pockknife" },
-          { "item": "diving_watch" },
-          { "group": "charged_smart_phone" },
-          { "item": "holster", "contents-group": "holster_supp_57" },
-          { "item": "suppressor" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "legpouch_large", "contents-group": "army_mags_57" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "mili_pilot",
     "name": "Military Pilot",
     "description": "You got to see things fall apart from the sky, transporting soldiers and survivors from one holdout to the next.  You knew it was only a matter of time before the horrors patrolling the skies shot you down.",
@@ -6155,7 +5432,7 @@
     "name": "EMT",
     "description": "You were responding to a call with your partner before you got separated.  Now all you have is your trusty ambulance, ready to transport patients through the apocalypse.",
     "points": 3,
-    "skills": [ { "level": 5, "name": "firstaid" }, { "level": 4, "name": "driving" }, { "level": 2, "name": "mechanics" } ],
+    "skills": [ { "level": 4, "name": "firstaid" }, { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
     "proficiencies": [ "prof_field_medic", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_driver" ],
     "traits": [ "PROF_MED" ],
     "vehicle": "ambulance",
@@ -6173,40 +5450,6 @@
           { "item": "adhesive_bandages", "count": 8 },
           { "group": "charged_smart_phone" },
           { "item": "pants" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "paramedic",
-    "name": "Paramedic",
-    "description": "You were separated from your partner while out on a call.  You managed to hang onto some medical supplies, but it's looking like the only life that needs saving now is yours.",
-    "points": 3,
-    "skills": [ { "level": 6, "name": "firstaid" }, { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
-    "proficiencies": [ "prof_field_medic", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_dissect_humans" ],
-    "traits": [ "PROF_MED" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt" },
-          { "item": "socks" },
-          { "item": "gloves_medical" },
-          { "item": "wristwatch" },
-          { "item": "boots" },
-          { "item": "mbag" },
-          { "item": "bandages", "count": 3 },
-          { "item": "stethoscope" },
-          { "item": "scissors" },
-          { "item": "syringe" },
-          { "item": "morphine" },
-          { "item": "adrenaline_injector" },
-          { "group": "charged_smart_phone" },
-          { "group": "full_1st_aid" },
-          { "item": "pants" },
-          { "item": "mask_dust" }
         ]
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
@@ -6285,36 +5528,6 @@
       },
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "relief_volunteer",
-    "name": "Relief Volunteer",
-    "description": "You were a member of a nonprofit organization dedicated to helping out where help was needed.  When the riots happened, you were eager to lend a hand.  But you had to cut your plans short when everyone was less interested in handouts, and more interested in eating you.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt" },
-          { "item": "jeans" },
-          { "item": "socks" },
-          { "item": "sneakers" },
-          { "item": "mbag" },
-          { "item": "adhesive_bandages", "count": 10 },
-          { "item": "bandages", "count": 3 },
-          { "item": "water_clean" },
-          { "item": "water_clean" },
-          { "item": "water_clean" },
-          { "item": "granola" },
-          { "item": "granola" },
-          { "item": "granola" },
-          { "group": "charged_smart_phone" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6404,108 +5617,6 @@
   },
   {
     "type": "profession",
-    "id": "mafia_boss",
-    "name": "Mafia Boss",
-    "description": "Born into poverty, you joined one of the organized crime families to make a living.  There, you quickly made it to the top and became the boss.  The government was building a RICO case against you, but doomsday arrived first.  Your crew is gone, but your past life has prepared you for a world where violence is common currency.",
-    "points": 5,
-    "skills": [
-      { "level": 6, "name": "speech" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "smg" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "dodge" }
-    ],
-    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_auto_pistols_familiar" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "fedora" },
-          { "item": "socks" },
-          { "item": "dress_shoes" },
-          { "item": "gold_watch" },
-          { "item": "diamond_ring" },
-          { "item": "diamond_gold_pendant_necklace" },
-          { "item": "cigar_cutter" },
-          { "item": "gold_bracelet" },
-          { "group": "charged_cell_phone" },
-          { "item": "cigar", "entry-wrapper": "case_cigar", "container-item": "null", "count": 2 },
-          { "group": "modular_deagle_44", "ammo-item": "44fmj", "container-item": "XL_holster", "charges": 8 },
-          { "item": "deaglemag", "ammo-item": "44fmj", "charges": 8, "count": 2 },
-          { "item": "knuckle_brass", "container-item": "tux" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "diamond_gold_cufflinks" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "diamond_gold_earring" } ] }
-    },
-    "traits": [ "LIAR" ],
-    "missions": [ "MISSION_MAFIA_BOSS", "MISSION_SOCIAL_BUTTERFLY" ],
-    "age_lower": 30
-  },
-  {
-    "type": "profession",
-    "id": "paranormal_investigator",
-    "name": "Paranormal Investigator",
-    "description": "You were dismissed from your position as a parapsychology professor at the local university and started your own business as a paranormal investigator.  Your former colleagues didn't approve of your research, but it looks like it's paying off now.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "electronics" }, { "level": 2, "name": "chemistry" }, { "level": 2, "name": "speech" } ],
-    "traits": [ "SPIRITUAL" ],
-    "proficiencies": [ "prof_electromagnetics" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "dress_shirt" },
-          { "item": "cleansuit" },
-          { "item": "socks" },
-          { "item": "gloves_rubber" },
-          { "item": "tool_belt" },
-          { "item": "glasses_safety" },
-          { "item": "camera_bag" },
-          { "group": "charged_smart_phone" },
-          { "group": "charged_flashlight" },
-          { "item": "pants" },
-          {
-            "item": "light_minus_battery_cell",
-            "ammo-item": "battery",
-            "charges": 50,
-            "container-item": "rad_monitor"
-          },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "radio" },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "camera_pro" },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "emf_detector" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "birder",
-    "name": "Bird Watcher",
-    "description": "You were at your favorite park looking at the robins when the Cataclysm struck.  Now all you have are your binoculars and a lot of trivia about local birds to share with any survivors you may find.",
-    "points": 1,
-    "skills": [ { "level": 3, "name": "survival" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "jeans" },
-          { "item": "longshirt" },
-          { "item": "socks" },
-          { "item": "sneakers" },
-          { "item": "mbag" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
-          { "item": "binoculars" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "cheerleader",
     "name": "Cheerleader",
     "description": "Your last cheerleader routine ended abruptly after your partners switched sides to the undead team.  Let's hope your quick reflexes and flexibility help you to find new members for the squad.",
@@ -6575,8 +5686,8 @@
       "both": {
         "entries": [
           { "item": "leather_belt" },
-          { "item": "dress_shirt" },
-          { "item": "jacket_leather" },
+          { "item": "sheriffshirt" },
+          { "item": "longcoat_leather" },
           { "item": "socks" },
           { "item": "cowboy_hat" },
           { "item": "wristwatch" },
@@ -6603,7 +5714,7 @@
   {
     "type": "profession",
     "id": "tourist_swimmer",
-    "name": "Tourist Swimmer",
+    "name": "Beachgoer",
     "description": "You were looking forward to a nice, relaxing day at the beach.  You had to run when some lunatics tried to rip your head off and play beach volleyball with it, but at least you managed to grab your bag on the way out.",
     "points": 0,
     "skills": [ { "level": 2, "name": "swimming" } ],
@@ -6634,36 +5745,6 @@
   },
   {
     "type": "profession",
-    "id": "surfer",
-    "name": "Surfer",
-    "description": "You went to ride the waves, but the waves ended up riding you instead when a putrid hand appeared from underwater and grabbed you by the ankle.  You had to ditch your surfboard in favor of a kickboard, and now you'll fight every day to stay ahead of the wave of the undead.",
-    "points": 1,
-    "flags": [ "NO_BONUS_ITEMS" ],
-    "skills": [ { "level": 4, "name": "dodge" }, { "level": 4, "name": "swimming" } ],
-    "traits": [ "OUTDOORSMAN" ],
-    "items": {
-      "both": { "entries": [ { "item": "swimming_kickboard" } ] },
-      "male": { "entries": [ { "item": "wetsuit_top" }, { "item": "wetsuit_shorts" } ] },
-      "female": { "entries": [ { "item": "wetsuit_spring_sleeveless" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "lifeguard",
-    "name": "Lifeguard",
-    "description": "Your job was to safeguard the lives of everyone at the beach, but when the swimmers started drowning each other, you knew the situation was out of your hands.",
-    "points": 2,
-    "skills": [ { "level": 4, "name": "firstaid" }, { "level": 4, "name": "swimming" } ],
-    "traits": [ "OUTDOORSMAN" ],
-    "proficiencies": [ "prof_field_medic" ],
-    "items": {
-      "both": { "entries": [ { "item": "whistle" }, { "item": "sunglasses" }, { "item": "diving_watch" } ] },
-      "male": { "entries": [ { "item": "trunks" }, { "item": "swim_briefs" }, { "item": "rashguard" } ] },
-      "female": { "entries": [ { "item": "bikini_top" }, { "item": "bikini_bottom" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "diver",
     "name": "Diver",
     "description": "You were exploring below the waves close to shore when you noticed something weird on the nearby beach, you decided to swim away when you heard the screams.",
@@ -6685,37 +5766,9 @@
     }
   },
   {
-    "id": "captain_inflatable",
-    "type": "profession",
-    "name": "Ship Captain",
-    "description": "You were the captain of your small ship, making a living by ferrying divers and tourists across the waves.  The last excursion went bad after your passengers tried to mutiny, but you managed to escape.  Will you ever sail the open ocean again?",
-    "points": 3,
-    "proficiencies": [ "prof_boat_pilot" ],
-    "skills": [ { "level": 4, "name": "driving" }, { "level": 3, "name": "swimming" } ],
-    "traits": [ "OUTDOORSMAN" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "trunks" },
-          { "item": "bastsandals" },
-          { "item": "dive_bag" },
-          { "item": "wristwatch" },
-          { "item": "flotation_vest" },
-          { "item": "hand_pump" },
-          { "item": "folded_inflatable_boat" },
-          { "item": "rashguard" },
-          { "item": "hat_ball" },
-          { "item": "waterproof_smart_phone_case", "contents-group": "charged_smart_phone" }
-        ]
-      },
-      "male": { "entries": [ { "item": "swim_briefs" } ] },
-      "female": { "entries": [ { "item": "bikini_top" }, { "item": "bikini_bottom" } ] }
-    }
-  },
-  {
     "type": "profession",
     "id": "hitman",
-    "name": { "male": "Hitman", "female": "Hitwoman" },
+    "name": { "male": "Hitman", "female": "Femme Fatale" },
     "description": "You were the best undercover agent they had, with a mission so vital that you had to take it even with the riots going on.  Your target seems to have turned feral as well as your contact, you are all alone now.",
     "points": 5,
     "skills": [
@@ -6749,66 +5802,6 @@
           { "group": "charged_cell_phone" },
           { "item": "glock_29", "ammo-item": "10mm_fmj", "charges": 15 },
           { "item": "glock_20mag", "ammo-item": "10mm_fmj", "charges": 15, "container-item": "bbholster" }
-        ]
-      },
-      "male": {
-        "entries": [
-          { "item": "briefs" },
-          { "item": "socks" },
-          { "item": "dress_shoes" },
-          { "item": "bowhat" },
-          { "item": "suit" },
-          { "item": "tie_necktie" },
-          { "item": "tieclip" },
-          { "item": "leather_belt" },
-          { "item": "briefcase" },
-          { "item": "cufflinks_intricate" }
-        ]
-      },
-      "female": {
-        "entries": [
-          { "item": "panties" },
-          { "item": "bra" },
-          { "item": "stockings" },
-          { "item": "garter_belt" },
-          { "item": "heels" },
-          { "item": "hat_cotton" },
-          { "item": "dress" },
-          { "item": "purse" },
-          { "item": "platinum_ear" },
-          { "item": "platinum_necklace" },
-          { "item": "platinum_hairpin" }
-        ]
-      }
-    },
-    "missions": [ "MISSION_ASSASSINATION" ]
-  },
-  {
-    "type": "profession",
-    "id": "assassin",
-    "name": "Assassin",
-    "description": "You were the best undercover agent they had, with a mission so vital that you had to take it even with the riots going on.  Your target seems to have turned feral as well as your contact, you are all alone now.",
-    "points": 5,
-    "skills": [
-      { "level": 6, "name": "throw" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "speech" }
-    ],
-    "proficiencies": [ "prof_spotting", "prof_wp_syn_armored", "prof_knives_familiar", "prof_knives_pro", "prof_knives_master" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "fancy_sunglasses" },
-          { "item": "platinum_watch" },
-          { "item": "knit_scarf_loose" },
-          { "item": "gloves_liner" },
-          { "item": "polaroid_photo" },
-          { "item": "switchblade" },
-          { "group": "charged_cell_phone" },
-          { "item": "knife_combat", "container-item": "gartersheath1" },
-          { "item": "leg_sheath6", "contents-group": "leg_sheath6_throwing_knives" }
         ]
       },
       "male": {
@@ -6882,73 +5875,6 @@
       "female": { "entries": [ { "item": "boy_shorts" }, { "item": "bra" } ] }
     },
     "age_lower": 50
-  },
-  {
-    "type": "profession",
-    "id": "urbex",
-    "name": "Urban Explorer",
-    "description": "You've always admired the beauty of urban desolation, and were ready for your next excursion when the end of the world hit.  You suppose that pretty much every building could be considered abandoned now.",
-    "points": 2,
-    "skills": [ { "level": 4, "name": "traps" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_lockpicking" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "wristwatch" },
-          { "item": "gloves_fingerless" },
-          { "item": "socks" },
-          { "item": "sneakers" },
-          { "item": "hoodie" },
-          { "item": "longshirt" },
-          { "item": "claw_bar" },
-          { "item": "camera_bag" },
-          { "item": "slingpack" },
-          { "item": "leather_belt" },
-          { "item": "urbexmap" },
-          { "group": "charged_smart_phone" },
-          { "item": "pants" },
-          { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" },
-          {
-            "item": "light_disposable_cell",
-            "ammo-item": "battery",
-            "charges": 300,
-            "container-item": "wearable_light"
-          }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
-    },
-    "age_lower": 16
-  },
-  {
-    "type": "profession",
-    "id": "officeworker",
-    "name": "Office Worker",
-    "description": "You felt years of your life being sapped away, slaving at your computer as you subsisted on a daily pot of coffee, microwave burritos and an endless supply of crumpled paper to toss.  Perhaps the Cataclysm is a refreshing change of pace…",
-    "points": 0,
-    "skills": [
-      { "level": 2, "name": "computer" },
-      { "level": 2, "name": "cooking" },
-      { "level": 2, "name": "throw" },
-      { "level": 2, "name": "speech" }
-    ],
-    "addictions": [ { "intensity": 10, "type": "caffeine" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "dress_shirt" },
-          { "item": "undershirt" },
-          { "item": "tie_clipon" },
-          { "group": "charged_smart_phone" },
-          { "group": "charged_penblack" },
-          { "item": "pants" },
-          { "item": "coffee", "container-item": "coffeepot" }
-        ]
-      },
-      "male": { "entries": [ { "item": "briefs" }, { "item": "socks" }, { "item": "dress_shoes" } ] },
-      "female": { "entries": [ { "item": "panties" }, { "item": "bra" }, { "item": "shoes_slip_on" } ] }
-    }
   },
   {
     "type": "profession",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -706,33 +706,6 @@
   },
   {
     "type": "profession",
-    "id": "video_blogger",
-    "name": "Video Blogger",
-    "description": "You made a career out of creating and commentating video content and posting it on various platforms.  Now most of your fans are dead, alongside your equipment.  Maybe you didn't cultivate the most practical skillset through your career, but you have learned a thing or two about troubleshooting software and getting people to listen to you.",
-    "points": 2,
-    "skills": [ { "level": 4, "name": "speech" }, { "level": 4, "name": "computer" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "longshirt" },
-          { "item": "socks" },
-          { "item": "sneakers" },
-          { "item": "backpack" },
-          { "item": "pockknife" },
-          { "item": "water_clean" },
-          { "item": "wearable_camera" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
-          { "group": "charged_laptop" },
-          { "group": "charged_matches" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "jeans" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "jeans_skinny" } ] }
-    }
-  },
-  {
-    "type": "profession",
     "id": "sheltered_survivor",
     "name": "Sheltered Survivor",
     "description": "At the start of the Cataclysm, you hunkered down in a bomb shelter.  You've spent the past months eating canned food, reading books, and tinkering.  Now it is winter - time to face the world above.",
@@ -5714,7 +5687,7 @@
   {
     "type": "profession",
     "id": "tourist_swimmer",
-    "name": "Beachgoer",
+    "name": "Swimmer",
     "description": "You were looking forward to a nice, relaxing day at the beach.  You had to run when some lunatics tried to rip your head off and play beach volleyball with it, but at least you managed to grab your bag on the way out.",
     "points": 0,
     "skills": [ { "level": 2, "name": "swimming" } ],

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -434,7 +434,7 @@
       "sloc_bikeshop",
       "sloc_petstore"
     ],
-    "professions": [ "svictim", "naked", "unemployed", "homeless", "hitchhiker", "patriot", "clown", "lost_sub", "spouse", "musician" ],
+    "professions": [ "svictim", "naked", "unemployed", "homeless", "hitchhiker", "patriot", "clown", "lost_sub", "spouse" ],
     "eoc": [ "scenario_infected", "scenario_bad_day" ],
     "requirement": "achievement_survive_28_days",
     "flags": [ "FIRE_START", "CHALLENGE", "CITY_START", "LONE_START" ]
@@ -654,13 +654,7 @@
     "description": "When the Cataclysm happened, you were convicted or working in a prison.  Now the inmates and guards alike have turned into mindless horrors and joined forces… you might need to expedite your escape plans.",
     "allowed_locs": [ "sloc_prison" ],
     "start_name": "Prison",
-    "professions": [
-      "convict",
-      "convict_assassin",
-      "convict_ratman",
-      "k9_cop",
-      "cop"
-    ],
+    "professions": [ "convict", "convict_assassin", "convict_ratman", "k9_cop", "cop" ],
     "flags": [ "CITY_START", "LONE_START" ]
   },
   {
@@ -671,13 +665,7 @@
     "description": "You were convicted or working in a high-security prison before the Cataclysm.  Unfortunately, you're still in it, so you need to figure out how to escape.  It's located on a remote island to boot; you'll eventually need to escape that also.",
     "allowed_locs": [ "sloc_prison_alcatraz", "sloc_prison_island" ],
     "start_name": "Island prison",
-    "professions": [
-      "convict",
-      "convict_assassin",
-      "convict_ratman",
-      "k9_cop",
-      "cop"
-    ],
+    "professions": [ "convict", "convict_assassin", "convict_ratman", "k9_cop", "cop" ],
     "requirement": "achievement_reach_island_prison",
     "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ]
@@ -828,7 +816,7 @@
     "description": "You were participating in a mining operation when you found… something.  You're not sure what, but it sure is dark down here.",
     "start_name": "Bottom of a mine",
     "allowed_locs": [ "sloc_mine_finale" ],
-    "professions": [ "miner", "labtech", "security", "archaeologist" ],
+    "professions": [ "miner", "labtech", "security" ],
     "requirement": "achievement_reach_mine",
     "flags": [ "CITY_START", "LONE_START", "CHALLENGE" ]
   },
@@ -879,7 +867,6 @@
       "cheerleader",
       "patriot",
       "tourist_swimmer",
-      "video_blogger",
       "chef",
       "scoundrel",
       "baseball_player",
@@ -891,7 +878,6 @@
       "clown",
       "spouse",
       "naked",
-      "musician",
       "super_biker",
       "local_drug_dealer",
       "hitman"
@@ -935,9 +921,7 @@
       "basketball_player",
       "baseball_player",
       "tailor",
-      "video_blogger",
       "spouse",
-      "musician",
       "chef",
       "senior",
       "otaku",
@@ -946,10 +930,7 @@
       "groundskeeper",
       "homemaker",
       "pizzaboy",
-      "paranormal_investigator",
-      "archaeologist",
       "tourist",
-      "urbex",
       "burglar",
       "urban_samurai",
       "fencer",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -657,9 +657,6 @@
     "professions": [
       "convict",
       "convict_assassin",
-      "convict_embezzler",
-      "convict_drugs",
-      "convict_political",
       "convict_ratman",
       "k9_cop",
       "cop"
@@ -677,9 +674,6 @@
     "professions": [
       "convict",
       "convict_assassin",
-      "convict_embezzler",
-      "convict_drugs",
-      "convict_political",
       "convict_ratman",
       "k9_cop",
       "cop"
@@ -811,14 +805,7 @@
       "national_guard",
       "politician",
       "hitman",
-      "assassin",
-      "mil_marksman",
       "mil_auto_rifleman",
-      "mil_grenadier",
-      "mil_breacher",
-      "mil_sniper",
-      "mil_hacker",
-      "mil_undercover",
       "mili_pilot",
       "mili_medic",
       "major-general",
@@ -860,13 +847,7 @@
       "specops",
       "labtech",
       "medic",
-      "mil_marksman",
       "mil_auto_rifleman",
-      "mil_grenadier",
-      "mil_breacher",
-      "mil_sniper",
-      "mil_hacker",
-      "mil_undercover",
       "mili_pilot",
       "mili_medic",
       "hazmat_unit",
@@ -913,9 +894,7 @@
       "musician",
       "super_biker",
       "local_drug_dealer",
-      "mafia_boss",
-      "hitman",
-      "assassin"
+      "hitman"
     ],
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
@@ -974,10 +953,8 @@
       "burglar",
       "urban_samurai",
       "fencer",
-      "mafia_boss",
       "major-general",
-      "hitman",
-      "assassin"
+      "hitman"
     ],
     "requirement": "achievement_reach_mansion",
     "missions": [ "MISSION_MANSION_START" ]


### PR DESCRIPTION
#### Summary
Hobby and Profession cleanup

#### Purpose of change
- There were a bunch of dumb redundant hobbies
- There were a bunch of silly or pointless professions
- This made chargen more confusing than it needed to be and took the focus off of customization

#### Describe the solution
- Remove all hobbies that are just skills
- Collapse all the MA hobbies into a weapon and an unarmed hobby
- Clean up and condense the starting hobbies
- Remove a bunch of redundant, extraneous, or silly professions.

#### Describe alternatives you've considered
- Professions need to be a source of gear and starting vehicles, rather than insane skills.
- Hobbies should be a source of proficiencies and addictions.
- Game Master and Skater need to be proficiencies.

#### Testing
Loads and runs, chargen looks good, NPCs aren't exploding. Old saves might throw an error but you can just skip it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
