### PR TITLE
Check for worn status on PROVIDES_TECHNIQUES

### DIFF
--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1409,8 +1409,10 @@ std::vector<matec_id> character_martial_arts::get_all_techniques( const item_loc
     const std::vector<const item *> tech_providing_items = u.cache_get_items_with(
                 json_flag_PROVIDES_TECHNIQUES );
     for( const item *it : tech_providing_items ) {
-        const std::set<matec_id> &item_techs = it->get_techniques();
-        tecs.insert( tecs.end(), item_techs.begin(), item_techs.end() );
+        if( u.is_wearing( it->typeId() ) ) {
+            const std::set<matec_id> &item_techs = it->get_techniques();
+            tecs.insert( tecs.end(), item_techs.begin(), item_techs.end() );
+        }
     }
     // and martial art techniques
     tecs.insert( tecs.end(), style.techniques.begin(), style.techniques.end() );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1275,8 +1275,9 @@ float Character::get_dodge() const
         ret *= 0.8;
     }
 
-    ret = std::max( 0.0, ret + ( enchantment_cache->modify_value( enchant_vals::mod::DODGE_CHANCE, 0 ) ) );
-        add_msg_debug( debugmode::DF_MELEE, "Dodge after DODGE_CHANCE enchantment modifier %.1f", ret );
+    ret = std::max( 0.0, ret + ( enchantment_cache->modify_value( enchant_vals::mod::DODGE_CHANCE,
+                                 0 ) ) );
+    add_msg_debug( debugmode::DF_MELEE, "Dodge after DODGE_CHANCE enchantment modifier %.1f", ret );
 
     return ret;
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -503,7 +503,7 @@ static void draw_stats_info( const catacurses::window &w_info, const Character &
         // NOLINTNEXTLINE(cata-use-named-point-constants)
         fold_and_print( w_info, point( 1, 0 ), FULL_SCREEN_WIDTH - 2, c_magenta,
                         _( "Intelligence affects your learning and crafting speed, your social skills, and your "
-                            "ability to perform complex intellectual tasks such as surgery." ) );
+                           "ability to perform complex intellectual tasks such as surgery." ) );
         print_colored_text( w_info, point( 1, 4 ), col_temp, c_light_gray,
                             string_format( _( "Read times: <color_white>%d%%</color>" ), you.read_speed() ) );
         print_colored_text( w_info, point( 1, 5 ), col_temp, c_light_gray,


### PR DESCRIPTION
#### Summary
Check for worn status on PROVIDES_TECHNIQUES

#### Purpose of change
Items that have PROVIDES_TECHNIQUES were granting their techs if they were in your inventory at all. This is inappropriate, they're supposed to only work when worn.

#### Describe the solution
- Add a check for whether the item is worn.

#### Testing
- Spawn with bagh nakhs. Wear them, claw stuff.
- Put them away. Do not claw stuff.
- Drop them. Do not claw stuff.
- Mutate fangs. Bite stuff.
- All seems good.

#### Additional context
This should not impact weapon techs (IE precise strike)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
