### PR TITLE
Fix releasing grapple

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1709,13 +1709,13 @@ void Character::release_grapple()
                 }
             }
         }
+        // TODO: Track our grabbing effects the same way we track grab_strength on the victim
         for( const effect &eff : get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
             const efftype_id effid = eff.get_id();
-            if( eff.get_intensity() == grab_1.grab_strength ) {
-                remove_effect( effid );
-            }
+            remove_effect( effid );
         }
     }
+    grab_1.clear();
 }
 
 void Character::mount_creature( monster &z )

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -706,6 +706,11 @@ static void grab()
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
 
+    if( you.grab_1.victim != nullptr ) {
+        you.release_grapple();
+        return;
+    }
+
     if( you.get_grab_type() != object_type::NONE ) {
         if( const optional_vpart_position vp = here.veh_at( you.pos_bub() + you.grab_point ) ) {
             add_msg( _( "You release the %s." ), vp->vehicle().name );
@@ -715,8 +720,6 @@ static void grab()
         you.grab( object_type::NONE );
         return;
     }
-
-    you.release_grapple();
 
     const std::optional<tripoint> grabp_ = choose_adjacent( _( "Grab where?" ) );
     if( !grabp_ ) {


### PR DESCRIPTION
#### Summary
Fix releasing grapple

#### Purpose of change
Pressing G to release a grapple wasn't properly getting rid of all the effects.

#### Describe the solution
Fix it and make sure it does grab_1.clear()

#### Describe alternatives you've considered
Multigrabs will require a thing that checks to make sure you're releasing the right enemy. I considered adding grab_strength to the grabbing effect (as intensity) but I think it's easier to just track grab_1.victim or whatever.

#### Testing
Grabbed a debug monster, released it, walked away no problem. Grabbed it, dragged it, threw it, everything worked.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
