### PR TITLE
Rebalance solar sensitivity damage

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1034,7 +1034,7 @@ void suffer::from_sunburn( Character &you, bool severe )
         float heavy_cumul_chance = heavy_eff_chance( exposure );
         float medium_cumul_chance = heavy_cumul_chance + medium_eff_chance( exposure );
         float light_cumul_chance = medium_cumul_chance + light_eff_chance( exposure );
-        float roll = rng_float( 0.0, 1.0 );
+        float roll = rng_float( 0.0, 0.98 );
 
         Sunburn eff;
         if( roll < heavy_cumul_chance ) {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1031,24 +1031,29 @@ void suffer::from_sunburn( Character &you, bool severe )
             continue;
         }
 
-        float heavy_cumul_chance = heavy_eff_chance( exposure );
-        float medium_cumul_chance = heavy_cumul_chance + medium_eff_chance( exposure );
-        float light_cumul_chance = medium_cumul_chance + light_eff_chance( exposure );
-        float roll = rng_float( 0.0, 0.98 );
-
+        // Damage player if coverage of body part is <95%
         Sunburn eff;
-        if( roll < heavy_cumul_chance ) {
-            eff = heavy_sunburn( bp );
-        } else if( roll < medium_cumul_chance ) {
-            eff = medium_sunburn( );
-        } else if( roll < light_cumul_chance ) {
-            eff = light_sunburn( );
+        if( exposure > 0.95 ) {
+            float heavy_cumul_chance = heavy_eff_chance( exposure );
+            float medium_cumul_chance = heavy_cumul_chance + medium_eff_chance( exposure );
+            float light_cumul_chance = medium_cumul_chance + light_eff_chance( exposure );
+            float roll = rng_float( 0.0, 1.0 );
+
+            if( roll < heavy_cumul_chance ) {
+                eff = heavy_sunburn( bp );
+            } else if( roll < medium_cumul_chance ) {
+                eff = medium_sunburn( );
+            } else if( roll < light_cumul_chance ) {
+                eff = light_sunburn( );
+            } else {
+                // Do nothing. Assert that exposure is lower than 0.05 as above that point at least light_eff should always happen
+                if( exposure > 0.05 ) {
+                    debugmsg( "No sunburn effect was applied although the bodypart %s is sufficiently exposed at %f exposure",
+                            body_part_name( bp ), exposure );
+                };
+                eff = None;
+            }
         } else {
-            // Do nothing. Assert that exposure is lower than 0.05 as above that point at least light_eff should always happen
-            if( exposure > 0.05 ) {
-                debugmsg( "No sunburn effect was applied although the bodypart %s is sufficiently exposed at %f exposure",
-                          body_part_name( bp ), exposure );
-            };
             eff = None;
         }
         affected_bodyparts.emplace( bp, eff );


### PR DESCRIPTION
#### Summary
Category "Brief description"
Adds a check in the code that runs the damage checks for solar sensitivity and irritation to need <95% coverage

#### Purpose of change

Changes to many clothing and armour being reduced from 100% meant that solar sensitivity checks were trigger more often than they were originally intended.


#### Describe the solution

Adds a check in suffer.cpp to check for body part coverage and only trigger when it's <95% coverage

#### Describe alternatives you've considered

Scale damage according to coverage, as the game doesn't allow you to take decimal point damage, you can't scale 1 damage to affect the body part without changing how hit points work.

#### Testing

Downloaded a fresh copy of the branch, compiled, opened game, tested behaviour and working according to what I believe it should.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
