### PR TITLE
Remove beta warning in motd

### DIFF
--- a/data/motd/ar.motd
+++ b/data/motd/ar.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/cs.motd
+++ b/data/motd/cs.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/de.motd
+++ b/data/motd/de.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/el.motd
+++ b/data/motd/el.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/en.motd
+++ b/data/motd/en.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/es_AR.motd
+++ b/data/motd/es_AR.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/es_ES.motd
+++ b/data/motd/es_ES.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/fil_PH.motd
+++ b/data/motd/fil_PH.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/fr.motd
+++ b/data/motd/fr.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/ga_IE.motd
+++ b/data/motd/ga_IE.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/hu.motd
+++ b/data/motd/hu.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/id.motd
+++ b/data/motd/id.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/it_IT.motd
+++ b/data/motd/it_IT.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/ja.motd
+++ b/data/motd/ja.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/ko.motd
+++ b/data/motd/ko.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/nb.motd
+++ b/data/motd/nb.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/pl.motd
+++ b/data/motd/pl.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/pt_BR.motd
+++ b/data/motd/pt_BR.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/ru.motd
+++ b/data/motd/ru.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/tr.motd
+++ b/data/motd/tr.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/uk_UA.motd
+++ b/data/motd/uk_UA.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/zh_CN.motd
+++ b/data/motd/zh_CN.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>

--- a/data/motd/zh_TW.motd
+++ b/data/motd/zh_TW.motd
@@ -6,11 +6,3 @@
 <color_white>Report bugs, suggestion and follow the development at:</color>
 
 <color_light_gray>* Github: </color><color_light_cyan>https://github.com/Cataclysm-TLG/Cataclysm-TLG</color>
-
-<color_light_red>******************************************************************************</color>
-<color_light_red>    This game is in beta!</color>
-<color_light_red>******************************************************************************</color>
-
-<color_white>Q: </color><color_yellow>What does that mean exactly?</color>
-
-<color_white>A: </color><color_light_gray>This game is undergoing heavy development, and will likely contain bugs or other issues.  Saves may not be compatible between versions, so make backups before you update.</color>


### PR DESCRIPTION
#### Summary
Remove beta warning in motd

#### Purpose of change
There were some old beta warnings in the message of the day. We're not in beta anymore!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
