### PR TITLE
Make Hakama worn on the Outer layer

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -661,7 +661,7 @@
     "color": "dark_gray",
     "warmth": 10,
     "material_thickness": 0.3,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "OUTER" ],
     "armor": [ { "covers": [ "leg_l", "leg_r" ], "coverage": 98, "encumbrance": 12 } ]
   },
   {


### PR DESCRIPTION
#### Summary
Make Hakama worn on the Outer layer

#### Purpose of change
Better reflect reality where Hakamas are often worn over kimonos but doing so in game causes conflic and extra encumbrance. It also would fix the Urban samurai starting gear having conflicting gear.

#### Describe the solution
Added the Outer flag to the Hakama in coats.json

#### Testing
Game launches and runs fine and the item is indeed now worn on the Outer layer. The Urban samurai starting clothing no longer has conflicts.