### PR TITLE
fix butoka profession description typo

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4242,7 +4242,7 @@
     "id": "martial_artist_japanese",
     "name": "Butōka",
     "npc_background": "BG_survival_story_SPORTS",
-    "description": "Your sensei prepared you for a lot of things, but somehow the end of the world never came up in traning.",
+    "description": "Your sensei prepared you for a lot of things, but somehow the end of the world never came up in training.",
     "points": 3,
     "starting_styles_choices": [ "style_aikido", "style_karate", "style_ninjutsu", "style_judo" ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],


### PR DESCRIPTION
#### Summary
Typo "Missing i in Butōka profession description"

#### Purpose of change
Fixes typo on Butōka profession description

#### Describe the solution
Replace "traning" with "training"

#### Describe alternatives you've considered
None.

#### Testing
After applying the fix:
<img width="870" height="50" alt="image" src="https://github.com/user-attachments/assets/aa230b96-0e37-46b8-aa5a-6ba2fa2e87f1" />
Before:
<img width="843" height="44" alt="image" src="https://github.com/user-attachments/assets/2c6f1c97-5a8a-4361-9e48-f9bc7838f611" />

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
