### PR TITLE
Fix dodge display in @

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3617,7 +3617,7 @@
     "id": "grabbed",
     "name": [ "Grabbed" ],
     "desc": [
-      "You have been grabbed and held in place by an attack.  You're not able to move until breaking the grab, and depending on the strength of your opponent using this limb is difficult to impossible.\nWait in place or attempt to move without attacking to try and remove this effect."
+      "You have been grabbed and held in place by an attack.  You cannot move or dodge, and depending on the strength of your opponent, use of this body part is hindered.\nWait in place or attempt to move without attacking to try and remove this effect."
     ],
     "rating": "bad",
     "//": "Removal handled in code, so no max duration needed, intensity set by the grab_strength, all effects are local-only",
@@ -3625,7 +3625,7 @@
     "show_in_info": true,
     "show_intensity": true,
     "//mods": "No swimmin' or manipulatin' with a held limb, other scores start severly debilitated and reach useless at about 50 grab strength",
-    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "multiply": 0.0 } ] } ],
+    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "add": -100.0 } ] } ],
     "limb_score_mods": [
       { "limb_score": "manip", "modifier": 0.0 },
       { "limb_score": "grip", "modifier": 0.0 },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4018,8 +4018,6 @@ void Character::reset_stats()
         update_mental_focus();
     }
 
-    mod_dodge_bonus( enchantment_cache->modify_value( enchant_vals::mod::DODGE_CHANCE, 0 ) );
-
     /** @EFFECT_STR_MAX above 15 decreases Dodge bonus by 1 (NEGATIVE) */
     if( str_max >= 16 ) {
         mod_dodge_bonus( -1 );   // Penalty if we're huge

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1275,7 +1275,10 @@ float Character::get_dodge() const
         ret *= 0.8;
     }
 
-    return std::max( 0.0f, ret );
+    ret = std::max( 0.0, ret + ( enchantment_cache->modify_value( enchant_vals::mod::DODGE_CHANCE, 0 ) ) );
+        add_msg_debug( debugmode::DF_MELEE, "Dodge after DODGE_CHANCE enchantment modifier %.1f", ret );
+
+    return ret;
 }
 
 float Character::dodge_roll() const

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -489,8 +489,8 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
     } else if( line == 1 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
-                        _( "Dexterity affects your chance to hit in melee combat, helps you steady your "
-                           "gun for ranged combat, and enhances many actions that require finesse." ) );
+                        _( "Dexterity affects your chance to hit in melee combat, helps you aim faster in "
+                           "ranged combat, and enhances many actions that require finesse." ) );
         print_colored_text( w_info, point( 1, 3 ), col_temp, c_light_gray,
                             string_format( _( "Melee to-hit bonus: <color_white>%+.1lf</color>" ), you.get_melee_hit_base() ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
@@ -502,8 +502,8 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
     } else if( line == 2 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
-                        _( "Intelligence is less important in most situations, but it is vital for more complex tasks like "
-                           "electronics crafting.  It also affects how much skill you can pick up from reading a book." ) );
+                        _( "Intelligence affects your learning and crafting speed, your social skills, and your "
+                            "ability to perform complex intellectual tasks such as surgery." ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Read times: <color_white>%d%%</color>" ), you.read_speed() ) );
         print_colored_text( w_info, point( 1, 5 ), col_temp, c_light_gray,
@@ -512,7 +512,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Perception is the most important stat for ranged combat.  It's also used for "
-                           "detecting traps and other things of interest." ) );
+                           "detecting traps, seeing in the dark, and noticing points of interest." ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Trap detection level: <color_white>%d</color>" ), you.get_per() ) );
         if( you.ranged_per_mod() > 0 ) {
@@ -524,7 +524,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
         const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                                           _( "Your weight is a general indicator of how much fat your body has stored up,"
                                              " which in turn shows how prepared you are to survive for a time without food."
-                                             "  Having too much, or too little, can be unhealthy." ) );
+                                             "  Having too much or too little can be unhealthy." ) );
         fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         display::weight_long_description( you ) );
     } else if( line == 5 ) {
@@ -534,7 +534,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
     } else if( line == 6 ) {
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         const int lines = fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
-                                          _( "Your height.  Simply how tall you are." ) );
+                                          _( "Your height when standing fully upright." ) );
         fold_and_print( w_info, point( 1, 1 + lines ), FULL_SCREEN_WIDTH - 2, c_light_gray,
                         you.height_string() );
     } else if( line == 7 ) {


### PR DESCRIPTION
#### Summary
Fix dodge display in @

#### Purpose of change
The DODGE_CHANCE enchantment has never properly displayed in either debug or the @ screen. This made it hard to track down issues with it.

#### Describe the solution
Move the function from Character::reset_stats() to Character::get_dodge(). I can't figure why it was in reset_stats() to begin with, except maybe that the original contributor was worried it wouldn't update as-needed if it was a scaling mod attached to a decaying effect. However, get_dodge() is called every single time the dodge score needs to be checked or displayed, so there are no issues with moving it.

#### Describe alternatives you've considered
Special case a check for that specific enchantment in player_display.cpp

#### Testing
TLG grabs affect dodge rate vis DODGE_CHANCE, so I was able to make a character, get grabbed, and see my dodge score in @ drop to zero. It was also correctly called out in the debug messages. Any DODGE_CHANCE effect would work for testing this.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
