### PR TITLE
Backport 76262 - fix pulping acid corpses

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7951,7 +7951,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             const mtype *corpse_mtype = corpse.get_mtype();
             const bool acid_immune = you.is_immune_damage( damage_acid ) ||
                                      you.is_immune_field( fd_acid );
-            if( corpse_mtype->bloodType().obj().has_acid && !corpse.has_flag( flag_BLED ) && ( !acid_immune ||
+            if( corpse_mtype->bloodType().obj().has_acid && !corpse.has_flag( flag_BLED ) && ( !acid_immune &&
                     !pulp_acid ) ) {
                 //don't smash acid zombies when auto pulping unprotected
                 continue;
@@ -8015,7 +8015,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
     // If we reach this, all corpses have been pulped, finish the activity
     act.moves_left = 0;
     if( num_corpses == 0 ) {
-        you.add_msg_if_player( m_bad, _( "The corpse moved before you could finish smashing it!" ) );
+        you.add_msg_if_player( m_bad, _( "Your smashing was interrupted." ) );
         return;
     }
     // TODO: Factor in how long it took to do the smashing.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11021,11 +11021,11 @@ point game::place_player( const tripoint &dest_loc, bool quick )
                     }
                 }
                 if( !places.empty() ) {
-                    u.assign_activity( pulp_activity_actor( places, true ) );
+                    u.assign_activity( pulp_activity_actor( places ) );
                 }
             } else {
                 if( corpse_available( u.pos_bub() ) ) {
-                    u.assign_activity( pulp_activity_actor( m.getglobal( u.pos_bub() ), true ) );
+                    u.assign_activity( pulp_activity_actor( m.getglobal( u.pos_bub() ) ) );
                 }
             }
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1088,7 +1088,7 @@ static void smash()
     }
 
     if( should_pulp ) {
-        player_character.assign_activity( pulp_activity_actor( here.getglobal( smashp ) ) );
+        player_character.assign_activity( pulp_activity_actor( here.getglobal( smashp ), true ) );
         return; // don't smash terrain if we've smashed a corpse
     }
 


### PR DESCRIPTION
#### Summary
Backport 76262 - fix pulping acid corpses

#### Purpose of change
A backport broke this, so let's backport the fix!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
