### PR TITLE
Logarithmic melee stamina scaling

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3250,19 +3250,21 @@ void Character::conduct_blood_analysis()
     }
 }
 
+
 int Character::get_standard_stamina_cost( const item *thrown_item ) const
 {
     // Previously calculated as 2_gram * std::max( 1, str_cur )
-    // using 16_gram normalizes it to 8 str. Same effort expenditure
-    // for each strike, regardless of weight. This is compensated
-    // for by the additional move cost as weapon weight increases
+    // using 20_gram normalizes it to 10 str. Heavier weapons
+    // get a discount on stamina burned/second.
     // If the item is thrown, override with the thrown item instead.
-
     item current_weapon = used_weapon() ? *used_weapon() : null_item_reference();
 
-    const int weight_cost = ( thrown_item == nullptr ) ? current_weapon.weight() /
-                            16_gram : thrown_item->weight() / 16_gram;
-    return ( weight_cost + 50 ) * -1 * get_modifier( character_modifier_melee_stamina_cost_mod );
+     const double normalized_weight = static_cast<double>( thrown_item == nullptr ) ? current_weapon.weight() /
+                             20_gram : thrown_item->weight() / 20_gram;
+
+    // Logarithmic stamina scaling
+    const double weight_cost = std::log( normalized_weight + 1.0 ) * 30.0;
+    return static_cast<int>( weight_cost * -1.0 * get_modifier( character_modifier_melee_stamina_cost_mod ) );
 }
 
 std::vector<item_location> Character::nearby( const

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -975,7 +975,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     }
 
     burn_energy_arms( std::min( -50, total_stam + deft_bonus ) );
-    add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (capped at -50): %d/%d", base_stam,
+    add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (always burn at least 50): %d/%d", base_stam,
                    total_stam + deft_bonus );
     // Weariness handling - 1 / the value, because it returns what % of the normal speed
     const float weary_mult = exertion_adjusted_move_multiplier( EXPLOSIVE_EXERCISE );


### PR DESCRIPTION
#### Summary
Logarithmic melee stamina scaling

#### Purpose of change
Heavy weapons are badly disadvantaged in Cataclysm. Not only do light weapons do far too much damage (a separate issue), heavy ones offer no real benefit, are harder to use, take more inventory space/weight, and if DPS is the same, they suffer from a significant time wasting issue when they overkill a target compared to light weapons.

#### Describe the solution

Done:
- Move stamina from linear to logarithmic scaling. Normalize it at 20g instead of 16g, implying that 10 strength is average and not 8.

Considering:
- Give an even more favorable weighting to heavy weapons.
- Momentum tech for heavy weapons that gives an attack speed buff when you kill the target, similar to a D&D 3.x cleave.

#### Describe alternatives you've considered
- Sharply reduce the damage of basically all knives. The fact that a ka-bar does the same damage as a zweihander is absurd.
- Similarly reduce the damage of all lighter swords. The whole thing needs a rebalance a la #810 etc.
- Remove DPS readouts. Make sure new stamina readouts are accurate.

#### Testing
Ongoing

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
