### PR TITLE
Sleeveless Coat Audit

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -2337,7 +2337,7 @@
     "color": "brown",
     "material_thickness": 1,
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 18, 24 ] },
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 18, 24 ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -379,7 +379,7 @@
     "color": "brown",
     "material_thickness": 2,
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 22, 28 ] },
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 22, 28 ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,
@@ -2222,7 +2222,7 @@
     "color": "brown",
     "material_thickness": 2,
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 22, 28 ] },
+      { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 22, 28 ] },
       {
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 85,


### PR DESCRIPTION
#### Summary
Remove extra coverage for torso from cutting off the sleeves.
#### Purpose of change
To make extra leather not magically appear on the chest because you cut off the sleeves
#### Describe the solution
Make the sleeveless longcoat also 95 torso coverage
#### Describe alternatives you've considered
not doing anything
#### Testing
The coverage is changed
#### Additional context
none
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
