### PR TITLE
No sailing on dry land

### DIFF
--- a/data/json/vehicleparts/manual.json
+++ b/data/json/vehicleparts/manual.json
@@ -69,7 +69,7 @@
       "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "6 m" },
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "60 m" }
     },
-    "flags": [ "ENGINE", "CONTROLS", "MUSCLE_ARMS", "E_STARTS_INSTANTLY" ],
+    "flags": [ "ENGINE", "CONTROLS", "MUSCLE_ARMS", "E_STARTS_INSTANTLY", "WATER_ONLY" ],
     "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] } ],
     "damage_reduction": { "all": 5 },
     "variants": [ { "symbols": "*", "symbols_broken": "#" } ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1235,7 +1235,16 @@
       "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "60 m" },
       "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
-    "flags": [ "ENGINE", "CONTROLS", "PROTRUSION", "E_STARTS_INSTANTLY", "WIND_POWERED", "STABLE", "UNMOUNT_ON_DAMAGE", "WATER_ONLY" ],
+    "flags": [
+      "ENGINE",
+      "CONTROLS",
+      "PROTRUSION",
+      "E_STARTS_INSTANTLY",
+      "WIND_POWERED",
+      "STABLE",
+      "UNMOUNT_ON_DAMAGE",
+      "WATER_ONLY"
+    ],
     "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "cotton_patchwork", "count": [ 1, 3 ] } ],
     "variants": [ { "symbols": "M", "symbols_broken": "#" } ]
   },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1235,7 +1235,7 @@
       "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "60 m" },
       "repair": { "skills": [ [ "tailor", 1 ] ], "time": "150 s", "using": [ [ "sewing_standard", 50 ], [ "fabric_standard", 1 ] ] }
     },
-    "flags": [ "ENGINE", "CONTROLS", "PROTRUSION", "E_STARTS_INSTANTLY", "WIND_POWERED", "STABLE", "UNMOUNT_ON_DAMAGE" ],
+    "flags": [ "ENGINE", "CONTROLS", "PROTRUSION", "E_STARTS_INSTANTLY", "WIND_POWERED", "STABLE", "UNMOUNT_ON_DAMAGE", "WATER_ONLY" ],
     "breaks_into": [ { "item": "splinter", "count": [ 2, 4 ] }, { "item": "cotton_patchwork", "count": [ 1, 3 ] } ],
     "variants": [ { "symbols": "M", "symbols_broken": "#" } ]
   },

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -703,5 +703,10 @@
     "id": "NEEDS_WHEEL_MOUNT_CONCRETE_MIX",
     "type": "json_flag",
     "requires_flag": "WHEEL_MOUNT_CONCRETE_MIX"
+  },
+  {
+    "id": "WATER_ONLY",
+    "info": "This part can only power a vehicle on water.",
+    "type": "json_flag"
   }
 ]

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1102,6 +1102,12 @@ units::power vehicle::part_vpower_w( const vehicle_part &vp, const bool at_full_
     const int vp_index = index_of_part( &vp );
     units::power pwr = vpi.power;
     if( vpi.has_flag( VPFLAG_ENGINE ) ) {
+        if( vpi.has_flag( "WATER_ONLY" ) ) {
+            map &here = get_map();
+            if( !here.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, bub_part_pos( vp_index ) ) ) {
+                return 0_W;
+            }
+        }
         if( vpi.fuel_type == fuel_type_animal ) {
             int factor = 0;
             if( const monster *mon = get_monster( vp_index ); mon && mon->has_effect( effect_harnessed ) ) {


### PR DESCRIPTION
#### Summary
Make hand paddles and sails only work in water

#### Purpose of change
Hand paddles need to output a lot of power to make boats move at a reasonable speed. That's fine in water, but they worked on land, too, and were better than pedals or hand rims. That doesn't make any sense!

#### Describe the solution
Sails and hand rims now only work if the terrain tile they're in has the SWIMMABLE flag. That's most water and water-like substances in the game.

#### Describe alternatives you've considered
It is kind of weird how engine power just directly provides propulsion to boats. Makes sense for paddles and sails, but not for foot pedals or a gas engine. We don't have any way to link parts up in separate tiles yet, but if we did we could make proper swan boats or outboard propellers.

#### Testing
- Spawned a wheelchair. It drove on the road OK.
- Took its hand rims off and applied hand paddles. It could no longer move.
- Spawned a rowboat, which uses hand paddles. It was still driveable in water just as before.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
