### PR TITLE
Fix autoattack adjacency check

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10603,7 +10603,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
         {
             std::vector<tripoint> path = here.find_clear_path( pos(), critter.pos() );
             for( const tripoint &point : path ) {
-                if( here.impassable( point ) &&
+                if( here.impassable( point ) && point != critter.pos() &&
                     !( weapon.has_flag( flag_SPEAR ) && // Fences etc. Spears can stab through those
                        here.has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE,
                                       point ) ) ) { //this mirrors melee.cpp function reach_attack


### PR DESCRIPTION
#### Summary
Fix autoattack reachability check

#### Purpose of change
Autoattack (pressing tab) runs a check to determine if any targets are in range of the player's weapon. This check fails if a monster is climbing on a chfence, even if that fence is adjacent to the player, because the game knows that impassable tiles block attacks if they're not THIN_OBSTACLE and the character is not wielding a weapon with the SPEAR flag. That's fine for reach attacks, but not adjacent ones, as a creature occupying a chain link fence tile is presumed to be halfway over it, and thus hittable from both sides.

#### Describe the solution
- Add a quick check that always considers impassable tiles valid for attacks if they're adjacent to the character.

#### Testing
Spawned a guy, spawned a feral, let feral climb fence, punched feral

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
