### PR TITLE
Replace shock absorbers with driver skill

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -123,6 +123,7 @@ static const proficiency_id proficiency_prof_athlete_master( "prof_athlete_maste
 static const proficiency_id proficiency_prof_boat_pilot( "prof_boat_pilot" );
 static const proficiency_id proficiency_prof_driver( "prof_driver" );
 
+static const skill_id skill_driving( "driving" );
 static const skill_id skill_swimming( "swimming" );
 
 static const vpart_id vpart_power_cord( "power_cord" );
@@ -7594,14 +7595,14 @@ void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type,
 
     for( const vpart_reference &vpr : get_all_parts() ) {
         vehicle_part &vp = vpr.part();
-        const vpart_info &vpi = vp.info();
-        const int distance = 1 + trig_dist( vp.mount, impact );
+        const int distance = 1 + square_dist( vp.mount, impact );
+        int reduced = 0;
+        // Driver skill can mitigate damage.
+        if( get_driver() && get_driver()->get_skill_level( skill_driving ) >= rng( 0, 11 ) ) {
+            reduced = rng( 0, 1 );
+        }
         if( distance > 1 ) {
-            int net_dmg = rng( dmg1, dmg2 ) / 1 + ( distance * distance );
-            if( vpi.location != part_location_structure || !vpi.has_flag( "PROTRUSION" ) ) {
-                int randomize = rng( 0, net_dmg / 2 );
-                net_dmg -= randomize;
-            }
+            int net_dmg = rng( dmg1, dmg2 ) / ( reduced + distance * distance );
             damage_direct( get_map(), vp, net_dmg, type );
         }
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7595,15 +7595,12 @@ void vehicle::damage_all( int dmg1, int dmg2, const damage_type_id &type,
     for( const vpart_reference &vpr : get_all_parts() ) {
         vehicle_part &vp = vpr.part();
         const vpart_info &vpi = vp.info();
-        const int distance = 1 + square_dist( vp.mount, impact );
+        const int distance = 1 + trig_dist( vp.mount, impact );
         if( distance > 1 ) {
-            int net_dmg = rng( dmg1, dmg2 ) / ( distance * distance );
+            int net_dmg = rng( dmg1, dmg2 ) / 1 + ( distance * distance );
             if( vpi.location != part_location_structure || !vpi.has_flag( "PROTRUSION" ) ) {
-                const int shock_absorber = part_with_feature( vp.mount, "SHOCK_ABSORBER", true );
-                if( shock_absorber >= 0 ) {
-                    const vehicle_part &vp_shock_absorber = part( shock_absorber );
-                    net_dmg = std::max( 0, net_dmg - vp_shock_absorber.info().bonus );
-                }
+                int randomize = rng( 0, net_dmg / 2 );
+                net_dmg -= randomize;
             }
             damage_direct( get_map(), vp, net_dmg, type );
         }


### PR DESCRIPTION
#### Summary
Replace shock absorbers with driver skill

#### Purpose of change
Shock absorbers were terribly annoying and not at all realistic. Shock absorbers are for absorbing energy from the tires going over uneven terrain which might otherwise damage the suspension. They have nothing to do with protecting solar panels from you running people over.

#### Describe the solution
- Shock absorbers now no longer do anything but provide a small amount of armor. You do not need them, and can safely ignore them.
- Damage propagating through a vehicle on impact has a chance to be reduced which increases with the driver's driving skill. This means that skilled drivers will generally damage their vehicles less when they hit stuff.

#### Describe alternatives you've considered
- Shock absorbers are not being removed because I'm going to use them for something else.

#### Testing
Crashed into everything. Seems fine. Mostly noticed that well-constructed cars tend to have their engines crap out rather than disintegrating. More lightweight cars can completely crumple still which is definitely intended.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
