### PR TITLE
Fix 2 Z level bugs

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -495,6 +495,28 @@ void activity_handlers::butcher_do_turn( player_activity *act, Character * )
         return;
     }
     item &corpse_item = *target;
+    if( action == butcher_type::DISSECT && ( corpse_item.has_flag( flag_QUARTERED ) ||
+            corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ||
+            corpse_item.has_flag( flag_GIBBED ) ) ) {
+        add_msg( m_bad, _( "You back off from the ruined corpse, unable to continue." ) );
+        act->set_to_null();
+        return;
+    }
+    if( action == butcher_type::BLEED && ( corpse_item.has_flag( flag_BLED ) ||
+                                           corpse_item.has_flag( flag_SKINNED ) ||
+                                           corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) ||
+                                           corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) ||
+                                           corpse_item.has_flag( flag_FIELD_DRESS ) ) ) {
+        add_msg( m_bad, _( "There's not much blood left in the corpse, so you give up." ) );
+        act->set_to_null();
+        return;
+    }
+    if( action == butcher_type::SKIN && ( corpse_item.has_flag( flag_SKINNED ) ||
+                                          corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) ) ) {
+        add_msg( m_bad, _( "The corpse is too damaged now, there's no usable hide left." ) );
+        act->set_to_null();
+        return;
+    }
     corpse_item.set_var( butcher_progress_var( action ), progress );
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -889,6 +889,12 @@ bool Creature::is_adjacent( const Creature *target, const bool allow_z_levels ) 
         return false;
     }
 
+    // Explicitly check for Z difference > 1
+    if( std::abs( posz() - target->posz() ) > 1 ) {
+
+        return false;
+    }
+
     map &here = get_map();
     if( posz() == target->posz() ) {
         return


### PR DESCRIPTION
#### Summary
Fix 2 Z level bugs

#### Purpose of change
1) Shockers were able to shoot you through the floor if they were directly below you. This was an oopsie on my part when I redid the adjacency checks.
2) NPCs were ascending through solid floors even if no stairs etc existed to help you craft if you were above them (or descending if you were below). This was a DDA bug, as clear_path() was not properly considering the fact that human beings cannot float directly upwards through solid roofs/floors.

#### Describe the solution
1) Fix creature::is_adjacent()
2) Add a bunch of checks to clear_path() now looks for stairs or whatever to get up and down floors, rather than just phasing through them.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
