### PR TITLE
Fix a bunch of quests

### DIFF
--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -314,7 +314,7 @@
     "difficulty": 1,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "slimepit_down", "om_special": "Slime Pit", "reveal_radius": 3, "search_range": 280 }
+      "assign_mission_target": { "om_terrain": "slimepit_down", "om_special": "Slime Pit", "reveal_radius": 3, "search_range": 400 }
     },
     "item": "slime_scrap",
     "count": 3,
@@ -383,7 +383,7 @@
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 3,
     "value": 0,
-    "start": { "assign_mission_target": { "om_terrain": "hive", "om_special": "Bee Hive", "reveal_radius": 3, "search_range": 280 } },
+    "start": { "assign_mission_target": { "om_terrain": "hive", "om_special": "Bee Hive", "reveal_radius": 3, "search_range": 400 } },
     "item": "bee_sting",
     "count": 1,
     "origins": [ "ORIGIN_SECONDARY" ],
@@ -416,7 +416,7 @@
     "difficulty": 5,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 1, "random": false, "search_range": 20, "min_distance": 5, "z": 0 },
+      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 1, "random": false, "search_range": 40, "min_distance": 5, "z": 0 },
       "update_mapgen": { "place_monster": [ { "monster": "mon_zombie_screecher", "x": 11, "y": 11, "target": true } ] }
     },
     "end": {
@@ -449,7 +449,7 @@
     "difficulty": 4,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 60, "min_distance": 20 },
+      "assign_mission_target": { "om_terrain": "field", "reveal_radius": 1, "random": true, "search_range": 140, "min_distance": 20 },
       "update_mapgen": {
         "rows": [
           "     ..............     ",
@@ -532,7 +532,7 @@
     "value": 0,
     "item": "small_relic",
     "start": {
-      "assign_mission_target": { "om_terrain": "cathedral_1_SE", "om_special": "cathedral", "reveal_radius": 1, "random": false, "search_range": 100 }
+      "assign_mission_target": { "om_terrain": "cathedral_1_SE", "om_special": "cathedral", "reveal_radius": 1, "random": false, "search_range": 200 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_GODCO_GREENWOOD_3",
@@ -553,19 +553,19 @@
     "id": "MISSION_GODCO_GREENWOOD_3",
     "type": "mission_definition",
     "name": { "str": "Bible Belt" },
-    "description": "Find twenty King James Bibles for Greenwood in exchange for <reward_count:icon> icons.",
+    "description": "Find ten King James Bibles for Greenwood in exchange for <reward_count:icon> icons.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 1,
     "value": 0,
     "item": "holybook_bible1",
-    "count": 20,
+    "count": 10,
     "start": {
-      "assign_mission_target": { "om_terrain": "s_bookstore", "om_special": "s_bookstore", "reveal_radius": 1, "random": false, "search_range": 100 }
+      "assign_mission_target": { "om_terrain": "s_bookstore", "om_special": "s_bookstore", "reveal_radius": 1, "random": false, "search_range": 200 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "I need your help…",
-      "offer": "When we skipped town during <the_cataclysm>, most of us left our possessions behind.  We only have a few Bibles here for all of us, and they're starting to fall apart.  If you could get 20 more, in the King James version, I'd pay well for them.",
+      "offer": "When we skipped town during <the_cataclysm>, most of us left our possessions behind.  We only have a few Bibles here for all of us, and they're starting to fall apart.  If you could get ten more of the King James version, I'd pay well for them.",
       "accepted": "May God bless you.",
       "rejected": "It'd really help us…",
       "advice": "A book store should have enough, I'll mark one for you.",
@@ -1216,7 +1216,7 @@
     "difficulty": 13,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "church", "om_special": "church", "reveal_radius": 1, "random": true, "search_range": 50 },
+      "assign_mission_target": { "om_terrain": "church", "om_special": "church", "reveal_radius": 1, "random": true, "search_range": 80 },
       "update_mapgen": {
         "place_npcs": [
           { "class": "bandit", "x": 15, "y": 8, "target": true },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -334,7 +334,7 @@
     "value": 1000,
     "item": "pants_leather",
     "start": {
-      "assign_mission_target": { "om_terrain": "cs_sex_shop", "reveal_radius": 1, "random": true, "search_range": 120 },
+      "assign_mission_target": { "om_terrain": "cs_sex_shop", "reveal_radius": 1, "random": true, "search_range": 200 },
       "update_mapgen": { "om_terrain": "cs_sex_shop", "place_item": [ { "item": "pants_leather", "x": 19, "y": 20 } ] },
       "effect": { "u_add_var": "mission_flag_Alonso_pants", "value": "in_progress" }
     },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -119,7 +119,7 @@
     "difficulty": 5,
     "value": 50000,
     "start": {
-      "assign_mission_target": { "om_terrain": "bandit_cabin", "om_special": "bandit_cabin", "reveal_radius": 1, "search_range": 60 },
+      "assign_mission_target": { "om_terrain": "bandit_cabin", "om_special": "bandit_cabin", "reveal_radius": 1, "search_range": 300 },
       "update_mapgen": {
         "set": [
           { "point": "trap", "id": "tr_landmine_buried", "x": 7, "y": 6 },
@@ -186,7 +186,7 @@
     "difficulty": 5,
     "value": 100000,
     "start": {
-      "assign_mission_target": { "om_terrain": "field", "reveal_radius": 5, "random": true, "search_range": 30 },
+      "assign_mission_target": { "om_terrain": "field", "reveal_radius": 5, "random": true, "search_range": 120 },
       "update_mapgen": {
         "place_monster": [
           { "monster": "mon_graboid", "name": "Little Guy", "x": 12, "y": 12, "target": true },
@@ -223,7 +223,7 @@
         "om_special": "bandit_camp",
         "reveal_radius": 1,
         "min_distance": 10,
-        "search_range": 120
+        "search_range": 800
       },
       "update_mapgen": { "place_npcs": [ { "class": "bandit", "x": 17, "y": 9, "target": true } ] },
       "effect": [

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -283,7 +283,7 @@
     "difficulty": 5,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT", "reveal_radius": 2, "random": true, "search_range": 80 },
+      "assign_mission_target": { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT", "reveal_radius": 2, "random": true, "search_range": 200 },
       "update_mapgen": { "place_nested": [ { "chunks": [ "robofac_mi2_convoy_ambush_chunk" ], "x": 0, "y": 0 } ] }
     },
     "end": {
@@ -383,7 +383,7 @@
         "om_special": "office_tower_collapsed",
         "reveal_radius": 1,
         "random": true,
-        "search_range": 180,
+        "search_range": 800,
         "z": -1
       },
       "update_mapgen": [ { "place_nested": [ { "chunks": [ "robofac_mi3_photonics_chunk" ], "x": 10, "y": 22 } ] } ]
@@ -601,7 +601,7 @@
     "difficulty": 5,
     "value": 0,
     "start": {
-      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 2, "random": true, "search_range": 70 },
+      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 2, "random": true, "search_range": 80 },
       "update_mapgen": {
         "rows": [
           "                        ",

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -319,12 +319,12 @@
   {
     "id": "MISSION_RANCH_FOREMAN_3",
     "type": "mission_definition",
-    "name": { "str": "Gather 2500 Nails" },
+    "name": { "str": "Gather 1500 Nails" },
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 5,
     "value": 50000,
     "item": "nail",
-    "count": 2500,
+    "count": 1500,
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "followup": "MISSION_RANCH_FOREMAN_4",
@@ -389,7 +389,7 @@
     "followup": "MISSION_RANCH_FOREMAN_5",
     "dialogue": {
       "describe": "We need help…",
-      "offer": "I'm sure you've noticed the new workers that have started trickling in.  The Free Merchant counsel is demanding that we immediately begin projects to become self-sufficient due to limited supplies.  We are going to need to rapidly setup an agricultural industry before winter and starvation catches us unprepared and unsupported.  In order to get a half dozen shovels and a couple of bags of seeds, we are going to have to trade for it.  I've already got the deal lined up, but the only thing they are willing to trade it for is salt.  I negotiated them down from 50 lbs to 30… we were hoping you might have access to a source.",
+      "offer": "I'm sure you've noticed the new workers that have started trickling in.  The Free Merchant council is demanding that we immediately begin projects to become self-sufficient due to limited supplies.  We are going to need to rapidly setup an agricultural industry before winter and starvation catches us unprepared and unsupported.  In order to get a half dozen shovels and a couple of bags of seeds, we are going to have to trade for it.  I've already got the deal lined up, but the only thing they are willing to trade it for is salt.  I negotiated them down from 50 lbs to 30… we were hoping you might have access to a source.",
       "accepted": "Salt is key to preserving meat and other perishables… without any excess food it wouldn't do us much good now, but I imagine we'll need to send you out to get more in the future.",
       "rejected": "Come back when you get a chance.  We need skilled survivors.",
       "advice": "If you can find a source of salt water you should be able to boil it down.  Alternatively, you can go into the cities and search restaurants.",


### PR DESCRIPTION
#### Summary
Fix a bunch of quests

#### Purpose of change
- Light Retrieval and several other quests were frequently failing to find a mapgen target. This is because the overmap has become more complex and restrictive as time goes on, so they've had some trouble placing their map locations.
- A few quests were asking for a large number of items. This was certainly appropriate before, but in TLG finding something like 20 King James bibles is a much bigger ask.
- The dazzle rifle is too inaccurate to be safely used in TLG thanks to our aiming RNG.

#### Describe the solution
- Dramatically increase the search radius for several quests, especially for Light Retrieval and the final Old Guard quests.
- Reduce the count of the NECC bible quest to 10.
- Fix a few typos.
- Make the dazzle rifle more accurate and increased its range.
- Redescribed the dazzle rifle as a modern anti-drone gun similar to the EDM4S and updated the quest text to reflect this.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
