### PR TITLE
Fix armor display bugs

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -362,7 +362,7 @@ class armor_inventory_preset: public inventory_selector_preset
             }, _( "WARMTH" ) );
 
             for( const damage_type &dt : damage_type::get_all() ) {
-                if( dt.no_resist ) {
+                if( dt.no_resist || dt.env ) {
                     continue;
                 }
                 const damage_type_id &dtid = dt.id;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3880,7 +3880,8 @@ static bool operator<( const armor_encumb_data &lhs, const armor_encumb_data &rh
     return lhs.encumb < rhs.encumb;
 }
 
-void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const
+void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
+                       bool debug ) const
 {
     if( !is_armor() ) {
         return;
@@ -4129,6 +4130,19 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts 
     }
 
     insert_separation_line( info );
+    
+    
+    if( covers_anything ) {
+        bool print_prot = true;
+        if( parts->test( iteminfo_parts::ARMOR_PROTECTION ) ) {
+            print_prot = !armor_full_protection_info( info, parts );
+        }
+        if( print_prot ) {
+            armor_protection_info( info, parts, batch, debug );
+        }
+        armor_protect_dmg_info( damage(), info );
+    }
+
 
     // Whatever the last entry was, we want a newline at this point
     info.back().bNewLine = true;
@@ -5978,7 +5992,7 @@ std::string item::info( std::vector<iteminfo> &info, const iteminfo_query *parts
             }
 
             gunmod_info( info, parts, batch, debug );
-            armor_info( info, parts );
+            armor_info( info, parts, batch, debug );
             animal_armor_info( info, parts, batch, debug );
             book_info( info, parts, batch, debug );
             battery_info( info, parts, batch, debug );

--- a/src/item.h
+++ b/src/item.h
@@ -501,7 +501,7 @@ class item : public visitable
         void armor_attribute_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                                    bool debug, const sub_bodypart_id &sbp = sub_bodypart_id() ) const;
         void pet_armor_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
-        void armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
+        void armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch, bool debug ) const;
         void animal_armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                                 bool debug ) const;
         void armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,


### PR DESCRIPTION
#### Summary
Fix armor display bugs

#### Purpose of change
- #952 broke armor display.
- Acid and fire resistance were always displaying wrong in the (W)ear menu.

#### Describe the solution
- Return the mistakenly removed code.
- Remove fire and acid protection from the (W)ear menu.

#### Describe alternatives you've considered
I would rather have the values display properly, but game_inventory.cpp is set up to take a simple average of the protection values and isn't able to handle the more complex material layer evaluation that fire and acid do in TLG, so for now it's best to simply remove them. They dispaly properly in the examine window.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
