### PR TITLE
Slightly adjust ant skill hp and armor

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -145,12 +145,7 @@
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
     },
-    "shoot": {
-      "reduce_damage": [ 5, 10 ],
-      "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 40, 80 ],
-      "no_laser_destroy": true
-    }
+    "shoot": { "reduce_damage": [ 5, 10 ], "reduce_damage_laser": [ 0, 10 ], "destroy_damage": [ 40, 80 ], "no_laser_destroy": true }
   },
   {
     "type": "terrain",
@@ -183,12 +178,7 @@
         { "item": "scrap", "count": [ 3, 5 ] }
       ]
     },
-    "shoot": {
-      "reduce_damage": [ 5, 10 ],
-      "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 40, 80 ],
-      "no_laser_destroy": true
-    }
+    "shoot": { "reduce_damage": [ 5, 10 ], "reduce_damage_laser": [ 0, 10 ], "destroy_damage": [ 40, 80 ], "no_laser_destroy": true }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2736,12 +2736,7 @@
       "ter_set": "t_floor",
       "items": [ { "item": "glass_shard", "charges": [ 15, 34 ] }, { "item": "wire", "prob": 20 } ]
     },
-    "shoot": {
-      "reduce_damage": [ 5, 10 ],
-      "reduce_damage_laser": [ 0, 10 ],
-      "destroy_damage": [ 40, 80 ],
-      "no_laser_destroy": true
-    }
+    "shoot": { "reduce_damage": [ 5, 10 ], "reduce_damage_laser": [ 0, 10 ], "destroy_damage": [ 40, 80 ], "no_laser_destroy": true }
   },
   {
     "type": "terrain",

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -425,7 +425,7 @@
     "color": "yellow",
     "flags": [ "FANCY", "SHIRT_CUFF_ACCESSORY", "CANT_WEAR" ]
   },
-    {
+  {
     "id": "diamond_cufflinks",
     "type": "ARMOR",
     "name": { "str": "diamond cufflinks" },

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -796,7 +796,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -877,7 +877,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -1268,7 +1268,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -1282,7 +1282,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -1651,7 +1651,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -1769,7 +1769,7 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",
@@ -1851,7 +1851,7 @@
         "max_contains_weight": "2 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      }
+      },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "400 ml",

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -94,17 +94,15 @@
     "price_postapoc": "10 cent",
     "material": [ "nylon" ],
     "pocket_data": [
-    {
-      "pocket_type": "CONTAINER",
-      "rigid": false,
-      "max_contains_weight": "14 g",
-      "max_contains_volume": "7 ml",
-      "max_item_length": "85 mm",
-      "moves": 100,
-      "flag_restriction": [
-        "NECKTIE_ACCESSORY"
-      ]
-    }
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "14 g",
+        "max_contains_volume": "7 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "flag_restriction": [ "NECKTIE_ACCESSORY" ]
+      }
     ],
     "symbol": "[",
     "color": "dark_gray",
@@ -192,18 +190,16 @@
     "price_postapoc": "10 cent",
     "material": [ "nylon" ],
     "pocket_data": [
-    {
-      "pocket_type": "CONTAINER",
-      "rigid": false,
-      "max_contains_weight": "14 g",
-      "max_contains_volume": "7 ml",
-      "max_item_length": "85 mm",
-      "moves": 100,
-      "flag_restriction": [
-        "NECKTIE_ACCESSORY"
-      ]
-    }
-  ],
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "14 g",
+        "max_contains_volume": "7 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "flag_restriction": [ "NECKTIE_ACCESSORY" ]
+      }
+    ],
     "symbol": "[",
     "color": "blue",
     "flags": [ "BELTED" ],
@@ -220,18 +216,16 @@
     "price_postapoc": "10 cent",
     "material": [ "nylon" ],
     "pocket_data": [
-    {
-      "pocket_type": "CONTAINER",
-      "rigid": false,
-      "max_contains_weight": "14 g",
-      "max_contains_volume": "7 ml",
-      "max_item_length": "85 mm",
-      "moves": 100,
-      "flag_restriction": [
-        "NECKTIE_ACCESSORY"
-      ]
-    }
-  ],
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": false,
+        "max_contains_weight": "14 g",
+        "max_contains_volume": "7 ml",
+        "max_item_length": "85 mm",
+        "moves": 100,
+        "flag_restriction": [ "NECKTIE_ACCESSORY" ]
+      }
+    ],
     "symbol": "[",
     "color": "green",
     "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -349,9 +349,7 @@
         "max_item_length": "85 mm",
         "moves": 100,
         "description": "Eyelets for a collar pin",
-        "flag_restriction": [
-          "SHIRT_COLLAR_ACCESSORY"
-        ]
+        "flag_restriction": [ "SHIRT_COLLAR_ACCESSORY" ]
       },
       {
         "pocket_type": "CONTAINER",
@@ -361,9 +359,7 @@
         "max_item_length": "85 mm",
         "moves": 100,
         "description": "Buttonholes for cufflinks",
-        "flag_restriction": [
-          "SHIRT_CUFF_ACCESSORY"
-        ]
+        "flag_restriction": [ "SHIRT_CUFF_ACCESSORY" ]
       }
     ],
     "warmth": 10,
@@ -885,9 +881,7 @@
         "max_item_length": "85 mm",
         "moves": 100,
         "description": "Eyelets for a collar pin",
-        "flag_restriction": [
-          "SHIRT_COLLAR_ACCESSORY"
-        ]
+        "flag_restriction": [ "SHIRT_COLLAR_ACCESSORY" ]
       }
     ],
     "warmth": 10,

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2239,7 +2239,7 @@
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 5, "cut": 10, "bullet": 8, "electric": 1 }
+    "armor": { "bash": 4, "cut": 5, "bullet": 3, "electric": 2 }
   },
   {
     "id": "mon_ant_acid_small",
@@ -2316,7 +2316,7 @@
     "harvest": "arachnid_acid",
     "dissect": "dissect_insect_sample_single",
     "flags": [ "ACIDPROOF", "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 6, "cut": 10, "bullet": 8, "electric": 2 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 3, "electric": 2 }
   },
   {
     "id": "mon_ant_acid_larva",
@@ -2373,19 +2373,19 @@
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true },
     "flags": [ "ACIDPROOF", "CLIMBS", "HEARS", "QUEEN", "SEES", "SMELLS", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1 }
+    "armor": { "bash": 8, "cut": 12, "bullet": 4, "electric": 2 }
   },
   {
     "id": "mon_ant_acid_soldier",
     "type": "MONSTER",
-    "description": "A massive woolly brown ant that towers over the worker ants.  Along with her huge mandibles, a corrosive liquid seeps from the end of her bloated abdomen.",
+    "description": "A human-sized ant covered in bristly brown chitin.  A corrosive liquid seeps from the end of her bloated abdomen.",
     "default_faction": "acid_ant",
     "bodytype": "insect",
     "species": [ "INSECT" ],
     "diff": 2,
     "volume": "62500 ml",
     "weight": "81500 g",
-    "hp": 100,
+    "hp": 120,
     "speed": 100,
     "material": [ "iflesh" ],
     "aggression": 40,
@@ -2393,9 +2393,9 @@
     "aggro_character": false,
     "symbol": "a",
     "color": "brown",
-    "melee_skill": 7,
-    "melee_dice": 1,
-    "melee_dice_sides": 8,
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "cut", "amount": 8 } ],
     "dodge": 2,
     "bleed_rate": 80,
@@ -2436,7 +2436,7 @@
       "PATH_AVOID_DANGER",
       "CORNERED_FIGHTER"
     ],
-    "armor": { "bash": 12, "cut": 14, "bullet": 11, "electric": 1 }
+    "armor": { "bash": 12, "cut": 14, "bullet": 6, "electric": 1 }
   },
   {
     "id": "mon_ant_acid_soldier_mega",
@@ -2530,34 +2530,34 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "fungalize_into": "mon_ant_fungus",
     "flags": [ "SMELLS", "QUEEN", "CLIMBS", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 2, "electric": 1 }
   },
   {
     "id": "mon_ant_soldier",
     "type": "MONSTER",
     "name": { "str": "oversized soldier ant" },
-    "description": "A huge and hairy red ant almost twice the size of other giant ants.  Bulging pincers extend from her jaws.",
+    "description": "An overgrown red ant the size of a wolf.  Bulging pincers extend from her jaws.",
     "default_faction": "ant",
     "bodytype": "insect",
     "species": [ "INSECT" ],
     "volume": "62500 ml",
     "weight": "81500 g",
-    "hp": 80,
+    "hp": 110,
     "speed": 100,
     "material": [ "iflesh" ],
     "symbol": "a",
     "color": "red",
     "aggression": 30,
     "aggro_character": false,
-    "melee_skill": 7,
-    "melee_dice": 1,
-    "melee_dice_sides": 8,
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 12,
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
-    "grab_strength": 35,
+    "melee_damage": [ { "damage_type": "cut", "amount": 10 } ],
+    "grab_strength": 40,
     "stomach_size": 600,
     "special_attacks": [ { "id": "bite_grab" }, [ "EAT_FOOD", 30 ], [ "BROWSE", 90 ], [ "EAT_CARRION", 90 ] ],
-    "dodge": 2,
+    "dodge": 3,
     "bleed_rate": 80,
     "weakpoint_sets": [ "wps_arthropod", "wps_arthropod_hymenoptera" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug", "prof_wp_hymenoptera" ],
@@ -2571,7 +2571,7 @@
     "fungalize_into": "mon_ant_fungus",
     "upgrades": { "age_grow": 42, "into": "mon_ant_soldier_mega" },
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 10, "cut": 12, "bullet": 10, "electric": 2 }
+    "armor": { "bash": 10, "cut": 12, "bullet": 8, "electric": 4 }
   },
   {
     "id": "mon_ant_soldier_mega",
@@ -2579,15 +2579,20 @@
     "name": { "str": "super soldier ant" },
     "description": "A cow-sized, hairy red ant.  Bulging pincers extend from her jaws.  Given the relative strength of ants to their body size, you don't doubt that this one could shove cars around or rip through solid walls.",
     "copy-from": "mon_ant_soldier",
-    "proportional": { "hp": 5, "dodge": 0.5, "vision_day": 2 },
+    "hp": 240,
     "volume": "625 L",
     "weight": "815 kg",
     "morale": 30,
-    "melee_dice": 2,
+    "melee_skill": 5,
+    "melee_dice": 3,
+    "vision_day": 12,
+    "vision_night": 6,
+    "melee_dice_sides": 8,
+    "path_settings": { "max_dist": 20, "avoid_sharp": true, "avoid_dangerous_fields": true },
+    "melee_damage": [ { "damage_type": "cut", "amount": 10 } ],
     "bleed_rate": 60,
     "grab_strength": 75,
     "stomach_size": 800,
-    "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "special_attacks": [
       { "id": "smash", "throw_strength": 48, "cooldown": 30 },
       { "id": "leg_sweep" },
@@ -2613,7 +2618,7 @@
     ],
     "dissect": "dissect_insect_sample_large",
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
-    "armor": { "bash": 15, "cut": 24, "bullet": 15, "electric": 4 }
+    "armor": { "bash": 12, "cut": 14, "bullet": 9, "electric": 4 }
   },
   {
     "id": "mon_locust_small",
@@ -4045,7 +4050,7 @@
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_single",
     "flags": [ "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 6, "cut": 10, "bullet": 8, "electric": 2, "acid": 3, "heat": 6 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 3, "electric": 2, "acid": 3, "heat": 6 }
   },
   {
     "id": "mon_ant_fire_queen",
@@ -4080,6 +4085,6 @@
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true },
     "flags": [ "CLIMBS", "HEARS", "QUEEN", "SEES", "SMELLS", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8, "electric": 1, "acid": 6, "heat": 12 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 4, "electric": 1, "acid": 6, "heat": 12 }
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -319,7 +319,12 @@
     "cancels": [ "GASTROPOD_FOOT" ],
     "category": [ "SPIDER", "MOUSE", "RABBIT", "BIRD", "FELINE" ],
     "types": [ "RUNNING" ],
-    "enchantments": [ { "condition": { "not": { "u_has_move_mode": "prone" } }, "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.15 } ] } ]
+    "enchantments": [
+      {
+        "condition": { "not": { "u_has_move_mode": "prone" } },
+        "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.15 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -4088,8 +4093,10 @@
         "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" }, { "u_has_trait": "WINGS_BAT" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
-      { "condition": { "not": { "u_has_move_mode": "prone" } },
-        "values": [ { "value": "MOVE_COST", "multiply": 0.38 } ] }
+      {
+        "condition": { "not": { "u_has_move_mode": "prone" } },
+        "values": [ { "value": "MOVE_COST", "multiply": 0.38 } ]
+      }
     ]
   },
   {
@@ -4585,7 +4592,10 @@
     "prereqs": [ "FLEET" ],
     "types": [ "RUNNING" ],
     "category": [ "BIRD" ],
-    "enchantments": [ { "condition": { "or": [ { "u_has_move_mode": "walk" }, { "u_has_move_mode": "run" } ] } }, { "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.3 } ] } ]
+    "enchantments": [
+      { "condition": { "or": [ { "u_has_move_mode": "walk" }, { "u_has_move_mode": "run" } ] } },
+      { "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": -0.3 } ] }
+    ]
   },
   {
     "type": "mutation",
@@ -5246,7 +5256,12 @@
     "visibility": 8,
     "ugliness": 9,
     "encumbrance_always": [ [ "leg_l", 10 ], [ "leg_r", 10 ], [ "foot_l", 10 ], [ "foot_r", 10 ] ],
-    "enchantments": [ { "condition": { "not": { "u_has_move_mode": "prone" } }, "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": 0.4 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.75 } ] } ],
+    "enchantments": [
+      {
+        "condition": { "not": { "u_has_move_mode": "prone" } },
+        "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": 0.4 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.75 } ]
+      }
+    ],
     "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
     "destroys_gear": true
   },
@@ -7299,7 +7314,6 @@
     "changes_to": [ "PONDEROUS2" ],
     "category": [ "URSINE", "CATTLE", "PLANT", "BATRACHIAN", "GASTROPOD", "CRUSTACEAN" ],
     "enchantments": [ { "condition": { "not": { "u_has_move_mode": "prone" } }, "values": [ { "value": "MOVE_COST", "multiply": 0.1 } ] } ]
-   
   },
   {
     "type": "mutation",
@@ -7835,7 +7849,7 @@
         "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" } ] },
         "ench_effects": [ { "effect": "wall_crawl", "intensity": 1 } ]
       },
-      { 
+      {
         "condition": { "not": { "u_has_move_mode": "prone" } },
         "values": [ { "value": "MOVE_COST", "multiply": 0.4 }, { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 } ]
       }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8360,7 +8360,8 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
     }
 
     if( hurt == bodypart_str_id::NULL_ID() ) {
-        add_msg_debug( debugmode::DF_CHAR_HEALTH, "apply_damage() picked a null bodypart, redirecting damage to torso." );
+        add_msg_debug( debugmode::DF_CHAR_HEALTH,
+                       "apply_damage() picked a null bodypart, redirecting damage to torso." );
         hurt = body_part_torso;
     }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -358,7 +358,7 @@ item_location Character::i_add( item it, int &copies_remaining,
             it.charges = copies_remaining;
             copies_remaining = 0;
             return i_add( it, true, avoid, original_inventory_item,
-                        allow_drop, allow_wield, ignore_pkt_settings );
+                          allow_drop, allow_wield, ignore_pkt_settings );
         }
 
         while( copies_remaining > max_stack ) {
@@ -367,7 +367,7 @@ item_location Character::i_add( item it, int &copies_remaining,
             copies_remaining -= max_stack;
 
             i_add( stack, true, avoid, original_inventory_item,
-                allow_drop, allow_wield, ignore_pkt_settings );
+                   allow_drop, allow_wield, ignore_pkt_settings );
         }
 
         // Add the last partial stack and return its result
@@ -375,7 +375,7 @@ item_location Character::i_add( item it, int &copies_remaining,
         final_stack.charges = copies_remaining;
         copies_remaining = 0;
         return i_add( final_stack, true, avoid, original_inventory_item,
-                    allow_drop, allow_wield, ignore_pkt_settings );
+                      allow_drop, allow_wield, ignore_pkt_settings );
     }
     invalidate_inventory_validity_cache();
     invalidate_leak_level_cache();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1796,10 +1796,10 @@ bool item::merge_charges( const item &rhs )
         return false;
     }
     if( type->stack_max > 0 ) {
-            const int total = ( count_by_charges() ? charges + rhs.charges : 2 );
-            if( total > type->stack_max ) {
-                return {};
-            }
+        const int total = ( count_by_charges() ? charges + rhs.charges : 2 );
+        if( total > type->stack_max ) {
+            return {};
+        }
     }
     // Prevent overflow when either item has "near infinite" charges.
     if( charges >= INFINITE_CHARGES / 2 || rhs.charges >= INFINITE_CHARGES / 2 ) {


### PR DESCRIPTION
#### Summary
Slightly adjust ant skill hp and armor

#### Purpose of change
Ants are weird. They were made a long time ago when copy-from was new I guess, and there are a lot of what seem to be mistakes in their stats.

#### Describe the solution
This is a quick fix, not a full audit, but it should be an improvement:
- Reduce soldier ant melee skill to 5
- Increase soldier ant damage from 1d8 to 2d6
- Increase ants' cut damage
- Reduce ants' armor, especially ballistic, in line with how chitinous armor works
- Increase HP for most ants
- Increase grab strength of soldier ants
- Adjust descriptions to make the sizes of these ants more clear

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
