### PR TITLE
Earplugs work again

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2369,7 +2369,7 @@
     "looks_like": "socks",
     "color": "light_blue",
     "material_thickness": 0.05,
-    "flags": [ "WATERPROOF", "OVERSIZE", "UNRESTRICTED", "SOFT" ],
+    "flags": [ "WATERPROOF", "OVERSIZE", "UNRESTRICTED", "SOFT", "ALLOWS_NATURAL_ATTACKS" ],
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -255,7 +255,8 @@
     "symbol": ";",
     "color": "light_gray",
     "material_thickness": 1,
-    "flags": [ "DEAF", "OVERSIZE", "POWERARMOR_COMPATIBLE" ]
+    "armor": [ { "encumbrance": 0, "coverage": 5, "covers": [ "head" ], "specifically_covers": [ "head_ear_r", "head_ear_l" ] } ],
+    "flags": [ "DEAF", "OVERSIZE", "SKINTIGHT", "SOFT", "UNRESTRICTED" ]
   },
   {
     "id": "gobag",
@@ -2900,7 +2901,7 @@
     "color": "blue",
     "name": { "str_sp": "shooter's ear plugs" },
     "description": "A pair of in-ear drivers designed to dampen loud sounds and amplify quiet sounds.  Without batteries or when turned off, they function like normal earplugs and block most sound.  They will only block sounds over a certain decibel amount when turned on, to protect your ears from injury while otherwise allowing you to hear normally.  The earplugs are currently off.",
-    "flags": [ "DEAF", "OVERSIZE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "DEAF", "OVERSIZE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC", "SOFT", "SKINTIGHT", "UNRESTRICTED" ],
     "price": "125 USD",
     "price_postapoc": "12 USD 50 cent",
     "material": [ "plastic" ],
@@ -2915,6 +2916,7 @@
       "need_charges": 1,
       "need_charges_msg": "The earplugs' batteries are dead."
     },
+    "armor": [ { "encumbrance": 0, "coverage": 5, "covers": [ "head" ], "specifically_covers": [ "head_ear_r", "head_ear_l" ] } ],
     "material_thickness": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } } ]
   },
@@ -2926,7 +2928,7 @@
     "color": "blue",
     "name": { "str_sp": "shooter's ear plugs (on)" },
     "description": "A pair of in-ear drivers designed to dampen loud sounds and amplify quiet sounds.  The earplugs are turned on, and will block sounds over a certain decibel amount while otherwise allowing you to hear normally.",
-    "flags": [ "OVERSIZE", "PARTIAL_DEAF", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "OVERSIZE", "PARTIAL_DEAF", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "SOFT", "SKINTIGHT", "UNRESTRICTED" ],
     "//": "same power draw as the earmuffs, much smaller internal battery",
     "power_draw": "60 mW",
     "revert_to": "powered_earplugs",


### PR DESCRIPTION
#### Summary
Earplugs work again

#### Purpose of change
Earplugs weren't working because of the mutation part changes.

#### Describe the solution
Give them coverage and some flags so everyone can wear them.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
