### PR TITLE
SW 610 fix json flags

### DIFF
--- a/data/json/items/gun/10mm.json
+++ b/data/json/items/gun/10mm.json
@@ -22,7 +22,7 @@
     "//": "165mm + 32mm max OAL for 10mm. Revolvers just built different.",
     "price": "740 USD",
     "price_postapoc": "22 USD 50 cent",
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ],
     "to_hit": -2,
     "material": [ "steel", "wood" ],
     "symbol": "(",


### PR DESCRIPTION


#### Summary
Category "Brief description"

The flag section on the S&W 610 (sw_610) replaced the ones inside of pistol_revolver so it wasn't behaving like a revolver.

#### Purpose of change

Make the SW 610 revolver behave like a revolver again.

#### Describe the solution

Copied the flags from pistol_revolver and added them to the flags in sw_610

#### Describe alternatives you've considered

Remove the flag section in sw_610 removing ALLOWS_BODY_BLOCK, so it just copies the flags from pistol_revolver.

#### Testing

Game runs, revolver behaves like it should

#### Additional context

Tekker on the TLG discord pointed this one out and I looked at it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
