### PR TITLE
Slightly nerf dodge bonus from dex

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4031,11 +4031,11 @@ void Character::reset_stats()
 
     /** @EFFECT_STR_MAX above 15 decreases Dodge bonus by 1 (NEGATIVE) */
     if( str_max >= 16 ) {
-        mod_dodge_bonus( -1 );   // Penalty if we're huge
+        mod_dodge_bonus( -1 );   // Penalty if we're buff
     }
     /** @EFFECT_STR_MAX below 6 increases Dodge bonus by 1 */
     else if( str_max <= 5 ) {
-        mod_dodge_bonus( 1 );   // Bonus if we're small
+        mod_dodge_bonus( 1 );   // Bonus if we're scrawny
     }
 
     apply_skill_boost();
@@ -5822,7 +5822,7 @@ float Character::get_dodge_base() const
     /** @EFFECT_DEX slightly increases dodge base */
     /** @EFFECT_PER increases dodge base a bit less */
     /** @EFFECT_DODGE increases dodge_base */
-    float dex_bonus = get_dex() / 4.0f;
+    float dex_bonus = get_dex() / 5.0f;
     float per_bonus = get_per() / 6.0f;
     return dex_bonus + per_bonus + get_skill_level( skill_dodge );
 }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1261,11 +1261,11 @@ double Character::crit_chance( float roll_hit, float target_dodge, const item &w
 
     // Examples (survivor stats/chances of each critical):
     // Fresh (skill-less) 8/8/8/8, unarmed:
-    //  50%, 49%, 25%; ~1/16 guaranteed critical + ~1/8 if roll>dodge*1.5
+    //  50%, 49%, 25%; ~1/16 guaranteed critical + ~1/8 if roll>defense*1.5
     // Expert (skills 10) 10/10/10/10, unarmed:
-    //  100%, 55%, 60%; ~1/3 guaranteed critical + ~4/10 if roll>dodge*1.5
+    //  100%, 55%, 60%; ~1/3 guaranteed critical + ~4/10 if roll>defense*1.5
     // Godlike with combat CBM 20/20/20/20, pipe (+1 accuracy):
-    //  60%, 100%, 42%; ~1/4 guaranteed critical + ~3/8 if roll>dodge*1.5
+    //  60%, 100%, 42%; ~1/4 guaranteed critical + ~3/8 if roll>defense*1.5
 
     // Note: the formulas below are only valid if none of the 3 critical chance values go above 1.0
     // It is therefore important to limit them to between 0.0 and 1.0


### PR DESCRIPTION
#### Summary
Slightly nerf dodge bonus from dex

#### Purpose of change
Dex was previously giving 1 point of dodge score per 4 points of dex. This meant that an 8 dex character had +2 dodge and a 12 dex character had +3. Dodge was previously way, way overtuned and I've been trying to work it back to a reasonable level without ruining everything.

#### Describe the solution
You now get 1 point of dodge for every 5 points of dex. As before, you still get 1 point of dodge for every 6 points of perception. Overall this should drop most characters down 1 point of dodge, or none.

#### Testing
Compiles, runs, dodge scores look good.

#### Additional context
Dodge as an all or nothing thing needs to go away in favor of it becoming a scaling damage reduction like block, with only "full" dodges totally avoiding the attack. This is complicated by a bunch of stuff being exploded out to melee, monster, and mattack_actors. So for now a little nerf and we move on.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
