### PR TITLE
Fix long-sleeved jumpsuits more

### DIFF
--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -268,7 +268,16 @@
     "name": { "str": "long-sleeved jumpsuit" },
     "copy-from": "jumpsuit_long",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] },
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "standard",
+        "name": { "str": "XL long-sleeved jumpsuit" },
+        "description": "Lightweight coveralls with long sleeves and a few pockets for storage.",
+        "weight": 0
+      }
+    ]
   },
   {
     "id": "jumpsuit_long_xs",
@@ -276,7 +285,16 @@
     "name": { "str": "long-sleeved jumpsuit" },
     "copy-from": "jumpsuit_long",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
+    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] },
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "standard",
+        "name": { "str": "XS long-sleeved jumpsuit" },
+        "description": "Lightweight coveralls with long sleeves and a few pockets for storage.",
+        "weight": 0
+      }
+    ]
   },
   {
     "id": "jumpsuit",


### PR DESCRIPTION
#### Summary
Fix long-sleeved jumpsuits more

#### Purpose of change
Long-sleeved jumpsuits have variants. The XL and XS didn't have any defined, but they used copy-from so they didn't have names in the crafting menu.

#### Describe the solution
Give them the generic jumpsuit variant, same as you'd see when crafting the normal one.

#### Describe alternatives you've considered
PREFIX_XL/XS doesn't apply to variant names, which is a problem that ought to be fixed.

#### Testing
Looks good

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
