### PR TITLE
Backport 81380 - Guilt trip murderers for more than 7 minutes

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2894,11 +2894,11 @@ void npc::die( Creature *nkiller )
             if( morale_effect == 0 ) {
                 // No morale effect
             } else if( morale_effect <= -50 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 2_days, 3_hours );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 14_days, 7_days );
             } else if( morale_effect > -50 && morale_effect < 0 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 1_days, 1_hours );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 10_days, 7_days );
             } else {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 3_hours, 7_minutes );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 7_days, 4_days );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Backport 81380 - Guilt trip murderers for more than 7 minutes

#### Purpose of change
Morale penalties for murdering innocencts were ridiculously undertuned, and people were farming NPCs for consequence-free loot because of it. While you should absolutely be able to play as a bandit like this, most of the game world isn't properly set up to react to you doing this, so it's more of an exploit than anything.

This is also a hardcore survival simulation with an emphasis on immersion. It is absolutely intended that everything you do comes at a cost, and morale is a solid way to simulate a reasonable cost.

#### Describe alternatives you've considered
There's some planned stuff in the future where the impact of morale effects can be lessened by how much your character has seen and done already. That will let you become a grizzled bastard without needing to start as a psychopath.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
