### PR TITLE
Remove obsoleted professions

### DIFF
--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -163,33 +163,5 @@
     "points": 0,
     "valid": false,
     "player_display": false
-  },
-  {
-    "type": "profession",
-    "id": "computer_literate",
-    "name": "Computer Literate",
-    "description": "You are computer literate.",
-    "points": 0
-  },
-  {
-    "type": "profession",
-    "id": "social_skills",
-    "name": "Social Skills",
-    "description": "You possess basic social skills.",
-    "points": 0
-  },
-  {
-    "type": "profession",
-    "id": "high_school_graduate",
-    "name": "High School Graduate",
-    "description": "You're a high school graduate, for all that's worth.",
-    "points": 0
-  },
-  {
-    "type": "profession",
-    "id": "mundane_survial",
-    "name": "Mundane Survival",
-    "description": "You survived the mundane world, but that's all over now.",
-    "points": 0
   }
 ]


### PR DESCRIPTION
#### Summary
Remove obsoleted professions

#### Purpose of change
I changed around some of the backgrounds you start with at chargen (The ones like Driver's License and stuff). A few got deleted. I stuck them in an obsoletion file and the game decided to populate the list at chargen with them.

#### Describe the solution
Delete them. Perhaps there's a proper way to obsolete professions, but I wouldn't know. Enjoy your error messages! (press i to skip them)

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
