### PR TITLE
Backports to fix scenario spawns

### DIFF
--- a/data/json/mapgen/hospital.json
+++ b/data/json/mapgen/hospital.json
@@ -153,6 +153,7 @@
       "palettes": [ "hospital" ],
       "terrain": { "5": "t_floor", "H": "t_floor", "X": [ "t_door_metal_locked", "t_door_metal_elocked" ], "=": "t_pavement" },
       "furniture": { "H": "f_locker" },
+      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 39, 41 ], "y": [ 45, 46 ] } ],
       "vendingmachines": { "D": { "item_group": "vending_drink", "lootable": true }, "F": { "item_group": "vending_food", "lootable": true } },
       "computers": {
         "5": {

--- a/data/json/mapgen/map_extras/mayhem.json
+++ b/data/json/mapgen/map_extras/mayhem.json
@@ -59,7 +59,7 @@
         "2": [ { "item": "corpses", "chance": 100 }, { "item": "guns_pistol_common_display", "chance": 80 } ]
       },
       "place_item": [ { "item": "9mm_casing", "x": [ 15, 17 ], "y": [ 2, 4 ], "chance": 50, "repeat": 9 } ],
-      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 20, 20 ], "y": [ 11, 11 ] } ],
+      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 18, 18 ], "y": [ 9, 9 ] } ],
       "fields": { "1": { "field": "fd_blood", "intensity": [ 1, 3 ] }, "~": { "field": "fd_blood" }, "2": { "field": "fd_blood" } },
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }

--- a/data/json/mapgen/map_extras/mayhem.json
+++ b/data/json/mapgen/map_extras/mayhem.json
@@ -8,6 +8,15 @@
       "place_nested": [ { "chunks": [ "24x24_mayhem_crash", "24x24_mayhem_limo", "24x24_mayhem_tire_change" ], "x": 0, "y": 0 } ]
     }
   },
+    {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_mayhem_crash_start",
+    "object": {
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "place_nested": [ { "chunks": [ "24x24_mayhem_crash" ], "x": 0, "y": 0 } ]
+    }
+  },
   {
     "type": "mapgen",
     "method": "json",

--- a/data/json/mapgen/map_extras/mayhem.json
+++ b/data/json/mapgen/map_extras/mayhem.json
@@ -8,7 +8,7 @@
       "place_nested": [ { "chunks": [ "24x24_mayhem_crash", "24x24_mayhem_limo", "24x24_mayhem_tire_change" ], "x": 0, "y": 0 } ]
     }
   },
-    {
+  {
     "type": "mapgen",
     "method": "json",
     "update_mapgen_id": "mx_mayhem_crash_start",
@@ -59,6 +59,7 @@
         "2": [ { "item": "corpses", "chance": 100 }, { "item": "guns_pistol_common_display", "chance": 80 } ]
       },
       "place_item": [ { "item": "9mm_casing", "x": [ 15, 17 ], "y": [ 2, 4 ], "chance": 50, "repeat": 9 } ],
+      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 20, 20 ], "y": [ 11, 11 ] } ],
       "fields": { "1": { "field": "fd_blood", "intensity": [ 1, 3 ] }, "~": { "field": "fd_blood" }, "2": { "field": "fd_blood" } },
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }

--- a/data/json/mapgen/private_resort.json
+++ b/data/json/mapgen/private_resort.json
@@ -317,6 +317,7 @@
         "                                                                        "
       ],
       "palettes": [ "p_resort_palette_living_floor" ],
+      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 29, 45 ], "y": [ 56, 58 ] } ],
       "place_items": [
         { "chance": 75, "item": "keg_beer", "x": 66, "y": 48 },
         { "chance": 75, "item": "keg_beer", "x": 65, "y": 48 },

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -250,7 +250,8 @@
         },
         { "chunks": [ "24x24_road_straight_vehicles" ], "x": 0, "y": 0 },
         { "chunks": [ "24x24_road_zombies" ], "x": 0, "y": 0 }
-      ]
+      ],
+      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 5, 19 ], "y": [ 5, 19 ] } ]
     }
   },
   {

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -250,8 +250,7 @@
         },
         { "chunks": [ "24x24_road_straight_vehicles" ], "x": 0, "y": 0 },
         { "chunks": [ "24x24_road_zombies" ], "x": 0, "y": 0 }
-      ],
-      "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": [ 5, 19 ], "y": [ 5, 19 ] } ]
+      ]
     }
   },
   {

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -60,6 +60,18 @@
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
+    "id": "mx_mayhem_crash_start",
+    "type": "map_extra",
+    "name": { "str": "Car Crash" },
+    "description": "Car crash is here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_mayhem_crash_start" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "M",
+    "color": "light_red",
+    "autonote": true,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
+  },
+  {
     "id": "mx_roadblock",
     "type": "map_extra",
     "name": { "str": "Roadblock (Police)" },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -460,7 +460,7 @@
     "description": "The scientists stopped their experiments on you abruptly, leaving you behind while they evacuated before lockdown.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
     "professions": [ "unemployed", "mutant_patient", "mutant_volunteer", "broken_cyborg", "bionic_patient" ],
-    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
+    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale" ],
     "traits": [
       "ELFAEYES",
       "MESOPIC",
@@ -520,7 +520,7 @@
     "description": "You were deemed an essential employee and required to stay behind during the lab's evacuation.  Find a way to escape or starve to death.",
     "start_name": "Locked Lab",
     "professions": [ "labtech", "security", "medic" ],
-    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale", "sloc_ice_lab_stairs", "sloc_ice_lab_finale" ],
+    "allowed_locs": [ "sloc_lab_random", "sloc_lab_escape_cells", "sloc_lab_finale" ],
     "requirement": "achievement_reach_lab_finale",
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -893,7 +893,7 @@
     "description": "You decided the open road would be a better prospect than the zombie-filled cities.  While en route to your destination, you were involved in a crash that totaled your vehicle.  Injured and alone, you'll need to think fast if you want to survive.",
     "allowed_locs": [ "sloc_road" ],
     "start_name": "Crash Site",
-    "map_extra": "mx_mayhem",
+    "map_extra": "mx_mayhem_crash_start",
     "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ]
   },
   {

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -687,7 +687,7 @@
     "type": "start_location",
     "id": "sloc_road",
     "name": "Road",
-    "terrain": [ { "om_terrain": "road_curved", "om_terrain_match_type": "TYPE" } ]
+    "terrain": [ "road_curved" ]
   },
   {
     "type": "start_location",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -352,7 +352,7 @@
     "type": "start_location",
     "id": "sloc_hospital",
     "name": "Hospital",
-    "terrain": [ { "om_terrain": "hospital", "om_terrain_match_type": "PREFIX" } ]
+    "terrain": [ "hospital_5" ]
   },
   {
     "type": "start_location",
@@ -687,7 +687,7 @@
     "type": "start_location",
     "id": "sloc_road",
     "name": "Road",
-    "terrain": [ { "om_terrain": "road", "om_terrain_match_type": "PREFIX" } ]
+    "terrain": [ { "om_terrain": "road", "om_terrain_match_type": "TYPE" } ]
   },
   {
     "type": "start_location",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -687,7 +687,7 @@
     "type": "start_location",
     "id": "sloc_road",
     "name": "Road",
-    "terrain": [ { "om_terrain": "road", "om_terrain_match_type": "TYPE" } ]
+    "terrain": [ { "om_terrain": "road_curved", "om_terrain_match_type": "TYPE" } ]
   },
   {
     "type": "start_location",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -687,7 +687,8 @@
     "type": "start_location",
     "id": "sloc_road",
     "name": "Road",
-    "terrain": [ "road_curved" ]
+    "city_distance": [ 10, -1 ],
+    "terrain": [ "field", { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
   },
   {
     "type": "start_location",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -688,7 +688,7 @@
     "id": "sloc_road",
     "name": "Road",
     "city_distance": [ 10, -1 ],
-    "terrain": [ "field", { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
+    "terrain": [ { "om_terrain": "road", "om_terrain_match_type": "TYPE" } ]
   },
   {
     "type": "start_location",


### PR DESCRIPTION
#### Summary
Backports to fix scenario spawns

#### Purpose of change
Some scenarios were starting the player in weird places, generating error messages, or failing entirely.

#### Describe the solution
Backport:
77483
77451
77541

Remove ice labs from lab starts.

#### Testing
Started a few different scenarios and saw that it worked fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
