### PR TITLE
Fix inconsistency/typo in vehicle seat descriptions

### DIFF
--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -28,7 +28,7 @@
   {
     "id": "BELTABLE",
     "type": "json_flag",
-    "info": "You can install a seatbelt or 5-point harness here to help keep you in your seat during a collision."
+    "info": "You can install a seat belt or 5-point harness here to help keep you in your seat during a collision."
   },
   {
     "id": "BOARD_INTERNAL",
@@ -118,7 +118,7 @@
   {
     "id": "NONBELTABLE",
     "type": "json_flag",
-    "info": "There's no place to attach a seatbelt, so you get thrown from the vehicle in a crash."
+    "info": "There's no place to attach a seat belt, so you get thrown from the vehicle in a crash."
   },
   {
     "id": "ROOF",


### PR DESCRIPTION
#### Summary
Fix inconsistency/typo in vehicle seat descriptions.

#### Purpose of change
Ensure that "5-point harness" is spelled correctly and matches the spelling used for the vehicle part and item of the same name.

#### Describe the solution
Replaced "5 part harness" with "5-point harness" in \data\json\vehicleparts\vp_flags.json.

#### Testing
Loads, runs, fix works for all vehicle parts with the "BELTABLE"  flag both while examining them and in the vehicle "install" menu.