### PR TITLE
Fix spell dodge messaging bug

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2513,7 +2513,7 @@
     "type": "MIGRATION",
     "replace": "pointy_stick_long"
   },
-    {
+  {
     "id": "spear_pipe",
     "type": "MIGRATION",
     "replace": "spear_wood"

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -69,6 +69,7 @@
 
 static const efftype_id effect_airborne( "airborne" );
 static const efftype_id effect_jumping( "jumping" );
+static const efftype_id effect_invisibility( "invisibility" );
 static const efftype_id effect_teleglow( "teleglow" );
 
 static const flag_id json_flag_FIT( "FIT" );
@@ -604,7 +605,14 @@ static void damage_targets( const spell &sp, Creature &caster,
         if( dodgeable ) {
             const float dodge_training = sp.dodge_training( caster );
             if( cr->dodge_check( spell_accuracy, dodge_training ) ) {
-                cr->add_msg_player_or_npc( "You dodge out of the way!", "%s dodges out of the way!" );
+                if( !cr->is_monster() ) {
+                    cr->add_msg_player_or_npc( "You dodge out of the way!", "%s dodges out of the way!" );
+                } else {
+                    if( !cr->has_effect( effect_invisibility ) ) {
+                        add_msg_if_player_sees( cr->pos(), m_bad, _( "%1$s dodges out of the way!" ),
+                                                cr->disp_name( false, true ) );
+                    }
+                }
                 cr->on_dodge( &caster, spell_accuracy, dodge_training );
                 continue;
             }


### PR DESCRIPTION
#### Summary
Fix spell dodge messaging bug

#### Purpose of change
Fix a messaging bug with dodgeable spells which sometimes throws errors.

#### Describe the solution
Special case monster dodge messaging, add a check for invisible monsters, use add_msg_if_player_sees() for the dodging monster.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
