### PR TITLE
Fix wont_train_marksmanship

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1208,12 +1208,14 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
     }
 
     // Practice the base gun skill proportionally to number of hits, but always by one.
-    if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
+    if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) || get_skill_level( skill_gun ) < 2 ) {
         practice( skill_gun, ( hits + 1 ) * 5 );
     }
     // launchers train weapon skill for both hits and misses.
     int practice_units = gun_skill == skill_launcher ? curshot : hits;
-    practice( gun_skill, ( practice_units + 1 ) * 5 );
+    if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) || get_skill_level( gun_skill ) < 1 ) {
+        practice( gun_skill, ( practice_units + 1 ) * 5 );
+    }
 
     if( !gun.is_gun() ) {
         // If we lose our gun as a side effect of firing it, skip the rest of the function.


### PR DESCRIPTION
#### Summary
Fix wont_train_marksmanship

#### Purpose of change
The change to ranged.cpp that was supposed to accompany #939 got lost in the shuffle

#### Describe the solution
Add it

#### Testing
Werks

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
