### PR TITLE
Fix hemlock harvested name/desc

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -1328,8 +1328,8 @@
   {
     "type": "terrain",
     "id": "t_tree_hemlock_harvested",
-    "name": "pine tree",
-    "description": "A towering coniferous tree that belongs to the 'Pinus' genus, with the New England species varying from 'P. strobus', 'P. resinosa' and 'P. rigida'.  Some of the branches and resin clumps have been stripped away and many of the pinecones aren't developed fully yet, but given a season, it could be harvestable again.",
+    "name": "hemlock tree",
+    "description": "This is an evergreen tree from the 'Tsuga' genus, superficially similar to a pine.  Some of the branches and resin clumps have been stripped away and many of the cones aren't developed fully yet, but given a season, it could be harvestable again.",
     "symbol": "4",
     "color": "brown",
     "roof": "t_treetop_evergreen",


### PR DESCRIPTION
#### Summary
Fix hemlock harvested name/desc

#### Purpose of change
Hemlock tree was named "pine tree" when harvested

#### Describe the solution
Fix name/desc


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
