### PR TITLE
Fix stray debug message

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -951,7 +951,6 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     if( hits && cur_weapon && !t.is_hallucination() ) {
         if( !cur_weapon->is_soft() && !cur_weapon->made_of( material_rubber ) ) {
             handle_melee_wear( cur_weapon );
-            add_msg( _( "wearing weapon" ) );
             // Soft weapons and clothing (IE a whip or cloth gloves on a punch) should not fall apart.
             // Neither should rubber-soled shoes.
         } else if( one_in( 5 ) ) {


### PR DESCRIPTION
#### Summary
Fix stray debug message

#### Purpose of change
Fix a random weird message popping up when attacking.

#### Describe the solution
I left a message that said "wearing weapon" in the melee code by accident. I was just checking something w/r/t weapon wear during combat. This removes it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
