### PR TITLE
Rename and enlarge chest minifreezer

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -659,14 +659,12 @@
   {
     "type": "vehicle_part",
     "id": "minifreezer",
-    "looks_like": "minifridge",
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
     "copy-from": "ap_minifreezer"
   },
   {
     "type": "vehicle_part",
     "id": "chest_minifreezer",
-    "looks_like": "minifridge",
     "delete": { "flags": [ "APPLIANCE", "CTRL_ELECTRONIC" ] },
     "copy-from": "ap_chest_minifreezer"
   },


### PR DESCRIPTION
#### Summary
Rename and enlarge chest minifreezer

#### Purpose of change
- Minifridge/freezer were too big
- Chest minifreezer had a silly name and was too small

#### Describe the solution
- Minifridge/freezer 96L -> 75L
- Chest minifreezer -> mini chest freezer
- mini chest freezer 99L -> 150L

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
