### PR TITLE
Nerf cocaine cream

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -2127,6 +2127,6 @@
     "addiction_potential": 5,
     "addiction_type": "cocaine",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE" ],
-    "use_action": { "type": "heal", "bleed": 20, "move_cost": 3000, "effects": [ { "id": "pkill1_generic", "duration": 720 } ] }
+    "use_action": { "type": "heal", "bleed": 10, "move_cost": 3000, "effects": [ { "id": "pkill1_generic", "duration": 720 } ] }
   }
 ]


### PR DESCRIPTION
#### Summary
Nerf cocaine cream

#### Purpose of change
Cocaine topical cream had the same bleed treatment level as hemostatic powder. This isn't what it's used for IRL, it's used for like eye and nasal surgery where there are a lot of tiny blood vessels close to the skin. It's not that it has this crazy bleed-stopping power, it just induces enough vasoconstriction to slow bleeding from these small vessels.

#### Describe the solution
Half the bleed treatment power. It's still a decent painkiller.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
