### PR TITLE
Adjust hazard damage for monsters

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -53,7 +53,7 @@
       "DROPS_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 14, "cut": 14, "bullet": 11 }
+    "armor": { "bash": 14, "cut": 14, "bullet": 11, "acid": 15 }
   },
   {
     "id": "mon_talon_m202a1",
@@ -109,7 +109,7 @@
       "DROPS_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 14, "cut": 14, "bullet": 11 }
+    "armor": { "bash": 14, "cut": 14, "bullet": 11, "acid": 15 }
   },
   {
     "id": "mon_secubot_america",
@@ -151,7 +151,7 @@
       "corpse_type": "NO_CORPSE"
     },
     "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER", "LOUDMOVES", "STUN_IMMUNE" ],
-    "armor": { "bash": 14, "cut": 14, "bullet": 11 }
+    "armor": { "bash": 14, "cut": 14, "bullet": 11, "acid": 15 }
   },
   {
     "id": "mon_secubot_america_refurbished",
@@ -203,7 +203,7 @@
       "corpse_type": "NO_CORPSE"
     },
     "flags": [ "SEES", "HEARS", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER", "LOUDMOVES", "STUN_IMMUNE" ],
-    "armor": { "bash": 14, "cut": 14, "bullet": 11 }
+    "armor": { "bash": 14, "cut": 14, "bullet": 11, "acid": 15 }
   },
   {
     "id": "mon_skitterbot",
@@ -231,7 +231,7 @@
     "death_drops": { "groups": [ [ "robots", 4 ], [ "skitterbot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
     "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER", "STUN_IMMUNE" ],
-    "armor": { "bash": 12, "cut": 12, "bullet": 10, "electric": 5 }
+    "armor": { "bash": 12, "cut": 12, "bullet": 10, "electric": 5, "acid": 15 }
   },
   {
     "id": "mon_science_bot",
@@ -276,7 +276,7 @@
       "DROPS_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 12, "cut": 12, "bullet": 10 }
+    "armor": { "bash": 12, "cut": 12, "bullet": 10, "acid": 15 }
   },
   {
     "id": "mon_robofac_prototype",
@@ -316,7 +316,7 @@
       "LOUDMOVES",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 15, "cut": 50, "bullet": 40 }
+    "armor": { "bash": 15, "cut": 50, "bullet": 40, "acid": 15 }
   },
   {
     "id": "mon_dispatch",
@@ -360,7 +360,7 @@
       "DROPS_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 8, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 8, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "mon_dispatch_military",
@@ -404,6 +404,6 @@
       "DROPS_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 12, "cut": 12, "bullet": 10 }
+    "armor": { "bash": 12, "cut": 12, "bullet": 10, "acid": 15 }
   }
 ]

--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -28,7 +28,7 @@
     "revert_to_itype": "bot_EMP_hack",
     "starting_ammo": { "grenade_emp": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
-    "armor": { "cut": 4, "bullet": 3 }
+    "armor": { "cut": 4, "bullet": 3, "acid": 10 }
   },
   {
     "id": "mon_c4_hack",
@@ -42,7 +42,7 @@
     "revert_to_itype": "bot_c4_hack",
     "starting_ammo": { "c4_payload": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
-    "armor": { "cut": 4, "bullet": 3 }
+    "armor": { "cut": 4, "bullet": 3, "acid": 10 }
   },
   {
     "id": "mon_flashbang_hack",
@@ -56,7 +56,7 @@
     "revert_to_itype": "bot_flashbang_hack",
     "starting_ammo": { "flashbang": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
-    "armor": { "cut": 4, "bullet": 3 }
+    "armor": { "cut": 4, "bullet": 3, "acid": 10 }
   },
   {
     "id": "mon_gasbomb_hack",
@@ -70,7 +70,7 @@
     "revert_to_itype": "bot_gasbomb_hack",
     "starting_ammo": { "tear_gas_payload": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
-    "armor": { "cut": 4, "bullet": 3 }
+    "armor": { "cut": 4, "bullet": 3, "acid": 10}
   },
   {
     "id": "mon_grenade_hack",
@@ -84,7 +84,7 @@
     "revert_to_itype": "bot_grenade_hack",
     "starting_ammo": { "grenade": 1 },
     "special_attacks": [ [ "KAMIKAZE", 0 ] ],
-    "armor": { "cut": 4, "bullet": 3 }
+    "armor": { "cut": 4, "bullet": 3, "acid": 10 }
   },
   {
     "id": "mon_manhack",
@@ -103,7 +103,7 @@
     "death_function": { "corpse_type": "BROKEN" },
     "extend": { "flags": [ "HIT_AND_RUN" ] },
     "delete": { "flags": [ "PACIFIST" ] },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 10 }
   },
   {
     "abstract": "balloon_sniper_drone",
@@ -163,7 +163,7 @@
       "HIT_AND_RUN",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 4, "cut": 3 }
+    "armor": { "bash": 4, "cut": 3, "acid": 6 }
   },
   {
     "id": "mon_tazer_hack",
@@ -177,6 +177,6 @@
     "revert_to_itype": "bot_tazer_hack",
     "death_function": { "corpse_type": "BROKEN" },
     "special_attacks": [ [ "TAZER", 5 ] ],
-    "armor": { "cut": 2, "bullet": 1 }
+    "armor": { "cut": 2, "bullet": 1, "acid": 10 }
   }
 ]

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -101,7 +101,7 @@
       "weakpoint_sets": [ "wps_humanoid_body_armor" ],
       "families": [ "prof_wp_syn_armored" ]
     },
-    "armor": { "bash": 9, "cut": 14, "acid": 4, "bullet": 18 }
+    "armor": { "bash": 9, "cut": 14, "acid": 6, "bullet": 18 }
   },
   {
     "id": "mon_feral_human_crowbar",
@@ -514,7 +514,7 @@
     "death_drops": "mon_feral_prepper_death_drops",
     "zombify_into": "mon_zombie_survivor",
     "extend": { "weakpoint_sets": [ "wps_humanoid_light_armor" ], "families": [ "prof_wp_syn_armored" ] },
-    "armor": { "bash": 4, "cut": 4, "acid": 4, "bullet": 4 }
+    "armor": { "bash": 4, "cut": 4, "acid": 7, "bullet": 4 }
   },
   {
     "id": "mon_feral_survivalist",
@@ -547,7 +547,7 @@
       "families": [ "prof_wp_syn_armored" ]
     },
     "fear_triggers": [ "HURT" ],
-    "armor": { "bash": 4, "cut": 4, "acid": 4, "bullet": 4, "electric": 3 }
+    "armor": { "bash": 4, "cut": 4, "acid": 8, "bullet": 4, "electric": 3 }
   },
   {
     "id": "mon_feral_militia",
@@ -600,7 +600,7 @@
       "families": [ "prof_wp_syn_armored" ]
     },
     "fear_triggers": [ "HURT" ],
-    "armor": { "bash": 5, "cut": 7, "acid": 5, "bullet": 10, "electric": 4 }
+    "armor": { "bash": 5, "cut": 7, "acid": 8, "bullet": 10, "electric": 4 }
   },
   {
     "id": "mon_feral_soldier",
@@ -622,7 +622,7 @@
     ],
     "zombify_into": "mon_zombie_soldier",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] },
-    "armor": { "bash": 4, "cut": 9, "bullet": 7, "electric": 3 }
+    "armor": { "bash": 4, "cut": 9, "bullet": 7, "acid": 8, "electric": 3 }
   },
   {
     "id": "mon_feral_jackboot",
@@ -663,6 +663,7 @@
       [ "BROWSE", 100 ],
       [ "EAT_FOOD", 100 ]
     ],
+    "armor": { "bash": 4, "cut": 9, "bullet": 7, "acid": 7, "electric": 3 },
     "death_drops": "mon_feral_jackboot_death_drops"
   },
   {
@@ -683,7 +684,7 @@
       [ "EAT_FOOD", 100 ]
     ],
     "zombify_into": "mon_zombie_sailor",
-    "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 2 }
+    "armor": { "bash": 2, "cut": 2, "bullet": 2, "acid": 7, "electric": 2 }
   },
   {
     "id": "mon_feral_sailor_axe",
@@ -752,7 +753,7 @@
       "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ],
       "families": [ "prof_wp_syn_armored" ]
     },
-    "armor": { "bash": 4, "cut": 6, "bullet": 10 }
+    "armor": { "bash": 4, "cut": 6, "acid": 8, "bullet": 10 }
   },
   {
     "id": "mon_feral_officer",
@@ -826,7 +827,7 @@
       "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ],
       "families": [ "prof_wp_syn_armored" ]
     },
-    "armor": { "bash": 8, "cut": 12, "stab": 9, "bullet": 14, "electric": 2 }
+    "armor": { "bash": 8, "cut": 12, "stab": 9, "bullet": 14, "acid": 8, "electric": 2 }
   },
   {
     "id": "mon_feral_cop_fungal_infected",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -263,7 +263,7 @@
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CARRION", 60 ] ],
     "flags": [ "SEES", "HEARS", "SMELLS", "EATS", "CLIMBS", "STUMBLES", "CORNERED_FIGHTER", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 5, "cut": 7, "bullet": 6 }
+    "armor": { "bash": 5, "cut": 7, "acid": 5, "bullet": 6 }
   },
   {
     "id": "mon_plague_nymph",
@@ -322,7 +322,7 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK" ],
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CARRION", 60 ] ],
     "flags": [ "SEES", "HEARS", "SMELLS", "EATS", "CLIMBS", "STUMBLES", "PATH_AVOID_DANGER", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 5, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 5, "cut": 10, "acid": 5, "bullet": 8 }
   },
   {
     "id": "mon_giant_cockroach",
@@ -361,7 +361,7 @@
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CARRION", 60 ] ],
     "fear_triggers": [ "BRIGHT_LIGHT" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "EATS", "PATH_AVOID_DANGER", "SMALL_HIDER", "CORNERED_FIGHTER", "EATS" ],
-    "armor": { "bash": 5, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 5, "cut": 10, "acid": 5, "bullet": 8 }
   },
   {
     "id": "mon_giant_cockroach_nymph",
@@ -446,7 +446,7 @@
     "upgrades": { "age_grow": 42, "into": "mon_bee_mega" },
     "fungalize_into": "mon_bee_fungus",
     "flags": [ "SEES", "SMELLS", "FLIES", "STUMBLES", "SWARMS", "GROUP_MORALE", "CANPLAY", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 4, "cut": 6, "bullet": 5 }
+    "armor": { "bash": 4, "cut": 6, "acid": 6, "bullet": 5 }
   },
   {
     "id": "mon_bee_mega",
@@ -464,7 +464,7 @@
     "fungalize_into": "mon_bee_mega_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
-    "armor": { "bash": 4, "cut": 6, "bullet": 5, "electric": 1 }
+    "armor": { "bash": 4, "cut": 6, "bullet": 5, "acid": 6, "electric": 1 }
   },
   {
     "id": "mon_centipede_small",
@@ -504,7 +504,7 @@
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "fear_triggers": [ "HURT" ],
     "upgrades": { "age_grow": 30, "into_group": "GROUP_CENTIPEDE_ADULT" },
-    "armor": { "bash": 1, "cut": 3, "stab": 2, "bullet": 2 },
+    "armor": { "bash": 1, "cut": 3, "stab": 2, "acid": 4, "bullet": 2 },
     "delete": { "flags": [ "GRABS" ] }
   },
   {
@@ -558,7 +558,7 @@
     "dissect": "dissect_insect_sample_small",
     "upgrades": { "age_grow": 45, "into_group": "GROUP_CENTIPEDE_GIANT" },
     "flags": [ "CLIMBS", "SEES", "GRABS", "SMELLS", "KEENNOSE", "HEARS", "GOODHEARING", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 10, "cut": 25, "stab": 14, "bullet": 12 }
+    "armor": { "bash": 10, "cut": 25, "stab": 14, "acid": 6, "bullet": 12 }
   },
   {
     "id": "mon_centipede_larva",
@@ -652,7 +652,7 @@
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "upgrades": { "age_grow": 45, "into_group": "GROUP_CENTIPEDE_MOM" },
     "delete": { "flags": [ "KEENNOSE", "GOODHEARING" ] },
-    "armor": { "bash": 10, "cut": 25, "stab": 14, "bullet": 12, "electric": 1 }
+    "armor": { "bash": 10, "cut": 25, "stab": 14, "bullet": 12, "acid": 6, "electric": 1 }
   },
   {
     "id": "mon_centipede_mega",
@@ -714,7 +714,7 @@
     "harvest": "arachnid_centipede_mega",
     "dissect": "dissect_insect_sample_large",
     "flags": [ "SEES", "SMELLS", "KEENNOSE", "HEARS", "GOODHEARING", "PATH_AVOID_DANGER", "DESTROYS", "PUSH_MON", "PUSH_VEH" ],
-    "armor": { "bash": 25, "cut": 35, "stab": 15, "bullet": 45, "electric": 3 }
+    "armor": { "bash": 25, "cut": 35, "stab": 15, "bullet": 45, "acid": 12, "electric": 3 }
   },
   {
     "id": "mon_dragonfly_naiad",
@@ -817,7 +817,8 @@
     "anger_triggers": [ "PLAYER_WEAK", "STALK" ],
     "fear_triggers": [ "HURT", "FIRE" ],
     "upgrades": { "age_grow": 60, "into": "mon_dragonfly_mega" },
-    "flags": [ "SWARMS", "HEARS", "SEES", "FLIES", "GRABS", "PATH_AVOID_DANGER", "EATS" ]
+    "flags": [ "SWARMS", "HEARS", "SEES", "FLIES", "GRABS", "PATH_AVOID_DANGER", "EATS" ],
+    "armor": { "acid": 4 }
   },
   {
     "id": "mon_dragonfly_mega",
@@ -861,7 +862,7 @@
     "upgrades": { "half_life": 10, "into_group": "GROUP_EMPTY" },
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "SWIMS", "BASHES", "PUSH_MON", "PUSH_VEH", "EATS", "PATH_AVOID_DANGER" ],
-    "armor": { "electric": 2 }
+    "armor": { "electric": 2, "acid": 6 }
   },
   {
     "id": "mon_firefly",
@@ -955,7 +956,8 @@
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "fear_triggers": [ "PLAYER_CLOSE", "HURT", "FIRE" ],
     "upgrades": { "age_grow": 42, "into": "mon_fly_mega" },
-    "flags": [ "SEES", "SMELLS", "FLIES", "STUMBLES", "HIT_AND_RUN", "CANPLAY", "PATH_AVOID_DANGER", "EATS" ]
+    "flags": [ "SEES", "SMELLS", "FLIES", "STUMBLES", "HIT_AND_RUN", "CANPLAY", "PATH_AVOID_DANGER", "EATS" ],
+    "armor": { "acid": 8 }
   },
   {
     "id": "mon_fly_larva",
@@ -1001,7 +1003,8 @@
       },
       [ "EAT_CARRION", 120 ]
     ],
-    "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH", "EATS" ] }
+    "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH", "EATS" ] },
+    "armor": { "acid": 10 }
   },
   {
     "id": "mon_mosquito_small",
@@ -1016,7 +1019,8 @@
     "dodge": 2,
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "upgrades": { "half_life": 20, "into": "mon_mosquito_giant" },
-    "extend": { "flags": [ "NO_BREED" ] }
+    "extend": { "flags": [ "NO_BREED" ] },
+    "armor": { "acid": 4 }
   },
   {
     "id": "mon_mosquito_giant",
@@ -1053,7 +1057,8 @@
     "fear_triggers": [ "HURT", "FIRE" ],
     "upgrades": { "half_life": 28, "into": "mon_mosquito_mega" },
     "special_attacks": [ { "id": "mosquito_bite_big" } ],
-    "flags": [ "SEES", "SMELLS", "STUMBLES", "FLIES", "HIT_AND_RUN", "PATH_AVOID_DANGER" ]
+    "flags": [ "SEES", "SMELLS", "STUMBLES", "FLIES", "HIT_AND_RUN", "PATH_AVOID_DANGER" ],
+    "armor": { "acid": 6 }
   },
   {
     "id": "mon_mosquito_larva",
@@ -1161,7 +1166,7 @@
     "fungalize_into": "mon_spider_fungus",
     "upgrades": { "half_life": 10, "into_group": "GROUP_SPIDER_CELLAR_GIANT" },
     "flags": [ "SEES", "SMELLS", "HEARS", "GRABS", "WEBWALK", "CLIMBS", "HARDTOSHOOT", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 1, "cut": 5, "acid": 3, "bullet": 2 }
+    "armor": { "bash": 1, "cut": 5, "acid": 7, "bullet": 2 }
   },
   {
     "id": "mon_spider_cellar_giant_s",
@@ -1294,7 +1299,7 @@
     "upgrades": { "half_life": 15, "into_group": "GROUP_EMPTY" },
     "extend": { "anger_triggers": [ "HOSTILE_SEEN" ], "flags": [ "BASHES" ] },
     "dissect": "dissect_spider_sample_large",
-    "armor": { "bullet": 2, "bash": 5, "cut": 7, "stab": 7, "acid": 5, "electric": 3 }
+    "armor": { "bullet": 2, "bash": 5, "cut": 7, "stab": 7, "acid": 7, "electric": 3 }
   },
   {
     "id": "mon_spider_cellar_leg",
@@ -1427,7 +1432,7 @@
     },
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH", "FLAMMABLE" ] },
     "upgrades": { "half_life": 15, "into_group": "GROUP_EMPTY" },
-    "armor": { "cut": 3, "bullet": 2, "electric": 1 }
+    "armor": { "cut": 3, "bullet": 2, "electric": 1, "acid": 6 }
   },
   {
     "id": "mon_spider_trapdoor_small",
@@ -1479,7 +1484,7 @@
     "fungalize_into": "mon_spider_fungus",
     "upgrades": { "half_life": 32, "into": "mon_spider_trapdoor_mega" },
     "flags": [ "SEES", "SMELLS", "HEARS", "VENOM", "GRABS", "CAN_DIG", "WEBWALK", "CLIMBS", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 4, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 4, "cut": 8, "bullet": 6, "acid": 7}
   },
   {
     "id": "mon_spider_trapdoor_s",
@@ -1570,7 +1575,7 @@
     "upgrades": { "half_life": 30, "into": "mon_spider_web_mega" },
     "trap_avoids": [ "tr_sinkhole" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "WEBWALK", "CLIMBS", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 2, "cut": 6, "bullet": 5 }
+    "armor": { "bash": 2, "cut": 6, "bullet": 5, "acid": 7 }
   },
   {
     "id": "mon_spider_web_mega",
@@ -1588,7 +1593,7 @@
     "special_attacks": [ { "id": "grab", "cooldown": 5, "condition": { "not": { "u_has_effect": "maimed_leg" } } } ],
     "upgrades": { "half_life": 20, "into_group": "GROUP_EMPTY" },
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
-    "armor": { "bash": 2, "cut": 6, "bullet": 5, "electric": 1 }
+    "armor": { "bash": 2, "cut": 6, "bullet": 5, "electric": 1, "acid": 7 }
   },
   {
     "id": "mon_spider_web_s",
@@ -1661,7 +1666,7 @@
     "fungalize_into": "mon_spider_fungus",
     "upgrades": { "half_life": 24, "into": "mon_spider_widow_mega" },
     "flags": [ "SEES", "SMELLS", "HEARS", "BADVENOM", "WEBWALK", "CLIMBS", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 2, "cut": 4, "bullet": 3 }
+    "armor": { "bash": 2, "cut": 4, "bullet": 3, "acid": 6 }
   },
   {
     "id": "mon_spider_widow_mega",
@@ -1753,7 +1758,7 @@
     "upgrades": { "half_life": 22, "into": "mon_spider_wolf_mega" },
     "flags": [ "SEES", "SMELLS", "HEARS", "CLIMBS", "PATH_AVOID_DANGER" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 4, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 4, "cut": 8, "bullet": 6, "acid": 6 }
   },
   {
     "id": "mon_spider_wolf_giant_s",
@@ -1898,7 +1903,7 @@
       "SMALL_HIDER"
     ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 1, "cut": 6, "stab": 4 }
+    "armor": { "bash": 1, "cut": 6, "stab": 4, "acid": 6 }
   },
   {
     "id": "mon_wasp_small_guard",
@@ -1928,7 +1933,7 @@
     "upgrades": { "age_grow": 30, "into": "mon_wasp_mega" },
     "fungalize_into": "mon_wasp_queen_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "electric": 3 }
+    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "electric": 3, "acid": 8 }
   },
   {
     "id": "mon_wasp",
@@ -1989,7 +1994,7 @@
     "fear_triggers": [ "HURT", "FIRE" ],
     "fungalize_into": "mon_wasp_fungus",
     "flags": [ "SEES", "SMELLS", "HEARS", "FLIES", "SWARMS", "GROUP_MORALE", "CANPLAY", "HARDTOSHOOT", "PATH_AVOID_DANGER", "EATS" ],
-    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12 }
+    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "acid": 8 }
   },
   {
     "id": "mon_wasp_guard",
@@ -2005,7 +2010,7 @@
     "delete": { "fear_triggers": [ "HURT", "FIRE" ] },
     "fungalize_into": "mon_wasp_guard_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "electric": 2 }
+    "armor": { "bash": 5, "cut": 14, "stab": 12, "bullet": 12, "electric": 2, "acid": 8 }
   },
   {
     "id": "mon_wasp_mega",
@@ -2054,7 +2059,7 @@
     "fungalize_into": "mon_wasp_mega_fungus",
     "delete": { "flags": [ "HARDTOSHOOT", "FLIES" ] },
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 8, "cut": 30, "stab": 18, "bullet": 22, "electric": 4 }
+    "armor": { "bash": 8, "cut": 30, "stab": 18, "bullet": 22, "electric": 4, "acid": 8 }
   },
   {
     "id": "mon_dermatik_larva",
@@ -2112,7 +2117,7 @@
     "fear_triggers": [ "HURT", "FIRE" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "flags": [ "SEES", "HEARS", "SMELLS", "FLIES", "PATH_AVOID_DANGER", "CANPLAY", "GRABS" ],
-    "armor": { "bash": 2, "cut": 5 }
+    "armor": { "bash": 2, "cut": 5, "acid": 4 }
   },
   {
     "id": "mon_dermatik_midwife",
@@ -2239,7 +2244,7 @@
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 4, "cut": 5, "bullet": 3, "electric": 2 }
+    "armor": { "bash": 4, "cut": 5, "bullet": 3, "electric": 2, "acid": 4 }
   },
   {
     "id": "mon_ant_acid_small",
@@ -2529,7 +2534,7 @@
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "fungalize_into": "mon_ant_fungus",
     "flags": [ "SMELLS", "QUEEN", "CLIMBS", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 6, "cut": 8, "bullet": 2, "electric": 1 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 2, "electric": 1, "acid": 8 }
   },
   {
     "id": "mon_ant_soldier",
@@ -2570,7 +2575,7 @@
     "fungalize_into": "mon_ant_fungus",
     "upgrades": { "age_grow": 42, "into": "mon_ant_soldier_mega" },
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 10, "cut": 12, "bullet": 8, "electric": 4 }
+    "armor": { "bash": 10, "cut": 12, "bullet": 8, "electric": 4, "acid": 8 }
   },
   {
     "id": "mon_ant_soldier_mega",
@@ -2678,7 +2683,7 @@
       [ "GRAZE", 120 ]
     ],
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "STUMBLES", "PATH_AVOID_DANGER", "EATS" ],
-    "armor": { "bash": 3, "cut": 4, "bullet": 3, "electric": 1 }
+    "armor": { "bash": 3, "cut": 4, "bullet": 3, "electric": 1, "acid": 5 }
   },
   {
     "id": "mon_locust_mega",
@@ -2707,7 +2712,7 @@
       { "id": "smash", "throw_strength": 36, "cooldown": 30 }
     ],
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
-    "armor": { "bash": 3, "cut": 4, "bullet": 3, "electric": 3 }
+    "armor": { "bash": 3, "cut": 4, "bullet": 3, "electric": 3, "acid": 6 }
   },
   {
     "id": "mon_locust_nymph",
@@ -2789,7 +2794,7 @@
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "biosignature": { "biosig_item": "honeydew", "biosig_timer": 600 },
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "SWARMS", "SMALL_HIDER" ],
-    "armor": { "bash": 2, "cut": 5, "bullet": 3 }
+    "armor": { "bash": 2, "cut": 5, "bullet": 3, "acid": 2 }
   },
   {
     "id": "mon_mantis_small",
@@ -2805,7 +2810,7 @@
     "extend": { "flags": [ "NO_BREED" ] },
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "upgrades": { "age_grow": 42, "into": "mon_mantis_giant" },
-    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 1 }
+    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 1, "acid": 2 }
   },
   {
     "id": "mon_mantis_giant",
@@ -2854,7 +2859,7 @@
     ],
     "upgrades": { "age_grow": 42, "into": "mon_mantis_mega" },
     "flags": [ "SEES", "HEARS", "CLIMBS", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 2 }
+    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 2, "acid": 4 }
   },
   {
     "id": "mon_mantis_nymph",
@@ -2920,7 +2925,7 @@
     ],
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 3 }
+    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 3, "acid": 10 }
   },
   {
     "id": "mon_mole_cricket",
@@ -2967,7 +2972,7 @@
     "anger_triggers": [ "HURT", "PLAYER_CLOSE" ],
     "fear_triggers": [ "FIRE" ],
     "flags": [ "SEES", "CAN_DIG", "BORES", "PUSH_VEH", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER", "SMELLS" ],
-    "armor": { "bash": 15, "cut": 18, "bullet": 20, "electric": 2 }
+    "armor": { "bash": 15, "cut": 18, "bullet": 20, "electric": 2, "acid": 15 }
   },
   {
     "id": "mon_mole_cricket_nymph",
@@ -3027,7 +3032,7 @@
     ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER" ],
     "upgrades": { "half_life": 28, "into": "mon_lady_bug_giant" },
-    "armor": { "bash": 3, "cut": 10, "bullet": 15, "electric": 3 }
+    "armor": { "bash": 3, "cut": 10, "bullet": 15, "electric": 3, "acid": 12 }
   },
   {
     "id": "mon_lady_bug_giant",
@@ -3073,7 +3078,7 @@
     "flags": [ "SEES", "HEARS", "SMELLS", "BASHES", "PATH_AVOID_DANGER" ],
     "weakpoint_sets": [ "wps_arthropod", "wps_arthropod_beetle" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug", "prof_wp_beetle" ],
-    "armor": { "bash": 7, "cut": 20, "bullet": 30, "electric": 3 }
+    "armor": { "bash": 7, "cut": 20, "bullet": 30, "electric": 3, "acid": 14 }
   },
   {
     "id": "mon_lady_bug_larva",
@@ -3096,7 +3101,7 @@
     "dissect": "dissect_insect_sample_single",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "upgrades": { "age_grow": 30, "into": "mon_lady_bug_giant" },
-    "armor": { "bash": 1, "cut": 2, "stab": 2 }
+    "armor": { "bash": 1, "cut": 2, "stab": 2, "acid": 4 }
   },
   {
     "id": "mon_grasshopper_small",
@@ -3159,7 +3164,7 @@
       }
     ],
     "flags": [ "SEES", "HEARS", "SMELLS", "CLIMBS", "PATH_AVOID_DANGER", "EATS" ],
-    "armor": { "bash": 5, "cut": 10 }
+    "armor": { "bash": 5, "cut": 10, "acid": 4 }
   },
   {
     "id": "mon_grasshopper_nymph",
@@ -3417,7 +3422,7 @@
     ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "flags": [ "SEES", "SMELLS", "IMMOBILE", "DIGS", "RANGED_ATTACKER", "ATTACK_LOWER" ],
-    "armor": { "bash": 4, "cut": 10, "bullet": 10 }
+    "armor": { "bash": 4, "cut": 10, "bullet": 10, "acid": 12 }
   },
   {
     "id": "mon_antlion_giant",
@@ -3504,7 +3509,7 @@
     "fear_triggers": [ "FIRE", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "SMALL_HIDER" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 1, "cut": 3, "bullet": 2 }
+    "armor": { "bash": 1, "cut": 3, "bullet": 2, "acid": 2 }
   },
   {
     "id": "mon_strider_nymph",
@@ -3824,7 +3829,7 @@
     "special_attacks": [ [ "GRAZE", 100 ] ],
     "flags": [ "SEES", "HEARS", "KEENNOSE", "PATH_AVOID_DANGER", "SMELLS", "EATS" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 15, "cut": 18, "bullet": 20, "electric": 2 }
+    "armor": { "bash": 15, "cut": 18, "bullet": 20, "electric": 2, "acid": 2 }
   },
   {
     "id": "mon_woodlouse_manca",
@@ -3904,7 +3909,7 @@
     "fear_triggers": [ "FIRE" ],
     "flags": [ "SEES", "HEARS", "GOODHEARING", "SWIMS", "WATER_CAMOUFLAGE" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 7, "cut": 9, "bullet": 10, "electric": 2 }
+    "armor": { "bash": 7, "cut": 9, "bullet": 10, "electric": 2, "acid": 2 }
   },
   {
     "id": "mon_water_scorpion",
@@ -3940,7 +3945,7 @@
     "fear_triggers": [ "HURT" ],
     "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "AQUATIC" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 1, "cut": 3, "bullet": 2 }
+    "armor": { "bash": 1, "cut": 3, "bullet": 2, "acid": 2 }
   },
   {
     "id": "mon_water_scorpion_larva",
@@ -4047,7 +4052,7 @@
     "harvest": "arachnid",
     "dissect": "dissect_insect_sample_single",
     "flags": [ "CLIMBS", "HEARS", "POISON", "SEES", "SMELLS", "PATH_AVOID_DANGER", "EATS", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 6, "cut": 8, "bullet": 3, "electric": 2, "acid": 3, "heat": 6 }
+    "armor": { "bash": 6, "cut": 8, "bullet": 3, "electric": 2, "acid": 4, "heat": 6 }
   },
   {
     "id": "mon_ant_fire_queen",
@@ -4082,6 +4087,6 @@
     "fungalize_into": "mon_ant_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true },
     "flags": [ "CLIMBS", "HEARS", "QUEEN", "SEES", "SMELLS", "PATH_AVOID_DANGER", "BASHES", "CORNERED_FIGHTER" ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 4, "electric": 1, "acid": 6, "heat": 12 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 4, "electric": 1, "acid": 15, "heat": 12 }
   }
 ]

--- a/data/json/monsters/jabberwock.json
+++ b/data/json/monsters/jabberwock.json
@@ -29,7 +29,7 @@
     "upgrades": { "half_life": 42, "into": "mon_flesh_golem" },
     "zombify_into": "mon_meat_cocoon_small",
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "ATTACKMON", "POISON" ],
-    "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 1 }
+    "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 1, "acid": 5 }
   },
   {
     "id": "mon_flesh_golem",
@@ -61,7 +61,7 @@
     "upgrades": { "half_life": 60, "into": "mon_jabberwock" },
     "zombify_into": "mon_meat_cocoon_med",
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "ATTACKMON", "POISON" ],
-    "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 1 }
+    "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 1, "acid": 5 }
   },
   {
     "id": "mon_jabberwock",
@@ -92,6 +92,6 @@
     "harvest": "jabberwock",
     "dissect": "dissect_mon_jabberwock",
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "DESTROYS", "ATTACKMON", "POISON", "NEVER_WANDER" ],
-    "armor": { "bash": 12, "cut": 8, "bullet": 6, "electric": 3 }
+    "armor": { "bash": 12, "cut": 8, "bullet": 6, "electric": 3, "acid": 5 }
   }
 ]

--- a/data/json/monsters/kraken_spawn.json
+++ b/data/json/monsters/kraken_spawn.json
@@ -34,9 +34,8 @@
     "dissect": "dissect_cephalopod_sample_small",
     "reproduction": { "baby_monster": "mon_octupus_stalker_spawn", "baby_count": 1, "baby_timer": 700 },
     "baby_flags": [ "SPRING" ],
-    "zombify_into": "mon_meat_cocoon_med",
     "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "PATH_AVOID_DANGER", "WATER_CAMOUFLAGE", "WARM", "EATS" ],
-    "armor": { "bash": 2, "cut": 8, "bullet": 12 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 12, "acid": 15 }
   },
   {
     "id": "mon_octupus_stalker_spawn",
@@ -58,7 +57,6 @@
     "dodge": 2,
     "dissect": "dissect_cephalopod_sample_single",
     "special_attacks": [ [ "EAT_FOOD", 60 ] ],
-    "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "age_grow": 480, "into": "mon_octupus_stalker" }
   },
   {
@@ -108,9 +106,8 @@
     "anger_triggers": [ "HURT", "PLAYER_WEAK", "FRIEND_ATTACKED", "FRIEND_DIED", "SOUND", "HURT", "PLAYER_CLOSE" ],
     "harvest": "kraken_large",
     "dissect": "dissect_cephalopod_sample_large",
-    "zombify_into": "mon_meat_cocoon_large",
     "flags": [ "SEES", "SMELLS", "KEENNOSE", "HEARS", "GOODHEARING", "SWIMS", "PATH_AVOID_FIRE", "DESTROYS", "PUSH_MON", "PUSH_VEH" ],
-    "armor": { "bash": 25, "cut": 35, "stab": 15, "bullet": 45, "electric": 3 }
+    "armor": { "bash": 25, "cut": 35, "stab": 15, "bullet": 45, "electric": 3, "acid": 20 }
   },
   {
     "id": "mon_kraken_queen",
@@ -156,8 +153,7 @@
     "anger_triggers": [ "HURT", "PLAYER_WEAK", "FRIEND_ATTACKED", "FRIEND_DIED", "SOUND", "HURT", "PLAYER_CLOSE" ],
     "harvest": "kraken_queen",
     "dissect": "dissect_cephalopod_sample_huge",
-    "zombify_into": "mon_meat_cocoon_large",
     "flags": [ "SEES", "SMELLS", "KEENNOSE", "HEARS", "GOODHEARING", "SWIMS", "PATH_AVOID_FIRE", "DESTROYS", "PUSH_MON", "PUSH_VEH" ],
-    "armor": { "bash": 35, "cut": 45, "stab": 25, "bullet": 75, "electric": 13 }
+    "armor": { "bash": 35, "cut": 45, "stab": 25, "bullet": 75, "electric": 13, "acid": 20 }
   }
 ]

--- a/data/json/monsters/lab_security_drones.json
+++ b/data/json/monsters/lab_security_drones.json
@@ -63,7 +63,7 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "yellow_maintenance_check",
@@ -124,7 +124,7 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "blue_maintenance_check",
@@ -184,7 +184,7 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "blue_maintenance_check2",
@@ -270,7 +270,7 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "green_researcher_check",
@@ -345,7 +345,7 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   },
   {
     "id": "black_security_check",
@@ -446,6 +446,6 @@
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "armor": { "bash": 2, "cut": 8, "bullet": 6 }
+    "armor": { "bash": 2, "cut": 8, "bullet": 6, "acid": 15 }
   }
 ]

--- a/data/json/monsters/robofac_robots.json
+++ b/data/json/monsters/robofac_robots.json
@@ -30,7 +30,7 @@
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
     "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "BIOLOGICALPROOF", "IMMOBILE", "NO_BREATHE", "STUN_IMMUNE" ],
-    "armor": { "bash": 2, "cut": 5, "bullet": 2 }
+    "armor": { "bash": 2, "cut": 5, "bullet": 2, "acid": 10 }
   },
   {
     "id": "mon_robofac_camspy",
@@ -75,7 +75,7 @@
       "PACIFIST",
       "KEEP_DISTANCE"
     ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 8, "acid": 10 }
   },
   {
     "id": "mon_robofac_skittergun",
@@ -135,6 +135,6 @@
       "PATH_AVOID_DANGER",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 12, "cut": 12, "bullet": 10, "electric": 5 }
+    "armor": { "bash": 12, "cut": 12, "bullet": 10, "electric": 5, "acid": 25 }
   }
 ]

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -36,7 +36,7 @@
       "PATH_AVOID_DANGER",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 10, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 10, "cut": 10, "bullet": 8, "acid": 20 }
   },
   {
     "id": "mon_grocerybot_busted",
@@ -72,7 +72,7 @@
       "PAY_BOT",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 4, "cut": 5, "bullet": 4 }
+    "armor": { "bash": 4, "cut": 5, "bullet": 4, "acid": 15 }
   },
   {
     "id": "mon_hazmatbot",
@@ -110,7 +110,7 @@
       "PATH_AVOID_DANGER",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 10, "cut": 12, "bullet": 10 }
+    "armor": { "bash": 10, "cut": 12, "bullet": 10, "acid": 25 }
   },
   {
     "id": "mon_molebot",
@@ -147,7 +147,7 @@
       "PATH_AVOID_DANGER",
       "STUN_IMMUNE"
     ],
-    "armor": { "cut": 12, "bullet": 10 }
+    "armor": { "cut": 12, "bullet": 10, "acid": 15 }
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",
@@ -186,7 +186,7 @@
       "PACIFIST",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 8, "acid": 15 }
   },
   {
     "//": "nurse_bot and nurse_bot_defective look very similar, part of the trick is figuring out which one is the good one.  So the sprites should probably look pretty similar to not give it away immediately",
@@ -230,6 +230,6 @@
       "INTERIOR_AMMO",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 8, "cut": 10, "bullet": 8 }
+    "armor": { "bash": 8, "cut": 10, "bullet": 8, "acid": 15 }
   }
 ]

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -141,7 +141,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 6, "cut": 6, "stab": 6, "bullet": 6, "electric": 2, "heat": 1 }
+    "armor": { "bash": 6, "cut": 6, "stab": 6, "bullet": 6, "electric": 2, "acid": 8, "heat": 1 }
   },
   {
     "id": "mon_zombie_crawler",
@@ -276,7 +276,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 6, "cut": 6, "acid": 6, "heat": 10, "bullet": 5, "electric": 4 }
+    "armor": { "bash": 6, "cut": 6, "acid": 8, "heat": 10, "bullet": 5, "electric": 4 }
   },
   {
     "id": "mon_zombie_hazmat",
@@ -332,7 +332,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 5, "electric": 8 }
+    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 5, "acid": 25, "electric": 8 }
   },
   {
     "id": "mon_zombie_rot",
@@ -416,7 +416,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 10, "cut": 16, "bullet": 18, "electric": 3, "heat": 4 }
+    "armor": { "bash": 10, "cut": 16, "bullet": 18, "electric": 3, "acid": 8, "heat": 4 }
   },
   {
     "id": "mon_zombie_tough",

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -332,7 +332,7 @@
       "PUSH_MON",
       "FILTHY"
     ],
-    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 5, "acid": 25, "electric": 8 }
+    "armor": { "bash": 5, "cut": 4, "bullet": 3, "heat": 3, "acid": 25, "electric": 8 }
   },
   {
     "id": "mon_zombie_rot",

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -33,7 +33,7 @@
     "death_drops": "default_zombie_clothes",
     "fungalize_into": "mon_skeleton_fungus",
     "flags": [ "SEES", "HEARS", "GRABS", "BASHES", "GROUP_BASH", "REVIVES", "NO_BREATHE", "POISON", "FILTHY" ],
-    "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 24, "electric": 3, "heat": 1 }
+    "armor": { "cut": 15, "stab": 30, "acid": 5, "bullet": 24, "electric": 3, "heat": 1 }
   },
   {
     "//": "Skelly brute gaps the evolution between normal and the juggernaut.",
@@ -78,7 +78,7 @@
     "death_drops": "default_zombie_clothes",
     "fungalize_into": "mon_skeleton_brute_fungus",
     "flags": [ "SEES", "HEARS", "GRABS", "BASHES", "GROUP_BASH", "REVIVES", "NO_BREATHE", "POISON", "FILTHY" ],
-    "armor": { "bash": 12, "cut": 30, "acid": 1, "bullet": 30, "electric": 4, "heat": 2 }
+    "armor": { "bash": 12, "cut": 30, "acid": 5, "bullet": 30, "electric": 4, "heat": 2 }
   },
   {
     "id": "mon_skeleton_electric",
@@ -121,7 +121,7 @@
     "death_drops": "default_zombie_clothes",
     "fungalize_into": "mon_skeleton_fungus",
     "flags": [ "SEES", "HEARS", "GRABS", "BASHES", "GROUP_BASH", "ELECTRIC", "REVIVES", "NO_BREATHE", "POISON", "FILTHY" ],
-    "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30, "heat": 2 }
+    "armor": { "cut": 15, "stab": 30, "acid": 5, "bullet": 30, "heat": 2 }
   },
   {
     "id": "mon_skeleton_hulk",
@@ -182,6 +182,6 @@
       "PUSH_VEH",
       "FILTHY"
     ],
-    "armor": { "bash": 20, "cut": 45, "bullet": 36, "electric": 8, "heat": 5 }
+    "armor": { "bash": 20, "cut": 45, "bullet": 36, "electric": 8, "heat": 5, "acid": 10 }
   }
 ]

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -34,7 +34,7 @@
     "burn_into": "mon_zombie_scorched",
     "fungalize_into": "mon_zombie_fungus",
     "flags": [ "SEES", "HEARS", "WARM", "GRABS", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
-    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "heat": 3 }
+    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "acid": 3, "heat": 3 }
   },
   {
     "id": "mon_zombie_soldier_blackops_1",
@@ -94,7 +94,7 @@
       "NIGHT_INVISIBILITY",
       "FILTHY"
     ],
-    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "heat": 3 }
+    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "acid": 3, "heat": 3 }
   },
   {
     "id": "mon_zombie_soldier_blackops_2",
@@ -217,7 +217,7 @@
     "upgrades": { "half_life": 42, "into": "mon_zombie_kevlar_1" },
     "burn_into": "mon_zombie_scorched",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
-    "armor": { "bash": 18, "cut": 28, "bullet": 22, "electric": 3, "heat": 5 }
+    "armor": { "bash": 18, "cut": 28, "bullet": 22, "electric": 3, "acid": 3, "heat": 5 }
   },
   {
     "id": "mon_zombie_kevlar_1",
@@ -257,7 +257,7 @@
     "upgrades": { "half_life": 42, "into": "mon_zombie_kevlar_2" },
     "burn_into": "mon_zombie_scorched",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
-    "armor": { "bash": 20, "cut": 30, "bullet": 24, "electric": 3, "heat": 6 }
+    "armor": { "bash": 20, "cut": 30, "bullet": 24, "electric": 3, "acid": 4, "heat": 6 }
   },
   {
     "id": "mon_zombie_kevlar_2",
@@ -305,7 +305,7 @@
     "death_drops": "mon_zombie_kevlar_death_drops",
     "burn_into": "mon_zombie_scorched",
     "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
-    "armor": { "bash": 30, "cut": 50, "bullet": 40, "electric": 6, "heat": 8 }
+    "armor": { "bash": 30, "cut": 50, "bullet": 40, "electric": 6, "acid": 20, "heat": 8 }
   },
   {
     "id": "mon_zombie_military_pilot",
@@ -341,7 +341,7 @@
     "burn_into": "mon_zombie_scorched",
     "flags": [ "SEES", "WARM", "GRABS", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "NOHEAD", "FILTHY" ],
     "//": "flight suits are made of nomex.",
-    "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 2, "heat": 8 }
+    "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 2, "acid": 8, "heat": 8 }
   },
   {
     "id": "mon_zombie_milbase_personnel",
@@ -364,7 +364,7 @@
     "looks_like": "mon_zombie_soldier",
     "//": "no provision for body armour or helmets in either the weak point set or dissection set, as Navy sailors aren't normally dressed in military combat gear whilst shipside.",
     "death_drops": "mon_zombie_sailor_death_drops",
-    "armor": { "electric": 2, "bash": 2, "cut": 2, "bullet": 2 }
+    "armor": { "electric": 2, "bash": 2, "cut": 2, "acid": 8, "bullet": 2 }
   },
   {
     "id": "mon_zombie_officer",
@@ -408,7 +408,7 @@
     "burn_into": "mon_zombie_scorched",
     "fungalize_into": "mon_zombie_fungus",
     "flags": [ "SEES", "HEARS", "WARM", "GRABS", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY" ],
-    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "heat": 3 }
+    "armor": { "bash": 12, "cut": 25, "bullet": 20, "electric": 3, "acid": 8, "heat": 3 }
   },
   {
     "id": "mon_zombie_marine_upgrade",
@@ -491,7 +491,7 @@
       "REVIVES",
       "FILTHY"
     ],
-    "armor": { "bash": 10, "cut": 18, "bullet": 14, "electric": 3, "heat": 4 }
+    "armor": { "bash": 10, "cut": 18, "bullet": 14, "electric": 3, "acid": 8, "heat": 4 }
   },
   {
     "id": "mon_zombie_bio_op2",
@@ -506,6 +506,6 @@
     "dodge": 4,
     "harvest": "zombie_humanoid",
     "special_attacks": [ [ "BIO_OP_BIOJUTSU", 15 ] ],
-    "armor": { "bullet": 14, "electric": 3, "bash": 15, "cut": 27, "heat": 8 }
+    "armor": { "bullet": 14, "electric": 3, "bash": 15, "cut": 27, "acid": 16, "heat": 8 }
   }
 ]

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -67,7 +67,10 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
+static const damage_type_id damage_acid( "acid" );
+
 static const efftype_id effect_airborne( "airborne" );
+static const efftype_id effect_corroding( "corroding" );
 static const efftype_id effect_jumping( "jumping" );
 static const efftype_id effect_invisibility( "invisibility" );
 static const efftype_id effect_teleglow( "teleglow" );
@@ -514,7 +517,7 @@ static void add_effect_to_target( const tripoint_bub_ms &target, const spell &sp
 {
     const int dur_moves = sp.duration( caster );
     const int effect_intensity = sp.effect_intensity( caster );
-    const time_duration dur_td = time_duration::from_moves( dur_moves );
+    time_duration dur_td = time_duration::from_moves( dur_moves );
     creature_tracker &creatures = get_creature_tracker();
     Creature *const critter = creatures.creature_at<Creature>( target );
     Character *const guy = creatures.creature_at<Character>( target );
@@ -560,6 +563,13 @@ static void add_effect_to_target( const tripoint_bub_ms &target, const spell &sp
     }
     // Either no parts were listed or this was a monster. Either way, just apply the effect to them generally.
     if( !bodypart_effected ) {
+        // A lazy way to deal with acid for now.
+        if( spell_effect == effect_corroding ) {
+            dur_td -= 1_seconds * critter->as_monster()->get_armor_type( damage_acid, bodypart_id( "torso" ) );
+            if( dur_td < 1_seconds ) {
+                return;
+            }
+        }
         critter->add_effect( spell_effect, dur_td );
     }
 }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1104,7 +1104,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
         if( !sheltered ) {
             if( precipitation > 0 &&
                 one_in( std::max( 1, ( cur.get_field_intensity() + 1 ) - precipitation ) ) ) {
-                cur.set_field_age( cur.get_field_age() + 5_minutes * precipitation );
+                cur.set_field_age( cur.get_field_age() + 18_minutes * precipitation );
             }
         }
         // Humidity automatically adjusts for inside/outside, so no need to check.
@@ -1931,17 +1931,14 @@ void map::monster_in_field( monster &z )
                 return;
             }
             // TODO: Replace the section below with proper json values
-            if( z.made_of_any( Creature::cmat_flesh ) ) {
+            if( z.made_of( material_vegetable ) ) {
                 dam += 2;
             }
-            if( z.made_of( material_vegetable ) ) {
-                dam += 3;
-            }
             if( z.made_of( phase_id::LIQUID ) || z.made_of_any( Creature::cmat_flammable ) ) {
-                dam += 20;
+                dam += 15;
             }
             if( z.made_of_any( Creature::cmat_flameres ) ) {
-                dam += -20;
+                dam += -15;
             }
             if( z.flies() ) {
                 dam -= 15;
@@ -1951,7 +1948,7 @@ void map::monster_in_field( monster &z )
             if( cur.get_field_intensity() == 1 ) {
                 dam += rng( 0, 3 );
             } else if( cur.get_field_intensity() == 2 ) {
-                dam += rng( 1, 6 );
+                dam += rng( 0, 5 );
                 if( !z.flies() && !z.in_species( species_ZOMBIE ) && !z.in_species( species_ROBOT ) &&
                     !z.in_species( species_ROBOT_FLYING ) ) {
                     z.mod_moves( -to_moves<int>( 1_seconds ) * 0.2 );
@@ -1960,7 +1957,7 @@ void map::monster_in_field( monster &z )
                     z.add_effect( effect_onfire, 1_turns * rng( dam / 2, dam * 2 ) );
                 }
             } else if( cur.get_field_intensity() == 3 ) {
-                dam += rng( 1, 12 );
+                dam += rng( 0, 7 );
                 if( !z.flies() && !z.in_species( species_ZOMBIE ) && !z.in_species( species_ROBOT ) &&
                     !z.in_species( species_ROBOT_FLYING ) ) {
                     z.mod_moves( -to_moves<int>( 1_seconds ) * 0.4 );
@@ -1986,21 +1983,7 @@ void map::monster_in_field( monster &z )
             if( z.made_of_any( Creature::cmat_flesh ) && !z.has_flag( mon_flag_NO_BREATHE ) ) {
                 // Ferals can power through it, but even they have limits.
                 if( !z.has_effect( effect_stunned ) && ( !z.in_species( species_FERAL ) || one_in( 3 ) ) ) {
-                    z.add_effect( effect_stunned, cur.get_field_intensity() * rng( 1_turns, 5_turns ) );
-                    if( z.type->has_fear_trigger( mon_trigger::HURT ) ) {
-                        z.morale -= ( 2 * cur.get_field_intensity() );
-                    }
-                    if( z.type->has_anger_trigger( mon_trigger::HURT ) ) {
-                        z.anger += ( 2 * cur.get_field_intensity() );
-                    }
-                }
-                // Cyborg monsters ignore it because of the protective lenses CBM.
-                if( z.has_flag( mon_flag_SEES ) && z.made_of_any( Creature::cmat_flesh ) &&
-                    !z.in_species( species_INSECT ) &&
-                    !z.in_species( species_INSECT_FLYING ) && !z.in_species( species_CENTIPEDE ) &&
-                    !z.in_species( species_SPIDER ) && !z.in_species( species_CYBORG ) &&
-                    !z.has_effect( effect_blind ) ) {
-                    z.add_effect( effect_blind, cur.get_field_intensity() * rng( 1_turns, 5_turns ) );
+                    z.add_effect( effect_stunned, cur.get_field_intensity() * rng( 1_turns, 4_turns ) );
                     if( z.type->has_fear_trigger( mon_trigger::HURT ) ) {
                         z.morale -= ( 2 * cur.get_field_intensity() );
                     }
@@ -2009,8 +1992,22 @@ void map::monster_in_field( monster &z )
                     }
                 }
             }
-
+            // Cyborg monsters ignore it because of the protective lenses CBM.
+            if( z.has_flag( mon_flag_SEES ) && z.made_of_any( Creature::cmat_flesh ) &&
+                !z.in_species( species_INSECT ) &&
+                !z.in_species( species_INSECT_FLYING ) && !z.in_species( species_CENTIPEDE ) &&
+                !z.in_species( species_SPIDER ) && !z.in_species( species_CYBORG ) &&
+                !z.has_effect( effect_blind ) ) {
+                z.add_effect( effect_blind, cur.get_field_intensity() * rng( 1_turns, 4_turns ) );
+                if( z.type->has_fear_trigger( mon_trigger::HURT ) ) {
+                    z.morale -= ( 2 * cur.get_field_intensity() );
+                }
+                if( z.type->has_anger_trigger( mon_trigger::HURT ) ) {
+                    z.anger += ( 2 * cur.get_field_intensity() );
+                }
+            }
         }
+
         if( cur_field_type == fd_relax_gas ) {
             if( z.made_of_any( Creature::cmat_fleshnveg ) && !z.has_flag( mon_flag_NO_BREATHE ) ) {
                 z.add_effect( effect_stunned, rng( cur.get_field_intensity() * 1_turns,
@@ -2057,13 +2054,13 @@ void map::monster_in_field( monster &z )
                 return;
             }
             if( z.made_of( material_vegetable ) ) {
-                dam += 3;
+                dam += 2;
             }
             if( z.made_of( phase_id::LIQUID ) || z.made_of_any( Creature::cmat_flammable ) ) {
-                dam += 20;
+                dam += 15;
             }
             if( z.made_of_any( Creature::cmat_flameres ) ) {
-                dam += -5;
+                dam += -15;
             }
             dam += rng( 0, 8 );
             z.mod_moves( -to_moves<int>( 1_seconds ) * 0.2 );
@@ -2085,13 +2082,13 @@ void map::monster_in_field( monster &z )
                 return;
             }
             if( z.made_of( material_vegetable ) ) {
-                dam += 3;
+                dam += 2;
             }
             if( z.made_of( phase_id::LIQUID ) || z.made_of_any( Creature::cmat_flammable ) ) {
-                dam += 20;
+                dam += 15;
             }
             if( z.made_of_any( Creature::cmat_flameres ) ) {
-                dam += -5;
+                dam += -15;
             }
 
             if( cur.get_field_intensity() == 1 ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1946,9 +1946,9 @@ void map::monster_in_field( monster &z )
             dam -= z.get_armor_type( damage_heat, bodypart_id( "torso" ) );
 
             if( cur.get_field_intensity() == 1 ) {
-                dam += rng( 0, 3 );
+                dam += rng( 0, 4 );
             } else if( cur.get_field_intensity() == 2 ) {
-                dam += rng( 0, 5 );
+                dam += rng( 0, 6 );
                 if( !z.flies() && !z.in_species( species_ZOMBIE ) && !z.in_species( species_ROBOT ) &&
                     !z.in_species( species_ROBOT_FLYING ) ) {
                     z.mod_moves( -to_moves<int>( 1_seconds ) * 0.2 );
@@ -1957,7 +1957,7 @@ void map::monster_in_field( monster &z )
                     z.add_effect( effect_onfire, 1_turns * rng( dam / 2, dam * 2 ) );
                 }
             } else if( cur.get_field_intensity() == 3 ) {
-                dam += rng( 0, 7 );
+                dam += rng( 0, 8 );
                 if( !z.flies() && !z.in_species( species_ZOMBIE ) && !z.in_species( species_ROBOT ) &&
                     !z.in_species( species_ROBOT_FLYING ) ) {
                     z.mod_moves( -to_moves<int>( 1_seconds ) * 0.4 );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2668,15 +2668,15 @@ float monster::fall_damage_mod() const
 
     switch( type->size ) {
         case creature_size::tiny:
-            return 0.2f;
+            return 0.25f;
         case creature_size::small:
-            return 0.6f;
-        case creature_size::medium:
             return 1.0f;
-        case creature_size::large:
-            return 1.4f;
-        case creature_size::huge:
+        case creature_size::medium:
             return 2.0f;
+        case creature_size::large:
+            return 2.5f;
+        case creature_size::huge:
+            return 4.0f;
         case creature_size::num_sizes:
             debugmsg( "ERROR: Invalid Creature size class." );
             return 0.0f;
@@ -2701,7 +2701,7 @@ int monster::impact( const int force, const tripoint &p )
     }
 
     const int bash_damage = std::max( 0.0f, force * mod - get_armor_type( damage_bash,
-                                      bodypart_id( "torso" ) ) );
+                                      bodypart_id( "torso" ) ) * 0.8f );
     apply_damage( nullptr, bodypart_id( "torso" ), bash_damage );
     total_dealt += force * mod;
 


### PR DESCRIPTION
#### Summary
Adjust hazard damage for monsters

#### Purpose of change
Monsters don't have body parts, instead using a single pool of HP. This makes them effectively much less durable than characters, something that needs to be accounted for. Additionally, they were basically all defenseless against acid unless they had the ACIDPROOF flag.

#### Describe the solution
- Fire does less damage to monsters. It's still pretty lethal to your typical zombie, but they don't instamelt in areas where a human could jog through and come out merely singed.
- Falls do more damage to monsters. They were getting the full benefit of their bash armor, and the base damage was just too low compared to how badly they mess up characters, damaging every body part and all.
- Acid armor now reduces the duration (and therefore the intensity) of the corroding effect when it's added by a splash attack. This includes monster special attacks and puddles of acid on the ground. 30 acid armor renders a monster effectively immune to the stuff, since that's the max duration.
- Gave a lot of acid armor to most/all robots. Gave a moderate amount of acid armor to most zombies who would be wearing boots, armor, etc. that would protect them from it. Gave a smaller amount to skeletal zombies. Gave a modest amount of armor to all arthropods. In most cases, this does not make them immune to acid, just more resistant to it.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
