### PR TITLE
Remove NV and IR goggles from firefighter zeds

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -2924,9 +2924,7 @@
       [ "mask_dust", 30 ],
       { "item": "mask_gas", "prob": 20, "charges": [ 0, -1 ] },
       { "item": "mask_gas_half", "prob": 20, "charges": [ 0, -1 ] },
-      { "item": "mask_filter", "prob": 10, "charges": [ 0, -1 ] },
-      { "item": "goggles_nv", "prob": 2, "charges": [ 0, 100 ] },
-      { "item": "goggles_ir", "prob": 1, "charges": [ 0, 100 ] }
+      { "item": "mask_filter", "prob": 10, "charges": [ 0, -1 ] }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Remove NV and IR goggles from firefighter zeds

#### Purpose of change
Firefighter zombies had NV and IR goggles. While some specialized firefighters do carry these items in specific locations (ie Navy fire controlmen), they're not a normal piece of kit for the guys at your local station. Additionally, their drop chance even at 1% wound up being way too high, so firefighter zombies became the most reliable place to get these items.

#### Describe the solution
Remove them from firefighter zeds.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
