### PR TITLE
remove light industry start from Safe Place scenario

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -140,8 +140,7 @@
       "sloc_horse_ranch",
       "sloc_lighthouse_ground",
       "sloc_lighthouse_small_ground",
-      "sloc_lodge_ground",
-      "sloc_light_industry_scen"
+      "sloc_lodge_ground"
     ],
     "start_name": "Safe Building",
     "flags": [ "LONE_START" ]


### PR DESCRIPTION
#### Summary
Bugfix "remove light industry start from Safe Place scenario"

#### Purpose of change
One of the starting locations for the Safe Place scenario is "Industrial Offices", which places you in a Light Industry location. However, due to TLG changes, there no longer exist Light Industry locations that are free of enemies, so this "Safe Place" start actually drops you in a decidedly unsafe location full of zombies and armed ferals.

#### Describe the solution
Remove the location from the scenario.

#### Describe alternatives you've considered
Re-adding a safe version of Light Industry to use for the scenario. I have elected not to do this as I believe it would spawn in the world even when you don't pick this scenario, which goes against the design intent of making Light Industry more dangerous in the first place.

#### Testing

#### Additional context
Once again I was about to submit this as a bug report, but I realized the solution was simple and obvious so I just submitted it as a PR instead. Feel free to close if you have a better idea.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
