### PR TITLE
Silence the other wacky body part error

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8360,7 +8360,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
     }
 
     if( hurt == bodypart_str_id::NULL_ID() ) {
-        debugmsg( "Wacky body part hurt!" );
+        add_msg_debug( debugmode::DF_CHAR_HEALTH, "apply_damage() picked a null bodypart, redirecting damage to torso." );
         hurt = body_part_torso;
     }
 
@@ -8423,7 +8423,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
 dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
         const damage_instance &d, const weakpoint_attack &attack )
 {
-    if( has_trait( trait_DEBUG_NODMG ) || has_effect( effect_incorporeal ) ) {
+    if( is_dead_state() || has_trait( trait_DEBUG_NODMG ) || has_effect( effect_incorporeal ) ) {
         return dealt_damage_instance();
     }
 
@@ -8485,7 +8485,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
         bp == body_part_hand_r || bp == body_part_arm_r ) {
         recoil_mul = 200;
     } else if( bp == bodypart_str_id::NULL_ID() ) {
-        debugmsg( "Wacky body part hit!" );
+        add_msg_debug( debugmode::DF_CHAR_HEALTH, "apply_damage() picked a null body part." );
     }
 
     // TODO: Scale with damage in a way that makes sense for power armors, plate armor and naked skin.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8485,7 +8485,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
         bp == body_part_hand_r || bp == body_part_arm_r ) {
         recoil_mul = 200;
     } else if( bp == bodypart_str_id::NULL_ID() ) {
-        add_msg_debug( debugmode::DF_CHAR_HEALTH, "apply_damage() picked a null body part." );
+        add_msg_debug( debugmode::DF_CHAR_HEALTH, "dealt_damage_instance() picked a null body part." );
     }
 
     // TODO: Scale with damage in a way that makes sense for power armors, plate armor and naked skin.


### PR DESCRIPTION
#### Summary
Silence the other wacky body part error

#### Purpose of change
An error message in apply_damage() was fixed back in #959 but I missed one in dealt_damage_instance().

#### Describe the solution
- Change the error to a quieter debug message.
- Prevent the error from happening when the character is dead (which is when we were seeing it) by exiting dealt_damage_instance() early if the character is_dead_state(), as was done with apply_damage() in #959 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
