### PR TITLE
Increase birdshot and beanbag recoil

### DIFF
--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -146,7 +146,7 @@
     "range": 10,
     "count": 10,
     "damage": { "damage_type": "bullet", "amount": 5 },
-    "recoil": 1000,
+    "recoil": 1500,
     "loudness": 100,
     "effects": [ "BEANBAG", "COOKOFF", "NOGIB" ]
   },
@@ -164,7 +164,7 @@
     "range": 18,
     "shot_damage": { "damage_type": "bullet", "amount": 0.2 },
     "damage": { "damage_type": "bullet", "amount": 50 },
-    "recoil": 800,
+    "recoil": 1500,
     "loudness": 128,
     "effects": [ "COOKOFF", "SHOT", "NOGIB" ]
   },

--- a/data/json/items/ammo/shot.json
+++ b/data/json/items/ammo/shot.json
@@ -146,7 +146,7 @@
     "range": 10,
     "count": 10,
     "damage": { "damage_type": "bullet", "amount": 5 },
-    "recoil": 1500,
+    "recoil": 2000,
     "loudness": 100,
     "effects": [ "BEANBAG", "COOKOFF", "NOGIB" ]
   },
@@ -164,7 +164,7 @@
     "range": 18,
     "shot_damage": { "damage_type": "bullet", "amount": 0.2 },
     "damage": { "damage_type": "bullet", "amount": 50 },
-    "recoil": 1500,
+    "recoil": 2000,
     "loudness": 128,
     "effects": [ "COOKOFF", "SHOT", "NOGIB" ]
   },


### PR DESCRIPTION
#### Summary
Increase birdshot and beanbag recoil

#### Purpose of change
A while back I buffed birdshot. Part of the buff was reducing its recoil. Unfortunately the game infers pressure from recoil and this was causing some shotguns to experience a very high number of failures to eject when using birdshot.

#### Describe the solution
Recoil 800 -> 2000. Ditto for beanbag rounds. I was gonna do 1500, but the base recoil needs to be high enough that derived recoil on IE black powder rounds needs to be enough for the gun to eject properly. 2000 is still substantially lower than buckshot.

#### Testing
Loaded these bad boys into a Tavor and went to town.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
