### PR TITLE
Martial Arts bugfixes

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1213,7 +1213,7 @@
     "repairs_with": [ "steel" ],
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 18 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
-    "weapon_category": [ "KNIVES" ],
+    "weapon_category": [ "KNIVES", "NINJUTSU_WEAPONS" ],
     "melee_damage": { "bash": 2, "stab": 18 }
   },
   {
@@ -1257,7 +1257,7 @@
     "techniques": [ "RAPID", "WBLOCK_2" ],
     "to_hit": { "grip": "weapon", "length": "short", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 12 ] ],
-    "weapon_category": [ "MEDIUM_SWORDS" ],
+    "weapon_category": [ "MEDIUM_SWORDS", "NINJUTSU_WEAPONS" ],
     "melee_damage": { "bash": 2, "cut": 27 }
   },
   {

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -51,7 +51,7 @@
     "melee_damage": { "bash": 2, "cut": 2 },
     "weapon_category": [ "SHIVS" ]
   },
-    {
+  {
     "type": "GENERIC",
     "id": "antler",
     "symbol": "%",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -73,7 +73,7 @@
       {
         "id": "buff_aikido_onblock",
         "name": "Fluid Blocking",
-        "description": "After a smooth block, you prepare to counter your foe.\n\n-10% move cost.\nLasts 1 turn.",
+        "description": "After a smooth block, you prepare to counter your foe.\n\n+10% move speed.\nLasts 1 turn.",
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -85,7 +85,7 @@
       {
         "id": "buff_aikido_ondodge",
         "name": "Fluid Dodging",
-        "description": "After a smooth dodge, you prepare to counter your foe.\n\n-10% move cost.\nLasts 1 turn.",
+        "description": "After a smooth dodge, you prepare to counter your foe.\n\n+10% move speed.\nLasts 1 turn.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 1,
@@ -179,7 +179,7 @@
       {
         "id": "buff_barbaran_onblock",
         "name": "Reversing Destreza",
-        "description": "Blocking a key strike will turn the battle around.\n\n-5% move cost.\nLasts 3 turns.  Stacks 2 times.",
+        "description": "Blocking a key strike will turn the battle around.\n\n+5% move speed.\nLasts 3 turns.  Stacks 2 times.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
         "max_stacks": 2,
@@ -736,7 +736,7 @@
       {
         "id": "buff_karate_onhit",
         "name": "Karate Kata",
-        "description": "Landing a hit allows you to perfectly position yourself for maximum defense against multiple opponents.\n\n+1 block attempt, +1 dodge attempt, blocked damage reduced by 50% of Strength, -10% move cost.\nLasts 2 turns.",
+        "description": "Landing a hit allows you to perfectly position yourself for maximum defense against multiple opponents.\n\n+1 block attempt, +1 dodge attempt, blocked damage reduced by 50% of Strength, +10% move speed.\nLasts 2 turns.",
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
@@ -893,7 +893,7 @@
       {
         "id": "buff_swordsmanship_onblock",
         "name": "Mastercut",
-        "description": "You parry and return the attack with greater vigor!\n\n+10% damage, -10% move cost.\nLasts 1 turn.",
+        "description": "You parry and return the attack with greater vigor!\n\n+10% damage, +10% move speed.\nLasts 1 turn.",
         "melee_allowed": true,
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
         "buff_duration": 1,
@@ -909,7 +909,7 @@
       {
         "id": "buff_swordsmanship_onhit",
         "name": "Conserve Momentum",
-        "description": "You maintain the momentum from your last strike to move more quickly.\n\n-20% move cost.\nLasts 2 turns.",
+        "description": "You maintain the momentum from your last strike to move more quickly.\n\n+20% move speed.\nLasts 2 turns.",
         "melee_allowed": true,
         "skill_requirements": [ { "name": "melee", "level": 2 } ],
         "buff_duration": 2,
@@ -1029,14 +1029,14 @@
       {
         "id": "buff_ninjutsu_onkill",
         "name": "Escape Plan",
-        "description": "Your target has perished.  It is time to leave and plan your next attack.\n\n+2 dodge attempts, +10 movement speed.\nLasts 3 turns, persists after switching styles.",
+        "description": "Your target has perished.  It is time to leave and plan your next attack.\n\n+2 dodge attempts, +10% movement speed.\nLasts 3 turns, persists after switching styles.",
         "skill_requirements": [ { "name": "melee", "level": 3 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 3,
         "persists": true,
         "bonus_dodges": 2,
-        "flat_bonuses": [ { "stat": "movecost", "scale": 10.0 } ]
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "techniques": [
@@ -1499,7 +1499,7 @@
       {
         "id": "buff_wingchun_onhit",
         "name": "Chain Punch",
-        "description": "Your punches are properly timed to give your opponent no rest from your strikes.\n\n-10% move cost.\nLasts 2 turns.  Stacks 3 times.",
+        "description": "Your punches are properly timed to give your opponent no rest from your strikes.\n\n+10% move speed.\nLasts 2 turns.  Stacks 3 times.",
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
         "unarmed_allowed": true,
         "buff_duration": 2,

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -634,6 +634,7 @@
         "name": "Tactical Retreat",
         "description": "You moved and nullified the effects of Stand Your Ground!\n\n-2 blocking effectiveness, -1 block attempt, +1.0 Dodging skill, blocked damage increased by 50% of Strength.\nPrevents \"High Round Strike\" technique.\nLasts 2 turns.",
         "melee_allowed": true,
+        "persists": true,
         "buff_duration": 2,
         "bonus_blocks": -1,
         "flat_bonuses": [
@@ -687,7 +688,7 @@
       {
         "id": "buff_judo_static",
         "name": "Judo Stance",
-        "description": "Your knowledge of grappling allows you to recover from knockdown effects instantly.  In addition, you can counter grabs and takedown attacks with a judo throw.",
+        "description": "Your knowledge of grappling allows you to recover from knockdown effects quickly.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "flags": [ "DOWNED_RECOVERY" ]
@@ -1035,7 +1036,7 @@
         "buff_duration": 3,
         "persists": true,
         "bonus_dodges": 2,
-        "flat_bonuses": [ { "stat": "speed", "scale": 10.0 } ]
+        "flat_bonuses": [ { "stat": "movecost", "scale": 10.0 } ]
       }
     ],
     "techniques": [
@@ -1170,8 +1171,7 @@
       "tec_pankration_kick",
       "tec_pankration_break",
       "tec_pankration_grabknee",
-      "tec_pankration_grabdisarm",
-      "tec_pankration_grabthrow"
+      "tec_pankration_grabdisarm"
     ]
   },
   {

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -449,7 +449,13 @@
     "autolearn": true,
     "reversible": true,
     "book_learn": [ [ "bronze_book", 4 ], [ "textbook_armwest", 4 ], [ "recipe_melee", 4 ] ],
-    "using": [ [ "forging_standard", 6 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 4 ], [ "clasps", 4 ], [ "bronze_tiny", 6 ] ],
+    "using": [
+      [ "forging_standard", 6 ],
+      [ "bronzesmithing_tools", 1 ],
+      [ "strap_small", 4 ],
+      [ "clasps", 4 ],
+      [ "bronze_tiny", 6 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_redsmithing" },
@@ -461,14 +467,26 @@
     "type": "recipe",
     "copy-from": "bronze_vambraces",
     "time": "7 h 30 m",
-    "using": [ [ "forging_standard", 4 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 3 ], [ "clasps", 3 ], [ "bronze_tiny", 4 ] ]
+    "using": [
+      [ "forging_standard", 4 ],
+      [ "bronzesmithing_tools", 1 ],
+      [ "strap_small", 3 ],
+      [ "clasps", 3 ],
+      [ "bronze_tiny", 4 ]
+    ]
   },
   {
     "result": "bronze_vambraces_xl",
     "type": "recipe",
     "copy-from": "bronze_vambraces",
     "time": "8 h 30 m",
-    "using": [ [ "forging_standard", 8 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 4 ], [ "clasps", 4 ], [ "bronze_tiny", 8 ] ]
+    "using": [
+      [ "forging_standard", 8 ],
+      [ "bronzesmithing_tools", 1 ],
+      [ "strap_small", 4 ],
+      [ "clasps", 4 ],
+      [ "bronze_tiny", 8 ]
+    ]
   },
   {
     "result": "platemail_arm_guards",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1603,10 +1603,7 @@
     "type": "technique",
     "id": "tec_judo_break",
     "name": "Grab Break",
-    "messages": [
-      "You were almost grabbed by %s, but you break their feeble grapple!",
-      "<npcname> was almost grabbed by %s, but they break its feeble grapple!"
-    ],
+    "messages": [ "You were almost grabbed by %s, but you break free!", "<npcname> was almost grabbed by %s, but they break free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -2067,7 +2064,12 @@
     },
     "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>identical or smaller</info> size incapable of flight",
     "down_dur": 1,
-    "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 }, { "stat": "damage", "type": "bash", "scale": 2.0 } ],
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.8 },
+      { "stat": "damage", "type": "bash", "scale": 2.0 },
+      { "stat": "damage", "type": "cut", "scale": 2.0 },
+      { "stat": "damage", "type": "stab", "scale": 2.0 }
+    ],
     "attack_vectors": [ "vector_punch" ]
   },
   {
@@ -2246,7 +2248,11 @@
       ]
     },
     "condition_desc": "* Only works on a <info>non-stunned mundane</info> target of <info>similar or smaller</info> size",
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.35 } ],
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 1.35 },
+      { "stat": "damage", "type": "cut", "scale": 1.35 },
+      { "stat": "damage", "type": "stab", "scale": 1.35 }
+    ],
     "attack_vectors": [ "vector_knee" ]
   },
   {
@@ -2324,7 +2330,6 @@
     "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight",
     "down_dur": 2,
     "weighting": 3,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 2.0 } ],
     "attack_vectors": [ "vector_grasp" ]
   },
   {
@@ -2348,7 +2353,6 @@
     "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight",
     "down_dur": 2,
     "weighting": 3,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 2.0 } ],
     "attack_vectors": [ "vector_grasp" ]
   },
   {
@@ -2594,7 +2598,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "condition": { "and": [ { "npc_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] },
-    "condition_desc": "* Only works on a <info>downed</info> target",
+    "condition_desc": "* Only works on a target you are <info>grabbing</info>.",
     "weighting": 3,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.5 } ],
     "attack_vectors": [ "vector_knee" ]
@@ -2607,7 +2611,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "condition": { "and": [ { "npc_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] },
-    "condition_desc": "* Only works on a <info>downed</info> target",
+    "condition_desc": "* Only works on a target you are <info>grabbing</info>.",
     "crit_ok": true,
     "weighting": 3,
     "disarms": true,
@@ -2615,49 +2619,6 @@
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 } ],
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.25 } ],
     "attack_vectors": [ "vector_arm_grapple" ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_pankration_grabthrow",
-    "name": "Grab and Throw",
-    "messages": [ "You throw %s", "<npcname> throws %s!" ],
-    "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
-    "unarmed_allowed": true,
-    "weighting": 3,
-    "crit_tec": true,
-    "down_dur": 2,
-    "knockback_dist": 2,
-    "knockback_spread": 2,
-    "//condition": "Humanoids of similar size and no flying",
-    "condition": {
-      "and": [
-        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
-        { "math": [ "n_val('size')", "!=", "1" ] },
-        { "not": { "npc_has_effect": "downed" } },
-        { "or": [ { "npc_bodytype": "human" }, { "npc_bodytype": "angel" } ] },
-        { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] },
-        {
-          "or": [
-            { "and": [ { "npc_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] },
-            {
-              "and": [
-                { "npc_has_flag": "GRAB_FILTER" },
-                { "u_has_flag": "GRAB" },
-                {
-                  "roll_contested": { "math": [ "u_val('strength')" ] },
-                  "die_size": 20,
-                  "difficulty": { "math": [ "n_val('grab_strength')" ] }
-                }
-              ]
-            },
-            { "not": { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] } }
-          ]
-        }
-      ]
-    },
-    "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight, may fail on targets <info>grabbing you</info>",
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 2.0 } ],
-    "attack_vectors": [ "vector_grasp" ]
   },
   {
     "type": "technique",
@@ -2822,7 +2783,11 @@
       { "stat": "arpen", "type": "cut", "scaling-stat": "per", "scale": 1.0 },
       { "stat": "arpen", "type": "stab", "scaling-stat": "per", "scale": 1.0 }
     ],
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.5 } ],
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 1.5 },
+      { "stat": "damage", "type": "cut", "scale": 1.5 },
+      { "stat": "damage", "type": "stab", "scale": 1.5 }
+    ],
     "attack_vectors": [ "vector_punch" ]
   },
   {
@@ -3287,7 +3252,7 @@
     "type": "technique",
     "id": "tec_tiger_wide",
     "name": "Tiger Rampage",
-    "messages": [ "You slash wildly at %s and those nearby", "<npcname> slashes wildly at %s and those nearby!" ],
+    "messages": [ "You slash wildly at %s and anything else nearby", "<npcname> slashes wildly at %s and anything else nearby!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
     "unarmed_allowed": true,
     "crit_tec": true,

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1914,6 +1914,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                                rng( -technique.knockback_spread, technique.knockback_spread ) );
         tripoint kb_point( posx() + kb_offset.x, posy() + kb_offset.y, posz() );
         for( int dist = rng( 1, technique.knockback_dist ); dist > 0; dist-- ) {
+            if( has_effect_with_flag( json_flag_GRAB_FILTER ) && grab_1.victim && &t == grab_1.victim.get() ) {
+                // Release grabbed creature just before launch
+                release_grapple();
+            }
             t.knock_back_from( kb_point );
         }
 


### PR DESCRIPTION
#### Summary
Martial Arts bugfixes

#### Purpose of change
- Fior di Battaglia had an exploit where its on-move debuff was not persisting, so you could get out of it by switching to another MA and then back to Fior
- Pankration's grabthrow was obsoleted by, uh, grabbing and throwing
- Player knockbacks were not releasing the target from grapples, causing some teleportation
- Ninjutsu wasn't able to use wakizashi
- Ninjutsu Escape Plan was adding 10% speed, not 10 move speed like it said

#### Describe the solution
- Ninjutsu Escape Plan - Flat bonuses are actually not possible, so it now adds 10% move speed
- Adjusted some MA buff texts for clarity
- Turned down damage on Ninjutsu Takedown (why was it so high?!)
- Removed Grab and Throw from Pankration
- Made Fior's on-move debuff persist if you switch styles
- Player knockbacks now properly check if the target is grappled by the player, releasing them if so
- Adjusted wording on a few messages
- Added cut/stab to damage bonuses for attacks where it made sense

#### Describe alternatives you've considered
- Pankration probably needs some kind of new thing. A passive buff while grappling?

#### Testing
Loads, runs, stuff looks good.

#### Additional context
Thanks to Mayitra on the discord for finding these.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
