### PR TITLE
Rework vision widget

### DIFF
--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -175,7 +175,6 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_SUIT",
     "skill_used": "tailor",
-    "difficulty": 0,
     "time": "10 m",
     "reversible": true,
     "autolearn": true,
@@ -1063,6 +1062,7 @@
     "subcategory": "CSC_ARMOR_SUIT",
     "skill_used": "survival",
     "difficulty": 2,
+    "reversible": true,
     "autolearn": true,
     "time": "5 m",
     "components": [ [ [ "bag_body_bag", 1 ] ], [ [ "withered", 180 ], [ "straw_pile", 180 ] ] ]
@@ -1075,7 +1075,6 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_SUIT",
     "skill_used": "fabrication",
-    "skill": 0,
     "time": "2 m",
     "reversible": true,
     "autolearn": true,

--- a/data/json/ui/lighting.json
+++ b/data/json/ui/lighting.json
@@ -2,12 +2,12 @@
   {
     "id": "lighting_desc",
     "type": "widget",
-    "label": "Visibility",
+    "label": "Vision",
     "style": "text",
     "clauses": [
       {
         "id": "blind",
-        "text": "blind!",
+        "text": "Blind!",
         "color": "red",
         "condition": {
           "or": [
@@ -19,43 +19,43 @@
       },
       {
         "id": "full",
-        "text": "full",
+        "text": "Full",
         "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "<=", "1" ] }
       },
       {
         "id": "fair",
-        "text": "fair",
+        "text": "Fair",
         "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "2" ] }
       },
       {
         "id": "moderate",
-        "text": "moderate",
+        "text": "Moderate",
         "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "3" ] }
       },
       {
         "id": "poor",
-        "text": "poor",
+        "text": "Poor",
         "color": "light_gray",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "4" ] }
       },
       {
         "id": "murky",
-        "text": "murky",
+        "text": "Murky",
         "color": "dark_gray",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "5" ] }
       },
       {
         "id": "very_murky",
-        "text": "very murky",
+        "text": "Very Murky",
         "color": "dark_gray",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "6" ] }
       },
       {
         "id": "nearly_blind",
-        "text": "nearly blind",
+        "text": "Nearly Blind",
         "color": "black_white",
         "condition": {
           "and": [

--- a/data/json/ui/lighting.json
+++ b/data/json/ui/lighting.json
@@ -2,38 +2,67 @@
   {
     "id": "lighting_desc",
     "type": "widget",
-    "label": "Lighting",
+    "label": "Visibility",
     "style": "text",
     "clauses": [
       {
-        "id": "bright",
-        "text": "bright",
-        "color": "yellow",
+        "id": "blind",
+        "text": "blind!",
+        "color": "red",
+        "condition": {
+          "or": [
+            { "u_has_effect": "blind" },
+            { "u_has_effect": "boomered" },
+            { "math": [ "u_val('fine_detail_vision_mod')", ">=", "11" ] }
+          ]
+        }
+      },
+      {
+        "id": "full",
+        "text": "full",
+        "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "<=", "1" ] }
       },
       {
-        "id": "cloudy",
-        "text": "cloudy",
+        "id": "fair",
+        "text": "fair",
         "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "2" ] }
       },
       {
-        "id": "shady",
-        "text": "shady",
-        "color": "light_gray",
+        "id": "moderate",
+        "text": "moderate",
+        "color": "white",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "3" ] }
       },
       {
-        "id": "dark",
-        "text": "dark",
-        "color": "dark_gray",
+        "id": "poor",
+        "text": "poor",
+        "color": "light_gray",
         "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "4" ] }
       },
       {
-        "id": "very dark",
-        "text": "very dark",
+        "id": "murky",
+        "text": "murky",
+        "color": "dark_gray",
+        "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "5" ] }
+      },
+      {
+        "id": "very_murky",
+        "text": "very murky",
+        "color": "dark_gray",
+        "condition": { "math": [ "u_val('fine_detail_vision_mod')", "==", "6" ] }
+      },
+      {
+        "id": "nearly_blind",
+        "text": "nearly blind",
         "color": "black_white",
-        "condition": { "math": [ "u_val('fine_detail_vision_mod')", ">=", "5" ] }
+        "condition": {
+          "and": [
+            { "math": [ "u_val('fine_detail_vision_mod')", ">=", "7" ] },
+            { "math": [ "u_val('fine_detail_vision_mod')", "<", "11" ] }
+          ]
+        }
       }
     ]
   },

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -408,7 +408,7 @@ float Character::hit_roll() const
     }
 
     // Fighting in the dark is hard.
-    if( !sight_impaired() && fine_detail_vision_mod() >= 6.0f ) {
+    if( !sight_impaired() && fine_detail_vision_mod() >= 7.0f ) {
         hit -= 1.0f;
     }
 
@@ -457,8 +457,8 @@ std::string Character::get_miss_reason()
         !reach_attacking &&
         cur_weap.has_flag( flag_POLEARM ) );
     add_miss_reason(
-        _( "You can't see well enough to fight in the dark." ),
-        fine_detail_vision_mod() >= 6 );
+        _( "You can't see well enough to fight." ),
+        fine_detail_vision_mod() >= 7 );
 
     const std::string *const reason = melee_miss_reasons.pick();
     if( reason == nullptr ) {
@@ -1345,7 +1345,7 @@ float Character::get_dodge() const
     add_msg_debug( debugmode::DF_MELEE, "Dodge after bodysize modifier %.1f", ret );
 
     // It's much harder to dodge when you can't see well
-    if( !sight_impaired() && fine_detail_vision_mod() >= 6.0f ) {
+    if( !sight_impaired() && fine_detail_vision_mod() >= 7.0f ) {
         add_msg_debug( debugmode::DF_MELEE, "Dodge after vision penalty %.1f", ret );
         ret *= 0.8;
     }


### PR DESCRIPTION
#### Summary
Rework vision widget

#### Purpose of change
There has always been a widget called Lighting on your sidebar and it has always been lying to you. That widget has NEVER said what the light level is. What it has always said is how well _you_ can see.

Different people have different vision levels, even in the same lighting. Some people have high perception, or night vision goggles, or mutated Gollum eyes. This meant that this widget was never reliably telling you what the lighting in your tile is, and that led people to incorrectly assume that it means how well others can see you, not how well you can see.

#### Describe the solution
Rename Lighting->Vision

Fix a random unrelated json error.

Rename levels and add more of them to more accurately describe the situation. No matter what your night vision capabilities are like, you can now trust that the side bar knows what it's talking about. These levels are:

Full: Your vision is not limited in any way.
Fair: You can still see pretty well, but it's starting to get worse.
Moderate: There are some limitations on your vision.
Poor: You can see well enough to get by, but you're having trouble making out fine detail. _Reading and crafting are slowed._
Very Murky: You can make out the creatures and terrain around you as vague shapes and track their movement, but that's all. _Crafting and reading are impossible._
Nearly Blind: You can barely see your hand in front of your face. _Crafting and reading are impossible, you suffer penalties to your dodge and melee to-hit scores._
Blind: You can't see at all, and suffer a huge host of penalties because of it.

These are color coded as well:
white = no penalty
light_gray = crafting speed penalty
dark_gray = crafting is impossible
black_white = crafting is impossible, dodge and melee accuracy penalty

#### Describe alternatives you've considered
I wanted to call the widget "visibility" as in "visibility conditions are good" but people would probably still go on mistaking that for their own visibility.

#### Testing
Loads, runs, works in all test cases I can think of.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
