### PR TITLE
Fix throwing axe length

### DIFF
--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -115,6 +115,7 @@
     "material": [ "steel", "wood" ],
     "volume": "750 ml",
     "weight": "792 g",
+    "longest_side": "30 cm",
     "to_hit": -1,
     "weapon_category": [ "HAND_AXES" ],
     "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ],


### PR DESCRIPTION
#### Summary
Fix throwing axe length

#### Purpose of change
Throwing axes didn't have a longest_side set.

#### Describe the solution
It's now 30cm (1 foot)

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
