### PR TITLE
Backport 79026 - Fix bad roof replacement

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4687,8 +4687,8 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
         spawn_items( p, item_group::items_from( bash->drop_group, calendar::turn ) );
     }
     //regenerates roofs for tiles that should be walkable from above
-    if( zlevels && smash_ter && !set_to_air  && ter( p )->has_flag( "EMPTY_SPACE" ) &&
-        ter( below )->has_flag( "WALL" ) ) {
+    if( zlevels && smash_ter && !set_to_air && ter( p )->has_flag( "EMPTY_SPACE" ) &&
+        ter( below )->has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ) {
         const ter_str_id roof = get_roof( below, params.bash_floor && ter( below ).obj().movecost != 0 );
         ter_set( p, roof );
     }


### PR DESCRIPTION
#### Summary
Backport 79026 - Fix bad roof replacement

#### Purpose of change
There was a bug where some terrains (mostly fence posts) were not turning into floors when destroyed above a roofed tile.

#### Describe the solution
Switch the check for the tile under the fence from WALL to SUPPORTS_ROOF

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
