### PR TITLE
Fix throwing knife damage again

### DIFF
--- a/data/json/items/melee/knives.json
+++ b/data/json/items/melee/knives.json
@@ -25,7 +25,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 25 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 11 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 11 } ],
     "melee_damage": { "stab": 13 }
   },
   {
@@ -45,7 +45,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 15 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
-    "thrown_damage": { "stab": 5 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 5 } ],
     "melee_damage": { "stab": 7 }
   },
   {
@@ -66,7 +66,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 10 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "melee_damage": { "stab": 6 },
-    "thrown_damage": { "stab": 4 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 4 } ],
     "weapon_category": [ "SHIVS" ]
   },
   {
@@ -87,7 +87,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 10 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 10 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 10 } ],
     "melee_damage": { "stab": 12 }
   },
   {
@@ -108,7 +108,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 22 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
-    "thrown_damage": { "stab": 9 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 9 } ],
     "melee_damage": { "stab": 11 }
   },
   {
@@ -129,7 +129,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 8 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "melee_damage": { "stab": 6 },
-    "thrown_damage": { "stab": 4 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 4 } ],
     "weapon_category": [ "SHIVS" ]
   },
   {
@@ -149,7 +149,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "neutral" },
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 15 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK" ],
-    "thrown_damage": { "cut": 9 },
+    "thrown_damage": [ { "damage_type": "cut", "amount": 9 } ],
     "melee_damage": { "bash": 3, "cut": 11 }
   },
   {
@@ -169,7 +169,7 @@
     "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "neutral" },
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 25 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK" ],
-    "thrown_damage": { "cut": 9 },
+    "thrown_damage": [ { "damage_type": "cut", "amount": 9 } ],
     "melee_damage": { "bash": 3, "cut": 12 }
   },
   {
@@ -190,7 +190,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 14 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
     "weapon_category": [ "SHIVS" ],
-    "thrown_damage": { "stab": 12 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 12 } ],
     "melee_damage": { "stab": 14 }
   },
   {
@@ -230,7 +230,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 12 ] ],
     "flags": [ "BELT_CLIP", "ALLOWS_BODY_BLOCK", "CONDUCTIVE" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 11 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 11 } ],
     "melee_damage": { "stab": 13 }
   },
   {
@@ -264,7 +264,7 @@
         "description": "A hidden handle compartment.  Unscrew the compass to access."
       }
     ],
-    "thrown_damage": { "stab": 12 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 12 } ],
     "melee_damage": { "stab": 14 }
   },
   {
@@ -307,7 +307,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 30 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK", "CONDUCTIVE", "DURABLE_MELEE" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 10 },
+    "thrown_damage": [ { "damage_type": "cut", "amount": 10 } ],
     "melee_damage": { "cut": 12 }
   },
   {
@@ -365,7 +365,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 15 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 15 } ],
     "melee_damage": { "stab": 17 }
   },
   {
@@ -435,7 +435,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 13 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 13 } ],
     "melee_damage": { "stab": 15 }
   },
   {
@@ -492,7 +492,7 @@
       "CONDUCTIVE"
     ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 14 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 14 } ],
     "melee_damage": { "stab": 16 }
   },
   {
@@ -536,7 +536,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 16 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 12 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 12 } ],
     "melee_damage": { "stab": 14 }
   },
   {
@@ -559,7 +559,7 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 19 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 11 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 11 } ],
     "melee_damage": { "stab": 13 }
   },
   {
@@ -617,7 +617,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 15 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "stab": 11 },
+    "thrown_damage": [ { "damage_type": "stab", "amount": 11 } ],
     "melee_damage": { "stab": 13 }
   },
   {
@@ -639,7 +639,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 12 ] ],
     "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
     "weapon_category": [ "KNIVES" ],
-    "thrown_damage": { "cut": 11 },
+    "thrown_damage": [ { "damage_type": "cut", "amount": 11 } ],
     "melee_damage": { "cut": 13 }
   },
   {


### PR DESCRIPTION
#### Summary
Fix throwing knife damage again

#### Purpose of change
Thrown_damage is an array, not an object like melee_damage

#### Testing
Loads, looks fine now

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
