### PR TITLE
Revert Chargen Languorous Removal

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1334,6 +1334,7 @@
     "name": { "str": "Languorous" },
     "points": -2,
     "description": "Whether due to lack of exercise and poor diet, or due to a natural disinclination to physical endurance, you tire due to physical exertion much more readily than others.",
+    "starting_trait": true,
     "valid": false,
     "types": [ "CARDIO" ],
     "enchantments": [ { "values": [ { "value": "CARDIO_MULTIPLIER", "multiply": -0.1 } ] } ]


### PR DESCRIPTION
#### Summary
Category "Brief description"

Alongside the removal and rebalancing of indefatigable and the other stamina traits from character creation into only being accessible by mutation, its opposite counterpart languorous was also removed. I feel its removal was unnecessary as the handicap both added a level of difficulty that encouraged more thoughtful and strategic play, and on a personal note I felt it represented my own mitochondrial myopathy and similar genetic metabolic disorders well. 

#### Purpose of change

To restore this trait to its previous state.

#### Describe the solution

Adding back the tag "starting trait: true"

#### Describe alternatives you've considered

Rebalancing the old trait further or creating a new trait, both felt outside of scope and reasonableness for a simple change to someone else's project in its early stages.
#### Testing
Loaded up, Languorous addable on character creation.
#### Additional context

None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
