### PR TITLE
Give professions replacement clothes for suit

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -404,6 +404,11 @@
     "item": "blazer",
     "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "jacket_leather" ] }, { "present": [ "VEGAN" ], "new": [ "jacket_light" ] } ]
   },
+    {
+    "type": "profession_item_substitutions",
+    "item": "suit",
+    "sub": [ { "present": [ "WOOLALLERGY" ], "new": [ "jacket_light", "pants", "dress_shirt" ] }, { "present": [ "VEGAN" ], "new": [ "jacket_light", "pants", "dress_shirt" ] } ]
+  },
   {
     "type": "profession_item_substitutions",
     "item": "jacket_leather",


### PR DESCRIPTION
#### Summary
Give professions replacement clothes for suit

#### Purpose of change
Suits are made of wool. If you pick a profession that starts with a suit and you have a wool allergy or are a vegan, you will spawn naked!

#### Describe the solution
Give suits some logic to swap them for a light jacket, dress shirt, and slacks if need be.

#### Testing
Spawned in with a wool allergy and saw my new duds.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
