### PR TITLE
Fix some leg armor encumbrance

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1017,7 +1017,7 @@
           { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.3 },
           { "type": "denim", "covered_by_mat": 100, "thickness": 0.6 }
         ],
-        "encumbrance": [ 10, 14 ],
+        "encumbrance": [ 18, 22 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ]
@@ -1088,7 +1088,7 @@
     "flags": [ "VARSIZE", "POCKETS", "ALLOWS_TAIL" ],
     "armor": [
       {
-        "encumbrance": [ 12, 16 ],
+        "encumbrance": [ 26, 28 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ],
@@ -1100,7 +1100,6 @@
         "layers": [ "OUTER", "NORMAL" ]
       },
       {
-        "encumbrance": [ 2, 2 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1017,7 +1017,7 @@
           { "type": "kevlar", "covered_by_mat": 100, "thickness": 0.3 },
           { "type": "denim", "covered_by_mat": 100, "thickness": 0.6 }
         ],
-        "encumbrance": [ 18, 22 ],
+        "encumbrance": [ 16, 20 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ]


### PR DESCRIPTION
#### Summary
Fix some leg armor encumbrance

#### Purpose of change
This stuff needs a full audit, but in the meantime here are a couple of fixes.

#### Describe the solution
- Increase encumbrance on jeans_mod and motorbike_pants
#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
