### PR TITLE
Fix arrow crafting results

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -759,7 +759,8 @@ std::vector<item> recipe::create_result( bool set_components, bool is_food,
     if( contained ) {
         newit = newit.in_container( container, amount, sealed, container_variant );
         return { newit };
-    } else if( newit.count_by_charges() ) {
+    // TODO: Special handling for stack_max > 1?
+    } else if( newit.count_by_charges() && newit.type->stack_max != 1 ) {
         newit.charges = amount;
         return { newit };
     } else {


### PR DESCRIPTION
#### Summary
Fix arrow crafting results

#### Purpose of change
Items that count by charges with stack_max of 1 were creating quantum tesseract weirdness by trying to make one arrow with 10 charges.

#### Describe the solution
Add a check in recipe.cpp that treats stack_max == 1 as if it was an item that didn't count by charges. Now you get 10 arrows when you make arrow.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
