### PR TITLE
Missing a reach attack while unstable can make you stumble

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -682,7 +682,7 @@
     "type": "effect_type",
     "id": "bouldering",
     "name": [ "Unstable Footing" ],
-    "desc": [ "Your footing is unstable.  It's more difficult to fight while standing here." ],
+    "desc": [ "Your footing is unstable.  It's more difficult to fight while standing here, and you could easily stumble or fall." ],
     "apply_message": "You try to keep your balance.",
     "resist_traits": [ "GASTROPOD_BALANCE", "BIRD_LEGS", "SCUTTLE", "LEG_TENT_BRACE" ],
     "rating": "bad",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -276,6 +276,7 @@ static const efftype_id effect_riding( "riding" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 static const efftype_id effect_slippery_terrain( "slippery_terrain" );
+static const efftype_id effect_sludged( "sludged" );
 static const efftype_id effect_stumbled_into_invisible( "stumbled_into_invisible" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_subaquatic_sonar( "subaquatic_sonar" );
@@ -289,6 +290,7 @@ static const faction_id faction_no_faction( "no_faction" );
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
 static const field_type_str_id field_fd_clairvoyant( "fd_clairvoyant" );
+static const field_type_str_id field_fd_web( "fd_web" );
 
 static const flag_id json_flag_PIT( "PIT" );
 
@@ -351,6 +353,7 @@ static const json_character_flag json_flag_UNCANNY_DODGE( "UNCANNY_DODGE" );
 static const json_character_flag json_flag_WALK_UNDERWATER( "WALK_UNDERWATER" );
 static const json_character_flag json_flag_WATCH( "WATCH" );
 static const json_character_flag json_flag_WEBBED_FEET( "WEBBED_FEET" );
+static const json_character_flag json_flag_WEBWALK( "WEBWALK" );
 static const json_character_flag json_flag_WINGS_1( "WINGS_1" );
 static const json_character_flag json_flag_WINGS_2( "WINGS_2" );
 static const json_character_flag json_flag_WING_ARMS( "WING_ARMS" );
@@ -444,6 +447,7 @@ static const trait_id trait_ELFA_NV( "ELFA_NV" );
 static const trait_id trait_FAERIECREATURE( "FAERIECREATURE" );
 static const trait_id trait_FAT( "FAT" );
 static const trait_id trait_FEL_NV( "FEL_NV" );
+static const trait_id trait_GASTROPOD_BALANCE( "GASTROPOD_BALANCE" );
 static const trait_id trait_GILLS( "GILLS" );
 static const trait_id trait_GILLS_CEPH( "GILLS_CEPH" );
 static const trait_id trait_GLASSJAW( "GLASSJAW" );
@@ -11296,37 +11300,76 @@ void Character::gravity_check()
     }
 }
 
+void Character::stagger_check()
+{
+        float balance_factor = ( get_dex() / 2 + 5.f * get_limb_score( limb_score_balance ) );
+        if( has_trait( trait_DEFT ) || has_effect( effect_sludged ) ) {
+            balance_factor += 2.0f;
+        }
+        if( has_trait( trait_CLUMSY ) ) {
+            balance_factor -= 2.0f;
+        }
+        if( !has_trait( trait_GASTROPOD_BALANCE ) && has_effect( effect_slippery_terrain ) ) {
+            balance_factor -= 2.0f;
+        }
+        map &here = get_map();
+        if( ( ( has_trait( trait_GASTROPOD_BALANCE ) || has_trait( trait_LEG_TENT_BRACE ) ) && is_barefoot() ) || ( has_flag( json_flag_WEBWALK ) && here.get_field( pos(), field_fd_web ) != nullptr ) ) {
+            balance_factor += 6.0f;
+        }
+        if( one_in( balance_factor ) ) {
+            stagger();
+        }
+}
+
 void Character::stagger()
 {
     map &here = get_map();
+    std::vector<tripoint> preferred_stumbles;
     std::vector<tripoint> valid_stumbles;
+
+    preferred_stumbles.reserve( 11 );
     valid_stumbles.reserve( 11 );
+
     for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1 ) ) {
         if( dest != pos_bub() ) {
+            tripoint target;
             if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
-                valid_stumbles.emplace_back( dest.xy().raw(), dest.z() - 1 );
+                target = tripoint( dest.xy().raw(), dest.z() - 1 );
             } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
-                valid_stumbles.emplace_back( dest.xy().raw(), dest.z() + 1 );
+                target = tripoint( dest.xy().raw(), dest.z() + 1 );
             } else {
-                valid_stumbles.push_back( dest.raw() );
+                target = dest.raw();
+            }
+
+            if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 2 ) ) {
+                preferred_stumbles.push_back( target );
+            } else {
+                valid_stumbles.push_back( target );
             }
         }
     }
+
     const tripoint_bub_ms below( posx(), posy(), posz() - 1 );
     if( here.valid_move( pos_bub(), below, false, true ) ) {
-        valid_stumbles.push_back( below.raw() );
-    }
-    creature_tracker &creatures = get_creature_tracker();
-    while( !valid_stumbles.empty() ) {
-        bool blocked = false;
-        const tripoint dest = random_entry_removed( valid_stumbles );
-        const optional_vpart_position vp_there = here.veh_at( dest );
-        if( vp_there ) {
-            vehicle &veh = vp_there->vehicle();
-            if( veh.enclosed_at( dest ) ) {
-                blocked = true;
-            }
+        tripoint target = below.raw();
+        if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 2 ) ) {
+            preferred_stumbles.push_back( target );
+        } else {
+            valid_stumbles.push_back( target );
         }
+    }
+
+    creature_tracker &creatures = get_creature_tracker();
+    std::vector<tripoint> &pool = preferred_stumbles.empty() ? valid_stumbles : preferred_stumbles;
+
+    while( !pool.empty() ) {
+        bool blocked = false;
+        const tripoint dest = random_entry_removed( pool );
+        const optional_vpart_position vp_there = here.veh_at( dest );
+        if( vp_there && vp_there->vehicle().enclosed_at( dest ) ) {
+            blocked = true;
+        }
+
         if( here.passable( dest ) && !blocked &&
             ( creatures.creature_at( dest, is_hallucination() ) == nullptr ) ) {
             avatar &player_avatar = get_avatar();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11302,23 +11302,29 @@ void Character::gravity_check()
 
 void Character::stagger_check()
 {
-        float balance_factor = ( get_dex() / 2 + 5.f * get_limb_score( limb_score_balance ) );
-        if( has_trait( trait_DEFT ) || has_effect( effect_sludged ) ) {
-            balance_factor += 2.0f;
-        }
-        if( has_trait( trait_CLUMSY ) ) {
-            balance_factor -= 2.0f;
-        }
-        if( !has_trait( trait_GASTROPOD_BALANCE ) && has_effect( effect_slippery_terrain ) ) {
-            balance_factor -= 2.0f;
-        }
-        map &here = get_map();
-        if( ( ( has_trait( trait_GASTROPOD_BALANCE ) || has_trait( trait_LEG_TENT_BRACE ) ) && is_barefoot() ) || ( has_flag( json_flag_WEBWALK ) && here.get_field( pos(), field_fd_web ) != nullptr ) ) {
-            balance_factor += 6.0f;
-        }
-        if( one_in( balance_factor ) ) {
-            stagger();
-        }
+    map &here = get_map();
+    if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos() ) ) {
+        return;
+    }
+    float balance_factor = ( get_skill_level( skill_swimming ) / 2.0f + get_dex() / 2 + 3.0f *
+                             get_limb_score( limb_score_balance ) + 2.0f * get_limb_score( limb_score_footing ) );
+    if( has_trait( trait_DEFT ) || has_effect( effect_sludged ) ) {
+        balance_factor += 2.0f;
+    }
+    if( has_trait( trait_CLUMSY ) ) {
+        balance_factor -= 2.0f;
+    }
+    if( !has_trait( trait_GASTROPOD_BALANCE ) && has_effect( effect_slippery_terrain ) ) {
+        balance_factor -= 2.0f;
+    }
+    if( ( ( has_trait( trait_GASTROPOD_BALANCE ) || has_trait( trait_LEG_TENT_BRACE ) ) &&
+          is_barefoot() ) || ( has_flag( json_flag_WEBWALK ) &&
+                               here.get_field( pos(), field_fd_web ) != nullptr ) ) {
+        balance_factor += 6.0f;
+    }
+    if( one_in( balance_factor ) ) {
+        stagger();
+    }
 }
 
 void Character::stagger()
@@ -11341,7 +11347,7 @@ void Character::stagger()
                 target = dest.raw();
             }
 
-            if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 2 ) ) {
+            if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 4 ) ) {
                 preferred_stumbles.push_back( target );
             } else {
                 valid_stumbles.push_back( target );
@@ -11352,7 +11358,7 @@ void Character::stagger()
     const tripoint_bub_ms below( posx(), posy(), posz() - 1 );
     if( here.valid_move( pos_bub(), below, false, true ) ) {
         tripoint target = below.raw();
-        if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 2 ) ) {
+        if( here.ter( target )->has_flag( "EMPTY_SPACE" ) && one_in( 4 ) ) {
             preferred_stumbles.push_back( target );
         } else {
             valid_stumbles.push_back( target );
@@ -11376,7 +11382,7 @@ void Character::stagger()
             if( is_avatar() && player_avatar.get_grab_type() != object_type::NONE ) {
                 player_avatar.grab( object_type::NONE );
             }
-            add_msg_player_or_npc( m_warning,
+            add_msg_player_or_npc( m_bad,
                                    _( "You stumble!" ),
                                    _( "<npcname> stumbles!" ) );
             setpos( dest );

--- a/src/character.h
+++ b/src/character.h
@@ -753,7 +753,11 @@ class Character : public Creature, public visitable
 
     public:
 
+        // Wile E Coyote looking down.
         void gravity_check();
+        // For events which might cause a stagger, such as missing an attack on unstable ground.
+        void stagger_check();
+        // Called by stagger_check(), or directly by things like being drunk.
         void stagger();
 
         void mod_stat( const std::string &stat, float modifier ) override;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1121,7 +1121,7 @@ int stumble( Character &u, const item_location &weap )
         units::mass str_mod = u.get_arm_str() * 10_gram;
         if( u.is_on_ground() ) {
             str_mod /= 4;
-        // Quadrupeds fight naturally on all fours, with their natural weapons anyway.
+            // Quadrupeds fight naturally on all fours, with their natural weapons anyway.
         } else if( u.is_crouching() && ( !u.has_effect( effect_natural_stance ) && !u.unarmed_attack() ) ) {
             str_mod /= 2;
         }
@@ -1131,7 +1131,7 @@ int stumble( Character &u, const item_location &weap )
         // 5 str with a battle axe: 26 + 49 = 75
         // Fist: 0
         stumble = ( weap->volume() / 125_ml ) +
-           ( weap->weight() / ( str_mod + 13.0_gram ) );
+                  ( weap->weight() / ( str_mod + 13.0_gram ) );
     }
     // 20% chance minimum to stagger_check().
     if( ( u.has_effect( effect_bouldering ) ) && ( rng( 0, 100 ) <= stumble + 20 ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -95,6 +95,7 @@ static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_amigara( "amigara" );
 static const efftype_id effect_beartrap( "beartrap" );
+static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_fearparalyze( "fearparalyze" );
@@ -105,6 +106,8 @@ static const efftype_id effect_lightsnare( "lightsnare" );
 static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_natural_stance( "natural_stance" );
 static const efftype_id effect_pet( "pet" );
+static const efftype_id effect_slippery_terrain( "slippery_terrain" );
+static const efftype_id effect_sludged( "sludged" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 static const efftype_id effect_venom_dmg( "venom_dmg" );
@@ -124,6 +127,8 @@ static const json_character_flag json_flag_HARDTOHIT( "HARDTOHIT" );
 static const json_character_flag json_flag_HYPEROPIC( "HYPEROPIC" );
 static const json_character_flag json_flag_NULL( "NULL" );
 static const json_character_flag json_flag_PSEUDOPOD_GRASP( "PSEUDOPOD_GRASP" );
+
+static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_block( "block" );
 static const limb_score_id limb_score_grip( "grip" );
 static const limb_score_id limb_score_reaction( "reaction" );
@@ -145,7 +150,6 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_ARM_TENTACLES( "ARM_TENTACLES" );
 static const trait_id trait_ARM_TENTACLES_4( "ARM_TENTACLES_4" );
 static const trait_id trait_ARM_TENTACLES_8( "ARM_TENTACLES_8" );
-static const trait_id trait_CLAWS_TENTACLE( "CLAWS_TENTACLE" );
 static const trait_id trait_CLUMSY( "CLUMSY" );
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEFT( "DEFT" );
@@ -717,7 +721,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             if( miss_recovery.id != tec_none ) {
                 add_msg( miss_recovery.avatar_message.translated(), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
-                add_msg( m_bad, _( "You miss and stumble with the momentum." ) );
+                add_msg( m_bad, _( "You miss and are thrown off balance by the momentum." ) );
             } else if( stumble_pen >= 10 ) {
                 add_msg( _( "You swing wildly and miss." ) );
             } else {
@@ -727,7 +731,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             if( miss_recovery.id != tec_none ) {
                 add_msg_if_npc( miss_recovery.npc_message.translated(), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
-                add_msg( _( "%s misses and stumbles with the momentum." ), get_name() );
+                add_msg( _( "%s misses and is thrown off balance by the momentum." ), get_name() );
             } else if( stumble_pen >= 10 ) {
                 add_msg( _( "%s swings wildly and misses." ), get_name() );
             } else {
@@ -1109,27 +1113,31 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
 
 int stumble( Character &u, const item_location &weap )
 {
+    int stumble = 0;
     if( !weap || u.has_trait( trait_DEFT ) ) {
-        return 0;
-    }
-    item cur_weap = weap ? *weap : null_item_reference();
-    units::mass str_mod = u.get_arm_str() * 10_gram;
-    // Ceph and Slime mutants still need good posture to prevent stumbling
-    if( u.is_on_ground() ) {
-        str_mod /= 4;
-        // but quadrupeds fight naturally on all fours
-    } else if( u.is_crouching() && ( !u.has_effect( effect_natural_stance ) && !u.unarmed_attack() ) ) {
-        str_mod /= 2;
-    }
-
-    // Examples:
-    // 10 str with a hatchet: 4 + 8 = 12
-    // 5 str with a battle axe: 26 + 49 = 75
-    // Fist: 0
-
-    /** @EFFECT_STR reduces chance of stumbling with heavier weapons */
-    return ( weap->volume() / 125_ml ) +
+        stumble = 0;
+    } else {
+        item cur_weap = weap ? *weap : null_item_reference();
+        units::mass str_mod = u.get_arm_str() * 10_gram;
+        if( u.is_on_ground() ) {
+            str_mod /= 4;
+        // Quadrupeds fight naturally on all fours, with their natural weapons anyway.
+        } else if( u.is_crouching() && ( !u.has_effect( effect_natural_stance ) && !u.unarmed_attack() ) ) {
+            str_mod /= 2;
+        }
+        /** @EFFECT_STR reduces chance of stumbling with heavier weapons */
+        // Examples:
+        // 10 str with a hatchet: 4 + 8 = 12
+        // 5 str with a battle axe: 26 + 49 = 75
+        // Fist: 0
+        stumble = ( weap->volume() / 125_ml ) +
            ( weap->weight() / ( str_mod + 13.0_gram ) );
+    }
+    // 20% chance minimum to stagger_check().
+    if( ( u.has_effect( effect_bouldering ) ) && ( rng( 0, 100 ) <= stumble + 20 ) ) {
+        u.stagger_check();
+    }
+    return stumble;
 }
 
 bool Character::scored_crit( float target_dodge, const item &weap ) const


### PR DESCRIPTION
#### Summary
Missing a reach attack while unstable can make you stumble

#### Purpose of change
- Work toward re-enabling learning on reach attacks by adding reasonable drawbacks and consequences.

#### Describe the solution
- Unstable footing (aka bouldering) is an existing effect granted by certain terrain. This effect now presents an additional hazard: missing an attack while standing here now poses a significant threat of making the character stumble.

The chance is based on strength versus weapon weight, the DEFT/CLUMSY traits, balance and footing scores, dexterity, athletics, GASTROPOD_BALANCE, WEB_WALKER with webs present in the tile, LEG_TENTACLE_BRACE, the presence of sludge in the tile, the presence of slippery substances (like bile) in the tile, and more. BIRD_LEGS, LEG_TENTACLE_BRACE, SCUTTLE, and GASTROPOD_BALANCE additionally prevent the footing and balance debuffs normally given by the unstable footing effect, which will help indirectly.

So in short:

- Don't fight on unstable tiles.
- If you must fight on unstable tiles, limit the number of adjacent hazardous tiles.
- If you must fight on unstable tiles near adjacent hazardous tiles, try not to miss.
- If you miss, try to have mutations, stats, and skills that help you out.

#### Describe alternatives you've considered
- I considered making this only apply to reach attacks, but it makes sense that any miss could cause a stumble.
- I debated not making empty space preferentially selected for stumbles, but you already have several dice rolls you can stack in your favor. This isn't supposed to be something that is ever risk free.
- I will probably introduce gabled roofs, which will be unstable on every tile. This will prevent people from just smashing gutters to ignore this mechanic.

#### Testing
- Got up on a roof with a pike. Poked at zombies on the ground. Fell off after a while.
- Got up on a roof with a pike. Poked at zombie predators. Fell off quite quickly (they love to dodge).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
