### PR TITLE
Reduce heat slowdown

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2790,13 +2790,13 @@
   {
     "type": "effect_type",
     "id": "hot_speed",
-    "name": [ "Slowdown", "Hampered", "Crushed" ],
-    "desc": [ "The heat slows you down.", "You struggle to move in this heat.", "The heat is crushing you." ],
+    "name": [ "Hot", "Sweltering", "Overheating" ],
+    "desc": [ "The heat slows you down.", "The heat is really slowing you down.", "The heat is crushing you." ],
     "speed_name": "Heat slowdown",
     "max_intensity": 3,
     "part_descs": true,
-    "base_mods": { "speed_mod": [ -2 ] },
-    "scaling_mods": { "speed_mod": [ -4 ] }
+    "base_mods": { "speed_mod": [ -1 ] },
+    "scaling_mods": { "speed_mod": [ -2 ] }
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
#### Summary
Reduce heat slowdown

#### Purpose of change
Temperature is mad fucked up, but there's only so much I can do about it without having to rewrite the whole thing. One major issue is that the heat slowdown effect seems really drastic, with the player losing 10% of their speed on a typical summer day and that easily jumping to 30% on a bad one. Given that we're already penalizing their armor, making them sweat buckets, etc. etc., let's chill out on the heat thing eh?

#### Describe the solution
Previously: Heat slowdown was 10, 30, and then 50
Now: Heat slowdown is 5, 15, and then 35.

#### Describe alternatives you've considered
- Rewrite the entire system to be less stupid (eventually!)
- Add fans and portable AC units (that's coming soon)

#### Testing
Loaded in, set temp to 95 degrees, saw a speed loss of 5. Yeah 95 Fahrenheit is pretty spicy but you have a lot of problems in that kind of weather that don't involve randomly becoming slower than a zombie, so it seems fine to me.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
