### PR TITLE
Finish removing autonote option

### DIFF
--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -399,12 +399,10 @@ void auto_note_manager_gui::show()
 
         int currentX = 60;
         mvwprintz( w_header, point( currentX, 1 ), c_white,
-                   std::string( FULL_SCREEN_WIDTH - 2 - currentX, ' ' ) );
-
-        const bool enabled_auto_notes_ME = get_option<bool>( "AUTO_NOTES_MAP_EXTRAS" );
+                   std::string( FULL_SCREEN_WIDTH - 2 - currentX, ' ' ) );;
         currentX += shortcut_print( w_header, point( currentX, 1 ),
-                                    enabled_auto_notes_ME ? c_light_green : c_light_red, c_white,
-                                    enabled_auto_notes_ME ? _( "True" ) : _( "False" ) );
+                                    c_light_red, c_white,
+                                    _( "False" ) );
 
         currentX += shortcut_print( w_header, point( currentX, 1 ), c_white, c_light_green, "  " );
         shortcut_print( w_header, point( currentX, 1 ), c_white, c_light_green, _( "<S>witch " ) );
@@ -436,8 +434,7 @@ void auto_note_manager_gui::show()
                                            global_mapExtraCache )[displayCacheEntry];
 
                 const nc_color lineColor = ( i == currentLine ) ? hilite( c_white ) : c_white;
-                const nc_color statusColor = enabled_auto_notes_ME ? ( cacheEntry.second ? c_green : c_red ) :
-                                             c_dark_gray;
+                const nc_color statusColor = ( cacheEntry.second ? c_green : c_red );
                 const std::string statusString = cacheEntry.second ? _( "yes" ) : _( "no" );
                 auto found_custom_symbol = ( bCharacter ? char_custom_symbol_cache :
                                              global_custom_symbol_cache ).find( displayCacheEntry );
@@ -482,10 +479,7 @@ void auto_note_manager_gui::show()
         const std::string action = ctxt.handle_input();
 
         // Actions that also work with no items to display
-        if( action == "SWITCH_AUTO_NOTE_OPTION" ) {
-            get_options().get_option( "AUTO_NOTES_MAP_EXTRAS" ).setNext();
-            get_options().save();
-        } else if( action == "QUIT" ) {
+        if( action == "QUIT" ) {
             break;
         } else if( action == "NEXT_TAB" ) {
             bCharacter = !bCharacter;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -272,7 +272,6 @@ class overmap
         bool has_extra( const tripoint_om_omt &p ) const;
         const map_extra_id &extra( const tripoint_om_omt &p ) const;
         void add_extra( const tripoint_om_omt &p, const map_extra_id &id );
-        void add_extra_note( const tripoint_om_omt &p );
         void delete_extra( const tripoint_om_omt &p );
 
         /**


### PR DESCRIPTION
#### Summary
Finish removing autonote option

#### Purpose of change
Some lurking dead code was making desired autonote features (stairs, dropped items) not work, and was throwing an error.

#### Describe the solution
Remove.

#### Testing
Confirmed that stairs and dropped items still work, no more errors.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
