### PR TITLE
Backport DDA 77551 - Check for nullptr before calling

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8508,8 +8508,9 @@ bool item::made_of_any_food_components( bool deep_search ) const
 
     for( const std::pair<itype_id, std::vector<item>> pair : components ) {
         for( const item &it : pair.second ) {
-            nutrients &maybe_food = it.get_comestible()->default_nutrition;
-            bool must_be_food = maybe_food.kcal() > 0 || maybe_food.vitamins().empty();
+            const auto &maybe_food = it.get_comestible();
+            bool must_be_food = maybe_food && ( maybe_food->default_nutrition.kcal() > 0 ||
+                                                !maybe_food->default_nutrition.vitamins().empty() );
             bool has_food_component = false;
             if( deep_search && !it.components.empty() ) {
                 // make true if any component has food values, even if some don't


### PR DESCRIPTION
#### Summary
Backport DDA 77551 - Check for nullptr before calling

#### Purpose of change
Fixes a bug with opening the eat menu around some items.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
