### PR TITLE
Fix solar panel windows on 2f motel

### DIFF
--- a/data/json/mapgen/motel.json
+++ b/data/json/mapgen/motel.json
@@ -607,8 +607,8 @@
         "           |||||||||||||||||||||||||||||||||||||",
         "                                              4 "
       ],
-      "palettes": [ "roof_palette", "motel_2x2_palette" ],
-      "terrain": { " ": "t_open_air", "*": "t_shingle_flat_roof" }
+      "palettes": [ "motel_2x2_palette" ],
+      "terrain": { " ": "t_open_air", "*": "t_shingle_flat_roof", "5": "t_gutter_drop" }
     }
   },
   {


### PR DESCRIPTION
#### Summary
Fix solar panel windows on 2f motel

#### Purpose of change
The 2f motel was needlessly using the roof palette, which used the same mapgen character for solar panels as the motel was using for windows.

#### Describe the solution
Remove the roof palette and manually define its tiles.

#### Testing
No solar panels.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
