### PR TITLE
fix protein bar size

### DIFF
--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -60,7 +60,7 @@
     "name": { "str": "protein bar" },
     "description": "A dense, chewy protein bar made from toasted grains with some fats and sweeteners to bind it all into a portable little snack.",
     "weight": "50 g",
-    "volume": "45 ml",
+    "volume": "48 ml",
     "price": "3 USD",
     "price_postapoc": "50 cent",
     "flags": [ "EDIBLE_FROZEN" ],


### PR DESCRIPTION
#### Summary
Bugfixes "Give protein bars a realistic size"

#### Purpose of change

469d695e5db3d543817f0ce8f61fcea917e7bd60 set the bar to 260 calories but didn't set the protein bar's weight and size to match.

#### Describe the solution

Give it a realistic caloric density with a weight of 50 grams, and a literal density that doesn't float on water.

Also while here adjust its vitamin contents to be proportionate with a ("No Nuts!" brand) nut-free dairy-free protein bar.

Set the pre-Cataclysm price of a single bar based on the same brand selling 12 bars for $35.

#### Describe alternatives you've considered

Making the protein bar not nut-free, or adding variants with peanuts or dairy in it.

Additionally adding spawns of `box_snack` full of these bars in stores or pantries or other locations it would make sense to find them.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
