### PR TITLE
Fixes Typo for Eskrima in Techniques

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1287,7 +1287,7 @@
         }
       ]
     },
-    "condition_desc": "* Only works on a <info>non-stunned living/info> target of <info>similar or smaller</info> size",
+    "condition_desc": "* Only works on a <info>non-stunned living</info> target of <info>similar or smaller</info> size",
     "stun_dur": 1,
     "attack_vectors": [ "vector_null" ]
   },


### PR DESCRIPTION
#### Summary
There was a typo in the description of an Eskrima technique. Was missing an "<"

#### Purpose of change
Fixes the description 

#### Describe the solution
Added the missing <

#### Describe alternatives you've considered
None

#### Testing
Description is now fixed in game

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
