### PR TITLE
Possibly fix mac build

### DIFF
--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -371,15 +371,13 @@ std::string wstr_to_utf8( const std::wstring &wstr )
     strip_trailing_nulls( str );
     return str;
 #else
-    try {
-        std::wstring_convert<std::codecvt_utf8<wchar_t>> converter;
-        std::string str = converter.to_bytes( wstr );
-        strip_trailing_nulls( str );
-        return str;
-    } catch( const std::exception &e ) {
-        debugmsg( "Invalid wide string in wstr_to_utf8()" );
-        return "[INVALID WCHAR]";
+    // Naive conversion assuming wchar_t values are all within ASCII
+    std::string str;
+    str.reserve( wstr.size() );
+    for( wchar_t wc : wstr ) {
+        str.push_back( static_cast<char>(wc) );
     }
+    return str;
 #endif
 }
 


### PR DESCRIPTION
#### Summary
Possibly fix mac build

#### Purpose of change
Codecvt is deprecated in the latest macos compilers, I guess, so while it fixed the Steam linux build, it broke mac.

#### Describe the solution
Blindly make a change and see if that breaks the other stuff.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
