### PR TITLE
Update Recycler CBM to be sleep friendly

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1382,6 +1382,7 @@
     "name": { "str": "Recycler Unit" },
     "description": "Your urinary tract is fitted with filters and reservoirs that allow your body to reclaim water from metabolic waste while this device is powered, greatly reducing your need to hydrate.",
     "occupied_bodyparts": [ [ "torso", 10 ] ],
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_SLEEP_FRIENDLY" ],
     "act_cost": "1 J",
     "react_cost": "3 J",
     "time": "1 s",


### PR DESCRIPTION
This adds the flags for BIONIC_TOGGLED & BIONIC_SLEEP_FRIENDLY to the recycler unit CBM. 

You should be able to sleep without a warning. And it is a toggled CBM.

#### Summary
This adds the flags for BIONIC_TOGGLED & BIONIC_SLEEP_FRIENDLY to the recycler unit CBM. 

#### Purpose of change
You should be able to sleep without a warning. And it is a toggled CBM.

#### Describe the solution
Flags added

#### Describe alternatives you've considered
No alternatives considered

#### Testing
Runs fine in game, no warning before you try to sleep with this CBM active.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
