### PR TITLE
Nerf tree-felling a bit

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1830,8 +1830,8 @@
     "connects_to": "WALL",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "bash": {
-      "str_min": 60,
-      "str_max": 160,
+      "str_min": 70,
+      "str_max": 250,
       "sound": "crash!",
       "sound_fail": "bash!",
       "ter_set": "t_null",
@@ -2130,8 +2130,8 @@
     "connects_to": "WALL",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND", "UNCLINGABLE" ],
     "bash": {
-      "str_min": 90,
-      "str_max": 350,
+      "str_min": 70,
+      "str_max": 300,
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_pit_shallow",

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9230,7 +9230,7 @@ void map::cut_down_tree( tripoint_bub_ms p, point dir )
     // TODO: make line_to type aware.
     std::vector<tripoint_bub_ms> tree = line_to( p, to, rng( 1, 8 ) );
     for( tripoint_bub_ms &elem : tree ) {
-        batter( elem, 300, 5 );
+        batter( elem, rng( 100, 250 ), 4 );
         ter_set( elem, ter_t_trunk );
     }
     ter_set( p, ter_t_stump );


### PR DESCRIPTION
#### Summary
Nerf tree-felling a bit

#### Purpose of change
Felled trees were punching through solid concrete. This was stupid.

#### Describe the solution
Reduce the number of bashes a felled tree attempts from 5 to 4, randomize the damage a bit, and reduce its maximum by 1/6.

#### Describe alternatives you've considered
There's a lot more to do here. This shouldn't really work very well at all honestly, falling trees damage houses, they don't cleave them in half IRL. There's also an issue where the bash doesn't affect furniture. Does it affect creatures? Vehicles?

#### Testing
Felled a tree. It went through drywall. Fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
