### PR TITLE
Sharp and flaking rocks don't stack either

### DIFF
--- a/data/json/items/resources/stone.json
+++ b/data/json/items/resources/stone.json
@@ -14,6 +14,7 @@
     "volume": "250 ml",
     "longest_side": "8 cm",
     "damage": { "damage_type": "stab", "amount": 7 },
+    "stack_max": 1,
     "range": 10,
     "dispersion": 14,
     "loudness": 0,


### PR DESCRIPTION
#### Summary
Sharp and flaking rocks don't stack either

#### Purpose of change
Sharp and flaking rocks still had the old stacking behavior

#### Describe the solution
Now they don't

#### Describe alternatives you've considered
There are probably other items

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
