### PR TITLE
Give knives throwing damage

### DIFF
--- a/data/json/items/melee/knives.json
+++ b/data/json/items/melee/knives.json
@@ -25,6 +25,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 25 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 11 },
     "melee_damage": { "stab": 13 }
   },
   {
@@ -44,6 +45,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 15 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
+    "thrown_damage": { "stab": 5 },
     "melee_damage": { "stab": 7 }
   },
   {
@@ -64,6 +66,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 10 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "melee_damage": { "stab": 6 },
+    "thrown_damage": { "stab": 4 },
     "weapon_category": [ "SHIVS" ]
   },
   {
@@ -84,6 +87,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 10 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 10 },
     "melee_damage": { "stab": 12 }
   },
   {
@@ -104,6 +108,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 22 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
+    "thrown_damage": { "stab": 9 },
     "melee_damage": { "stab": 11 }
   },
   {
@@ -124,6 +129,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 8 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "melee_damage": { "stab": 6 },
+    "thrown_damage": { "stab": 4 },
     "weapon_category": [ "SHIVS" ]
   },
   {
@@ -143,6 +149,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "neutral" },
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 15 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK" ],
+    "thrown_damage": { "cut": 9 },
     "melee_damage": { "bash": 3, "cut": 11 }
   },
   {
@@ -162,6 +169,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "neutral" },
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 25 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK" ],
+    "thrown_damage": { "cut": 9 },
     "melee_damage": { "bash": 3, "cut": 12 }
   },
   {
@@ -182,6 +190,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 14 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
     "weapon_category": [ "SHIVS" ],
+    "thrown_damage": { "stab": 12 },
     "melee_damage": { "stab": 14 }
   },
   {
@@ -221,6 +230,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 12 ] ],
     "flags": [ "BELT_CLIP", "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 11 },
     "melee_damage": { "stab": 13 }
   },
   {
@@ -254,6 +264,7 @@
         "description": "A hidden handle compartment.  Unscrew the compass to access."
       }
     ],
+    "thrown_damage": { "stab": 12 },
     "melee_damage": { "stab": 14 }
   },
   {
@@ -296,6 +307,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 30 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK", "CONDUCTIVE", "DURABLE_MELEE" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 10 },
     "melee_damage": { "cut": 12 }
   },
   {
@@ -353,6 +365,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 15 },
     "melee_damage": { "stab": 17 }
   },
   {
@@ -422,6 +435,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 13 },
     "melee_damage": { "stab": 15 }
   },
   {
@@ -478,6 +492,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 14 },
     "melee_damage": { "stab": 16 }
   },
   {
@@ -521,6 +536,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 16 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 12 },
     "melee_damage": { "stab": 14 }
   },
   {
@@ -543,6 +559,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 19 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 11 },
     "melee_damage": { "stab": 13 }
   },
   {
@@ -561,7 +578,7 @@
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 11 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
-    "weapon_category": [ "KNIVES" ],
+    "weapon_category": [ "SHIVS" ],
     "melee_damage": { "stab": 8 }
   },
   {
@@ -600,6 +617,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 15 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
+    "thrown_damage": { "stab": 11 },
     "melee_damage": { "stab": 13 }
   },
   {
@@ -621,7 +639,8 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 12 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
     "weapon_category": [ "KNIVES" ],
-    "melee_damage": { "stab": 13 }
+    "thrown_damage": { "cut": 11 },
+    "melee_damage": { "cut": 13 }
   },
   {
     "id": "kris_fake",


### PR DESCRIPTION
#### Summary
Give knives throwing damage

#### Purpose of change
Throwing damage was previously set on only a few knives. I removed it, thinking this was unnecessary, but it turns out they do like none without it, so I re-added it. In the process, I gave a bunch of knives that make sense to throw some damage. Now you can throw steak knives and stuff.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
