### PR TITLE
Backport 77665 - Fix godco mapgen_updates searches

### DIFF
--- a/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
@@ -3,14 +3,17 @@
     "type": "effect_on_condition",
     "id": "godco_place_coop_new",
     "global": false,
-    "effect": [ { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7" }, { "math": [ "darryl_building_coop", "=", "2" ] } ]
+    "effect": [
+      { "mapgen_update": "darryl_place_coop", "om_terrain": "godco_7", "target_var": { "context_val": "search_locale" } },
+      { "math": [ "darryl_building_coop", "=", "2" ] }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "godco_place_herb_garden_new",
     "global": false,
     "effect": [
-      { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2" },
+      { "mapgen_update": "place_herb_garden", "om_terrain": "godco_1_2", "target_var": { "context_val": "search_locale" } },
       { "math": [ "kostas_building_garden", "=", "2" ] }
     ]
   },
@@ -20,14 +23,46 @@
     "global": false,
     "//": "4 hours 20 minutes per wall (from regular ground to full palisade) * 373 walls = ~1,567 hours.  Divided into 8-hour work shifts, thats ~196 days, or six and a half months for one person.  Presuming we have ~11 people working in a single shift, each building 1 wall, that should be ~18 days to build.  Please correct me if I messed up the math.",
     "effect": [
-      { "mapgen_update": "place_right_corner_wall", "om_terrain": "godco_1" },
-      { "mapgen_update": "place_gate_wall", "om_terrain": "godco_2" },
-      { "mapgen_update": "place_left_corner_wall", "om_terrain": "godco_3" },
-      { "mapgen_update": "place_straight_up_wall_right", "om_terrain": "godco_4" },
-      { "mapgen_update": "place_straight_up_wall_left", "om_terrain": "godco_6" },
-      { "mapgen_update": "place_right_corner_wall_bottom", "om_terrain": "godco_7" },
-      { "mapgen_update": "place_straight_bottom_wall", "om_terrain": "godco_8" },
-      { "mapgen_update": "place_left_corner_wall_bottom", "om_terrain": "godco_9" },
+      {
+        "mapgen_update": "place_right_corner_wall",
+        "om_terrain": "godco_1",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_gate_wall",
+        "om_terrain": "godco_2",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_left_corner_wall",
+        "om_terrain": "godco_3",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_up_wall_right",
+        "om_terrain": "godco_4",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_up_wall_left",
+        "om_terrain": "godco_6",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_right_corner_wall_bottom",
+        "om_terrain": "godco_7",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_straight_bottom_wall",
+        "om_terrain": "godco_8",
+        "target_var": { "context_val": "search_locale" }
+      },
+      {
+        "mapgen_update": "place_left_corner_wall_bottom",
+        "om_terrain": "godco_9",
+        "target_var": { "context_val": "search_locale" }
+      },
       { "math": [ "wall_in_progress", "=", "2" ] }
     ]
   },
@@ -38,7 +73,11 @@
     "//": "1 hour 30 minutes per wood wall * 50 walls = 75 hours for walls. 132 wood floors * 1 hour 40 minutes a floor = 220 hours. 1 hour 30 minutes per shelf * 68 shelves = 102 hours. (397 so far)  2 hours per roof * 132 roof tiles (assume same as floors) = 264 hours.",
     "//2": "In total, this takes 661 labor hours to build. Assuming work is in 8-hour shifts, that's 83 days, or 2 months and 22 days for a single worker.  Assume we have ~6 people on the job (isn't as urgent as a wall), this takes us ~14 days to build, or two weeks.",
     "effect": [
-      { "mapgen_update": "place_food_warehouse", "om_terrain": "forest_thick" },
+      {
+        "mapgen_update": "place_food_warehouse",
+        "om_terrain": "forest_thick",
+        "target_var": { "context_val": "search_locale" }
+      },
       { "math": [ "godco_warehouse_in_progress", "=", "2" ] }
     ]
   }

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -175,7 +175,12 @@
     },
     "end": {
       "effect": [
-        { "queue_eocs": "godco_place_warehouse_new", "time_in_future": "336 hours" },
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_warehouse_new",
+          "time_in_future": "336 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 137 }
       ],
       "opinion": { "trust": 7, "value": 6, "anger": -3 }
@@ -299,8 +304,13 @@
     },
     "end": {
       "effect": [
+        { "npc_location_variable": { "context_val": "search_locale" } },
         { "math": [ "darryl_building_coop", "=", "1" ] },
-        { "queue_eocs": "godco_place_coop_new", "time_in_future": "168 hours" },
+        {
+          "queue_eocs": "godco_place_coop_new",
+          "time_in_future": "168 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 6 }
       ]
     }
@@ -926,8 +936,14 @@
     "end": {
       "effect": [
         { "u_spawn_item": "icon", "count": 90 },
-        { "queue_eocs": "godco_place_herb_garden_new", "time_in_future": "72 hours" }
-      ]
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_herb_garden_new",
+          "time_in_future": "72 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        }
+      ],
+      "opinion": { "trust": 3, "value": 2 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_GODCO_KOSTAS_3",
@@ -1188,7 +1204,12 @@
     "end": {
       "effect": [
         { "mapgen_update": "helena_planer", "om_terrain": "godco_8" },
-        { "queue_eocs": "godco_place_wall_new", "time_in_future": "432 hours" },
+        { "npc_location_variable": { "context_val": "search_locale" } },
+        {
+          "queue_eocs": "godco_place_wall_new",
+          "time_in_future": "432 hours",
+          "variables": { "search_locale": { "context_val": "search_locale" } }
+        },
         { "u_spawn_item": "icon", "count": 40 }
       ]
     },


### PR DESCRIPTION
#### Summary
Backport 77665 - Fix godco mapgen_updates searches

#### Purpose of change
Fixing missions

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
