### PR TITLE
Clamp NPC starting kcal a bit tighter

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -649,10 +649,10 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     catchup_skills();
     set_body();
     recalc_hp();
-    int days_since_cata = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+    int days_since_cata = to_days<int>( calendar::turn - calendar::fall_of_civilization );
     double time_influence = days_since_cata >= 180 ? 3.0 : 6.0 - 3.0 * days_since_cata / 180.0;
     double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
-                            0.2, 5.0 );
+                            0.4, 4.0 );
     set_stored_kcal( weight_percent * get_healthy_kcal() );
     starting_weapon( myclass );
     starting_clothes( *this, myclass, male );


### PR DESCRIPTION
#### Summary
Clamp NPC starting kcal a bit tighter

#### Purpose of change
NPCs were frequently (like 5-10% of the time!) spawning emaciated. This was really onerous to deal with and not very intuitive, partly because NPCs weren't letting the player know they were starving and partly because with NPC needs disabled, most people aren't aware that NPCs can still eat if they need to.

#### Describe the solution
Clamp the initial starting kcal to ~50,000 to ~450,000. This still results in people who have higher or lower body fat, and still trends toward leaner as time goes on, but will stop short of handing you a recruitable skeleton.

#### Describe alternatives you've considered
Starvation is a reasonable issue and some NPCs should start out emaciated, but they ought to be assigned special quests to bring them food. It should also be easier to fatten them back up, and to know when they need help with that sort of thing if you've already recruited them.

#### Testing
Spawned several NPCs. All had normal weight.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
