### PR TITLE
Remove vestigial construction_scaling code

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2438,16 +2438,6 @@ int construction::print_time( const catacurses::window &w, const point &p, int w
     return fold_and_print( w, p, width, col, text );
 }
 
-float construction::time_scale() const
-{
-    //incorporate construction time scaling
-    if( get_option<int>( "CONSTRUCTION_SCALING" ) == 0 ) {
-        return calendar::season_ratio();
-    } else {
-        return get_option<int>( "CONSTRUCTION_SCALING" ) / 100.0;
-    }
-}
-
 int construction::adjusted_time() const
 {
     int final_time = time;
@@ -2464,8 +2454,6 @@ int construction::adjusted_time() const
     } else if( assistants == 1 ) {
         final_time *= 0.75f;
     }
-
-    final_time *= time_scale();
 
     return final_time;
 }


### PR DESCRIPTION
#### Summary
Remove vestigial construction_scaling code

#### Purpose of change
Some vestigial code was causing an error

#### Describe the solution
Removed

#### Testing
Press *, no error

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
