### PR TITLE
Roadrunner mutation requires you to stand

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4600,13 +4600,13 @@
   {
     "type": "mutation",
     "id": "FLEET2",
-    "name": { "str": "Road-Runner" },
+    "name": { "str": "Roadrunner" },
     "points": 3,
-    "description": "Your legs are extremely limber and fast-moving.  You move 30% faster on flat surfaces.",
+    "description": "Your legs are extremely limber and fast-moving.  You can walk and run 30% faster on flat surfaces.",
     "prereqs": [ "FLEET" ],
     "types": [ "RUNNING" ],
     "category": [ "BIRD" ],
-    "enchantments": [ { "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.3 } ] } ]
+    "enchantments": [ { "condition": { "or": [ { "u_has_move_mode": "walk" }, { "u_has_move_mode": "run" } ] } }, { "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.3 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Roadrunner mutation requires you to stand

#### Purpose of change
The roadrunner mutation was making birds crawl super fast.

#### Describe the solution
The mutation only works if you are walking or running.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
