### PR TITLE
Encumbrance tweaks

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -152,7 +152,7 @@
     "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
-        "armor": [
+    "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 9,

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -121,7 +121,7 @@
       {
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 8,
-        "coverage": 90,
+        "coverage": 85,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l", "arm_upper_l", "arm_upper_r" ],
         "rigid_layer_only": true
       }
@@ -152,6 +152,15 @@
     "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
+        "armor": [
+      {
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 9,
+        "coverage": 85,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l", "arm_elbow_r", "arm_elbow_l", "arm_upper_l", "arm_upper_r" ],
+        "rigid_layer_only": true
+      }
+    ],
     "melee_damage": { "bash": 5 }
   },
   {

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1135,7 +1135,15 @@
     "warmth": 5,
     "material_thickness": 1.5,
     "flags": [ "SKINTIGHT", "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 4, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 4,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
   {
     "id": "footrags_fur",
@@ -1153,7 +1161,15 @@
     "warmth": 20,
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 6, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 6,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
   {
     "id": "footrags_faux_fur",
@@ -1171,7 +1187,15 @@
     "warmth": 18,
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 6, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 6,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
   {
     "id": "footrags_leather",
@@ -1189,7 +1213,15 @@
     "warmth": 10,
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 14, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 5, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 14, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 5,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
   {
     "id": "footrags_wool",
@@ -1207,9 +1239,17 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 5, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 5,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
-    {
+  {
     "id": "footrags_nomex",
     "type": "ARMOR",
     "name": { "str": "pair of Nomex foot wraps", "str_pl": "pairs of Nomex foot wraps" },
@@ -1225,7 +1265,15 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
-    "armor": [ { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] }, { "encumbrance": 4, "coverage": 85, "covers": [ "hoof_l", "hoof_r" ], "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ] } ]
+    "armor": [
+      { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      {
+        "encumbrance": 4,
+        "coverage": 85,
+        "covers": [ "hoof_l", "hoof_r" ],
+        "specifically_covers": [ "hoof_fetlock_l", "hoof_fetlock_r", "hoof_toe_r", "hoof_toe_l" ]
+      }
+    ]
   },
   {
     "id": "geta",
@@ -2393,16 +2441,9 @@
         "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.01 } ],
         "coverage": 20
       },
-            {
+      {
         "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [
-          "hoof_frog_r",
-          "hoof_frog_l",
-          "hoof_sole_r",
-          "hoof_sole_l",
-          "hoof_toe_r",
-          "hoof_toe_l"
-        ],
+        "specifically_covers": [ "hoof_frog_r", "hoof_frog_l", "hoof_sole_r", "hoof_sole_l", "hoof_toe_r", "hoof_toe_l" ],
         "material": [ { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.01 } ],
         "encumbrance": 15,
         "coverage": 100

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -19,7 +19,7 @@
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "POCKETS", "COLLAR" ],
     "use_action": [ "POST_UP" ],
     "armor": [
-      { "encumbrance": 13, "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 10, "coverage": 60, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 60,
@@ -1801,7 +1801,7 @@
     "material_thickness": 0.5,
     "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 8, "coverage": 95, "covers": [ "torso", "arm_r", "arm_l", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 95,
@@ -1858,7 +1858,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 4,
+        "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1885,11 +1885,11 @@
     "color": "light_blue",
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "STURDY", "POCKETS" ],
     "armor": [
-      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 8,
+        "encumbrance": 3,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -1916,7 +1916,7 @@
     "flags": [ "OVERSIZE", "BELTED", "POCKETS" ],
     "variant_type": "generic",
     "armor": [
-      { "encumbrance": 2, "coverage": 50, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 3, "coverage": 50, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 50,
@@ -1959,11 +1959,11 @@
     "flags": [ "OVERSIZE", "BELTED", "POCKETS", "HOOD" ],
     "variant_type": "generic",
     "armor": [
-      { "encumbrance": 2, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 3, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 3,
+        "encumbrance": 2,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -2002,11 +2002,11 @@
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "RAINPROOF", "POCKETS" ],
     "armor": [
-      { "encumbrance": 9, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 8, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 9,
+        "encumbrance": 4,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -2035,7 +2035,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 8,
+        "encumbrance": 4,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -2060,11 +2060,11 @@
     "environmental_protection": 3,
     "flags": [ "OVERSIZE", "HOOD", "BELTED", "POCKETS" ],
     "armor": [
-      { "encumbrance": 5, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
+      { "encumbrance": 6, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 5,
+        "encumbrance": 3,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -2102,7 +2102,7 @@
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 65,
-        "encumbrance": 25,
+        "encumbrance": 12,
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       }
@@ -2157,18 +2157,18 @@
     "environmental_protection": 1,
     "flags": [ "BELTED", "OVERSIZE", "POCKETS" ],
     "armor": [
-      { "encumbrance": 5, "coverage": 85, "covers": [ "torso" ] },
+      { "encumbrance": 7, "coverage": 85, "covers": [ "torso" ] },
       {
         "covers": [ "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ],
         "coverage": 100,
-        "encumbrance": 5,
+        "encumbrance": 7,
         "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ],
         "layers": [ "BELTED" ]
       },
       {
         "covers": [ "arm_l", "arm_r" ],
         "coverage": 85,
-        "encumbrance": 5,
+        "encumbrance": 0,
         "specifically_covers": [ "arm_upper_r", "arm_upper_l" ],
         "layers": [ "BELTED" ]
       }
@@ -2263,7 +2263,7 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "coverage": 100,
-        "encumbrance": 8
+        "encumbrance": 4
       },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 40, "encumbrance": 8 },
       { "covers": [ "wing_bird_l", "wing_bird_r" ], "coverage": 40, "encumbrance": 8 }

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -980,7 +980,7 @@
     "looks_like": "jacket_windbreaker",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 16, 18 ] },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 14, 16 ] },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 16, 16 ] }
     ],
@@ -1018,7 +1018,7 @@
     "looks_like": "vest_leather",
     "color": "light_blue",
     "armor": [
-      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 16, 18 ] },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 14, 16 ] },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95 }
     ],
     "pocket_data": [

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -29,7 +29,7 @@
     "id": "bandana_head",
     "type": "TOOL_ARMOR",
     "category": "clothing",
-    "name": { "str": "kercheif" },
+    "name": { "str": "kerchief" },
     "description": "A cotton bandana worn over the head.  It can be adjusted to cover the mouth and nose instead.",
     "weight": "42 g",
     "volume": "250 ml",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -98,7 +98,7 @@
     "id": "legguard_chitin",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "pair of chitin leg guards", "str_pl": "pairs of chitin leg guards" },
+    "name": { "str": "pair of chitin greaves", "str_pl": "pairs of chitin greaves" },
     "description": "A pair of guards for the lower legs and knees made from the exoskeletons of insects.",
     "weight": "790 g",
     "volume": "5000 ml",
@@ -116,8 +116,8 @@
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 2,
-        "coverage": 90,
+        "encumbrance": 4,
+        "coverage": 85,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ],
         "rigid_layer_only": true
       }
@@ -128,7 +128,7 @@
     "id": "xl_legguard_chitin",
     "copy-from": "legguard_chitin",
     "type": "ARMOR",
-    "name": { "str": "pair of chitin leg guards", "str_pl": "pairs of chitin leg guards" },
+    "name": { "str": "pair of chitin greaves", "str_pl": "pairs of chitin greaves" },
     "material": [ "chitin" ],
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
@@ -137,7 +137,7 @@
     "id": "xs_legguard_chitin",
     "type": "ARMOR",
     "copy-from": "legguard_chitin",
-    "name": { "str": "pair of chitin leg guards", "str_pl": "pairs of chitin leg guards" },
+    "name": { "str": "pair of chitin greaves", "str_pl": "pairs of chitin greaves" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
@@ -147,7 +147,7 @@
     "looks_like": "legguard_chitin",
     "type": "ARMOR",
     "price_postapoc": "12 USD 50 cent",
-    "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
+    "name": { "str": "pair of biosilicified chitin greaves", "str_pl": "pairs of biosilicified greaves" },
     "description": "A pair of leg guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
     "melee_damage": { "bash": 5 }
@@ -156,7 +156,7 @@
     "id": "xl_legguard_acidchitin",
     "copy-from": "legguard_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
+    "name": { "str": "pair of biosilicified chitin greaves", "str_pl": "pairs of biosilicified chitin greaves" },
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
@@ -165,7 +165,7 @@
     "id": "xs_legguard_acidchitin",
     "copy-from": "legguard_acidchitin",
     "type": "ARMOR",
-    "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
+    "name": { "str": "pair of biosilicified chitin greaves", "str_pl": "pairs of biosilicified chitin greaves" },
     "material": [ "acidchitin" ],
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -150,7 +150,16 @@
     "name": { "str": "pair of biosilicified chitin greaves", "str_pl": "pairs of biosilicified greaves" },
     "description": "A pair of leg guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
-    "melee_damage": { "bash": 5 }
+    "melee_damage": { "bash": 5 },
+    "armor": [
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "encumbrance": 6,
+        "coverage": 85,
+        "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_knee_r", "leg_knee_l" ],
+        "rigid_layer_only": true
+      }
+    ]
   },
   {
     "id": "xl_legguard_acidchitin",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -553,8 +553,8 @@
     "looks_like": "jumpsuit",
     "color": "light_gray",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 6 },
-      { "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "coverage": 90, "encumbrance": 6 }
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": 8 },
+      { "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ], "coverage": 90, "encumbrance": 8 }
     ],
     "warmth": 10,
     "material_thickness": 0.2,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -99,7 +99,7 @@
     "name": { "str": "biosilicified chitin armor" },
     "description": "Leg and body armor crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
-        "armor": [
+    "armor": [
       { "covers": [ "torso" ], "coverage": 90, "encumbrance": 14 },
       {
         "covers": [ "leg_l", "leg_r" ],

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -63,7 +63,7 @@
     "material_thickness": 4,
     "flags": [ "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
-      { "covers": [ "torso" ], "coverage": 90, "encumbrance": 10 },
+      { "covers": [ "torso" ], "coverage": 90, "encumbrance": 11 },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 90,
@@ -99,6 +99,16 @@
     "name": { "str": "biosilicified chitin armor" },
     "description": "Leg and body armor crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
+        "armor": [
+      { "covers": [ "torso" ], "coverage": 90, "encumbrance": 14 },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 90,
+        "encumbrance": 6,
+        "specifically_covers": [ "leg_upper_r", "leg_upper_l", "leg_hip_r", "leg_hip_l" ],
+        "rigid_layer_only": true
+      }
+    ],
     "environmental_protection": 2,
     "price_postapoc": "35 USD",
     "melee_damage": { "bash": 4 }

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -57,13 +57,13 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "flags": [ "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
   },
   {
     "id": "bellywrap",
     "type": "ARMOR",
     "name": { "str": "belly wrap" },
-    "description": "Rags wrapped around the belly.  Usually worn in combination with a chestwrap.  Provides negligible protection against punches to your stomach.",
+    "description": "Rags wrapped around the belly.  Usually worn in combination with a chestwrap.",
     "weight": "120 g",
     "volume": "500 ml",
     "looks_like": "bellyband",
@@ -75,7 +75,7 @@
     "warmth": 3,
     "material_thickness": 0.2,
     "flags": [ "SKINTIGHT", "OVERSIZE" ],
-    "armor": [ { "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ] } ]
   },
   {
     "id": "bellywrap_fur",
@@ -96,7 +96,7 @@
     "id": "bellywrap_leather",
     "type": "ARMOR",
     "name": { "str": "leather belly wrap" },
-    "description": "Leather patches wrapped around the belly.  Usually worn in combination with a chestwrap.  Provides weak protection against punches to your stomach.",
+    "description": "Leather patches wrapped around the belly.  Usually worn in combination with a chestwrap.",
     "copy-from": "bellywrap",
     "weight": "888 g",
     "volume": "750 ml",
@@ -111,7 +111,7 @@
     "id": "bellywrap_wool",
     "type": "ARMOR",
     "name": { "str": "wool belly wrap" },
-    "description": "Felt patches wrapped around the belly.  Usually worn in combination with a chestwrap.  Provides negligible protection against punches to your stomach.",
+    "description": "Felt patches wrapped around the belly.  Usually worn in combination with a chestwrap.",
     "copy-from": "bellywrap",
     "price": "5 USD",
     "material": [ "wool" ],
@@ -136,7 +136,7 @@
     "warmth": 10,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
+    "armor": [ {  "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
   {
     "id": "bikini_top_leather",
@@ -154,7 +154,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
+    "armor": [ {  "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
   {
     "id": "binder_top",
@@ -172,121 +172,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 10, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ],
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "binder_top_black",
-        "name": { "str": "black binder" },
-        "description": "This one is black.",
-        "weight": 140,
-        "append": true
-      },
-      {
-        "id": "binder_top_gray",
-        "name": { "str": "gray binder" },
-        "description": "This one is gray.",
-        "weight": 90,
-        "append": true
-      },
-      {
-        "id": "binder_top_white",
-        "name": { "str": "white binder" },
-        "description": "This one is white.",
-        "weight": 70,
-        "append": true
-      },
-      {
-        "id": "binder_top_blue",
-        "name": { "str": "blue binder" },
-        "description": "This one is blue.",
-        "weight": 25,
-        "append": true
-      },
-      {
-        "id": "binder_top_green",
-        "name": { "str": "green binder" },
-        "description": "This one is green.",
-        "weight": 25,
-        "append": true
-      },
-      {
-        "id": "binder_top_red",
-        "name": { "str": "red binder" },
-        "description": "This one is red.",
-        "weight": 12,
-        "append": true
-      },
-      {
-        "id": "binder_top_orange",
-        "name": { "str": "orange binder" },
-        "description": "This one is orange.",
-        "weight": 12,
-        "append": true
-      },
-      {
-        "id": "binder_top_pink",
-        "name": { "str": "pink binder" },
-        "description": "This one is pink.",
-        "weight": 4,
-        "append": true
-      },
-      {
-        "id": "binder_top_american",
-        "name": { "str": "American binder" },
-        "description": "This one is painted with the star spangled banner, the red white and blue, old glory, the American flag.",
-        "append": true
-      },
-      {
-        "id": "binder_top_ribcage",
-        "name": { "str": "ribcage binder" },
-        "description": "This one is black, with white rib bones.",
-        "weight": 12,
-        "append": true
-      },
-      {
-        "id": "binder_top_mushroom",
-        "name": { "str": "mushroom binder" },
-        "description": "This one has a row of mushrooms on it.",
-        "weight": 10,
-        "append": true
-      },
-      {
-        "id": "binder_top_floral",
-        "name": { "str": "floral binder" },
-        "description": "This one has a floral pattern.",
-        "weight": 10,
-        "append": true
-      },
-      {
-        "id": "binder_top_dinos",
-        "name": { "str": "dinosaur binder" },
-        "description": "This one has a cartoon rendition of a stegosaurus on it.",
-        "weight": 8,
-        "append": true
-      },
-      {
-        "id": "binder_top_trans",
-        "name": { "str": "trans flag binder" },
-        "description": "This one is painted after the trans pride flag.",
-        "weight": 20,
-        "append": true
-      },
-      {
-        "id": "binder_top_nonbinary",
-        "name": { "str": "non-binary flag binder" },
-        "description": "This one is painted after the non-binary pride flag.",
-        "weight": 6,
-        "append": true
-      },
-      {
-        "id": "binder_top_meme",
-        "name": { "str": "meme binder" },
-        "description": "This one has an image of a stuffed rat chef, looking up with arms spread to the heavens, with text above reading \"I don't want to cook anymore\", and the bottom text reading \"I want to DIE\" all in a comic sans font.",
-        "weight": 4,
-        "append": true
-      }
-    ]
+    "armor": [ { "encumbrance": 6, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ],
   },
   {
     "id": "xl_binder_top",
@@ -344,21 +230,6 @@
     "type": "ARMOR",
     "name": { "str": "boxer shorts", "str_pl": "pairs of boxer shorts" },
     "description": "Men's boxer shorts.  More fashionable than briefs and just as comfortable.",
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "generic_boxer_shorts",
-        "name": { "str": "boxer shorts", "str_pl": "pairs of boxer shorts" },
-        "description": "Men's boxer shorts.  More fashionable than briefs and just as comfortable.",
-        "weight": 30
-      },
-      {
-        "id": "flag_boxer_shorts",
-        "name": { "str": "star-spangled boxer shorts", "str_pl": "pairs of star-spangled boxer shorts" },
-        "description": "This pair has been printed with the pattern of an American flag, with stars and miniature eagles embroidered at strategic positions.",
-        "append": true
-      }
-    ],
     "weight": "42 g",
     "volume": "250 ml",
     "price": "10 USD",
@@ -397,21 +268,6 @@
     "type": "ARMOR",
     "name": { "str": "boy shorts", "str_pl": "pairs of boy shorts" },
     "description": "Female underwear similar to men's boxer shorts, but much more close-fitting.",
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "generic_boy_shorts",
-        "name": { "str": "boy shorts", "str_pl": "pairs of boy shorts" },
-        "description": "Female underwear similar to men's boxer shorts, but much more close-fitting.",
-        "weight": 30
-      },
-      {
-        "id": "flag_boy_shorts",
-        "name": { "str": "star-spangled boy shorts", "str_pl": "pairs of star-spangled boy shorts" },
-        "description": "This pair has been printed with the pattern of an American flag, with stars and miniature eagles embroidered at strategic positions.",
-        "append": true
-      }
-    ],
     "weight": "42 g",
     "volume": "250 ml",
     "price": "10 USD",
@@ -811,7 +667,7 @@
     "warmth": 10,
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 3, "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": 8, "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "long_undertop",
@@ -830,12 +686,12 @@
     "material_thickness": 0.2,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
     "armor": [
-      { "encumbrance": 3, "coverage": 100, "covers": [ "arm_l", "arm_r" ] },
+      { "encumbrance": 8, "coverage": 100, "covers": [ "arm_l", "arm_r" ] },
       {
         "covers": [ "torso" ],
         "specifically_covers": [ "torso_upper", "torso_lower" ],
         "coverage": 100,
-        "encumbrance": 3
+        "encumbrance": 8
       }
     ]
   },

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -136,7 +136,7 @@
     "warmth": 10,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ {  "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
+    "armor": [ { "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
   {
     "id": "bikini_top_leather",
@@ -154,7 +154,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ {  "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
+    "armor": [ { "encumbrance": 2, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
   {
     "id": "binder_top",
@@ -172,7 +172,7 @@
     "warmth": 5,
     "material_thickness": 0.5,
     "flags": [ "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 6, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ],
+    "armor": [ { "encumbrance": 6, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] } ]
   },
   {
     "id": "xl_binder_top",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -616,7 +616,7 @@
     "using": [ [ "tailoring_cotton_patchwork_simple", 2 ] ],
     "flags": [ "BLIND_HARD" ]
   },
-    {
+  {
     "result": "footrags_nomex",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",


### PR DESCRIPTION
#### Summary
Encumbrance tweaks

#### Purpose of change
Correct various encumbrance issues and errors

#### Describe the solution
- Long underwear encumbrance now matches union suit.
- Added some encumbrance to belly wraps and other items which had none.
- Reduced jean jacket torso encumbrance slightly. Sleeve encumbrance stays the same - this is heavier weight denim than jeans, but that matters a bit less on the torso.
- Reduced most cloak encumbrance slightly.
- Increased chitinous armor encumbrance slightly.
- Increased biosilicified chitinous armor encumbrance slightly.
- Reduced chitin arm guard coverage slightly.
- Renamed chitin leg guards to chitin greaves.
- Decreased chitin greaves coverage slightly.
- Kercheif -> kerchief.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
