### PR TITLE
Fix trading segfault

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1566,7 +1566,7 @@ void iexamine::chainfence( Character &you, const tripoint &examp )
             add_msg( _( "You vault over the obstacle." ) );
             move_cost = 300; // Most common move cost for barricades pre-change.
         }
-    // Weight discounted 50% here vs ladders etc. as we're just climbing over, not up to another level.
+        // Weight discounted 50% here vs ladders etc. as we're just climbing over, not up to another level.
     } else if( !( ( here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, examp ) &&
                     you.get_weight() / 15000_gram <= here.furn( examp ).obj().bash.str_min ) ||
                   ( here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, examp ) &&

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2840,12 +2840,12 @@ double Character::melee_value( const item &weap ) const
         my_value *= 1.0f + 0.5f * ( std::sqrt( reach ) - 1.0f );
     }
     // Value polearms less to account for the trickiness of keeping the right range.
-    if( weapon.has_flag( flag_POLEARM ) ) {
+    if( weap.has_flag( flag_POLEARM ) ) {
         my_value *= 0.8;
     }
 
     // If weapon category is empty, it's probably a random object and not a real weapon.
-    if( weapon.type->weapon_category.empty() ) {
+    if( weap.type->weapon_category.empty() ) {
         my_value *= 0.5;
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2826,40 +2826,49 @@ double Character::weapon_value( const item &weap, int ammo ) const
 
 double Character::melee_value( const item &weap ) const
 {
-    // Start with damage.
-    double my_value = weap.damage();
-
-    // Adjust for how heavy it is.
+    double my_value = 0.0;
     if( !weap.is_null() ) {
-        my_value *= std::min( 1.0, static_cast<double>( 1200_gram / weap.weight() ) );
+        // Tally up all the damage.
+        int total = 0;
+        std::map<damage_type_id, int> dmg_vals;
+        for( const damage_type &dt : damage_type::get_all() ) {
+            if( !dt.melee_only ) {
+                continue;
+            }
+            int dmg = weap.damage_melee( dt.id );
+            dmg_vals[dt.id] = dmg;
+            total += dmg;
+        }
+        my_value += total;
+        if( weap.weight() > 0_gram ) {
+            my_value *= std::min( 1.0, static_cast<double>( 1200_gram / weap.weight() ) );
+        }
+        float reach = weap.reach_range( *this );
+        if( reach > 1.0f ) {
+            my_value *= 1.0f + 0.5f * ( std::sqrt( reach ) - 1.0f );
+        }
+        // POLEARMs are valued lower due to the difficulty of keeping at proper range.
+        if( weap.has_flag( flag_POLEARM ) ) {
+            my_value *= 0.8;
+        }
+        // Items without categories are probably just random objects and not real weapons.
+        if( weap.type != nullptr && weap.type->weapon_category.empty() ) {
+            my_value *= 0.5;
+        }
+        // Items we can use with our martial arts are heavily favored.
+        if( !martial_arts_data->enumerate_known_styles( weap.type->get_id() ).empty() ) {
+            my_value *= 1.5;
+        }
+        if( weap.type != nullptr ) {
+            add_msg_debug( debugmode::DF_MELEE, "%s as melee: %.1f", weap.type->get_id().str(), my_value );
+        } else {
+            add_msg_debug( debugmode::DF_MELEE, "Unarmed as melee: 0.0" );
+        }
     }
-
-    float reach = weap.reach_range( *this );
-    // Value reach weapons more.
-    if( reach > 1.0f ) {
-        my_value *= 1.0f + 0.5f * ( std::sqrt( reach ) - 1.0f );
-    }
-    // Value polearms less to account for the trickiness of keeping the right range.
-    if( weap.has_flag( flag_POLEARM ) ) {
-        my_value *= 0.8;
-    }
-
-    // If weapon category is empty, it's probably a random object and not a real weapon.
-    if( weap.type->weapon_category.empty() ) {
-        my_value *= 0.5;
-    }
-
-    // Walue style weapons more.
-    // TODO: Value proficient categories more.
-    // TODO: Make sure we're not a weakling trying to use a bash weapon over a knife.
-    if( !martial_arts_data->enumerate_known_styles( weap.type->get_id() ).empty() ) {
-        my_value *= 1.5;
-    }
-
-    add_msg_debug( debugmode::DF_MELEE, "%s as melee: %.1f", weap.type->get_id().str(), my_value );
 
     return std::max( 0.0, my_value );
 }
+
 
 double Character::unarmed_value() const
 {

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -298,13 +298,17 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
     if( climb_cost > 0 && p_special & PathfindingFlag::Climbable ) {
         creature_tracker &creatures = get_creature_tracker();
         Creature *climber = creatures.creature_at<Creature>( p );
-        if( ( ( furniture.has_flag(ter_furn_flag::TFLAG_LADDER) || furniture.has_flag(ter_furn_flag::TFLAG_CLIMBABLE) ) ? climber->enum_size() * 2 > furniture.bash.str_min : false ) && ( ( terrain.has_flag(ter_furn_flag::TFLAG_LADDER) || terrain.has_flag(ter_furn_flag::TFLAG_CLIMBABLE) ) ? climber->enum_size() * 2 > terrain.bash.str_min : false ) ) {
+        if( ( ( furniture.has_flag( ter_furn_flag::TFLAG_LADDER ) ||
+                furniture.has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ) ? climber->enum_size() * 2 >
+              furniture.bash.str_min : false ) && ( ( terrain.has_flag( ter_furn_flag::TFLAG_LADDER ) ||
+                      terrain.has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ) ? climber->enum_size() * 2 >
+                      terrain.bash.str_min : false ) ) {
             return 0;
         }
         return climb_cost;
     }
 
-    
+
     // If it's a door and we can open it from the tile we're on, cool.
     if( allow_open_doors && ( terrain.open || furniture.open ) &&
         ( ( !terrain.has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE ) &&


### PR DESCRIPTION
#### Summary
Fix trading segfault

#### Purpose of change
- The game was segfaulting in the trade window

#### Describe the solution
- melee_value() needed to be rewritten a bit more carefully.

#### Testing
Loaded in, made an NPC friend, traded with them, saw they were assessing values on weapons. 

#### Additional context
Assessments still aren't very good and shouldn't be used in place of what the player wants their party members to do, but I'll get to that later. This is just a quick fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
