### PR TITLE
Make armor work and display on mutated parts

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -1171,6 +1171,7 @@
     "side": 2,
     "opposite": "hand_wrist_l",
     "name_multiple": "wrists",
+    "similar_bodyparts": [ "hand_webbed_wrist_r" ],
     "name": "right wrist"
   },
   {
@@ -1180,6 +1181,7 @@
     "parent": "hand_r",
     "side": 2,
     "opposite": "hand_palm_l",
+    "similar_bodyparts": [ "hand_webbed_palm_r" ],
     "name_multiple": "palms",
     "name": "right palm"
   },
@@ -1190,6 +1192,7 @@
     "parent": "hand_r",
     "side": 2,
     "opposite": "hand_back_l",
+    "similar_bodyparts": [ "hand_webbed_back_r" ],
     "name_multiple": "back of hands",
     "name": "right back of hand"
   },
@@ -1200,6 +1203,7 @@
     "parent": "hand_r",
     "side": 2,
     "opposite": "hand_fingers_l",
+    "similar_bodyparts": [ "hand_webbed_fingers_r" ],
     "name_multiple": "fingers",
     "name": "right fingers"
   },
@@ -1210,6 +1214,7 @@
     "parent": "hand_l",
     "side": 1,
     "opposite": "hand_wrist_r",
+    "similar_bodyparts": [ "hand_webbed_wrist_l" ],
     "name_multiple": "wrists",
     "name": "left wrist"
   },
@@ -1220,6 +1225,7 @@
     "parent": "hand_l",
     "side": 1,
     "opposite": "hand_palm_r",
+    "similar_bodyparts": [ "hand_webbed_palm_l" ],
     "name_multiple": "palms",
     "name": "left palm"
   },
@@ -1231,6 +1237,7 @@
     "side": 1,
     "opposite": "hand_back_r",
     "name_multiple": "back of hands",
+    "similar_bodyparts": [ "hand_webbed_back_l" ],
     "name": "left back of hand"
   },
   {
@@ -1240,6 +1247,7 @@
     "parent": "hand_l",
     "side": 1,
     "opposite": "hand_fingers_r",
+    "similar_bodyparts": [ "hand_webbed_fingers_l" ],
     "name_multiple": "fingers",
     "name": "left fingers"
   },

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -19,7 +19,7 @@
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "POCKETS", "COLLAR" ],
     "use_action": [ "POST_UP" ],
     "armor": [
-      { "encumbrance": 13, "coverage": 60, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 13, "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 60,
@@ -1801,7 +1801,7 @@
     "material_thickness": 0.5,
     "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l" ] },
+      { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 95,
@@ -1854,7 +1854,7 @@
     "looks_like": "coat_rain",
     "color": "green",
     "armor": [
-      { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 4, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -1885,7 +1885,7 @@
     "color": "light_blue",
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY", "POCKETS" ],
     "armor": [
-      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -1916,7 +1916,7 @@
     "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "variant_type": "generic",
     "armor": [
-      { "encumbrance": 2, "coverage": 50, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 2, "coverage": 50, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 50,
@@ -1959,7 +1959,7 @@
     "flags": [ "OVERSIZE", "BELTED", "POCKETS", "HOOD" ],
     "variant_type": "generic",
     "armor": [
-      { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -2002,7 +2002,7 @@
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "POCKETS" ],
     "armor": [
-      { "encumbrance": 9, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 9, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -2031,7 +2031,7 @@
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "POCKETS" ],
     "armor": [
-      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -2060,7 +2060,7 @@
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "POCKETS" ],
     "armor": [
-      { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -2098,7 +2098,7 @@
     },
     "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF", "POCKETS", "COLLAR" ],
     "armor": [
-      { "encumbrance": 25, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 25, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
@@ -2159,7 +2159,7 @@
     "armor": [
       { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] },
       {
-        "covers": [ "arm_l", "arm_r" ],
+        "covers": [ "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ],
         "coverage": 100,
         "encumbrance": 5,
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
@@ -2217,6 +2217,29 @@
         "coverage": 100,
         "encumbrance": 4
       },
+      {
+        "covers": [ "wing_bird_l", "wing_bird_r" ],
+        "specifically_covers": [
+          "wing_bird_shoulder_l",
+          "wing_bird_shoulder_r",
+          "wing_bird_upper_r",
+          "wing_bird_upper_l",
+          "wing_bird_elbow_r",
+          "wing_bird_elbow_l",
+          "wing_bird_wrist_r",
+          "wing_bird_wrist_l",
+          "wing_bird_fingers_r",
+          "wing_bird_fingers_l"
+        ],
+        "coverage": 100,
+        "encumbrance": 4
+      },
+      {
+        "covers": [ "wing_bird_l", "wing_bird_r" ],
+        "specifically_covers": [ "wing_bird_lower_l", "wing_bird_lower_r" ],
+        "coverage": 90,
+        "encumbrance": 4
+      },
       { "covers": [ "arm_l", "arm_r" ], "specifically_covers": [ "arm_lower_l", "arm_lower_r" ], "coverage": 90 }
     ]
   },
@@ -2242,7 +2265,8 @@
         "coverage": 100,
         "encumbrance": 8
       },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 8 }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 8 },
+      { "covers": [ "wing_bird_l", "wing_bird_r" ], "coverage": 40, "encumbrance": 8 }
     ],
     "warmth": 15,
     "material_thickness": 2,
@@ -2266,6 +2290,12 @@
     "material_thickness": 2,
     "environmental_protection": 1,
     "flags": [ "UNRESTRICTED", "OUTER", "POCKETS", "HOOD" ],
-    "armor": [ { "encumbrance": 20, "coverage": 85, "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
+    "armor": [
+      {
+        "encumbrance": 20,
+        "coverage": 85,
+        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "wing_bird_l", "wing_bird_r" ]
+      }
+    ]
   }
 ]

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -186,6 +186,12 @@
       },
       {
         "material": [ { "type": "feathers", "covered_by_mat": 100, "thickness": 4 } ],
+        "covers": [ "wing_bird_l", "wing_bird_r" ],
+        "coverage": 100,
+        "encumbrance": 4
+      },
+      {
+        "material": [ { "type": "feathers", "covered_by_mat": 100, "thickness": 4 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
         "coverage": 80,

--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -33,7 +33,14 @@
     "smash_message": "You buffet the %s with your wing.",
     "side": "left",
     "base_hp": 45,
-    "sub_parts": [ "arm_shoulder_l", "arm_upper_l", "arm_elbow_l", "arm_lower_l", "hand_fingers_l", "hand_wrist_l" ],
+    "sub_parts": [
+      "wing_bird_shoulder_l",
+      "wing_bird_upper_l",
+      "wing_bird_elbow_l",
+      "wing_bird_lower_l",
+      "wing_bird_fingers_l",
+      "wing_bird_wrist_l"
+    ],
     "armor": { "cut": 3, "bash": 4 },
     "unarmed_damage": [ { "damage_type": "bash", "amount": -2 } ]
   },
@@ -71,9 +78,136 @@
     "smash_message": "You buffet the %s with your wing.",
     "side": "right",
     "base_hp": 45,
-    "sub_parts": [ "arm_shoulder_r", "arm_upper_r", "arm_elbow_r", "arm_lower_r", "hand_fingers_r", "hand_wrist_r" ],
+    "sub_parts": [
+      "wing_bird_shoulder_r",
+      "wing_bird_upper_r",
+      "wing_bird_elbow_r",
+      "wing_bird_lower_r",
+      "wing_bird_fingers_r",
+      "wing_bird_wrist_r"
+    ],
     "armor": { "cut": 3, "bash": 4 },
     "unarmed_damage": [ { "damage_type": "bash", "amount": -2 } ]
+  },
+  {
+    "id": "wing_bird_shoulder_r",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "wing_bird_r",
+    "side": 2,
+    "opposite": "wing_bird_shoulder_l",
+    "name_multiple": "shoulders",
+    "name": "right shoulder"
+  },
+  {
+    "id": "wing_bird_upper_r",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "wing_bird_r",
+    "side": 2,
+    "opposite": "wing_bird_upper_l",
+    "name_multiple": "brachia",
+    "name": "right brachium"
+  },
+  {
+    "id": "wing_bird_elbow_r",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "wing_bird_r",
+    "side": 2,
+    "opposite": "wing_bird_elbow_l",
+    "name_multiple": "elbows",
+    "name": "right elbow"
+  },
+  {
+    "id": "wing_bird_lower_r",
+    "type": "sub_body_part",
+    "max_coverage": 35,
+    "parent": "wing_bird_r",
+    "side": 2,
+    "opposite": "wing_bird_lower_l",
+    "name_multiple": "antebrachia",
+    "name": "right antebrachium"
+  },
+  {
+    "id": "wing_bird_shoulder_l",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "wing_bird_l",
+    "side": 1,
+    "opposite": "wing_bird_shoulder_r",
+    "name_multiple": "shoulders",
+    "name": "left shoulder"
+  },
+  {
+    "id": "wing_bird_upper_l",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "wing_bird_l",
+    "side": 1,
+    "opposite": "wing_bird_upper_r",
+    "name_multiple": "brachia",
+    "name": "left brachium"
+  },
+  {
+    "id": "wing_bird_elbow_l",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "wing_bird_l",
+    "side": 1,
+    "opposite": "wing_bird_elbow_r",
+    "name_multiple": "elbows",
+    "name": "left elbow"
+  },
+  {
+    "id": "wing_bird_lower_l",
+    "type": "sub_body_part",
+    "max_coverage": 35,
+    "parent": "wing_bird_l",
+    "side": 1,
+    "opposite": "wing_bird_lower_r",
+    "name_multiple": "antebrachia",
+    "name": "left antebrachium"
+  },
+  {
+    "id": "wing_bird_fingers_r",
+    "type": "sub_body_part",
+    "max_coverage": 15,
+    "parent": "wing_bird_r",
+    "side": 2,
+    "opposite": "wing_bird_fingers_l",
+    "name_multiple": "fingers",
+    "name": "right fingers"
+  },
+  {
+    "id": "wing_bird_wrist_l",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "wing_bird_l",
+    "side": 1,
+    "opposite": "wing_bird_wrist_r",
+    "name_multiple": "wrists",
+    "name": "left wrist"
+  },
+  {
+    "id": "wing_bird_fingers_l",
+    "type": "sub_body_part",
+    "max_coverage": 15,
+    "parent": "wing_bird_l",
+    "side": 2,
+    "opposite": "wing_bird_fingers_r",
+    "name_multiple": "fingers",
+    "name": "left fingers"
+  },
+  {
+    "id": "wing_bird_wrist_r",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "wing_bird_r",
+    "side": 1,
+    "opposite": "wing_bird_wrist_l",
+    "name_multiple": "wrists",
+    "name": "right wrist"
   },
   {
     "id": "hand_webbed_l",
@@ -103,7 +237,7 @@
     "drench_capacity": 400,
     "smash_message": "You smash the %s with your fist.",
     "bionic_slots": 5,
-    "sub_parts": [ "hand_wrist_l", "hand_palm_l", "hand_back_l", "hand_fingers_l" ],
+    "sub_parts": [ "hand_webbed_wrist_l", "hand_webbed_palm_l", "hand_webbed_back_l", "hand_webbed_fingers_l" ],
     "bmi_encumbrance_threshold": 20,
     "bmi_encumbrance_scalar": 0.15
   },
@@ -134,8 +268,88 @@
     "drench_capacity": 400,
     "smash_message": "You smash the %s with your fist.",
     "bionic_slots": 5,
-    "sub_parts": [ "hand_wrist_r", "hand_palm_r", "hand_back_r", "hand_fingers_r" ],
+    "sub_parts": [ "hand_webbed_wrist_r", "hand_webbed_palm_r", "hand_webbed_back_r", "hand_webbed_fingers_r" ],
     "bmi_encumbrance_threshold": 20,
     "bmi_encumbrance_scalar": 0.15
+  },
+  {
+    "id": "hand_webbed_wrist_r",
+    "type": "sub_body_part",
+    "max_coverage": 10,
+    "parent": "hand_webbed_r",
+    "side": 2,
+    "opposite": "hand_webbed_wrist_l",
+    "name_multiple": "wrists",
+    "name": "right wrist"
+  },
+  {
+    "id": "hand_webbed_palm_r",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "hand_webbed_r",
+    "side": 2,
+    "opposite": "hand_webbed_palm_l",
+    "name_multiple": "palms",
+    "name": "right palm"
+  },
+  {
+    "id": "hand_webbed_back_r",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "hand_webbed_r",
+    "side": 2,
+    "opposite": "hand_webbed_back_l",
+    "name_multiple": "back of hands",
+    "name": "right back of hand"
+  },
+  {
+    "id": "hand_webbed_fingers_r",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "hand_webbed_r",
+    "side": 2,
+    "opposite": "hand_webbed_fingers_l",
+    "name_multiple": "webbed fingers",
+    "name": "right fingers"
+  },
+  {
+    "id": "hand_webbed_wrist_l",
+    "type": "sub_body_part",
+    "max_coverage": 10,
+    "parent": "hand_webbed_l",
+    "side": 1,
+    "opposite": "hand_webbed_wrist_r",
+    "name_multiple": "wrists",
+    "name": "left wrist"
+  },
+  {
+    "id": "hand_webbed_palm_l",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "hand_webbed_l",
+    "side": 1,
+    "opposite": "hand_webbed_palm_r",
+    "name_multiple": "palms",
+    "name": "left palm"
+  },
+  {
+    "id": "hand_webbed_back_l",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "hand_webbed_l",
+    "side": 1,
+    "opposite": "hand_webbed_back_r",
+    "name_multiple": "back of hands",
+    "name": "left back of hand"
+  },
+  {
+    "id": "hand_webbed_fingers_l",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "hand_webbed_l",
+    "side": 1,
+    "opposite": "hand_webbed_fingers_r",
+    "name_multiple": "webbed fingers",
+    "name": "left fingers"
   }
 ]

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -262,7 +262,6 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
 bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp,
                               const sub_bodypart_id &sbp, int roll ) const
 {
-
     // if the core armor is missed then exit
     if( roll > armor.get_coverage( sbp ) ) {
         return false;
@@ -291,6 +290,9 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
 
 bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp, int roll ) const
 {
+    if( !has_part( bp ) ) {
+        return false;
+    }
 
     if( roll > armor.get_coverage( bp ) ) {
         return false;

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -127,6 +127,17 @@ ret_val<void> Character::can_wear( const item &it, bool with_equip_change ) cons
     if( !it.is_armor() ) {
         return ret_val<void>::make_failure( _( "Putting on a %s would be tricky." ), it.tname() );
     }
+    {
+        body_part_set covered = it.get_covered_body_parts();
+        body_part_set character_parts;
+        for( const bodypart_id &bp : get_all_body_parts() ) {
+            character_parts.set( bp.id() );
+        }
+        covered.intersect_set( character_parts );
+        if( covered.none() ) {
+            return ret_val<void>::make_failure( _( "You lack the appropriate body parts to wear that." ) );
+        }
+    }
 
     if( has_trait( trait_WOOLALLERGY ) && ( it.made_of( material_wool ) ||
                                             it.has_own_flag( flag_wooled ) ) ) {

--- a/src/item.h
+++ b/src/item.h
@@ -501,7 +501,8 @@ class item : public visitable
         void armor_attribute_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                                    bool debug, const sub_bodypart_id &sbp = sub_bodypart_id() ) const;
         void pet_armor_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
-        void armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch, bool debug ) const;
+        void armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch, bool debug,
+                         const Character &you ) const;
         void animal_armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                                 bool debug ) const;
         void armor_fit_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
@@ -3039,7 +3040,8 @@ class item : public visitable
         std::list<const item *> all_items_top_recursive( pocket_type pk_type ) const;
 
         /** Returns true if protection info was printed as well */
-        bool armor_full_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
+        bool armor_full_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
+                                         const Character &you ) const;
 
         void update_inherited_flags();
         /**


### PR DESCRIPTION
#### Summary
Make armor work and display on mutated parts

#### Purpose of change
Mutated parts (bird/bat wings, webbed hands) were added in using the semi-finished limb system, but several features weren't functioning properly, most of them related to armor.

#### Describe the solution
- Make armor now only display parts and subparts which you have in all of its menus.
- Make armor coverage, warmth, etc. apply properly to nonstandard parts.
- Make it impossible to wear armor for parts which you do not possess.
- Update feathers, lightfur, and fur to have explicit coverage for the wings.
- Update all cloaks to have explicit coverage for the wings.

#### Describe alternatives you've considered
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa this took forever

#### Testing
Wear mittens, mutate webbed hands, wear mittens. Works.
Wear a cloak, mutate feathers, mutate wings, wear a cloak, mutare feathers. Works.

#### Additional context
I am so tired

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
