### PR TITLE
Balance updates for zombies, regenerators, and ferals

### DIFF
--- a/data/json/monster_special_attacks/feral_weapon_attacks.json
+++ b/data/json/monster_special_attacks/feral_weapon_attacks.json
@@ -24,8 +24,7 @@
     "type": "monster_attack",
     "attack_type": "bite",
     "id": "feral_bite",
-    "cooldown": 2,
-    "//": "Cooldown to simulate grab break attempts, or trying to re-equip its weapon, etc",
+    "cooldown": 10,
     "move_cost": 100,
     "condition": { "or": [ { "not": { "test_eoc": "is_disarmed" } }, { "u_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] }
   },

--- a/data/json/monster_special_attacks/feral_weapon_attacks.json
+++ b/data/json/monster_special_attacks/feral_weapon_attacks.json
@@ -11,8 +11,6 @@
     "cooldown": 2,
     "//": "Cooldown to simulate grab break attempts, or trying to re-equip its weapon, etc",
     "move_cost": 80,
-    "accuracy": 3,
-    "//2": "Feral melee skill + weapon's to hit, so 3+0=3",
     "damage_max_instance": [ { "damage_type": "bash", "amount": 6 } ],
     "condition": { "or": [ { "not": { "test_eoc": "is_disarmed" } }, { "u_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] },
     "hit_dmg_u": "%1$s flails a fist at your %2$s!",
@@ -21,6 +19,15 @@
     "miss_msg_npc": "%1$s swings a fist, but <npcname> dodges!",
     "no_dmg_msg_u": "%1$s hits your %2$s without penetrating your armor.",
     "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
+  },
+    {
+    "type": "monster_attack",
+    "attack_type": "bite",
+    "id": "feral_bite",
+    "cooldown": 2,
+    "//": "Cooldown to simulate grab break attempts, or trying to re-equip its weapon, etc",
+    "move_cost": 100,
+    "condition": { "or": [ { "not": { "test_eoc": "is_disarmed" } }, { "u_has_flag": "GRAB" }, { "u_has_flag": "GRAB_FILTER" } ] }
   },
   {
     "type": "monster_attack",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -53,6 +53,7 @@
       },
       { "id": "feral_weapon_pipe" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -88,6 +89,7 @@
       [ "PARROT_AT_DANGER", 0 ],
       { "id": "feral_weapon_spear_knife" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -129,6 +131,7 @@
       },
       { "id": "feral_weapon_crowbar" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -174,6 +177,7 @@
       },
       { "id": "feral_weapon_hammer" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -249,7 +253,7 @@
     "melee_skill": 4,
     "vision_day": 50,
     "death_drops": "feral_scientists_death_drops_scalpel",
-    "special_attacks": [ { "id": "feral_weapon_scalpel" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_scalpel" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "zombify_into": "mon_zombie_scientist"
   },
   {
@@ -287,6 +291,7 @@
       },
       { "id": "feral_weapon_feral_m9" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -304,6 +309,7 @@
       [ "TAZER", 10 ],
       { "id": "feral_weapon_heavy_flashlight" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -317,7 +323,7 @@
     "description": "Once a fancy servant of some rich family, this maniac walks around with a broom in hand, searching for a victim to sweep off this mortal coil.",
     "copy-from": "mon_feral_human_pipe",
     "melee_skill": 2,
-    "special_attacks": [ { "id": "feral_weapon_broom" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_broom" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_maids_death_drops_broom"
   },
   {
@@ -326,7 +332,7 @@
     "copy-from": "mon_feral_maid_broom",
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a candlestick in hand, ready to snuff out your life.",
-    "special_attacks": [ { "id": "feral_weapon_candlestick" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_candlestick" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_maids_death_drops_candlestick"
   },
   {
@@ -336,7 +342,7 @@
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a knife in hand, searching for some victims to butcher.",
     "melee_skill": 3,
-    "special_attacks": [ { "id": "feral_weapon_knife_chef" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_knife_chef" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_maids_death_drops_knife"
   },
   {
@@ -346,7 +352,7 @@
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
     "melee_skill": 4,
-    "special_attacks": [ { "id": "feral_weapon_rapier" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_rapier" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_fancy_death_drops_rapier"
   },
   {
@@ -355,7 +361,7 @@
     "copy-from": "mon_feral_fancy_rapier",
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
-    "special_attacks": [ { "id": "feral_weapon_rapier_fake" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_rapier_fake" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_fancy_death_drops_rapier_fake"
   },
   {
@@ -388,6 +394,7 @@
       },
       { "id": "feral_weapon_crossbow_melee" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -402,7 +409,7 @@
     "description": "Clad in ancient armor and with a mace in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their mace.",
     "melee_skill": 3,
     "speed": 85,
-    "special_attacks": [ { "id": "feral_weapon_mace" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_mace" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_armored_death_drops_mace",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ] },
     "//": "No synthetic armor proficiency because plate armor doesn't work the same as modern armor",
@@ -415,7 +422,7 @@
     "color": "i_magenta",
     "name": { "str": "armored feral" },
     "description": "Clad in ancient armor and with a battle axe in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their axe.",
-    "special_attacks": [ { "id": "feral_weapon_battleaxe" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_battleaxe" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "feral_armored_death_drops_battleaxe"
   },
   {
@@ -452,6 +459,7 @@
       },
       { "id": "feral_weapon_feral_m9" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -476,7 +484,7 @@
     "vision_day": 50,
     "luminance": 500,
     "death_drops": "mon_feral_survivalist_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_makeshift_machete" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_makeshift_machete" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "zombify_into": "mon_zombie_survivor",
     "delete": { "anger_triggers": [ "HURT" ] },
     "extend": {
@@ -525,6 +533,7 @@
       },
       { "id": "feral_weapon_feral_militia_gun" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -550,7 +559,7 @@
     "dodge": 4,
     "vision_night": 5,
     "death_drops": "mon_feral_soldier_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_knife_combat" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_knife_combat" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "zombify_into": "mon_zombie_soldier",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] },
     "armor": { "bash": 4, "cut": 9, "bullet": 7, "electric": 3 }
@@ -590,6 +599,7 @@
       },
       { "id": "feral_weapon_shotgun_melee" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -605,7 +615,7 @@
     "aggression": 40,
     "dodge": 2,
     "death_drops": "mon_feral_sailor_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_wrench_large" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_wrench_large" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "zombify_into": "mon_zombie_sailor",
     "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 2 }
   },
@@ -614,7 +624,7 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Spattered from head to toe in large swaths of dried viscera, the deep blue of this person's tattered naval uniform has been stained the color of rust.  Having seemingly had enough presence of mind to consider arming themself, this former crewman carries a crash axe in their shaking hands.  The veins on the back of their neck are visibly bulging, their eyes bloodshot, and a mass of crisscrossing blackened veins stand out against the pale skin of their face as they regard the area around them for perceived threats.",
-    "special_attacks": [ { "id": "feral_weapon_crash_axe" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_crash_axe" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "mon_feral_sailor_axe_death_drops"
   },
   {
@@ -622,7 +632,7 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Clutching a stout mop in their quivering hands, this crewman was presumably assigned to basic deck sweeping in their final moments, before the Cataclysm struck and stripped them of their humanity.  Dressed in basic naval fatigues, you'd be forgiven for believing them to be another survivor.  However, their bloodshot eyes, blackened veins, and spastic twitching tell a far different story.",
-    "special_attacks": [ { "id": "feral_weapon_mop_folded" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_mop_folded" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "mon_feral_sailor_mop_death_drops"
   },
   {
@@ -630,7 +640,7 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Still dressed in a grease spattered uniform, this crewman appears to have once been a naval engineer.  With tangled hair, oil stained working attire, and a lug wrench clenched in their fist, you assume that they were either assigned to shipside maintenance or responsible for servicing onboard aircraft.  Now all that's left of the crewman that this person once was is a madly twitching, psychopathic monster.",
-    "special_attacks": [ { "id": "feral_weapon_lug_wrench" }, { "id": "feral_unarmed" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [ { "id": "feral_weapon_lug_wrench" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
     "death_drops": "mon_feral_sailor_lug_wrench_death_drops"
   },
   {
@@ -647,6 +657,7 @@
       [ "PARROT_AT_DANGER", 0 ],
       { "id": "feral_weapon_feral_m4_carbine_bayonet" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -695,6 +706,7 @@
       },
       { "id": "feral_weapon_m18" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
@@ -718,6 +730,7 @@
       [ "BLOW_WHISTLE", 25 ],
       { "id": "feral_weapon_baton" },
       { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -217,6 +217,7 @@
     "special_attacks": [ [ "DARKMAN", 5 ], [ "scratch", 15 ] ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s melts away.", "effect": { "id": "death_darkman" } },
     "regenerates_in_dark": true,
+    "melee_training_cap": 3,
     "flags": [ "NOHEAD", "HARDTOSHOOT", "WEBWALK", "FLIES", "PLASTIC", "ELECTRIC", "ACIDPROOF", "SUNDEATH", "NO_BREATHE" ],
     "armor": { "bash": 12, "cut": 8, "bullet": 6, "electric": 3 }
   },
@@ -959,6 +960,7 @@
     "path_settings": { "max_dist": 5 },
     "special_attacks": [ [ "PARROT", 400 ], [ "ABSORB_ITEMS", 0 ], [ "SPLIT", 5 ] ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s melts away." },
+    "melee_training_cap": 5,
     "regenerates": 50,
     "regen_morale": true,
     "absorb_ml_per_hp": 250,

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -398,6 +398,7 @@
     "attack_effs": [ { "id": "paralyzepoison", "duration": 33 } ],
     "//grab": "Let's say the thorns make it half again as grabby",
     "grab_strength": 45,
+    "path_settings": { "max_dist": 45 },
     "special_attacks": [ { "id": "scratch" }, { "id": "grab", "cooldown": 7 }, [ "PARA_STING", 30 ] ],
     "flags": [
       "SEES",
@@ -411,6 +412,8 @@
       "REVIVES",
       "PUSH_MON",
       "FILTHY",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL",
       "PARALYZEVENOM"
     ],
     "armor": { "electric": 2, "bash": 8, "cut": 8, "bullet": 6 }

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -45,7 +45,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 6, "cut": 8, "bullet": 6, "electric": 1 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 6, "electric": 1, "heat": 1 }
   },
   {
     "id": "mon_zombie",
@@ -276,7 +276,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 6, "cut": 6, "acid": 6, "heat": 9, "bullet": 5, "electric": 4 }
+    "armor": { "bash": 6, "cut": 6, "acid": 6, "heat": 10, "bullet": 5, "electric": 4 }
   },
   {
     "id": "mon_zombie_hazmat",
@@ -332,7 +332,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 3, "electric": 8 }
+    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 5, "electric": 8 }
   },
   {
     "id": "mon_zombie_rot",
@@ -416,7 +416,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 10, "cut": 16, "bullet": 18, "electric": 3, "heat": 2 }
+    "armor": { "bash": 10, "cut": 16, "bullet": 18, "electric": 3, "heat": 4 }
   },
   {
     "id": "mon_zombie_tough",
@@ -470,7 +470,7 @@
       "FILTHY",
       "GEN_DORMANT"
     ],
-    "armor": { "bash": 2, "cut": 1, "bullet": 1, "electric": 2 }
+    "armor": { "bash": 2, "cut": 1, "bullet": 1, "electric": 2, "heat": 2 }
   },
   {
     "id": "mon_zombie_resort_dancer",

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -174,7 +174,6 @@
       "GROUP_BASH",
       "POISON",
       "NO_BREATHE",
-      "DRIPS_GASOLINE",
       "PUSH_MON",
       "FILTHY"
     ],

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -110,6 +110,7 @@
       }
     ],
     "regenerates": 12,
+    "melee_training_cap": 2,
     "armor": { "bash": 12, "cut": 2, "bullet": 1, "electric": 2 }
   },
   {
@@ -680,6 +681,7 @@
     "special_attacks": [ { "id": "grab", "cooldown": 7 }, { "id": "scratch_humanoid" }, { "id": "smash" } ],
     "death_drops": "mon_zombie_hulk_death_drops",
     "regenerates": 15,
+    "melee_training_cap": 2,
     "flags": [
       "ALL_SEEING",
       "SEES",
@@ -955,14 +957,15 @@
     "burn_into": "mon_zombie_scorched",
     "upgrades": { "half_life": 42, "into": "mon_zombie_predator" },
     "fungalize_into": "mon_zombie_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "CLIMBS", "PUSH_MON", "FILTHY" ],
+    "path_settings": { "max_dist": 45 },
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "CLIMBS", "PUSH_MON", "FILTHY", "PATH_AVOID_FIRE", "PATH_AVOID_FALL" ],
     "armor": { "electric": 1 }
   },
   {
     "id": "mon_zombie_mancroc",
     "type": "MONSTER",
     "name": { "str": "zombie snapper" },
-    "description": "With a crocodile-like snout and rows of protruding teeth, this swimwear-clad zombie lurks in the water.",
+    "description": "This zombie's elongated head is nearly entirely given over to a crocodilian maw full of daggerlike teeth.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE", "HUMAN" ],
@@ -1221,6 +1224,7 @@
     "special_attacks": [ { "id": "grab", "cooldown": 7 }, { "id": "scratch_humanoid" }, { "id": "bite_humanoid", "cooldown": 5 } ],
     "death_drops": "default_zombie_death_drops",
     "regenerates": 12,
+    "melee_training_cap": 2,
     "burn_into": "mon_zombie_scorched",
     "flags": [
       "SEES",
@@ -1272,7 +1276,7 @@
     "vision_day": 45,
     "vision_night": 15,
     "harvest": "zombie_humanoid",
-    "path_settings": { "max_dist": 5 },
+    "path_settings": { "max_dist": 45 },
     "special_attacks": [
       { "type": "leap", "cooldown": 10, "max_range": 5, "min_consider_range": 2, "max_consider_range": 4 },
       {
@@ -1284,7 +1288,7 @@
     ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "CLIMBS", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "CLIMBS", "FILTHY", "PATH_AVOID_FIRE", "PATH_AVOID_FALL" ],
     "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 1 }
   },
   {
@@ -1543,7 +1547,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "heat": 5, "electric": 1 }
+    "armor": { "heat": 10, "electric": 1 }
   },
   {
     "id": "mon_smoker_brute",
@@ -1601,13 +1605,13 @@
       "FILTHY",
       "RANGED_ATTACKER"
     ],
-    "armor": { "bash": 2, "cut": 8, "stab": 8, "heat": 5, "bullet": 10, "electric": 2 }
+    "armor": { "bash": 2, "cut": 8, "stab": 8, "heat": 10, "bullet": 10, "electric": 2 }
   },
   {
     "id": "mon_zombie_swimmer_base",
     "type": "MONSTER",
-    "name": { "str": "swimmer zombie" },
-    "description": "A zombie clad in swimwear.  Probably not a very graceful swimmer anymore.",
+    "name": { "str": "drowned zombie" },
+    "description": "A zombie that must have died in or near water judging by its pallor and swollen state.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE", "HUMAN" ],
@@ -1655,8 +1659,8 @@
   {
     "id": "mon_zombie_swimmer",
     "type": "MONSTER",
-    "name": { "str": "webbed zombie" },
-    "description": "A slick and glistening human body clad in swimwear.  Its hands and feet are heavily webbed, suggesting some kind of rapid evolutionary adaptation to water.",
+    "name": { "str": "swimmer zombie" },
+    "description": "A slick and glistening human body, bloated from what must have been a watery death.  Its hands and feet are elongated and webbed, suggesting some kind of rapid aquatic evolution.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE", "HUMAN" ],
@@ -1802,6 +1806,7 @@
     "harvest": "zombie_thorny",
     "attack_effs": [ { "id": "paralyzepoison", "duration": 33 } ],
     "grab_strength": 20,
+    "path_settings": { "max_dist": 15 },
     "special_attacks": [ { "id": "grab", "cooldown": 7 }, { "id": "scratch_humanoid" }, [ "PARA_STING", 30 ] ],
     "death_drops": "mon_zombie_thorny_death_drops",
     "burn_into": "mon_zombie_scorched",
@@ -1818,7 +1823,9 @@
       "REVIVES",
       "PUSH_MON",
       "FILTHY",
-      "PARALYZEVENOM"
+      "PARALYZEVENOM",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL"
     ],
     "armor": { "bash": 2, "cut": 4, "bullet": 3, "electric": 1 }
   },
@@ -1834,8 +1841,7 @@
   {
     "id": "mon_zombie_fursuit",
     "type": "MONSTER",
-    "name": { "str": "malicious mane" },
-    "//": "A pun. 'Mane' being an archaic synonym of zombie, which also refers hair on the back of an animals neck.",
+    "name": { "str": "zombie fursuiter" },
     "description": "A human body, swaying awkwardly in a torn cloth suit of an anthropomorphized animal.  Black goo and blood cakes the suit, and it gives off a foul, rotting odor.",
     "copy-from": "mon_zombie",
     "default_faction": "zombie",


### PR DESCRIPTION
#### Summary
Balance updates for zombies, regenerators, and ferals

#### Purpose of change
Patches several exploits and areas where the game was not giving appropriate pushback.

#### Describe the solution
- Ferals can now bite things when they're grabbed. There's a 10 second cooldown on this so it's not extremely dangerous, but it's still a wrinkle that makes grabbing them a little more balanced.
- The existing feral grapple attack now uses the feral's melee skill instead of a set accuracy of 3.
- A few zombies have a few more points of fire armor.
- Zombie hunters and predators will now avoid falls and fire. These are meant to be capable, intelligent (in terms of predation) hunters rather than an unruly mob like the others.
- Thorny shamblers and thorny moose shamblers now avoid falls and fire. The triffids parasitizing them are able to exert limited control over their behavior, and do not like dying.
- Regenerating enemies now have melee training caps a few points below their actual skill. This is to address an exploit where players were fighting them for long periods of time in zero-risk situations to try to get tons of free exp.
- Gasoline zombies no longer leak gasoline. They do still explode.
- Renamed swimmer zombies to drowned zombies, and webbed zombies to swimmer zombies.

#### Testing
Loads, runs, ferals work, relevant monsters avoid fire as intended. Lookin good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
