### PR TITLE
Backport 74957 - Remove roof magic and a work around

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8920,9 +8920,9 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
                     }
                 }
 
-                if( zlevels ) {
-                    add_roofs( tripoint_rel_sm( grid.x(), grid.y(), z ) );
-                }
+        if( zlevels ) {
+            add_tree_tops( tripoint_rel_sm( grid.x(), grid.y(), z ) );
+        }
 
                 ++iter;
             } else {
@@ -9369,7 +9369,7 @@ void map::actualize( const tripoint_rel_sm &grid )
     tmpsub->last_touched = calendar::turn;
 }
 
-void map::add_roofs( const tripoint_rel_sm &grid )
+void map::add_tree_tops( const tripoint_rel_sm &grid )
 {
     if( !zlevels ) {
         // Can't add things on the level above when the map doesn't contain that level.
@@ -9378,17 +9378,18 @@ void map::add_roofs( const tripoint_rel_sm &grid )
 
     submap *const sub_here = get_submap_at_grid( grid );
     if( sub_here == nullptr ) {
-        debugmsg( "Tried to add roofs/floors on null submap on %d,%d,%d",
+        debugmsg( "Tried to add tree tops on null submap on %d,%d,%d",
                   grid.x(), grid.y(), grid.z() );
         return;
     }
 
-    bool check_roof = grid.z() > -OVERMAP_DEPTH;
+    bool check_tree_tops = grid.z() > -OVERMAP_DEPTH;
 
-    submap *const sub_below = check_roof ? get_submap_at_grid( grid + tripoint_rel_sm_below ) : nullptr;
+    submap *const sub_below = check_tree_tops ? get_submap_at_grid( grid + tripoint_rel_sm_below ) :
+                              nullptr;
 
-    if( check_roof && sub_below == nullptr ) {
-        debugmsg( "Tried to add roofs to sm at %d,%d,%d, but sm below doesn't exist",
+    if( check_tree_tops && sub_below == nullptr ) {
+        debugmsg( "Tried to add tree tops to sm at %d,%d,%d, but sm below doesn't exist",
                   grid.x(), grid.y(), grid.z() );
         return;
     }
@@ -9400,7 +9401,7 @@ void map::add_roofs( const tripoint_rel_sm &grid )
                 continue;
             }
 
-            if( !check_roof ) {
+            if( !check_tree_tops ) {
                 // Make sure we don't have empty space at lowest z-level
                 sub_here->set_ter( { x, y }, ter_t_rock_floor );
                 continue;

--- a/src/map.h
+++ b/src/map.h
@@ -2182,7 +2182,7 @@ class map
          * to get regional translation code to deal with chunks instead of terrain, and then use these
          * chunks everywhere instead of tree terrain tokens. Maybe some day...
          */
-        void add_roofs( const tripoint_rel_sm &grid );
+        void add_tree_tops( const tripoint_rel_sm &grid );
         /**
          * Try to fill funnel based items here. Simulates rain from @p since till now.
          * @param p The location in this map where to fill funnels.


### PR DESCRIPTION
#### Summary
Backport 74957 - Remove roof magic and a work around

#### Purpose of change
Catching up on some roof/treetop stuff that got missed due to typification

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
