### PR TITLE
Fix RAS option bug

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2721,7 +2721,6 @@ target_handler::trajectory target_ui::run()
 
     map &here = get_map();
     // Load settings
-    unload_RAS_weapon = get_option<bool>( "UNLOAD_RAS_WEAPON" );
     snap_to_target = get_option<bool>( "SNAP_TO_TARGET" );
     if( mode == TargetMode::Turrets ) {
         // Due to how cluttered the display would become, disable it by default


### PR DESCRIPTION
#### Summary
Fix RAS option bug

#### Purpose of change
A random reference to the RAS unload option was left in after its removal. Whoops.

#### Describe the solution
Remove


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
