### PR TITLE
Fix invisible creature name spoiler

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -67,6 +67,7 @@ static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_immobilization( "immobilization" );
 static const efftype_id effect_in_pit( "in_pit" );
+static const efftype_id effect_invisibility( "invisibility" );
 static const efftype_id effect_led_by_leash( "led_by_leash" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_operating( "operating" );
@@ -2439,8 +2440,12 @@ void monster::shove_vehicle( const tripoint &remote_destination,
             }
             if( shove_velocity > 0 ) {
                 //~ %1$s - monster name, %2$s - vehicle name
-                add_msg_if_player_sees( this->pos(), m_bad, _( "%1$s shoves %2$s out of their way!" ),
-                                        this->disp_name(),
+                std::string monster_name = "Something";
+                if( !this->has_effect( effect_invisibility ) ) {
+                    monster_name = this->disp_name( false, true );
+                }
+                add_msg_if_player_sees( this->pos(), m_bad, _( "%1$s shoves %2$s out of the way!" ),
+                                        monster_name,
                                         veh.disp_name() );
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;
                 shove_moves = std::max( shove_moves, shove_moves_minimal );


### PR DESCRIPTION
#### Summary
Fix invisible creature name spoiler

#### Purpose of change
- Star vampires can shove vehicles. They can do this while invisible. This was revealing their name, which shouldn't happen if they're invisible.

#### Describe the solution
- Add a simple check for the invisibility effect in the vehicle shove effect, as we're already checking if the player can see the tile. If true, the creature is called "Something" instead of its name.

#### Testing
Had a star vampire and a hulk shove cars. The vampire was Something while it was invisible. The hulk was A zombie hulk.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
