### PR TITLE
Fix MSVC builds, maybe

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   build_catatclysm:
     name: Build
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           - name: Windows Tiles x64 MSVC
             artifact: windows-tiles-x64-msvc
             arch: x64
-            os: windows-2019
+            os: windows-2022
             mxe: none
             ext: zip
             content: application/zip
@@ -61,7 +61,7 @@ jobs:
           - name: Windows Tiles Sounds x64 MSVC
             artifact: windows-tiles-sounds-x64-msvc
             arch: x64
-            os: windows-2019
+            os: windows-2022
             mxe: none
             ext: zip
             content: application/zip


### PR DESCRIPTION
#### Summary
Fix MSVC builds, maybe

#### Purpose of change
Windows-2019 reached end of life back in June. We're told to use Windows-2022 instead. Well, let's see if that works.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
