### PR TITLE
Atlatl Audit

### DIFF
--- a/data/json/items/ranged/atlatl.json
+++ b/data/json/items/ranged/atlatl.json
@@ -53,7 +53,7 @@
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.5, "armor_penetration": 2 },
     "dispersion": 180,
     "loudness": 0,
-    "critical_multiplier": 10,
+    "critical_multiplier": 2,
     "recovery_chance": 97,
     "melee_damage": { "stab": 10 }
   },
@@ -74,7 +74,7 @@
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 1.25, "armor_penetration": 1.25 },
     "dispersion": 180,
     "loudness": 0,
-    "critical_multiplier": 10,
+    "critical_multiplier": 2,
     "recovery_chance": 96,
     "melee_damage": { "stab": 8 }
   },
@@ -95,7 +95,7 @@
     "damage": { "damage_type": "stab", "constant_damage_multiplier": 0.75 },
     "dispersion": 200,
     "loudness": 0,
-    "critical_multiplier": 8,
+    "critical_multiplier": 2,
     "recovery_chance": 83,
     "melee_damage": { "stab": 5 }
   }


### PR DESCRIPTION
#### Summary
After the updates to crossbows and bows, all ranged weapons from slings to arrows to bows have a crit multiplier of 2, leaving the atlatl as the sole remnant using the old 10x crit damage multiplier. This changes atlatls to 2 as well.
#### Purpose of change
To standardize atlatl damage.
#### Describe the solution
Change the 10x (and 8x with one version for some reason) multiplier to 2x.
#### Describe alternatives you've considered
Not changing it and leaving atlatls magically more powerful than other ranged weapons.
#### Testing
Does 2x instead of 10x.
#### Additional context
none
