### PR TITLE
Fix dodge bonus display

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -875,7 +875,7 @@ class Character : public Creature, public visitable
         /** Returns the player's dodge_roll to be compared against an aggressor's hit_roll() */
         float dodge_roll() const override;
         /** Returns Creature::get_dodge() modified by any Character effects */
-        float get_dodge() const override;
+        float get_dodge( bool critfail = true ) const override;
         /** in this case spell resistance is just the spellcraft skill for characters. */
         int get_spell_resist() const override;
         /** Handles the uncanny dodge bionic and effects, returns true if the player successfully dodges */

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2382,9 +2382,9 @@ int Creature::get_eff_per() const
     return 0;
 }
 
-float Creature::get_dodge() const
+float Creature::get_dodge( bool critfail ) const
 {
-    if( rng( 0, 99 ) == 0 ) {
+    if( critfail && rng( 0, 99 ) == 0 ) {
         return 0.0f;
     }
     return get_dodge_base() + get_dodge_bonus();

--- a/src/creature.h
+++ b/src/creature.h
@@ -746,7 +746,7 @@ class Creature : public viewer
 
         virtual int get_armor_type( const damage_type_id &dt, bodypart_id bp ) const = 0;
 
-        virtual float get_dodge() const;
+        virtual float get_dodge( bool critfail = true ) const;
         virtual float get_melee() const = 0;
         virtual float get_hit() const;
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1297,13 +1297,13 @@ int Character::get_spell_resist() const
     return round( get_skill_level( skill_spellcraft ) );
 }
 
-float Character::get_dodge() const
+float Character::get_dodge( bool critfail ) const
 {
     if( !can_try_dodge().success() ) {
         return 0.0f;
     }
 
-    float ret = Creature::get_dodge();
+    float ret = Creature::get_dodge( critfail );
     add_msg_debug( debugmode::DF_MELEE, "Base dodge %.1f", ret );
 
     // Chop in half if we are unable to move

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2592,13 +2592,13 @@ float monster::stability_roll() const
     return stability;
 }
 
-float monster::get_dodge() const
+float monster::get_dodge( bool critfail ) const
 {
     if( has_effect( effect_downed ) ) {
         return 0.0f;
     }
 
-    float ret = Creature::get_dodge();
+    float ret = Creature::get_dodge( critfail );
     if( has_effect( effect_lightsnare ) || has_effect( effect_heavysnare ) ||
         has_effect( effect_beartrap ) || has_effect( effect_tied ) ) {
         ret /= 2;

--- a/src/monster.h
+++ b/src/monster.h
@@ -408,7 +408,8 @@ class monster : public Creature
         float get_hit_base() const override;
         float get_dodge_base() const override;
 
-        float  get_dodge() const override;       // Natural dodge, or 0 if we're occupied
+        float  get_dodge( bool critfail = true ) const
+        override;       // Natural dodge, or 0 if we're occupied
         float  get_melee() const override; // For determining attack skill when awarding dodge practice.
         float  hit_roll() const override;  // For the purposes of comparing to player::dodge_roll()
         float  dodge_roll() const override;  // For the purposes of comparing to player::hit_roll()

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1301,7 +1301,7 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                 description_str += "\n";
             }
             description_str +=
-                string_format( _( "\nDodge bonus: %.f" ), u.get_dodge( false ) )
+                string_format( _( "\nDodge bonus: %.1f" ), u.get_dodge( false ) )
                 + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
                 + _( "\n\nAffects:" )
                 + colorize(
@@ -1360,7 +1360,7 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                                 COL_STAT_PENALTY );
             }
             description_str +=
-                string_format( _( "\nDodge bonus: %.f" ), u.get_dodge( false ) )
+                string_format( _( "\nDodge bonus: %.1f" ), u.get_dodge( false ) )
                 + string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
                 + _( "\n\nAffects:" )
                 + colorize(

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1301,7 +1301,7 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                 description_str += "\n";
             }
             description_str +=
-                string_format( _( "\nDodge skill: %.f" ), u.get_dodge() )
+                string_format( _( "\nDodge bonus: %.f" ), u.get_dodge( false ) )
                 + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
                 + _( "\n\nAffects:" )
                 + colorize(
@@ -1360,7 +1360,8 @@ static std::string assemble_stat_details( avatar &u, const unsigned char sel )
                                 COL_STAT_PENALTY );
             }
             description_str +=
-                string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
+                string_format( _( "\nDodge bonus: %.f" ), u.get_dodge( false ) )
+                + string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
                 + _( "\n\nAffects:" )
                 + colorize(
                     _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -839,7 +839,8 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             }
             mvwprintz( w_skills, point( 1, y_pos ), cstatus, "%s:", aSkill->name() );
             if( aSkill->ident() == skill_dodge ) {
-                mvwprintz( w_skills, point( width - 11, y_pos ), cstatus, "%4.1f/%-2d(%2d%%)", you.get_dodge(),
+                mvwprintz( w_skills, point( width - 11, y_pos ), cstatus, "%4.1f/%-2d(%2d%%)",
+                           you.get_dodge( false ),
                            level_num, ( exercise < 0 ? 0 : exercise ) );
             } else {
                 mvwprintz( w_skills, point( width - 6, y_pos ), cstatus, "%-2d(%2d%%)", level_num,


### PR DESCRIPTION
#### Summary
Fix dodge bonus display

#### Purpose of change
- Critfails were sometimes showing in the dodge readout due to living in creature::get_dodge() for simplicity's sake.
- Dodge bonus wasn't showing under perception in charge.
- "Dodge skill" it's literally not.
- Dodge bonus is a float but was only displaying the int in chargen.

#### Describe the solution
- Display dodge bonus as a float in chargen.
- Edit the text to say Dodge bonus and not Dodge skill.
- Add it to the perception readout.
- Add a bool that lets us optionally check get_dodge() without the possibility of a critfail, and use it in newcharacter and player_display.

#### Describe alternatives you've considered
The chargen readout is still showing dodge bonus with the darkness penalty. Not a big deal, but it'd be nice to be able to fix that.

#### Testing
Loads, runs, looks good. Tried chargen, tried @, got in some fights. All good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
