### PR TITLE
Remove BLOCK_WHILE_WORN

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -17,7 +17,7 @@
     "warmth": 5,
     "material_thickness": 3,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "OUTER", "WATER_FRIENDLY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -51,7 +51,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NO_REPAIR" ],
+    "flags": [ "OUTER",  "NO_REPAIR" ],
     "armor": [
       {
         "material": [
@@ -84,7 +84,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NO_REPAIR" ],
+    "flags": [ "OUTER",  "NO_REPAIR" ],
     "armor": [
       {
         "material": [
@@ -116,7 +116,7 @@
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER",  "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -199,7 +199,7 @@
     "warmth": 35,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "BLOCK_WHILE_WORN" ]
+    "flags": [ "VARSIZE" ]
   },
   {
     "id": "armguard_hard",
@@ -219,7 +219,7 @@
     "warmth": 20,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "WATER_FRIENDLY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -289,7 +289,7 @@
     "color": "brown",
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER",  "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -333,7 +333,7 @@
     "color": "blue",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -361,7 +361,7 @@
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 4,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NONCONDUCTIVE" ],
+    "flags": [ "OUTER",  "NONCONDUCTIVE" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -405,7 +405,7 @@
     "looks_like": "leather_vambraces",
     "color": "light_gray",
     "warmth": 10,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER" ],
     "armor": [
       {
         "material": [
@@ -454,7 +454,7 @@
     "color": "light_gray",
     "warmth": 10,
     "material_thickness": 4,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "NONCONDUCTIVE" ],
+    "flags": [ "OUTER",  "NONCONDUCTIVE" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -500,7 +500,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -546,7 +546,7 @@
     "color": "light_gray",
     "warmth": 50,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "STURDY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY" ],
     "use_action": {
       "type": "transform",
       "menu_text": "Loosen",
@@ -611,7 +611,7 @@
     "color": "light_gray",
     "warmth": 50,
     "material_thickness": 5,
-    "flags": [ "VARSIZE", "STURDY", "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
     "armor": [
       {
         "material": [
@@ -676,7 +676,7 @@
     "looks_like": "armguard_metal",
     "color": "light_red",
     "warmth": 10,
-    "flags": [ "STURDY", "NORMAL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -912,7 +912,7 @@
     "warmth": 10,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -968,7 +968,7 @@
     "warmth": 10,
     "longest_side": "60 cm",
     "material_thickness": 1.3,
-    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "CONDUCTIVE" ],
     "armor": [
       {
         "material": [
@@ -1111,7 +1111,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "40 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -51,7 +51,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER",  "NO_REPAIR" ],
+    "flags": [ "OUTER", "NO_REPAIR" ],
     "armor": [
       {
         "material": [
@@ -84,7 +84,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER",  "NO_REPAIR" ],
+    "flags": [ "OUTER", "NO_REPAIR" ],
     "armor": [
       {
         "material": [
@@ -116,7 +116,7 @@
     "warmth": 5,
     "material_thickness": 3,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "OUTER",  "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -289,7 +289,7 @@
     "color": "brown",
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER",  "WATER_FRIENDLY" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -361,7 +361,7 @@
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 4,
-    "flags": [ "OUTER",  "NONCONDUCTIVE" ],
+    "flags": [ "OUTER", "NONCONDUCTIVE" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
@@ -454,7 +454,7 @@
     "color": "light_gray",
     "warmth": 10,
     "material_thickness": 4,
-    "flags": [ "OUTER",  "NONCONDUCTIVE" ],
+    "flags": [ "OUTER", "NONCONDUCTIVE" ],
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],

--- a/data/json/items/armor/brigandine.json
+++ b/data/json/items/armor/brigandine.json
@@ -63,7 +63,7 @@
     "looks_like": "armguard_hard",
     "color": "light_gray",
     "environmental_protection": 1,
-    "flags": [ "OUTER", "BLOCK_WHILE_WORN", "STURDY", "VARSIZE" ],
+    "flags": [ "OUTER", "STURDY", "VARSIZE" ],
     "armor": [
       {
         "material": [

--- a/data/json/items/armor/gambesons.json
+++ b/data/json/items/armor/gambesons.json
@@ -14,7 +14,7 @@
     "looks_like": "jacket_light",
     "color": "light_gray",
     "warmth": 50,
-    "flags": [ "VARSIZE", "STURDY", "NORMAL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "menu_text": "Loosen",
@@ -97,7 +97,7 @@
     "looks_like": "jacket_light",
     "color": "light_gray",
     "warmth": 50,
-    "flags": [ "VARSIZE", "STURDY", "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
     "use_action": { "type": "transform", "menu_text": "Tighten", "target": "gambeson", "msg": "You tighten the fit of your gambeson." },
     "armor": [
       {

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -606,7 +606,6 @@
     "flags": [
       "INTEGRATED",
       "ALLOWS_NATURAL_ATTACKS",
-      "BLOCK_WHILE_WORN",
       "UNBREAKABLE",
       "SKINTIGHT",
       "NORMAL",
@@ -770,7 +769,6 @@
     "flags": [
       "INTEGRATED",
       "ALLOWS_NATURAL_ATTACKS",
-      "BLOCK_WHILE_WORN",
       "UNBREAKABLE",
       "NORMAL",
       "SKINTIGHT",
@@ -918,7 +916,7 @@
     "color": "brown",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED", "BLOCK_WHILE_WORN" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED" ],
     "armor": [
       {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 2.8 } ],
@@ -998,7 +996,7 @@
     "color": "brown",
     "warmth": 7,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "BLOCK_WHILE_WORN", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "NORMAL", "SKINTIGHT", "PADDED" ],
     "armor": [
       {
         "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -47,7 +47,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -80,7 +80,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "NO_REPAIR", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -112,7 +112,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "environmental_protection": 2,
-    "flags": [ "STURDY", "OUTER", "BLOCK_WHILE_WORN", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -240,7 +240,7 @@
     "looks_like": "legguard_hard",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -528,7 +528,7 @@
     "looks_like": "legguard_hard",
     "color": "dark_gray",
     "material_thickness": 5,
-    "flags": [ "WATER_FRIENDLY", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "WATER_FRIENDLY", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -561,7 +561,7 @@
     "color": "yellow",
     "warmth": 15,
     "material_thickness": 3,
-    "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -607,7 +607,7 @@
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -869,7 +869,7 @@
     "looks_like": "legguard_hard",
     "color": "light_gray",
     "warmth": 20,
-    "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -927,7 +927,7 @@
     "color": "blue",
     "warmth": 5,
     "material_thickness": 3,
-    "flags": [ "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -956,7 +956,7 @@
     "color": "light_gray",
     "warmth": 10,
     "material_thickness": 4,
-    "flags": [ "OUTER", "NONCONDUCTIVE", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "OUTER", "NONCONDUCTIVE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -1076,7 +1076,7 @@
     "color": "light_blue",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "POCKETS", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": [ 12, 16 ],
@@ -1149,7 +1149,7 @@
     "color": "light_green",
     "environmental_protection": 2,
     "material_thickness": 15,
-    "flags": [ "STURDY", "OUTER", "RAINPROOF", "ONLY_ONE", "NORMAL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "RAINPROOF", "ONLY_ONE", "NORMAL" ],
     "use_action": [ { "type": "attach_molle", "size": 4 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -1181,7 +1181,7 @@
     "color": "light_gray",
     "environmental_protection": 2,
     "material_thickness": 7,
-    "flags": [ "STURDY", "OUTER", "RAINPROOF", "ONLY_ONE", "NORMAL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "RAINPROOF", "ONLY_ONE", "NORMAL" ],
     "use_action": [ { "type": "attach_molle", "size": 6 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -1214,7 +1214,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "40 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "ALLOWS_TAIL" ],
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
@@ -1256,7 +1256,7 @@
     "color": "brown",
     "warmth": 25,
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [ { "covers": [ "leg_l", "leg_r" ], "encumbrance": 7, "coverage": 90 } ],
     "melee_damage": { "bash": 2 }
   },

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -40,7 +40,7 @@
     ],
     "warmth": 20,
     "material_thickness": 2.5,
-    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 3 }
   },
   {
@@ -61,7 +61,7 @@
     "warmth": 10,
     "longest_side": "60 cm",
     "material_thickness": 4,
-    "flags": [ "STURDY", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 90, "encumbrance": 10 },
       {
@@ -177,7 +177,7 @@
     ],
     "warmth": 45,
     "material_thickness": 4,
-    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "POCKETS", "RAINPROOF", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -353,7 +353,7 @@
     "warmth": 25,
     "longest_side": "60 cm",
     "material_thickness": 1.6,
-    "flags": [ "VARSIZE", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
         "encumbrance": 34,
@@ -381,7 +381,7 @@
     "warmth": 20,
     "longest_side": "60 cm",
     "material_thickness": 2,
-    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ONLY_ONE", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
+    "flags": [ "OUTER", "STURDY", "CONDUCTIVE", "ONLY_ONE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 } ],
@@ -474,7 +474,7 @@
     "color": "light_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "flags": [ "STURDY", "GROUNDING", "ONLY_ONE", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "GROUNDING", "ONLY_ONE" ],
     "armor": [
       {
         "material": [
@@ -660,7 +660,7 @@
     ],
     "warmth": 35,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "melee_damage": { "bash": 5 }
   },
   {
@@ -696,7 +696,7 @@
     "color": "dark_gray",
     "warmth": 20,
     "longest_side": "60 cm",
-    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "BLOCK_WHILE_WORN", "ALLOWS_TAIL" ],
+    "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "PADDED", "ALLOWS_TAIL" ],
     "use_action": [ { "type": "attach_molle", "size": 6 }, { "type": "detach_molle" } ],
     "armor": [
       {
@@ -836,7 +836,7 @@
     "looks_like": "boiled_leather_armor_suit",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY", "ALLOWS_TAIL", "NORMAL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -1007,7 +1007,7 @@
     "looks_like": "touring_suit",
     "color": "light_red",
     "warmth": 15,
-    "flags": [ "STURDY", "ALLOWS_TAIL", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
@@ -1219,7 +1219,7 @@
         "layers": [ "OUTER", "NORMAL" ]
       }
     ],
-    "flags": [ "GROUNDING", "BLOCK_WHILE_WORN" ],
+    "flags": [ "GROUNDING" ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -1488,7 +1488,7 @@
     "color": "light_gray",
     "warmth": 50,
     "material_thickness": 4,
-    "flags": [ "STURDY", "NONCONDUCTIVE", "NORMAL", "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "STURDY", "NONCONDUCTIVE", "NORMAL", "OUTER" ],
     "armor": [
       {
         "material": [

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -683,7 +683,7 @@
     "warmth": 15,
     "material_thickness": 4,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "WATERPROOF", "OUTER", "BLOCK_WHILE_WORN" ],
+    "flags": [ "VARSIZE", "WATERPROOF", "OUTER" ],
     "melee_damage": { "bash": 2 }
   },
   {


### PR DESCRIPTION
#### Summary
Remove BLOCK_WHILE_WORN

#### Purpose of change
Due to a confusing code comment, I misunderstood how BLOCK_WHILE_WORN works. If you have the flag on a piece of armor (any armor!) it allows you to do arm blocks as if you had them via a martial art, but with a +2 bonus. It feels like a kludged attempt at including shields, and we're not there yet. We'll get there, just, not yet.

Given that this devalues martial arts, it shouldn't go on anything. It especially shouldn't go on stuff that doesn't cover your arms, but that's sort of beside the point. Yes, it makes sense that if you have metal bracers on you might block attacks with them...which is already what you'll do if you have a martial art that has an arm block technique!

#### Describe the solution
- Remove from all items.

#### Describe alternatives you've considered
I could maybe see a case for this flag on like...an artifact? But it's not exactly impressive, so into the trash it goes. I'll leave the flag active in the code in case any mods want to make use of it. Bracers of defense or something.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
