### PR TITLE
 Finish September Backports

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -340,7 +340,8 @@
     "price_postapoc": "16 cent",
     "material": [ "veggy" ],
     "volume": "70 ml",
-    "flags": [ "FREEZERBURN", "RAW" ],
+    "smoking_result": "dry_chili",
+    "flags": [ "FREEZERBURN", "RAW", "SMOKABLE" ],
     "vitamins": [ [ "vitC", "64700 μg" ], [ "iron", "500 μg" ], [ "calcium", "6300 μg" ], [ "veggy_allergen", 1 ] ],
     "fun": -2
   },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -718,7 +718,7 @@
   {
     "type": "overmap_terrain",
     "id": "natural_spring",
-    "copy-from": "generic_city_building_no_sidewalk",
+    "copy-from": "pond_field",
     "name": "natural spring",
     "sym": "o",
     "color": "blue"

--- a/doc/VITAMIN.md
+++ b/doc/VITAMIN.md
@@ -17,7 +17,7 @@
   "flags": [ "FOO" ],
   "disease": [ [ -4800, -5600 ], [ -5601, -6400 ], [ -6401, -12000 ] ],
   "disease_excess": [ [ 10, 19 ], [ 20, 29 ], [ 30, 40 ] ],
-  "decays_into": [ "calcium", 2 ]
+  "decays_into": [ [ "calcium", 2 ], [ "blood", 6 ] ]
 },
 ```
 ### `id`

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4987,7 +4987,7 @@ void milk_activity_actor::do_turn( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         // We might end up here if the creature dies while being milked
@@ -5004,7 +5004,7 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4987,7 +4987,7 @@ void milk_activity_actor::do_turn( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
+    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         // We might end up here if the creature dies while being milked
@@ -5004,7 +5004,7 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
         return;
     }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.bub_from_abs( monster_coords.at( 0 ) );
+    const tripoint_bub_ms source_pos = here.bub_from_abs( tripoint_abs_ms( monster_coords.at( 0 ) ) );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1828,7 +1828,7 @@ void activity_handlers::game_do_turn( player_activity *act, Character *you )
 
 void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 {
-    const tripoint_bub_ms &pos = get_map().bub_from_abs( act->placement );
+    const tripoint &pos = get_map().getlocal( act->placement );
     sfx::play_activity_sound( "tool", "pickaxe", sfx::get_heard_volume( pos ) );
     // each turn is too much
     if( calendar::once_every( 1_minutes ) ) {
@@ -2125,7 +2125,7 @@ void activity_handlers::vehicle_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
     //Grab this now, in case the vehicle gets shifted
-    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( act->values[0],
+    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( tripoint( act->values[0],
                                        act->values[1],
                                        you->posz() ) ) );
     veh_interact::complete_vehicle( *you );
@@ -3165,12 +3165,11 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
     time_duration time_left = time_duration::from_moves( act->moves_left );
 
     map &here = get_map();
-    if( autodoc && here.inbounds( you->pos_bub() ) ) {
+    if( autodoc && here.inbounds( you->pos() ) ) {
         const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( you->pos(), 1,
                                              ter_furn_flag::TFLAG_AUTODOC );
 
-        if( !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, you->pos_bub() ) ||
-            autodocs.empty() ) {
+        if( !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, you->pos() ) || autodocs.empty() ) {
             you->remove_effect( effect_under_operation );
             act->set_to_null();
 
@@ -3522,9 +3521,9 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 {
     map &here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( here.bub_from_abs( act->placement ) ) );
+                              sfx::get_heard_volume( here.getlocal( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( here.bub_from_abs( act->placement ), 15, sounds::sound_t::destructive_activity,
+        sounds::sound( here.getlocal( act->placement ), 15, sounds::sound_t::destructive_activity,
                        //~ Sound of a jackhammer at work!
                        _( "TATATATATATATAT!" ) );
     }
@@ -3893,7 +3892,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
 
     // choose target for spell before continuing
     const std::optional<tripoint_bub_ms> target = act->coords.empty() ? spell_being_cast.select_target(
-                you ) : get_map().bub_from_abs( tripoint_abs_ms( act->coords.front() ) );
+                you ) : get_map().bub_from_abs( act->coords.front() );
     if( target ) {
         // npcs check for target viability
         if( !you->is_npc() || spell_being_cast.is_valid_target( *you, *target ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1828,7 +1828,7 @@ void activity_handlers::game_do_turn( player_activity *act, Character *you )
 
 void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 {
-    const tripoint &pos = get_map().getlocal( act->placement );
+    const tripoint_bub_ms &pos = get_map().bub_from_abs( act->placement );
     sfx::play_activity_sound( "tool", "pickaxe", sfx::get_heard_volume( pos ) );
     // each turn is too much
     if( calendar::once_every( 1_minutes ) ) {
@@ -2125,7 +2125,7 @@ void activity_handlers::vehicle_finish( player_activity *act, Character *you )
 {
     map &here = get_map();
     //Grab this now, in case the vehicle gets shifted
-    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( tripoint( act->values[0],
+    const optional_vpart_position vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( act->values[0],
                                        act->values[1],
                                        you->posz() ) ) );
     veh_interact::complete_vehicle( *you );
@@ -3165,11 +3165,12 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
     time_duration time_left = time_duration::from_moves( act->moves_left );
 
     map &here = get_map();
-    if( autodoc && here.inbounds( you->pos() ) ) {
+    if( autodoc && here.inbounds( you->pos_bub() ) ) {
         const std::list<tripoint> autodocs = here.find_furnitures_with_flag_in_radius( you->pos(), 1,
                                              ter_furn_flag::TFLAG_AUTODOC );
 
-        if( !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, you->pos() ) || autodocs.empty() ) {
+        if( !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, you->pos_bub() ) ||
+            autodocs.empty() ) {
             you->remove_effect( effect_under_operation );
             act->set_to_null();
 
@@ -3521,9 +3522,9 @@ void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 {
     map &here = get_map();
     sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( here.getlocal( act->placement ) ) );
+                              sfx::get_heard_volume( here.bub_from_abs( act->placement ) ) );
     if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( here.getlocal( act->placement ), 15, sounds::sound_t::destructive_activity,
+        sounds::sound( here.bub_from_abs( act->placement ), 15, sounds::sound_t::destructive_activity,
                        //~ Sound of a jackhammer at work!
                        _( "TATATATATATATAT!" ) );
     }
@@ -3892,7 +3893,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
 
     // choose target for spell before continuing
     const std::optional<tripoint_bub_ms> target = act->coords.empty() ? spell_being_cast.select_target(
-                you ) : get_map().bub_from_abs( act->coords.front() );
+                you ) : get_map().bub_from_abs( tripoint_abs_ms( act->coords.front() ) );
     if( target ) {
         // npcs check for target viability
         if( !you->is_npc() || spell_being_cast.is_valid_target( *you, *target ) ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1823,7 +1823,7 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
                     loot_abspos, zone_src_set );
         // Find the nearest unsorted zone to dump objects at
         for( const tripoint_abs_ms &src_elem : zone_src_sorted ) {
-            if( !here.can_put_items_ter_furn( here.getlocal( src_elem ) ) ) {
+            if( !here.can_put_items_ter_furn( here.bub_from_abs( src_elem ) ) ) {
                 continue;
             }
             loot_src_lot = here.bub_from_abs( src_elem );
@@ -1858,7 +1858,8 @@ static bool fetch_activity(
     const int distance = ACTIVITY_SEARCH_DISTANCE )
 {
     map &here = get_map();
-    if( !here.can_put_items_ter_furn( here.bub_from_abs( you.backlog.front().coords.back() ) ) ) {
+    if( !here.can_put_items_ter_furn( here.bub_from_abs( tripoint_abs_ms(
+                                          you.backlog.front().coords.back() ) ) ) ) {
         return false;
     }
     const std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> mental_map_2 =
@@ -1874,7 +1875,8 @@ static bool fetch_activity(
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
                     if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
                         move_item( you, veh_elem, veh_elem.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                                   here.bub_from_abs( you.backlog.front().coords.back() ), ovp, activity_to_restore );
+                                   here.bub_from_abs( tripoint_abs_ms( you.backlog.front().coords.back() ) ), ovp,
+                                   activity_to_restore );
                         return true;
                     }
                 }
@@ -1889,7 +1891,8 @@ static bool fetch_activity(
                 if( !you.backlog.empty() && ( you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ||
                                               you.backlog.front().id() == ACT_MULTIPLE_DIS ) ) {
                     move_item( you, it, it.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                               here.bub_from_abs( you.backlog.front().coords.back() ), ovp, activity_to_restore );
+                               here.bub_from_abs( tripoint_abs_ms( you.backlog.front().coords.back() ) ), ovp,
+                               activity_to_restore );
 
                     return true;
                     // other tasks want the tool picked up
@@ -2047,7 +2050,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
 
             const tripoint_bub_ms src_loc = here.bub_from_abs( src );
             if( !here.inbounds( src_loc ) ) {
-                if( !here.inbounds( you.pos() ) ) {
+                if( !here.inbounds( you.pos_bub() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
                     // and unload them
                     you.cancel_activity();
@@ -2549,11 +2552,11 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     const tripoint_abs_ms abspos = here.getglobal( localpos );
     if( act_id == ACT_TIDY_UP ) {
         dark_capable = true;
-        tripoint unsorted_spot;
+        tripoint_bub_ms unsorted_spot;
         std::unordered_set<tripoint_abs_ms> unsorted_set =
             mgr.get_near( zone_type_LOOT_UNSORTED, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr, _fac_id( you ) );
         if( !unsorted_set.empty() ) {
-            unsorted_spot = here.getlocal( random_entry( unsorted_set ) );
+            unsorted_spot = here.bub_from_abs( random_entry( unsorted_set ) );
         }
         bool found_one_point = false;
         bool found_route = true;
@@ -2590,7 +2593,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
                 }
             }
         }
-        if( src_set.empty() && unsorted_spot != tripoint_zero ) {
+        if( src_set.empty() && unsorted_spot != tripoint_bub_ms_zero ) {
             for( const item *inv_elem : you.inv_dump() ) {
                 if( inv_elem->has_var( "activity_var" ) ) {
                     // we've gone to tidy up all the things lying around, now tidy up the things we picked up.
@@ -3217,7 +3220,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     for( const tripoint_abs_ms &src : src_sorted ) {
         const tripoint_bub_ms &src_loc = here.bub_from_abs( src );
         if( !here.inbounds( src_loc ) && !check_only ) {
-            if( !here.inbounds( you.pos() ) ) {
+            if( !here.inbounds( you.pos_bub() ) ) {
                 // p is implicitly an NPC that has been moved off the map, so reset the activity
                 // and unload them
                 you.assign_activity( activity_to_restore );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1823,7 +1823,7 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
                     loot_abspos, zone_src_set );
         // Find the nearest unsorted zone to dump objects at
         for( const tripoint_abs_ms &src_elem : zone_src_sorted ) {
-            if( !here.can_put_items_ter_furn( here.bub_from_abs( src_elem ) ) ) {
+            if( !here.can_put_items_ter_furn( here.getlocal( src_elem ) ) ) {
                 continue;
             }
             loot_src_lot = here.bub_from_abs( src_elem );
@@ -1858,8 +1858,7 @@ static bool fetch_activity(
     const int distance = ACTIVITY_SEARCH_DISTANCE )
 {
     map &here = get_map();
-    if( !here.can_put_items_ter_furn( here.bub_from_abs( tripoint_abs_ms(
-                                          you.backlog.front().coords.back() ) ) ) ) {
+    if( !here.can_put_items_ter_furn( here.bub_from_abs( you.backlog.front().coords.back() ) ) ) {
         return false;
     }
     const std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> mental_map_2 =
@@ -1875,8 +1874,7 @@ static bool fetch_activity(
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
                     if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
                         move_item( you, veh_elem, veh_elem.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                                   here.bub_from_abs( tripoint_abs_ms( you.backlog.front().coords.back() ) ), ovp,
-                                   activity_to_restore );
+                                   here.bub_from_abs( you.backlog.front().coords.back() ), ovp, activity_to_restore );
                         return true;
                     }
                 }
@@ -1891,8 +1889,7 @@ static bool fetch_activity(
                 if( !you.backlog.empty() && ( you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ||
                                               you.backlog.front().id() == ACT_MULTIPLE_DIS ) ) {
                     move_item( you, it, it.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                               here.bub_from_abs( tripoint_abs_ms( you.backlog.front().coords.back() ) ), ovp,
-                               activity_to_restore );
+                               here.bub_from_abs( you.backlog.front().coords.back() ), ovp, activity_to_restore );
 
                     return true;
                     // other tasks want the tool picked up
@@ -2050,7 +2047,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
 
             const tripoint_bub_ms src_loc = here.bub_from_abs( src );
             if( !here.inbounds( src_loc ) ) {
-                if( !here.inbounds( you.pos_bub() ) ) {
+                if( !here.inbounds( you.pos() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
                     // and unload them
                     you.cancel_activity();
@@ -2552,11 +2549,11 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     const tripoint_abs_ms abspos = here.getglobal( localpos );
     if( act_id == ACT_TIDY_UP ) {
         dark_capable = true;
-        tripoint_bub_ms unsorted_spot;
+        tripoint unsorted_spot;
         std::unordered_set<tripoint_abs_ms> unsorted_set =
             mgr.get_near( zone_type_LOOT_UNSORTED, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr, _fac_id( you ) );
         if( !unsorted_set.empty() ) {
-            unsorted_spot = here.bub_from_abs( random_entry( unsorted_set ) );
+            unsorted_spot = here.getlocal( random_entry( unsorted_set ) );
         }
         bool found_one_point = false;
         bool found_route = true;
@@ -2593,7 +2590,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
                 }
             }
         }
-        if( src_set.empty() && unsorted_spot != tripoint_bub_ms_zero ) {
+        if( src_set.empty() && unsorted_spot != tripoint_zero ) {
             for( const item *inv_elem : you.inv_dump() ) {
                 if( inv_elem->has_var( "activity_var" ) ) {
                     // we've gone to tidy up all the things lying around, now tidy up the things we picked up.
@@ -3220,7 +3217,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     for( const tripoint_abs_ms &src : src_sorted ) {
         const tripoint_bub_ms &src_loc = here.bub_from_abs( src );
         if( !here.inbounds( src_loc ) && !check_only ) {
-            if( !here.inbounds( you.pos_bub() ) ) {
+            if( !here.inbounds( you.pos() ) ) {
                 // p is implicitly an NPC that has been moved off the map, so reset the activity
                 // and unload them
                 you.assign_activity( activity_to_restore );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2274,7 +2274,7 @@ void advanced_inventory::draw_minimap()
     tripoint pc = {getmaxx( minimap ) / 2, getmaxy( minimap ) / 2, 0};
     Character &player_character = get_player_character();
     // draw the 3x3 tiles centered around player
-    get_map().draw( minimap, player_character.pos() );
+    get_map().draw( minimap, player_character.pos_bub() );
     for( const side s : sides ) {
         char sym = get_minimap_sym( s );
         if( sym == '\0' ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2274,7 +2274,7 @@ void advanced_inventory::draw_minimap()
     tripoint pc = {getmaxx( minimap ) / 2, getmaxy( minimap ) / 2, 0};
     Character &player_character = get_player_character();
     // draw the 3x3 tiles centered around player
-    get_map().draw( minimap, player_character.pos_bub() );
+    get_map().draw( minimap, player_character.pos() );
     for( const side s : sides ) {
         char sym = get_minimap_sym( s );
         if( sym == '\0' ) {

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1237,7 +1237,8 @@ void avatar::rebuild_aim_cache()
 
     double pi = 2 * acos( 0.0 );
 
-    const tripoint_bub_ms local_last_target = get_map().bub_from_abs( last_target_pos.value() );
+    const tripoint_bub_ms local_last_target = get_map().bub_from_abs( tripoint_abs_ms(
+                last_target_pos.value() ) );
 
     float base_angle = atan2f( local_last_target.y() - posy(),
                                local_last_target.x() - posx() );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1237,8 +1237,7 @@ void avatar::rebuild_aim_cache()
 
     double pi = 2 * acos( 0.0 );
 
-    const tripoint_bub_ms local_last_target = get_map().bub_from_abs( tripoint_abs_ms(
-                last_target_pos.value() ) );
+    const tripoint_bub_ms local_last_target = get_map().bub_from_abs( last_target_pos.value() );
 
     float base_angle = atan2f( local_last_target.y() - posy(),
                                local_last_target.x() - posx() );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -697,7 +697,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
     }
     // NPC camps may never have had bb_pos registered
     validate_bb_pos( project_to<coords::ms>( omt_pos ) );
-    tripoint src_loc = here.getlocal( bb_pos ) + point_north;
+    tripoint_bub_ms src_loc = here.bub_from_abs( bb_pos ) + point_north;
     std::vector<tripoint_abs_ms> possible_liquid_dumps;
     if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, 60 ) ) {
         const std::vector<const zone_data *> zones = mgr.get_near_zones( zone_type_CAMP_STORAGE, abspos,
@@ -714,7 +714,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
                 }
                 set_storage_tiles( src_set );
             }
-            src_loc = here.getlocal( zones.front()->get_center_point() );
+            src_loc = here.bub_from_abs( zones.front()->get_center_point() );
             set_storage_zone( zones );
         }
         map &here = get_map();
@@ -722,7 +722,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
             if( zone->get_type() == zone_type_CAMP_STORAGE ) {
                 for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
                          zone->get_start_point(), zone->get_end_point() ) ) {
-                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.getlocal( p ) ) ) {
+                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.bub_from_abs( p ) ) ) {
                         possible_liquid_dumps.emplace_back( p );
                     }
                 }
@@ -1020,7 +1020,7 @@ void basecamp_action_components::consume_components()
     std::vector<tripoint> src;
     src.resize( base_.src_set.size() );
     for( const tripoint_abs_ms &p : base_.src_set ) {
-        src.emplace_back( target_map.getlocal( p ) );
+        src.emplace_back( target_map.bub_from_abs( p ).raw() );
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -697,7 +697,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
     }
     // NPC camps may never have had bb_pos registered
     validate_bb_pos( project_to<coords::ms>( omt_pos ) );
-    tripoint_bub_ms src_loc = here.bub_from_abs( bb_pos ) + point_north;
+    tripoint src_loc = here.getlocal( bb_pos ) + point_north;
     std::vector<tripoint_abs_ms> possible_liquid_dumps;
     if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, 60 ) ) {
         const std::vector<const zone_data *> zones = mgr.get_near_zones( zone_type_CAMP_STORAGE, abspos,
@@ -714,7 +714,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
                 }
                 set_storage_tiles( src_set );
             }
-            src_loc = here.bub_from_abs( zones.front()->get_center_point() );
+            src_loc = here.getlocal( zones.front()->get_center_point() );
             set_storage_zone( zones );
         }
         map &here = get_map();
@@ -722,7 +722,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
             if( zone->get_type() == zone_type_CAMP_STORAGE ) {
                 for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
                          zone->get_start_point(), zone->get_end_point() ) ) {
-                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.bub_from_abs( p ) ) ) {
+                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.getlocal( p ) ) ) {
                         possible_liquid_dumps.emplace_back( p );
                     }
                 }
@@ -1020,7 +1020,7 @@ void basecamp_action_components::consume_components()
     std::vector<tripoint> src;
     src.resize( base_.src_set.size() );
     for( const tripoint_abs_ms &p : base_.src_set ) {
-        src.emplace_back( target_map.bub_from_abs( p ).raw() );
+        src.emplace_back( target_map.getlocal( p ) );
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1662,8 +1662,8 @@ bool Character::check_outbounds_activity( const player_activity &act, bool check
 {
     map &here = get_map();
     if( ( act.placement != tripoint_abs_ms() && act.placement != player_activity::invalid_place &&
-          !here.inbounds( here.bub_from_abs( act.placement ) ) ) || ( !act.coords.empty() &&
-                  !here.inbounds( here.bub_from_abs( tripoint_abs_ms( act.coords.back() ) ) ) ) ) {
+          !here.inbounds( here.getlocal( act.placement ) ) ) || ( !act.coords.empty() &&
+                  !here.inbounds( here.bub_from_abs( act.coords.back() ) ) ) ) {
         if( is_npc() && !check_only ) {
             // stash activity for when reloaded.
             stashed_outbounds_activity = act;
@@ -11669,7 +11669,7 @@ bool Character::has_destination() const
 bool Character::has_destination_activity() const
 {
     return !get_destination_activity().is_null() && destination_point &&
-           pos_bub() == get_map().bub_from_abs( tripoint_abs_ms( *destination_point ) );
+           pos_bub() == get_map().bub_from_abs( *destination_point );
 }
 
 void Character::start_destination_activity()

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1662,8 +1662,8 @@ bool Character::check_outbounds_activity( const player_activity &act, bool check
 {
     map &here = get_map();
     if( ( act.placement != tripoint_abs_ms() && act.placement != player_activity::invalid_place &&
-          !here.inbounds( here.getlocal( act.placement ) ) ) || ( !act.coords.empty() &&
-                  !here.inbounds( here.bub_from_abs( act.coords.back() ) ) ) ) {
+          !here.inbounds( here.bub_from_abs( act.placement ) ) ) || ( !act.coords.empty() &&
+                  !here.inbounds( here.bub_from_abs( tripoint_abs_ms( act.coords.back() ) ) ) ) ) {
         if( is_npc() && !check_only ) {
             // stash activity for when reloaded.
             stashed_outbounds_activity = act;
@@ -11669,7 +11669,7 @@ bool Character::has_destination() const
 bool Character::has_destination_activity() const
 {
     return !get_destination_activity().is_null() && destination_point &&
-           pos_bub() == get_map().bub_from_abs( *destination_point );
+           pos_bub() == get_map().bub_from_abs( tripoint_abs_ms( *destination_point ) );
 }
 
 void Character::start_destination_activity()

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8001,6 +8001,16 @@ ret_val<void> Character::can_wield( const item &it ) const
         mount->type->mech_weapon && it.typeId() != mount->type->mech_weapon ) {
         return ret_val<void>::make_failure( _( "You cannot wield anything while piloting a mech." ) );
     }
+    if( controlling_vehicle ) {
+        if( worn_with_flag( flag_RESTRICT_HANDS ) ) {
+            return ret_val<void>::make_failure(
+                       _( "Something you are wearing hinders the use of both hands." ) );
+        }
+        if( !has_two_arms_lifting() || it.has_flag( flag_ALWAYS_TWOHAND ) ) {
+            return ret_val<void>::make_failure( _( "You can't wield your %s while driving." ),
+                                                it.tname() );
+        }
+    }
 
     return ret_val<void>::make_success();
 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -957,7 +957,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ).raw() );
+                    res.emplace( here.getlocal( point ) );
                 }
             }
         }
@@ -968,7 +968,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.bub_from_abs( point ).raw() );
+                    res.emplace( here.getlocal( point ) );
                 }
             }
         }
@@ -979,7 +979,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
             zone_type_id type = zone_data::unhash_type( cache.first );
             if( type == zone_type_NO_NPC_PICKUP ) {
                 for( tripoint_abs_ms point : cache.second ) {
-                    res.erase( here.bub_from_abs( point ).raw() );
+                    res.erase( here.getlocal( point ) );
                 }
             }
         }
@@ -1391,7 +1391,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options, personal );
     // only non personal zones can be vehicle zones
     if( !personal ) {
-        optional_vpart_position const vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( start ) ) );
+        optional_vpart_position const vp = here.veh_at( here.bub_from_abs( start ) );
         if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
             // TODO:Allow for loot zones on vehicles to be larger than 1x1
             if( start == end &&
@@ -1481,27 +1481,27 @@ namespace
 void _rotate_zone( map &target_map, zone_data &zone, int turns )
 {
     const point dim( SEEX * 2, SEEY * 2 );
-    const tripoint_bub_ms a_start( 0, 0, target_map.get_abs_sub().z() );
-    const tripoint_bub_ms a_end( SEEX * 2 - 1, SEEY * 2 - 1, a_start.z() );
-    const tripoint_bub_ms z_start = target_map.bub_from_abs( zone.get_start_point() );
-    const tripoint_bub_ms z_end = target_map.bub_from_abs( zone.get_end_point() );
-    const inclusive_cuboid<tripoint_bub_ms> boundary( a_start, a_end );
+    const tripoint a_start( 0, 0, target_map.get_abs_sub().z() );
+    const tripoint a_end( SEEX * 2 - 1, SEEY * 2 - 1, a_start.z );
+    const tripoint z_start = target_map.getlocal( zone.get_start_point() );
+    const tripoint z_end = target_map.getlocal( zone.get_end_point() );
+    const inclusive_cuboid<tripoint> boundary( a_start, a_end );
     if( boundary.contains( z_start ) && boundary.contains( z_end ) ) {
         // don't rotate centered squares
-        if( z_start.x() == z_start.y() && z_end.x() == z_end.y() &&
-            z_start.x() + z_end.x() == a_end.x() ) {
+        if( z_start.x == z_start.y && z_end.x == z_end.y &&
+            z_start.x + z_end.x == a_end.x ) {
             return;
         }
-        point z_l_start = z_start.xy().raw().rotate( turns, dim );
-        point z_l_end = z_end.xy().raw().rotate( turns, dim );
+        point z_l_start = z_start.xy().rotate( turns, dim );
+        point z_l_end = z_end.xy().rotate( turns, dim );
         tripoint_abs_ms first =
-            target_map.getglobal( tripoint_bub_ms( std::min( z_l_start.x, z_l_end.x ),
-                                  std::min( z_l_start.y, z_l_end.y ),
-                                  z_start.z() ) );
+            target_map.getglobal( tripoint( std::min( z_l_start.x, z_l_end.x ),
+                                            std::min( z_l_start.y, z_l_end.y ),
+                                            z_start.z ) );
         tripoint_abs_ms second =
-            target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x, z_l_end.x ),
-                                  std::max( z_l_start.y, z_l_end.y ),
-                                  z_end.z() ) );
+            target_map.getglobal( tripoint( std::max( z_l_start.x, z_l_end.x ),
+                                            std::max( z_l_start.y, z_l_end.y ),
+                                            z_end.z ) );
         zone.set_position( std::make_pair( first.raw(), second.raw() ), false, true, false, true );
     }
 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -957,7 +957,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.getlocal( point ) );
+                    res.emplace( here.bub_from_abs( point ).raw() );
                 }
             }
         }
@@ -968,7 +968,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
             for( tripoint_abs_ms point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
-                    res.emplace( here.getlocal( point ) );
+                    res.emplace( here.bub_from_abs( point ).raw() );
                 }
             }
         }
@@ -979,7 +979,7 @@ std::unordered_set<tripoint> zone_manager::get_point_set_loot( const tripoint_ab
             zone_type_id type = zone_data::unhash_type( cache.first );
             if( type == zone_type_NO_NPC_PICKUP ) {
                 for( tripoint_abs_ms point : cache.second ) {
-                    res.erase( here.getlocal( point ) );
+                    res.erase( here.bub_from_abs( point ).raw() );
                 }
             }
         }
@@ -1391,7 +1391,7 @@ void zone_manager::add( const std::string &name, const zone_type_id &type, const
     zone_data new_zone = zone_data( name, type, fac, invert, enabled, start, end, options, personal );
     // only non personal zones can be vehicle zones
     if( !personal ) {
-        optional_vpart_position const vp = here.veh_at( here.bub_from_abs( start ) );
+        optional_vpart_position const vp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( start ) ) );
         if( vp && vp->vehicle().get_owner() == fac && vp.cargo() ) {
             // TODO:Allow for loot zones on vehicles to be larger than 1x1
             if( start == end &&
@@ -1481,27 +1481,27 @@ namespace
 void _rotate_zone( map &target_map, zone_data &zone, int turns )
 {
     const point dim( SEEX * 2, SEEY * 2 );
-    const tripoint a_start( 0, 0, target_map.get_abs_sub().z() );
-    const tripoint a_end( SEEX * 2 - 1, SEEY * 2 - 1, a_start.z );
-    const tripoint z_start = target_map.getlocal( zone.get_start_point() );
-    const tripoint z_end = target_map.getlocal( zone.get_end_point() );
-    const inclusive_cuboid<tripoint> boundary( a_start, a_end );
+    const tripoint_bub_ms a_start( 0, 0, target_map.get_abs_sub().z() );
+    const tripoint_bub_ms a_end( SEEX * 2 - 1, SEEY * 2 - 1, a_start.z() );
+    const tripoint_bub_ms z_start = target_map.bub_from_abs( zone.get_start_point() );
+    const tripoint_bub_ms z_end = target_map.bub_from_abs( zone.get_end_point() );
+    const inclusive_cuboid<tripoint_bub_ms> boundary( a_start, a_end );
     if( boundary.contains( z_start ) && boundary.contains( z_end ) ) {
         // don't rotate centered squares
-        if( z_start.x == z_start.y && z_end.x == z_end.y &&
-            z_start.x + z_end.x == a_end.x ) {
+        if( z_start.x() == z_start.y() && z_end.x() == z_end.y() &&
+            z_start.x() + z_end.x() == a_end.x() ) {
             return;
         }
-        point z_l_start = z_start.xy().rotate( turns, dim );
-        point z_l_end = z_end.xy().rotate( turns, dim );
+        point z_l_start = z_start.xy().raw().rotate( turns, dim );
+        point z_l_end = z_end.xy().raw().rotate( turns, dim );
         tripoint_abs_ms first =
-            target_map.getglobal( tripoint( std::min( z_l_start.x, z_l_end.x ),
-                                            std::min( z_l_start.y, z_l_end.y ),
-                                            z_start.z ) );
+            target_map.getglobal( tripoint_bub_ms( std::min( z_l_start.x, z_l_end.x ),
+                                  std::min( z_l_start.y, z_l_end.y ),
+                                  z_start.z() ) );
         tripoint_abs_ms second =
-            target_map.getglobal( tripoint( std::max( z_l_start.x, z_l_end.x ),
-                                            std::max( z_l_start.y, z_l_end.y ),
-                                            z_end.z ) );
+            target_map.getglobal( tripoint_bub_ms( std::max( z_l_start.x, z_l_end.x ),
+                                  std::max( z_l_start.y, z_l_end.y ),
+                                  z_end.z() ) );
         zone.set_position( std::make_pair( first.raw(), second.raw() ), false, true, false, true );
     }
 }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1682,7 +1682,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
         terrain = false;
     }
     return [terrain, furn_type, loc_var]( dialogue const & d ) {
-        tripoint loc = get_map().getlocal( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
         if( terrain ) {
             return get_map().ter( loc )->has_flag( furn_type.evaluate( d ) );
         } else {
@@ -1697,7 +1697,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
     var_info loc_var = read_var_info( jo.get_object( "loc" ) );
 
     return [member, furn_type, loc_var]( dialogue const & d ) {
-        tripoint loc = get_map().getlocal( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
         if( member == "map_terrain_id" ) {
             return get_map().ter( loc ) == ter_id( furn_type.evaluate( d ) );
         } else if( member == "map_furniture_id" ) {
@@ -1984,7 +1984,7 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, target]( dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.actor( is_npc )->can_see_location( get_map().getlocal( target_pos ) );
+        return d.actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
     };
 }
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1682,7 +1682,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
         terrain = false;
     }
     return [terrain, furn_type, loc_var]( dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint loc = get_map().getlocal( get_tripoint_from_var( loc_var, d, false ) );
         if( terrain ) {
             return get_map().ter( loc )->has_flag( furn_type.evaluate( d ) );
         } else {
@@ -1697,7 +1697,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
     var_info loc_var = read_var_info( jo.get_object( "loc" ) );
 
     return [member, furn_type, loc_var]( dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint loc = get_map().getlocal( get_tripoint_from_var( loc_var, d, false ) );
         if( member == "map_terrain_id" ) {
             return get_map().ter( loc ) == ter_id( furn_type.evaluate( d ) );
         } else if( member == "map_furniture_id" ) {
@@ -1984,7 +1984,7 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, target]( dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
+        return d.actor( is_npc )->can_see_location( get_map().getlocal( target_pos ) );
     };
 }
 

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -46,10 +46,6 @@ point_rel_ms rebase_rel( point_bub_ms p )
 {
     return point_rel_ms( p.raw() );
 }
-point_rel_sm rebase_rel( point_bub_sm p )
-{
-    return point_rel_sm( p.raw() );
-}
 point_sm_ms rebase_sm( point_rel_ms p )
 {
     return point_sm_ms( p.raw() );
@@ -61,10 +57,6 @@ point_omt_ms rebase_omt( point_rel_ms p )
 point_bub_ms rebase_bub( point_rel_ms p )
 {
     return point_bub_ms( p.raw() );
-}
-point_bub_sm rebase_bub( point_rel_sm p )
-{
-    return point_bub_sm( p.raw() );
 }
 tripoint_rel_ms rebase_rel( tripoint_sm_ms p )
 {

--- a/src/coordinates.cpp
+++ b/src/coordinates.cpp
@@ -46,6 +46,10 @@ point_rel_ms rebase_rel( point_bub_ms p )
 {
     return point_rel_ms( p.raw() );
 }
+point_rel_sm rebase_rel( point_bub_sm p )
+{
+    return point_rel_sm( p.raw() );
+}
 point_sm_ms rebase_sm( point_rel_ms p )
 {
     return point_sm_ms( p.raw() );
@@ -57,6 +61,10 @@ point_omt_ms rebase_omt( point_rel_ms p )
 point_bub_ms rebase_bub( point_rel_ms p )
 {
     return point_bub_ms( p.raw() );
+}
+point_bub_sm rebase_bub( point_rel_sm p )
+{
+    return point_bub_sm( p.raw() );
 }
 tripoint_rel_ms rebase_rel( tripoint_sm_ms p )
 {

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -761,11 +761,9 @@ using coords::project_bounds;
 point_rel_ms rebase_rel( point_sm_ms );
 point_rel_ms rebase_rel( point_omt_ms p );
 point_rel_ms rebase_rel( point_bub_ms p );
-point_rel_sm rebase_rel( point_bub_sm p );
 point_sm_ms rebase_sm( point_rel_ms p );
 point_omt_ms rebase_omt( point_rel_ms p );
 point_bub_ms rebase_bub( point_rel_ms p );
-point_bub_sm rebase_bub( point_rel_sm p );
 
 tripoint_rel_ms rebase_rel( tripoint_sm_ms p );
 tripoint_rel_ms rebase_rel( tripoint_omt_ms p );

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -761,9 +761,11 @@ using coords::project_bounds;
 point_rel_ms rebase_rel( point_sm_ms );
 point_rel_ms rebase_rel( point_omt_ms p );
 point_rel_ms rebase_rel( point_bub_ms p );
+point_rel_sm rebase_rel( point_bub_sm p );
 point_sm_ms rebase_sm( point_rel_ms p );
 point_omt_ms rebase_omt( point_rel_ms p );
 point_bub_ms rebase_bub( point_rel_ms p );
+point_bub_sm rebase_bub( point_rel_sm p );
 
 tripoint_rel_ms rebase_rel( tripoint_sm_ms p );
 tripoint_rel_ms rebase_rel( tripoint_omt_ms p );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -200,7 +200,7 @@ Creature::~Creature() = default;
 
 tripoint Creature::pos() const
 {
-    return get_map().getlocal( location );
+    return Creature::pos_bub().raw();
 }
 
 tripoint_bub_ms Creature::pos_bub() const
@@ -280,6 +280,10 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
         }
     }
     if( capacity > 0_ml ) {
+        // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
+        if( !veh.enclosed_at( here.bub_from_abs( loc ).raw() ) ) {
+            free_cargo *= 1.2;
+        }
         const creature_size size = get_size();
         units::volume critter_volume;
         if( mon ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -200,7 +200,7 @@ Creature::~Creature() = default;
 
 tripoint Creature::pos() const
 {
-    return get_map().getlocal( location );
+    return Creature::pos_bub().raw();
 }
 
 tripoint_bub_ms Creature::pos_bub() const

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -200,7 +200,7 @@ Creature::~Creature() = default;
 
 tripoint Creature::pos() const
 {
-    return Creature::pos_bub().raw();
+    return get_map().getlocal( location );
 }
 
 tripoint_bub_ms Creature::pos_bub() const
@@ -280,10 +280,6 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
         }
     }
     if( capacity > 0_ml ) {
-        // First, we'll try to squeeze in. Open-topped vehicle parts have more room to step over cargo.
-        if( !veh.enclosed_at( here.bub_from_abs( loc ).raw() ) ) {
-            free_cargo *= 1.2;
-        }
         const creature_size size = get_size();
         units::volume critter_volume;
         if( mon ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1712,13 +1712,13 @@ static void spawn_nested_mapgen()
 
         map target_map;
         target_map.load( abs_sub, true );
-        const tripoint_bub_ms local_ms = target_map.bub_from_abs( abs_ms );
+        const tripoint local_ms = target_map.getlocal( abs_ms );
         mapgendata md( abs_omt, target_map, 0.0f, calendar::turn, nullptr );
         const auto &ptr = nested_mapgens[nest_ids[nest_choice]].funcs().pick();
         if( ptr == nullptr ) {
             return;
         }
-        ( *ptr )->nest( md, tripoint_rel_ms( local_ms.x(), local_ms.y(), 0 ), "debug menu" );
+        ( *ptr )->nest( md, tripoint_rel_ms( local_ms.x, local_ms.y, 0 ), "debug menu" );
         target_map.save();
         g->load_npcs();
         here.invalidate_map_cache( here.get_abs_sub().z() );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1712,13 +1712,13 @@ static void spawn_nested_mapgen()
 
         map target_map;
         target_map.load( abs_sub, true );
-        const tripoint local_ms = target_map.getlocal( abs_ms );
+        const tripoint_bub_ms local_ms = target_map.bub_from_abs( abs_ms );
         mapgendata md( abs_omt, target_map, 0.0f, calendar::turn, nullptr );
         const auto &ptr = nested_mapgens[nest_ids[nest_choice]].funcs().pick();
         if( ptr == nullptr ) {
             return;
         }
-        ( *ptr )->nest( md, tripoint_rel_ms( local_ms.x, local_ms.y, 0 ), "debug menu" );
+        ( *ptr )->nest( md, tripoint_rel_ms( local_ms.x(), local_ms.y(), 0 ), "debug menu" );
         target_map.save();
         g->load_npcs();
         here.invalidate_map_cache( here.get_abs_sub().z() );

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -668,7 +668,7 @@ void editmap::draw_main_ui_overlay()
             std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
             for( int x = 0; x < 2; x++ ) {
                 for( int y = 0; y < 2; y++ ) {
-                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z()} );
+                    submap *sm = tmpmap.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
                     if( sm ) {
                         const tripoint_bub_ms sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z() );
                         for( const spawn_point &sp : sm->spawns ) {
@@ -2008,7 +2008,7 @@ vehicle *editmap::mapgen_veh_query( const tripoint_abs_omt &omt_tgt )
     std::vector<vehicle *> possible_vehicles;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
+            submap *destsm = target_bay.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to get vehicles at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;
@@ -2045,7 +2045,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
     target_bay.load( omt_tgt, false );
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
+            submap *destsm = target_bay.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to destroy vehicle at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -668,7 +668,7 @@ void editmap::draw_main_ui_overlay()
             std::map<tripoint_bub_ms, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
             for( int x = 0; x < 2; x++ ) {
                 for( int y = 0; y < 2; y++ ) {
-                    submap *sm = tmpmap.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
+                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z()} );
                     if( sm ) {
                         const tripoint_bub_ms sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z() );
                         for( const spawn_point &sp : sm->spawns ) {
@@ -2008,7 +2008,7 @@ vehicle *editmap::mapgen_veh_query( const tripoint_abs_omt &omt_tgt )
     std::vector<vehicle *> possible_vehicles;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
+            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to get vehicles at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;
@@ -2045,7 +2045,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
     target_bay.load( omt_tgt, false );
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( tripoint_rel_sm{ x, y, target.z()} );
+            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z()} );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to destroy vehicle at (%d,%d,%d) but the submap is not loaded", x, y, target.z() );
                 continue;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2071,8 +2071,8 @@ void basecamp::abandon_camp()
     known_camps.erase( omt_pos );
     overmap_buffer.remove_camp( *this );
     map &here = get_map();
-    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
-    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
+    const tripoint sm_pos = omt_to_sm_copy( omt_pos.raw() );
+    const tripoint ms_pos = sm_to_ms_copy( sm_pos );
     // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
     // here.remove_submap_camp( here.getlocal( bb_pos ) );
     here.remove_submap_camp( here.bub_from_abs( ms_pos ) );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2071,8 +2071,8 @@ void basecamp::abandon_camp()
     known_camps.erase( omt_pos );
     overmap_buffer.remove_camp( *this );
     map &here = get_map();
-    const tripoint sm_pos = omt_to_sm_copy( omt_pos.raw() );
-    const tripoint ms_pos = sm_to_ms_copy( sm_pos );
+    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
+    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
     // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
     // here.remove_submap_camp( here.getlocal( bb_pos ) );
     here.remove_submap_camp( here.bub_from_abs( ms_pos ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5652,8 +5652,7 @@ void game::control_vehicle()
                     } else {
                         return;
                     }
-                }
-                if( weapon->is_two_handed( u ) ) {
+                } else if( weapon->is_two_handed( u ) ) {
                     if( query_yn(
                             _( "You can't drive because you have to wield a %s with both hands.\n\nPut it away?" ),
                             weapon->tname() ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5636,6 +5636,35 @@ void game::control_vehicle()
             if( !veh->handle_potential_theft( u ) ) {
                 return; // player not owner and refused to steal
             }
+            const item_location weapon = u.get_wielded_item();
+            if( weapon ) {
+                if( u.worn_with_flag( flag_RESTRICT_HANDS ) ) {
+                    add_msg( m_info, _( "Something you are wearing hinders the use of both hands." ) );
+                    return;
+                }
+                if( !u.has_two_arms_lifting() ) {
+                    if( query_yn(
+                            _( "You can't drive because you have to wield a %s.\n\nPut it away?" ),
+                            weapon->tname() ) ) {
+                        if( !u.unwield() ) {
+                            return;
+                        }
+                    } else {
+                        return;
+                    }
+                }
+                if( weapon->is_two_handed( u ) ) {
+                    if( query_yn(
+                            _( "You can't drive because you have to wield a %s with both hands.\n\nPut it away?" ),
+                            weapon->tname() ) ) {
+                        if( !u.unwield() ) {
+                            return;
+                        }
+                    } else {
+                        return;
+                    }
+                }
+            }
             if( veh->engine_on ) {
                 u.controlling_vehicle = true;
                 add_msg( _( "You take control of the %s." ), veh->name );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -934,7 +934,7 @@ bool game::start_game()
     load_map( lev, /*pump_events=*/true );
 
     int level = m.get_abs_sub().z();
-    u.setpos( m.getlocal( project_to<coords::ms>( omtstart ) ) );
+    u.setpos( m.bub_from_abs( project_to<coords::ms>( omtstart ) ) );
     m.invalidate_map_cache( level );
     m.build_map_cache( level );
     // Do this after the map cache has been built!
@@ -1229,7 +1229,7 @@ void game::load_npcs()
         add_msg_debug( debugmode::DF_NPC, "game::load_npcs: Spawning static NPC, %s %s",
                        abs_sub.to_string_writable(), sm_loc.to_string_writable() );
         temp->place_on_map();
-        if( !m.inbounds( temp->pos() ) ) {
+        if( !m.inbounds( temp->pos_bub() ) ) {
             continue;
         }
         // In the rare case the npc was marked for death while
@@ -4209,7 +4209,7 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
 {
     ter_view_p = center;
 
-    m.draw( w_terrain, center );
+    m.draw( w_terrain, tripoint_bub_ms( center ) );
 
     if( draw_sounds ) {
         draw_footsteps( w_terrain, tripoint( -center.x, -center.y, center.z ) + point( POSX, POSY ) );
@@ -7048,8 +7048,8 @@ void game::zones_manager()
         if( zone_cnt > 0 ) {
             blink = !blink;
             const zone_data &zone = zones[active_index].get();
-            zone_start = m.getlocal( zone.get_start_point() );
-            zone_end = m.getlocal( zone.get_end_point() );
+            zone_start = m.bub_from_abs( zone.get_start_point() ).raw();
+            zone_end = m.bub_from_abs( zone.get_end_point() ).raw();
             ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         } else {
             blink = false;
@@ -7279,14 +7279,14 @@ void game::zones_manager()
                         static_popup message_pop;
                         message_pop.on_top( true );
                         message_pop.message( "%s", _( "Moving zone." ) );
-                        const tripoint zone_local_start_point = m.getlocal( zone.get_start_point() );
-                        const tripoint zone_local_end_point = m.getlocal( zone.get_end_point() );
+                        const tripoint_bub_ms zone_local_start_point = m.bub_from_abs( zone.get_start_point() );
+                        const tripoint_bub_ms zone_local_end_point = m.bub_from_abs( zone.get_end_point() );
                         // local position of the zone center, used to calculate the u.view_offset,
                         // could center the screen to the position it represents
-                        tripoint view_center = m.getlocal( zone.get_center_point() );
-                        const look_around_result result_local = look_around( false, view_center,
-                                                                zone_local_start_point, false, false,
-                                                                false, true, zone_local_end_point );
+                        tripoint_bub_ms view_center = m.bub_from_abs( zone.get_center_point() );
+                        const look_around_result result_local = look_around( false, view_center.raw(),
+                                                                zone_local_start_point.raw(), false, false,
+                                                                false, true, zone_local_end_point.raw() );
                         if( result_local.position ) {
                             const tripoint_abs_ms new_start_point = m.getglobal( *result_local.position );
                             const tripoint_abs_ms new_end_point = zone.get_end_point() - zone.get_start_point() +
@@ -12742,7 +12742,7 @@ void game::shift_monsters( const tripoint &shift )
             critter.shift( shift.xy() );
         }
 
-        if( m.inbounds( critter.pos() ) ) {
+        if( m.inbounds( critter.pos_bub() ) ) {
             // We're inbounds, so don't despawn after all.
             continue;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -934,7 +934,7 @@ bool game::start_game()
     load_map( lev, /*pump_events=*/true );
 
     int level = m.get_abs_sub().z();
-    u.setpos( m.bub_from_abs( project_to<coords::ms>( omtstart ) ) );
+    u.setpos( m.getlocal( project_to<coords::ms>( omtstart ) ) );
     m.invalidate_map_cache( level );
     m.build_map_cache( level );
     // Do this after the map cache has been built!
@@ -1229,7 +1229,7 @@ void game::load_npcs()
         add_msg_debug( debugmode::DF_NPC, "game::load_npcs: Spawning static NPC, %s %s",
                        abs_sub.to_string_writable(), sm_loc.to_string_writable() );
         temp->place_on_map();
-        if( !m.inbounds( temp->pos_bub() ) ) {
+        if( !m.inbounds( temp->pos() ) ) {
             continue;
         }
         // In the rare case the npc was marked for death while
@@ -4209,7 +4209,7 @@ void game::draw_ter( const tripoint &center, const bool looking, const bool draw
 {
     ter_view_p = center;
 
-    m.draw( w_terrain, tripoint_bub_ms( center ) );
+    m.draw( w_terrain, center );
 
     if( draw_sounds ) {
         draw_footsteps( w_terrain, tripoint( -center.x, -center.y, center.z ) + point( POSX, POSY ) );
@@ -7048,8 +7048,8 @@ void game::zones_manager()
         if( zone_cnt > 0 ) {
             blink = !blink;
             const zone_data &zone = zones[active_index].get();
-            zone_start = m.bub_from_abs( zone.get_start_point() ).raw();
-            zone_end = m.bub_from_abs( zone.get_end_point() ).raw();
+            zone_start = m.getlocal( zone.get_start_point() );
+            zone_end = m.getlocal( zone.get_end_point() );
             ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         } else {
             blink = false;
@@ -7279,14 +7279,14 @@ void game::zones_manager()
                         static_popup message_pop;
                         message_pop.on_top( true );
                         message_pop.message( "%s", _( "Moving zone." ) );
-                        const tripoint_bub_ms zone_local_start_point = m.bub_from_abs( zone.get_start_point() );
-                        const tripoint_bub_ms zone_local_end_point = m.bub_from_abs( zone.get_end_point() );
+                        const tripoint zone_local_start_point = m.getlocal( zone.get_start_point() );
+                        const tripoint zone_local_end_point = m.getlocal( zone.get_end_point() );
                         // local position of the zone center, used to calculate the u.view_offset,
                         // could center the screen to the position it represents
-                        tripoint_bub_ms view_center = m.bub_from_abs( zone.get_center_point() );
-                        const look_around_result result_local = look_around( false, view_center.raw(),
-                                                                zone_local_start_point.raw(), false, false,
-                                                                false, true, zone_local_end_point.raw() );
+                        tripoint view_center = m.getlocal( zone.get_center_point() );
+                        const look_around_result result_local = look_around( false, view_center,
+                                                                zone_local_start_point, false, false,
+                                                                false, true, zone_local_end_point );
                         if( result_local.position ) {
                             const tripoint_abs_ms new_start_point = m.getglobal( *result_local.position );
                             const tripoint_abs_ms new_end_point = zone.get_end_point() - zone.get_start_point() +
@@ -12742,7 +12742,7 @@ void game::shift_monsters( const tripoint &shift )
             critter.shift( shift.xy() );
         }
 
-        if( m.inbounds( critter.pos_bub() ) ) {
+        if( m.inbounds( critter.pos() ) ) {
             // We're inbounds, so don't despawn after all.
             continue;
         }

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -57,35 +57,14 @@ void handle_all_liquid( item liquid, int radius, const item *avoid = nullptr );
 bool consume_liquid( item &liquid, int radius = 0, const item *avoid = nullptr );
 
 /**
- * Handle finite liquid from ground. The function also handles consuming move points.
- * This may start a player activity.
- * @param on_ground Iterator to the item on the ground. Must be valid and point to an
- * item in the stack at `m.i_at(pos)`
- * @param pos The position of the item on the map.
+ * Handle liquids from inside a container item. The function also handles consuming move points.
+  * @param container Container of the liquid
  * @param radius around position to handle liquid for
  * @return Whether the item has been removed (which implies it was handled completely).
  * The iterator is invalidated in that case. Otherwise the item remains but may have
  * fewer charges.
  */
-bool handle_liquid_from_ground( const map_stack::iterator &on_ground, const tripoint &pos,
-                                int radius = 0 );
-
-/**
- * Handle liquid from inside a container item. The function also handles consuming move points.
- * @param in_container Iterator to the liquid. Must be valid and point to an
- * item in the @ref item::contents of the container.
- * @param container Container of the liquid
- * @param radius around position to handle liquid for
- * @return Whether the item has been removed (which implies it was handled completely).
- * The iterator is invalidated in that case. Otherwise the item remains but may have
- * fewer charges.
- */
-bool handle_liquid_from_container( item *in_container, item &container,
-                                   int radius = 0 );
-/**
- * Shortcut to the above: handles the first item in the container.
- */
-bool handle_liquid_from_container( item &container, int radius = 0 );
+bool handle_all_liquids_from_container( item_location &container, int radius = 0 );
 
 bool can_handle_liquid( const item &liquid );
 
@@ -110,13 +89,15 @@ bool can_handle_liquid( const item &liquid );
  */
 bool handle_liquid( item &liquid, const item *source = nullptr, int radius = 0,
                     const tripoint *source_pos = nullptr,
-                    vehicle *source_veh = nullptr, int part_num = -1,
+                    const vehicle *source_veh = nullptr, int part_num = -1,
                     const monster *source_mon = nullptr );
+bool handle_liquid( item_location &liquid, const item *source = nullptr, int radius = 0 );
 
 /* Not to be used directly. Use liquid_handler::handle_liquid instead. */
 bool perform_liquid_transfer( item &liquid, const tripoint *source_pos,
-                              vehicle *source_veh, int part_num,
+                              const vehicle *source_veh, int part_num,
                               const monster * /*source_mon*/, liquid_dest_opt &target );
+bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target );
 } // namespace liquid_handler
 
 #endif // CATA_SRC_HANDLE_LIQUID_H

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -558,7 +558,8 @@ void iexamine::gaspump( Character &you, const tripoint_bub_ms &examp )
                 }
 
             } else {
-                liquid_handler::handle_liquid_from_ground( item_it, examp.raw(), 1 );
+                item_location loc( map_cursor( examp ), &*item_it );
+                liquid_handler::handle_liquid( loc, nullptr, 1 );
             }
             return;
         }
@@ -3560,7 +3561,8 @@ void iexamine::fvat_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             case REMOVE_BREW: {
-                liquid_handler::handle_liquid_from_ground( here.i_at( examp ).begin(), examp.raw() );
+                item_location loc( map_cursor( examp ), &*here.i_at( examp ).begin() );
+                liquid_handler::handle_liquid( loc );
                 return;
             }
             case START_FERMENT: {
@@ -3683,7 +3685,8 @@ void iexamine::fvat_full( Character &you, const tripoint_bub_ms &examp )
     }
 
     const std::string booze_name = brew_i.tname();
-    if( liquid_handler::handle_liquid_from_ground( items_here.begin(), examp.raw() ) ) {
+    item_location loc( map_cursor( examp ), &*items_here.begin() );
+    if( liquid_handler::handle_liquid( loc ) ) {
         fvat_set_empty( examp );
         add_msg( _( "You squeeze the last drops of %s from the vat." ), booze_name );
     }
@@ -3787,7 +3790,8 @@ void iexamine::compost_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             case REMOVE_COMPOST: {
-                liquid_handler::handle_liquid_from_ground( here.i_at( examp ).begin(), examp.raw() );
+                item_location loc( map_cursor( examp ), &*here.i_at( examp ).begin() );
+                liquid_handler::handle_liquid( loc );
                 return;
             }
             case START_FERMENT: {
@@ -3964,7 +3968,8 @@ void iexamine::compost_full( Character &you, const tripoint_bub_ms &examp )
     }
 
     const std::string compost_name = compost_i.tname();
-    if( liquid_handler::handle_liquid_from_ground( items_here.begin(), examp.raw() ) ) {
+    item_location loc( map_cursor( examp ), &*items_here.begin() );
+    if( liquid_handler::handle_liquid( loc ) ) {
         compost_set_empty( examp );
         add_msg( _( "You squeeze the last drops of %s from the tank." ), compost_name );
     }
@@ -4125,13 +4130,14 @@ void iexamine::keg( Character &you, const tripoint_bub_ms &examp )
         selectmenu.query();
 
         switch( selectmenu.ret ) {
-            case DISPENSE:
-                if( liquid_handler::handle_liquid_from_ground( items.begin(), examp.raw() ) ) {
+            case DISPENSE: {
+                item_location loc( map_cursor( examp ), &*items.begin() );
+                if( liquid_handler::handle_liquid( loc ) ) {
                     add_msg( _( "You squeeze the last drops of %1$s from the %2$s." ),
                              drink_tname, keg_name );
                 }
                 return;
-
+            }
             case HAVE_A_DRINK:
                 if( !you.can_consume_as_is( drink ) ) {
                     return; // They didn't actually drink
@@ -4416,7 +4422,8 @@ void iexamine::tree_maple_tapped( Character &you, const tripoint_bub_ms &examp )
         }
 
         case HARVEST_SAP: {
-            liquid_handler::handle_liquid_from_container( *container, PICKUP_RANGE );
+            item_location loc( map_cursor( examp ), container );
+            liquid_handler::handle_all_liquids_from_container( loc, PICKUP_RANGE );
             return;
         }
 
@@ -4634,9 +4641,10 @@ void iexamine::water_source( Character &, const tripoint_bub_ms &examp )
 void iexamine::finite_water_source( Character &, const tripoint_bub_ms &examp )
 {
     map_stack items = get_map().i_at( examp );
-    for( auto item_it = items.begin(); item_it != items.end(); ++item_it ) {
-        if( item_it->made_of( phase_id::LIQUID ) ) {
-            liquid_handler::handle_liquid_from_ground( item_it, examp.raw() );
+    for( item &it : items ) {
+        if( it.made_of( phase_id::LIQUID ) ) {
+            item_location loc( map_cursor( examp ), &it );
+            liquid_handler::handle_liquid( loc );
             break;
         }
     }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -493,7 +493,7 @@ void inventory::form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zon
     std::vector<tripoint> pts;
     pts.reserve( zone_pts.size() );
     for( const tripoint_abs_ms &elem : zone_pts ) {
-        pts.push_back( m.bub_from_abs( elem ).raw() );
+        pts.push_back( m.getlocal( elem ) );
     }
     form_from_map( m, pts, pl, assign_invlet );
 }

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -493,7 +493,7 @@ void inventory::form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zon
     std::vector<tripoint> pts;
     pts.reserve( zone_pts.size() );
     for( const tripoint_abs_ms &elem : zone_pts ) {
-        pts.push_back( m.getlocal( elem ) );
+        pts.push_back( m.bub_from_abs( elem ).raw() );
     }
     form_from_map( m, pts, pl, assign_invlet );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14251,7 +14251,7 @@ bool item::process_internal( map &here, Character *carrier, const tripoint &pos,
             process_temperature_rot( insulation, pos, here, carrier, flag, spoil_modifier,
                                      watertight_container ) ) {
             if( is_comestible() ) {
-                here.rotten_item_spawn( *this, tripoint_bub_ms( pos ) );
+                here.rotten_item_spawn( *this, pos );
             }
             if( is_corpse() ) {
                 here.handle_decayed_corpse( *this, here.getglobal( pos ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14251,7 +14251,7 @@ bool item::process_internal( map &here, Character *carrier, const tripoint &pos,
             process_temperature_rot( insulation, pos, here, carrier, flag, spoil_modifier,
                                      watertight_container ) ) {
             if( is_comestible() ) {
-                here.rotten_item_spawn( *this, pos );
+                here.rotten_item_spawn( *this, tripoint_bub_ms( pos ) );
             }
             if( is_corpse() ) {
                 here.handle_decayed_corpse( *this, here.getglobal( pos ) );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -90,6 +90,9 @@ class item_location::impl
         }
         virtual tripoint position() const = 0;
         virtual Character *carrier() const = 0;
+        virtual const vehicle_cursor *veh_cursor() const {
+            return nullptr;
+        };
         virtual std::string describe( const Character * ) const = 0;
         virtual item_location obtain( Character &, int ) = 0;
         virtual units::volume volume_capacity() const = 0;
@@ -487,6 +490,10 @@ class item_location::impl::item_on_vehicle : public item_location::impl
 
         Character *carrier() const override {
             return nullptr;
+        }
+
+        const vehicle_cursor *veh_cursor() const override {
+            return &cur;
         }
 
         std::string describe( const Character *ch ) const override {
@@ -1107,6 +1114,11 @@ void item_location::set_should_stack( bool should_stack ) const
 Character *item_location::carrier() const
 {
     return ptr->carrier();
+}
+
+const vehicle_cursor *item_location::veh_cursor() const
+{
+    return ptr->veh_cursor();
 }
 
 bool item_location::held_by( Character const &who ) const

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -111,6 +111,9 @@ class item_location
         /** returns the character whose inventory contains this item, nullptr if none **/
         Character *carrier() const;
 
+        /** returns the character whose inventory contains this item, nullptr if none **/
+        const vehicle_cursor *veh_cursor() const;
+
         /** returns true if the item is in the inventory of the given character **/
         bool held_by( Character const &who ) const;
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -114,7 +114,7 @@ bool map::build_transparency_cache( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{smx, smy, zlev} );
+            const submap *cur_submap = get_submap_at_grid( {smx, smy, zlev} );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to build transparency cache at (%d,%d,%d) but the submap is not loaded", smx, smy,
                           zlev );
@@ -438,7 +438,7 @@ void map::generate_lightmap( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{ smx, smy, zlev } );
+            const submap *cur_submap = get_submap_at_grid( { smx, smy, zlev } );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to generate lightmap at (%d,%d,%d) but the submap is not loaded", smx, smy, zlev );
                 continue;
@@ -1104,20 +1104,19 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z, i
 }
 
 void map::seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
-                                     const array_of_grids_of<const bool> &floor_caches,
-                                     const std::optional<tripoint_bub_ms> &override_p ) const
+                                     const array_of_grids_of<const bool> &floor_caches, const std::optional<tripoint> &override_p ) const
 {
     Character &player_character = get_player_character();
     // If override is not given, use player character for calculations
-    const tripoint_bub_ms origin = override_p.value_or( player_character.pos_bub() );
-    const int min_z = std::max( origin.z() - fov_3d_z_range, -OVERMAP_DEPTH );
+    const tripoint origin = override_p.value_or( player_character.pos() );
+    const int min_z = std::max( origin.z - fov_3d_z_range, -OVERMAP_DEPTH );
     // For each tile
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
                     // Iterate down z-levels starting from 1 level below origin
-                    for( int sz = origin.z() - 1; sz >= min_z; --sz ) {
+                    for( int sz = origin.z - 1; sz >= min_z; --sz ) {
                         const tripoint p( sx + smx * SEEX, sy + smy * SEEY, sz );
                         const int cache_z = sz + OVERMAP_DEPTH;
                         // Until invisible tile reached
@@ -1127,7 +1126,7 @@ void map::seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
                         // Or floor reached
                         if( ( *floor_caches[cache_z] ) [p.x][p.y] ) {
                             // In which case check if it should be obscured by a ledge
-                            if( override_p ? ledge_concealment( origin.raw(), p ) >= 100 : ledge_concealment( player_character,
+                            if( override_p ? ledge_concealment( origin, p ) >= 100 : ledge_concealment( player_character,
                                     p ) >= player_character.eye_level() ) {
                                 ( *seen_caches[cache_z] )[p.x][p.y] = 0.0f;
                             }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -114,7 +114,7 @@ bool map::build_transparency_cache( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( {smx, smy, zlev} );
+            const submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{smx, smy, zlev} );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to build transparency cache at (%d,%d,%d) but the submap is not loaded", smx, smy,
                           zlev );
@@ -438,7 +438,7 @@ void map::generate_lightmap( const int zlev )
     // Traverse the submaps in order
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            const submap *cur_submap = get_submap_at_grid( { smx, smy, zlev } );
+            const submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{ smx, smy, zlev } );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to generate lightmap at (%d,%d,%d) but the submap is not loaded", smx, smy, zlev );
                 continue;
@@ -1104,19 +1104,20 @@ void map::build_seen_cache( const tripoint_bub_ms &origin, const int target_z, i
 }
 
 void map::seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
-                                     const array_of_grids_of<const bool> &floor_caches, const std::optional<tripoint> &override_p ) const
+                                     const array_of_grids_of<const bool> &floor_caches,
+                                     const std::optional<tripoint_bub_ms> &override_p ) const
 {
     Character &player_character = get_player_character();
     // If override is not given, use player character for calculations
-    const tripoint origin = override_p.value_or( player_character.pos() );
-    const int min_z = std::max( origin.z - fov_3d_z_range, -OVERMAP_DEPTH );
+    const tripoint_bub_ms origin = override_p.value_or( player_character.pos_bub() );
+    const int min_z = std::max( origin.z() - fov_3d_z_range, -OVERMAP_DEPTH );
     // For each tile
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
             for( int sx = 0; sx < SEEX; ++sx ) {
                 for( int sy = 0; sy < SEEY; ++sy ) {
                     // Iterate down z-levels starting from 1 level below origin
-                    for( int sz = origin.z - 1; sz >= min_z; --sz ) {
+                    for( int sz = origin.z() - 1; sz >= min_z; --sz ) {
                         const tripoint p( sx + smx * SEEX, sy + smy * SEEY, sz );
                         const int cache_z = sz + OVERMAP_DEPTH;
                         // Until invisible tile reached
@@ -1126,7 +1127,7 @@ void map::seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
                         // Or floor reached
                         if( ( *floor_caches[cache_z] ) [p.x][p.y] ) {
                             // In which case check if it should be obscured by a ledge
-                            if( override_p ? ledge_concealment( origin, p ) >= 100 : ledge_concealment( player_character,
+                            if( override_p ? ledge_concealment( origin.raw(), p ) >= 100 : ledge_concealment( player_character,
                                     p ) >= player_character.eye_level() ) {
                                 ( *seen_caches[cache_z] )[p.x][p.y] = 0.0f;
                             }

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -85,10 +85,11 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     if( !global_dest ) {
         return false;
     }
-    tripoint local_dest = omt_dest.getlocal( *global_dest ) + point( 60, 60 );
+    tripoint_omt_ms local_dest = omt_dest.omt_from_abs( tripoint_abs_ms( *global_dest ) ) + point( 60,
+                                 60 );
     you.add_effect( effect_ignore_fall_damage, 1_seconds, false, 0, true );
     g->place_player_overmap( omt_pt );
-    g->place_player( local_dest );
+    g->place_player( local_dest.raw() );
     return true;
 }
 

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -85,11 +85,10 @@ bool teleporter_list::place_avatar_overmap( Character &you, const tripoint_abs_o
     if( !global_dest ) {
         return false;
     }
-    tripoint_omt_ms local_dest = omt_dest.omt_from_abs( tripoint_abs_ms( *global_dest ) ) + point( 60,
-                                 60 );
+    tripoint local_dest = omt_dest.getlocal( *global_dest ) + point( 60, 60 );
     you.add_effect( effect_ignore_fall_damage, 1_seconds, false, 0, true );
     g->place_player_overmap( omt_pt );
-    g->place_player( local_dest.raw() );
+    g->place_player( local_dest );
     return true;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,11 +514,11 @@ void map::add_vehicle_to_cache( vehicle *veh )
         if( vpr.part().removed ) {
             continue;
         }
-        const tripoint p = veh->global_part_pos3( vpr.part() );
-        level_cache &ch = get_cache( p.z );
-        ch.set_veh_cached_parts( p, *veh, static_cast<int>( vpr.part_index() ) );
+        const tripoint_bub_ms p = veh->bub_part_pos( vpr.part() );
+        level_cache &ch = get_cache( p.z() );
+        ch.set_veh_cached_parts( p.raw(), *veh, static_cast<int>( vpr.part_index() ) );
         if( inbounds( p ) ) {
-            ch.set_veh_exists_at( p, true );
+            ch.set_veh_exists_at( p.raw(), true );
         }
     }
 }
@@ -1275,7 +1275,7 @@ void map::register_vehicle_zone( vehicle *veh, const int zlev )
 
 bool map::deregister_vehicle_zone( zone_data &zone ) const
 {
-    const tripoint pos = getlocal( zone.get_start_point() );
+    const tripoint_bub_ms pos = bub_from_abs( zone.get_start_point() );
     if( const std::optional<vpart_reference> vp = veh_at( pos ).cargo() ) {
         vehicle &veh = vp->vehicle();
         auto bounds = veh.loot_zones.equal_range( vp->mount() );
@@ -1344,7 +1344,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
     for( int cx = chunk_sx; cx <= chunk_ex; ++cx ) {
         for( int cy = chunk_sy; cy <= chunk_ey; ++cy ) {
             for( int cz = chunk_sz; cz <= chunk_ez; ++cz ) {
-                submap *current_submap = get_submap_at_grid( { cx, cy, cz } );
+                submap *current_submap = get_submap_at_grid( tripoint_rel_sm{ cx, cy, cz } );
                 if( current_submap == nullptr ) {
                     debugmsg( "Tried to process vehicle at (%d,%d,%d) but the submap is not loaded", cx, cy, cz );
                     continue;
@@ -1366,7 +1366,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
-    return veh_at( getlocal( p ) );
+    return veh_at( bub_from_abs( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint &p ) const
@@ -3833,7 +3833,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
     const auto &outside_cache = get_cache_ref( smz ).outside_cache;
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            submap *cur_submap = get_submap_at_grid( { smx, smy, smz } );
+            submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{ smx, smy, smz } );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", smx, smy, smz );
                 continue;
@@ -4378,11 +4378,6 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
     }
 }
 
-ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
-{
-    return map::get_roof( tripoint_bub_ms( p ), allow_air );
-}
-
 ter_str_id map::get_roof( const tripoint_bub_ms &p, const bool allow_air ) const
 {
     // This function should not be called from the 2D mode
@@ -4435,11 +4430,6 @@ static bool furn_is_supported( const map &m, const tripoint_bub_ms &p )
     }
 
     return false;
-}
-
-void map::bash_ter_furn( const tripoint &p, bash_params &params )
-{
-    map::bash_ter_furn( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
@@ -4771,11 +4761,6 @@ bash_params map::bash( const tripoint_bub_ms &p, const int str,
     return bsh;
 }
 
-void map::bash_items( const tripoint &p, bash_params &params )
-{
-    map::bash_items( tripoint_bub_ms( p ), params );
-}
-
 void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
 {
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
@@ -4810,11 +4795,6 @@ void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
     }
 }
 
-void map::bash_vehicle( const tripoint &p, bash_params &params )
-{
-    map::bash_vehicle( tripoint_bub_ms( p ), params );
-}
-
 void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
 {
     // Smash vehicle if present
@@ -4829,11 +4809,6 @@ void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
         params.success = true;
         params.bashed_solid = true;
     }
-}
-
-void map::bash_field( const tripoint &p, bash_params &params )
-{
-    map::bash_field( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_field( const tripoint_bub_ms &p, bash_params &params )
@@ -7605,7 +7580,7 @@ static std::optional<char32_t> get_memory_at( const tripoint &p )
     return std::nullopt;
 }
 
-void map::draw( const catacurses::window &w, const tripoint &center )
+void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
 {
     // We only need to draw anything if we're not in tiles mode.
     if( is_draw_tiles_mode() ) {
@@ -7614,31 +7589,30 @@ void map::draw( const catacurses::window &w, const tripoint &center )
 
     g->reset_light_level();
 
-    update_visibility_cache( center.z );
+    update_visibility_cache( center.z() );
     const visibility_variables &cache = get_visibility_variables_cache();
 
-    const auto &visibility_cache = get_cache_ref( center.z ).visibility_cache;
+    const auto &visibility_cache = get_cache_ref( center.z() ).visibility_cache;
 
     int wnd_h = getmaxy( w );
     int wnd_w = getmaxx( w );
-    const tripoint offs = center - tripoint( wnd_w / 2, wnd_h / 2, 0 );
+    const tripoint_bub_ms offs = center - tripoint_rel_ms( wnd_w / 2, wnd_h / 2, 0 );
 
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the terminal
     // since displayed area may be bigger than view range.
-    const point min_mm_reg = point(
-                                 std::min( 0, offs.x ),
-                                 std::min( 0, offs.y )
-                             );
-    const point max_mm_reg = point(
-                                 std::max( MAPSIZE_X, offs.x + wnd_w ),
-                                 std::max( MAPSIZE_Y, offs.y + wnd_h )
-                             );
+    const point_bub_ms min_mm_reg{
+        std::min( 0, offs.x() ),
+        std::min( 0, offs.y() )
+    };
+    const point_bub_ms max_mm_reg{
+        std::max( MAPSIZE_X, offs.x() + wnd_w ),
+        std::max( MAPSIZE_Y, offs.y() + wnd_h )
+    };
     avatar &player_character = get_avatar();
     player_character.prepare_map_memory_region(
-        getglobal( tripoint( min_mm_reg, center.z ) ),
-        getglobal( tripoint( max_mm_reg, center.z ) )
-    );
+        getglobal( { min_mm_reg, center.z() } ),
+        getglobal( { max_mm_reg, center.z() } ) );
 
     const auto draw_background = [&]( const tripoint & p ) {
         int sym = ' ';
@@ -7676,13 +7650,13 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     for( int wy = 0; wy < wnd_h; wy++ ) {
         for( int wx = 0; wx < wnd_w; wx++ ) {
             wmove( w, point( wx, wy ) );
-            const tripoint p = offs + tripoint( wx, wy, 0 );
+            const tripoint_bub_ms p = offs + tripoint_rel_ms( wx, wy, 0 );
             if( !inbounds( p ) ) {
-                draw_background( p );
+                draw_background( p.raw() );
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x][p.y];
+            const lit_level lighting = visibility_cache[p.x()][p.y()];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( draw_vision_effect( vis ) ) {
@@ -7690,7 +7664,7 @@ void map::draw( const catacurses::window &w, const tripoint &center )
             }
 
             if( vis == visibility_type::HIDDEN || vis == visibility_type::DARK ) {
-                draw_background( p );
+                draw_background( p.raw() );
                 continue;
             }
 
@@ -7702,22 +7676,22 @@ void map::draw( const catacurses::window &w, const tripoint &center )
                 continue;
             }
             const maptile tile_below = maptile_at_internal( p + tripoint_below );
-            draw_from_above( w, tripoint( p.xy(), p.z - 1 ), tile_below, params );
+            draw_from_above( w, p + tripoint_below, tile_below, params );
         }
     }
 
     // Memorize off-screen tiles
-    half_open_rectangle<point> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
+    half_open_rectangle<point_bub_ms> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
     drawsq_params mm_params = drawsq_params().memorize( true ).output( false );
     for( int y = 0; y < MAPSIZE_Y; y++ ) {
         for( int x = 0; x < MAPSIZE_X; x++ ) {
-            const tripoint p( x, y, center.z );
+            const tripoint_bub_ms p( x, y, center.z() );
             if( display.contains( p.xy() ) ) {
                 // Have been memorized during display loop
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x][p.y];
+            const lit_level lighting = visibility_cache[p.x()][p.y()];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( vis != visibility_type::CLEAR ) {
@@ -7737,6 +7711,12 @@ void map::draw( const catacurses::window &w, const tripoint &center )
 void map::drawsq( const catacurses::window &w, const tripoint &p,
                   const drawsq_params &params ) const
 {
+    map::drawsq( w, tripoint_bub_ms( p ), params );
+}
+
+void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
+                  const drawsq_params &params ) const
+{
     // If we are in tiles mode, the only thing we want to potentially draw is a highlight
     if( is_draw_tiles_mode() ) {
         if( params.highlight() ) {
@@ -7750,8 +7730,8 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
     }
 
     const tripoint_bub_ms view_center = params.center();
-    const int k = p.x + getmaxx( w ) / 2 - view_center.x();
-    const int j = p.y + getmaxy( w ) / 2 - view_center.y();
+    const int k = p.x() + getmaxx( w ) / 2 - view_center.x();
+    const int j = p.y() + getmaxy( w ) / 2 - view_center.y();
     if( k < 0 || k >= getmaxx( w ) || j < 0 || j >= getmaxy( w ) ) {
         return;
     }
@@ -7762,15 +7742,9 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
         return;
     }
 
-    tripoint below( p.xy(), p.z - 1 );
+    tripoint_bub_ms below( p + tripoint_below );
     const const_maptile tile_below = maptile_at( below );
     draw_from_above( w, below, tile_below, params );
-}
-
-void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
-                  const drawsq_params &params ) const
-{
-    map::drawsq( w, p.raw(), params );
 }
 
 // a check to see if the lower floor needs to be rendered in tiles
@@ -7785,7 +7759,7 @@ bool map::dont_draw_lower_floor( const tripoint &p ) const
     }
 }
 
-bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
+bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
                         const const_maptile &curr_maptile, const drawsq_params &params ) const
 {
     drawsq_params param = params;
@@ -7815,7 +7789,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
         sym = curr_furn.symbol();
         tercol = curr_furn.color();
         if( !( player_character.get_grab_type() == object_type::FURNITURE
-               && tripoint_bub_ms( p ) == player_character.pos_bub() + player_character.grab_point ) ) {
+               && p == player_character.pos_bub() + player_character.grab_point ) ) {
             memory_sym = sym;
         }
     }
@@ -7849,8 +7823,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
             memory_sym = sym = curr_trap.sym;
         }
     }
-    // FIXME: fix point type
-    if( const_cast<map *>( this )->partial_con_at( tripoint_bub_ms( p ) ) != nullptr ) {
+    if( const_cast<map *>( this )->partial_con_at( p ) != nullptr ) {
         tercol = tr_unfinished_construction->color;
         memory_sym = sym = tr_unfinished_construction->sym;
     }
@@ -7971,7 +7944,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     }
 
     if( item_sym.empty() && sym == ' ' ) {
-        if( !zlevels || p.z <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
+        if( !zlevels || p.z() <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
             // Print filler symbol
             tercol = c_black;
         } else {
@@ -7990,7 +7963,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     return true;
 }
 
-void map::draw_from_above( const catacurses::window &w, const tripoint &p,
+void map::draw_from_above( const catacurses::window &w, const tripoint_bub_ms &p,
                            const const_maptile &curr_tile, const drawsq_params &params ) const
 {
     static const int AUTO_WALL_PLACEHOLDER = 2; // this should never appear as a real symbol!
@@ -8723,10 +8696,10 @@ void map::save()
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
             if( zlevels ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    saven( tripoint( gridx, gridy, gridz ) );
+                    saven( { gridx, gridy, gridz } );
                 }
             } else {
-                saven( tripoint( gridx, gridy, abs_sub.z() ) );
+                saven( { gridx, gridy, abs_sub.z() } );
             }
         }
     }
@@ -8754,7 +8727,7 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     clear_vehicle_level_caches();
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            loadn( point( gridx, gridy ), update_vehicle );
+            loadn( { gridx, gridy }, update_vehicle );
             if( pump_events ) {
                 inp_mngr.pump_events();
             }
@@ -8780,10 +8753,10 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     }
 }
 
-void map::shift_traps( const tripoint &shift )
+void map::shift_traps( const point_rel_sm &shift )
 {
     // Offset needs to have sign opposite to shift direction
-    const tripoint_rel_ms offset( -shift.x * SEEX, -shift.y * SEEY, -shift.z );
+    const tripoint_rel_ms offset( -shift.x() * SEEX, -shift.y() * SEEY, 0 );
     for( auto iter = field_furn_locs.begin(); iter != field_furn_locs.end(); ) {
         tripoint_bub_ms &pos = *iter;
         pos += offset;
@@ -8873,7 +8846,7 @@ void map::shift( const point_rel_sm &sp )
 
     g->shift_destination_preview( point( -sp.x() * SEEX, -sp.y() * SEEY ) );
 
-    shift_traps( tripoint( sp.raw(), 0 ) );
+    shift_traps( sp );
 
     vehicle *remoteveh = g->remoteveh();
 
@@ -8930,7 +8903,7 @@ void map::shift( const point_rel_sm &sp )
                     update_vehicle_list( cur_submap, gridz );
                 }
             } else {
-                loadn( point( gridx, gridy ), true );
+                loadn( { gridx, gridy }, true );
 
                 for( int gridz = zmin; gridz <= zmax; gridz++ ) {
                     loaded_grids.emplace_back( gridx, gridy, gridz );
@@ -8984,23 +8957,23 @@ void map::vertical_shift( const int newz )
 // 0,2 1,2 2,2
 // (worldx,worldy,worldz) denotes the absolute coordinate of the submap
 // in grid[0].
-void map::saven( const tripoint &grid )
+void map::saven( const tripoint_bub_sm &grid )
 {
     dbg( D_INFO ) << "map::saven(worldx[" << abs_sub.x() << "], worldy[" << abs_sub.y()
                   << "], worldz[" << abs_sub.z()
-                  << "], gridx[" << grid.x << "], gridy[" << grid.y << "], gridz[" << grid.z << "])";
-    const int gridn = get_nonant( tripoint_rel_sm( grid ) );
+                  << "], gridx[" << grid.x() << "], gridy[" << grid.y() << "], gridz[" << grid.z() << "])";
+    const int gridn = get_nonant( rebase_rel( grid ) );
     submap *submap_to_save = getsubmap( gridn );
     if( submap_to_save == nullptr ) {
         debugmsg( "Tried to save submap node (%d) but it's not loaded", gridn );
         return;
     }
 
-    const tripoint_abs_sm abs = abs_sub.xy() + grid;
+    const tripoint_abs_sm abs = abs_sub.xy() + rebase_rel( grid );
 
-    if( !zlevels && grid.z != abs_sub.z() ) {
+    if( !zlevels && grid.z() != abs_sub.z() ) {
         debugmsg( "Tried to save submap (%d,%d,%d) as (%d,%d,%d), which isn't supported in non-z-level builds",
-                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z );
+                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z() );
     }
 
     dbg( D_INFO ) << "map::saven abs: " << abs
@@ -9056,12 +9029,12 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
     return ret;
 }
 
-void map::loadn( const point &grid, bool update_vehicles )
+void map::loadn( const point_bub_sm &grid, bool update_vehicles )
 {
     dbg( D_INFO ) << "map::loadn(game[" << g.get() << "], worldx[" << abs_sub.x()
                   << "], worldy[" << abs_sub.y() << "], grid " << grid << ")";
 
-    const tripoint_abs_sm grid_abs_sub = abs_sub + grid;
+    const tripoint_abs_sm grid_abs_sub = abs_sub + rebase_rel( grid );
     const tripoint_abs_omt grid_abs_omt = project_to<coords::omt>( grid_abs_sub );
     // Get the base submap "grid" is an offset from.
     const tripoint_abs_sm grid_sm_base = project_to<coords::sm>( grid_abs_omt );
@@ -9115,12 +9088,12 @@ void map::loadn( const point &grid, bool update_vehicles )
         set_floor_cache_dirty( z );
         set_pathfinding_cache_dirty( z );
         tmpsub = MAPBUFFER.lookup_submap( pos );
-        setsubmap( get_nonant( tripoint_rel_sm{ grid.x, grid.y, z } ), tmpsub );
+        setsubmap( get_nonant( tripoint_rel_sm{ grid.x(), grid.y(), z} ), tmpsub );
         if( !tmpsub->active_items.empty() ) {
             submaps_with_active_items_dirty.emplace( pos );
         }
         if( tmpsub->field_count > 0 ) {
-            get_cache( z ).field_cache.set( grid.x + grid.y * MAPSIZE );
+            get_cache( z ).field_cache.set( grid.x() + grid.y() * MAPSIZE );
         }
 
         // Destroy bugged no-part vehicles
@@ -9129,7 +9102,7 @@ void map::loadn( const point &grid, bool update_vehicles )
             vehicle *veh = iter->get();
             if( veh->part_count() > 0 ) {
                 // Always fix submap coordinates for easier Z-level-related operations
-                veh->sm_pos = { grid, z };
+                veh->sm_pos = { grid.raw(), z };
                 if( main_inbounds ) {
                     _main_requires_cleanup = true;
                 }
@@ -9145,7 +9118,7 @@ void map::loadn( const point &grid, bool update_vehicles )
                 }
 
                 if( zlevels ) {
-                    add_roofs( tripoint_rel_sm( grid.x, grid.y, z ) );
+                    add_roofs( tripoint_rel_sm( grid.x(), grid.y(), z ) );
                 }
 
                 ++iter;
@@ -9204,14 +9177,15 @@ void map::handle_decayed_corpse( const item &it, const tripoint_abs_ms &pnt )
             }
             add_item_or_charges( bub_from_abs( pnt ), harvest, false );
             if( anything_left && notify_player ) {
-                add_msg_if_player_sees( getlocal( pnt ), _( "You notice a %1$s has rotted away, leaving a %2$s." ),
+                add_msg_if_player_sees( bub_from_abs( pnt ),
+                                        _( "You notice a %1$s has rotted away, leaving a %2$s." ),
                                         it.tname(), harvest.tname() );
             }
         }
     }
 }
 
-void map::rotten_item_spawn( const item &item, const tripoint &pnt )
+void map::rotten_item_spawn( const item &item, const tripoint_bub_ms &pnt )
 {
     if( get_creature_tracker().creature_at( pnt ) != nullptr ) {
         return;
@@ -9237,7 +9211,7 @@ void map::rotten_item_spawn( const item &item, const tripoint &pnt )
     }
 }
 
-void map::fill_funnels( const tripoint &p, const time_point &since )
+void map::fill_funnels( const tripoint_bub_ms &p, const time_point &since )
 {
     const trap &tr = tr_at( p );
     if( !tr.is_funnel() ) {
@@ -9260,7 +9234,7 @@ void map::fill_funnels( const tripoint &p, const time_point &since )
     }
 }
 
-void map::grow_plant( const tripoint &p )
+void map::grow_plant( const tripoint_bub_ms &p )
 {
     const furn_t &furn = this->furn( p ).obj();
     if( !furn.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
@@ -9319,7 +9293,7 @@ void map::grow_plant( const tripoint &p )
                 items.erase( fertilizer );
             }
             // spawn appropriate amount of rot_spawn, equivalent to number of times we iterate this loop
-            rotten_item_spawn( *seed, p );
+            rotten_item_spawn( *seed, tripoint_bub_ms( p ) );
             // Get an updated reference to the furniture each time we go through this loop, to make sure we transform each step in turn
             const furn_t &current_furn = this->furn( p ).obj();
             furn_set( p, furn_str_id( current_furn.plant->transform ) );
@@ -9328,7 +9302,7 @@ void map::grow_plant( const tripoint &p )
     }
 }
 
-void map::restock_fruits( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::restock_fruits( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     const ter_t &ter = this->ter( p ).obj();
     if( !ter.has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
@@ -9342,7 +9316,7 @@ void map::restock_fruits( const tripoint &p, const time_duration &time_since_las
     }
 }
 
-void map::produce_sap( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     if( time_since_last_actualize <= 0_turns ) {
         return;
@@ -9415,7 +9389,7 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
 
     item sap( "maple_sap", calendar::turn );
 
-    sap.set_item_temperature( get_weather().get_temperature( p ) );
+    sap.set_item_temperature( get_weather().get_temperature( p.raw() ) );
     sap.charges = new_charges;
 
     // Is there a proper container?
@@ -9460,7 +9434,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     ter_set( p, ter_t_stump );
 }
 
-void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     const int rads = get_radiation( p );
     if( rads == 0 ) {
@@ -9506,7 +9480,7 @@ void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_ac
     }
 }
 
-void map::decay_cosmetic_fields( const tripoint &p,
+void map::decay_cosmetic_fields( const tripoint_bub_ms &p,
                                  const time_duration &time_since_last_actualize )
 {
     for( auto &pr : field_at( p ) ) {
@@ -9573,18 +9547,18 @@ void map::actualize( const tripoint_rel_sm &grid )
             }
 
             if( do_funnels ) {
-                fill_funnels( pnt.raw(), tmpsub->last_touched );
+                fill_funnels( pnt, tmpsub->last_touched );
             }
 
-            grow_plant( pnt.raw() );
+            grow_plant( pnt );
 
-            restock_fruits( pnt.raw(), time_since_last_actualize );
+            restock_fruits( pnt, time_since_last_actualize );
 
-            produce_sap( pnt.raw(), time_since_last_actualize );
+            produce_sap( pnt, time_since_last_actualize );
 
-            rad_scorch( pnt.raw(), time_since_last_actualize );
+            rad_scorch( pnt, time_since_last_actualize );
 
-            decay_cosmetic_fields( pnt.raw(), time_since_last_actualize );
+            decay_cosmetic_fields( pnt, time_since_last_actualize );
         }
     }
 
@@ -9949,23 +9923,23 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
 
 bool map::inbounds( const tripoint &p ) const
 {
-    return p.x >= 0 && p.x < my_MAPSIZE * SEEX &&
-           p.y >= 0 && p.y < my_MAPSIZE * SEEY &&
-           p.z >= -OVERMAP_DEPTH && p.z <= OVERMAP_HEIGHT;
-    // && ( zlevels || p.z == get_abs_sub().z() );
-    // Cannot actually let inbounds check the bounds for maps not supporting Z levels, as
-    // tests explicitly expect other Z level coordinates to return t_null when read
-    // and write terrain to the Z level of the map rather than fail or do nothing.
+    return inbounds( tripoint_bub_ms( p ) );
 }
 
 bool map::inbounds( const tripoint_abs_ms &p ) const
 {
-    return inbounds( getlocal( p ) );
+    return inbounds( bub_from_abs( p ) );
 }
 
 bool map::inbounds( const tripoint_bub_ms &p ) const
 {
-    return inbounds( p.raw() );
+    return p.x() >= 0 && p.x() < my_MAPSIZE * SEEX &&
+           p.y() >= 0 && p.y() < my_MAPSIZE * SEEY &&
+           p.z() >= -OVERMAP_DEPTH && p.z() <= OVERMAP_HEIGHT;
+    // && ( zlevels || p.z == get_abs_sub().z() );
+    // Cannot actually let inbounds check the bounds for maps not supporting Z levels, as
+    // tests explicitly expect other Z level coordinates to return t_null when read
+    // and write terrain to the Z level of the map rather than fail or do nothing.
 }
 
 bool map::inbounds( const tripoint_abs_omt &p ) const
@@ -10047,7 +10021,7 @@ fake_map::fake_map( const ter_id &ter_type )
             sm->set_all_furn( furn_str_id::NULL_ID() );
             sm->set_all_traps( tr_null );
 
-            setsubmap( get_nonant( { gridx, gridy, fake_map_z } ), sm.get() );
+            setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, fake_map_z } ), sm.get() );
 
             temp_submaps_.emplace_back( std::move( sm ) );
         }
@@ -10069,7 +10043,7 @@ small_fake_map::small_fake_map( const ter_id &ter_type )
                 sm->set_all_furn( furn_str_id::NULL_ID() );
                 sm->set_all_traps( tr_null );
 
-                setsubmap( get_nonant( { gridx, gridy, gridz } ), sm.get() );
+                setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, gridz } ), sm.get() );
 
                 temp_submaps_.emplace_back( std::move( sm ) );
             }
@@ -10157,10 +10131,10 @@ bool map::has_graffiti_at( const tripoint_bub_ms &p ) const
     return current_submap->has_graffiti( l );
 }
 
-int map::determine_wall_corner( const tripoint &p ) const
+int map::determine_wall_corner( const tripoint_bub_ms &p ) const
 {
     const std::bitset<NUM_TERCONN> &test_connect_group = ter( p ).obj().connect_to_groups;
-    uint8_t connections = get_known_connections( tripoint_bub_ms( p ), test_connect_group );
+    uint8_t connections = get_known_connections( p, test_connect_group );
     // The bits in connections are SEWN, whereas the characters in LINE_
     // constants are NESW, so we want values in 8 | 2 | 1 | 4 order.
     switch( connections ) {
@@ -10477,13 +10451,13 @@ void map::do_vehicle_caching( int z )
     }
     for( vehicle *v : ch->vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts_with_fakes() ) {
-            const tripoint part_pos = v->global_part_pos3( vp.part() );
+            const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
             if( !inbounds( part_pos.xy() ) ) {
                 continue;
             }
-            vehicle_caching_internal( get_cache( part_pos.z ), vp, v );
-            if( part_pos.z < OVERMAP_HEIGHT ) {
-                vehicle_caching_internal_above( get_cache( part_pos.z + 1 ), vp, v );
+            vehicle_caching_internal( get_cache( part_pos.z() ), vp, v );
+            if( part_pos.z() < OVERMAP_HEIGHT ) {
+                vehicle_caching_internal_above( get_cache( part_pos.z() + 1 ), vp, v );
             }
         }
     }
@@ -10571,17 +10545,6 @@ tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
     return project_to<coords::ms>( abs_sub.xy() ) + p.raw();
 }
 
-tripoint map::getlocal( const tripoint_abs_ms &p ) const
-{
-    return ( p - sm_to_ms_copy( abs_sub.xy().raw() ) ).raw();
-}
-
-tripoint_bub_ms map::bub_from_abs( const tripoint &p ) const
-{
-    // TODO: fix point types
-    return bub_from_abs( tripoint_abs_ms( p ) );
-}
-
 tripoint_bub_ms map::bub_from_abs( const tripoint_abs_ms &p ) const
 {
     return tripoint_bub_ms() + ( p - project_to<coords::ms>( abs_sub.xy() ) );
@@ -10618,6 +10581,18 @@ const submap *map::getsubmap( const size_t grididx ) const
     return getsubmap_helper( grid, grididx );
 }
 
+submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p )
+{
+    cata_assert( inbounds( p ) );
+    return get_submap_at_grid( tripoint_rel_sm{ p.x() / SEEX, p.y() / SEEY, p.z() } );
+}
+
+const submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p ) const
+{
+    cata_assert( inbounds( p ) );
+    return get_submap_at_grid( { p.x() / SEEX, p.y() / SEEY, p.z() } );
+}
+
 void map::setsubmap( const size_t grididx, submap *const smap )
 {
     if( grididx >= grid.size() ) {
@@ -10630,18 +10605,13 @@ void map::setsubmap( const size_t grididx, submap *const smap )
     grid[grididx] = smap;
 }
 
-submap *map::get_submap_at( const tripoint &p )
+submap *map::get_submap_at( const tripoint_bub_ms &p )
 {
     if( !inbounds( p ) ) {
         debugmsg( "Tried to access invalid map position %s", p.to_string() );
         return nullptr;
     }
     return unsafe_get_submap_at( p );
-}
-
-submap *map::get_submap_at( const tripoint_bub_ms &p )
-{
-    return map::get_submap_at( p.raw() );
 }
 
 const submap *map::get_submap_at( const tripoint_bub_ms &p ) const
@@ -10710,7 +10680,7 @@ void map::draw_fill_background( const ter_id &type )
     // Fill each submap rather than each tile
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            submap *sm = get_submap_at_grid( point{gridx, gridy} );
+            submap *sm = get_submap_at_grid( point_rel_sm{gridx, gridy} );
             if( sm == nullptr ) {
                 debugmsg( "Tried to fill background at (%d,%d) but the submap is not loaded", gridx, gridy );
                 continue;
@@ -10824,11 +10794,6 @@ void map::add_corpse( const tripoint_bub_ms &p )
     add_item_or_charges( p, body );
 }
 
-field &map::get_field( const tripoint &p )
-{
-    return field_at( tripoint_bub_ms( p ) );
-}
-
 field &map::get_field( const tripoint_bub_ms &p )
 {
     return field_at( p );
@@ -10938,42 +10903,46 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
 }
 
 template<typename Functor>
-void map::function_over( const tripoint &start, const tripoint &end, Functor fun ) const
+void map::function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                         Functor fun ) const
 {
     // start and end are just two points, end can be "before" start
     // Also clip the area to map area
-    const tripoint min( std::max( std::min( start.x, end.x ), 0 ), std::max( std::min( start.y, end.y ),
-                        0 ), std::max( std::min( start.z, end.z ), -OVERMAP_DEPTH ) );
-    const tripoint max( std::min( std::max( start.x, end.x ), SEEX * my_MAPSIZE - 1 ),
-                        std::min( std::max( start.y, end.y ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z, end.z ),
-                                OVERMAP_HEIGHT ) );
+    const tripoint_bub_ms min( std::max( std::min( start.x(), end.x() ), 0 ),
+                               std::max( std::min( start.y(), end.y() ),
+                                         0 ), std::max( std::min( start.z(), end.z() ), -OVERMAP_DEPTH ) );
+    const tripoint_bub_ms max( std::min( std::max( start.x(), end.x() ), SEEX * my_MAPSIZE - 1 ),
+                               std::min( std::max( start.y(), end.y() ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z(),
+                                       end.z() ),
+                                       OVERMAP_HEIGHT ) );
 
     // Submaps that contain the bounding points
-    const point min_sm( min.x / SEEX, min.y / SEEY );
-    const point max_sm( max.x / SEEX, max.y / SEEY );
+    const point_bub_sm min_sm( min.x() / SEEX, min.y() / SEEY );
+    const point_bub_sm max_sm( max.x() / SEEX, max.y() / SEEY );
     // Z outermost, because submaps are flat
-    tripoint gp;
-    int &z = gp.z;
-    int &smx = gp.x;
-    int &smy = gp.y;
-    for( z = min.z; z <= max.z; z++ ) {
-        for( smx = min_sm.x; smx <= max_sm.x; smx++ ) {
-            for( smy = min_sm.y; smy <= max_sm.y; smy++ ) {
+    tripoint_rel_sm gp;
+    int &z = gp.z();
+    int &smx = gp.x();
+    int &smy = gp.y();
+    for( z = min.z(); z <= max.z(); z++ ) {
+        for( smx = min_sm.x(); smx <= max_sm.x(); smx++ ) {
+            for( smy = min_sm.y(); smy <= max_sm.y(); smy++ ) {
                 submap const *cur_submap = get_submap_at_grid( { smx, smy, z } );
                 if( cur_submap == nullptr ) {
                     debugmsg( "Tried to function over (%d,%d,%d) but the submap is not loaded", smx, smy, z );
                     continue;
                 }
                 // Bounds on the submap coordinates
-                const point sm_min( smx > min_sm.x ? 0 : min.x % SEEX, smy > min_sm.y ? 0 : min.y % SEEY );
-                const point sm_max( smx < max_sm.x ? SEEX - 1 : max.x % SEEX,
-                                    smy < max_sm.y ? SEEY - 1 : max.y % SEEY );
+                const point_bub_sm sm_min( smx > min_sm.x() ? 0 : min.x() % SEEX,
+                                           smy > min_sm.y() ? 0 : min.y() % SEEY );
+                const point_bub_sm sm_max( smx < max_sm.x() ? SEEX - 1 : max.x() % SEEX,
+                                           smy < max_sm.y() ? SEEY - 1 : max.y() % SEEY );
 
                 point_sm_ms lp;
                 int &sx = lp.x();
                 int &sy = lp.y();
-                for( sx = sm_min.x; sx <= sm_max.x; ++sx ) {
-                    for( sy = sm_min.y; sy <= sm_max.y; ++sy ) {
+                for( sx = sm_min.x(); sx <= sm_max.x(); ++sx ) {
+                    for( sy = sm_min.y(); sy <= sm_max.y(); ++sy ) {
                         const iteration_state rval = fun( gp, cur_submap, lp );
                         if( rval != ITER_CONTINUE ) {
                             switch( rval ) {
@@ -10998,13 +10967,13 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
 
 void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
                           std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                          const point &min, const point &max )
+                          const point_bub_ms &min, const point_bub_ms &max )
 {
     ter_furn_flag reduce = ter_furn_flag::TFLAG_REDUCE_SCENT;
     ter_furn_flag block = ter_furn_flag::TFLAG_NO_SCENT;
-    auto fill_values = [&]( const tripoint & gp, const submap * sm, const point_sm_ms & lp ) {
+    auto fill_values = [&]( const tripoint_rel_sm & gp, const submap * sm, const point_sm_ms & lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
-        const point_sm_ms p = lp + sm_to_ms_copy( gp.xy() );
+        const point_sm_ms p = lp + coords::project_to<coords::ms>( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {
             blocks_scent[p.x()][p.y()] = true;
             reduces_scent[p.x()][p.y()] = false;
@@ -11020,9 +10989,10 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         return ITER_CONTINUE;
     };
 
-    function_over( tripoint( min, abs_sub.z() ), tripoint( max, abs_sub.z() ), fill_values );
+    function_over( tripoint_bub_ms( min, abs_sub.z() ), tripoint_bub_ms( max, abs_sub.z() ),
+                   fill_values );
 
-    const inclusive_rectangle<point> local_bounds( min, max );
+    const inclusive_rectangle<point_bub_ms> local_bounds( min, max );
 
     // Now vehicles
 
@@ -11034,9 +11004,9 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
                 ( !vp.has_feature( VPFLAG_OPENABLE ) || !vp.part().open ) ) {
                 continue;
             }
-            const tripoint part_pos = vp.pos();
+            const tripoint_bub_ms part_pos = vp.pos_bub();
             if( local_bounds.contains( part_pos.xy() ) ) {
-                reduces_scent[part_pos.x][part_pos.y] = true;
+                reduces_scent[part_pos.x()][part_pos.y()] = true;
             }
         }
     }
@@ -11258,7 +11228,7 @@ void map::set_pathfinding_cache_dirty( const int zlev )
 void map::set_pathfinding_cache_dirty( const tripoint_bub_ms &p )
 {
     if( inbounds( p ) ) {
-        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy().raw() );
+        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy() );
     }
 }
 
@@ -11293,12 +11263,12 @@ const pathfinding_cache &map::get_pathfinding_cache_ref( int zlev ) const
     return cache;
 }
 
-void map::update_pathfinding_cache( const tripoint &p ) const
+void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
         return;
     }
-    pathfinding_cache &cache = get_pathfinding_cache( p.z );
+    pathfinding_cache &cache = get_pathfinding_cache( p.z() );
     PathfindingFlags cur_value = PathfindingFlag::Ground;
 
     const_maptile tile = maptile_at_internal( p );
@@ -11358,7 +11328,7 @@ void map::update_pathfinding_cache( const tripoint &p ) const
         cur_value |= PathfindingFlag::Sharp;
     }
 
-    cache.special[p.x][p.y] = cur_value;
+    cache.special[p.x()][p.y()] = cur_value;
 }
 
 void map::update_pathfinding_cache( int zlev ) const
@@ -11374,7 +11344,7 @@ void map::update_pathfinding_cache( int zlev ) const
         }
         cache.dirty = false;
     } else {
-        for( const point &p : cache.dirty_points ) {
+        for( const point_bub_ms &p : cache.dirty_points ) {
             update_pathfinding_cache( { p, zlev } );
         }
     }
@@ -11462,7 +11432,7 @@ int map::calc_max_populated_zlev()
         bool level_done = false;
         for( int sx = 0; sx < my_MAPSIZE; sx++ ) {
             for( int sy = 0; sy < my_MAPSIZE; sy++ ) {
-                const submap *sm = get_submap_at_grid( { sx, sy, sz } );
+                const submap *sm = get_submap_at_grid( tripoint_rel_sm{ sx, sy, sz } );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to calc max populated zlev at (%d,%d,%d) but the submap is not loaded", sx, sy,
                               sz );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,11 +514,11 @@ void map::add_vehicle_to_cache( vehicle *veh )
         if( vpr.part().removed ) {
             continue;
         }
-        const tripoint p = veh->global_part_pos3( vpr.part() );
-        level_cache &ch = get_cache( p.z );
-        ch.set_veh_cached_parts( p, *veh, static_cast<int>( vpr.part_index() ) );
+        const tripoint_bub_ms p = veh->bub_part_pos( vpr.part() );
+        level_cache &ch = get_cache( p.z() );
+        ch.set_veh_cached_parts( p.raw(), *veh, static_cast<int>( vpr.part_index() ) );
         if( inbounds( p ) ) {
-            ch.set_veh_exists_at( p, true );
+            ch.set_veh_exists_at( p.raw(), true );
         }
     }
 }
@@ -1275,7 +1275,7 @@ void map::register_vehicle_zone( vehicle *veh, const int zlev )
 
 bool map::deregister_vehicle_zone( zone_data &zone ) const
 {
-    const tripoint pos = getlocal( zone.get_start_point() );
+    const tripoint_bub_ms pos = bub_from_abs( zone.get_start_point() );
     if( const std::optional<vpart_reference> vp = veh_at( pos ).cargo() ) {
         vehicle &veh = vp->vehicle();
         auto bounds = veh.loot_zones.equal_range( vp->mount() );
@@ -1344,7 +1344,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
     for( int cx = chunk_sx; cx <= chunk_ex; ++cx ) {
         for( int cy = chunk_sy; cy <= chunk_ey; ++cy ) {
             for( int cz = chunk_sz; cz <= chunk_ez; ++cz ) {
-                submap *current_submap = get_submap_at_grid( { cx, cy, cz } );
+                submap *current_submap = get_submap_at_grid( tripoint_rel_sm{ cx, cy, cz } );
                 if( current_submap == nullptr ) {
                     debugmsg( "Tried to process vehicle at (%d,%d,%d) but the submap is not loaded", cx, cy, cz );
                     continue;
@@ -1366,7 +1366,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
-    return veh_at( getlocal( p ) );
+    return veh_at( bub_from_abs( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint &p ) const
@@ -3833,7 +3833,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
     const auto &outside_cache = get_cache_ref( smz ).outside_cache;
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            submap *cur_submap = get_submap_at_grid( { smx, smy, smz } );
+            submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{ smx, smy, smz } );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", smx, smy, smz );
                 continue;
@@ -4378,11 +4378,6 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
     }
 }
 
-ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
-{
-    return map::get_roof( tripoint_bub_ms( p ), allow_air );
-}
-
 ter_str_id map::get_roof( const tripoint_bub_ms &p, const bool allow_air ) const
 {
     // This function should not be called from the 2D mode
@@ -4435,11 +4430,6 @@ static bool furn_is_supported( const map &m, const tripoint_bub_ms &p )
     }
 
     return false;
-}
-
-void map::bash_ter_furn( const tripoint &p, bash_params &params )
-{
-    map::bash_ter_furn( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
@@ -4771,11 +4761,6 @@ bash_params map::bash( const tripoint_bub_ms &p, const int str,
     return bsh;
 }
 
-void map::bash_items( const tripoint &p, bash_params &params )
-{
-    map::bash_items( tripoint_bub_ms( p ), params );
-}
-
 void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
 {
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
@@ -4810,11 +4795,6 @@ void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
     }
 }
 
-void map::bash_vehicle( const tripoint &p, bash_params &params )
-{
-    map::bash_vehicle( tripoint_bub_ms( p ), params );
-}
-
 void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
 {
     // Smash vehicle if present
@@ -4829,11 +4809,6 @@ void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
         params.success = true;
         params.bashed_solid = true;
     }
-}
-
-void map::bash_field( const tripoint &p, bash_params &params )
-{
-    map::bash_field( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_field( const tripoint_bub_ms &p, bash_params &params )
@@ -7605,7 +7580,7 @@ static std::optional<char32_t> get_memory_at( const tripoint &p )
     return std::nullopt;
 }
 
-void map::draw( const catacurses::window &w, const tripoint &center )
+void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
 {
     // We only need to draw anything if we're not in tiles mode.
     if( is_draw_tiles_mode() ) {
@@ -7614,31 +7589,30 @@ void map::draw( const catacurses::window &w, const tripoint &center )
 
     g->reset_light_level();
 
-    update_visibility_cache( center.z );
+    update_visibility_cache( center.z() );
     const visibility_variables &cache = get_visibility_variables_cache();
 
-    const auto &visibility_cache = get_cache_ref( center.z ).visibility_cache;
+    const auto &visibility_cache = get_cache_ref( center.z() ).visibility_cache;
 
     int wnd_h = getmaxy( w );
     int wnd_w = getmaxx( w );
-    const tripoint offs = center - tripoint( wnd_w / 2, wnd_h / 2, 0 );
+    const tripoint_bub_ms offs = center - tripoint_rel_ms( wnd_w / 2, wnd_h / 2, 0 );
 
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the terminal
     // since displayed area may be bigger than view range.
-    const point min_mm_reg = point(
-                                 std::min( 0, offs.x ),
-                                 std::min( 0, offs.y )
-                             );
-    const point max_mm_reg = point(
-                                 std::max( MAPSIZE_X, offs.x + wnd_w ),
-                                 std::max( MAPSIZE_Y, offs.y + wnd_h )
-                             );
+    const point_bub_ms min_mm_reg{
+        std::min( 0, offs.x() ),
+        std::min( 0, offs.y() )
+    };
+    const point_bub_ms max_mm_reg{
+        std::max( MAPSIZE_X, offs.x() + wnd_w ),
+        std::max( MAPSIZE_Y, offs.y() + wnd_h )
+    };
     avatar &player_character = get_avatar();
     player_character.prepare_map_memory_region(
-        getglobal( tripoint( min_mm_reg, center.z ) ),
-        getglobal( tripoint( max_mm_reg, center.z ) )
-    );
+        getglobal( { min_mm_reg, center.z() } ),
+        getglobal( { max_mm_reg, center.z() } ) );
 
     const auto draw_background = [&]( const tripoint & p ) {
         int sym = ' ';
@@ -7676,13 +7650,13 @@ void map::draw( const catacurses::window &w, const tripoint &center )
     for( int wy = 0; wy < wnd_h; wy++ ) {
         for( int wx = 0; wx < wnd_w; wx++ ) {
             wmove( w, point( wx, wy ) );
-            const tripoint p = offs + tripoint( wx, wy, 0 );
+            const tripoint_bub_ms p = offs + tripoint_rel_ms( wx, wy, 0 );
             if( !inbounds( p ) ) {
-                draw_background( p );
+                draw_background( p.raw() );
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x][p.y];
+            const lit_level lighting = visibility_cache[p.x()][p.y()];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( draw_vision_effect( vis ) ) {
@@ -7690,7 +7664,7 @@ void map::draw( const catacurses::window &w, const tripoint &center )
             }
 
             if( vis == visibility_type::HIDDEN || vis == visibility_type::DARK ) {
-                draw_background( p );
+                draw_background( p.raw() );
                 continue;
             }
 
@@ -7702,22 +7676,22 @@ void map::draw( const catacurses::window &w, const tripoint &center )
                 continue;
             }
             const maptile tile_below = maptile_at_internal( p + tripoint_below );
-            draw_from_above( w, tripoint( p.xy(), p.z - 1 ), tile_below, params );
+            draw_from_above( w, p + tripoint_below, tile_below, params );
         }
     }
 
     // Memorize off-screen tiles
-    half_open_rectangle<point> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
+    half_open_rectangle<point_bub_ms> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
     drawsq_params mm_params = drawsq_params().memorize( true ).output( false );
     for( int y = 0; y < MAPSIZE_Y; y++ ) {
         for( int x = 0; x < MAPSIZE_X; x++ ) {
-            const tripoint p( x, y, center.z );
+            const tripoint_bub_ms p( x, y, center.z() );
             if( display.contains( p.xy() ) ) {
                 // Have been memorized during display loop
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x][p.y];
+            const lit_level lighting = visibility_cache[p.x()][p.y()];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( vis != visibility_type::CLEAR ) {
@@ -7737,6 +7711,12 @@ void map::draw( const catacurses::window &w, const tripoint &center )
 void map::drawsq( const catacurses::window &w, const tripoint &p,
                   const drawsq_params &params ) const
 {
+    map::drawsq( w, tripoint_bub_ms( p ), params );
+}
+
+void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
+                  const drawsq_params &params ) const
+{
     // If we are in tiles mode, the only thing we want to potentially draw is a highlight
     if( is_draw_tiles_mode() ) {
         if( params.highlight() ) {
@@ -7750,8 +7730,8 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
     }
 
     const tripoint_bub_ms view_center = params.center();
-    const int k = p.x + getmaxx( w ) / 2 - view_center.x();
-    const int j = p.y + getmaxy( w ) / 2 - view_center.y();
+    const int k = p.x() + getmaxx( w ) / 2 - view_center.x();
+    const int j = p.y() + getmaxy( w ) / 2 - view_center.y();
     if( k < 0 || k >= getmaxx( w ) || j < 0 || j >= getmaxy( w ) ) {
         return;
     }
@@ -7762,15 +7742,9 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
         return;
     }
 
-    tripoint below( p.xy(), p.z - 1 );
+    tripoint_bub_ms below( p + tripoint_below );
     const const_maptile tile_below = maptile_at( below );
     draw_from_above( w, below, tile_below, params );
-}
-
-void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
-                  const drawsq_params &params ) const
-{
-    map::drawsq( w, p.raw(), params );
 }
 
 // a check to see if the lower floor needs to be rendered in tiles
@@ -7785,7 +7759,7 @@ bool map::dont_draw_lower_floor( const tripoint &p ) const
     }
 }
 
-bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
+bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
                         const const_maptile &curr_maptile, const drawsq_params &params ) const
 {
     drawsq_params param = params;
@@ -7815,7 +7789,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
         sym = curr_furn.symbol();
         tercol = curr_furn.color();
         if( !( player_character.get_grab_type() == object_type::FURNITURE
-               && tripoint_bub_ms( p ) == player_character.pos_bub() + player_character.grab_point ) ) {
+               && p == player_character.pos_bub() + player_character.grab_point ) ) {
             memory_sym = sym;
         }
     }
@@ -7849,8 +7823,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
             memory_sym = sym = curr_trap.sym;
         }
     }
-    // FIXME: fix point type
-    if( const_cast<map *>( this )->partial_con_at( tripoint_bub_ms( p ) ) != nullptr ) {
+    if( const_cast<map *>( this )->partial_con_at( p ) != nullptr ) {
         tercol = tr_unfinished_construction->color;
         memory_sym = sym = tr_unfinished_construction->sym;
     }
@@ -7971,7 +7944,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     }
 
     if( item_sym.empty() && sym == ' ' ) {
-        if( !zlevels || p.z <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
+        if( !zlevels || p.z() <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
             // Print filler symbol
             tercol = c_black;
         } else {
@@ -7990,7 +7963,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
     return true;
 }
 
-void map::draw_from_above( const catacurses::window &w, const tripoint &p,
+void map::draw_from_above( const catacurses::window &w, const tripoint_bub_ms &p,
                            const const_maptile &curr_tile, const drawsq_params &params ) const
 {
     static const int AUTO_WALL_PLACEHOLDER = 2; // this should never appear as a real symbol!
@@ -8723,10 +8696,10 @@ void map::save()
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
             if( zlevels ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    saven( tripoint( gridx, gridy, gridz ) );
+                    saven( { gridx, gridy, gridz } );
                 }
             } else {
-                saven( tripoint( gridx, gridy, abs_sub.z() ) );
+                saven( { gridx, gridy, abs_sub.z() } );
             }
         }
     }
@@ -8754,7 +8727,7 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     clear_vehicle_level_caches();
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            loadn( point( gridx, gridy ), update_vehicle );
+            loadn( { gridx, gridy }, update_vehicle );
             if( pump_events ) {
                 inp_mngr.pump_events();
             }
@@ -8780,10 +8753,10 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     }
 }
 
-void map::shift_traps( const tripoint &shift )
+void map::shift_traps( const point_rel_sm &shift )
 {
     // Offset needs to have sign opposite to shift direction
-    const tripoint_rel_ms offset( -shift.x * SEEX, -shift.y * SEEY, -shift.z );
+    const tripoint_rel_ms offset( -shift.x() * SEEX, -shift.y() * SEEY, 0 );
     for( auto iter = field_furn_locs.begin(); iter != field_furn_locs.end(); ) {
         tripoint_bub_ms &pos = *iter;
         pos += offset;
@@ -8873,7 +8846,7 @@ void map::shift( const point_rel_sm &sp )
 
     g->shift_destination_preview( point( -sp.x() * SEEX, -sp.y() * SEEY ) );
 
-    shift_traps( tripoint( sp.raw(), 0 ) );
+    shift_traps( sp );
 
     vehicle *remoteveh = g->remoteveh();
 
@@ -8930,7 +8903,7 @@ void map::shift( const point_rel_sm &sp )
                     update_vehicle_list( cur_submap, gridz );
                 }
             } else {
-                loadn( point( gridx, gridy ), true );
+                loadn( { gridx, gridy }, true );
 
                 for( int gridz = zmin; gridz <= zmax; gridz++ ) {
                     loaded_grids.emplace_back( gridx, gridy, gridz );
@@ -8984,23 +8957,23 @@ void map::vertical_shift( const int newz )
 // 0,2 1,2 2,2
 // (worldx,worldy,worldz) denotes the absolute coordinate of the submap
 // in grid[0].
-void map::saven( const tripoint &grid )
+void map::saven( const tripoint_bub_sm &grid )
 {
     dbg( D_INFO ) << "map::saven(worldx[" << abs_sub.x() << "], worldy[" << abs_sub.y()
                   << "], worldz[" << abs_sub.z()
-                  << "], gridx[" << grid.x << "], gridy[" << grid.y << "], gridz[" << grid.z << "])";
-    const int gridn = get_nonant( tripoint_rel_sm( grid ) );
+                  << "], gridx[" << grid.x() << "], gridy[" << grid.y() << "], gridz[" << grid.z() << "])";
+    const int gridn = get_nonant( rebase_rel( grid ) );
     submap *submap_to_save = getsubmap( gridn );
     if( submap_to_save == nullptr ) {
         debugmsg( "Tried to save submap node (%d) but it's not loaded", gridn );
         return;
     }
 
-    const tripoint_abs_sm abs = abs_sub.xy() + grid;
+    const tripoint_abs_sm abs = abs_sub.xy() + rebase_rel( grid );
 
-    if( !zlevels && grid.z != abs_sub.z() ) {
+    if( !zlevels && grid.z() != abs_sub.z() ) {
         debugmsg( "Tried to save submap (%d,%d,%d) as (%d,%d,%d), which isn't supported in non-z-level builds",
-                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z );
+                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z() );
     }
 
     dbg( D_INFO ) << "map::saven abs: " << abs
@@ -9056,12 +9029,12 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
     return ret;
 }
 
-void map::loadn( const point &grid, bool update_vehicles )
+void map::loadn( const point_bub_sm &grid, bool update_vehicles )
 {
     dbg( D_INFO ) << "map::loadn(game[" << g.get() << "], worldx[" << abs_sub.x()
                   << "], worldy[" << abs_sub.y() << "], grid " << grid << ")";
 
-    const tripoint_abs_sm grid_abs_sub = abs_sub + grid;
+    const tripoint_abs_sm grid_abs_sub = abs_sub + rebase_rel( grid );
     const tripoint_abs_omt grid_abs_omt = project_to<coords::omt>( grid_abs_sub );
     // Get the base submap "grid" is an offset from.
     const tripoint_abs_sm grid_sm_base = project_to<coords::sm>( grid_abs_omt );
@@ -9115,12 +9088,12 @@ void map::loadn( const point &grid, bool update_vehicles )
         set_floor_cache_dirty( z );
         set_pathfinding_cache_dirty( z );
         tmpsub = MAPBUFFER.lookup_submap( pos );
-        setsubmap( get_nonant( tripoint_rel_sm{ grid.x, grid.y, z } ), tmpsub );
+        setsubmap( get_nonant( tripoint_rel_sm{ grid.x(), grid.y(), z} ), tmpsub );
         if( !tmpsub->active_items.empty() ) {
             submaps_with_active_items_dirty.emplace( pos );
         }
         if( tmpsub->field_count > 0 ) {
-            get_cache( z ).field_cache.set( grid.x + grid.y * MAPSIZE );
+            get_cache( z ).field_cache.set( grid.x() + grid.y() * MAPSIZE );
         }
 
         // Destroy bugged no-part vehicles
@@ -9129,7 +9102,8 @@ void map::loadn( const point &grid, bool update_vehicles )
             vehicle *veh = iter->get();
             if( veh->part_count() > 0 ) {
                 // Always fix submap coordinates for easier Z-level-related operations
-                veh->sm_pos = { grid, z };
+                veh->sm_pos = { grid.raw(), z};
+                iter++;
                 if( main_inbounds ) {
                     _main_requires_cleanup = true;
                 }
@@ -9145,7 +9119,7 @@ void map::loadn( const point &grid, bool update_vehicles )
                 }
 
                 if( zlevels ) {
-                    add_roofs( tripoint_rel_sm( grid.x, grid.y, z ) );
+                    add_roofs( tripoint_rel_sm( grid.x(), grid.y(), z ) );
                 }
 
                 ++iter;
@@ -9157,6 +9131,21 @@ void map::loadn( const point &grid, bool update_vehicles )
                 iter = veh_vec.erase( iter );
             }
         }
+
+        // Update vehicle data
+        if( update_vehicles ) {
+            level_cache &map_cache = get_cache( z );
+            for( const auto &veh : tmpsub->vehicles ) {
+                // Only add if not tracking already.
+                if( map_cache.vehicle_list.find( veh.get() ) == map_cache.vehicle_list.end() ) {
+                    map_cache.vehicle_list.insert( veh.get() );
+                    if( !veh->loot_zones.empty() ) {
+                        map_cache.zone_vehicles.insert( veh.get() );
+                    }
+                }
+            }
+        }
+
     }
 }
 
@@ -9204,14 +9193,15 @@ void map::handle_decayed_corpse( const item &it, const tripoint_abs_ms &pnt )
             }
             add_item_or_charges( bub_from_abs( pnt ), harvest, false );
             if( anything_left && notify_player ) {
-                add_msg_if_player_sees( getlocal( pnt ), _( "You notice a %1$s has rotted away, leaving a %2$s." ),
+                add_msg_if_player_sees( bub_from_abs( pnt ),
+                                        _( "You notice a %1$s has rotted away, leaving a %2$s." ),
                                         it.tname(), harvest.tname() );
             }
         }
     }
 }
 
-void map::rotten_item_spawn( const item &item, const tripoint &pnt )
+void map::rotten_item_spawn( const item &item, const tripoint_bub_ms &pnt )
 {
     if( get_creature_tracker().creature_at( pnt ) != nullptr ) {
         return;
@@ -9237,7 +9227,7 @@ void map::rotten_item_spawn( const item &item, const tripoint &pnt )
     }
 }
 
-void map::fill_funnels( const tripoint &p, const time_point &since )
+void map::fill_funnels( const tripoint_bub_ms &p, const time_point &since )
 {
     const trap &tr = tr_at( p );
     if( !tr.is_funnel() ) {
@@ -9260,7 +9250,7 @@ void map::fill_funnels( const tripoint &p, const time_point &since )
     }
 }
 
-void map::grow_plant( const tripoint &p )
+void map::grow_plant( const tripoint_bub_ms &p )
 {
     const furn_t &furn = this->furn( p ).obj();
     if( !furn.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
@@ -9319,7 +9309,7 @@ void map::grow_plant( const tripoint &p )
                 items.erase( fertilizer );
             }
             // spawn appropriate amount of rot_spawn, equivalent to number of times we iterate this loop
-            rotten_item_spawn( *seed, p );
+            rotten_item_spawn( *seed, tripoint_bub_ms( p ) );
             // Get an updated reference to the furniture each time we go through this loop, to make sure we transform each step in turn
             const furn_t &current_furn = this->furn( p ).obj();
             furn_set( p, furn_str_id( current_furn.plant->transform ) );
@@ -9328,7 +9318,7 @@ void map::grow_plant( const tripoint &p )
     }
 }
 
-void map::restock_fruits( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::restock_fruits( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     const ter_t &ter = this->ter( p ).obj();
     if( !ter.has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
@@ -9342,7 +9332,7 @@ void map::restock_fruits( const tripoint &p, const time_duration &time_since_las
     }
 }
 
-void map::produce_sap( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     if( time_since_last_actualize <= 0_turns ) {
         return;
@@ -9415,7 +9405,7 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
 
     item sap( "maple_sap", calendar::turn );
 
-    sap.set_item_temperature( get_weather().get_temperature( p ) );
+    sap.set_item_temperature( get_weather().get_temperature( p.raw() ) );
     sap.charges = new_charges;
 
     // Is there a proper container?
@@ -9460,7 +9450,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     ter_set( p, ter_t_stump );
 }
 
-void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize )
+void map::rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
 {
     const int rads = get_radiation( p );
     if( rads == 0 ) {
@@ -9506,7 +9496,7 @@ void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_ac
     }
 }
 
-void map::decay_cosmetic_fields( const tripoint &p,
+void map::decay_cosmetic_fields( const tripoint_bub_ms &p,
                                  const time_duration &time_since_last_actualize )
 {
     for( auto &pr : field_at( p ) ) {
@@ -9573,18 +9563,18 @@ void map::actualize( const tripoint_rel_sm &grid )
             }
 
             if( do_funnels ) {
-                fill_funnels( pnt.raw(), tmpsub->last_touched );
+                fill_funnels( pnt, tmpsub->last_touched );
             }
 
-            grow_plant( pnt.raw() );
+            grow_plant( pnt );
 
-            restock_fruits( pnt.raw(), time_since_last_actualize );
+            restock_fruits( pnt, time_since_last_actualize );
 
-            produce_sap( pnt.raw(), time_since_last_actualize );
+            produce_sap( pnt, time_since_last_actualize );
 
-            rad_scorch( pnt.raw(), time_since_last_actualize );
+            rad_scorch( pnt, time_since_last_actualize );
 
-            decay_cosmetic_fields( pnt.raw(), time_since_last_actualize );
+            decay_cosmetic_fields( pnt, time_since_last_actualize );
         }
     }
 
@@ -9949,23 +9939,23 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
 
 bool map::inbounds( const tripoint &p ) const
 {
-    return p.x >= 0 && p.x < my_MAPSIZE * SEEX &&
-           p.y >= 0 && p.y < my_MAPSIZE * SEEY &&
-           p.z >= -OVERMAP_DEPTH && p.z <= OVERMAP_HEIGHT;
-    // && ( zlevels || p.z == get_abs_sub().z() );
-    // Cannot actually let inbounds check the bounds for maps not supporting Z levels, as
-    // tests explicitly expect other Z level coordinates to return t_null when read
-    // and write terrain to the Z level of the map rather than fail or do nothing.
+    return inbounds( tripoint_bub_ms( p ) );
 }
 
 bool map::inbounds( const tripoint_abs_ms &p ) const
 {
-    return inbounds( getlocal( p ) );
+    return inbounds( bub_from_abs( p ) );
 }
 
 bool map::inbounds( const tripoint_bub_ms &p ) const
 {
-    return inbounds( p.raw() );
+    return p.x() >= 0 && p.x() < my_MAPSIZE * SEEX &&
+           p.y() >= 0 && p.y() < my_MAPSIZE * SEEY &&
+           p.z() >= -OVERMAP_DEPTH && p.z() <= OVERMAP_HEIGHT;
+    // && ( zlevels || p.z == get_abs_sub().z() );
+    // Cannot actually let inbounds check the bounds for maps not supporting Z levels, as
+    // tests explicitly expect other Z level coordinates to return t_null when read
+    // and write terrain to the Z level of the map rather than fail or do nothing.
 }
 
 bool map::inbounds( const tripoint_abs_omt &p ) const
@@ -10047,7 +10037,7 @@ fake_map::fake_map( const ter_id &ter_type )
             sm->set_all_furn( furn_str_id::NULL_ID() );
             sm->set_all_traps( tr_null );
 
-            setsubmap( get_nonant( { gridx, gridy, fake_map_z } ), sm.get() );
+            setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, fake_map_z } ), sm.get() );
 
             temp_submaps_.emplace_back( std::move( sm ) );
         }
@@ -10069,7 +10059,7 @@ small_fake_map::small_fake_map( const ter_id &ter_type )
                 sm->set_all_furn( furn_str_id::NULL_ID() );
                 sm->set_all_traps( tr_null );
 
-                setsubmap( get_nonant( { gridx, gridy, gridz } ), sm.get() );
+                setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, gridz } ), sm.get() );
 
                 temp_submaps_.emplace_back( std::move( sm ) );
             }
@@ -10157,10 +10147,10 @@ bool map::has_graffiti_at( const tripoint_bub_ms &p ) const
     return current_submap->has_graffiti( l );
 }
 
-int map::determine_wall_corner( const tripoint &p ) const
+int map::determine_wall_corner( const tripoint_bub_ms &p ) const
 {
     const std::bitset<NUM_TERCONN> &test_connect_group = ter( p ).obj().connect_to_groups;
-    uint8_t connections = get_known_connections( tripoint_bub_ms( p ), test_connect_group );
+    uint8_t connections = get_known_connections( p, test_connect_group );
     // The bits in connections are SEWN, whereas the characters in LINE_
     // constants are NESW, so we want values in 8 | 2 | 1 | 4 order.
     switch( connections ) {
@@ -10477,13 +10467,13 @@ void map::do_vehicle_caching( int z )
     }
     for( vehicle *v : ch->vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts_with_fakes() ) {
-            const tripoint part_pos = v->global_part_pos3( vp.part() );
+            const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
             if( !inbounds( part_pos.xy() ) ) {
                 continue;
             }
-            vehicle_caching_internal( get_cache( part_pos.z ), vp, v );
-            if( part_pos.z < OVERMAP_HEIGHT ) {
-                vehicle_caching_internal_above( get_cache( part_pos.z + 1 ), vp, v );
+            vehicle_caching_internal( get_cache( part_pos.z() ), vp, v );
+            if( part_pos.z() < OVERMAP_HEIGHT ) {
+                vehicle_caching_internal_above( get_cache( part_pos.z() + 1 ), vp, v );
             }
         }
     }
@@ -10571,17 +10561,6 @@ tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
     return project_to<coords::ms>( abs_sub.xy() ) + p.raw();
 }
 
-tripoint map::getlocal( const tripoint_abs_ms &p ) const
-{
-    return ( p - sm_to_ms_copy( abs_sub.xy().raw() ) ).raw();
-}
-
-tripoint_bub_ms map::bub_from_abs( const tripoint &p ) const
-{
-    // TODO: fix point types
-    return bub_from_abs( tripoint_abs_ms( p ) );
-}
-
 tripoint_bub_ms map::bub_from_abs( const tripoint_abs_ms &p ) const
 {
     return tripoint_bub_ms() + ( p - project_to<coords::ms>( abs_sub.xy() ) );
@@ -10618,6 +10597,18 @@ const submap *map::getsubmap( const size_t grididx ) const
     return getsubmap_helper( grid, grididx );
 }
 
+submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p )
+{
+    cata_assert( inbounds( p ) );
+    return get_submap_at_grid( tripoint_rel_sm{ p.x() / SEEX, p.y() / SEEY, p.z() } );
+}
+
+const submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p ) const
+{
+    cata_assert( inbounds( p ) );
+    return get_submap_at_grid( { p.x() / SEEX, p.y() / SEEY, p.z() } );
+}
+
 void map::setsubmap( const size_t grididx, submap *const smap )
 {
     if( grididx >= grid.size() ) {
@@ -10630,18 +10621,13 @@ void map::setsubmap( const size_t grididx, submap *const smap )
     grid[grididx] = smap;
 }
 
-submap *map::get_submap_at( const tripoint &p )
+submap *map::get_submap_at( const tripoint_bub_ms &p )
 {
     if( !inbounds( p ) ) {
         debugmsg( "Tried to access invalid map position %s", p.to_string() );
         return nullptr;
     }
     return unsafe_get_submap_at( p );
-}
-
-submap *map::get_submap_at( const tripoint_bub_ms &p )
-{
-    return map::get_submap_at( p.raw() );
 }
 
 const submap *map::get_submap_at( const tripoint_bub_ms &p ) const
@@ -10710,7 +10696,7 @@ void map::draw_fill_background( const ter_id &type )
     // Fill each submap rather than each tile
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            submap *sm = get_submap_at_grid( point{gridx, gridy} );
+            submap *sm = get_submap_at_grid( point_rel_sm{gridx, gridy} );
             if( sm == nullptr ) {
                 debugmsg( "Tried to fill background at (%d,%d) but the submap is not loaded", gridx, gridy );
                 continue;
@@ -10824,11 +10810,6 @@ void map::add_corpse( const tripoint_bub_ms &p )
     add_item_or_charges( p, body );
 }
 
-field &map::get_field( const tripoint &p )
-{
-    return field_at( tripoint_bub_ms( p ) );
-}
-
 field &map::get_field( const tripoint_bub_ms &p )
 {
     return field_at( p );
@@ -10938,42 +10919,46 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
 }
 
 template<typename Functor>
-void map::function_over( const tripoint &start, const tripoint &end, Functor fun ) const
+void map::function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                         Functor fun ) const
 {
     // start and end are just two points, end can be "before" start
     // Also clip the area to map area
-    const tripoint min( std::max( std::min( start.x, end.x ), 0 ), std::max( std::min( start.y, end.y ),
-                        0 ), std::max( std::min( start.z, end.z ), -OVERMAP_DEPTH ) );
-    const tripoint max( std::min( std::max( start.x, end.x ), SEEX * my_MAPSIZE - 1 ),
-                        std::min( std::max( start.y, end.y ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z, end.z ),
-                                OVERMAP_HEIGHT ) );
+    const tripoint_bub_ms min( std::max( std::min( start.x(), end.x() ), 0 ),
+                               std::max( std::min( start.y(), end.y() ),
+                                         0 ), std::max( std::min( start.z(), end.z() ), -OVERMAP_DEPTH ) );
+    const tripoint_bub_ms max( std::min( std::max( start.x(), end.x() ), SEEX * my_MAPSIZE - 1 ),
+                               std::min( std::max( start.y(), end.y() ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z(),
+                                       end.z() ),
+                                       OVERMAP_HEIGHT ) );
 
     // Submaps that contain the bounding points
-    const point min_sm( min.x / SEEX, min.y / SEEY );
-    const point max_sm( max.x / SEEX, max.y / SEEY );
+    const point_bub_sm min_sm( min.x() / SEEX, min.y() / SEEY );
+    const point_bub_sm max_sm( max.x() / SEEX, max.y() / SEEY );
     // Z outermost, because submaps are flat
-    tripoint gp;
-    int &z = gp.z;
-    int &smx = gp.x;
-    int &smy = gp.y;
-    for( z = min.z; z <= max.z; z++ ) {
-        for( smx = min_sm.x; smx <= max_sm.x; smx++ ) {
-            for( smy = min_sm.y; smy <= max_sm.y; smy++ ) {
+    tripoint_rel_sm gp;
+    int &z = gp.z();
+    int &smx = gp.x();
+    int &smy = gp.y();
+    for( z = min.z(); z <= max.z(); z++ ) {
+        for( smx = min_sm.x(); smx <= max_sm.x(); smx++ ) {
+            for( smy = min_sm.y(); smy <= max_sm.y(); smy++ ) {
                 submap const *cur_submap = get_submap_at_grid( { smx, smy, z } );
                 if( cur_submap == nullptr ) {
                     debugmsg( "Tried to function over (%d,%d,%d) but the submap is not loaded", smx, smy, z );
                     continue;
                 }
                 // Bounds on the submap coordinates
-                const point sm_min( smx > min_sm.x ? 0 : min.x % SEEX, smy > min_sm.y ? 0 : min.y % SEEY );
-                const point sm_max( smx < max_sm.x ? SEEX - 1 : max.x % SEEX,
-                                    smy < max_sm.y ? SEEY - 1 : max.y % SEEY );
+                const point_bub_sm sm_min( smx > min_sm.x() ? 0 : min.x() % SEEX,
+                                           smy > min_sm.y() ? 0 : min.y() % SEEY );
+                const point_bub_sm sm_max( smx < max_sm.x() ? SEEX - 1 : max.x() % SEEX,
+                                           smy < max_sm.y() ? SEEY - 1 : max.y() % SEEY );
 
                 point_sm_ms lp;
                 int &sx = lp.x();
                 int &sy = lp.y();
-                for( sx = sm_min.x; sx <= sm_max.x; ++sx ) {
-                    for( sy = sm_min.y; sy <= sm_max.y; ++sy ) {
+                for( sx = sm_min.x(); sx <= sm_max.x(); ++sx ) {
+                    for( sy = sm_min.y(); sy <= sm_max.y(); ++sy ) {
                         const iteration_state rval = fun( gp, cur_submap, lp );
                         if( rval != ITER_CONTINUE ) {
                             switch( rval ) {
@@ -10998,13 +10983,13 @@ void map::function_over( const tripoint &start, const tripoint &end, Functor fun
 
 void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
                           std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                          const point &min, const point &max )
+                          const point_bub_ms &min, const point_bub_ms &max )
 {
     ter_furn_flag reduce = ter_furn_flag::TFLAG_REDUCE_SCENT;
     ter_furn_flag block = ter_furn_flag::TFLAG_NO_SCENT;
-    auto fill_values = [&]( const tripoint & gp, const submap * sm, const point_sm_ms & lp ) {
+    auto fill_values = [&]( const tripoint_rel_sm & gp, const submap * sm, const point_sm_ms & lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
-        const point_sm_ms p = lp + sm_to_ms_copy( gp.xy() );
+        const point_sm_ms p = lp + coords::project_to<coords::ms>( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {
             blocks_scent[p.x()][p.y()] = true;
             reduces_scent[p.x()][p.y()] = false;
@@ -11020,9 +11005,10 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         return ITER_CONTINUE;
     };
 
-    function_over( tripoint( min, abs_sub.z() ), tripoint( max, abs_sub.z() ), fill_values );
+    function_over( tripoint_bub_ms( min, abs_sub.z() ), tripoint_bub_ms( max, abs_sub.z() ),
+                   fill_values );
 
-    const inclusive_rectangle<point> local_bounds( min, max );
+    const inclusive_rectangle<point_bub_ms> local_bounds( min, max );
 
     // Now vehicles
 
@@ -11034,9 +11020,9 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
                 ( !vp.has_feature( VPFLAG_OPENABLE ) || !vp.part().open ) ) {
                 continue;
             }
-            const tripoint part_pos = vp.pos();
+            const tripoint_bub_ms part_pos = vp.pos_bub();
             if( local_bounds.contains( part_pos.xy() ) ) {
-                reduces_scent[part_pos.x][part_pos.y] = true;
+                reduces_scent[part_pos.x()][part_pos.y()] = true;
             }
         }
     }
@@ -11258,7 +11244,7 @@ void map::set_pathfinding_cache_dirty( const int zlev )
 void map::set_pathfinding_cache_dirty( const tripoint_bub_ms &p )
 {
     if( inbounds( p ) ) {
-        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy().raw() );
+        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy() );
     }
 }
 
@@ -11293,12 +11279,12 @@ const pathfinding_cache &map::get_pathfinding_cache_ref( int zlev ) const
     return cache;
 }
 
-void map::update_pathfinding_cache( const tripoint &p ) const
+void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
 {
     if( !inbounds( p ) ) {
         return;
     }
-    pathfinding_cache &cache = get_pathfinding_cache( p.z );
+    pathfinding_cache &cache = get_pathfinding_cache( p.z() );
     PathfindingFlags cur_value = PathfindingFlag::Ground;
 
     const_maptile tile = maptile_at_internal( p );
@@ -11358,7 +11344,7 @@ void map::update_pathfinding_cache( const tripoint &p ) const
         cur_value |= PathfindingFlag::Sharp;
     }
 
-    cache.special[p.x][p.y] = cur_value;
+    cache.special[p.x()][p.y()] = cur_value;
 }
 
 void map::update_pathfinding_cache( int zlev ) const
@@ -11374,7 +11360,7 @@ void map::update_pathfinding_cache( int zlev ) const
         }
         cache.dirty = false;
     } else {
-        for( const point &p : cache.dirty_points ) {
+        for( const point_bub_ms &p : cache.dirty_points ) {
             update_pathfinding_cache( { p, zlev } );
         }
     }
@@ -11462,7 +11448,7 @@ int map::calc_max_populated_zlev()
         bool level_done = false;
         for( int sx = 0; sx < my_MAPSIZE; sx++ ) {
             for( int sy = 0; sy < my_MAPSIZE; sy++ ) {
-                const submap *sm = get_submap_at_grid( { sx, sy, sz } );
+                const submap *sm = get_submap_at_grid( tripoint_rel_sm{ sx, sy, sz } );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to calc max populated zlev at (%d,%d,%d) but the submap is not loaded", sx, sy,
                               sz );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -514,11 +514,11 @@ void map::add_vehicle_to_cache( vehicle *veh )
         if( vpr.part().removed ) {
             continue;
         }
-        const tripoint_bub_ms p = veh->bub_part_pos( vpr.part() );
-        level_cache &ch = get_cache( p.z() );
-        ch.set_veh_cached_parts( p.raw(), *veh, static_cast<int>( vpr.part_index() ) );
+        const tripoint p = veh->global_part_pos3( vpr.part() );
+        level_cache &ch = get_cache( p.z );
+        ch.set_veh_cached_parts( p, *veh, static_cast<int>( vpr.part_index() ) );
         if( inbounds( p ) ) {
-            ch.set_veh_exists_at( p.raw(), true );
+            ch.set_veh_exists_at( p, true );
         }
     }
 }
@@ -1275,7 +1275,7 @@ void map::register_vehicle_zone( vehicle *veh, const int zlev )
 
 bool map::deregister_vehicle_zone( zone_data &zone ) const
 {
-    const tripoint_bub_ms pos = bub_from_abs( zone.get_start_point() );
+    const tripoint pos = getlocal( zone.get_start_point() );
     if( const std::optional<vpart_reference> vp = veh_at( pos ).cargo() ) {
         vehicle &veh = vp->vehicle();
         auto bounds = veh.loot_zones.equal_range( vp->mount() );
@@ -1344,7 +1344,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
     for( int cx = chunk_sx; cx <= chunk_ex; ++cx ) {
         for( int cy = chunk_sy; cy <= chunk_ey; ++cy ) {
             for( int cz = chunk_sz; cz <= chunk_ez; ++cz ) {
-                submap *current_submap = get_submap_at_grid( tripoint_rel_sm{ cx, cy, cz } );
+                submap *current_submap = get_submap_at_grid( { cx, cy, cz } );
                 if( current_submap == nullptr ) {
                     debugmsg( "Tried to process vehicle at (%d,%d,%d) but the submap is not loaded", cx, cy, cz );
                     continue;
@@ -1366,7 +1366,7 @@ VehicleList map::get_vehicles( const tripoint_bub_ms &start, const tripoint_bub_
 
 optional_vpart_position map::veh_at( const tripoint_abs_ms &p ) const
 {
-    return veh_at( bub_from_abs( p ) );
+    return veh_at( getlocal( p ) );
 }
 
 optional_vpart_position map::veh_at( const tripoint &p ) const
@@ -3833,7 +3833,7 @@ void map::decay_fields_and_scent( const time_duration &amount )
     const auto &outside_cache = get_cache_ref( smz ).outside_cache;
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {
         for( int smy = 0; smy < my_MAPSIZE; ++smy ) {
-            submap *cur_submap = get_submap_at_grid( tripoint_rel_sm{ smx, smy, smz } );
+            submap *cur_submap = get_submap_at_grid( { smx, smy, smz } );
             if( cur_submap == nullptr ) {
                 debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", smx, smy, smz );
                 continue;
@@ -4378,6 +4378,11 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
     }
 }
 
+ter_str_id map::get_roof( const tripoint &p, const bool allow_air ) const
+{
+    return map::get_roof( tripoint_bub_ms( p ), allow_air );
+}
+
 ter_str_id map::get_roof( const tripoint_bub_ms &p, const bool allow_air ) const
 {
     // This function should not be called from the 2D mode
@@ -4430,6 +4435,11 @@ static bool furn_is_supported( const map &m, const tripoint_bub_ms &p )
     }
 
     return false;
+}
+
+void map::bash_ter_furn( const tripoint &p, bash_params &params )
+{
+    map::bash_ter_furn( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
@@ -4761,6 +4771,11 @@ bash_params map::bash( const tripoint_bub_ms &p, const int str,
     return bsh;
 }
 
+void map::bash_items( const tripoint &p, bash_params &params )
+{
+    map::bash_items( tripoint_bub_ms( p ), params );
+}
+
 void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
 {
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
@@ -4795,6 +4810,11 @@ void map::bash_items( const tripoint_bub_ms &p, bash_params &params )
     }
 }
 
+void map::bash_vehicle( const tripoint &p, bash_params &params )
+{
+    map::bash_vehicle( tripoint_bub_ms( p ), params );
+}
+
 void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
 {
     // Smash vehicle if present
@@ -4809,6 +4829,11 @@ void map::bash_vehicle( const tripoint_bub_ms &p, bash_params &params )
         params.success = true;
         params.bashed_solid = true;
     }
+}
+
+void map::bash_field( const tripoint &p, bash_params &params )
+{
+    map::bash_field( tripoint_bub_ms( p ), params );
 }
 
 void map::bash_field( const tripoint_bub_ms &p, bash_params &params )
@@ -7580,7 +7605,7 @@ static std::optional<char32_t> get_memory_at( const tripoint &p )
     return std::nullopt;
 }
 
-void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
+void map::draw( const catacurses::window &w, const tripoint &center )
 {
     // We only need to draw anything if we're not in tiles mode.
     if( is_draw_tiles_mode() ) {
@@ -7589,30 +7614,31 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
 
     g->reset_light_level();
 
-    update_visibility_cache( center.z() );
+    update_visibility_cache( center.z );
     const visibility_variables &cache = get_visibility_variables_cache();
 
-    const auto &visibility_cache = get_cache_ref( center.z() ).visibility_cache;
+    const auto &visibility_cache = get_cache_ref( center.z ).visibility_cache;
 
     int wnd_h = getmaxy( w );
     int wnd_w = getmaxx( w );
-    const tripoint_bub_ms offs = center - tripoint_rel_ms( wnd_w / 2, wnd_h / 2, 0 );
+    const tripoint offs = center - tripoint( wnd_w / 2, wnd_h / 2, 0 );
 
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the terminal
     // since displayed area may be bigger than view range.
-    const point_bub_ms min_mm_reg{
-        std::min( 0, offs.x() ),
-        std::min( 0, offs.y() )
-    };
-    const point_bub_ms max_mm_reg{
-        std::max( MAPSIZE_X, offs.x() + wnd_w ),
-        std::max( MAPSIZE_Y, offs.y() + wnd_h )
-    };
+    const point min_mm_reg = point(
+                                 std::min( 0, offs.x ),
+                                 std::min( 0, offs.y )
+                             );
+    const point max_mm_reg = point(
+                                 std::max( MAPSIZE_X, offs.x + wnd_w ),
+                                 std::max( MAPSIZE_Y, offs.y + wnd_h )
+                             );
     avatar &player_character = get_avatar();
     player_character.prepare_map_memory_region(
-        getglobal( { min_mm_reg, center.z() } ),
-        getglobal( { max_mm_reg, center.z() } ) );
+        getglobal( tripoint( min_mm_reg, center.z ) ),
+        getglobal( tripoint( max_mm_reg, center.z ) )
+    );
 
     const auto draw_background = [&]( const tripoint & p ) {
         int sym = ' ';
@@ -7650,13 +7676,13 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
     for( int wy = 0; wy < wnd_h; wy++ ) {
         for( int wx = 0; wx < wnd_w; wx++ ) {
             wmove( w, point( wx, wy ) );
-            const tripoint_bub_ms p = offs + tripoint_rel_ms( wx, wy, 0 );
+            const tripoint p = offs + tripoint( wx, wy, 0 );
             if( !inbounds( p ) ) {
-                draw_background( p.raw() );
+                draw_background( p );
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x()][p.y()];
+            const lit_level lighting = visibility_cache[p.x][p.y];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( draw_vision_effect( vis ) ) {
@@ -7664,7 +7690,7 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
             }
 
             if( vis == visibility_type::HIDDEN || vis == visibility_type::DARK ) {
-                draw_background( p.raw() );
+                draw_background( p );
                 continue;
             }
 
@@ -7676,22 +7702,22 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
                 continue;
             }
             const maptile tile_below = maptile_at_internal( p + tripoint_below );
-            draw_from_above( w, p + tripoint_below, tile_below, params );
+            draw_from_above( w, tripoint( p.xy(), p.z - 1 ), tile_below, params );
         }
     }
 
     // Memorize off-screen tiles
-    half_open_rectangle<point_bub_ms> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
+    half_open_rectangle<point> display( offs.xy(), offs.xy() + point( wnd_w, wnd_h ) );
     drawsq_params mm_params = drawsq_params().memorize( true ).output( false );
     for( int y = 0; y < MAPSIZE_Y; y++ ) {
         for( int x = 0; x < MAPSIZE_X; x++ ) {
-            const tripoint_bub_ms p( x, y, center.z() );
+            const tripoint p( x, y, center.z );
             if( display.contains( p.xy() ) ) {
                 // Have been memorized during display loop
                 continue;
             }
 
-            const lit_level lighting = visibility_cache[p.x()][p.y()];
+            const lit_level lighting = visibility_cache[p.x][p.y];
             const visibility_type vis = get_visibility( lighting, cache );
 
             if( vis != visibility_type::CLEAR ) {
@@ -7711,12 +7737,6 @@ void map::draw( const catacurses::window &w, const tripoint_bub_ms &center )
 void map::drawsq( const catacurses::window &w, const tripoint &p,
                   const drawsq_params &params ) const
 {
-    map::drawsq( w, tripoint_bub_ms( p ), params );
-}
-
-void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
-                  const drawsq_params &params ) const
-{
     // If we are in tiles mode, the only thing we want to potentially draw is a highlight
     if( is_draw_tiles_mode() ) {
         if( params.highlight() ) {
@@ -7730,8 +7750,8 @@ void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
     }
 
     const tripoint_bub_ms view_center = params.center();
-    const int k = p.x() + getmaxx( w ) / 2 - view_center.x();
-    const int j = p.y() + getmaxy( w ) / 2 - view_center.y();
+    const int k = p.x + getmaxx( w ) / 2 - view_center.x();
+    const int j = p.y + getmaxy( w ) / 2 - view_center.y();
     if( k < 0 || k >= getmaxx( w ) || j < 0 || j >= getmaxy( w ) ) {
         return;
     }
@@ -7742,9 +7762,15 @@ void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
         return;
     }
 
-    tripoint_bub_ms below( p + tripoint_below );
+    tripoint below( p.xy(), p.z - 1 );
     const const_maptile tile_below = maptile_at( below );
     draw_from_above( w, below, tile_below, params );
+}
+
+void map::drawsq( const catacurses::window &w, const tripoint_bub_ms &p,
+                  const drawsq_params &params ) const
+{
+    map::drawsq( w, p.raw(), params );
 }
 
 // a check to see if the lower floor needs to be rendered in tiles
@@ -7759,7 +7785,7 @@ bool map::dont_draw_lower_floor( const tripoint &p ) const
     }
 }
 
-bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
+bool map::draw_maptile( const catacurses::window &w, const tripoint &p,
                         const const_maptile &curr_maptile, const drawsq_params &params ) const
 {
     drawsq_params param = params;
@@ -7789,7 +7815,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
         sym = curr_furn.symbol();
         tercol = curr_furn.color();
         if( !( player_character.get_grab_type() == object_type::FURNITURE
-               && p == player_character.pos_bub() + player_character.grab_point ) ) {
+               && tripoint_bub_ms( p ) == player_character.pos_bub() + player_character.grab_point ) ) {
             memory_sym = sym;
         }
     }
@@ -7823,7 +7849,8 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
             memory_sym = sym = curr_trap.sym;
         }
     }
-    if( const_cast<map *>( this )->partial_con_at( p ) != nullptr ) {
+    // FIXME: fix point type
+    if( const_cast<map *>( this )->partial_con_at( tripoint_bub_ms( p ) ) != nullptr ) {
         tercol = tr_unfinished_construction->color;
         memory_sym = sym = tr_unfinished_construction->sym;
     }
@@ -7944,7 +7971,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
     }
 
     if( item_sym.empty() && sym == ' ' ) {
-        if( !zlevels || p.z() <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
+        if( !zlevels || p.z <= -OVERMAP_DEPTH || !curr_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ) {
             // Print filler symbol
             tercol = c_black;
         } else {
@@ -7963,7 +7990,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
     return true;
 }
 
-void map::draw_from_above( const catacurses::window &w, const tripoint_bub_ms &p,
+void map::draw_from_above( const catacurses::window &w, const tripoint &p,
                            const const_maptile &curr_tile, const drawsq_params &params ) const
 {
     static const int AUTO_WALL_PLACEHOLDER = 2; // this should never appear as a real symbol!
@@ -8696,10 +8723,10 @@ void map::save()
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
             if( zlevels ) {
                 for( int gridz = -OVERMAP_DEPTH; gridz <= OVERMAP_HEIGHT; gridz++ ) {
-                    saven( { gridx, gridy, gridz } );
+                    saven( tripoint( gridx, gridy, gridz ) );
                 }
             } else {
-                saven( { gridx, gridy, abs_sub.z() } );
+                saven( tripoint( gridx, gridy, abs_sub.z() ) );
             }
         }
     }
@@ -8727,7 +8754,7 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     clear_vehicle_level_caches();
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            loadn( { gridx, gridy }, update_vehicle );
+            loadn( point( gridx, gridy ), update_vehicle );
             if( pump_events ) {
                 inp_mngr.pump_events();
             }
@@ -8753,10 +8780,10 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
     }
 }
 
-void map::shift_traps( const point_rel_sm &shift )
+void map::shift_traps( const tripoint &shift )
 {
     // Offset needs to have sign opposite to shift direction
-    const tripoint_rel_ms offset( -shift.x() * SEEX, -shift.y() * SEEY, 0 );
+    const tripoint_rel_ms offset( -shift.x * SEEX, -shift.y * SEEY, -shift.z );
     for( auto iter = field_furn_locs.begin(); iter != field_furn_locs.end(); ) {
         tripoint_bub_ms &pos = *iter;
         pos += offset;
@@ -8846,7 +8873,7 @@ void map::shift( const point_rel_sm &sp )
 
     g->shift_destination_preview( point( -sp.x() * SEEX, -sp.y() * SEEY ) );
 
-    shift_traps( sp );
+    shift_traps( tripoint( sp.raw(), 0 ) );
 
     vehicle *remoteveh = g->remoteveh();
 
@@ -8903,7 +8930,7 @@ void map::shift( const point_rel_sm &sp )
                     update_vehicle_list( cur_submap, gridz );
                 }
             } else {
-                loadn( { gridx, gridy }, true );
+                loadn( point( gridx, gridy ), true );
 
                 for( int gridz = zmin; gridz <= zmax; gridz++ ) {
                     loaded_grids.emplace_back( gridx, gridy, gridz );
@@ -8957,23 +8984,23 @@ void map::vertical_shift( const int newz )
 // 0,2 1,2 2,2
 // (worldx,worldy,worldz) denotes the absolute coordinate of the submap
 // in grid[0].
-void map::saven( const tripoint_bub_sm &grid )
+void map::saven( const tripoint &grid )
 {
     dbg( D_INFO ) << "map::saven(worldx[" << abs_sub.x() << "], worldy[" << abs_sub.y()
                   << "], worldz[" << abs_sub.z()
-                  << "], gridx[" << grid.x() << "], gridy[" << grid.y() << "], gridz[" << grid.z() << "])";
-    const int gridn = get_nonant( rebase_rel( grid ) );
+                  << "], gridx[" << grid.x << "], gridy[" << grid.y << "], gridz[" << grid.z << "])";
+    const int gridn = get_nonant( tripoint_rel_sm( grid ) );
     submap *submap_to_save = getsubmap( gridn );
     if( submap_to_save == nullptr ) {
         debugmsg( "Tried to save submap node (%d) but it's not loaded", gridn );
         return;
     }
 
-    const tripoint_abs_sm abs = abs_sub.xy() + rebase_rel( grid );
+    const tripoint_abs_sm abs = abs_sub.xy() + grid;
 
-    if( !zlevels && grid.z() != abs_sub.z() ) {
+    if( !zlevels && grid.z != abs_sub.z() ) {
         debugmsg( "Tried to save submap (%d,%d,%d) as (%d,%d,%d), which isn't supported in non-z-level builds",
-                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z() );
+                  abs.x(), abs.y(), abs_sub.z(), abs.x(), abs.y(), grid.z );
     }
 
     dbg( D_INFO ) << "map::saven abs: " << abs
@@ -9029,12 +9056,12 @@ bool generate_uniform_omt( const tripoint_abs_sm &p, const oter_id &terrain_type
     return ret;
 }
 
-void map::loadn( const point_bub_sm &grid, bool update_vehicles )
+void map::loadn( const point &grid, bool update_vehicles )
 {
     dbg( D_INFO ) << "map::loadn(game[" << g.get() << "], worldx[" << abs_sub.x()
                   << "], worldy[" << abs_sub.y() << "], grid " << grid << ")";
 
-    const tripoint_abs_sm grid_abs_sub = abs_sub + rebase_rel( grid );
+    const tripoint_abs_sm grid_abs_sub = abs_sub + grid;
     const tripoint_abs_omt grid_abs_omt = project_to<coords::omt>( grid_abs_sub );
     // Get the base submap "grid" is an offset from.
     const tripoint_abs_sm grid_sm_base = project_to<coords::sm>( grid_abs_omt );
@@ -9088,12 +9115,12 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
         set_floor_cache_dirty( z );
         set_pathfinding_cache_dirty( z );
         tmpsub = MAPBUFFER.lookup_submap( pos );
-        setsubmap( get_nonant( tripoint_rel_sm{ grid.x(), grid.y(), z} ), tmpsub );
+        setsubmap( get_nonant( tripoint_rel_sm{ grid.x, grid.y, z } ), tmpsub );
         if( !tmpsub->active_items.empty() ) {
             submaps_with_active_items_dirty.emplace( pos );
         }
         if( tmpsub->field_count > 0 ) {
-            get_cache( z ).field_cache.set( grid.x() + grid.y() * MAPSIZE );
+            get_cache( z ).field_cache.set( grid.x + grid.y * MAPSIZE );
         }
 
         // Destroy bugged no-part vehicles
@@ -9102,8 +9129,7 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
             vehicle *veh = iter->get();
             if( veh->part_count() > 0 ) {
                 // Always fix submap coordinates for easier Z-level-related operations
-                veh->sm_pos = { grid.raw(), z};
-                iter++;
+                veh->sm_pos = { grid, z };
                 if( main_inbounds ) {
                     _main_requires_cleanup = true;
                 }
@@ -9119,7 +9145,7 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
                 }
 
                 if( zlevels ) {
-                    add_roofs( tripoint_rel_sm( grid.x(), grid.y(), z ) );
+                    add_roofs( tripoint_rel_sm( grid.x, grid.y, z ) );
                 }
 
                 ++iter;
@@ -9131,21 +9157,6 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
                 iter = veh_vec.erase( iter );
             }
         }
-
-        // Update vehicle data
-        if( update_vehicles ) {
-            level_cache &map_cache = get_cache( z );
-            for( const auto &veh : tmpsub->vehicles ) {
-                // Only add if not tracking already.
-                if( map_cache.vehicle_list.find( veh.get() ) == map_cache.vehicle_list.end() ) {
-                    map_cache.vehicle_list.insert( veh.get() );
-                    if( !veh->loot_zones.empty() ) {
-                        map_cache.zone_vehicles.insert( veh.get() );
-                    }
-                }
-            }
-        }
-
     }
 }
 
@@ -9193,15 +9204,14 @@ void map::handle_decayed_corpse( const item &it, const tripoint_abs_ms &pnt )
             }
             add_item_or_charges( bub_from_abs( pnt ), harvest, false );
             if( anything_left && notify_player ) {
-                add_msg_if_player_sees( bub_from_abs( pnt ),
-                                        _( "You notice a %1$s has rotted away, leaving a %2$s." ),
+                add_msg_if_player_sees( getlocal( pnt ), _( "You notice a %1$s has rotted away, leaving a %2$s." ),
                                         it.tname(), harvest.tname() );
             }
         }
     }
 }
 
-void map::rotten_item_spawn( const item &item, const tripoint_bub_ms &pnt )
+void map::rotten_item_spawn( const item &item, const tripoint &pnt )
 {
     if( get_creature_tracker().creature_at( pnt ) != nullptr ) {
         return;
@@ -9227,7 +9237,7 @@ void map::rotten_item_spawn( const item &item, const tripoint_bub_ms &pnt )
     }
 }
 
-void map::fill_funnels( const tripoint_bub_ms &p, const time_point &since )
+void map::fill_funnels( const tripoint &p, const time_point &since )
 {
     const trap &tr = tr_at( p );
     if( !tr.is_funnel() ) {
@@ -9250,7 +9260,7 @@ void map::fill_funnels( const tripoint_bub_ms &p, const time_point &since )
     }
 }
 
-void map::grow_plant( const tripoint_bub_ms &p )
+void map::grow_plant( const tripoint &p )
 {
     const furn_t &furn = this->furn( p ).obj();
     if( !furn.has_flag( ter_furn_flag::TFLAG_PLANT ) ) {
@@ -9309,7 +9319,7 @@ void map::grow_plant( const tripoint_bub_ms &p )
                 items.erase( fertilizer );
             }
             // spawn appropriate amount of rot_spawn, equivalent to number of times we iterate this loop
-            rotten_item_spawn( *seed, tripoint_bub_ms( p ) );
+            rotten_item_spawn( *seed, p );
             // Get an updated reference to the furniture each time we go through this loop, to make sure we transform each step in turn
             const furn_t &current_furn = this->furn( p ).obj();
             furn_set( p, furn_str_id( current_furn.plant->transform ) );
@@ -9318,7 +9328,7 @@ void map::grow_plant( const tripoint_bub_ms &p )
     }
 }
 
-void map::restock_fruits( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
+void map::restock_fruits( const tripoint &p, const time_duration &time_since_last_actualize )
 {
     const ter_t &ter = this->ter( p ).obj();
     if( !ter.has_flag( ter_furn_flag::TFLAG_HARVESTED ) ) {
@@ -9332,7 +9342,7 @@ void map::restock_fruits( const tripoint_bub_ms &p, const time_duration &time_si
     }
 }
 
-void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
+void map::produce_sap( const tripoint &p, const time_duration &time_since_last_actualize )
 {
     if( time_since_last_actualize <= 0_turns ) {
         return;
@@ -9405,7 +9415,7 @@ void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since
 
     item sap( "maple_sap", calendar::turn );
 
-    sap.set_item_temperature( get_weather().get_temperature( p.raw() ) );
+    sap.set_item_temperature( get_weather().get_temperature( p ) );
     sap.charges = new_charges;
 
     // Is there a proper container?
@@ -9450,7 +9460,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     ter_set( p, ter_t_stump );
 }
 
-void map::rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize )
+void map::rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize )
 {
     const int rads = get_radiation( p );
     if( rads == 0 ) {
@@ -9496,7 +9506,7 @@ void map::rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_
     }
 }
 
-void map::decay_cosmetic_fields( const tripoint_bub_ms &p,
+void map::decay_cosmetic_fields( const tripoint &p,
                                  const time_duration &time_since_last_actualize )
 {
     for( auto &pr : field_at( p ) ) {
@@ -9563,18 +9573,18 @@ void map::actualize( const tripoint_rel_sm &grid )
             }
 
             if( do_funnels ) {
-                fill_funnels( pnt, tmpsub->last_touched );
+                fill_funnels( pnt.raw(), tmpsub->last_touched );
             }
 
-            grow_plant( pnt );
+            grow_plant( pnt.raw() );
 
-            restock_fruits( pnt, time_since_last_actualize );
+            restock_fruits( pnt.raw(), time_since_last_actualize );
 
-            produce_sap( pnt, time_since_last_actualize );
+            produce_sap( pnt.raw(), time_since_last_actualize );
 
-            rad_scorch( pnt, time_since_last_actualize );
+            rad_scorch( pnt.raw(), time_since_last_actualize );
 
-            decay_cosmetic_fields( pnt, time_since_last_actualize );
+            decay_cosmetic_fields( pnt.raw(), time_since_last_actualize );
         }
     }
 
@@ -9939,23 +9949,23 @@ const std::vector<tripoint_bub_ms> &map::trap_locations( const trap_id &type ) c
 
 bool map::inbounds( const tripoint &p ) const
 {
-    return inbounds( tripoint_bub_ms( p ) );
-}
-
-bool map::inbounds( const tripoint_abs_ms &p ) const
-{
-    return inbounds( bub_from_abs( p ) );
-}
-
-bool map::inbounds( const tripoint_bub_ms &p ) const
-{
-    return p.x() >= 0 && p.x() < my_MAPSIZE * SEEX &&
-           p.y() >= 0 && p.y() < my_MAPSIZE * SEEY &&
-           p.z() >= -OVERMAP_DEPTH && p.z() <= OVERMAP_HEIGHT;
+    return p.x >= 0 && p.x < my_MAPSIZE * SEEX &&
+           p.y >= 0 && p.y < my_MAPSIZE * SEEY &&
+           p.z >= -OVERMAP_DEPTH && p.z <= OVERMAP_HEIGHT;
     // && ( zlevels || p.z == get_abs_sub().z() );
     // Cannot actually let inbounds check the bounds for maps not supporting Z levels, as
     // tests explicitly expect other Z level coordinates to return t_null when read
     // and write terrain to the Z level of the map rather than fail or do nothing.
+}
+
+bool map::inbounds( const tripoint_abs_ms &p ) const
+{
+    return inbounds( getlocal( p ) );
+}
+
+bool map::inbounds( const tripoint_bub_ms &p ) const
+{
+    return inbounds( p.raw() );
 }
 
 bool map::inbounds( const tripoint_abs_omt &p ) const
@@ -10037,7 +10047,7 @@ fake_map::fake_map( const ter_id &ter_type )
             sm->set_all_furn( furn_str_id::NULL_ID() );
             sm->set_all_traps( tr_null );
 
-            setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, fake_map_z } ), sm.get() );
+            setsubmap( get_nonant( { gridx, gridy, fake_map_z } ), sm.get() );
 
             temp_submaps_.emplace_back( std::move( sm ) );
         }
@@ -10059,7 +10069,7 @@ small_fake_map::small_fake_map( const ter_id &ter_type )
                 sm->set_all_furn( furn_str_id::NULL_ID() );
                 sm->set_all_traps( tr_null );
 
-                setsubmap( get_nonant( tripoint_rel_sm{ gridx, gridy, gridz } ), sm.get() );
+                setsubmap( get_nonant( { gridx, gridy, gridz } ), sm.get() );
 
                 temp_submaps_.emplace_back( std::move( sm ) );
             }
@@ -10147,10 +10157,10 @@ bool map::has_graffiti_at( const tripoint_bub_ms &p ) const
     return current_submap->has_graffiti( l );
 }
 
-int map::determine_wall_corner( const tripoint_bub_ms &p ) const
+int map::determine_wall_corner( const tripoint &p ) const
 {
     const std::bitset<NUM_TERCONN> &test_connect_group = ter( p ).obj().connect_to_groups;
-    uint8_t connections = get_known_connections( p, test_connect_group );
+    uint8_t connections = get_known_connections( tripoint_bub_ms( p ), test_connect_group );
     // The bits in connections are SEWN, whereas the characters in LINE_
     // constants are NESW, so we want values in 8 | 2 | 1 | 4 order.
     switch( connections ) {
@@ -10467,13 +10477,13 @@ void map::do_vehicle_caching( int z )
     }
     for( vehicle *v : ch->vehicle_list ) {
         for( const vpart_reference &vp : v->get_all_parts_with_fakes() ) {
-            const tripoint_bub_ms part_pos = v->bub_part_pos( vp.part() );
+            const tripoint part_pos = v->global_part_pos3( vp.part() );
             if( !inbounds( part_pos.xy() ) ) {
                 continue;
             }
-            vehicle_caching_internal( get_cache( part_pos.z() ), vp, v );
-            if( part_pos.z() < OVERMAP_HEIGHT ) {
-                vehicle_caching_internal_above( get_cache( part_pos.z() + 1 ), vp, v );
+            vehicle_caching_internal( get_cache( part_pos.z ), vp, v );
+            if( part_pos.z < OVERMAP_HEIGHT ) {
+                vehicle_caching_internal_above( get_cache( part_pos.z + 1 ), vp, v );
             }
         }
     }
@@ -10561,6 +10571,17 @@ tripoint_abs_ms map::getglobal( const tripoint_bub_ms &p ) const
     return project_to<coords::ms>( abs_sub.xy() ) + p.raw();
 }
 
+tripoint map::getlocal( const tripoint_abs_ms &p ) const
+{
+    return ( p - sm_to_ms_copy( abs_sub.xy().raw() ) ).raw();
+}
+
+tripoint_bub_ms map::bub_from_abs( const tripoint &p ) const
+{
+    // TODO: fix point types
+    return bub_from_abs( tripoint_abs_ms( p ) );
+}
+
 tripoint_bub_ms map::bub_from_abs( const tripoint_abs_ms &p ) const
 {
     return tripoint_bub_ms() + ( p - project_to<coords::ms>( abs_sub.xy() ) );
@@ -10597,18 +10618,6 @@ const submap *map::getsubmap( const size_t grididx ) const
     return getsubmap_helper( grid, grididx );
 }
 
-submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p )
-{
-    cata_assert( inbounds( p ) );
-    return get_submap_at_grid( tripoint_rel_sm{ p.x() / SEEX, p.y() / SEEY, p.z() } );
-}
-
-const submap *map::unsafe_get_submap_at( const tripoint_bub_ms &p ) const
-{
-    cata_assert( inbounds( p ) );
-    return get_submap_at_grid( { p.x() / SEEX, p.y() / SEEY, p.z() } );
-}
-
 void map::setsubmap( const size_t grididx, submap *const smap )
 {
     if( grididx >= grid.size() ) {
@@ -10621,13 +10630,18 @@ void map::setsubmap( const size_t grididx, submap *const smap )
     grid[grididx] = smap;
 }
 
-submap *map::get_submap_at( const tripoint_bub_ms &p )
+submap *map::get_submap_at( const tripoint &p )
 {
     if( !inbounds( p ) ) {
         debugmsg( "Tried to access invalid map position %s", p.to_string() );
         return nullptr;
     }
     return unsafe_get_submap_at( p );
+}
+
+submap *map::get_submap_at( const tripoint_bub_ms &p )
+{
+    return map::get_submap_at( p.raw() );
 }
 
 const submap *map::get_submap_at( const tripoint_bub_ms &p ) const
@@ -10696,7 +10710,7 @@ void map::draw_fill_background( const ter_id &type )
     // Fill each submap rather than each tile
     for( int gridx = 0; gridx < my_MAPSIZE; gridx++ ) {
         for( int gridy = 0; gridy < my_MAPSIZE; gridy++ ) {
-            submap *sm = get_submap_at_grid( point_rel_sm{gridx, gridy} );
+            submap *sm = get_submap_at_grid( point{gridx, gridy} );
             if( sm == nullptr ) {
                 debugmsg( "Tried to fill background at (%d,%d) but the submap is not loaded", gridx, gridy );
                 continue;
@@ -10810,6 +10824,11 @@ void map::add_corpse( const tripoint_bub_ms &p )
     add_item_or_charges( p, body );
 }
 
+field &map::get_field( const tripoint &p )
+{
+    return field_at( tripoint_bub_ms( p ) );
+}
+
 field &map::get_field( const tripoint_bub_ms &p )
 {
     return field_at( p );
@@ -10919,46 +10938,42 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
 }
 
 template<typename Functor>
-void map::function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
-                         Functor fun ) const
+void map::function_over( const tripoint &start, const tripoint &end, Functor fun ) const
 {
     // start and end are just two points, end can be "before" start
     // Also clip the area to map area
-    const tripoint_bub_ms min( std::max( std::min( start.x(), end.x() ), 0 ),
-                               std::max( std::min( start.y(), end.y() ),
-                                         0 ), std::max( std::min( start.z(), end.z() ), -OVERMAP_DEPTH ) );
-    const tripoint_bub_ms max( std::min( std::max( start.x(), end.x() ), SEEX * my_MAPSIZE - 1 ),
-                               std::min( std::max( start.y(), end.y() ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z(),
-                                       end.z() ),
-                                       OVERMAP_HEIGHT ) );
+    const tripoint min( std::max( std::min( start.x, end.x ), 0 ), std::max( std::min( start.y, end.y ),
+                        0 ), std::max( std::min( start.z, end.z ), -OVERMAP_DEPTH ) );
+    const tripoint max( std::min( std::max( start.x, end.x ), SEEX * my_MAPSIZE - 1 ),
+                        std::min( std::max( start.y, end.y ), SEEY * my_MAPSIZE - 1 ), std::min( std::max( start.z, end.z ),
+                                OVERMAP_HEIGHT ) );
 
     // Submaps that contain the bounding points
-    const point_bub_sm min_sm( min.x() / SEEX, min.y() / SEEY );
-    const point_bub_sm max_sm( max.x() / SEEX, max.y() / SEEY );
+    const point min_sm( min.x / SEEX, min.y / SEEY );
+    const point max_sm( max.x / SEEX, max.y / SEEY );
     // Z outermost, because submaps are flat
-    tripoint_rel_sm gp;
-    int &z = gp.z();
-    int &smx = gp.x();
-    int &smy = gp.y();
-    for( z = min.z(); z <= max.z(); z++ ) {
-        for( smx = min_sm.x(); smx <= max_sm.x(); smx++ ) {
-            for( smy = min_sm.y(); smy <= max_sm.y(); smy++ ) {
+    tripoint gp;
+    int &z = gp.z;
+    int &smx = gp.x;
+    int &smy = gp.y;
+    for( z = min.z; z <= max.z; z++ ) {
+        for( smx = min_sm.x; smx <= max_sm.x; smx++ ) {
+            for( smy = min_sm.y; smy <= max_sm.y; smy++ ) {
                 submap const *cur_submap = get_submap_at_grid( { smx, smy, z } );
                 if( cur_submap == nullptr ) {
                     debugmsg( "Tried to function over (%d,%d,%d) but the submap is not loaded", smx, smy, z );
                     continue;
                 }
                 // Bounds on the submap coordinates
-                const point_bub_sm sm_min( smx > min_sm.x() ? 0 : min.x() % SEEX,
-                                           smy > min_sm.y() ? 0 : min.y() % SEEY );
-                const point_bub_sm sm_max( smx < max_sm.x() ? SEEX - 1 : max.x() % SEEX,
-                                           smy < max_sm.y() ? SEEY - 1 : max.y() % SEEY );
+                const point sm_min( smx > min_sm.x ? 0 : min.x % SEEX, smy > min_sm.y ? 0 : min.y % SEEY );
+                const point sm_max( smx < max_sm.x ? SEEX - 1 : max.x % SEEX,
+                                    smy < max_sm.y ? SEEY - 1 : max.y % SEEY );
 
                 point_sm_ms lp;
                 int &sx = lp.x();
                 int &sy = lp.y();
-                for( sx = sm_min.x(); sx <= sm_max.x(); ++sx ) {
-                    for( sy = sm_min.y(); sy <= sm_max.y(); ++sy ) {
+                for( sx = sm_min.x; sx <= sm_max.x; ++sx ) {
+                    for( sy = sm_min.y; sy <= sm_max.y; ++sy ) {
                         const iteration_state rval = fun( gp, cur_submap, lp );
                         if( rval != ITER_CONTINUE ) {
                             switch( rval ) {
@@ -10983,13 +10998,13 @@ void map::function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &en
 
 void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
                           std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                          const point_bub_ms &min, const point_bub_ms &max )
+                          const point &min, const point &max )
 {
     ter_furn_flag reduce = ter_furn_flag::TFLAG_REDUCE_SCENT;
     ter_furn_flag block = ter_furn_flag::TFLAG_NO_SCENT;
-    auto fill_values = [&]( const tripoint_rel_sm & gp, const submap * sm, const point_sm_ms & lp ) {
+    auto fill_values = [&]( const tripoint & gp, const submap * sm, const point_sm_ms & lp ) {
         // We need to generate the x/y coordinates, because we can't get them "for free"
-        const point_sm_ms p = lp + coords::project_to<coords::ms>( gp.xy() );
+        const point_sm_ms p = lp + sm_to_ms_copy( gp.xy() );
         if( sm->get_ter( lp ).obj().has_flag( block ) ) {
             blocks_scent[p.x()][p.y()] = true;
             reduces_scent[p.x()][p.y()] = false;
@@ -11005,10 +11020,9 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
         return ITER_CONTINUE;
     };
 
-    function_over( tripoint_bub_ms( min, abs_sub.z() ), tripoint_bub_ms( max, abs_sub.z() ),
-                   fill_values );
+    function_over( tripoint( min, abs_sub.z() ), tripoint( max, abs_sub.z() ), fill_values );
 
-    const inclusive_rectangle<point_bub_ms> local_bounds( min, max );
+    const inclusive_rectangle<point> local_bounds( min, max );
 
     // Now vehicles
 
@@ -11020,9 +11034,9 @@ void map::scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &bl
                 ( !vp.has_feature( VPFLAG_OPENABLE ) || !vp.part().open ) ) {
                 continue;
             }
-            const tripoint_bub_ms part_pos = vp.pos_bub();
+            const tripoint part_pos = vp.pos();
             if( local_bounds.contains( part_pos.xy() ) ) {
-                reduces_scent[part_pos.x()][part_pos.y()] = true;
+                reduces_scent[part_pos.x][part_pos.y] = true;
             }
         }
     }
@@ -11244,7 +11258,7 @@ void map::set_pathfinding_cache_dirty( const int zlev )
 void map::set_pathfinding_cache_dirty( const tripoint_bub_ms &p )
 {
     if( inbounds( p ) ) {
-        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy() );
+        get_pathfinding_cache( p.z() ).dirty_points.insert( p.xy().raw() );
     }
 }
 
@@ -11279,12 +11293,12 @@ const pathfinding_cache &map::get_pathfinding_cache_ref( int zlev ) const
     return cache;
 }
 
-void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
+void map::update_pathfinding_cache( const tripoint &p ) const
 {
     if( !inbounds( p ) ) {
         return;
     }
-    pathfinding_cache &cache = get_pathfinding_cache( p.z() );
+    pathfinding_cache &cache = get_pathfinding_cache( p.z );
     PathfindingFlags cur_value = PathfindingFlag::Ground;
 
     const_maptile tile = maptile_at_internal( p );
@@ -11344,7 +11358,7 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
         cur_value |= PathfindingFlag::Sharp;
     }
 
-    cache.special[p.x()][p.y()] = cur_value;
+    cache.special[p.x][p.y] = cur_value;
 }
 
 void map::update_pathfinding_cache( int zlev ) const
@@ -11360,7 +11374,7 @@ void map::update_pathfinding_cache( int zlev ) const
         }
         cache.dirty = false;
     } else {
-        for( const point_bub_ms &p : cache.dirty_points ) {
+        for( const point &p : cache.dirty_points ) {
             update_pathfinding_cache( { p, zlev } );
         }
     }
@@ -11448,7 +11462,7 @@ int map::calc_max_populated_zlev()
         bool level_done = false;
         for( int sx = 0; sx < my_MAPSIZE; sx++ ) {
             for( int sy = 0; sy < my_MAPSIZE; sy++ ) {
-                const submap *sm = get_submap_at_grid( tripoint_rel_sm{ sx, sy, sz } );
+                const submap *sm = get_submap_at_grid( { sx, sy, sz } );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to calc max populated zlev at (%d,%d,%d) but the submap is not loaded", sx, sy,
                               sz );

--- a/src/map.h
+++ b/src/map.h
@@ -492,7 +492,7 @@ class map
          * @param center The coordinate of the center of the viewport, this can
          *               be different from the player coordinate.
          */
-        void draw( const catacurses::window &w, const tripoint &center );
+        void draw( const catacurses::window &w, const tripoint_bub_ms &center );
 
         /**
          * Draw the map tile at the given coordinate. Called by `map::draw()`.
@@ -1986,7 +1986,7 @@ class map
         // TODO: make it typed.
         void scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
                              std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                             const point &min, const point &max );
+                             const point_bub_ms &min, const point_bub_ms &max );
 
         // Computers
         computer *computer_at( const tripoint_bub_ms &p );
@@ -2165,13 +2165,6 @@ class map
         /**
          * Inverse of @ref getglobal
          */
-        // TODO: Get rid of these and use bub_from_abs instead
-        tripoint getlocal( const tripoint_abs_ms &p ) const;
-        point getlocal( const point &p ) const {
-            return getlocal( tripoint_abs_ms( point_abs_ms( p ), abs_sub.z() ) ).xy();
-        }
-        // TODO: fix point types (remove the first overload)
-        tripoint_bub_ms bub_from_abs( const tripoint &p ) const;
         tripoint_bub_ms bub_from_abs( const tripoint_abs_ms &p ) const;
         point_bub_ms bub_from_abs( const point_abs_ms &p ) const {
             return bub_from_abs( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
@@ -2183,8 +2176,8 @@ class map
             return inbounds( project_to<coords::omt>( p ) );
         }
         bool inbounds( const tripoint_abs_omt &p ) const;
-        bool inbounds( const point &p ) const {
-            return inbounds( tripoint_bub_ms( p.x, p.y, 0 ) );
+        bool inbounds( const point_bub_ms &p ) const {
+            return inbounds( tripoint_bub_ms( p, 0 ) );
         }
 
         bool inbounds_z( const int z ) const {
@@ -2244,7 +2237,7 @@ class map
         * @param item item that is spawning creatures
         * @param p The point on this map where the item is and creature will be
         */
-        void rotten_item_spawn( const item &item, const tripoint &p );
+        void rotten_item_spawn( const item &item, const tripoint_bub_ms &p );
     private:
         // Helper #1 - spawns monsters on one submap
         void spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight,
@@ -2254,8 +2247,8 @@ class map
                                           bool ignore_sight );
 
     protected:
-        void saven( const tripoint &grid );
-        void loadn( const point &grid, bool update_vehicles );
+        void saven( const tripoint_bub_sm &grid );
+        void loadn( const point_bub_sm &grid, bool update_vehicles );
         /**
          * Fast forward a submap that has just been loading into this map.
          * This is used to rot and remove rotten items, grow plants, fill funnels etc.
@@ -2271,25 +2264,25 @@ class map
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.
          */
-        void fill_funnels( const tripoint &p, const time_point &since );
+        void fill_funnels( const tripoint_bub_ms &p, const time_point &since );
         /**
          * Try to grow a harvestable plant to the next stage(s).
          */
-        void grow_plant( const tripoint &p );
+        void grow_plant( const tripoint_bub_ms &p );
         /**
          * Try to grow fruits on static plants (not planted by the player)
          * @param p Place to restock
          * @param time_since_last_actualize Time since this function has been
          * called the last time.
          */
-        void restock_fruits( const tripoint &p, const time_duration &time_since_last_actualize );
+        void restock_fruits( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
         /**
          * Produce sap on tapped maple trees
          * @param p Location of tapped tree
          * @param time_since_last_actualize Time since this function has been
          * called the last time.
          */
-        void produce_sap( const tripoint &p, const time_duration &time_since_last_actualize );
+        void produce_sap( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
     public:
         /**
         * Removes the tree at 'p' and produces a trunk_yield length line of trunks in the 'dir'
@@ -2300,8 +2293,9 @@ class map
         /**
          * Radiation-related plant (and fungus?) death.
          */
-        void rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize );
-        void decay_cosmetic_fields( const tripoint &p, const time_duration &time_since_last_actualize );
+        void rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
+        void decay_cosmetic_fields( const tripoint_bub_ms &p,
+                                    const time_duration &time_since_last_actualize );
 
         void player_in_field( Character &you );
         void monster_in_field( monster &z );
@@ -2309,7 +2303,7 @@ class map
          * As part of the map shifting, this shifts the trap locations stored in @ref traplocs.
          * @param shift The amount shifting in submap, the same as go into @ref shift.
          */
-        void shift_traps( const tripoint &shift );
+        void shift_traps( const point_rel_sm &shift );
 
         void copy_grid( const tripoint_rel_sm &to, const tripoint_rel_sm &from );
         void draw_map( mapgendata &dat );
@@ -2334,7 +2328,7 @@ class map
         void build_floor_caches();
         void seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
                                         const array_of_grids_of<const bool> &floor_caches,
-                                        const std::optional<tripoint> &override_p ) const;
+                                        const std::optional<tripoint_bub_ms> &override_p ) const;
 
     protected:
         void generate_lightmap( int zlev );
@@ -2362,8 +2356,6 @@ class map
         void set_abs_sub( const tripoint_abs_sm &p );
 
     private:
-        // TODO: Get rid of untyped overload
-        field &get_field( const tripoint &p );
         field &get_field( const tripoint_bub_ms &p );
 
         /**
@@ -2375,49 +2367,18 @@ class map
          * Get the submap pointer containing the specified position within the reality bubble.
          * (p) must be a valid coordinate, check with @ref inbounds.
          */
-        // TODO: fix point types (remove the first overload)
-        inline submap *unsafe_get_submap_at( const tripoint &p ) {
-            cata_assert( inbounds( p ) );
-            return get_submap_at_grid( tripoint_rel_sm{ p.x / SEEX, p.y / SEEY, p.z } );
-        }
-        inline submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) {
-            return unsafe_get_submap_at( p.raw() );
-        }
-        // TODO: fix point types (remove the first overload)
-        inline const submap *unsafe_get_submap_at( const tripoint &p ) const {
-            cata_assert( inbounds( p ) );
-            return get_submap_at_grid( { p.x / SEEX, p.y / SEEY, p.z } );
-        }
-        inline const submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) const {
-            return unsafe_get_submap_at( p.raw() );
-        }
-        // TODO: Get rid of untyped overload
-        submap *get_submap_at( const tripoint &p );
+        submap *unsafe_get_submap_at( const tripoint_bub_ms &p );
+        const submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) const;
         submap *get_submap_at( const tripoint_bub_ms &p );
         const submap *get_submap_at( const tripoint_bub_ms &p ) const;
-        submap *get_submap_at( const point &p ) {
-            return get_submap_at( tripoint( p, abs_sub.z() ) );
-        }
         /**
          * Get the submap pointer containing the specified position within the reality bubble.
          * The same as other get_submap_at, (p) must be valid (@ref inbounds).
          * Also writes the position within the submap to offset_p
          */
-        // TODO: fix point types (remove the first overload)
-        submap *unsafe_get_submap_at( const tripoint &p, point &offset_p ) {
-            offset_p.x = p.x % SEEX;
-            offset_p.y = p.y % SEEY;
-            return unsafe_get_submap_at( p );
-        }
         submap *unsafe_get_submap_at( const tripoint_bub_ms p, point_sm_ms &offset_p ) {
             tripoint_bub_sm sm;
             std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
-            return unsafe_get_submap_at( p );
-        }
-        // TODO: fix point types (remove the first overload)
-        const submap *unsafe_get_submap_at( const tripoint &p, point &offset_p ) const {
-            offset_p.x = p.x % SEEX;
-            offset_p.y = p.y % SEEY;
             return unsafe_get_submap_at( p );
         }
         const submap *unsafe_get_submap_at(
@@ -2430,7 +2391,7 @@ class map
         submap *get_submap_at( const tripoint &p, point &offset_p ) {
             offset_p.x = p.x % SEEX;
             offset_p.y = p.y % SEEY;
-            return get_submap_at( p );
+            return get_submap_at( tripoint_bub_ms( p ) );
         }
         submap *get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) {
             offset_p.x() = p.x() % SEEX;
@@ -2450,10 +2411,7 @@ class map
          * be valid: 0 <= x < my_MAPSIZE, same for y.
          * z must be between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
-        submap *get_submap_at_grid( const point &gridp ) {
-            return getsubmap( get_nonant( gridp ) );
-        }
-        const submap *get_submap_at_grid( const point &gridp ) const {
+        submap *get_submap_at_grid( const point_rel_sm &gridp ) {
             return getsubmap( get_nonant( gridp ) );
         }
         submap *get_submap_at_grid( const tripoint_rel_sm &gridp );
@@ -2465,8 +2423,8 @@ class map
          * Version with z-levels checks for z between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
         size_t get_nonant( const tripoint_rel_sm &gridp ) const;
-        size_t get_nonant( const point &gridp ) const {
-            return get_nonant( tripoint_rel_sm{ gridp.x, gridp.y, abs_sub.z() } );
+        size_t get_nonant( const point_rel_sm &gridp ) const {
+            return get_nonant( tripoint_rel_sm{ gridp.x(), gridp.y(), abs_sub.z()} );
         }
         /**
          * Set the submap pointer in @ref grid at the give index. This is the inverse of
@@ -2501,15 +2459,15 @@ class map
          * Internal version of the drawsq. Keeps a cached maptile for less re-getting.
          * Returns false if it has drawn all it should, true if `draw_from_above` should be called after.
          */
-        bool draw_maptile( const catacurses::window &w, const tripoint &p,
+        bool draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
                            const const_maptile &tile, const drawsq_params &params ) const;
         /**
          * Draws the tile as seen from above.
          */
-        void draw_from_above( const catacurses::window &w, const tripoint &p,
+        void draw_from_above( const catacurses::window &w, const tripoint_bub_ms &p,
                               const const_maptile &tile, const drawsq_params &params ) const;
 
-        int determine_wall_corner( const tripoint &p ) const;
+        int determine_wall_corner( const tripoint_bub_ms &p ) const;
         // apply a circular light pattern immediately, however it's best to use...
         void apply_light_source( const tripoint_bub_ms &p, float luminance );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
@@ -2526,24 +2484,14 @@ class map
 
         // Internal methods used to bash just the selected features
         // Information on what to bash/what was bashed is read from/written to the bash_params struct
-        // TODO: Get rid of untyped overload.
-        void bash_ter_furn( const tripoint &p, bash_params &params );
         void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params );
-        // TODO: Get rid of untyped overload.
-        void bash_items( const tripoint &p, bash_params &params );
         void bash_items( const tripoint_bub_ms &p, bash_params &params );
-        // TODO: Get rid of untyped overload.
-        void bash_vehicle( const tripoint &p, bash_params &params );
         void bash_vehicle( const tripoint_bub_ms &p, bash_params &params );
-        // TODO: Get rid of untyped overload.
-        void bash_field( const tripoint &p, bash_params &params );
         void bash_field( const tripoint_bub_ms &p, bash_params &params );
 
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
-        // TODO: Get rid of untyped overload.
-        ter_str_id get_roof( const tripoint &p, bool allow_air ) const;
         ter_str_id get_roof( const tripoint_bub_ms &p, bool allow_air ) const;
 
     public:
@@ -2574,7 +2522,7 @@ class map
         */
         /*@{*/
         template<typename Functor>
-        void function_over( const tripoint &start, const tripoint &end, Functor fun ) const;
+        void function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &end, Functor fun ) const;
         /*@}*/
 
         /**
@@ -2655,7 +2603,7 @@ class map
 
         const pathfinding_cache &get_pathfinding_cache_ref( int zlev ) const;
 
-        void update_pathfinding_cache( const tripoint &p ) const;
+        void update_pathfinding_cache( const tripoint_bub_ms &p ) const;
         void update_pathfinding_cache( int zlev ) const;
 
         void update_visibility_cache( int zlev );
@@ -2764,7 +2712,7 @@ class tinymap : private map
             return map::inbounds( p );
         }
         bool inbounds( const tripoint_omt_ms &p ) const {
-            return map::inbounds( p.raw() );
+            return map::inbounds( rebase_bub( p ) );
         }
 
         map *cast_to_map() {
@@ -3054,19 +3002,12 @@ class tinymap : private map
                           bool destroy_pos = true ) {
             map::collapse_at( rebase_bub( p ), silent, was_supporting, destroy_pos );
         }
-        tripoint getlocal( const tripoint &p ) const {
-            return map::getlocal( tripoint_abs_ms( p ) );  // TODO: Make it typed
-        }
         tripoint_abs_sm get_abs_sub() const {
             return map::get_abs_sub();    // TODO: Convert to tripoint_abs_omt
         }
         tripoint_abs_ms getglobal( const tripoint_omt_ms &p ) const {
             return map::getglobal( rebase_bub( p ) );
         }
-        // TODO: Get rid of untyped overload.
-        tripoint getlocal( const tripoint_abs_ms &p ) const {
-            return map::getlocal( p );
-        };
         tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
             return rebase_omt( map::bub_from_abs( p ) );
         };

--- a/src/map.h
+++ b/src/map.h
@@ -492,7 +492,7 @@ class map
          * @param center The coordinate of the center of the viewport, this can
          *               be different from the player coordinate.
          */
-        void draw( const catacurses::window &w, const tripoint_bub_ms &center );
+        void draw( const catacurses::window &w, const tripoint &center );
 
         /**
          * Draw the map tile at the given coordinate. Called by `map::draw()`.
@@ -1986,7 +1986,7 @@ class map
         // TODO: make it typed.
         void scent_blockers( std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &blocks_scent,
                              std::array<std::array<bool, MAPSIZE_X>, MAPSIZE_Y> &reduces_scent,
-                             const point_bub_ms &min, const point_bub_ms &max );
+                             const point &min, const point &max );
 
         // Computers
         computer *computer_at( const tripoint_bub_ms &p );
@@ -2165,6 +2165,13 @@ class map
         /**
          * Inverse of @ref getglobal
          */
+        // TODO: Get rid of these and use bub_from_abs instead
+        tripoint getlocal( const tripoint_abs_ms &p ) const;
+        point getlocal( const point &p ) const {
+            return getlocal( tripoint_abs_ms( point_abs_ms( p ), abs_sub.z() ) ).xy();
+        }
+        // TODO: fix point types (remove the first overload)
+        tripoint_bub_ms bub_from_abs( const tripoint &p ) const;
         tripoint_bub_ms bub_from_abs( const tripoint_abs_ms &p ) const;
         point_bub_ms bub_from_abs( const point_abs_ms &p ) const {
             return bub_from_abs( tripoint_abs_ms( p, abs_sub.z() ) ).xy();
@@ -2176,8 +2183,8 @@ class map
             return inbounds( project_to<coords::omt>( p ) );
         }
         bool inbounds( const tripoint_abs_omt &p ) const;
-        bool inbounds( const point_bub_ms &p ) const {
-            return inbounds( tripoint_bub_ms( p, 0 ) );
+        bool inbounds( const point &p ) const {
+            return inbounds( tripoint_bub_ms( p.x, p.y, 0 ) );
         }
 
         bool inbounds_z( const int z ) const {
@@ -2237,7 +2244,7 @@ class map
         * @param item item that is spawning creatures
         * @param p The point on this map where the item is and creature will be
         */
-        void rotten_item_spawn( const item &item, const tripoint_bub_ms &p );
+        void rotten_item_spawn( const item &item, const tripoint &p );
     private:
         // Helper #1 - spawns monsters on one submap
         void spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight,
@@ -2247,8 +2254,8 @@ class map
                                           bool ignore_sight );
 
     protected:
-        void saven( const tripoint_bub_sm &grid );
-        void loadn( const point_bub_sm &grid, bool update_vehicles );
+        void saven( const tripoint &grid );
+        void loadn( const point &grid, bool update_vehicles );
         /**
          * Fast forward a submap that has just been loading into this map.
          * This is used to rot and remove rotten items, grow plants, fill funnels etc.
@@ -2264,25 +2271,25 @@ class map
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.
          */
-        void fill_funnels( const tripoint_bub_ms &p, const time_point &since );
+        void fill_funnels( const tripoint &p, const time_point &since );
         /**
          * Try to grow a harvestable plant to the next stage(s).
          */
-        void grow_plant( const tripoint_bub_ms &p );
+        void grow_plant( const tripoint &p );
         /**
          * Try to grow fruits on static plants (not planted by the player)
          * @param p Place to restock
          * @param time_since_last_actualize Time since this function has been
          * called the last time.
          */
-        void restock_fruits( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
+        void restock_fruits( const tripoint &p, const time_duration &time_since_last_actualize );
         /**
          * Produce sap on tapped maple trees
          * @param p Location of tapped tree
          * @param time_since_last_actualize Time since this function has been
          * called the last time.
          */
-        void produce_sap( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
+        void produce_sap( const tripoint &p, const time_duration &time_since_last_actualize );
     public:
         /**
         * Removes the tree at 'p' and produces a trunk_yield length line of trunks in the 'dir'
@@ -2293,9 +2300,8 @@ class map
         /**
          * Radiation-related plant (and fungus?) death.
          */
-        void rad_scorch( const tripoint_bub_ms &p, const time_duration &time_since_last_actualize );
-        void decay_cosmetic_fields( const tripoint_bub_ms &p,
-                                    const time_duration &time_since_last_actualize );
+        void rad_scorch( const tripoint &p, const time_duration &time_since_last_actualize );
+        void decay_cosmetic_fields( const tripoint &p, const time_duration &time_since_last_actualize );
 
         void player_in_field( Character &you );
         void monster_in_field( monster &z );
@@ -2303,7 +2309,7 @@ class map
          * As part of the map shifting, this shifts the trap locations stored in @ref traplocs.
          * @param shift The amount shifting in submap, the same as go into @ref shift.
          */
-        void shift_traps( const point_rel_sm &shift );
+        void shift_traps( const tripoint &shift );
 
         void copy_grid( const tripoint_rel_sm &to, const tripoint_rel_sm &from );
         void draw_map( mapgendata &dat );
@@ -2328,7 +2334,7 @@ class map
         void build_floor_caches();
         void seen_cache_process_ledges( array_of_grids_of<float> &seen_caches,
                                         const array_of_grids_of<const bool> &floor_caches,
-                                        const std::optional<tripoint_bub_ms> &override_p ) const;
+                                        const std::optional<tripoint> &override_p ) const;
 
     protected:
         void generate_lightmap( int zlev );
@@ -2356,6 +2362,8 @@ class map
         void set_abs_sub( const tripoint_abs_sm &p );
 
     private:
+        // TODO: Get rid of untyped overload
+        field &get_field( const tripoint &p );
         field &get_field( const tripoint_bub_ms &p );
 
         /**
@@ -2367,18 +2375,49 @@ class map
          * Get the submap pointer containing the specified position within the reality bubble.
          * (p) must be a valid coordinate, check with @ref inbounds.
          */
-        submap *unsafe_get_submap_at( const tripoint_bub_ms &p );
-        const submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) const;
+        // TODO: fix point types (remove the first overload)
+        inline submap *unsafe_get_submap_at( const tripoint &p ) {
+            cata_assert( inbounds( p ) );
+            return get_submap_at_grid( tripoint_rel_sm{ p.x / SEEX, p.y / SEEY, p.z } );
+        }
+        inline submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) {
+            return unsafe_get_submap_at( p.raw() );
+        }
+        // TODO: fix point types (remove the first overload)
+        inline const submap *unsafe_get_submap_at( const tripoint &p ) const {
+            cata_assert( inbounds( p ) );
+            return get_submap_at_grid( { p.x / SEEX, p.y / SEEY, p.z } );
+        }
+        inline const submap *unsafe_get_submap_at( const tripoint_bub_ms &p ) const {
+            return unsafe_get_submap_at( p.raw() );
+        }
+        // TODO: Get rid of untyped overload
+        submap *get_submap_at( const tripoint &p );
         submap *get_submap_at( const tripoint_bub_ms &p );
         const submap *get_submap_at( const tripoint_bub_ms &p ) const;
+        submap *get_submap_at( const point &p ) {
+            return get_submap_at( tripoint( p, abs_sub.z() ) );
+        }
         /**
          * Get the submap pointer containing the specified position within the reality bubble.
          * The same as other get_submap_at, (p) must be valid (@ref inbounds).
          * Also writes the position within the submap to offset_p
          */
+        // TODO: fix point types (remove the first overload)
+        submap *unsafe_get_submap_at( const tripoint &p, point &offset_p ) {
+            offset_p.x = p.x % SEEX;
+            offset_p.y = p.y % SEEY;
+            return unsafe_get_submap_at( p );
+        }
         submap *unsafe_get_submap_at( const tripoint_bub_ms p, point_sm_ms &offset_p ) {
             tripoint_bub_sm sm;
             std::tie( sm, offset_p ) = project_remain<coords::sm>( p );
+            return unsafe_get_submap_at( p );
+        }
+        // TODO: fix point types (remove the first overload)
+        const submap *unsafe_get_submap_at( const tripoint &p, point &offset_p ) const {
+            offset_p.x = p.x % SEEX;
+            offset_p.y = p.y % SEEY;
             return unsafe_get_submap_at( p );
         }
         const submap *unsafe_get_submap_at(
@@ -2391,7 +2430,7 @@ class map
         submap *get_submap_at( const tripoint &p, point &offset_p ) {
             offset_p.x = p.x % SEEX;
             offset_p.y = p.y % SEEY;
-            return get_submap_at( tripoint_bub_ms( p ) );
+            return get_submap_at( p );
         }
         submap *get_submap_at( const tripoint_bub_ms &p, point_sm_ms &offset_p ) {
             offset_p.x() = p.x() % SEEX;
@@ -2411,7 +2450,10 @@ class map
          * be valid: 0 <= x < my_MAPSIZE, same for y.
          * z must be between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
-        submap *get_submap_at_grid( const point_rel_sm &gridp ) {
+        submap *get_submap_at_grid( const point &gridp ) {
+            return getsubmap( get_nonant( gridp ) );
+        }
+        const submap *get_submap_at_grid( const point &gridp ) const {
             return getsubmap( get_nonant( gridp ) );
         }
         submap *get_submap_at_grid( const tripoint_rel_sm &gridp );
@@ -2423,8 +2465,8 @@ class map
          * Version with z-levels checks for z between -OVERMAP_DEPTH and OVERMAP_HEIGHT
          */
         size_t get_nonant( const tripoint_rel_sm &gridp ) const;
-        size_t get_nonant( const point_rel_sm &gridp ) const {
-            return get_nonant( tripoint_rel_sm{ gridp.x(), gridp.y(), abs_sub.z()} );
+        size_t get_nonant( const point &gridp ) const {
+            return get_nonant( tripoint_rel_sm{ gridp.x, gridp.y, abs_sub.z() } );
         }
         /**
          * Set the submap pointer in @ref grid at the give index. This is the inverse of
@@ -2459,15 +2501,15 @@ class map
          * Internal version of the drawsq. Keeps a cached maptile for less re-getting.
          * Returns false if it has drawn all it should, true if `draw_from_above` should be called after.
          */
-        bool draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
+        bool draw_maptile( const catacurses::window &w, const tripoint &p,
                            const const_maptile &tile, const drawsq_params &params ) const;
         /**
          * Draws the tile as seen from above.
          */
-        void draw_from_above( const catacurses::window &w, const tripoint_bub_ms &p,
+        void draw_from_above( const catacurses::window &w, const tripoint &p,
                               const const_maptile &tile, const drawsq_params &params ) const;
 
-        int determine_wall_corner( const tripoint_bub_ms &p ) const;
+        int determine_wall_corner( const tripoint &p ) const;
         // apply a circular light pattern immediately, however it's best to use...
         void apply_light_source( const tripoint_bub_ms &p, float luminance );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
@@ -2484,14 +2526,24 @@ class map
 
         // Internal methods used to bash just the selected features
         // Information on what to bash/what was bashed is read from/written to the bash_params struct
+        // TODO: Get rid of untyped overload.
+        void bash_ter_furn( const tripoint &p, bash_params &params );
         void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
+        void bash_items( const tripoint &p, bash_params &params );
         void bash_items( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
+        void bash_vehicle( const tripoint &p, bash_params &params );
         void bash_vehicle( const tripoint_bub_ms &p, bash_params &params );
+        // TODO: Get rid of untyped overload.
+        void bash_field( const tripoint &p, bash_params &params );
         void bash_field( const tripoint_bub_ms &p, bash_params &params );
 
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
+        // TODO: Get rid of untyped overload.
+        ter_str_id get_roof( const tripoint &p, bool allow_air ) const;
         ter_str_id get_roof( const tripoint_bub_ms &p, bool allow_air ) const;
 
     public:
@@ -2522,7 +2574,7 @@ class map
         */
         /*@{*/
         template<typename Functor>
-        void function_over( const tripoint_bub_ms &start, const tripoint_bub_ms &end, Functor fun ) const;
+        void function_over( const tripoint &start, const tripoint &end, Functor fun ) const;
         /*@}*/
 
         /**
@@ -2603,7 +2655,7 @@ class map
 
         const pathfinding_cache &get_pathfinding_cache_ref( int zlev ) const;
 
-        void update_pathfinding_cache( const tripoint_bub_ms &p ) const;
+        void update_pathfinding_cache( const tripoint &p ) const;
         void update_pathfinding_cache( int zlev ) const;
 
         void update_visibility_cache( int zlev );
@@ -2712,7 +2764,7 @@ class tinymap : private map
             return map::inbounds( p );
         }
         bool inbounds( const tripoint_omt_ms &p ) const {
-            return map::inbounds( rebase_bub( p ) );
+            return map::inbounds( p.raw() );
         }
 
         map *cast_to_map() {
@@ -3002,12 +3054,19 @@ class tinymap : private map
                           bool destroy_pos = true ) {
             map::collapse_at( rebase_bub( p ), silent, was_supporting, destroy_pos );
         }
+        tripoint getlocal( const tripoint &p ) const {
+            return map::getlocal( tripoint_abs_ms( p ) );  // TODO: Make it typed
+        }
         tripoint_abs_sm get_abs_sub() const {
             return map::get_abs_sub();    // TODO: Convert to tripoint_abs_omt
         }
         tripoint_abs_ms getglobal( const tripoint_omt_ms &p ) const {
             return map::getglobal( rebase_bub( p ) );
         }
+        // TODO: Get rid of untyped overload.
+        tripoint getlocal( const tripoint_abs_ms &p ) const {
+            return map::getlocal( p );
+        };
         tripoint_omt_ms omt_from_abs( const tripoint_abs_ms &p ) const {
             return rebase_omt( map::bub_from_abs( p ) );
         };

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1332,13 +1332,13 @@ static void burned_ground_parser( map &m, const tripoint &loc )
 
     VehicleList vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
-    std::vector<tripoint> points;
+    std::vector<tripoint_bub_ms> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
         // Important that this loop excludes fake parts, because those can be
         // outside map bounds
         for( const vpart_reference &vp : vehicle.v->get_all_parts() ) {
-            tripoint t = vp.pos();
+            tripoint_bub_ms t = vp.pos_bub();
             if( m.inbounds( t ) ) {
                 points.push_back( t );
             } else {
@@ -1358,7 +1358,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     for( vehicle *vrem : vehicles ) {
         m.destroy_vehicle( vrem );
     }
-    for( const tripoint &tri : points ) {
+    for( const tripoint_bub_ms &tri : points ) {
         m.furn_set( tri, furn_f_wreckage );
     }
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1332,13 +1332,13 @@ static void burned_ground_parser( map &m, const tripoint &loc )
 
     VehicleList vehs = m.get_vehicles();
     std::vector<vehicle *> vehicles;
-    std::vector<tripoint_bub_ms> points;
+    std::vector<tripoint> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
         // Important that this loop excludes fake parts, because those can be
         // outside map bounds
         for( const vpart_reference &vp : vehicle.v->get_all_parts() ) {
-            tripoint_bub_ms t = vp.pos_bub();
+            tripoint t = vp.pos();
             if( m.inbounds( t ) ) {
                 points.push_back( t );
             } else {
@@ -1358,7 +1358,7 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     for( vehicle *vrem : vehicles ) {
         m.destroy_vehicle( vrem );
     }
-    for( const tripoint_bub_ms &tri : points ) {
+    for( const tripoint &tri : points ) {
         m.furn_set( tri, furn_f_wreckage );
     }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -166,7 +166,7 @@ void map::process_fields()
         for( int x = 0; x < my_MAPSIZE; x++ ) {
             for( int y = 0; y < my_MAPSIZE; y++ ) {
                 if( field_cache[ x + y * MAPSIZE ] ) {
-                    submap *const current_submap = get_submap_at_grid( { x, y, z } );
+                    submap *const current_submap = get_submap_at_grid( tripoint_rel_sm{ x, y, z } );
                     if( current_submap == nullptr ) {
                         debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", x, y, z );
                         continue;
@@ -1526,7 +1526,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( you.pos() );
+    field &curfield = get_field( you.pos_bub() );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -166,7 +166,7 @@ void map::process_fields()
         for( int x = 0; x < my_MAPSIZE; x++ ) {
             for( int y = 0; y < my_MAPSIZE; y++ ) {
                 if( field_cache[ x + y * MAPSIZE ] ) {
-                    submap *const current_submap = get_submap_at_grid( tripoint_rel_sm{ x, y, z } );
+                    submap *const current_submap = get_submap_at_grid( { x, y, z } );
                     if( current_submap == nullptr ) {
                         debugmsg( "Tried to process field at (%d,%d,%d) but the submap is not loaded", x, y, z );
                         continue;
@@ -1526,7 +1526,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( you.pos_bub() );
+    field &curfield = get_field( you.pos() );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -300,10 +300,11 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         density = density / 100;
 
         // Not sure if we actually have to check all submaps.
-        const bool any_missing = !generated.at( get_nonant( { point_rel_sm_zero, p_sm.z() } ) ) ||
-                                 !generated.at( get_nonant( { point_rel_sm_east, p_sm.z() } ) ) ||
-                                 !generated.at( get_nonant( { point_rel_sm_south_east, p_sm.z() } ) ) ||
-                                 !generated.at( get_nonant( { point_rel_sm_south, p_sm.z() } ) );
+        const bool any_missing = !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_zero, p_sm.z() } ) )
+                                 ||
+                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_east, p_sm.z() } ) ) ||
+                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_south_east, p_sm.z() } ) ) ||
+                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_south, p_sm.z() } ) );
 
         mapgendata dat( { p.xy(), gridz}, *this, density, when, nullptr );
         if( ( any_missing || !save_results ) &&
@@ -7227,10 +7228,10 @@ void map::rotate( int turns )
     for( int z_level = bottom_level; z_level <= top_level; z_level++ ) {
         clear_vehicle_list( z_level );
 
-        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
-        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
-        submap *pe = get_submap_at_grid( { point_rel_sm_east, z_level } );
-        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
+        submap *pz = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_east, z_level } );
+        submap *ps = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", point_zero.x,
                       point_zero.y );
@@ -7321,11 +7322,11 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
 
     for( int z_level = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
          z_level <= ( zlevels ? OVERMAP_HEIGHT : abs_sub.z() ); z_level++ ) {
-        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
-        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
-        submap *pe = get_submap_at_grid( {point_rel_sm_east, z_level
-                                         } );
-        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
+        submap *pz = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( tripoint_rel_sm{point_rel_sm_east, z_level
+                                                        } );
+        submap *ps = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", point_zero.x,
                       point_zero.y, z_level );
@@ -7346,7 +7347,7 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
         for( int j = 0; j < 2; ++j ) {
             for( int i = 0; i < 2; ++i ) {
                 point_rel_sm p( i, j );
-                submap *sm = get_submap_at_grid( { p, z_level } );
+                submap *sm = get_submap_at_grid( tripoint_rel_sm{ p, z_level } );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", p.x(), p.y(),
                               z_level );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -300,11 +300,10 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         density = density / 100;
 
         // Not sure if we actually have to check all submaps.
-        const bool any_missing = !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_zero, p_sm.z() } ) )
-                                 ||
-                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_east, p_sm.z() } ) ) ||
-                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_south_east, p_sm.z() } ) ) ||
-                                 !generated.at( get_nonant( tripoint_rel_sm{ point_rel_sm_south, p_sm.z() } ) );
+        const bool any_missing = !generated.at( get_nonant( { point_rel_sm_zero, p_sm.z() } ) ) ||
+                                 !generated.at( get_nonant( { point_rel_sm_east, p_sm.z() } ) ) ||
+                                 !generated.at( get_nonant( { point_rel_sm_south_east, p_sm.z() } ) ) ||
+                                 !generated.at( get_nonant( { point_rel_sm_south, p_sm.z() } ) );
 
         mapgendata dat( { p.xy(), gridz}, *this, density, when, nullptr );
         if( ( any_missing || !save_results ) &&
@@ -7228,10 +7227,10 @@ void map::rotate( int turns )
     for( int z_level = bottom_level; z_level <= top_level; z_level++ ) {
         clear_vehicle_list( z_level );
 
-        submap *pz = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_zero, z_level } );
-        submap *pse = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south_east, z_level } );
-        submap *pe = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_east, z_level } );
-        submap *ps = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south, z_level } );
+        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( { point_rel_sm_east, z_level } );
+        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to rotate map at (%d,%d) but the submap is not loaded", point_zero.x,
                       point_zero.y );
@@ -7322,11 +7321,11 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
 
     for( int z_level = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
          z_level <= ( zlevels ? OVERMAP_HEIGHT : abs_sub.z() ); z_level++ ) {
-        submap *pz = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_zero, z_level } );
-        submap *pse = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south_east, z_level } );
-        submap *pe = get_submap_at_grid( tripoint_rel_sm{point_rel_sm_east, z_level
-                                                        } );
-        submap *ps = get_submap_at_grid( tripoint_rel_sm{ point_rel_sm_south, z_level } );
+        submap *pz = get_submap_at_grid( { point_rel_sm_zero, z_level } );
+        submap *pse = get_submap_at_grid( { point_rel_sm_south_east, z_level } );
+        submap *pe = get_submap_at_grid( {point_rel_sm_east, z_level
+                                         } );
+        submap *ps = get_submap_at_grid( { point_rel_sm_south, z_level } );
         if( pz == nullptr || pse == nullptr || pe == nullptr || ps == nullptr ) {
             debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", point_zero.x,
                       point_zero.y, z_level );
@@ -7347,7 +7346,7 @@ void map::mirror( bool mirror_horizontal, bool mirror_vertical )
         for( int j = 0; j < 2; ++j ) {
             for( int i = 0; i < 2; ++i ) {
                 point_rel_sm p( i, j );
-                submap *sm = get_submap_at_grid( tripoint_rel_sm{ p, z_level } );
+                submap *sm = get_submap_at_grid( { p, z_level } );
                 if( sm == nullptr ) {
                     debugmsg( "Tried to mirror map at (%d, %d, %d) but the submap is not loaded", p.x(), p.y(),
                               z_level );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -124,7 +124,7 @@ bool leap_actor::call( monster &z ) const
         }
     }
 
-    std::vector<tripoint> options;
+    std::vector<tripoint_bub_ms> options;
     const tripoint_abs_ms target_abs = z.get_dest();
     // Calculate distance to target
     const float best_float = rl_dist( z.get_location(), target_abs );
@@ -142,22 +142,22 @@ bool leap_actor::call( monster &z ) const
         return false;
     }
     map &here = get_map();
-    const tripoint target = here.getlocal( target_abs );
-    add_msg_debug( debugmode::DF_MATTACK, "Target at coordinates %d,%d,%d",
-                   target.x, target.y, target.z );
+    const tripoint_bub_ms target = here.bub_from_abs( target_abs );
+    add_msg_debug( debugmode::DF_MATTACK, "Target at coordinates %s",
+                   target.to_string_writable() );
 
-    std::multimap<int, tripoint> candidates;
-    for( const tripoint &candidate : here.points_in_radius( z.pos(), max_range ) ) {
-        if( candidate == z.pos() ) {
-            add_msg_debug( debugmode::DF_MATTACK, "Monster at coordinates %d,%d,%d",
-                           candidate.x, candidate.y, candidate.z );
+    std::multimap<int, tripoint_bub_ms> candidates;
+    for( const tripoint_bub_ms &candidate : here.points_in_radius( z.pos_bub(), max_range ) ) {
+        if( candidate == z.pos_bub() ) {
+            add_msg_debug( debugmode::DF_MATTACK, "Monster at coordinates %s",
+                           candidate.to_string_writable() );
             continue;
         }
-        float leap_dist = trigdist ? trig_dist( z.pos(), candidate ) :
-                          square_dist( z.pos(), candidate );
+        float leap_dist = trigdist ? trig_dist( z.pos_bub(), candidate ) :
+                          square_dist( z.pos_bub(), candidate );
         add_msg_debug( debugmode::DF_MATTACK,
-                       "Candidate coordinates %d,%d,%d, distance %.1f, min range %.1f, max range %.1f",
-                       candidate.x, candidate.y, candidate.z, leap_dist, min_range, max_range );
+                       "Candidate coordinates %s, distance %.1f, min range %.1f, max range %.1f",
+                       candidate.to_string_writable(), leap_dist, min_range, max_range );
         if( leap_dist > max_range || leap_dist < min_range ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate outside of allowed range, discarded" );
@@ -169,12 +169,12 @@ bool leap_actor::call( monster &z ) const
                            "Candidate farther from target than optimal path, discarded" );
             continue;
         }
-        if( !ignore_dest_terrain && !z.will_move_to( candidate ) ) {
+        if( !ignore_dest_terrain && !z.will_move_to( candidate.raw() ) ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate place it can't enter, discarded" );
             continue;
         }
-        if( !ignore_dest_danger && !z.know_danger_at( candidate ) ) {
+        if( !ignore_dest_danger && !z.know_danger_at( candidate.raw() ) ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate with dangerous conditions, discarded" );
             continue;
@@ -183,7 +183,7 @@ bool leap_actor::call( monster &z ) const
     }
     for( const auto &candidate : candidates ) {
         const int &cur_dist = candidate.first;
-        const tripoint &dest = candidate.second;
+        const tripoint_bub_ms &dest = candidate.second;
         if( cur_dist > best && !random_leap ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Distance %d larger than previous best %d, candidate discarded", cur_dist, best );
@@ -198,8 +198,8 @@ bool leap_actor::call( monster &z ) const
         }
         bool blocked_path = false;
         // check if monster has a clear path to the proposed point
-        std::vector<tripoint> line = here.find_clear_path( z.pos(), dest );
-        for( tripoint &i : line ) {
+        std::vector<tripoint_bub_ms> line = here.find_clear_path( z.pos_bub(), dest );
+        for( tripoint_bub_ms &i : line ) {
             if( here.impassable( i ) ) {
                 add_msg_debug( debugmode::DF_MATTACK, "Path blocked, candidate discarded" );
                 blocked_path = true;
@@ -226,7 +226,7 @@ bool leap_actor::call( monster &z ) const
 
     z.mod_moves( -move_cost );
     viewer &player_view = get_player_view();
-    const tripoint chosen = random_entry( options );
+    const tripoint_bub_ms chosen = random_entry( options );
     bool seen = player_view.sees( z ); // We can see them jump...
     z.setpos( chosen );
     seen |= player_view.sees( z ); // ... or we can see them land

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -124,7 +124,7 @@ bool leap_actor::call( monster &z ) const
         }
     }
 
-    std::vector<tripoint_bub_ms> options;
+    std::vector<tripoint> options;
     const tripoint_abs_ms target_abs = z.get_dest();
     // Calculate distance to target
     const float best_float = rl_dist( z.get_location(), target_abs );
@@ -142,22 +142,22 @@ bool leap_actor::call( monster &z ) const
         return false;
     }
     map &here = get_map();
-    const tripoint_bub_ms target = here.bub_from_abs( target_abs );
-    add_msg_debug( debugmode::DF_MATTACK, "Target at coordinates %s",
-                   target.to_string_writable() );
+    const tripoint target = here.getlocal( target_abs );
+    add_msg_debug( debugmode::DF_MATTACK, "Target at coordinates %d,%d,%d",
+                   target.x, target.y, target.z );
 
-    std::multimap<int, tripoint_bub_ms> candidates;
-    for( const tripoint_bub_ms &candidate : here.points_in_radius( z.pos_bub(), max_range ) ) {
-        if( candidate == z.pos_bub() ) {
-            add_msg_debug( debugmode::DF_MATTACK, "Monster at coordinates %s",
-                           candidate.to_string_writable() );
+    std::multimap<int, tripoint> candidates;
+    for( const tripoint &candidate : here.points_in_radius( z.pos(), max_range ) ) {
+        if( candidate == z.pos() ) {
+            add_msg_debug( debugmode::DF_MATTACK, "Monster at coordinates %d,%d,%d",
+                           candidate.x, candidate.y, candidate.z );
             continue;
         }
-        float leap_dist = trigdist ? trig_dist( z.pos_bub(), candidate ) :
-                          square_dist( z.pos_bub(), candidate );
+        float leap_dist = trigdist ? trig_dist( z.pos(), candidate ) :
+                          square_dist( z.pos(), candidate );
         add_msg_debug( debugmode::DF_MATTACK,
-                       "Candidate coordinates %s, distance %.1f, min range %.1f, max range %.1f",
-                       candidate.to_string_writable(), leap_dist, min_range, max_range );
+                       "Candidate coordinates %d,%d,%d, distance %.1f, min range %.1f, max range %.1f",
+                       candidate.x, candidate.y, candidate.z, leap_dist, min_range, max_range );
         if( leap_dist > max_range || leap_dist < min_range ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate outside of allowed range, discarded" );
@@ -169,12 +169,12 @@ bool leap_actor::call( monster &z ) const
                            "Candidate farther from target than optimal path, discarded" );
             continue;
         }
-        if( !ignore_dest_terrain && !z.will_move_to( candidate.raw() ) ) {
+        if( !ignore_dest_terrain && !z.will_move_to( candidate ) ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate place it can't enter, discarded" );
             continue;
         }
-        if( !ignore_dest_danger && !z.know_danger_at( candidate.raw() ) ) {
+        if( !ignore_dest_danger && !z.know_danger_at( candidate ) ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate with dangerous conditions, discarded" );
             continue;
@@ -183,7 +183,7 @@ bool leap_actor::call( monster &z ) const
     }
     for( const auto &candidate : candidates ) {
         const int &cur_dist = candidate.first;
-        const tripoint_bub_ms &dest = candidate.second;
+        const tripoint &dest = candidate.second;
         if( cur_dist > best && !random_leap ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Distance %d larger than previous best %d, candidate discarded", cur_dist, best );
@@ -198,8 +198,8 @@ bool leap_actor::call( monster &z ) const
         }
         bool blocked_path = false;
         // check if monster has a clear path to the proposed point
-        std::vector<tripoint_bub_ms> line = here.find_clear_path( z.pos_bub(), dest );
-        for( tripoint_bub_ms &i : line ) {
+        std::vector<tripoint> line = here.find_clear_path( z.pos(), dest );
+        for( tripoint &i : line ) {
             if( here.impassable( i ) ) {
                 add_msg_debug( debugmode::DF_MATTACK, "Path blocked, candidate discarded" );
                 blocked_path = true;
@@ -226,7 +226,7 @@ bool leap_actor::call( monster &z ) const
 
     z.mod_moves( -move_cost );
     viewer &player_view = get_player_view();
-    const tripoint_bub_ms chosen = random_entry( options );
+    const tripoint chosen = random_entry( options );
     bool seen = player_view.sees( z ); // We can see them jump...
     z.setpos( chosen );
     seen |= player_view.sees( z ); // ... or we can see them land

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1251,15 +1251,15 @@ void monster::move()
     // Finished logic section.  By this point, we should have chosen a square to
     //  move to (moved = true).
     if( moved ) { // Actual effects of moving to the square we've chosen
-        const tripoint_bub_ms local_next_step = here.bub_from_abs( next_step );
+        const tripoint local_next_step = here.getlocal( next_step );
         const bool did_something =
-            ( !pacified && attack_at( local_next_step.raw() ) ) ||
+            ( !pacified && attack_at( local_next_step ) ) ||
             ( !pacified && can_open_doors &&
               here.open_door( *this, local_next_step, !here.is_outside( pos_bub() ) ) ) ||
-            ( !pacified && bash_at( local_next_step.raw() ) ) ||
-            ( !pacified && push_to( local_next_step.raw(), 0, 0 ) ) ||
-            move_to( local_next_step.raw(), false, false, get_stagger_adjust( pos(), destination.raw(),
-                     local_next_step.raw() ) );
+            ( !pacified && bash_at( local_next_step ) ) ||
+            ( !pacified && push_to( local_next_step, 0, 0 ) ) ||
+            move_to( local_next_step, false, false, get_stagger_adjust( pos(), destination.raw(),
+                     local_next_step ) );
 
         if( !did_something ) {
             mod_moves( -get_speed() ); // If we don't do this, we'll get infinite loops.
@@ -1325,7 +1325,7 @@ void monster::nursebot_operate( Character *dragged_foe )
     creature_tracker &creatures = get_creature_tracker();
     map &here = get_map();
     if( rl_dist( get_location(), get_dest() ) == 1 &&
-        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.bub_from_abs( get_dest() ) ) &&
+        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.getlocal( get_dest() ) ) &&
         !has_effect( effect_operating ) ) {
         if( dragged_foe->has_effect( effect_grabbed ) && !has_effect( effect_countdown ) &&
             ( creatures.creature_at( get_dest() ) == nullptr ||
@@ -1343,7 +1343,7 @@ void monster::nursebot_operate( Character *dragged_foe )
                            string_format(
                                _( "a soft robotic voice say, \"Please step away from the Autodoc, this patient needs immediate care.\"" ) ) );
             // TODO: Make it able to push NPC/player
-            push_to( here.bub_from_abs( get_dest() ).raw(), 4, 0 );
+            push_to( here.getlocal( get_dest() ), 4, 0 );
         }
     }
     if( get_effect_dur( effect_countdown ) == 1_turns && !has_effect( effect_operating ) ) {
@@ -2355,7 +2355,7 @@ bool monster::will_reach( const point &p )
         return true;
     }
 
-    if( can_hear() && wandf > 0 && rl_dist( get_map().bub_from_abs( wander_pos ).xy().raw(), p ) <= 2 &&
+    if( can_hear() && wandf > 0 && rl_dist( get_map().getlocal( wander_pos ).xy(), p ) <= 2 &&
         rl_dist( get_location().xy(), wander_pos.xy() ) <= wandf ) {
         return true;
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1251,15 +1251,15 @@ void monster::move()
     // Finished logic section.  By this point, we should have chosen a square to
     //  move to (moved = true).
     if( moved ) { // Actual effects of moving to the square we've chosen
-        const tripoint local_next_step = here.getlocal( next_step );
+        const tripoint_bub_ms local_next_step = here.bub_from_abs( next_step );
         const bool did_something =
-            ( !pacified && attack_at( local_next_step ) ) ||
+            ( !pacified && attack_at( local_next_step.raw() ) ) ||
             ( !pacified && can_open_doors &&
               here.open_door( *this, local_next_step, !here.is_outside( pos_bub() ) ) ) ||
-            ( !pacified && bash_at( local_next_step ) ) ||
-            ( !pacified && push_to( local_next_step, 0, 0 ) ) ||
-            move_to( local_next_step, false, false, get_stagger_adjust( pos(), destination.raw(),
-                     local_next_step ) );
+            ( !pacified && bash_at( local_next_step.raw() ) ) ||
+            ( !pacified && push_to( local_next_step.raw(), 0, 0 ) ) ||
+            move_to( local_next_step.raw(), false, false, get_stagger_adjust( pos(), destination.raw(),
+                     local_next_step.raw() ) );
 
         if( !did_something ) {
             mod_moves( -get_speed() ); // If we don't do this, we'll get infinite loops.
@@ -1325,7 +1325,7 @@ void monster::nursebot_operate( Character *dragged_foe )
     creature_tracker &creatures = get_creature_tracker();
     map &here = get_map();
     if( rl_dist( get_location(), get_dest() ) == 1 &&
-        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.getlocal( get_dest() ) ) &&
+        !here.has_flag_furn( ter_furn_flag::TFLAG_AUTODOC_COUCH, here.bub_from_abs( get_dest() ) ) &&
         !has_effect( effect_operating ) ) {
         if( dragged_foe->has_effect( effect_grabbed ) && !has_effect( effect_countdown ) &&
             ( creatures.creature_at( get_dest() ) == nullptr ||
@@ -1343,7 +1343,7 @@ void monster::nursebot_operate( Character *dragged_foe )
                            string_format(
                                _( "a soft robotic voice say, \"Please step away from the Autodoc, this patient needs immediate care.\"" ) ) );
             // TODO: Make it able to push NPC/player
-            push_to( here.getlocal( get_dest() ), 4, 0 );
+            push_to( here.bub_from_abs( get_dest() ).raw(), 4, 0 );
         }
     }
     if( get_effect_dur( effect_countdown ) == 1_turns && !has_effect( effect_operating ) ) {
@@ -2355,7 +2355,7 @@ bool monster::will_reach( const point &p )
         return true;
     }
 
-    if( can_hear() && wandf > 0 && rl_dist( get_map().getlocal( wander_pos ).xy(), p ) <= 2 &&
+    if( can_hear() && wandf > 0 && rl_dist( get_map().bub_from_abs( wander_pos ).xy().raw(), p ) <= 2 &&
         rl_dist( get_location().xy(), wander_pos.xy() ) <= wandf ) {
         return true;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -296,9 +296,8 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
 
         if( retreat_target && *retreat_target != abs_pos ) {
             add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                           "<color_light_gray>%s is </color><color_brown>repositioning</color> to %i %i %i", name,
-                           here.getlocal( *retreat_target ).x, here.getlocal( *retreat_target ).y,
-                           here.getlocal( *retreat_target ).z );
+                           "<color_light_gray>%s is </color><color_brown>repositioning</color> to %s", name,
+                           here.bub_from_abs( *retreat_target ).to_string_writable() );
             update_path( here.bub_from_abs( *retreat_target ) );
         }
         if( !path.empty() ) {
@@ -1218,9 +1217,10 @@ void npc::regen_ai_cache()
         }
     }
     while( i != std::end( ai_cache.sound_alerts ) ) {
-        if( sees( here.bub_from_abs( i->abs_pos ) ) ) {
+        if( sees( here.bub_from_abs( tripoint_abs_ms( i->abs_pos ) ) ) ) {
             // if they were responding to a call for guards because of thievery
-            npc *const sound_source = creatures.creature_at<npc>( here.bub_from_abs( i->abs_pos ) );
+            npc *const sound_source = creatures.creature_at<npc>( here.bub_from_abs( tripoint_abs_ms(
+                                          i->abs_pos ) ) );
             if( sound_source ) {
                 if( my_fac == sound_source->my_fac && sound_source->known_stolen_item ) {
                     sound_source->known_stolen_item = nullptr;
@@ -1461,7 +1461,7 @@ void npc::move()
         if( !activity_route.empty() && !has_destination_activity() ) {
             tripoint_bub_ms final_destination;
             if( destination_point ) {
-                final_destination = here.bub_from_abs( *destination_point );
+                final_destination = here.bub_from_abs( tripoint_abs_ms( *destination_point ) );
             } else {
                 final_destination = activity_route.back();
             }
@@ -1594,10 +1594,10 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_investigate_sound: {
-            tripoint cur_pos = pos();
-            update_path( here.bub_from_abs( ai_cache.s_abs_pos ) );
+            tripoint_bub_ms cur_pos = pos_bub();
+            update_path( here.bub_from_abs( tripoint_abs_ms( ai_cache.s_abs_pos ) ) );
             move_to_next();
-            if( pos() == cur_pos ) {
+            if( pos_bub() == cur_pos ) {
                 ai_cache.stuck += 1;
             }
         }
@@ -1735,7 +1735,7 @@ void npc::execute_action( npc_action action )
 
         case npc_look_for_player:
             if( saw_player_recently() && last_player_seen_pos &&
-                sees( here.getlocal( *last_player_seen_pos ) ) ) {
+                sees( here.bub_from_abs( *last_player_seen_pos ) ) ) {
                 update_path( here.bub_from_abs( *last_player_seen_pos ) );
                 move_to_next();
             } else {
@@ -2992,7 +2992,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
                 if( !activity_route.empty() && !np->has_destination_activity() ) {
                     tripoint_bub_ms final_destination;
                     if( destination_point ) {
-                        final_destination = here.bub_from_abs( *destination_point );
+                        final_destination = here.bub_from_abs( tripoint_abs_ms( *destination_point ) );
                     } else {
                         final_destination = activity_route.back();
                     }
@@ -3364,7 +3364,7 @@ void npc::worker_downtime()
         basecamp *temp_camp = *bcp;
         std::vector<tripoint_bub_ms> pts;
         for( const tripoint_bub_ms &elem : here.points_in_radius( here.bub_from_abs(
-                    temp_camp->get_bb_pos() ), 10 ) ) {
+                    tripoint_abs_ms( temp_camp->get_bb_pos() ) ), 10 ) ) {
             if( creatures.creature_at( elem ) || !could_move_onto( elem ) ||
                 here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, elem ) ||
                 !here.has_floor_or_water( elem ) || g->is_dangerous_tile( elem.raw() ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -296,8 +296,9 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
 
         if( retreat_target && *retreat_target != abs_pos ) {
             add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                           "<color_light_gray>%s is </color><color_brown>repositioning</color> to %s", name,
-                           here.bub_from_abs( *retreat_target ).to_string_writable() );
+                           "<color_light_gray>%s is </color><color_brown>repositioning</color> to %i %i %i", name,
+                           here.getlocal( *retreat_target ).x, here.getlocal( *retreat_target ).y,
+                           here.getlocal( *retreat_target ).z );
             update_path( here.bub_from_abs( *retreat_target ) );
         }
         if( !path.empty() ) {
@@ -1217,10 +1218,9 @@ void npc::regen_ai_cache()
         }
     }
     while( i != std::end( ai_cache.sound_alerts ) ) {
-        if( sees( here.bub_from_abs( tripoint_abs_ms( i->abs_pos ) ) ) ) {
+        if( sees( here.bub_from_abs( i->abs_pos ) ) ) {
             // if they were responding to a call for guards because of thievery
-            npc *const sound_source = creatures.creature_at<npc>( here.bub_from_abs( tripoint_abs_ms(
-                                          i->abs_pos ) ) );
+            npc *const sound_source = creatures.creature_at<npc>( here.bub_from_abs( i->abs_pos ) );
             if( sound_source ) {
                 if( my_fac == sound_source->my_fac && sound_source->known_stolen_item ) {
                     sound_source->known_stolen_item = nullptr;
@@ -1461,7 +1461,7 @@ void npc::move()
         if( !activity_route.empty() && !has_destination_activity() ) {
             tripoint_bub_ms final_destination;
             if( destination_point ) {
-                final_destination = here.bub_from_abs( tripoint_abs_ms( *destination_point ) );
+                final_destination = here.bub_from_abs( *destination_point );
             } else {
                 final_destination = activity_route.back();
             }
@@ -1594,10 +1594,10 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_investigate_sound: {
-            tripoint_bub_ms cur_pos = pos_bub();
-            update_path( here.bub_from_abs( tripoint_abs_ms( ai_cache.s_abs_pos ) ) );
+            tripoint cur_pos = pos();
+            update_path( here.bub_from_abs( ai_cache.s_abs_pos ) );
             move_to_next();
-            if( pos_bub() == cur_pos ) {
+            if( pos() == cur_pos ) {
                 ai_cache.stuck += 1;
             }
         }
@@ -1735,7 +1735,7 @@ void npc::execute_action( npc_action action )
 
         case npc_look_for_player:
             if( saw_player_recently() && last_player_seen_pos &&
-                sees( here.bub_from_abs( *last_player_seen_pos ) ) ) {
+                sees( here.getlocal( *last_player_seen_pos ) ) ) {
                 update_path( here.bub_from_abs( *last_player_seen_pos ) );
                 move_to_next();
             } else {
@@ -2992,7 +2992,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
                 if( !activity_route.empty() && !np->has_destination_activity() ) {
                     tripoint_bub_ms final_destination;
                     if( destination_point ) {
-                        final_destination = here.bub_from_abs( tripoint_abs_ms( *destination_point ) );
+                        final_destination = here.bub_from_abs( *destination_point );
                     } else {
                         final_destination = activity_route.back();
                     }
@@ -3364,7 +3364,7 @@ void npc::worker_downtime()
         basecamp *temp_camp = *bcp;
         std::vector<tripoint_bub_ms> pts;
         for( const tripoint_bub_ms &elem : here.points_in_radius( here.bub_from_abs(
-                    tripoint_abs_ms( temp_camp->get_bb_pos() ) ), 10 ) ) {
+                    temp_camp->get_bb_pos() ), 10 ) ) {
             if( creatures.creature_at( elem ) || !could_move_onto( elem ) ||
                 here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, elem ) ||
                 !here.has_floor_or_water( elem ) || g->is_dangerous_tile( elem.raw() ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4922,7 +4922,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                 if( target_var.has_value() ) {
                     tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
-                        guy->invoke_item( it->get_item(), method_str, get_map().bub_from_abs( target_pos ).raw() );
+                        guy->invoke_item( it->get_item(), method_str, get_map().getlocal( target_pos ) );
                         return;
                     }
                 }
@@ -5035,7 +5035,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
         } else {
             translated_message = message.evaluate( d );
         }
-        sounds::sound( get_map().bub_from_abs( target_pos ), volume.evaluate( d ), type, translated_message,
+        sounds::sound( get_map().getlocal( target_pos ), volume.evaluate( d ), type, translated_message,
                        ambient );
     };
 }
@@ -5467,10 +5467,10 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
         tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, is_npc );
         std::vector<item_location> items;
         map &here = get_map();
-        tripoint_bub_ms center = here.bub_from_abs( target_location );
+        tripoint center = here.getlocal( target_location );
         int max_radius = dov_max_radius.evaluate( d );
         int min_radius = dov_min_radius.evaluate( d );
-        for( const tripoint_bub_ms &pos : here.points_in_radius( center, max_radius ) ) {
+        for( const tripoint &pos : here.points_in_radius( center, max_radius ) ) {
             if( rl_dist( center, pos ) >= min_radius && here.inbounds( pos ) ) {
                 for( item &it : here.i_at( pos ) ) {
                     items.emplace_back( map_cursor( tripoint_bub_ms( pos ) ), &it );
@@ -5486,9 +5486,9 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos.raw() );
+                    inv_s.add_map_items( pos );
                 }
             }
             if( inv_s.empty() ) {
@@ -5504,9 +5504,9 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos.raw() );
+                    inv_s.add_map_items( pos );
                 }
             }
             if( inv_s.empty() ) {
@@ -6017,7 +6017,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) ).raw();
+            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6152,7 +6152,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) ).raw();
+            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4922,7 +4922,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                 if( target_var.has_value() ) {
                     tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
-                        guy->invoke_item( it->get_item(), method_str, get_map().getlocal( target_pos ) );
+                        guy->invoke_item( it->get_item(), method_str, get_map().bub_from_abs( target_pos ).raw() );
                         return;
                     }
                 }
@@ -5035,7 +5035,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
         } else {
             translated_message = message.evaluate( d );
         }
-        sounds::sound( get_map().getlocal( target_pos ), volume.evaluate( d ), type, translated_message,
+        sounds::sound( get_map().bub_from_abs( target_pos ), volume.evaluate( d ), type, translated_message,
                        ambient );
     };
 }
@@ -5467,10 +5467,10 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
         tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, is_npc );
         std::vector<item_location> items;
         map &here = get_map();
-        tripoint center = here.getlocal( target_location );
+        tripoint_bub_ms center = here.bub_from_abs( target_location );
         int max_radius = dov_max_radius.evaluate( d );
         int min_radius = dov_min_radius.evaluate( d );
-        for( const tripoint &pos : here.points_in_radius( center, max_radius ) ) {
+        for( const tripoint_bub_ms &pos : here.points_in_radius( center, max_radius ) ) {
             if( rl_dist( center, pos ) >= min_radius && here.inbounds( pos ) ) {
                 for( item &it : here.i_at( pos ) ) {
                     items.emplace_back( map_cursor( tripoint_bub_ms( pos ) ), &it );
@@ -5486,9 +5486,9 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos );
+                    inv_s.add_map_items( pos.raw() );
                 }
             }
             if( inv_s.empty() ) {
@@ -5504,9 +5504,9 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
-                    inv_s.add_map_items( pos );
+                    inv_s.add_map_items( pos.raw() );
                 }
             }
             if( inv_s.empty() ) {
@@ -6017,7 +6017,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) ).raw();
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6152,7 +6152,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint target_pos = d.actor( is_npc )->pos();
         if( target_var.has_value() ) {
-            target_pos = get_map().getlocal( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().bub_from_abs( get_tripoint_from_var( target_var, d, is_npc ) ).raw();
         }
         int visible_spawns = 0;
         int spawns = 0;

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -135,12 +135,12 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
         bool leftover = true;
         for( tripoint_abs_ms const &dpoint : dest ) {
-            tripoint_bub_ms const dpoint_here = here.bub_from_abs( dpoint );
+            tripoint const dpoint_here = here.getlocal( dpoint );
             std::optional<vpart_reference> const vp = here.veh_at( dpoint_here ).cargo();
             if( vp && vp->vehicle().get_owner() == fac_id ) {
                 leftover = _to_veh( it, vp );
             } else {
-                leftover = _to_map( it, here, dpoint_here.raw() );
+                leftover = _to_map( it, here, dpoint_here );
             }
             if( !leftover ) {
                 break;

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -135,12 +135,12 @@ std::list<item> distribute_items_to_npc_zones( std::list<item> &items, npc &guy 
 
         bool leftover = true;
         for( tripoint_abs_ms const &dpoint : dest ) {
-            tripoint const dpoint_here = here.getlocal( dpoint );
+            tripoint_bub_ms const dpoint_here = here.bub_from_abs( dpoint );
             std::optional<vpart_reference> const vp = here.veh_at( dpoint_here ).cargo();
             if( vp && vp->vehicle().get_owner() == fac_id ) {
                 leftover = _to_veh( it, vp );
             } else {
-                leftover = _to_map( it, here, dpoint_here );
+                leftover = _to_map( it, here, dpoint_here.raw() );
             }
             if( !leftover ) {
                 break;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1578,13 +1578,13 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
         const map &here = get_map();
-        const tripoint_bub_ms local = here.bub_from_abs( this_monster.get_location() );
+        const tripoint local = here.bub_from_abs( this_monster.get_location() ).raw();
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );
         }
         monster *const placed = g->place_critter_around( make_shared_fast<monster>( this_monster ),
-                                local.raw(), 0, true );
+                                local, 0, true );
         if( placed ) {
             placed->on_load();
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1578,13 +1578,13 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
         const map &here = get_map();
-        const tripoint local = here.bub_from_abs( this_monster.get_location() ).raw();
+        const tripoint_bub_ms local = here.bub_from_abs( this_monster.get_location() );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );
         }
         monster *const placed = g->place_critter_around( make_shared_fast<monster>( this_monster ),
-                                local, 0, true );
+                                local.raw(), 0, true );
         if( placed ) {
             placed->on_load();
         }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -572,39 +572,39 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
             valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
-                              cur, above );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
+                              cur, above.raw() );
             }
         }
         if( cur.z < max.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
             valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
-                              cur, above );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
+                              cur, above.raw() );
             }
         }
         if( cur.z > min.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
             valid_move( cur, tripoint( cur.xy(), cur.z - 1 ), false, true, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z - 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint below( cur.x + x_offset[it], cur.y + y_offset[it], cur.z - 1 );
+                const tripoint_bub_ms below( cur.x + x_offset[it], cur.y + y_offset[it], cur.z - 1 );
                 if( !inbounds( below ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( below, t ),
-                              cur, below );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( below.raw(), t ),
+                              cur, below.raw() );
             }
         }
 

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -572,39 +572,39 @@ std::vector<tripoint> map::route( const tripoint &f, const tripoint &t,
             valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
-                              cur, above.raw() );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
+                              cur, above );
             }
         }
         if( cur.z < max.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
             valid_move( cur, tripoint( cur.xy(), cur.z + 1 ), false, true, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z + 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
+                const tripoint above( cur.x + x_offset[it], cur.y + y_offset[it], cur.z + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above.raw(), t ),
-                              cur, above.raw() );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
+                              cur, above );
             }
         }
         if( cur.z > min.z && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
             valid_move( cur, tripoint( cur.xy(), cur.z - 1 ), false, true, true ) ) {
             path_data_layer &layer = pf.get_layer( cur.z - 1 );
             for( size_t it = 0; it < 8; it++ ) {
-                const tripoint_bub_ms below( cur.x + x_offset[it], cur.y + y_offset[it], cur.z - 1 );
+                const tripoint below( cur.x + x_offset[it], cur.y + y_offset[it], cur.z - 1 );
                 if( !inbounds( below ) ) {
                     continue;
                 }
                 pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( below.raw(), t ),
-                              cur, below.raw() );
+                              layer.score[parent_index] + 4 + 2 * rl_dist( below, t ),
+                              cur, below );
             }
         }
 

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -123,7 +123,7 @@ struct pathfinding_cache {
     pathfinding_cache();
 
     bool dirty = false;
-    std::unordered_set<point> dirty_points;
+    std::unordered_set<point_bub_ms> dirty_points;
 
     cata::mdarray<PathfindingFlags, point_bub_ms> special;
 };

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -123,7 +123,7 @@ struct pathfinding_cache {
     pathfinding_cache();
 
     bool dirty = false;
-    std::unordered_set<point_bub_ms> dirty_points;
+    std::unordered_set<point> dirty_points;
 
     cata::mdarray<PathfindingFlags, point_bub_ms> special;
 };

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -518,12 +518,12 @@ void pixel_minimap::render_critters( const tripoint &center )
     creature_tracker &creatures = get_creature_tracker();
     for( int y = 0; y < total_tiles_count.y; y++ ) {
         for( int x = 0; x < total_tiles_count.x; x++ ) {
-            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z );
+            const tripoint p = start + tripoint( x, y, center.z );
             if( !m.inbounds( p ) ) {
                 // p might be out-of-bounds when peeking at submap boundary. Example: center=(64,59,-5), start=(4,-1) -> p=(4,-1,-5)
                 continue;
             }
-            const lit_level lighting = access_cache.visibility_cache[p.x()][p.y()];
+            const lit_level lighting = access_cache.visibility_cache[p.x][p.y];
 
             if( lighting == lit_level::DARK || lighting == lit_level::BLANK ) {
                 continue;

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -518,12 +518,12 @@ void pixel_minimap::render_critters( const tripoint &center )
     creature_tracker &creatures = get_creature_tracker();
     for( int y = 0; y < total_tiles_count.y; y++ ) {
         for( int x = 0; x < total_tiles_count.x; x++ ) {
-            const tripoint p = start + tripoint( x, y, center.z );
+            const tripoint_bub_ms p = start + tripoint_bub_ms( x, y, center.z );
             if( !m.inbounds( p ) ) {
                 // p might be out-of-bounds when peeking at submap boundary. Example: center=(64,59,-5), start=(4,-1) -> p=(4,-1,-5)
                 continue;
             }
-            const lit_level lighting = access_cache.visibility_cache[p.x][p.y];
+            const lit_level lighting = access_cache.visibility_cache[p.x()][p.y()];
 
             if( lighting == lit_level::DARK || lighting == lit_level::BLANK ) {
                 continue;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3291,7 +3291,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
     }
 
     // Try to re-acquire target tile or tile where the target creature used to be
-    tripoint_bub_ms local_lt = get_map().bub_from_abs( tripoint_abs_ms( *you->last_target_pos ) );
+    tripoint_bub_ms local_lt = get_map().bub_from_abs( *you->last_target_pos );
     if( dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
@@ -3520,7 +3520,7 @@ void target_ui::recalc_aim_turning_penalty()
     if( lt_ptr ) {
         curr_recoil_pos = lt_ptr->pos_bub();
     } else if( you->last_target_pos ) {
-        curr_recoil_pos = get_map().bub_from_abs( tripoint_abs_ms( *you->last_target_pos ) );
+        curr_recoil_pos = get_map().bub_from_abs( *you->last_target_pos );
     } else {
         curr_recoil_pos = src;
     }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3291,7 +3291,7 @@ bool target_ui::try_reacquire_target( bool critter, tripoint_bub_ms &new_dst )
     }
 
     // Try to re-acquire target tile or tile where the target creature used to be
-    tripoint_bub_ms local_lt = get_map().bub_from_abs( *you->last_target_pos );
+    tripoint_bub_ms local_lt = get_map().bub_from_abs( tripoint_abs_ms( *you->last_target_pos ) );
     if( dist_fn( local_lt ) <= range ) {
         new_dst = local_lt;
         // Abort aiming if a creature moved in
@@ -3520,7 +3520,7 @@ void target_ui::recalc_aim_turning_penalty()
     if( lt_ptr ) {
         curr_recoil_pos = lt_ptr->pos_bub();
     } else if( you->last_target_pos ) {
-        curr_recoil_pos = get_map().bub_from_abs( *you->last_target_pos );
+        curr_recoil_pos = get_map().bub_from_abs( tripoint_abs_ms( *you->last_target_pos ) );
     } else {
         curr_recoil_pos = src;
     }

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -198,8 +198,8 @@ void scent_map::update( const tripoint &center, map &m )
     const int diffusivity = 100;
 
     // The new scent flag searching function. Should be wayyy faster than the old one.
-    m.scent_blockers( blocks_scent, reduces_scent, point( scentmap_minx - 1, scentmap_miny - 1 ),
-                      point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
+    m.scent_blockers( blocks_scent, reduces_scent, point_bub_ms( scentmap_minx - 1, scentmap_miny - 1 ),
+                      point_bub_ms( scentmap_maxx + 1, scentmap_maxy + 1 ) );
     // Sum neighbors in the y direction.  This way, each square gets called 3 times instead of 9
     // times. This cost us an extra loop here, but it also eliminated a loop at the end, so there
     // is a net performance improvement over the old code. Could probably still be better.

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -198,8 +198,8 @@ void scent_map::update( const tripoint &center, map &m )
     const int diffusivity = 100;
 
     // The new scent flag searching function. Should be wayyy faster than the old one.
-    m.scent_blockers( blocks_scent, reduces_scent, point_bub_ms( scentmap_minx - 1, scentmap_miny - 1 ),
-                      point_bub_ms( scentmap_maxx + 1, scentmap_maxy + 1 ) );
+    m.scent_blockers( blocks_scent, reduces_scent, point( scentmap_minx - 1, scentmap_miny - 1 ),
+                      point( scentmap_maxx + 1, scentmap_maxy + 1 ) );
     // Sum neighbors in the y direction.  This way, each square gets called 3 times instead of 9
     // times. This cost us an extra loop here, but it also eliminated a loop at the end, so there
     // is a net performance improvement over the old code. Could probably still be better.

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -456,7 +456,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
     // Sometimes it may be impossible to automatically found an ideal location
     // but the player may be more creative than this algorithm and do away with just "good"
     int best_rate = 0;
-    tripoint_bub_ms best_spot = you.pos_bub();
+    tripoint best_spot = you.pos();
     // In which attempt did this area get checked?
     // We can overwrite earlier attempts, but not start in them
     cata::mdarray<int, point_bub_ms> checked = {};
@@ -470,7 +470,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
         if( zone.get_type() == zone_type_ZONE_START_POINT ) {
             if( here.inbounds( zone.get_center_point() ) ) {
                 found_good_spot = true;
-                best_spot = here.bub_from_abs( zone.get_center_point() );
+                best_spot = here.getlocal( zone.get_center_point() );
                 break;
             }
         }
@@ -479,10 +479,9 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
     // Otherwise, find a random starting spot
 
     int tries = 0;
-    const auto check_spot = [&]( const tripoint_bub_ms & pt ) {
+    const auto check_spot = [&]( const tripoint & pt ) {
         ++tries;
-        const int rate = rate_location( here, pt.raw(), must_be_inside, accommodate_npc, bash, tries,
-                                        checked );
+        const int rate = rate_location( here, pt, must_be_inside, accommodate_npc, bash, tries, checked );
         if( best_rate < rate ) {
             best_rate = rate;
             best_spot = pt;
@@ -494,17 +493,17 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
     };
 
     while( !found_good_spot && tries < 100 ) {
-        tripoint_bub_ms rand_point( HALF_MAPSIZE_X + rng( 0, SEEX * 2 - 1 ),
-                                    HALF_MAPSIZE_Y + rng( 0, SEEY * 2 - 1 ),
-                                    you.posz() );
+        tripoint rand_point( HALF_MAPSIZE_X + rng( 0, SEEX * 2 - 1 ),
+                             HALF_MAPSIZE_Y + rng( 0, SEEY * 2 - 1 ),
+                             you.posz() );
         found_good_spot = check_spot( rand_point );
     }
     // If we haven't got a good location by now, screw it and brute force it
     // This only happens in exotic locations (deep of a science lab), but it does happen
     if( !found_good_spot ) {
-        tripoint_bub_ms tmp = you.pos_bub();
-        int &x = tmp.x();
-        int &y = tmp.y();
+        tripoint tmp = you.pos();
+        int &x = tmp.x;
+        int &y = tmp.y;
         for( x = 0; x < MAPSIZE_X; x++ ) {
             for( y = 0; y < MAPSIZE_Y && !found_good_spot; y++ ) {
                 found_good_spot = check_spot( tmp );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1383,7 +1383,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
 
     item jetpack = you->item_worn_with_flag( STATIC( flag_id( "JETPACK" ) ) );
     // TODO: Typify this whole function
-    tripoint_bub_ms p_bub = tripoint_bub_ms( p );
+    tripoint_bub_ms p_bub = here.bub_from_abs( p );
     if( you->has_flag( json_flag_WALL_CLING ) &&  get_map().is_clingable_wall_adjacent( p_bub ) ) {
         you->add_msg_player_or_npc( _( "You cling to the nearby wall." ),
                                     _( "<npcname> clings to the wall." ) );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1383,7 +1383,7 @@ bool trapfunc::ledge( const tripoint &p, Creature *c, item * )
 
     item jetpack = you->item_worn_with_flag( STATIC( flag_id( "JETPACK" ) ) );
     // TODO: Typify this whole function
-    tripoint_bub_ms p_bub = here.bub_from_abs( p );
+    tripoint_bub_ms p_bub = tripoint_bub_ms( p );
     if( you->has_flag( json_flag_WALL_CLING ) &&  get_map().is_clingable_wall_adjacent( p_bub ) ) {
         you->add_msg_player_or_npc( _( "You cling to the nearby wall." ),
                                     _( "<npcname> clings to the wall." ) );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3075,7 +3075,7 @@ void veh_interact::complete_vehicle( Character &you )
         // during this player/NPCs activity.
         // check the vehicle points that were stored at beginning of activity.
         for( const tripoint &pt : you.activity.coord_set ) {
-            ovp = here.veh_at( here.bub_from_abs( pt ) );
+            ovp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( pt ) ) );
             if( ovp ) {
                 break;
             }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3075,7 +3075,7 @@ void veh_interact::complete_vehicle( Character &you )
         // during this player/NPCs activity.
         // check the vehicle points that were stored at beginning of activity.
         for( const tripoint &pt : you.activity.coord_set ) {
-            ovp = here.veh_at( here.bub_from_abs( tripoint_abs_ms( pt ) ) );
+            ovp = here.veh_at( here.bub_from_abs( pt ) );
             if( ovp ) {
                 break;
             }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -654,7 +654,7 @@ void vehicle::autopilot_patrol()
             autodrive_local_target = tripoint_zero;
             return;
         }
-        if( !here.inbounds( here.bub_from_abs( tripoint_abs_ms( autodrive_local_target ) ) ) ) {
+        if( !here.inbounds( here.bub_from_abs( autodrive_local_target ) ) ) {
             autodrive_local_target = tripoint_zero;
             is_patrolling = false;
             return;
@@ -823,17 +823,17 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     bool stop = false;
     creature_tracker &creatures = get_creature_tracker();
     for( const point &pt_elem : points_to_check ) {
-        point_bub_ms elem = here.bub_from_abs( point_abs_ms( pt_elem ) );
+        point elem = here.getlocal( pt_elem );
         if( stop ) {
             break;
         }
-        const optional_vpart_position ovp = here.veh_at( tripoint_bub_ms( elem.x(), elem.y(), sm_pos.z ) );
-        if( here.impassable_ter_furn( tripoint_bub_ms( elem.x(), elem.y(), sm_pos.z ) ) || ( ovp &&
+        const optional_vpart_position ovp = here.veh_at( tripoint_bub_ms( elem.x, elem.y, sm_pos.z ) );
+        if( here.impassable_ter_furn( tripoint_bub_ms( elem.x, elem.y, sm_pos.z ) ) || ( ovp &&
                 &ovp->vehicle() != this ) ) {
             stop = true;
             break;
         }
-        if( elem == player_character.pos_bub().xy() ) {
+        if( elem == player_character.pos().xy() ) {
             if( follow_protocol || player_character.in_vehicle ) {
                 continue;
             } else {
@@ -842,15 +842,15 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
             }
         }
         bool its_a_pet = false;
-        if( creatures.creature_at( tripoint_bub_ms( elem, sm_pos.z ) ) ) {
-            npc *guy = creatures.creature_at<npc>( tripoint_bub_ms( elem, sm_pos.z ) );
+        if( creatures.creature_at( tripoint( elem, sm_pos.z ) ) ) {
+            npc *guy = creatures.creature_at<npc>( tripoint( elem, sm_pos.z ) );
             if( guy && !guy->in_vehicle ) {
                 stop = true;
                 break;
             }
             for( const vehicle_part &p : parts ) {
                 monster *mon = get_monster( index_of_part( &p ) );
-                if( mon && mon->pos_bub().xy() == elem ) {
+                if( mon && mon->pos().xy() == elem ) {
                     its_a_pet = true;
                     break;
                 }
@@ -2023,7 +2023,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
         return false;
     }
 
-    const tripoint_bub_ms part_loc = bub_part_pos( vp );
+    const tripoint part_loc = global_part_pos3( vp );
 
     if( !handler.get_map_ref().inbounds( part_loc ) ) {
         debugmsg( "vehicle::remove_part part '%s' at mount %s bub pos %s is out of map "
@@ -2034,11 +2034,11 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
 
     // Unboard any entities standing on removed boardable parts
     if( vpi.has_flag( "BOARDABLE" ) && vp.has_flag( vp_flag::passenger_flag ) ) {
-        handler.unboard( part_loc.raw() );
+        handler.unboard( part_loc );
     }
 
     for( const item &it : vp.tools ) {
-        handler.add_item_or_charges( part_loc.raw(), it, false );
+        handler.add_item_or_charges( part_loc, it, false );
     }
 
     // If `p` has flag `parent_flag`, remove child with flag `child_flag`
@@ -2050,7 +2050,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             return false;
         }
         vehicle_part &vp_dep = parts[dep];
-        handler.add_item_or_charges( part_loc.raw(), part_to_item( vp_dep ), false );
+        handler.add_item_or_charges( part_loc, part_to_item( vp_dep ), false );
         remove_part( vp_dep, handler );
         return true;
     };
@@ -2072,7 +2072,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     // Release any animal held by the part
     if( vp.has_flag( vp_flag::animal_flag ) ) {
         item base = vp.get_base();
-        handler.spawn_animal_from_part( base, part_loc.raw() );
+        handler.spawn_animal_from_part( base, part_loc );
         vp.set_base( std::move( base ) );
         vp.remove_flag( vp_flag::animal_flag );
     }
@@ -2126,13 +2126,13 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
         // Note: this can spawn items on the other side of the wall!
         // TODO: fix this ^^
         if( !magic ) {
-            tripoint_bub_ms dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
+            tripoint dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
             // This new point might be out of the map bounds.  It's not
             // reasonable to try to spawn it outside the currently valid map,
             // so we pass true here to cause such points to be clamped to the
             // valid bounds without printing an error (as would normally
             // occur).
-            handler.add_item_or_charges( dest.raw(), i, true );
+            handler.add_item_or_charges( dest, i, true );
         }
     }
     refresh( false );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -654,7 +654,7 @@ void vehicle::autopilot_patrol()
             autodrive_local_target = tripoint_zero;
             return;
         }
-        if( !here.inbounds( here.bub_from_abs( autodrive_local_target ) ) ) {
+        if( !here.inbounds( here.bub_from_abs( tripoint_abs_ms( autodrive_local_target ) ) ) ) {
             autodrive_local_target = tripoint_zero;
             is_patrolling = false;
             return;
@@ -823,17 +823,17 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
     bool stop = false;
     creature_tracker &creatures = get_creature_tracker();
     for( const point &pt_elem : points_to_check ) {
-        point elem = here.getlocal( pt_elem );
+        point_bub_ms elem = here.bub_from_abs( point_abs_ms( pt_elem ) );
         if( stop ) {
             break;
         }
-        const optional_vpart_position ovp = here.veh_at( tripoint_bub_ms( elem.x, elem.y, sm_pos.z ) );
-        if( here.impassable_ter_furn( tripoint_bub_ms( elem.x, elem.y, sm_pos.z ) ) || ( ovp &&
+        const optional_vpart_position ovp = here.veh_at( tripoint_bub_ms( elem.x(), elem.y(), sm_pos.z ) );
+        if( here.impassable_ter_furn( tripoint_bub_ms( elem.x(), elem.y(), sm_pos.z ) ) || ( ovp &&
                 &ovp->vehicle() != this ) ) {
             stop = true;
             break;
         }
-        if( elem == player_character.pos().xy() ) {
+        if( elem == player_character.pos_bub().xy() ) {
             if( follow_protocol || player_character.in_vehicle ) {
                 continue;
             } else {
@@ -842,15 +842,15 @@ bool vehicle::precollision_check( units::angle &angle, map &here, bool follow_pr
             }
         }
         bool its_a_pet = false;
-        if( creatures.creature_at( tripoint( elem, sm_pos.z ) ) ) {
-            npc *guy = creatures.creature_at<npc>( tripoint( elem, sm_pos.z ) );
+        if( creatures.creature_at( tripoint_bub_ms( elem, sm_pos.z ) ) ) {
+            npc *guy = creatures.creature_at<npc>( tripoint_bub_ms( elem, sm_pos.z ) );
             if( guy && !guy->in_vehicle ) {
                 stop = true;
                 break;
             }
             for( const vehicle_part &p : parts ) {
                 monster *mon = get_monster( index_of_part( &p ) );
-                if( mon && mon->pos().xy() == elem ) {
+                if( mon && mon->pos_bub().xy() == elem ) {
                     its_a_pet = true;
                     break;
                 }
@@ -2023,7 +2023,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
         return false;
     }
 
-    const tripoint part_loc = global_part_pos3( vp );
+    const tripoint_bub_ms part_loc = bub_part_pos( vp );
 
     if( !handler.get_map_ref().inbounds( part_loc ) ) {
         debugmsg( "vehicle::remove_part part '%s' at mount %s bub pos %s is out of map "
@@ -2034,11 +2034,11 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
 
     // Unboard any entities standing on removed boardable parts
     if( vpi.has_flag( "BOARDABLE" ) && vp.has_flag( vp_flag::passenger_flag ) ) {
-        handler.unboard( part_loc );
+        handler.unboard( part_loc.raw() );
     }
 
     for( const item &it : vp.tools ) {
-        handler.add_item_or_charges( part_loc, it, false );
+        handler.add_item_or_charges( part_loc.raw(), it, false );
     }
 
     // If `p` has flag `parent_flag`, remove child with flag `child_flag`
@@ -2050,7 +2050,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
             return false;
         }
         vehicle_part &vp_dep = parts[dep];
-        handler.add_item_or_charges( part_loc, part_to_item( vp_dep ), false );
+        handler.add_item_or_charges( part_loc.raw(), part_to_item( vp_dep ), false );
         remove_part( vp_dep, handler );
         return true;
     };
@@ -2072,7 +2072,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     // Release any animal held by the part
     if( vp.has_flag( vp_flag::animal_flag ) ) {
         item base = vp.get_base();
-        handler.spawn_animal_from_part( base, part_loc );
+        handler.spawn_animal_from_part( base, part_loc.raw() );
         vp.set_base( std::move( base ) );
         vp.remove_flag( vp_flag::animal_flag );
     }
@@ -2126,13 +2126,13 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
         // Note: this can spawn items on the other side of the wall!
         // TODO: fix this ^^
         if( !magic ) {
-            tripoint dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
+            tripoint_bub_ms dest( part_loc + point( rng( -3, 3 ), rng( -3, 3 ) ) );
             // This new point might be out of the map bounds.  It's not
             // reasonable to try to spawn it outside the currently valid map,
             // so we pass true here to cause such points to be clamped to the
             // valid bounds without printing an error (as would normally
             // occur).
-            handler.add_item_or_charges( dest, i, true );
+            handler.add_item_or_charges( dest.raw(), i, true );
         }
     }
     refresh( false );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -794,7 +794,7 @@ void vehicle::autodrive_controller::compute_obstacles()
     point_queue ramp_points;
     for( int dx = 0; dx < NAV_VIEW_SIZE_X; dx++ ) {
         for( int dy = 0; dy < NAV_VIEW_SIZE_Y; dy++ ) {
-            const tripoint_abs_ms abs_map_pt( data.view_to_map.transform( point( dx, dy ), z ) );
+            const tripoint abs_map_pt = data.view_to_map.transform( point( dx, dy ), z );
             const tripoint_bub_ms p = here.bub_from_abs( abs_map_pt );
             data.is_obstacle[dx][dy] = !check_drivable( p );
             data.ground_z[dx][dy] = z;

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -794,7 +794,7 @@ void vehicle::autodrive_controller::compute_obstacles()
     point_queue ramp_points;
     for( int dx = 0; dx < NAV_VIEW_SIZE_X; dx++ ) {
         for( int dy = 0; dy < NAV_VIEW_SIZE_Y; dy++ ) {
-            const tripoint abs_map_pt = data.view_to_map.transform( point( dx, dy ), z );
+            const tripoint_abs_ms abs_map_pt( data.view_to_map.transform( point( dx, dy ), z ) );
             const tripoint_bub_ms p = here.bub_from_abs( abs_map_pt );
             data.is_obstacle[dx][dy] = !check_drivable( p );
             data.ground_z[dx][dy] = z;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1812,11 +1812,10 @@ bool vehicle::is_wheel_state_correct_to_turn_on_rails( int wheels_on_rail, int w
 
 vehicle *vehicle::act_on_map()
 {
-    const tripoint_bub_ms pt = pos_bub();
+    const tripoint pt = global_pos3();
     map &here = get_map();
     if( !here.inbounds( pt ) ) {
-        dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x() << "," << pt.y() << "," <<
-                      pt.z() <<
+        dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x << "," << pt.y << "," << pt.z <<
                       ")";
         stop();
         of_turn = 0;

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1812,10 +1812,11 @@ bool vehicle::is_wheel_state_correct_to_turn_on_rails( int wheels_on_rail, int w
 
 vehicle *vehicle::act_on_map()
 {
-    const tripoint pt = global_pos3();
+    const tripoint_bub_ms pt = pos_bub();
     map &here = get_map();
     if( !here.inbounds( pt ) ) {
-        dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x << "," << pt.y << "," << pt.z <<
+        dbg( D_INFO ) << "stopping out-of-map vehicle.  (x,y,z)=(" << pt.x() << "," << pt.y() << "," <<
+                      pt.z() <<
                       ")";
         stop();
         of_turn = 0;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -508,7 +508,7 @@ VisitResponse map_cursor::visit_items(
         // around that location to do our work.
         tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
         here.load( project_to<coords::omt>( abs_pos ), false );
-        tripoint_omt_ms p = here.omt_from_abs( abs_pos );
+        tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
         return visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
     }
 }

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -508,7 +508,7 @@ VisitResponse map_cursor::visit_items(
         // around that location to do our work.
         tripoint_abs_ms abs_pos = get_map().getglobal( pos() );
         here.load( project_to<coords::omt>( abs_pos ), false );
-        tripoint_omt_ms p = tripoint_omt_ms( here.getlocal( abs_pos ) );
+        tripoint_omt_ms p = here.omt_from_abs( abs_pos );
         return visit_items_internal( here.cast_to_map(), rebase_bub( p ), func );
     }
 }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -36,7 +36,7 @@ void run_activities( Character &u, int max_moves )
     while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
         u.set_moves( u.get_speed() );
         if( u.is_auto_moving() ) {
-            u.setpos( get_map().bub_from_abs( *u.destination_point ) );
+            u.setpos( get_map().bub_from_abs( tripoint_abs_ms( *u.destination_point ) ) );
             get_map().build_map_cache( u.pos().z );
             u.start_destination_activity();
         }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -36,7 +36,7 @@ void run_activities( Character &u, int max_moves )
     while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
         u.set_moves( u.get_speed() );
         if( u.is_auto_moving() ) {
-            u.setpos( get_map().bub_from_abs( tripoint_abs_ms( *u.destination_point ) ) );
+            u.setpos( get_map().bub_from_abs( *u.destination_point ) );
             get_map().build_map_cache( u.pos().z );
             u.start_destination_activity();
         }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -181,7 +181,7 @@ void check_ter_in_line( tripoint_abs_ms const &first, tripoint_abs_ms const &sec
     tripoint_abs_ms const orig = coord_min( first, second );
     tm.load( project_to<coords::sm>( orig ), false, false );
     for( tripoint_abs_ms p : line_to( first, second ) ) {
-        REQUIRE( tm.ter( tm.getlocal( p ) ) == ter );
+        REQUIRE( tm.ter( tm.bub_from_abs( p ) ) == ter );
     }
 }
 
@@ -1072,11 +1072,11 @@ TEST_CASE( "EOC_run_inv_test", "[eoc]" )
 
     // Activate test for item
     CHECK( effect_on_condition_EOC_item_activate_test->activate( d ) );
-    CHECK( get_map().furn( get_map().getlocal( pos_after ) ) == furn_f_cardboard_box );
+    CHECK( get_map().furn( get_map().bub_from_abs( pos_after ) ) == furn_f_cardboard_box );
 
     // Teleport test for item
     CHECK( effect_on_condition_EOC_item_teleport_test->activate( d ) );
-    CHECK( get_map().i_at( get_map().getlocal( pos_after ) ).size() == 3 );
+    CHECK( get_map().i_at( get_map().bub_from_abs( pos_after ) ).size() == 3 );
 
     // Math function test for armor
     CHECK( effect_on_condition_EOC_armor_math_test->activate( d ) );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -181,7 +181,7 @@ void check_ter_in_line( tripoint_abs_ms const &first, tripoint_abs_ms const &sec
     tripoint_abs_ms const orig = coord_min( first, second );
     tm.load( project_to<coords::sm>( orig ), false, false );
     for( tripoint_abs_ms p : line_to( first, second ) ) {
-        REQUIRE( tm.ter( tm.bub_from_abs( p ) ) == ter );
+        REQUIRE( tm.ter( tm.getlocal( p ) ) == ter );
     }
 }
 
@@ -1072,11 +1072,11 @@ TEST_CASE( "EOC_run_inv_test", "[eoc]" )
 
     // Activate test for item
     CHECK( effect_on_condition_EOC_item_activate_test->activate( d ) );
-    CHECK( get_map().furn( get_map().bub_from_abs( pos_after ) ) == furn_f_cardboard_box );
+    CHECK( get_map().furn( get_map().getlocal( pos_after ) ) == furn_f_cardboard_box );
 
     // Teleport test for item
     CHECK( effect_on_condition_EOC_item_teleport_test->activate( d ) );
-    CHECK( get_map().i_at( get_map().bub_from_abs( pos_after ) ).size() == 3 );
+    CHECK( get_map().i_at( get_map().getlocal( pos_after ) ).size() == 3 );
 
     // Math function test for armor
     CHECK( effect_on_condition_EOC_armor_math_test->activate( d ) );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -55,6 +55,12 @@ TEST_CASE( "map_coordinate_conversion_functions" )
     CAPTURE( test_bub );
     CAPTURE( test_abs );
 
+    // Verify consistency between different implementations
+    CHECK( here.getglobal( test_bub ) == here.getglobal( test_bub.raw() ) );
+    CHECK( here.getlocal( test_abs ) == here.bub_from_abs( test_abs ).raw() );
+    CHECK( here.bub_from_abs( test_abs ) == here.bub_from_abs( test_abs.raw() ) );
+    CHECK( here.getlocal( test_abs ) == here.bub_from_abs( test_abs ).raw() );
+
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
     CHECK( here.bub_from_abs( here.getglobal( test_point ) ).raw() == test_point );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -55,12 +55,6 @@ TEST_CASE( "map_coordinate_conversion_functions" )
     CAPTURE( test_bub );
     CAPTURE( test_abs );
 
-    // Verify consistency between different implementations
-    CHECK( here.getglobal( test_bub ) == here.getglobal( test_bub.raw() ) );
-    CHECK( here.getlocal( test_abs ) == here.bub_from_abs( test_abs ).raw() );
-    CHECK( here.bub_from_abs( test_abs ) == here.bub_from_abs( test_abs.raw() ) );
-    CHECK( here.getlocal( test_abs ) == here.bub_from_abs( test_abs ).raw() );
-
     // Verify round-tripping
     CHECK( here.getglobal( here.bub_from_abs( test_abs ) ) == test_abs );
     CHECK( here.bub_from_abs( here.getglobal( test_point ) ).raw() == test_point );

--- a/tests/mapgen_place_vehicles_test.cpp
+++ b/tests/mapgen_place_vehicles_test.cpp
@@ -17,13 +17,13 @@ namespace
 void update_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
-    REQUIRE( m.veh_at( m.getlocal( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
 }
 
 void nested_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_nested_mapgen, nested_mapgen_test_nested_place_shopping_cart );
-    REQUIRE( m.veh_at( m.getlocal( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
 }
 } // namespace
 

--- a/tests/mapgen_place_vehicles_test.cpp
+++ b/tests/mapgen_place_vehicles_test.cpp
@@ -17,13 +17,13 @@ namespace
 void update_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
-    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.getlocal( project_to<coords::ms>( loc ) ) ) );
 }
 
 void nested_test( map &m, tripoint_abs_omt const &loc )
 {
     manual_mapgen( loc, manual_nested_mapgen, nested_mapgen_test_nested_place_shopping_cart );
-    REQUIRE( m.veh_at( m.bub_from_abs( project_to<coords::ms>( loc ) ) ) );
+    REQUIRE( m.veh_at( m.getlocal( project_to<coords::ms>( loc ) ) ) );
 }
 } // namespace
 

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -123,8 +123,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     SECTION( "update place then nested remove all on main map" ) {
         tripoint_abs_omt const this_test_omt =
             project_to<coords::omt>( get_map().getglobal( test_loc ) );
-        tripoint_bub_ms const this_test_loc = get_map().bub_from_abs( project_to<coords::ms>
-                                              ( this_test_omt ) );
+        tripoint const this_test_loc = get_map().getlocal( project_to<coords::ms>( this_test_omt ) );
         manual_mapgen( this_test_omt, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
         REQUIRE( here.get_vehicles().size() == 2 );
         REQUIRE( here.veh_at( this_test_loc ).has_value() );

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -123,7 +123,8 @@ TEST_CASE( "mapgen_remove_vehicles" )
     SECTION( "update place then nested remove all on main map" ) {
         tripoint_abs_omt const this_test_omt =
             project_to<coords::omt>( get_map().getglobal( test_loc ) );
-        tripoint const this_test_loc = get_map().getlocal( project_to<coords::ms>( this_test_omt ) );
+        tripoint_bub_ms const this_test_loc = get_map().bub_from_abs( project_to<coords::ms>
+                                              ( this_test_omt ) );
         manual_mapgen( this_test_omt, manual_update_mapgen, update_mapgen_test_update_place_shopping_cart );
         REQUIRE( here.get_vehicles().size() == 2 );
         REQUIRE( here.veh_at( this_test_loc ).has_value() );

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -594,8 +594,8 @@ static void run_spot_check( const grid_overlay &test_case, const grid_overlay &e
 
     if( fov_3d ) {
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>( seen_squares,
-                transparency_cache, floor_cache, ORIGIN - tripoint( 0, 0, OVERMAP_DEPTH ), 0, 1.0 );
-        get_map().seen_cache_process_ledges( seen_squares, floor_cache, ORIGIN.raw() - tripoint( 0, 0,
+                transparency_cache, floor_cache, ORIGIN - tripoint_rel_ms( 0, 0, OVERMAP_DEPTH ), 0, 1.0 );
+        get_map().seen_cache_process_ledges( seen_squares, floor_cache, ORIGIN - tripoint_rel_ms( 0, 0,
                                              OVERMAP_DEPTH ) );
     } else {
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -594,8 +594,8 @@ static void run_spot_check( const grid_overlay &test_case, const grid_overlay &e
 
     if( fov_3d ) {
         cast_zlight<float, sight_calc, sight_check, accumulate_transparency>( seen_squares,
-                transparency_cache, floor_cache, ORIGIN - tripoint_rel_ms( 0, 0, OVERMAP_DEPTH ), 0, 1.0 );
-        get_map().seen_cache_process_ledges( seen_squares, floor_cache, ORIGIN - tripoint_rel_ms( 0, 0,
+                transparency_cache, floor_cache, ORIGIN - tripoint( 0, 0, OVERMAP_DEPTH ), 0, 1.0 );
+        get_map().seen_cache_process_ledges( seen_squares, floor_cache, ORIGIN.raw() - tripoint( 0, 0,
                                              OVERMAP_DEPTH ) );
     } else {
         castLightAll<float, float, sight_calc, sight_check, update_light, accumulate_transparency>(


### PR DESCRIPTION
#### Summary
Finish September Backports

#### Purpose of change
75955 - Prevent wielding big items while driving
76829 - Fix for above
76819 - Fix consume activity from liquid handler
76851 - Make chilis smokeable
76887 - Update vitamin documentation
76885 - Fix natural spring visibility
76795 - Typified map.h

#### Testing
Loads, runs, I can drink out of pools.

#### Additional context
76754 and 76900 are next. Apparently they can't be done concurrently with 76795, so here we are.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
