### PR TITLE
Intermediate archery training autolearn 2->3

### DIFF
--- a/data/json/recipes/practice/ranged.json
+++ b/data/json/recipes/practice/ranged.json
@@ -95,8 +95,8 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 2 },
     "proficiencies": [ { "proficiency": "prof_bow_basic", "time_multiplier": 1.5, "skill_penalty": 0 } ],
-    "autolearn": [ [ "archery", 4 ] ],
-    "book_learn": [ [ "book_archery", 2 ], [ "manual_archery", 2 ] ],
+    "autolearn": [ [ "archery", 3 ] ],
+    "book_learn": [ [ "book_archery", 1 ], [ "manual_archery", 1 ] ],
     "tools": [
       [
         "selfbow",

--- a/data/json/recipes/practice/ranged.json
+++ b/data/json/recipes/practice/ranged.json
@@ -95,7 +95,7 @@
     "time": "1 h",
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 2 },
     "proficiencies": [ { "proficiency": "prof_bow_basic", "time_multiplier": 1.5, "skill_penalty": 0 } ],
-    "autolearn": [ [ "archery", 2 ] ],
+    "autolearn": [ [ "archery", 4 ] ],
     "book_learn": [ [ "book_archery", 2 ], [ "manual_archery", 2 ] ],
     "tools": [
       [


### PR DESCRIPTION
#### Summary
Intermediate archery training autolearn 2->3

#### Purpose of change
Move the intermediate archery training recipe's autolearn to 3 archery. You can get it from a book at 1 rank which is ideal, but you can still figure out basic archer's form on your own if you have some significant self-training.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
