### PR TITLE
Backport 82178 - Gradually mutate over time

### DIFF
--- a/data/json/effects_on_condition/debug_eocs.json
+++ b/data/json/effects_on_condition/debug_eocs.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TEST_MUTATION_GRADUAL",
+    "effect": [
+      { "u_message": "Initial setup complete (1 if true): <u_val:setup_gland>" },
+      { "u_message": "Mutation vitamin: <u_val:mutagen_gland_vitamin>" },
+      { "u_message": "Mutation threshold: <u_val:mutagen_gland_threshold>" },
+      { "u_message": "Post-mutation cooldown (-1 if off cooldown): <u_val:recently_mutated_cooldown>hrs" },
+      { "u_message": "Surplus mutagen since cooldown: <u_val:mutagen_gland_surplus>mg" },
+      { "set_string_var": "MUTAGEN_GRADUAL_CEPHALOPOD", "target_var": { "context_val": "trait" } },
+      {
+        "if": { "test_eoc": "EOC_IS_MUTATION_GRADUAL" },
+        "then": [
+          { "set_string_var": "CEPHALOPOD", "target_var": { "context_val": "trait" } },
+          {
+            "if": { "test_eoc": "EOC_IS_MUTATION_GRADUAL" },
+            "then": { "u_message": "EOC_IS_MUTATION_GRADUAL giving false positive" },
+            "else": { "u_message": "EOC_IS_MUTATION_GRADUAL working as intended" }
+          }
+        ],
+        "else": { "u_message": "EOC_IS_MUTATION_GRADUAL giving false negative" }
+      }
+    ]
+  }
+]

--- a/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
@@ -1,0 +1,277 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TRAIT_IS_MUTATING_GRADUAL",
+    "condition": {
+      "compare_string": [
+        { "context_val": "trait" },
+        "MUTATING_GRADUAL_BATRACHIAN",
+        "MUTATING_GRADUAL_AVIAN",
+        "MUTATING_GRADUAL_BOVOID",
+        "MUTATING_GRADUAL_CEPHALOPOD",
+        "MUTATING_GRADUAL_CHIROPTERAN",
+        "MUTATING_GRADUAL_CRUSTACEAN",
+        "MUTATING_GRADUAL_FELINE",
+        "MUTATING_GRADUAL_PISCINE",
+        "MUTATING_GRADUAL_GASTROPOD",
+        "MUTATING_GRADUAL_INSECT",
+        "MUTATING_GRADUAL_SLIME",
+        "MUTATING_GRADUAL_REPTILIAN",
+        "MUTATING_GRADUAL_CANINE",
+        "MUTATING_GRADUAL_MURINE",
+        "MUTATING_GRADUAL_PLANT",
+        "MUTATING_GRADUAL_RATTINE",
+        "MUTATING_GRADUAL_ARANEAN",
+        "MUTATING_GRADUAL_TROGLOBITE",
+        "MUTATING_GRADUAL_URSINE"
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOSE_MUTATING_GRADUAL",
+    "effect": [
+      {
+        "u_message": "The everpresent churning in your tortured flesh finally ceases.  Is it over?"
+      },
+      { "u_lose_trait": "MUTATING_GRADUAL_BATRACHIAN" },
+      { "u_lose_trait": "MUTATING_GRADUAL_BIRD" },
+      { "u_lose_trait": "MUTATING_GRADUAL_CATTLE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_CEPHALOPOD" },
+      { "u_lose_trait": "MUTATING_GRADUAL_CHIROPTERAN" },
+      { "u_lose_trait": "MUTATING_GRADUAL_CRUSTACEAN" },
+      { "u_lose_trait": "MUTATING_GRADUAL_FELINE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_PISCINE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_GASTROPOD" },
+      { "u_lose_trait": "MUTATING_GRADUAL_INSECT" },
+      { "u_lose_trait": "MUTATING_GRADUAL_REPTILIAN" },
+      { "u_lose_trait": "MUTATING_GRADUAL_CANINE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_MURINE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_PLANT" },
+      { "u_lose_trait": "MUTATING_GRADUAL_RATTINE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_SLIME" },
+      { "u_lose_trait": "MUTATING_GRADUAL_ARANEAN" },
+      { "u_lose_trait": "MUTATING_GRADUAL_TROGLOBITE" },
+      { "u_lose_trait": "MUTATING_GRADUAL_URSINE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATING_GRADUAL_FLUSH",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "//": "Purge built up stores of mutagen post mutation and don't build up again for a period of time",
+    "condition": { "and": [ { "not": { "test_eoc": "EOC_TRAIT_IS_MUTATING_GRADUAL" } }, { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] } ] },
+    "effect": [
+      { "math": [ "u_recently_mutated_cooldown = 36 + u_mutations_gained" ] },
+      { "math": [ "u_mutations_gained++" ] },
+      { "math": [ "u_vitamin('mutagen') = max( 0, u_vitamin('mutagen') - u_MUTATING_GRADUAL_surplus )" ] },
+      {
+        "math": [ "u_vitamin(u_MUTATING_GRADUAL_vitamin) = max( 0, u_vitamin(u_MUTATING_GRADUAL_vitamin) - u_MUTATING_GRADUAL_surplus )" ]
+      },
+      {
+        "math": [ "u_val('thirst') = min( 400, u_val('thirst') + u_MUTATING_GRADUAL_surplus )" ]
+      },
+      { "math": [ "u_MUTATING_GRADUAL_surplus = 0" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATING_GRADUAL_PASSED_THRESHOLD",
+    "eoc_type": "EVENT",
+    "required_event": "crosses_mutation_threshold",
+    "condition": { "and": [ { "not": { "test_eoc": "EOC_TRAIT_IS_MUTATING_GRADUAL" } }, { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] } ] },
+    "effect": [
+      {
+        "if": { "math": [ "u_has_trait(u_MUTATING_GRADUAL_threshold)" ] },
+        "then": { "u_message": "You are new born, complete." },
+        "else": [ { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATING_GRADUAL_SETUP",
+    "condition": { "test_eoc": "EOC_TRAIT_IS_MUTATING_GRADUAL" },
+    "effect": [
+      { "math": [ "u_mutations_gained = 0" ] },
+      { "math": [ "u_recently_mutated_cooldown = 0" ] },
+      { "math": [ "u_MUTATING_GRADUAL_surplus = 0" ] },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_ARANEAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_spider" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_SPIDER" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_BATRACHIAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_batrachian" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_BATRACHIAN" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_AVIAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_bird" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_BIRD" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_BOVOID" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_cattle" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_CATTLE" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_CEPHALOPOD" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_cephalopod" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_CEPHALOPOD" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_CHIROPTERAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_chiropteran" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_CHIROPTERAN" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_CRUSTACEAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_crustacean" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_CRUSTACEAN" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_FELINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_feline" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_FELINE" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_PISCINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_fish" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_FISH" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_GASTROPOD" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_gastropod" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_GASTROPOD" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_INSECT" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_insect" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_INSECT" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_REPTILIAN" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_lizard" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_LIZARD" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_CANINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_lupine" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_LUPINE" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_MURINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_mouse" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_MOUSE" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_PLANT" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_plant" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_PLANT" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_RATTINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_rat" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_RAT" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_SLIME" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_slime" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_SLIME" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_TROGLOBITE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_troglobite" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_TROGLOBITE" }
+        ]
+      },
+      {
+        "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_URSINE" ] },
+        "then": [
+          { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_ursine" },
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_URSINE" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATING_GRADUAL_SETUP_POST_START",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "effect": { "run_eocs": [ "EOC_MUTATING_GRADUAL_SETUP" ], "variables": { "trait": { "context_val": "trait" } } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATING_GRADUAL_SETUP_PRE_START",
+    "//": "Once for each character",
+    "recurrence": 1,
+    "deactivate_condition": { "math": [ "u_setup_mutating_gradual == 1" ] },
+    "effect": [
+      { "run_eocs": [ "EOC_MUTATING_GRADUAL_SETUP" ], "variables": { "trait": { "context_val": "trait" } } },
+      { "math": [ "u_setup_mutating_gradual = 1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AM_BECOME_MUTANT",
+    "//": "Counter passive decay and then if haven't mutated recently roll a chance to gain mutagen, lower chance after threshold",
+    "condition": { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] },
+    "effect": [
+      { "math": [ "u_vitamin(u_MUTATING_GRADUAL_vitamin) += 1" ] },
+      { "math": [ "u_vitamin('mutagen') += 1" ] },
+      { "math": [ "u_val('thirst') += 1" ] },
+      {
+        "if": { "math": [ "u_recently_mutated_cooldown <= 0" ] },
+        "then": {
+          "if": { "math": [ "rng( 0, u_has_trait(u_MUTATING_GRADUAL_threshold) ? 30 : 5) < 1" ] },
+          "then": [
+            { "math": [ "u_vitamin(u_MUTATING_GRADUAL_vitamin) += 50" ] },
+            { "math": [ "u_vitamin('mutagen') += 50" ] },
+            { "math": [ "u_MUTATING_GRADUAL_surplus += 50" ] },
+            { "math": [ "u_val('thirst') += 50" ] }
+          ]
+        },
+        "else": { "math": [ "u_recently_mutated_cooldown -= 1" ] }
+      }
+    ]
+  }
+]

--- a/data/json/mutations/mutation_gradual.json
+++ b/data/json/mutations/mutation_gradual.json
@@ -1,0 +1,185 @@
+[
+  {
+    "type": "mutation",
+    "abstract": "MUTATING_GRADUAL_ABSTRACT",
+    "name": "",
+    "description": "",
+    "points": 0,
+    "time": 3600,
+    "processed_eocs": [ "EOC_AM_BECOME_MUTANT" ],
+    "cancels": [
+      "MUTATING_GRADUAL_BATRACHIAN",
+      "MUTATING_GRADUAL_AVIAN",
+      "MUTATING_GRADUAL_BOVOID",
+      "MUTATING_GRADUAL_CEPHALOPOD",
+      "MUTATING_GRADUAL_CHIMERA",
+      "MUTATING_GRADUAL_CHIROPTERAN",
+      "MUTATING_GRADUAL_CRUSTACEAN",
+      "MUTATING_GRADUAL_FELINE",
+      "MUTATING_GRADUAL_PISCINE",
+      "MUTATING_GRADUAL_GASTROPOD",
+      "MUTATING_GRADUAL_INSECT",
+      "MUTATING_GRADUAL_REPTILIAN",
+      "MUTATING_GRADUAL_CANINE",
+      "MUTATING_GRADUAL_MURINE",
+      "MUTATING_GRADUAL_PLANT",
+      "MUTATING_GRADUAL_RATTINE",
+      "MUTATING_GRADUAL_SLIME",
+      "MUTATING_GRADUAL_ARANEAN",
+      "MUTATING_GRADUAL_TROGLOBITE",
+      "MUTATING_GRADUAL_URSINE"
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_ARANEAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Aranean" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more aranean traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_ARANEAN" ] }
+  },
+    {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_AVIAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Avian" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more bovoid traits..",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_AVIAN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_BATRACHIAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Batrachian" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more batrachian traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_BATRACHIAN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_BOVOID",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Bovoid" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more bovoid traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_BOVOID" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_CANINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Canine" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more canine traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_CANINE" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_CEPHALOPOD",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Cephalopod" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more cephalopod traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_CEPHALOPOD" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_CHIROPTERAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Chiropteran" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more chiropteran traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_CHIROPTERAN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_CRUSTACEAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Crustacean" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more crustacean traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_CRUSTACEAN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_FELINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Feline" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more feline traits.",
+    "delete": { "cancels": [ "MUTAGEN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_GASTROPOD",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Gastropod" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more gastropod traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_GASTROPOD" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_PISCINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Piscine" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more piscine traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_PISCINE" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_INSECT",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Insect" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more insect traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_INSECT" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_REPTILIAN",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Reptilian" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more reptilian traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_REPTILIAN" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_MURINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Murine" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more murine traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_MURINE" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_PLANT",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Plant" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more plant traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_PLANT" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_RATTINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Rattine" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more rattine traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_RATTINE" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_SLIME",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Slime" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more slime traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_SLIME" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_TROGLOBITE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Troglobite" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more troglobite traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_TROGLOBITE" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "MUTATING_GRADUAL_URSINE",
+    "copy-from": "MUTATING_GRADUAL_ABSTRACT",
+    "name": { "str": "Gradual Mutation - Ursine" },
+    "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more ursine traits.",
+    "delete": { "cancels": [ "MUTATING_GRADUAL_URSINE" ] }
+  }
+]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2768,6 +2768,33 @@ Adds `hair_mohawk` trait with the `purple` variant to the character:
 { "u_add_trait": "hair_mohawk", "variant": "purple" }
 ```
 
+
+#### `u_lose_trait`, `npc_lose_trait`
+Character or NPC got trait or mutation removed, if it has one
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- | 
+| "u_lose_trait" / "npc_lose_trait" | **mandatory** | string or [variable object](#variable-object) | id of mutation to be removed; if character or NPC has no such mutation, nothing happens |
+
+##### Valid talkers:
+
+| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+##### Examples
+
+`CHITIN` mutation is removed from character:
+```jsonc
+{ "u_lose_trait": "CHITIN" }
+```
+
+mutation, stored in `mutation_id`  context value, is removed from character:
+```jsonc
+{ "u_lose_trait": { "context_val": "mutation_id" } }
+```
+
+
 #### `u_lose_effect`, `npc_lose_effect`
 Remove effect from character or NPC, if it has one
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -644,7 +644,8 @@ static void check_consistency( const std::vector<trait_id> &mvec, const trait_id
             debugmsg( "mutation %s refers to undefined %s %s", mid.c_str(), what.c_str(), m.c_str() );
         }
 
-        if( m == mid ) {
+        // TODO: The context check here is gross but this is throwing false positives on #81278 that I don't know how to check for in a better way and I can't repro a crash even if the mutation doesn't cancel cancelling itself it just makes the UI a bit unintuitive
+        if( m == mid && what != "cancels" ) {
             debugmsg( "mutation %s refers to itself in %s context.  The program will crash if the player gains this mutation.",
                       mid.c_str(), what.c_str() );
         }


### PR DESCRIPTION
#### Summary
Backport 82178 - Gradually mutate over time

#### Purpose of change
#62 - It was a goal that we'd have starting traits available which gradually transform you into a post-threshold mutant. Someone at DDA went ahead and did it, albeit in a mod.

#### Describe the solution
- Change the flavor. It's not CRISPR and it's not a gland. You're just mutating for some reason. Maybe portal energies got you, maybe the blob just likes you, maybe you got experimented on.
- Remove the advanced mutant types from the list. Those are meant to be rarer and harder to acquire.
- Move it from a mod to mainline.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
