### PR TITLE
Need a martial art to arm/leg block

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -6,7 +6,7 @@
     "description": "Not a martial art, this is just plain old punching and kicking.",
     "initiate": [ "You decide to not use any martial arts.", "%s enters a generic combat stance." ],
     "priority": 0,
-    "arm_block": 1,
+    "arm_block": 99,
     "leg_block": 99,
     "allow_all_weapons": true,
     "teachable": false
@@ -18,7 +18,7 @@
     "description": "Not a martial art, setting this style will prevent weapon attacks and force punches (with a free hand) or kicks.",
     "initiate": [ "You force yourself to fight unarmed.", "%s decides to fight unarmed." ],
     "priority": -1,
-    "arm_block": 1,
+    "arm_block": 99,
     "leg_block": 99,
     "force_unarmed": true,
     "prevent_weapon_blocking": true,
@@ -32,7 +32,7 @@
     "initiate": [ "You enter the hanmi stance.", "%s enters a relaxed combat posture." ],
     "priority": 1,
     "learn_difficulty": 5,
-    "arm_block": 0,
+    "arm_block": 1,
     "static_buffs": [
       {
         "id": "buff_aikido_static1",
@@ -1388,7 +1388,7 @@
     "initiate": [ "You settle into a gentle stance and prepare to defend yourself.", "%s settles into a gentle stance." ],
     "priority": 1,
     "learn_difficulty": 4,
-    "arm_block": 0,
+    "arm_block": 1,
     "static_buffs": [
       {
         "id": "buff_tai_chi_static",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -6,8 +6,6 @@
     "description": "Not a martial art, this is just plain old punching and kicking.",
     "initiate": [ "You decide to not use any martial arts.", "%s enters a generic combat stance." ],
     "priority": 0,
-    "arm_block": 99,
-    "leg_block": 99,
     "allow_all_weapons": true,
     "teachable": false
   },
@@ -18,8 +16,6 @@
     "description": "Not a martial art, setting this style will prevent weapon attacks and force punches (with a free hand) or kicks.",
     "initiate": [ "You force yourself to fight unarmed.", "%s decides to fight unarmed." ],
     "priority": -1,
-    "arm_block": 99,
-    "leg_block": 99,
     "force_unarmed": true,
     "prevent_weapon_blocking": true,
     "teachable": false


### PR DESCRIPTION
#### Summary
Need a martial art to arm/leg block

#### Purpose of change
For some reason, "no style" gave you arm block at 1 skill. This meant that you could turn off your martial arts to be great at blocking attacks, but half the martial arts would disable this ability. That...doesn't really make any sense, and was likely unintentional.

#### Describe the solution
No more arm block on no style or force unarmed. Use a martial art or a weapon!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
