### PR TITLE
Don't auto-eat marloss berries

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -133,7 +133,7 @@
     "price_postapoc": "1 cent",
     "material": [ "fruit" ],
     "volume": "62 ml",
-    "flags": [ "MYCUS_OK" ],
+    "flags": [ "MYCUS_OK", "NO_AUTO_CONSUME" ],
     "fun": 30,
     "vitamins": [ [ "fruit_allergen", 1 ] ]
   },
@@ -155,6 +155,7 @@
     "price": "1 cent",
     "price_postapoc": "1 cent",
     "material": [ "fruit" ],
+    "flags": [ "NO_AUTO_CONSUME" ],
     "volume": "10 ml",
     "fun": 30,
     "vitamins": [ [ "fruit_allergen", 1 ] ]


### PR DESCRIPTION
#### Summary
Don't auto-eat marloss berries

#### Purpose of change
Marloss berries and gelatin were auto-eatable. That's bad!

#### Describe the solution
Now they are not auto-eatable.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
