### PR TITLE
Release grapples on dying NPCs

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -253,7 +253,13 @@
     "melee_skill": 4,
     "vision_day": 50,
     "death_drops": "feral_scientists_death_drops_scalpel",
-    "special_attacks": [ { "id": "feral_weapon_scalpel" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_scalpel" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "zombify_into": "mon_zombie_scientist"
   },
   {
@@ -323,7 +329,13 @@
     "description": "Once a fancy servant of some rich family, this maniac walks around with a broom in hand, searching for a victim to sweep off this mortal coil.",
     "copy-from": "mon_feral_human_pipe",
     "melee_skill": 2,
-    "special_attacks": [ { "id": "feral_weapon_broom" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_broom" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_maids_death_drops_broom"
   },
   {
@@ -332,7 +344,13 @@
     "copy-from": "mon_feral_maid_broom",
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a candlestick in hand, ready to snuff out your life.",
-    "special_attacks": [ { "id": "feral_weapon_candlestick" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_candlestick" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_maids_death_drops_candlestick"
   },
   {
@@ -342,7 +360,13 @@
     "name": { "str": "feral servant" },
     "description": "Once a fancy servant of some rich family, this maniac walks around with a knife in hand, searching for some victims to butcher.",
     "melee_skill": 3,
-    "special_attacks": [ { "id": "feral_weapon_knife_chef" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_knife_chef" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_maids_death_drops_knife"
   },
   {
@@ -352,7 +376,13 @@
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
     "melee_skill": 4,
-    "special_attacks": [ { "id": "feral_weapon_rapier" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_rapier" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_fancy_death_drops_rapier"
   },
   {
@@ -361,7 +391,13 @@
     "copy-from": "mon_feral_fancy_rapier",
     "name": { "str": "well dressed feral" },
     "description": "Wearing fancy clothes and with a rapier in hand, this maniac was once a socialite.  They smile with madness and seem like they want to invite you to dinner.",
-    "special_attacks": [ { "id": "feral_weapon_rapier_fake" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_rapier_fake" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_fancy_death_drops_rapier_fake"
   },
   {
@@ -409,7 +445,13 @@
     "description": "Clad in ancient armor and with a mace in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their mace.",
     "melee_skill": 3,
     "speed": 85,
-    "special_attacks": [ { "id": "feral_weapon_mace" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_mace" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_armored_death_drops_mace",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ] },
     "//": "No synthetic armor proficiency because plate armor doesn't work the same as modern armor",
@@ -422,7 +464,13 @@
     "color": "i_magenta",
     "name": { "str": "armored feral" },
     "description": "Clad in ancient armor and with a battle axe in hand, this maniac walks around in search of their next prey.  You can see stains of dried blood all over their axe.",
-    "special_attacks": [ { "id": "feral_weapon_battleaxe" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_battleaxe" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "feral_armored_death_drops_battleaxe"
   },
   {
@@ -484,7 +532,13 @@
     "vision_day": 50,
     "luminance": 500,
     "death_drops": "mon_feral_survivalist_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_makeshift_machete" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_makeshift_machete" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "zombify_into": "mon_zombie_survivor",
     "delete": { "anger_triggers": [ "HURT" ] },
     "extend": {
@@ -559,7 +613,13 @@
     "dodge": 4,
     "vision_night": 5,
     "death_drops": "mon_feral_soldier_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_knife_combat" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_knife_combat" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "zombify_into": "mon_zombie_soldier",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] },
     "armor": { "bash": 4, "cut": 9, "bullet": 7, "electric": 3 }
@@ -615,7 +675,13 @@
     "aggression": 40,
     "dodge": 2,
     "death_drops": "mon_feral_sailor_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_wrench_large" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_wrench_large" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "zombify_into": "mon_zombie_sailor",
     "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 2 }
   },
@@ -624,7 +690,13 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Spattered from head to toe in large swaths of dried viscera, the deep blue of this person's tattered naval uniform has been stained the color of rust.  Having seemingly had enough presence of mind to consider arming themself, this former crewman carries a crash axe in their shaking hands.  The veins on the back of their neck are visibly bulging, their eyes bloodshot, and a mass of crisscrossing blackened veins stand out against the pale skin of their face as they regard the area around them for perceived threats.",
-    "special_attacks": [ { "id": "feral_weapon_crash_axe" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_crash_axe" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "mon_feral_sailor_axe_death_drops"
   },
   {
@@ -632,7 +704,13 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Clutching a stout mop in their quivering hands, this crewman was presumably assigned to basic deck sweeping in their final moments, before the Cataclysm struck and stripped them of their humanity.  Dressed in basic naval fatigues, you'd be forgiven for believing them to be another survivor.  However, their bloodshot eyes, blackened veins, and spastic twitching tell a far different story.",
-    "special_attacks": [ { "id": "feral_weapon_mop_folded" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_mop_folded" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "mon_feral_sailor_mop_death_drops"
   },
   {
@@ -640,7 +718,13 @@
     "type": "MONSTER",
     "copy-from": "mon_feral_sailor_wrench",
     "description": "Still dressed in a grease spattered uniform, this crewman appears to have once been a naval engineer.  With tangled hair, oil stained working attire, and a lug wrench clenched in their fist, you assume that they were either assigned to shipside maintenance or responsible for servicing onboard aircraft.  Now all that's left of the crewman that this person once was is a madly twitching, psychopathic monster.",
-    "special_attacks": [ { "id": "feral_weapon_lug_wrench" }, { "id": "feral_unarmed" }, { "id": "feral_bite" }, [ "BROWSE", 100 ], [ "EAT_FOOD", 100 ] ],
+    "special_attacks": [
+      { "id": "feral_weapon_lug_wrench" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ],
     "death_drops": "mon_feral_sailor_lug_wrench_death_drops"
   },
   {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11380,7 +11380,8 @@ void Character::stagger()
     }
 
     creature_tracker &creatures = get_creature_tracker();
-    std::vector<tripoint_bub_ms> &pool = preferred_stumbles.empty() ? valid_stumbles : preferred_stumbles;
+    std::vector<tripoint_bub_ms> &pool = preferred_stumbles.empty() ? valid_stumbles :
+                                         preferred_stumbles;
 
     while( !pool.empty() ) {
         bool blocked = false;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -441,7 +441,8 @@ std::set<tripoint_bub_ms> calculate_spell_effect_area( const spell &sp,
     if( sp.shape() == spell_shape::blast && !sp.has_flag( spell_flag::NO_PROJECTILE ) ) {
         map &here = get_map();
         std::vector<tripoint_bub_ms> trajectory = line_to( caster.pos_bub(), target );
-        for( std::vector<tripoint_bub_ms>::iterator iter = trajectory.begin(); iter != trajectory.end(); iter++ ) {
+        for( std::vector<tripoint_bub_ms>::iterator iter = trajectory.begin(); iter != trajectory.end();
+             iter++ ) {
             if( here.impassable( *iter ) ) {
                 if( iter != trajectory.begin() ) {
                     epicenter = *( iter - 1 );
@@ -1022,7 +1023,8 @@ static std::pair<field, tripoint_bub_ms> spell_remove_field( const spell &sp,
     return std::pair<field, tripoint_bub_ms> {field_removed, field_position};
 }
 
-static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint_bub_ms> &fd_fatigue_field,
+static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint_bub_ms>
+        &fd_fatigue_field,
         Creature &caster )
 {
     for( const std::pair<const field_type_id, field_entry> &fd : std::get<0>( fd_fatigue_field ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2927,11 +2927,7 @@ void monster::die( Creature *nkiller )
                 continue;
             }
             if( grabber && !grabber->is_monster() ) {
-                for( const effect &eff : grabber->get_effects_with_flag( json_flag_GRAB_FILTER ) ) {
-                    const efftype_id effid = eff.get_id();
-                    grabber->remove_effect( effid );
-                    grabber->as_character()->grab_1.clear();
-                }
+                grabber->as_character()->release_grapple();
             }
             remove_effect( grab.get_id() );
         }


### PR DESCRIPTION
#### Summary
Release grapples on dying NPCs

#### Purpose of change
- Killing a grappled NPC was causing a segfault, because their die() event wasn't calling release_grapple() on the character grabbing them.
- monster::die() wasn't calling release_grapple(), it was just manually doing that stuff.

#### Describe the solution
- Have both monsters and npcs call release_grapple() on whoever's grabbing them when they die.
- Call release_grapple() for NPCs who die. They can't grab anything yet, but this should be called when they can, and it's harmless to add it now.

#### Testing
Killed a grappled NPC and monster and everything worked.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
