### PR TITLE
Fix reinforced glass doors

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -132,23 +132,23 @@
     "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "BLOCK_WIND", "SUPPORTS_ROOF" ],
     "open": "t_reinforced_door_glass_o",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "count": [ 15, 34 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
     },
     "shoot": {
-      "reduce_damage": [ 15, 30 ],
+      "reduce_damage": [ 5, 10 ],
       "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 60, 160 ],
+      "destroy_damage": [ 40, 80 ],
       "no_laser_destroy": true
     }
   },
@@ -170,23 +170,23 @@
     "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "SUPPORTS_ROOF" ],
     "open": "t_reinforced_door_glass_lab_o",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
-      "ter_set": "t_thconc_floor",
+      "ter_set": "t_mdoor_frame",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "count": [ 15, 34 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
     },
     "shoot": {
-      "reduce_damage": [ 15, 30 ],
+      "reduce_damage": [ 5, 10 ],
       "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 60, 160 ],
+      "destroy_damage": [ 40, 80 ],
       "no_laser_destroy": true
     }
   },
@@ -206,15 +206,15 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
     "close": "t_reinforced_door_glass_c",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "charges": [ 15, 34 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
@@ -236,15 +236,15 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
     "close": "t_reinforced_door_glass_lab_c",
     "bash": {
-      "str_min": 40,
-      "str_max": 210,
+      "str_min": 16,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_thconc_floor",
       "items": [
-        { "item": "glass_shard", "count": [ 42, 84 ] },
+        { "item": "glass_shard", "charges": [ 15, 34 ] },
         { "item": "wire", "prob": 20 },
         { "item": "scrap", "count": [ 3, 5 ] }
       ]

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2734,12 +2734,12 @@
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_floor",
-      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] }, { "item": "wire", "prob": 20 } ]
+      "items": [ { "item": "glass_shard", "charges": [ 15, 34 ] }, { "item": "wire", "prob": 20 } ]
     },
     "shoot": {
       "reduce_damage": [ 5, 10 ],
       "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 60, 160 ],
+      "destroy_damage": [ 40, 80 ],
       "no_laser_destroy": true
     }
   },


### PR DESCRIPTION
#### Summary
Fix reinforced glass doors

#### Purpose of change
Someone, probably me, forgot to update reinforced glass doors when standardizing glass wall/window strength.

#### Describe the solution
They're now as weak as reinforced glass walls.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
