### PR TITLE
Fix wield/eat/etc range

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2190,10 +2190,18 @@ void inventory_selector::_add_map_items( tripoint const &target, item_category c
 void inventory_selector::add_nearby_items( int radius )
 {
     if( radius >= 0 ) {
+        const tripoint &center = u.pos();
         map &here = get_map();
-        for( const tripoint &pos : closest_points_first( u.pos(), radius ) ) {
-            // can not reach this -> can not access its contents
-            if( u.pos() != pos && !here.clear_path( u.pos(), pos, rl_dist( u.pos(), pos ), 1, 100 ) ) {
+        for( const tripoint &pos : closest_points_first( center, radius ) ) {
+            if( square_dist( center, pos ) <= 1 ) {
+                add_map_items( pos );
+                add_vehicle_items( pos );
+                continue;
+            }
+            int dist = ( radius <= 1 ) ?
+                       square_dist( center, pos ) :
+                       static_cast<int>( trig_dist_z_adjust( center, pos ) );
+            if( !here.clear_path( center, pos, dist, 1, 100 ) ) {
                 continue;
             }
             add_map_items( pos );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8359,7 +8359,7 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     }
 
     // Handle direct vertical neighbor (1 tile away, different Z)
-    if( rl_dist( f, t ) == 1 && f.z() != t.z() ) {
+    if( trig_dist_z_adjust( f.raw(), t.raw() ) == 1 && f.z() != t.z() ) {
         const bool going_up = t.z() > f.z();
         const tripoint_bub_ms &lower = going_up ? f : t;
         const tripoint_bub_ms &upper = going_up ? t : f;


### PR DESCRIPTION
#### Summary
Fix wield/eat/etc range

#### Purpose of change
#971 generated a few bugs, as anticipated. These in particular are due to the rl_dist issue being a load-bearing bug, particular in that clear_path required an int and trig_dists are floats.

#### Describe the solution
add_nearby_items now does a square_dist check on adjacent tiles before getting into larger radii. This ensures that if radius >= 1, you'll always be able to reach the adjacent 8 tiles.

#### Testing
Can wield and eat from adjacent tiles orthogonal and diagonal. Cannot eat or wield from farther away. Cannot eat or wield from closed display cases.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
