### PR TITLE
Reimplement treetops

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -219,6 +219,7 @@ static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_blood_spiders( "blood_spiders" );
 static const efftype_id effect_bloodworms( "bloodworms" );
 static const efftype_id effect_boomered( "boomered" );
+static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_brainworms( "brainworms" );
 static const efftype_id effect_chafing( "chafing" );
 static const efftype_id effect_common_cold( "common_cold" );
@@ -8317,6 +8318,9 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
             add_effect( effect_downed, 2_turns, false, 0, true );
         }
     }
+    if( has_effect( effect_bouldering ) && ( rng( 0, 100 ) <= 10 ) ) {
+        stagger_check();
+    }
 
     enchantment_cache->cast_hit_me( *this, source );
 }
@@ -9165,7 +9169,7 @@ void Character::resume_backlog_activity()
 
 void Character::fall_asleep()
 {
-    // Communicate to the player that he is using items on the floor
+    // Communicate to the player that they are using items on the floor
     std::string item_name = is_snuggling();
     if( item_name == "many" ) {
         if( one_in( 15 ) ) {
@@ -11482,7 +11486,6 @@ bool Character::can_sleep()
         // Sleep ain't happening until that meth wears off completely.
         return false;
     }
-
     // Since there's a bit of randomness to falling asleep, we want to
     // prevent exploiting this if can_sleep() gets called over and over.
     // Only actually check if we can fall asleep no more frequently than

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11978,7 +11978,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     if( !force && movez == 1 && !here.has_flag( ter_furn_flag::TFLAG_GOES_UP, u.pos_bub() ) &&
         !u.is_underwater() ) {
         // Climbing
-        for( const tripoint_bub_ms &p : here.points_in_radius( u.pos_bub(), 2 ) ) {
+        for( const tripoint_bub_ms &p : here.points_in_radius( u.pos_bub(), 1 ) ) {
             if( here.has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, p ) ) {
                 adjacent_climb = true;
             }
@@ -12323,6 +12323,12 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     u.recoil = MAX_RECOIL;
+    if( m.has_flag( ter_furn_flag::TFLAG_UNSTABLE, u.pos_bub() ) &&
+        !u.is_mounted() && !m.has_vehicle_floor( u.pos_bub() ) ) {
+        u.add_effect( effect_bouldering, 1_turns, true );
+    } else if( u.has_effect( effect_bouldering ) ) {
+        u.remove_effect( effect_bouldering );
+    }
 
     cata_event_dispatch::avatar_moves( old_abs_pos.raw(), u, m );
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8920,10 +8920,6 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
                     }
                 }
 
-        if( zlevels ) {
-            add_tree_tops( tripoint_rel_sm( grid.x(), grid.y(), z ) );
-        }
-
                 ++iter;
             } else {
                 if( veh->tracking_on ) {
@@ -8932,6 +8928,9 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
                 dirty_vehicle_list.erase( veh );
                 iter = veh_vec.erase( iter );
             }
+        }
+        if( zlevels ) {
+            add_tree_tops( tripoint_rel_sm( grid.x(), grid.y(), z ) );
         }
     }
 }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1200,7 +1200,7 @@ int stumble( Character &u, const item_location &weap )
                   ( weap->weight() / ( str_mod + 13.0_gram ) );
     }
     // 20% chance minimum to stagger_check().
-    if( ( u.has_effect( effect_bouldering ) ) && ( rng( 0, 100 ) <= stumble + 20 ) ) {
+    if( ( u.has_effect( effect_bouldering ) ) && ( rng( 0, 100 ) <= stumble + 10 ) ) {
         u.stagger_check();
     }
     return stumble;


### PR DESCRIPTION
#### Summary
Reimplement treetops

#### Purpose of change
Fixes #918 (kind of)

#### Describe the solution
- Treetops got deleted for a bit, but now they're fixed.
- Treetops are unstable. It is not safe to attack or be attacked while up there.
- Trees were accidentally climbable from 2 tiles away. Now they only help when adjacent. This means you can use trees to climb onto people's roofs if they planted them close to their house. This is intended, though perhaps it would be nice if not every tree was helpful in this manner.

#### Describe alternatives you've considered
- Treetops need more limitations.
- We need trees that aren't big enough to climb but are still adults. We also need multitile trees and canopies.

#### Testing
Climbed a tree, saw that it was good

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
