### PR TITLE
Update OSX shell script to fix mac curses

### DIFF
--- a/build-data/osx/Cataclysm.sh
+++ b/build-data/osx/Cataclysm.sh
@@ -19,8 +19,8 @@ if [[ "${V_OS_VERSION}" -lt 11 ]] && [[ ! -f "libz_patched.txt" ]]; then
     echo "This file signifies (to the launch script) that libz.1.3.1.dylib has been patched by replacing it with /usr/lib/libz.1.dylib. This happened because the included libz is unreadable on Mac OS versions below 10.15. The game will function normally." > "libz_patched.txt"
 fi
 
-if [[ -f cataclysm ]]; then
-    V_SHELL_SCRIPT="export PATH=${PATH} ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.; cd '${PWD}' && ./cataclysm; exit"
+if [[ -f cataclysm-tlg ]]; then
+    V_SHELL_SCRIPT="export PATH=${PATH} ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.; cd '${PWD}' && ./cataclysm-tlg; exit"
     osascript -e "tell application \"Terminal\" to activate do script \"${V_SHELL_SCRIPT}\""
 else
     export ${K_LIBRARY_PATH}=. ${K_FRAMEWORK_PATH}=.


### PR DESCRIPTION
#### Summary
Update OSX shell script to fix mac curses

#### Purpose of change
Fixes #900 

#### Describe the solution
Fingies crossed!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
