### PR TITLE
Fix stray backgrounds

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11061,7 +11061,7 @@ void Character::process_one_effect( effect &it, bool is_new )
                                          it.get_max_val( "HEART_RATE", reduced ), 0 ) );
         }
     }
-    // handle perspiration rate
+    // handle respiration rate
     val = get_effect( "RESPIRATION_RATE", reduced );
     if( val != 0 ) {
         if( is_new || it.activated( calendar::turn, "RESPIRATION_RATE", val, reduced, mod ) ) {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -440,7 +440,7 @@ std::vector<string_id<profession>> scenario::permitted_professions() const
         bool conflicting_traits = scenario_traits_conflict_with_profession_traits( p );
 
         if( blacklist || professions.empty() ) {
-            if( !present && !p.has_flag( "SCEN_ONLY" ) && !conflicting_traits ) {
+            if( !present && !p.has_flag( "SCEN_ONLY" ) && !conflicting_traits && !p.is_hobby() ) {
                 res.push_back( p.ident() );
             }
         } else if( present ) {


### PR DESCRIPTION
#### Summary
Fix stray backgrounds

#### Purpose of change
Some of the adult_basic backgrounds (IE Driver's License) were not properly being filtered out of the profession list in cases where the chosen scenario had no professions defined.

#### Describe the solution
- Add && !is_hobby() to the function that populates the list when no professions are defined for the scenario.
- Fix a random typo in a comment in a totally unrelated file

#### Testing
Works


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
