### PR TITLE
Quick fix for XL, XS bronze vambraces not requiring any bronze

### DIFF
--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -301,6 +301,11 @@
     ]
   },
   {
+    "id": "bronze_bits",
+    "type": "item_group",
+    "items": [ { "item": "scrap_bronze" } ]
+  },
+  {
     "id": "pencil_case_with_contents",
     "type": "item_group",
     "subtype": "collection",


### PR DESCRIPTION
#### Summary
Fixes an issue I'd mentioned in the discord abt XL / XS bronze vambraces not needing any bronze since copy-from doesn't respect components

#### Purpose of change

Fix the issue with XL / XS bronze vambraces not needing any bronze
#### Describe the solution

Added an itemgroup to misc.json called bronze_bits which is just scrap bronze, make original recipe require bronze_bits 6 to reflect original cost of recipe, make XS require 4 and XL require 8 (same ratios as forging_standard.)
#### Describe alternatives you've considered

Leaving it busted and waiting for a fix for components from copy-from to come through the pipeline
#### Testing

Will test after I finish writing it and attach screenshots. Don't merge unless you see them.
#### Additional context

https://discord.com/channels/1341953719889170594/1381106065176793220

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
