### PR TITLE
Fix nunchaku length

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -66,7 +66,7 @@
     "name": { "str": "nunchaku" },
     "description": "A weapon originating from East Asia consisting of a pair of short sticks connected by a shorter rope or chain.  The design is a bit unwieldy, but fast and deadly in the right hands.",
     "weight": "800 g",
-    "longest_side": "160 cm",
+    "longest_side": "33 cm",
     "volume": "1030 ml",
     "price": "40 USD",
     "price_postapoc": "10 USD",


### PR DESCRIPTION
#### Summary
Fix nunchaku length

#### Purpose of change
Nunchaku were 160cm long lol

#### Describe the solution
Shorten them to 33cm

#### Describe alternatives you've considered
![image](https://github.com/user-attachments/assets/897a7d3d-48a1-430c-99f2-0835676c98dd)


#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
