### PR TITLE
Silence post-death error messages

### DIFF
--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -217,7 +217,10 @@ bodypart_id anatomy::select_body_part( const Creature *you, int min_hit, int max
                                        bool can_attack_high,
                                        int hit_roll ) const
 {
-
+    if( you->is_dead_state() ) {
+        add_msg_debug( debugmode::DF_ANATOMY_BP, "Creature is dead; skipping body part selection." );
+        return bodypart_str_id::NULL_ID().id();
+    }
     weighted_float_list<bodypart_id> hit_weights;
     for( const bodypart_id &bp : cached_bps ) {
         float weight = bp->hit_size;


### PR DESCRIPTION
#### Summary
Silence post-death error messages

#### Purpose of change
The code in anatomy.cpp that determines which part you get hit in does so by process of elimination, excluding 0 HP parts and parts the enemy can't reach, etc. This has always worked fine, except when I added webbed hands, characters went from having 0-13 out of 13 body parts to having 0-13 out of 15 body parts (this might actually be 20 if we count bird/bat wings and gastropod foot), since no one has both hands and webbed hands. This meant that dead characters had -2 or fewer available body parts, which the code doesn't know how to deal with.

#### Describe the solution
Check if the character is dead and exit early if so. This may not be a perfect solution, as the day may come when we have enough variant body parts that it may be possible for a living character to get a negative result on this check. At that point, I think we'll be able to simply remove the error message, as it will no longer indicate that something has gone wrong.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
