### PR TITLE
Encumbrance adjustments

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -38,7 +38,7 @@
           { "type": "kevlar", "covered_by_mat": 97, "thickness": 2.25 }
         ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "encumbrance": [ 14, 22 ],
+        "encumbrance": [ 14, 18 ],
         "specifically_covers": [
           "arm_shoulder_l",
           "arm_shoulder_r",
@@ -186,7 +186,7 @@
           { "type": "kevlar", "covered_by_mat": 97, "thickness": 2.25 }
         ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "encumbrance": [ 16, 24 ],
+        "encumbrance": [ 16, 20 ],
         "specifically_covers": [
           "arm_shoulder_l",
           "arm_shoulder_r",
@@ -341,7 +341,7 @@
         ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
         "coverage": 98,
-        "encumbrance": [ 16, 22 ]
+        "encumbrance": [ 16, 20 ]
       }
     ],
     "pocket_data": [

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -127,8 +127,8 @@
     "symbol": "[",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 7, 12 ] },
-      { "covers": [ "torso" ], "coverage": 80, "encumbrance": [ 7, 12 ] }
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": [ 14, 16 ] },
+      { "covers": [ "torso" ], "coverage": 70, "encumbrance": [ 10, 12 ] }
     ],
     "pocket_data": [
       {
@@ -192,8 +192,8 @@
     "looks_like": "jumpsuit",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 95, "encumbrance": [ 1, 2 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 95, "encumbrance": [ 1, 1 ] }
+      { "covers": [ "torso", "leg_l", "leg_r" ], "coverage": 95, "encumbrance": [ 5, 6 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 95, "encumbrance": [ 5, 9 ] }
     ],
     "pocket_data": [
       {
@@ -390,7 +390,7 @@
       {
         "material": [ { "type": "nylon", "covered_by_mat": 100, "thickness": 0.6 } ],
         "covers": [ "leg_l", "leg_r", "arm_l", "arm_r" ],
-        "encumbrance": [ 9, 13 ],
+        "encumbrance": [ 9, 10 ],
         "specifically_covers": [
           "arm_shoulder_l",
           "arm_shoulder_r",
@@ -500,9 +500,9 @@
     "looks_like": "jumpsuit",
     "color": "yellow",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 3, 7 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 2, 2 ] },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 60, "encumbrance": [ 2, 5 ] }
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 8, 12 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 4, 4 ] },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 60, "encumbrance": [ 8, 10 ] }
     ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -527,9 +527,9 @@
     "looks_like": "jumpsuit",
     "color": "yellow",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 3, 7 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 2, 2 ] },
-      { "covers": [ "leg_l", "leg_r" ], "coverage": 60, "encumbrance": [ 2, 5 ] }
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 8, 12 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 4, 4 ] },
+      { "covers": [ "leg_l", "leg_r" ], "coverage": 60, "encumbrance": [ 8, 10 ] }
     ],
     "pocket_data": [
       { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "2 kg", "moves": 80 },
@@ -553,8 +553,8 @@
     "looks_like": "jumpsuit",
     "color": "light_gray",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 3 },
-      { "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "coverage": 90, "encumbrance": 3 }
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 6 },
+      { "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "coverage": 90, "encumbrance": 6 }
     ],
     "warmth": 10,
     "material_thickness": 0.2,


### PR DESCRIPTION
#### Summary
Encumbrance adjustments

#### Describe the solution
- Denim overalls are now as encumbering as blue jeans on the legs, a bit less so on the torso. Coverage on the torso was reduced to 70.
- Survivor suits (all kinds) now add less encumbrance to the arms and legs when their pockets are filled. Torso encumbrance is unaffected.
- Fixed some inconsistencies with other jumpsuits.
- Reduced leg encumbrance when pockets are filled on other jumpsuits.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
