### PR TITLE
fix hoof vectors

### DIFF
--- a/data/json/attack_vectors.json
+++ b/data/json/attack_vectors.json
@@ -132,14 +132,16 @@
     "id": "vector_hoof_toe",
     "limbs": [ "hoof_l", "hoof_r" ],
     "contact_area": [ "hoof_toe_l", "hoof_toe_r" ],
-    "limb_req": [ [ "leg", 2 ] ]
+    "limb_req": [ [ "leg", 2 ] ],
+    "natural_attack": true
   },
   {
     "type": "attack_vector",
     "id": "vector_hoof_sole",
     "limbs": [ "hoof_l", "hoof_r" ],
     "contact_area": [ "hoof_sole_l", "hoof_sole_r" ],
-    "limb_req": [ [ "leg", 2 ] ]
+    "limb_req": [ [ "leg", 2 ] ],
+    "natural_attack": true
   },
   {
     "type": "attack_vector",


### PR DESCRIPTION
#### Summary
Bugfixes "fix hoof vectors"

#### Purpose of change
`vector_hoof_toe` and `vector_hoof_sole` lack the `"natural_attack": true` flag, which prevents the damage from a `NATURAL_WEAPON` like hooves from applying. As a consequence, hooves are not adding damage to kicks.

#### Describe the solution
Set `"natural_attack": true` for the relevant vectors.

#### Describe alternatives you've considered
Removing the `NATURAL_WEAPON` flag from Hooves. It makes sense that claws and fangs have that flag because you want to be able to distinguish between a punch and a claw slash, but for things like hooves, horns and toe talons, it feels kind of weird that the relevant body part can make contact without inflicting bonus damage.
But I'm a little concerned that would set a weird precedent of having natural weapons that don't have the NATURAL_WEAPON flag. Perhaps that'd be a sensible larger-scale reworking, but the way the system is set up right now this is the correct solution.

e: actually, that doesn't even seem to work. guess it's more complicated

#### Testing
Learned Taekwondo and did some kicking, with and without the change.

Damage before:
![image](https://github.com/user-attachments/assets/2e0f4563-0d22-4822-b869-a498104b44af)

Damage after:
![image](https://github.com/user-attachments/assets/bdceabfa-4779-4d0e-99bd-aa55070c04b2)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
