### PR TITLE
Minor MA tweaks

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1047,9 +1047,9 @@
     "stun_dur": 1,
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.75 },
-      { "stat": "damage", "type": "bash", "scale": 1.4 },
-      { "stat": "damage", "type": "cut", "scale": 1.4 },
-      { "stat": "damage", "type": "stab", "scale": 1.4 }
+      { "stat": "damage", "type": "bash", "scale": 1.33 },
+      { "stat": "damage", "type": "cut", "scale": 1.33 },
+      { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "vector_foot_sole" ]
   },
@@ -1139,9 +1139,9 @@
     "condition_desc": "* Only works on a <info>non-stunned mundane</info> target of <info>similar or smaller</info> size",
     "stun_dur": 2,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.5 },
-      { "stat": "damage", "type": "cut", "scale": 1.5 },
-      { "stat": "damage", "type": "stab", "scale": 1.5 }
+      { "stat": "damage", "type": "bash", "scale": 1.33 },
+      { "stat": "damage", "type": "cut", "scale": 1.33 },
+      { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "vector_wrist" ]
   },
@@ -1150,7 +1150,7 @@
     "id": "tec_dragon_claw",
     "name": "Dragon Claw",
     "unarmed_allowed": true,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.2 } ],
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.2 }, { "stat": "damage", "type": "cut", "scale": 1.2 }, { "stat": "damage", "type": "stab", "scale": 1.2 } ],
     "messages": [ "You lash out at %s with a Dragon Claw", "<npcname> lashes out at %s with a Dragon Claw!" ],
     "attack_vectors": [ "vector_claw", "vector_claw_right", "vector_punch" ]
   },
@@ -1176,9 +1176,9 @@
     "condition_desc": "* Only works on a <info>non-downed</info> target of <info>similar</info> size incapable of flight",
     "down_dur": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.4 },
-      { "stat": "damage", "type": "cut", "scale": 1.4 },
-      { "stat": "damage", "type": "stab", "scale": 1.4 }
+      { "stat": "damage", "type": "bash", "scale": 1.2 },
+      { "stat": "damage", "type": "cut", "scale": 1.2 },
+      { "stat": "damage", "type": "stab", "scale": 1.2 }
     ],
     "attack_vectors": [ "vector_foot_heel" ]
   },
@@ -1194,9 +1194,9 @@
     "condition_desc": "* Only works on a <info>downed</info> target",
     "stun_dur": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.5 },
-      { "stat": "damage", "type": "cut", "scale": 1.5 },
-      { "stat": "damage", "type": "stab", "scale": 1.5 }
+      { "stat": "damage", "type": "bash", "scale": 1.33 },
+      { "stat": "damage", "type": "cut", "scale": 1.33 },
+      { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "vector_claw", "vector_claw_right", "vector_punch" ]
   },
@@ -1240,9 +1240,9 @@
     "crit_tec": true,
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.8 },
-      { "stat": "damage", "type": "bash", "scale": 1.5 },
-      { "stat": "damage", "type": "cut", "scale": 1.5 },
-      { "stat": "damage", "type": "stab", "scale": 1.5 }
+      { "stat": "damage", "type": "bash", "scale": 1.1 },
+      { "stat": "damage", "type": "cut", "scale": 1.1 },
+      { "stat": "damage", "type": "stab", "scale": 1.1 }
     ],
     "attack_vectors": [ "vector_null" ]
   },
@@ -1277,7 +1277,6 @@
     },
     "condition_desc": "* Only works on a <info>non-stunned living/info> target of <info>similar or smaller</info> size",
     "stun_dur": 1,
-    "mult_bonuses": [ { "stat": "movecost", "scale": 0.8 } ],
     "attack_vectors": [ "vector_null" ]
   },
   {
@@ -2046,9 +2045,9 @@
     "down_dur": 1,
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.8 },
-      { "stat": "damage", "type": "bash", "scale": 2.0 },
-      { "stat": "damage", "type": "cut", "scale": 2.0 },
-      { "stat": "damage", "type": "stab", "scale": 2.0 }
+      { "stat": "damage", "type": "bash", "scale": 1.33 },
+      { "stat": "damage", "type": "cut", "scale": 1.33 },
+      { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "vector_punch" ]
   },
@@ -2286,9 +2285,9 @@
     "crit_tec": true,
     "weighting": 3,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.33 },
-      { "stat": "damage", "type": "cut", "scale": 1.33 },
-      { "stat": "damage", "type": "stab", "scale": 1.33 }
+      { "stat": "damage", "type": "bash", "scale": 1.5 },
+      { "stat": "damage", "type": "cut", "scale": 1.5 },
+      { "stat": "damage", "type": "stab", "scale": 1.5 }
     ],
     "attack_vectors": [ "vector_null" ]
   },
@@ -3136,9 +3135,10 @@
     "unarmed_allowed": true,
     "crit_tec": true,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.25 },
-      { "stat": "damage", "type": "cut", "scale": 1.25 },
-      { "stat": "damage", "type": "stab", "scale": 1.25 }
+      { "stat": "movecost", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scale": 1.33 },
+      { "stat": "damage", "type": "cut", "scale": 1.33 },
+      { "stat": "damage", "type": "stab", "scale": 1.33 }
     ],
     "attack_vectors": [ "vector_claw", "vector_claw_right", "vector_punch" ]
   },


### PR DESCRIPTION
#### Summary
Minor MA tweaks

#### Purpose of change
Fine-tune some martial arts stuff

#### Describe the solution
- Eskrima is all rapid attacks. It was also giving some +damage, but given that rapid attacking is already a damage increase, this is not especially appropriate, so the damage buffs were mostly removed.
- Increased Ninjutsu's assassinate from 1.33 to 1.5x damage boost. It's really meant to be doing a significant amount of damage.
- Removed some of the damage boost from dragon tail and dragon claw. They still retain a 1.2x boost, but the MA is supposed to be going for dragon strike as a finisher.
- Added cut/stab to dragon claw, as it's a claw attack and the user may very well have claws.
- Per a suggestion on the discord, adjusted tiger claw. It now confers a slightly larger damage buff than dragon palm (1.33x vs 1.25x) and instead of the extra damage from strength that Palm gets, it has a 0.75x attack cost multiplier. This means that crits while using Tiger Kung Fu are potentially less impactful in terms of direct damage (unless you have claws) but they are faster, which is arguably a much bigger advantage.
- Dropped capoeira spinkick and crane strike to 1.33x damage from 1.5 and 1.4 respectively. These MAs are supposed to be more defensive, and crane strike also has a very good stun attached to it, so whatever.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
