### PR TITLE
increase weighting of FANGS_BITE_MUZZLE_BEAR

### DIFF
--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -591,7 +591,7 @@
     "messages": [ "You maul %s", "<npcname> mauls %s" ],
     "unarmed_allowed": true,
     "basic": true,
-    "weighting": -4,
+    "weighting": -2,
     "reach_ok": false,
     "crit_ok": true,
     "attack_vectors": [ "vector_bite" ],


### PR DESCRIPTION
#### Summary
Balance "increase weighting of Ursine Muzzle bite attack"

#### Purpose of change
The bear bite attack is weighted very low. At -4 it's only possible 25% of the time, and that 25% of the time it still might not happen if there are other eligible techniques. Unlike other mutation lines, Ursine mutants also lack a natural stance option to deliberately increase the likelihood of using the technique. Since the technique is _also_ conditional on the opponent being Downed, and Downing usually relies on RNG to begin with, that means you very rarely see it even if you're actively trying to play towards it.

#### Describe the solution
Increase the weighting to -2, . This makes both mechanical and intuitive sense to me; I see it as the animal instincts kicking in when you see a Downed enemy and compelling you strike. It also matches the natural stance versions of the other bite attacks, which seems fair considering you can't activate this one at will.

#### Describe alternatives you've considered
I'm honestly tempted to bring the weighting all the way up to 1 to ensure you ALWAYS maul a downed target unless there are competing techniques, but I'm concerned that this might have odd and unintended consequences. For example, if you Sweep a Kevlar zombie with a mace, you'll be forced to chew on it with your bite attack that can't pierce its armor instead of your high-damage weapon attacks. It'll also interfere more with martial arts techniques that require downed enemies.
Personally I think that might be cool, as it kind of simulates your animal nature getting in the way of more "civilized" combat, but having it happen _every_ single time is maybe a little much.

#### Testing
Increased the weighting and batted around a Kevlar Brute with various MAs capable of Downing. A moderate amount of mauling was observed, up from a pitiful amount of mauling.

#### Additional context
I was gonna submit this as a suggestion, but I realized it's only one number so it'll be quicker to just propose the change and you can merge or close the PR as you see fit.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
