### PR TITLE
Silo OSX user data from other forks

### DIFF
--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -86,7 +86,7 @@ void PATH_INFO::init_user_dir( std::string dir )
         dir = std::string( user_dir ) + "/cataclysm-tlg/";
 #elif defined(MACOSX)
         user_dir = getenv_or_abort( "HOME" );
-        dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm/";
+        dir = std::string( user_dir ) + "/Library/Application Support/Cataclysm-TLG/";
 #elif defined(USE_XDG_DIR)
         if( ( user_dir = getenv( "XDG_DATA_HOME" ) ) ) {
             dir = std::string( user_dir ) + "/cataclysm-tlg/";


### PR DESCRIPTION
#### Summary
Silo OSX user data from other forks

#### Purpose of change
The OSX application data's default path was shared with Cataclysm DDA, we don't want that as it makes it awkward to try to play both games.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
