### PR TITLE
Fix neckties not fitting, re-add cufflinks etc

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2529,5 +2529,20 @@
     "id": "CROSSBOW",
     "type": "json_flag",
     "//": "If this ranged weapon uses the archery skill, it will not drain stamina when aiming, nor will it teach archer's form."
+  },
+  {
+    "id": "NECKTIE_ACCESSORY",
+    "type": "json_flag",
+    "info": "This item is designed to attach to a necktie."
+  },
+  {
+    "id": "SHIRT_COLLAR_ACCESSORY",
+    "type": "json_flag",
+    "info": "This item is designed to fit in the collar of a button-up shirt."
+  },
+  {
+    "id": "SHIRT_CUFF_ACCESSORY",
+    "type": "json_flag",
+    "info": "This item is meant to fit in the cuffs of a dress shirt."
   }
 ]

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -22,7 +22,7 @@
       }
     ],
     "use_action": [ "MEDITATE" ],
-    "flags": [ "BELTED", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "BELTED", "UNRESTRICTED", "SOFT", "OVERSIZE", "UNRESTRICTED" ]
   },
   {
     "id": "bead_ear",
@@ -38,7 +38,7 @@
     "looks_like": "gold_ear",
     "color": "brown",
     "armor": [ { "encumbrance": 0, "coverage": 4, "covers": [ "head" ], "specifically_covers": [ "head_ear_l", "head_ear_r" ] } ],
-    "flags": [ "SKINTIGHT", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "SKINTIGHT", "UNRESTRICTED", "SOFT", "OVERSIZE", "UNRESTRICTED" ]
   },
   {
     "id": "bead_necklace",
@@ -55,7 +55,7 @@
     "color": "brown",
     "use_action": [ "MEDITATE" ],
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
-    "flags": [ "NO_WEAR_EFFECT", "BELTED", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "NO_WEAR_EFFECT", "BELTED", "UNRESTRICTED", "SOFT", "OVERSIZE" ]
   },
   {
     "id": "bracelet_friendship",
@@ -79,7 +79,7 @@
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
       }
     ],
-    "flags": [ "NO_WEAR_EFFECT", "PERSONAL", "UNRESTRICTED" ]
+    "flags": [ "NO_WEAR_EFFECT", "PERSONAL", "UNRESTRICTED", "OVERSIZE", "SOFT" ]
   },
   {
     "id": "bronze_medal",
@@ -95,7 +95,7 @@
     "looks_like": "copper_locket",
     "color": "brown",
     "armor": [ { "encumbrance": 0, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
-    "flags": [ "NO_WEAR_EFFECT", "BELTED", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "BELTED", "UNRESTRICTED", "SOFT", "OVERSIZE" ]
   },
   {
     "id": "cowrie_bracelet",
@@ -180,13 +180,14 @@
     "description": "A staple accessory for gentlemen.  Keeps your shirt collar in place and provides a more aesthetically pleasing arc to your necktie.",
     "weight": "10 g",
     "volume": "2 ml",
+    "longest_side": "80 mm",
     "price": "250 USD",
     "price_postapoc": "10 cent",
     "material": [ "silver" ],
     "symbol": "[",
     "looks_like": "tieclip",
     "color": "light_gray",
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "flags": [ "FANCY", "SHIRT_COLLAR_ACCESSORY", "CANT_WEAR" ]
   },
   {
     "id": "copper_bracelet",
@@ -210,7 +211,7 @@
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
       }
     ],
-    "flags": [ "BELTED", "NO_WEAR_EFFECT", "OVERSIZE" ]
+    "flags": [ "BELTED", "NO_WEAR_EFFECT", "OVERSIZE", "UNRESTRICTED" ]
   },
   {
     "id": "copper_earring",
@@ -226,7 +227,7 @@
     "looks_like": "gold_earring",
     "color": "brown",
     "armor": [ { "encumbrance": 0, "coverage": 4, "covers": [ "head" ], "specifically_covers": [ "head_ear_l", "head_ear_r" ] } ],
-    "flags": [ "SKINTIGHT", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "SKINTIGHT", "UNRESTRICTED", "SOFT", "OVERSIZE" ]
   },
   {
     "id": "copper_hairpin",
@@ -255,7 +256,7 @@
     "looks_like": "silver_necklace",
     "color": "brown",
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
-    "flags": [ "BELTED", "UNRESTRICTED", "SOFT" ]
+    "flags": [ "BELTED", "UNRESTRICTED", "SOFT", "OVERSIZE" ]
   },
   {
     "id": "copper_ring",
@@ -303,7 +304,7 @@
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
       }
     ],
-    "flags": [ "FANCY", "BELTED", "NO_WEAR_EFFECT", "OVERSIZE" ]
+    "flags": [ "FANCY", "BELTED", "NO_WEAR_EFFECT", "OVERSIZE", "UNRESTRICTED" ]
   },
   {
     "id": "gold_dental_grill",
@@ -367,9 +368,10 @@
     "price": "100 USD",
     "price_postapoc": "25 cent",
     "material": [ "gold" ],
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
     "symbol": "[",
     "color": "yellow",
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "flags": [ "BELTED", "UNRESTRICTED", "SOFT" ]
   },
   {
     "id": "service_medal",
@@ -383,7 +385,7 @@
     "material": [ { "type": "gold", "portion": 1 }, { "type": "bronze", "portion": 4 } ],
     "symbol": "[",
     "color": "brown",
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "flags": [ "UNRESTRICTED", "SOFT", "NO_WEAR_EFFECT" ]
   },
   {
     "id": "gold_ring",
@@ -410,6 +412,34 @@
     "flags": [ "FANCY", "NO_WEAR_EFFECT", "SKINTIGHT", "ALLOWS_TALONS" ]
   },
   {
+    "id": "gold_cufflinks",
+    "type": "ARMOR",
+    "name": { "str": "gold cufflinks" },
+    "description": "A tasteful pair of gold buttons with toggles on the back.  These are meant to be worn in the buttonholes in the cuffs of a dress shirt.",
+    "weight": "20 g",
+    "volume": "2 ml",
+    "price": "600 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "gold" ],
+    "symbol": "[",
+    "color": "yellow",
+    "flags": [ "FANCY", "SHIRT_CUFF_ACCESSORY", "CANT_WEAR" ]
+  },
+    {
+    "id": "diamond_cufflinks",
+    "type": "ARMOR",
+    "name": { "str": "diamond cufflinks" },
+    "description": "Sparkling diamonds are set into gold buttons with toggles on the back.  These are meant to be worn in the buttonholes in the cuffs of a dress shirt.",
+    "weight": "20 g",
+    "volume": "2 ml",
+    "price": "1200 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "gold", "diamond" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "flags": [ "SUPER_FANCY", "SHIRT_CUFF_ACCESSORY", "CANT_WEAR" ]
+  },
+  {
     "id": "gold_watch",
     "type": "ARMOR",
     "name": { "str": "gold watch", "str_pl": "gold watches" },
@@ -430,7 +460,7 @@
     "id": "tieclip",
     "type": "ARMOR",
     "name": { "str": "tie clip" },
-    "description": "A fancy silver tie clip, a great match for a necktie.",
+    "description": "A shiny silver tie clip, a great match for a necktie.",
     "weight": "12 g",
     "volume": "5 ml",
     "price": "280 USD",
@@ -438,7 +468,7 @@
     "material": [ "silver" ],
     "symbol": "[",
     "color": "light_gray",
-    "flags": [ "FANCY", "NO_WEAR_EFFECT" ]
+    "flags": [ "FANCY", "NECKTIE_ACCESSORY" ]
   },
   {
     "id": "silver_watch",
@@ -1120,9 +1150,10 @@
     "price": "50 USD",
     "price_postapoc": "10 cent",
     "material": [ "silver" ],
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
     "symbol": "[",
     "color": "light_gray",
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "flags": [ "BELTED", "UNRESTRICTED", "SOFT" ]
   },
   {
     "id": "silver_ring",

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -87,12 +87,25 @@
     "id": "tie_skinny",
     "type": "ARMOR",
     "name": { "str": "skinny tie" },
-    "description": "A skinny black and white checkered necktie.",
+    "description": "A necktie much narrower than usual, popularized by mid-century rock musicians and an enduring symbol of subculture ever since, it can nonetheless still serve as a high-class accessory.",
     "weight": "12 g",
     "volume": "50 ml",
     "price": "7 USD 50 cent",
     "price_postapoc": "10 cent",
-    "material": [ "cotton" ],
+    "material": [ "nylon" ],
+    "pocket_data": [
+    {
+      "pocket_type": "CONTAINER",
+      "rigid": false,
+      "max_contains_weight": "20 g",
+      "max_contains_volume": "15 ml",
+      "max_item_length": "85 mm",
+      "moves": 100,
+      "flag_restriction": [
+        "NECKTIE_ACCESSORY"
+      ]
+    }
+    ],
     "symbol": "[",
     "color": "dark_gray",
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
@@ -177,10 +190,23 @@
     "volume": "20 ml",
     "price": "5 USD",
     "price_postapoc": "10 cent",
-    "material": [ "cotton" ],
+    "material": [ "nylon" ],
+    "pocket_data": [
+    {
+      "pocket_type": "CONTAINER",
+      "rigid": false,
+      "max_contains_weight": "20 g",
+      "max_contains_volume": "15 ml",
+      "max_item_length": "85 mm",
+      "moves": 100,
+      "flag_restriction": [
+        "NECKTIE_ACCESSORY"
+      ]
+    }
+  ],
     "symbol": "[",
     "color": "blue",
-    "flags": [ "FANCY", "BELTED" ],
+    "flags": [ "BELTED" ],
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ]
   },
   {
@@ -192,7 +218,20 @@
     "volume": "25 ml",
     "price": "10 USD",
     "price_postapoc": "10 cent",
-    "material": [ "cotton" ],
+    "material": [ "nylon" ],
+    "pocket_data": [
+    {
+      "pocket_type": "CONTAINER",
+      "rigid": false,
+      "max_contains_weight": "20 g",
+      "max_contains_volume": "15 ml",
+      "max_item_length": "85 mm",
+      "moves": 100,
+      "flag_restriction": [
+        "NECKTIE_ACCESSORY"
+      ]
+    }
+  ],
     "symbol": "[",
     "color": "green",
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
@@ -201,7 +240,7 @@
   {
     "id": "vampire_fangs",
     "type": "ARMOR",
-    "name": { "str_sp": "vampire fangs" },
+    "name": { "str_sp": "plastic vampire fangs" },
     "description": "A pair of white vampire fangs made of plastic.",
     "weight": "23 g",
     "volume": "250 ml",
@@ -213,8 +252,8 @@
     "looks_like": "mouthpiece",
     "color": "white",
     "material_thickness": 0.01,
-    "flags": [ "SKINTIGHT", "NO_WEAR_EFFECT" ],
-    "armor": [ { "encumbrance": 5, "coverage": 10, "covers": [ "mouth" ] } ]
+    "flags": [ "SKINTIGHT" ],
+    "armor": [ { "encumbrance": 10, "coverage": 10, "covers": [ "mouth" ] } ]
   },
   {
     "id": "veil_wedding",
@@ -404,7 +443,7 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "flags": [ "NO_WEAR_EFFECT", "BELTED" ],
+    "flags": [ "BELTED" ],
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
     "//": "dog tags are roughly 50mm x 28mm x 0.4mm, or 0.56 ml, but that's so small I needed to round up to 1 ml"
   }

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -9,13 +9,13 @@
     "price": "25 USD",
     "price_postapoc": "10 cent",
     "to_hit": -3,
-    "material": [ "nylon" ],
+    "material": [ "vinyl" ],
     "symbol": "[",
     "color": "pink",
     "warmth": 20,
     "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "SKINTIGHT" ],
     "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "head" ] } ]
   },
   {
@@ -29,6 +29,7 @@
     "price_postapoc": "10 cent",
     "material": [ "rubber" ],
     "symbol": ".",
+    "armor": [ { "encumbrance": 5, "coverage": 90, "covers": [ "mouth" ], "specifically_covers": [ "mouth_nose" ] } ],
     "color": "red"
   },
   {
@@ -94,7 +95,8 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "dark_gray",
-    "flags": [ "FANCY" ]
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
+    "flags": [ "FANCY", "BELTED" ]
   },
   {
     "id": "sleeping_bag_roll",
@@ -163,7 +165,8 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "black",
-    "flags": [ "FANCY" ]
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
+    "flags": [ "FANCY", "BELTED" ]
   },
   {
     "id": "tie_clipon",
@@ -177,7 +180,8 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "blue",
-    "flags": [ "FANCY" ]
+    "flags": [ "FANCY", "BELTED" ],
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ]
   },
   {
     "id": "tie_necktie",
@@ -191,7 +195,8 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "color": "green",
-    "flags": [ "FANCY" ]
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
+    "flags": [ "FANCY", "BELTED" ]
   },
   {
     "id": "vampire_fangs",
@@ -368,13 +373,13 @@
     "price": "25 USD",
     "price_postapoc": "10 cent",
     "to_hit": -3,
-    "material": [ "cotton" ],
+    "material": [ "vinyl" ],
     "symbol": "[",
     "color": "blue",
     "warmth": 10,
     "material_thickness": 0.2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
     "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "head" ] } ]
   },
   {
@@ -399,7 +404,8 @@
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",
-    "flags": [ "NO_WEAR_EFFECT" ],
+    "flags": [ "NO_WEAR_EFFECT", "BELTED" ],
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
     "//": "dog tags are roughly 50mm x 28mm x 0.4mm, or 0.56 ml, but that's so small I needed to round up to 1 ml"
   }
 ]

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -115,14 +115,14 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1 L",
+        "max_contains_volume": "750 ml",
         "max_contains_weight": "3 kg",
         "max_item_length": "28 cm",
         "moves": 80
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1 L",
+        "max_contains_volume": "750 ml",
         "max_contains_weight": "3 kg",
         "max_item_length": "28 cm",
         "moves": 80
@@ -179,24 +179,17 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "750 ml",
-        "max_contains_weight": "3 kg",
-        "max_item_length": "11 cm",
-        "moves": 80
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "750 ml",
-        "max_contains_weight": "3 kg",
-        "max_item_length": "11 cm",
-        "moves": 80
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "350 ml",
+        "max_contains_volume": "300 ml",
         "max_contains_weight": "2 kg",
-        "max_item_length": "9 cm",
-        "moves": 100
+        "max_item_length": "11 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "300 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "11 cm",
+        "moves": 80
       }
     ],
     "warmth": 25,
@@ -244,14 +237,14 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "500 ml",
+        "max_contains_volume": "350 ml",
         "max_contains_weight": "1 kg",
         "max_item_length": "13 cm",
         "moves": 120
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "500 ml",
+        "max_contains_volume": "350 ml",
         "max_contains_weight": "1 kg",
         "max_item_length": "13 cm",
         "moves": 120
@@ -309,8 +302,8 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "400 ml",
-        "max_contains_weight": "4 kg",
+        "max_contains_volume": "350 ml",
+        "max_contains_weight": "2 kg",
         "max_item_length": "10 cm",
         "moves": 75
       }
@@ -343,10 +336,34 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "450 ml",
+        "max_contains_volume": "250 ml",
         "max_contains_weight": "1 kg",
         "max_item_length": "12 cm",
         "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "12 g",
+        "max_contains_volume": "3 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "description": "Eyelets for a collar pin",
+        "flag_restriction": [
+          "SHIRT_COLLAR_ACCESSORY"
+        ]
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "22 g",
+        "max_contains_volume": "3 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "description": "Buttonholes for cufflinks",
+        "flag_restriction": [
+          "SHIRT_CUFF_ACCESSORY"
+        ]
       }
     ],
     "warmth": 10,
@@ -547,8 +564,8 @@
   {
     "id": "longshirt",
     "type": "ARMOR",
-    "name": { "str": "long-sleeved shirt" },
-    "description": "A long-sleeved cotton shirt.",
+    "name": { "str": "long-sleeved t-shirt" },
+    "description": "A soft cotton shirt with long sleeves.",
     "weight": "146 g",
     "volume": "750 ml",
     "price": "20 USD",
@@ -859,6 +876,18 @@
         "max_contains_weight": "1 kg",
         "max_item_length": "12 cm",
         "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "12 g",
+        "max_contains_volume": "3 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "description": "Eyelets for a collar pin",
+        "flag_restriction": [
+          "SHIRT_COLLAR_ACCESSORY"
+        ]
       }
     ],
     "warmth": 10,

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -403,7 +403,7 @@
     "color": "yellow",
     "description": "A candy bracelet made by stringing candies onto a thread.  In theory, you could both wear and eat the bracelet.",
     "copy-from": "candy4",
-    "flags": [ "EDIBLE_FROZEN", "BELTED" ],
+    "flags": [ "EDIBLE_FROZEN", "BELTED", "OVERSIZE", "UNRESTRICTED" ],
     "material": [ "junk" ],
     "armor_data": {
       "sided": true,

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -403,6 +403,7 @@
     "color": "yellow",
     "description": "A candy bracelet made by stringing candies onto a thread.  In theory, you could both wear and eat the bracelet.",
     "copy-from": "candy4",
+    "flags": [ "EDIBLE_FROZEN", "BELTED" ],
     "material": [ "junk" ],
     "armor_data": {
       "sided": true,


### PR DESCRIPTION
#### Summary
Fix neckties not fitting, re-add cufflinks etc

#### Purpose of change
A few items still didn't fit.

#### Describe the solution
- Make neckties worn on the neck.
- Re-add cufflinks.
- Tie bars/clips, cufflinks, and collar pins now fit in specific pockets on the items designed to admit them.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
