### PR TITLE
Backport 77906 - fix pickaxe error message

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1862,12 +1862,10 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
                                 _( "<npcname> finishes digging." ) );
     here.destroy( pos, true );
     if( !act->targets.empty() ) {
-        item &it = *act->targets.front();
-        if( it.is_null() || ( it.count_by_charges() && it.charges <= 0 ) ) {
-            debugmsg( "pickaxe expired during mining" );
-            return;
+        item_location it = act->targets.front();
+        if( it ) {
+            you->consume_charges( *it, it->ammo_required() );
         }
-        you->consume_charges( it, it.ammo_required() );
     } else {
         debugmsg( "pickaxe activity targets empty" );
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1863,7 +1863,7 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
     here.destroy( pos, true );
     if( !act->targets.empty() ) {
         item &it = *act->targets.front();
-        if( it.is_null() || it.charges <= 0 ) {
+        if( it.is_null() || ( it.count_by_charges() && it.charges <= 0 ) ) {
             debugmsg( "pickaxe expired during mining" );
             return;
         }


### PR DESCRIPTION
#### Summary
Backport 77906 - fix pickaxe error message

#### Purpose of change
Pickaxe was always displaying an error message about expiring when used.

#### Describe the solution
Backport!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
