### PR TITLE
replace "Crossbow Hunter" Profession's Rifle skill with archery

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2768,7 +2768,7 @@
     "points": 3,
     "proficiencies": [ "prof_bow_basic", "prof_gunsmithing_spring", "prof_knives_familiar" ],
     "skills": [
-      { "level": 4, "name": "rifle" },
+      { "level": 4, "name": "archery" },
       { "level": 4, "name": "gun" },
       { "level": 2, "name": "swimming" },
       { "level": 3, "name": "survival" }


### PR DESCRIPTION
#### Summary
Bugfixes "Change Crossbow Hunter's Rifle skill to archery."

#### Purpose of change

reflect the skill change of crossbows for the crossbow hunter

#### Describe the solution

simple json rewording

#### Describe alternatives you've considered

#### Testing



#### Additional context
