### PR TITLE
Hub 01 buys (most) artifacts

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -53,7 +53,27 @@
         "refusal": "You're not yet qualified to buy this"
       }
     ],
-    "shopkeeper_blacklist": "robofac_blacklist"
+    "shopkeeper_blacklist": "robofac_blacklist",
+    "shopkeeper_price_rules": [
+      { "item": "petrified_eye", "price": 2000 },
+      { "item": "altered_phone", "price": 4000 },
+      { "item": "spiral_stone", "price": 1000 },
+      { "item": "altered_exposed_wiring_prototype", "price": 4000 },
+      { "item": "altered_comb", "price": 4000 },
+      { "item": "altered_rubiks_cube", "price": 4000 },
+      { "item": "altered_keyring", "price": 4000 },
+      { "item": "altered_teapot", "price": 4000 },
+      { "item": "altered_stopwatch", "price": 4000 },
+      { "item": "altered_shirt", "price": 4000 },
+      { "item": "altered_badge", "price": 4000 },
+      { "item": "altered_sunglasses", "price": 4000 },
+      { "item": "altered_scissors", "price": 4000 },
+      { "item": "altered_necklace", "price": 4000 },
+      { "item": "altered_jacket", "price": 4000 },
+      { "item": "altered_apron", "price": 4000 },
+      { "item": "monolith_disc", "price": 1000 },
+      { "item": "monolith_brick", "price": 1000 }
+    ]
   },
   {
     "type": "item_group",
@@ -211,6 +231,7 @@
     "responses": [
       { "text": "Let's discuss contracts.", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" },
       { "text": "Let's trade.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES", "effect": "start_trade" },
+      { "text": "You mentioned wanting unusual items?", "topic": "TALK_ROBOFAC_INTERCOM_UNUSUAL_ITEMS" },
       {
         "text": "The traders at the refugee center asked me to deliver this drive of FEMA data…",
         "condition": {
@@ -233,6 +254,12 @@
       },
       { "text": "I have to go.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_UNUSUAL_ITEMS",
+    "type": "talk_topic",
+    "dynamic_line": "You may rarely come across certain items which have been affected by the…ongoing phenomena.  They may seem like mundane household objects, but exhibit properties which seem to defy casual explanation.  I'm afraid that we cannot be clearer on this matter - suffice to say that you will likely know it when you see it.  We are willing to barter for these items at a high value.",
+    "responses": [ { "text": "I see.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_INTRO",
@@ -349,7 +376,7 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_1_JOBS_2",
     "type": "talk_topic",
-    "dynamic_line": "Certainly.  I've just finished speaking with a certain individual, who has authorized you limited access to a selection of our internal stores.  We will provide you with pay for contracts in the form of tokens to be used as an exchange currency, which you can then trade for goods.  We are also amenable to bartering in exchange for supplies that are currently difficult for us to obtain from outside the facility.",
+    "dynamic_line": "Certainly.  I've just finished speaking with a certain individual, who has authorized you limited access to a selection of our internal stores.  We will provide you with pay for contracts in the form of tokens to be used as an exchange currency, which you can then trade for goods.  We are also amenable to bartering in exchange for supplies that are currently difficult for us to obtain from outside the facility, and are especially interested in any…especially unusual items you may find.",
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_npc_intercom_trade", "value": "yes" },


### PR DESCRIPTION
#### Summary
Hub 01 buys (most) artifacts

#### Purpose of change
- Artifacts are often really disappointing due to their randomness
- Some items (spiral stone, petrified eyeball) seem important but don't do anything
- Hub 01 is being reworked later, and they'll eventually only buy this kind of stuff (or their coins). They'll still sell most of the stuff they sell now

#### Describe the solution
- Add a bit of dialog with the Hub 01 intercom once you unlock the ability to trade. This explains that they'll pay good money for artifacts.
- Add all the "altered X" artifacts (hawaiian shirt, bakelite phone, etc) to their purchase list.
- Add the monolith disc and brick (are those even accessible in TLG?).
- Add the petrified eye and spiral stone to their purchase list. They pay decent money for the eye and not much for the stone, as the stone is easier to get.

#### Testing
Went to Hub 01, saw the dialog, traded items to them and saw good prices for those things.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
