### PR TITLE
Add repeating and pistol crossbow to itemgroups

### DIFF
--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -122,6 +122,8 @@
     "entries": [
       { "item": "crossbow", "prob": 70 },
       { "item": "compcrossbow", "prob": 10 },
+      { "item": "rep_compcrossbow", "prob": 5 },
+      { "item": "pistol_crossbow", "prob": 5 },
       { "item": "bullet_crossbow", "prob": 10 },
       { "item": "hand_crossbow", "prob": 10 },
       { "item": "bow_sling", "prob": 10 },


### PR DESCRIPTION
#### Summary
Add repeating and pistol crossbow to itemgroups

#### Purpose of change
I forgot to add some of the new crossbows to the archery itemgroup, so they weren't going to spawn anywhere.

#### Describe the solution
add

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
