### PR TITLE
Migrate a few missed jewelry items

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -1004,6 +1004,11 @@
     "replace": "silver_earring"
   },
   {
+    "id": "diamond_silver_earring",
+    "type": "MIGRATION",
+    "replace": "silver_earring"
+  },
+  {
     "id": "emerald_silver_earring",
     "type": "MIGRATION",
     "replace": "silver_earring"
@@ -2492,5 +2497,10 @@
     "id": "veggy_pickled_fried",
     "type": "MIGRATION",
     "replace": "vegetable_pickled_fried"
+  },
+  {
+    "id": "cufflinks_intricate",
+    "type": "MIGRATION",
+    "replace": "tie_necktie"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate a few missed jewelry items

#### Purpose of change
diamond_silver_earrings and cufflinks_intricate were throwing errors for a few people.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
