### PR TITLE
Migrate the homemade halfpike

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2552,5 +2552,10 @@
     "id": "yoghurt",
     "type": "MIGRATION",
     "replace": "yogurt"
+  },
+  {
+    "id": "spear_homemade_halfpike",
+    "type": "MIGRATION",
+    "replace": "pointy_stick_long"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate the homemade halfpike

#### Purpose of change
The homemade halfpike was removed but not migrated, resulting in errors in old saves which contained it.

#### Describe the solution
Migrate it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
