### PR TITLE
Patch flags and add fire_twohand to firearms

### DIFF
--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -70,6 +70,7 @@
     "copy-from": "gun_base",
     "type": "GUN",
     "name": { "str": "base pistol" },
+    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "skill": "pistol",
     "sight_dispersion": 60,
     "//": "default handling for anything without a stock",
@@ -130,7 +131,7 @@
     "type": "GUN",
     "name": { "str": "revolver" },
     "//proportional": { "reload": 0.7 },
-    "extend": { "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ] },
+    "extend": { "flags": [ "ALLOWS_BODY_BLOCK", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ] },
     "//": "Revolvers exclude the muzzle location preventing installation of suppressors",
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
     "valid_mod_locations": [
@@ -149,7 +150,7 @@
     "type": "GUN",
     "name": { "str": "cap & ball revolver" },
     "reload": 150,
-    "extend": { "flags": [ "RELOAD_ONE", "NO_UNLOAD", "EASY_CLEAN" ] },
+    "extend": { "flags": [ "ALLOWS_BODY_BLOCK", "RELOAD_ONE", "NO_UNLOAD", "EASY_CLEAN" ] },
     "//": "Slower reloads, no unloading.  Base, unskilled person should take 1.5 seconds per chamber.  No underbarrel mods, that's where the ram goes.",
     "valid_mod_locations": [ [ "barrel", 1 ], [ "grip", 1 ], [ "stock", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
@@ -159,6 +160,7 @@
     "copy-from": "gun_base",
     "type": "GUN",
     "name": { "str": "base rifle" },
+    "flags": [ "FIRE_TWOHAND" ],
     "skill": "rifle",
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -235,6 +237,7 @@
     "copy-from": "gun_base",
     "type": "GUN",
     "name": { "str": "base shotgun" },
+    "flags": [ "FIRE_TWOHAND" ],
     "skill": "shotgun",
     "ammo": [ "shot" ],
     "valid_mod_locations": [
@@ -286,6 +289,7 @@
     "copy-from": "gun_base",
     "type": "GUN",
     "name": { "str": "base SMG" },
+    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "skill": "smg"
   }
 ]

--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -260,7 +260,7 @@
     "type": "GUN",
     "name": { "str": "pump-action shotgun" },
     "reload_noise": "chuk chuk.",
-    "flags": [ "RELOAD_ONE", "PUMP_ACTION" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "PUMP_ACTION" ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
   },
   {

--- a/data/json/items/gun/10mm.json
+++ b/data/json/items/gun/10mm.json
@@ -22,7 +22,6 @@
     "//": "165mm + 32mm max OAL for 10mm. Revolvers just built different.",
     "price": "740 USD",
     "price_postapoc": "22 USD 50 cent",
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "to_hit": -2,
     "material": [ "steel", "wood" ],
     "symbol": "(",
@@ -66,7 +65,6 @@
     "price_postapoc": "25 USD",
     "to_hit": -2,
     "material": [ "plastic", "steel" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "symbol": "(",
     "color": "dark_gray",
@@ -108,7 +106,6 @@
     "price_postapoc": "25 USD",
     "to_hit": -2,
     "material": [ "plastic", "steel" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "symbol": "(",
     "color": "dark_gray",
@@ -204,7 +201,6 @@
     "durability": 6,
     "min_cycle_recoil": 570,
     "blackpowder_tolerance": 48,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "60 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m1911_10mag" ] } ],
     "melee_damage": { "bash": 12 }
@@ -237,7 +233,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 675,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "84 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "witness_mag_10" ] } ],
     "melee_damage": { "bash": 8 }
@@ -271,7 +266,6 @@
     "dispersion": 410,
     "durability": 7,
     "min_cycle_recoil": 675,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "60 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p220_10_mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -305,7 +299,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 675,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "81 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "xd_10_mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -338,7 +331,6 @@
     "skill": "pistol",
     "ammo": "10mm",
     "min_cycle_recoil": 675,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "103 ml", "item_restriction": [ "glock_20mag", "tdi_10mm_mag" ] } ]
@@ -374,7 +366,6 @@
     "durability": 6,
     "min_cycle_recoil": 570,
     "blackpowder_tolerance": 48,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "60 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "2011_17_mag", "2011_22_mag" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -30,7 +30,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "hk_g80mag" ] } ],
     "melee_damage": { "bash": 6 }
   }

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -2,8 +2,8 @@
   {
     "id": "american_180",
     "looks_like": "hk_mp5",
+    "copy-from": "smg_base",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": ".22 caliber submachine gun" },
     "description": "A dramatically uncommon automatic weapon, making use of high-capacity pan magazines and firing the low power .22 caliber cartridge: an unusual ammunition choice for a submachine gun.  With negligible recoil on account of its modest cartridge and a suppressively high rate of fire, a burst of .22 LR rounds from this little machine gun can be best likened with a swarm of hornets… an incredibly angry swarm of hornets.",
     "variant_type": "gun",
@@ -26,7 +26,6 @@
     "color": "light_gray",
     "range": 6,
     "ammo": [ "22" ],
-    "skill": "smg",
     "ranged_damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 280,
     "durability": 6,
@@ -55,8 +54,8 @@
   {
     "id": "marlin_9a",
     "looks_like": "ar15",
+    "copy-from": "rifle_base",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "small game rifle" },
     "description": "A venerable .22 caliber lever-action rifle, with a 19-round tube magazine and a classic design that dates back over a century.  Generally used for the hunting of small game like rabbits, the strict taxonomic classification of zombies as 'small game' is debatable, but this decades-old weapon can still be counted upon to help manage the undead population.",
     "variant_type": "gun",
@@ -80,7 +79,6 @@
     "color": "brown",
     "range": 7,
     "ammo": [ "22" ],
-    "skill": "rifle",
     "ranged_damage": { "damage_type": "bullet", "amount": 5 },
     "dispersion": 90,
     "durability": 8,
@@ -100,7 +98,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE",
@@ -185,15 +183,15 @@
     "barrel_volume": "360 ml",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "22": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "ruger_1022",
     "looks_like": "ar15",
+    "copy-from": "rifle_base",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "varmint rifle" },
     "description": "A lightweight and modular pistol caliber hunting carbine, firing the low power .22 LR cartridge.  Before the Cataclysm, a mix of high customizability, cheap ammunition, and low recoil made this a very popular varmint rifle amongst civilian shooters.",
     "variant_type": "gun",
@@ -218,7 +216,6 @@
     "range": 6,
     "//range": "It is a blowback action, like most non-target, sporting rifles of this caliber.",
     "ammo": [ "22" ],
-    "skill": "rifle",
     "ranged_damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 110,
     "durability": 8,
@@ -300,8 +297,8 @@
   {
     "id": "sig_mosquito",
     "looks_like": "glock_17",
+    "copy-from": "pistol_base",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "firefly training pistol" },
     "//": "Was the sig mosquito, has been renamed to the more common GSG firefly",
     "description": "A medium sized, .22 caliber semi-automatic pistol, for training with a pistol similar to more powerful pistols.  Built from aluminum and polymer components, the weapon is lightweight and concealable, but its chambering is not very powerful.",
@@ -325,7 +322,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "22" ],
-    "skill": "pistol",
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "durability": 7,
@@ -341,15 +337,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "mosquitomag" ] } ],
     "melee_damage": { "bash": 9 }
@@ -383,7 +370,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 39,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -440,7 +426,6 @@
       [ "underbarrel mount", 1 ]
     ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
     "pocket_data": [ { "magazine_well": "27 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "j22mag" ] } ],
     "melee_damage": { "bash": 1 }
   },
@@ -505,7 +490,6 @@
     "dispersion": 480,
     "durability": 6,
     "min_cycle_recoil": 100,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -560,7 +544,6 @@
     "dispersion": 400,
     "durability": 8,
     "min_cycle_recoil": 100,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       { "rigid": false, "magazine_well": "96 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ruger_mk4_mag" ] }
@@ -570,9 +553,9 @@
   {
     "id": "ruger_charger",
     "looks_like": "modular_ar_pistol",
+    "copy-from": "pistol_base",
     "type": "GUN",
     "//": "Stats are from https://ruger.com/products/22Charger/specSheets/4923.html",
-    "reload_noise_volume": 10,
     "name": { "str": "varmint pistol" },
     "description": "Essentially a varmint rifle with no stock and a shorter barrel, this gun loses out on a bit of energy with its shorter barrel and is a bit more uncomfortable to hold, but a fair bit lighter.  Includes a bipod.",
     "variant_type": "gun",
@@ -596,7 +579,6 @@
     "color": "brown",
     "range": 3,
     "ammo": [ "22" ],
-    "skill": "pistol",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 140,
     "durability": 8,
@@ -613,14 +595,6 @@
       [ "stock mount", 1 ],
       [ "stock accessory", 2 ],
       [ "underbarrel mount", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "built_in_mods": [ "bipod" ],
     "pocket_data": [
@@ -647,9 +621,9 @@
   },
   {
     "id": "rossi_gallery",
+    "copy-from": "rifle_base",
     "looks_like": "ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "pump action varmint rifle" },
     "description": "A lightweight, wood framed pump action rifle, holding 15 rounds of .22 with an 18 inch barrel.  While pump actions tend to be largely shotguns, they can be made in calibers such as .22 LR.",
     "variant_type": "gun",
@@ -672,7 +646,6 @@
     "color": "brown",
     "range": 7,
     "ammo": [ "22" ],
-    "skill": "rifle",
     "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 140,
     "durability": 8,
@@ -690,7 +663,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "22": 15 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -766,9 +739,9 @@
   },
   {
     "id": "rio_bravo",
+    "copy-from": "rifle_base",
     "looks_like": "marlin_9a",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "small game lever-action rifle" },
     "description": "A .22 Long Rifle lever-action rifle, which holds 15 rounds of ammo.  While quite useful against small game, its effectiveness isn't as great against the undead.",
     "variant_type": "gun",
@@ -793,7 +766,6 @@
     "color": "brown",
     "range": 5,
     "ammo": [ "22" ],
-    "skill": "rifle",
     "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 110,
     "durability": 8,
@@ -817,9 +789,9 @@
   },
   {
     "id": "henry_golden_boy",
+    "copy-from": "rifle_base",
     "looks_like": "marlin_9a",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "small game lever-action rifle" },
     "description": "A .22 Long Rifle lever-action rifle, which holds 16 rounds of ammo.  While quite useful against small game, its effectiveness isn't as great against the undead.",
     "variant_type": "gun",
@@ -844,7 +816,6 @@
     "color": "brown",
     "range": 6,
     "ammo": [ "22" ],
-    "skill": "rifle",
     "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 100,
     "durability": 8,
@@ -862,7 +833,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "22": 16 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -783,7 +783,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "22": 15 } } ],
     "melee_damage": { "bash": 9 }
   },

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -22,7 +22,7 @@
     "min_cycle_recoil": 1350,
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 2 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "melee_damage": { "bash": 12 }
   },
@@ -239,7 +239,7 @@
       [ "stock", 1 ]
     ],
     "melee_damage": { "bash": 12 },
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow."
   },
   {
@@ -455,7 +455,7 @@
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 2 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "melee_damage": { "bash": 12 }
   },
@@ -489,7 +489,7 @@
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ] ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 2 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "melee_damage": { "bash": 12 }
   },
@@ -514,7 +514,7 @@
       }
     ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow."
   },
   {
@@ -930,7 +930,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "pocket_data": [
       {
@@ -1073,7 +1073,7 @@
       [ "stock accessory", 2 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "NO_TURRET", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET", "EASY_CLEAN" ],
     "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "melee_damage": { "bash": 10 }
   },

--- a/data/json/items/gun/270win.json
+++ b/data/json/items/gun/270win.json
@@ -30,7 +30,7 @@
     "clip_size": 4,
     "barrel_volume": "750 ml",
     "barrel_length": "610 mm",
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/300.json
+++ b/data/json/items/gun/300.json
@@ -19,7 +19,7 @@
     "dispersion": 90,
     "durability": 8,
     "barrel_volume": "500 ml",
-    "flags": [ "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m2010mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -46,7 +46,7 @@
     "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_volume": "750 ml",
-    "flags": [ "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -84,7 +84,7 @@
     "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_volume": "750 ml",
-    "flags": [ "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -136,7 +136,7 @@
       [ "stock accessory", 2 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [
       {
         "magazine_well": "300 ml",

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "browning_blr",
+    "Copy-from": "rifle_manual",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Browning BLR rifle" },
     "description": "A highly accurate lever-action hunting rifle chambered for the powerful .30-06 round.  Notable for using a detachable magazine instead of a traditional tube.",
     "weight": "3290 g",
@@ -17,7 +17,6 @@
     "symbol": "(",
     "color": "brown",
     "ammo": [ "3006" ],
-    "skill": "rifle",
     "dispersion": 90,
     "durability": 7,
     "blackpowder_tolerance": 24,
@@ -35,16 +34,15 @@
       [ "stock accessory", 2 ],
       [ "underbarrel mount", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "blrmag" ] } ],
     "melee_damage": { "bash": 12 }
   },
   {
     "id": "garand",
+    "Copy-from": "rifle_base",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "M1 Garand rifle" },
     "description": "A semi-automatic .30-06 battle rifle, developed to replace the M1903 Springfield.  It didn't completely supplant the older bolt-action until after World War II.",
     "ascii_picture": "m1_garand",
@@ -59,7 +57,6 @@
     "symbol": "(",
     "color": "brown",
     "ammo": [ "3006" ],
-    "skill": "rifle",
     "dispersion": 200,
     "durability": 8,
     "min_cycle_recoil": 3420,
@@ -77,14 +74,6 @@
       [ "stock mount", 1 ],
       [ "stock accessory", 2 ],
       [ "underbarrel mount", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "garandclip" ] } ],
     "melee_damage": { "bash": 12 }
@@ -124,7 +113,7 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "3006": 5 }, "allowed_speedloaders": [ "3006_clip" ] }
     ],
@@ -132,9 +121,9 @@
   },
   {
     "id": "m1918",
+    "copy-from": "rifle_auto",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Browning Automatic Rifle" },
     "description": "Designed near the end of World War I, the BAR provided fire support for the US Army from World War II all the way to the Vietnam War.  Too much firepower to serve as a battle rifle, but not enough to be an ideal light machine gun, it still found a niche on the battlefield.",
     "ascii_picture": "1918_BAR",
@@ -149,7 +138,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "3006" ],
-    "skill": "rifle",
     "dispersion": 180,
     "durability": 8,
     "min_cycle_recoil": 3420,
@@ -169,7 +157,6 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m1918mag", "m1918bigmag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -196,7 +183,7 @@
     "blackpowder_tolerance": 24,
     "clip_size": 4,
     "barrel_volume": "750 ml",
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "3006": 4 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -240,7 +227,7 @@
       [ "stock accessory", 2 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "3006": 4 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "browning_blr",
-    "Copy-from": "rifle_manual",
+    "copy-from": "rifle_manual",
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Browning BLR rifle" },
@@ -40,7 +40,7 @@
   },
   {
     "id": "garand",
-    "Copy-from": "rifle_base",
+    "copy-from": "rifle_base",
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M1 Garand rifle" },

--- a/data/json/items/gun/303.json
+++ b/data/json/items/gun/303.json
@@ -28,7 +28,7 @@
     "dispersion": 170,
     "durability": 8,
     "blackpowder_tolerance": 40,
-    "flags": [ "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "bayonet lug", 1 ],
@@ -74,7 +74,7 @@
     "dispersion": 150,
     "durability": 8,
     "blackpowder_tolerance": 40,
-    "flags": [ "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "bayonet lug", 1 ],

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -289,7 +289,7 @@
     "blackpowder_tolerance": 24,
     "clip_size": 3,
     "barrel_volume": "750 ml",
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "308": 3 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -351,7 +351,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "308": 5 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -566,7 +566,7 @@
       [ "underbarrel", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "steyr_scout_mag", "steyr_scout_mag_makeshift" ] } ],
     "melee_damage": { "bash": 10 }
   }

--- a/data/json/items/gun/30carbine.json
+++ b/data/json/items/gun/30carbine.json
@@ -33,14 +33,6 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m1carbinemag", "m1carbinebigmag" ] } ],
     "melee_damage": { "bash": 9 }
   },

--- a/data/json/items/gun/32.json
+++ b/data/json/items/gun/32.json
@@ -2,8 +2,8 @@
   {
     "id": "sig_p230",
     "looks_like": "glock_17",
+    "copy-from": "pistol_backup",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "SIG P230 pistol" },
     "description": "The SIG Sauer P230 is a small, semi-automatic handgun chambered in .32 ACP.  Due to its small dimensions, it was often carried as a backup weapon.",
     "weight": "460 g",
@@ -17,7 +17,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "32" ],
-    "skill": "pistol",
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 135,
@@ -32,15 +31,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "sigp230mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -48,8 +38,8 @@
   {
     "id": "walther_ppk",
     "looks_like": "glock_17",
+    "copy-from": "pistol_backup",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str_sp": "Walther PPK pistol" },
     "description": "One of the most famous handguns of the 20th century.  Your name is not Bond, but you might find this little gun still useful.",
     "ascii_picture": "ppk",
@@ -64,7 +54,6 @@
     "symbol": "(",
     "color": "light_gray",
     "ammo": [ "32" ],
-    "skill": "pistol",
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 135,
@@ -79,15 +68,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ppkmag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -113,7 +93,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 135,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "41 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "kp32mag" ] } ],
     "melee_damage": { "bash": 1 }
@@ -155,7 +134,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "32": 1 } } ],
     "melee_damage": { "bash": 10 }
   }

--- a/data/json/items/gun/338lapua.json
+++ b/data/json/items/gun/338lapua.json
@@ -28,7 +28,7 @@
     "durability": 10,
     "blackpowder_tolerance": 24,
     "default_mods": [ "cheek_pad", "butt_hook", "bipod", "rifle_scope", "muzzle_brake" ],
-    "flags": [ "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ai_338mag", "ai_338mag_10" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -74,7 +74,7 @@
       [ "rail mount", 1 ],
       [ "stock mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "338lapua": 1 } } ],
     "barrel_volume": "820 ml",
     "melee_damage": { "bash": 12 }
@@ -108,7 +108,7 @@
     "durability": 10,
     "blackpowder_tolerance": 24,
     "built_in_mods": [ "cheek_pad" ],
-    "flags": [ "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "//": "Cheek pad required for holding the buttstock in place and keep it from folding.",
     "default_mods": [ "match_trigger", "muzzle_brake" ],
     "valid_mod_locations": [
@@ -166,7 +166,7 @@
       [ "underbarrel", 1 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "NO_TURRET", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
     "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/357sig.json
+++ b/data/json/items/gun/357sig.json
@@ -20,7 +20,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 540,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p226mag_12rd_357sig" ] } ],
     "melee_damage": { "bash": 8 }
@@ -62,7 +61,6 @@
     "dispersion": 480,
     "durability": 6,
     "min_cycle_recoil": 540,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p320mag_13rd_357sig" ] } ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -28,7 +28,7 @@
     "reload": 200,
     "valid_mod_locations": [  ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "RELOAD_ONE", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "38": 2 } } ],
     "melee_damage": { "bash": 3 }
   },
@@ -63,7 +63,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "RELOAD_ONE", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 4, "38": 4 } } ],
     "melee_damage": { "bash": 3 }
   },
@@ -144,9 +144,9 @@
   },
   {
     "id": "rifle_38",
-    "copy-from": "gun_base",
     "looks_like": "modular_ar15",
     "type": "GUN",
+    "reload_noise_volume": 10,
     "name": { "str_sp": "pipe rifle" },
     "description": "A home-made rifle.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",
     "ascii_picture": "ps_pipe_gun",
@@ -170,7 +170,7 @@
     "barrel_length": "600 mm",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "38": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
@@ -500,7 +500,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 10, "38": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -544,7 +544,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 10, "38": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -588,7 +588,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 8, "38": 8 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -144,9 +144,9 @@
   },
   {
     "id": "rifle_38",
+    "copy-from": "gun_base",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str_sp": "pipe rifle" },
     "description": "A home-made rifle.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",
     "ascii_picture": "ps_pipe_gun",
@@ -170,7 +170,7 @@
     "barrel_length": "600 mm",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "38": 1 } } ],
     "melee_damage": { "bash": 10 }
   },

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -54,7 +54,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 270,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "60 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fn1910mag" ] } ],
     "melee_damage": { "bash": 1 }
@@ -80,7 +79,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 270,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "60 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "rugerlcpmag" ] } ],
     "melee_damage": { "bash": 1 }
@@ -104,7 +102,6 @@
     "ammo": [ "380" ],
     "dispersion": 480,
     "durability": 7,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "min_cycle_recoil": 270,
     "pocket_data": [
@@ -136,7 +133,6 @@
     "ammo": [ "380" ],
     "dispersion": 480,
     "durability": 7,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "min_cycle_recoil": 225,
     "pocket_data": [ { "magazine_well": "74 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "taurus_spectrum_mag" ] } ],
@@ -179,12 +175,13 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "380": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "hpt3895",
+    "copy-from": "rifle_semi",
     "looks_like": "cx4",
     "type": "GUN",
     "name": { "str": ".380 ACP pistol-caliber carbine" },
@@ -209,7 +206,6 @@
     "color": "dark_gray",
     "range": 6,
     "ammo": [ "380" ],
-    "skill": "rifle",
     "dispersion": 180,
     "durability": 8,
     "blackpowder_tolerance": 30,
@@ -226,14 +222,6 @@
       [ "stock", 1 ],
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "pocket_data": [ { "magazine_well": "236 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hpt3895mag_10rd" ] } ],

--- a/data/json/items/gun/38super.json
+++ b/data/json/items/gun/38super.json
@@ -21,7 +21,6 @@
     "min_cycle_recoil": 225,
     "blackpowder_tolerance": 48,
     "modes": [ [ "DEFAULT", "double", 2 ] ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -32,7 +31,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "af2011a1mag" ] } ],
     "melee_damage": { "bash": 12 }
@@ -57,7 +55,6 @@
     "ammo": [ "38super" ],
     "dispersion": 480,
     "durability": 7,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m1911mag_10rd_38super" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -21,16 +21,15 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 504,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "90two40mag" ] } ],
     "melee_damage": { "bash": 8 }
   },
   {
     "id": "glock_22",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str_sp": "Glock 22 pistol" },
     "description": "A .40 S&W variant of the popular Glock 17 pistol.  The standard-issue firearm of the FBI and of countless other law enforcement agencies worldwide.",
     "ascii_picture": "glock_17",
@@ -45,12 +44,10 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "40" ],
-    "skill": "pistol",
     "dispersion": 480,
     "durability": 6,
     "blackpowder_tolerance": 48,
     "min_cycle_recoil": 425,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -62,14 +59,6 @@
       [ "sights", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "glock40mag", "glock40bigmag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -96,7 +85,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 504,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "px4_40mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -137,15 +125,15 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "sig_40",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str_sp": "SIG Pro pistol" },
     "description": "Originally marketed as a lightweight and compact alternative to older SIG handguns, the Pro .40 is popular among European police forces.",
     "ascii_picture": "sig_pro_40",
@@ -160,7 +148,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "40" ],
-    "skill": "pistol",
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 504,
@@ -175,15 +162,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "sig40mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -280,7 +258,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 504,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "185 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "bhp40mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -304,7 +281,6 @@
     "dispersion": 480,
     "durability": 9,
     "min_cycle_recoil": 504,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -335,7 +311,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 504,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "312 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hptjcpmag" ] } ],
     "melee_damage": { "bash": 8 }

--- a/data/json/items/gun/40x46mm.json
+++ b/data/json/items/gun/40x46mm.json
@@ -55,7 +55,7 @@
     "blackpowder_tolerance": 60,
     "clip_size": 1,
     "reload": 150,
-    "flags": [ "EASY_CLEAN" ],
+    "flags": [ "EASY_CLEAN", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40x46mm": 1 } } ],
     "melee_damage": { "bash": 6 }
   },
@@ -90,7 +90,7 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "EASY_CLEAN" ],
+    "flags": [ "EASY_CLEAN", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40x46mm": 1 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -137,6 +137,7 @@
     "clip_size": 3,
     "price_postapoc": "17 USD 50 cent",
     "modes": [ [ "DEFAULT", "single", 1, "NPC_AVOID" ], [ "MULTI", "multi", 3, [ "NPC_AVOID" ] ] ],
+    "flags": [ "EASY_CLEAN" ],
     "proportional": { "weight": 1.5, "volume": 1.8, "price": 2 },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40x46mm": 3 } } ]
   },

--- a/data/json/items/gun/410shot.json
+++ b/data/json/items/gun/410shot.json
@@ -18,7 +18,7 @@
     "durability": 7,
     "barrel_volume": "750 ml",
     "ammo": [ "410shot" ],
-    "flags": [ "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "saiga410mag_10rd", "saiga410mag_30rd" ] } ],
     "melee_damage": { "bash": 12 }
   },

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "modular_deagle",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str_sp": "Desert Eagle pistol" },
     "description": "An icon of popular culture more than a practical weapon, this massive pistol can shoot a variety of magnum handgun rounds depending on the conversion kit and magazine used.",
     "weight": "1407 g",
@@ -31,7 +31,6 @@
     "symbol": "(",
     "color": "light_gray",
     "ammo": [ "NULL" ],
-    "skill": "pistol",
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 1413,
@@ -39,14 +38,6 @@
     "//2": "NO_TURRET should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 2 ], [ "stock", 1 ], [ "underbarrel mount", 1 ] ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -83,7 +74,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -116,7 +107,7 @@
     "barrel_length": "600 mm",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
@@ -311,7 +302,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 8 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -355,7 +346,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 10 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "TDI",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "//": [
       "Yes, I know it's not really a glock smg.",
       "It takes glock magazines, and it's own special one that I am also renaming to a glock magazine",
@@ -31,7 +31,6 @@
     "color": "dark_gray",
     "range": 1,
     "ammo": [ "45" ],
-    "skill": "smg",
     "dispersion": 280,
     "durability": 7,
     "min_cycle_recoil": 540,
@@ -47,14 +46,6 @@
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "default_mods": [ "folding_stock" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "tdi_mag", "glock_21mag", "glock_21mag26" ] } ],
@@ -107,14 +98,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "default_mods": [ "folding_stock" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ump45mag" ] } ],
     "melee_damage": { "bash": 11 }
@@ -156,16 +139,15 @@
     "durability": 7,
     "min_cycle_recoil": 450,
     "blackpowder_tolerance": 48,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m1911mag", "m1911bigmag" ] } ],
     "melee_damage": { "bash": 12 }
   },
   {
     "id": "mac_10",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "MAC-10 submachine gun" },
     "description": "A submachine gun chambered in .45 ACP and accepting MAC-10 magazines.",
     "variant_type": "gun",
@@ -187,7 +169,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "45" ],
-    "skill": "smg",
     "dispersion": 520,
     "durability": 7,
     "min_cycle_recoil": 540,
@@ -205,7 +186,6 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "mac10mag", "smg_45_mag" ] } ],
     "melee_damage": { "bash": 8 }
   },
@@ -357,9 +337,9 @@
   },
   {
     "id": "tommygun",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Thompson submachine gun" },
     "description": "A submachine gun chambered in .45 ACP and accepting Thompson magazines.",
     "variant_type": "gun",
@@ -383,7 +363,6 @@
     "range": 4,
     "//range": "Blish \"lock\" is considered to be a straight blowback in modern firearm design.",
     "ammo": [ "45" ],
-    "skill": "smg",
     "dispersion": 360,
     "durability": 7,
     "min_cycle_recoil": 540,
@@ -402,7 +381,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
+    "flags": [ "FIRE_TWOHAND" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -437,7 +416,6 @@
     "price": "700 USD",
     "price_postapoc": "25 USD",
     "built_in_mods": [ "match_trigger" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "usp45mag" ] } ]
   },
@@ -468,7 +446,6 @@
     "dispersion": 480,
     "durability": 9,
     "min_cycle_recoil": 540,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "240 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ppq45mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -501,7 +478,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 540,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "353 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hptjhpmag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -544,9 +520,9 @@
   },
   {
     "id": "greasegun",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": ".45 WWII submachine gun" },
     "description": "A WWII submachine gun, lacking semi-auto fire selector and chambered in .45 ACP.",
     "variant_type": "gun",
@@ -569,7 +545,6 @@
     "color": "light_gray",
     "range": 2,
     "ammo": [ "45" ],
-    "skill": "smg",
     "dispersion": 500,
     "durability": 7,
     "min_cycle_recoil": 540,
@@ -585,7 +560,6 @@
       [ "sights mount", 1 ],
       [ "stock", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "greasegun30mag" ] } ],
     "melee_damage": { "bash": 9 }
   }

--- a/data/json/items/gun/450bushmaster.json
+++ b/data/json/items/gun/450bushmaster.json
@@ -18,7 +18,7 @@
     "ammo": [ "450" ],
     "dispersion": 120,
     "durability": 8,
-    "flags": [ "NEVER_JAMS", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "EASY_CLEAN" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/4570.json
+++ b/data/json/items/gun/4570.json
@@ -32,7 +32,7 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "4570": 6 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -108,7 +108,7 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "4570": 1 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/458wm.json
+++ b/data/json/items/gun/458wm.json
@@ -19,7 +19,7 @@
     "price": "1760 USD",
     "price_postapoc": "50 USD",
     "ammo": [ "458wm" ],
-    "flags": [ "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS" "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "458wm": 3 } } ]
   }
 ]

--- a/data/json/items/gun/458wm.json
+++ b/data/json/items/gun/458wm.json
@@ -19,7 +19,7 @@
     "price": "1760 USD",
     "price_postapoc": "50 USD",
     "ammo": [ "458wm" ],
-    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS" "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "458wm": 3 } } ]
   }
 ]

--- a/data/json/items/gun/45colt.json
+++ b/data/json/items/gun/45colt.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "bond_410",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Bond Arms Derringer pistol" },
     "description": "The Bond Arms Derringer is a series of multi-barrel compact pistols.  Most commonly chambered for .45 Colt, with chambers long enough to accept .410 shotgun shells.",
     "weight": "566 g",
@@ -17,7 +17,6 @@
     "symbol": "(",
     "color": "brown",
     "ammo": [ "45colt", "410shot" ],
-    "skill": "pistol",
     "dispersion": 520,
     "durability": 6,
     "clip_size": 2,
@@ -58,7 +57,7 @@
     "clip_size": 14,
     "blackpowder_tolerance": 56,
     "reload_noise": "chik chik.",
-    "flags": [ "RELOAD_ONE" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],

--- a/data/json/items/gun/46.json
+++ b/data/json/items/gun/46.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "hk_mp7",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "H&K MP7A2 SMG" },
     "description": "Designed as a personal defense weapon, the MP7 fires the high-powered 4.6x30mm round while being lightweight, compact in size, and practically recoil-free.",
     "weight": "1960 g",
@@ -18,7 +18,6 @@
     "color": "dark_gray",
     "range": 2,
     "ammo": [ "46" ],
-    "skill": "smg",
     "dispersion": 260,
     "durability": 8,
     "min_cycle_recoil": 81,
@@ -35,14 +34,6 @@
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hk46mag", "hk46bigmag" ] } ],
     "melee_damage": { "bash": 7 }

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -22,7 +22,7 @@
     "durability": 8,
     "min_cycle_recoil": 23625,
     "default_mods": [ "bipod", "rifle_scope", "muzzle_brake" ],
-    "flags": [ "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m107a1mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -86,7 +86,7 @@
     "reload": 400,
     "barrel_volume": "1250 ml",
     "default_mods": [ "bipod", "rifle_scope", "muzzle_brake" ],
-    "flags": [ "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "as50mag" ] } ],
     "melee_damage": { "bash": 13 }
   },
@@ -114,7 +114,7 @@
     "reload": 450,
     "barrel_volume": "1250 ml",
     "default_mods": [ "recoil_stock", "bipod", "rifle_scope", "muzzle_brake" ],
-    "flags": [ "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "tac50mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -154,7 +154,7 @@
     ],
     "default_mods": [ "bipod", "rifle_scope", "muzzle_brake" ],
     "clip_size": 1,
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "50": 1 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/545x39.json
+++ b/data/json/items/gun/545x39.json
@@ -88,7 +88,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "MISSION_ITEM" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "MISSION_ITEM" ],
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ak74mag", "rpk74mag", "casket74mag" ] } ],
     "melee_damage": { "bash": 11 }

--- a/data/json/items/gun/57.json
+++ b/data/json/items/gun/57.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "fn57",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "5.7mm pistol" },
     "description": "Firing the armor-piercing 5.7x28mm round, this lightweight handgun was developed for NATO use as a sidearm capable of penetrating body armor.  Its proprietary and nonprolific ammunition kept it comparatively rare amongst both civilian and militant use, but the gun's ability to ignore most forms of conventional ballistic armor can't be argued with.  Given that its tiny bullets have next to no stopping power, its armor-penetrating capability comes at a considerable trade-off.",
     "variant_type": "gun",
@@ -26,12 +26,10 @@
     "symbol": "(",
     "color": "light_gray",
     "ammo": [ "57" ],
-    "skill": "pistol",
     "ranged_damage": { "damage_type": "bullet", "amount": -2 },
     "dispersion": 440,
     "durability": 8,
     "min_cycle_recoil": 81,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -44,22 +42,14 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fn57mag" ] } ],
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "fn_p90",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "5.7mm automatic PDW" },
     "description": "A late 90s manufactured personal defense weapon (PDW), this automatic firearm fires the high-velocity, proprietary 5.7x28mm cartridge.  Making use of top-mounted 50-round custom magazines which lock into the receiver of the weapon behind the grip, this little submachine gun packs quite the nasty payload.  Its small, high-speed caliber makes it excellent at both defeating armored opponents and firing short bursts manageably.",
     "variant_type": "gun",
@@ -82,7 +72,6 @@
     "color": "light_gray",
     "range": 4,
     "ammo": [ "57" ],
-    "skill": "smg",
     "dispersion": 260,
     "durability": 8,
     "min_cycle_recoil": 81,
@@ -97,22 +86,14 @@
       [ "sling", 1 ],
       [ "stock accessory", 2 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fnp90mag" ] } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "p50",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "high-capacity 5.7mm handgun" },
     "description": "A large and retro-looking semi-automatic pistol firing the high-velocity 5.7x28mm cartridge, mainly constructed out of polymer-based materials.  Making use of standard 5.7x28mm 50-round magazines which are inserted horizontally over the grip, the top of the gun swings forwards and away from the frame to facilitate reloading.  If you were looking to add a touch of retro-futuristic spice to your new life in the ruins of New England, this firearm just might become your best friend.",
     "variant_type": "gun",
@@ -135,12 +116,10 @@
     "color": "light_gray",
     "range": 3,
     "ammo": [ "57" ],
-    "skill": "pistol",
     "dispersion": 380,
     "durability": 8,
     "min_cycle_recoil": 81,
     "reload": 500,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -153,22 +132,14 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fnp90mag" ] } ],
     "melee_damage": { "bash": 6 }
   },
   {
     "id": "ruger_57",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Ruger-57 handgun" },
     "description": "Produced by the Ruger gun company, this full-sized pistol makes use of the 5.7x28mm cartridge.  One of the first pistols to both make use of the unusual round and achieve market success within the civilian world, it opened the door for accessible 5.7mm shooting due to its low price and reliable design.",
     "variant_type": "gun",
@@ -190,12 +161,10 @@
     "symbol": "(",
     "color": "light_gray",
     "ammo": [ "57" ],
-    "skill": "pistol",
     "ranged_damage": { "damage_type": "bullet", "amount": -2 },
     "dispersion": 400,
     "durability": 8,
     "min_cycle_recoil": 81,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -207,14 +176,6 @@
       [ "sights", 1 ],
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [
       {
@@ -243,7 +204,6 @@
     "barrel_length": "407 mm",
     "price": "1995 USD",
     "price_postapoc": "30 USD",
-    "skill": "rifle",
     "range": 6,
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
@@ -256,14 +216,6 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "stock accessory", 2 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fnp90mag" ] } ]
   }

--- a/data/json/items/gun/5x50.json
+++ b/data/json/items/gun/5x50.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "needlegun",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM216 needle SMG" },
     "description": "This odd-looking prototype submachine fires 5x50mm saboted flechette rounds which offer excellent ballistic performance with less recoil and about half the weight of a traditional round.  It was developed by Rivtech for the US military shortly before the end of the world.",
     "weight": "1302 g",
@@ -16,7 +16,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "5x50" ],
-    "skill": "smg",
     "range": 10,
     "ranged_damage": { "damage_type": "bullet", "amount": 10 },
     "dispersion": 220,
@@ -43,9 +42,9 @@
   },
   {
     "id": "needlepistol",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM232 needle pistol" },
     "description": "This lightweight machine pistol fires 5x50mm saboted flechette rounds which offer excellent ballistic performance with less recoil and about half the weight of a traditional round. It was developed by Rivtech for the US military shortly before the end of the world.",
     "weight": "682 g",
@@ -58,7 +57,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "5x50" ],
-    "skill": "pistol",
     "dispersion": 280,
     "durability": 9,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "2 rd.", 2 ], [ "AUTO", "auto", 4 ] ],

--- a/data/json/items/gun/66mm.json
+++ b/data/json/items/gun/66mm.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "m202_flash",
+    "copy-from": "launcher_base",
     "looks_like": "m79",
     "type": "GUN",
     "symbol": "(",
@@ -10,12 +11,10 @@
     "price": "29000 USD",
     "price_postapoc": "40 USD",
     "material": [ "steel" ],
-    "skill": "launcher",
     "ammo": [ "m235" ],
     "weight": "5220 g",
     "volume": "12120 ml",
     "longest_side": "693 mm",
-    "reload_noise_volume": 10,
     "to_hit": -3,
     "dispersion": 300,
     "durability": 7,
@@ -23,7 +22,7 @@
     "reload": 600,
     "loudness": 200,
     "valid_mod_locations": [ [ "grip", 1 ], [ "sling", 1 ] ],
-    "flags": [ "BACKBLAST", "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "BACKBLAST", "NEVER_JAMS" ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m74_clip" ] } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/762R.json
+++ b/data/json/items/gun/762R.json
@@ -51,7 +51,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "762R": 5 }, "allowed_speedloaders": [ "762R_clip" ] }
     ],
@@ -107,7 +107,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "762R": 5 }, "allowed_speedloaders": [ "762R_clip" ] }
     ],

--- a/data/json/items/gun/762x25.json
+++ b/data/json/items/gun/762x25.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "ppsh",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "PPSh-41 submachine gun" },
     "description": "The Soviet-made PPSh-41 is a mass-produced selective-fire submachine gun.  It has a relatively high rate of fire.",
     "variant_type": "gun",
@@ -25,7 +25,6 @@
     "symbol": "(",
     "color": "brown",
     "ammo": [ "762x25" ],
-    "skill": "smg",
     "range": 2,
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 120,
@@ -46,7 +45,6 @@
       [ "underbarrel", 1 ],
       [ "rail mount", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ppshmag", "ppshdrum" ] } ],
     "melee_damage": { "bash": 10 }
   },
@@ -78,7 +76,6 @@
     "dispersion": 225,
     "durability": 7,
     "min_cycle_recoil": 270,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "tokarevmag" ] } ],
     "melee_damage": { "bash": 10 }

--- a/data/json/items/gun/77mm_arisaka.json
+++ b/data/json/items/gun/77mm_arisaka.json
@@ -34,7 +34,7 @@
     "durability": 10,
     "blackpowder_tolerance": 24,
     "clip_size": 5,
-    "flags": [ "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NEVER_JAMS", "EASY_CLEAN", "NO_TURRET" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "bayonet lug", 1 ],

--- a/data/json/items/gun/84x246mm.json
+++ b/data/json/items/gun/84x246mm.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "m3_carlgustav",
+    "copy-from": "launcher_base",
     "looks_like": "m79",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "symbol": "(",
     "color": "green",
     "name": { "str": "M3 rocket launcher" },
@@ -11,9 +11,8 @@
     "price": "13000 USD",
     "price_postapoc": "60 USD",
     "material": [ "steel" ],
-    "flags": [ "RELOAD_ONE", "BACKBLAST", "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "BACKBLAST", "NEVER_JAMS" ],
     "//": "100m backblast.",
-    "skill": "launcher",
     "ammo": [ "84x246mm" ],
     "weight": "10 kg",
     "longest_side": "1065 mm",

--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "rm103a_pistol",
+    "copy-from": "pistol_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM103A pistol" },
     "//": "Rivtech don't come cheap.",
     "description": "Designed for style rather than practicality, the Rivtech RM103A is an impressive-looking pistol with less-than-impressive results.  Too short to properly utilize Rivtech's proprietary 8mm caseless ammunition, this status symbol is still a capable sidearm.  Accepts stick magazines.",
@@ -15,12 +15,10 @@
     "price_postapoc": "60 USD",
     "to_hit": -2,
     "material": [ "steel", "carbonfiber" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "8x40mm" ],
-    "skill": "pistol",
     "dispersion": 175,
     "durability": 9,
     "valid_mod_locations": [
@@ -33,14 +31,20 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "faults": [
+      "fault_gun_blackpowder",
+      "fault_gun_dirt",
+      "fault_fail_to_feed",
+      "fault_double_feed"
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
   {
     "id": "rm11b_sniper_rifle",
+    "copy-from": "rifle_auto",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM11B rifle" },
     "description": "Intended to function as a long-range sharpshooter support weapon for the military, the Rivtech RM11B scout rifle was designed for durability and accuracy under less than ideal circumstances.  Its bullpup layout, digital scope, and two round burst mode allow it to deliver precise long-range takedowns, utilizing the proprietary Rivtech 8mm caseless round.  Accepts stick magazines.",
     "weight": "3100 g",
@@ -55,7 +59,6 @@
     "color": "dark_gray",
     "ammo": [ "8x40mm" ],
     "//2": "Barrel length is estimated to be 24 inches.",
-    "skill": "rifle",
     "range": 20,
     "dispersion": 10,
     "durability": 9,
@@ -72,14 +75,20 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "faults": [
+      "fault_gun_blackpowder",
+      "fault_gun_dirt",
+      "fault_fail_to_feed",
+      "fault_double_feed"
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "rm2000_smg",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM2000 SMG" },
     "description": "Utilizing a powerful and unusual caliber, the Rivtech RM2000 submachine gun was designed for durability and ease of carrying under less than ideal circumstances.  Accepts stick magazines.",
     "weight": "1900 g",
@@ -94,7 +103,6 @@
     "color": "dark_gray",
     "ammo": [ "8x40mm" ],
     "//2": "Barrel length is estimated to be 9-inches.",
-    "skill": "smg",
     "dispersion": 120,
     "durability": 9,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
@@ -108,13 +116,19 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
+    "faults": [
+      "fault_gun_blackpowder",
+      "fault_gun_dirt",
+      "fault_fail_to_feed",
+      "fault_double_feed"
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_25_mag", "8x40_10_mag" ] } ],
     "melee_damage": { "bash": 11 }
   },
   {
     "id": "rm51_assault_rifle",
+    "copy-from": "rifle_auto",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "RM51 rifle" },
     "description": "Originally produced for military use, the Rivtech RM51 assault rifle was designed for durability and ease of use under less than ideal circumstances, with its considerable bulk minimized by a compact and ergonomic layout.  Accepts box magazines.",
     "weight": "2850 g",
@@ -128,7 +142,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "8x40mm" ],
-    "skill": "rifle",
     "dispersion": 50,
     "durability": 9,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
@@ -141,6 +154,12 @@
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
+    ],
+    "faults": [
+      "fault_gun_blackpowder",
+      "fault_gun_dirt",
+      "fault_fail_to_feed",
+      "fault_double_feed"
     ],
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_50_mag", "8x40_100_mag" ] } ],

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "calico",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Calico automatic carbine" },
     "description": "The Calico automatic carbine is a submachine gun with a unique circular magazine that allows for high capacities and reduced recoil.",
     "variant_type": "gun",
@@ -26,7 +26,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "smg",
     "range": 6,
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 280,
@@ -45,22 +44,14 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "calicomag", "calicomag_100rd" ] } ],
     "melee_damage": { "bash": 9 }
   },
   {
     "id": "cx4",
+    "copy-from": "rifle_semi",
     "looks_like": "modular_ar15",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "9x19mm pistol-caliber carbine" },
     "description": "Designed to be a companion rifle with provided M9 handguns, this compact and light weight pistol-caliber carbine makes use of the same 9x19mm magazines.  Originally intended for use by law enforcement units, this style of small caliber, semi-automatic carbine failed to achieve the same level of popularity as regular and more potent rifles.  However, despite being inadequate for their original purpose, before the Cataclysm these modestly sized weapons still found a home in sport shooting and self-defense civilian roles.",
     "variant_type": "gun",
@@ -82,7 +73,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "rifle",
     "range": 6,
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 180,
@@ -101,14 +91,6 @@
       [ "stock", 1 ],
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [
       {
@@ -150,7 +132,6 @@
     "durability": 6,
     "blackpowder_tolerance": 48,
     "min_cycle_recoil": 380,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -163,9 +144,9 @@
   },
   {
     "id": "hk_mp5",
+    "copy-from": "smg_base",
     "//": "Tileset whitelist for SMGs",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "H&K MP5A2 SMG" },
     "description": "The Heckler & Koch MP5 is one of the most widely-used submachine guns in the world, and has been adopted by special police forces and militaries alike.  Its high degree of accuracy and low recoil are universally praised.",
     "ascii_picture": "hk_mp5a2",
@@ -180,7 +161,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "smg",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 4,
     "dispersion": 240,
@@ -200,14 +180,6 @@
       [ "sling", 1 ],
       [ "stock", 1 ],
       [ "stock accessory", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [
       {
@@ -352,7 +324,6 @@
     "color": "dark_gray",
     "ammo": [ "9mm" ],
     "ranged_damage": { "damage_type": "bullet", "amount": -1 },
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "dispersion": 420,
     "durability": 8,
@@ -565,9 +536,9 @@
   },
   {
     "id": "ksub2000",
+    "copy-from": "rifle_semi",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Kel-Tec SUB-2000 carbine" },
     "description": "With its claim to fame being its ease of portability when compared to other conventional rifles and carbines, the Kel-Tec SUB-2000 is a uniquely-designed pistol caliber carbine sporting an integral folding mechanism and chambered for 9x19mm cartridges, making use of regular Glock compatible magazines.  With its mechanism engaged, the barrel assembly swings rearwards and causes the firearm to fold to half its regular length, packing up into a very compact package with ergonomics unfortunately having to take a backseat to allow for the weapon's extreme portability.  With a mainly polymer constructed receiver, the carbine is relatively light and incredibly transportable when fully folded.",
     "weight": "1930 g",
@@ -582,7 +553,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "rifle",
     "range": 6,
     "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 180,
@@ -599,14 +569,6 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "stock", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [
       {
@@ -653,7 +615,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -679,7 +640,6 @@
     "price_postapoc": "25 USD",
     "to_hit": -2,
     "material": [ "plastic", "steel" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "symbol": "(",
     "color": "dark_gray",
@@ -736,7 +696,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9mm": 1 } } ],
     "melee_damage": { "bash": 10 }
   },
@@ -782,9 +742,9 @@
   },
   {
     "id": "sten",
+    "copy-from": "smg_base",
     "looks_like": "hk_mp5",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "STEN Mk II SMG" },
     "description": "The standard issue 9mm submachine gun of the British military throughout most of the Second World War.  The STEN is aesthetically far from pretty.  Featuring an iconic side mounted magazine well and a design optimized for mass production using unskilled labor, the STEN was developed to make up for drastic supply shortages during the early days of the war.  Likely entering the US prior to the 1960s, either as a war time holdover or a museum purchase; you suppose that if you were to try and defend your nation, whatever the cost may be, and fight the undead 'on the beaches, fight on the landing grounds, fight in the fields and in the streets, fight in the hills; and never surrender', then it might be the time for the STEN to come back into frontline service.",
     "weight": "3200 g",
@@ -797,7 +757,6 @@
     "symbol": "[",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "smg",
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 2,
     "dispersion": 360,
@@ -815,15 +774,14 @@
       [ "sights mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "stenmag", "survivor9mm_mag" ] } ],
     "melee_damage": { "bash": 10 }
   },
   {
     "id": "tec9",
+    "copy-from": "smg_base",
     "looks_like": "glock_17",
     "type": "GUN",
-    "reload_noise_volume": 10,
     "name": { "str": "Intratec TEC-9 pistol" },
     "description": "The TEC-9 is a semi-automatic 'pistol' made of cheap polymers and machine stamped parts.  Its rise in popularity among criminals is largely due to its intimidating looks, low cost and relative ease of converting to fully automatic.",
     "weight": "1400 g",
@@ -837,7 +795,6 @@
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "skill": "smg",
     "dispersion": 520,
     "durability": 6,
     "min_cycle_recoil": 450,
@@ -853,7 +810,6 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -885,7 +841,6 @@
     "durability": 9,
     "blackpowder_tolerance": 48,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -973,7 +928,6 @@
     "durability": 6,
     "blackpowder_tolerance": 48,
     "min_cycle_recoil": 380,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "//2": "Glock 17s cannot load magazines shorter than the standard 17rd magazine.",
     "pocket_data": [
@@ -1038,7 +992,6 @@
     "price_postapoc": "30 USD",
     "to_hit": -2,
     "material": [ "plastic", "steel" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "color": "dark_gray",
     "ammo": [ "9mm" ],
@@ -1076,7 +1029,6 @@
     "dispersion": 480,
     "durability": 6,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -1122,7 +1074,6 @@
     "material": [ "steel", "aluminum", "plastic" ],
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "dispersion": 480,
     "durability": 8,
@@ -1152,7 +1103,6 @@
     "material": [ "plastic", "steel" ],
     "color": "dark_gray",
     "ammo": [ "9mm" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "dispersion": 480,
     "durability": 7,
@@ -1185,7 +1135,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       { "magazine_well": "191 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "bhp9mag_13rd", "bhp9mag_15rd" ] }
@@ -1212,7 +1161,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "228 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p38mag" ] } ],
     "melee_damage": { "bash": 8 }
@@ -1236,7 +1184,6 @@
     "dispersion": 480,
     "durability": 9,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -1266,7 +1213,6 @@
     "ammo": [ "9mm" ],
     "dispersion": 480,
     "durability": 7,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "min_cycle_recoil": 450,
     "pocket_data": [
@@ -1298,7 +1244,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [
       {
@@ -1329,7 +1274,6 @@
     "dispersion": 480,
     "durability": 8,
     "min_cycle_recoil": 450,
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "pocket_data": [ { "magazine_well": "176 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ccpmag", "ccpmag_9rd" ] } ],
     "melee_damage": { "bash": 8 }
@@ -1369,14 +1313,6 @@
       [ "underbarrel mount", 1 ],
       [ "sling", 1 ],
       [ "stock", 1 ]
-    ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
     ],
     "pocket_data": [
       {

--- a/data/json/items/gun/9x18.json
+++ b/data/json/items/gun/9x18.json
@@ -29,7 +29,6 @@
     "durability": 6,
     "min_cycle_recoil": 270,
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
-    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -81,7 +80,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "RELOAD_EJECT" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9x18": 1 } } ],
     "melee_damage": { "bash": 10 }
   }

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -11,7 +11,7 @@
     "price": "2595 USD",
     "price_postapoc": "15 USD",
     "material": [ "steel", "wood" ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "RELOAD_EJECT" ],
     "skill": "rifle",
     "ammo": [ "3006" ],
     "weight": "4200 g",

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -64,7 +64,7 @@
     "clip_size": 1,
     "reload": 2500,
     "valid_mod_locations": [ [ "grip mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
-    "flags": [ "NEVER_JAMS", "EASY_CLEAN" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "NEVER_JAMS", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 1 } } ],
     "melee_damage": { "bash": 5 }
   },
@@ -103,7 +103,7 @@
       [ "sights mount", 1 ],
       [ "stock mount", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "DURABLE_MELEE", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "DURABLE_MELEE", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 1 } } ],
     "melee_damage": { "bash": 15 }
   },

--- a/data/json/items/gun/nail.json
+++ b/data/json/items/gun/nail.json
@@ -25,11 +25,11 @@
     "valid_mod_locations": [ [ "grip mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "nail": 20 } } ],
     "melee_damage": { "bash": 6 },
-    "flags": [ "WONT_TRAIN_MARKSMANSHIP" ]
+    "flags": [ "ALLOWS_BODY_BLOCK", "WONT_TRAIN_MARKSMANSHIP" ]
   },
   {
     "id": "coilgun",
-    "copy-from": "gun_base",
+    "copy-from": "rifle_base",
     "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "coilgun" },
@@ -43,7 +43,6 @@
     "to_hit": -2,
     "material": [ "copper", "steel" ],
     "ammo": [ "nail" ],
-    "skill": "rifle",
     "range": 12,
     "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 180,
@@ -52,7 +51,7 @@
     "energy_drain": "2 kJ",
     "valid_mod_locations": [ [ "grip", 1 ], [ "sights", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "rail mount", 1 ], [ "underbarrel mount", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "nailmag" ] } ],
-    "flags": [ "USE_UPS" ],
+    "flags": [ "FIRE_TWOHAND", "USE_UPS" ],
     "melee_damage": { "bash": 10 }
   }
 ]

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -25,7 +25,7 @@
     "reload": 80,
     "valid_mod_locations": [  ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 1 } } ],
     "melee_damage": { "bash": 6 }
   },
@@ -88,7 +88,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "clip_size": 6,
-    "extend": { "flags": [ "RELOAD_ONE", "EASY_CLEAN" ] },
+    "extend": { "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "EASY_CLEAN" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ],
     "melee_damage": { "bash": 10 }
   },
@@ -368,7 +368,7 @@
     "relative": { "weight": "625 g", "volume": "360 ml", "price": "50 USD" },
     "barrel_volume": "720 ml",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
-    "extend": { "flags": [ "RELOAD_ONE" ] },
+    "extend": { "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 2 } } ]
   },
   {
@@ -393,7 +393,7 @@
     "barrel_volume": "360 ml",
     "barrel_length": "600 mm",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 1 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -538,7 +538,7 @@
     "reload": 200,
     "barrel_volume": "360 ml",
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
-    "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -610,7 +610,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "extend": { "flags": [ "RELOAD_ONE" ] },
+    "extend": { "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 2 } } ]
   },
   {
@@ -644,7 +644,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "RELOAD_EJECT", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 1 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -689,7 +689,7 @@
       [ "stock", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 12 } } ],
     "melee_damage": { "bash": 8 }
   },
@@ -731,7 +731,7 @@
       [ "sights", 1 ],
       [ "sling", 1 ]
     ],
-    "flags": [ "RELOAD_ONE" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 15 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -814,7 +814,7 @@
       [ "sights mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "RELOAD_ONE", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ],
     "melee_damage": { "bash": 8 }
   },
@@ -857,7 +857,7 @@
       [ "underbarrel", 1 ]
     ],
     "default_mods": [ "sword_bayonet" ],
-    "flags": [ "RELOAD_ONE" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ],
     "melee_damage": { "bash": 11 }
   },
@@ -910,7 +910,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "NO_TURRET", "RELOAD_ONE" ],
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET", "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 4 } } ]
   },
   {
@@ -969,7 +969,7 @@
     "reload": 600,
     "modes": [ [ "DEFAULT", "single", 1 ] ],
     "valid_mod_locations": [ [ "sling", 1 ], [ "sights mount", 1 ] ],
-    "flags": [ "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "EASY_CLEAN", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 1 } } ],
     "melee_damage": { "bash": 8 }
   },

--- a/data/json/items/gun/signal_flare.json
+++ b/data/json/items/gun/signal_flare.json
@@ -21,7 +21,7 @@
     "loudness": 40,
     "clip_size": 1,
     "valid_mod_locations": [ [ "grip", 1 ], [ "stock", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "underbarrel mount", 1 ] ],
-    "flags": [ "WATERPROOF_GUN", "NEVER_JAMS", "RELOAD_EJECT" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "WATERPROOF_GUN", "NEVER_JAMS", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "signal_flare": 1 } } ]
   }
 ]

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -38,7 +38,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "EMP" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 12 }
   },
@@ -67,7 +67,7 @@
     "reload": 0,
     "modes": [ [ "DEFAULT", "3 rd.", 3 ], [ "BURST", "5 rd.", 5 ], [ "AUTO", "high auto", 15 ] ],
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
-    "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
+    "flags": [ "FIRE_TWOHAND", "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
     "overheat_threshold": 200,
     "cooling_value": 2,
     "heat_per_shot": 6,
@@ -99,6 +99,7 @@
     "reload": 0,
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
     "flags": [
+      "FIRE_TWOHAND",
       "NO_UNLOAD",
       "NEVER_JAMS",
       "NO_UNWIELD",
@@ -155,7 +156,7 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "IGNITE" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 12 }
   },
@@ -177,7 +178,7 @@
     "to_hit": -2,
     "range": 40,
     "dispersion": 6,
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
     "valid_mod_locations": [
       [ "grip", 1 ],
       [ "rail", 1 ],
@@ -218,7 +219,7 @@
     "heat_per_shot": 6,
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "flags": [ "ALLOWS_BODY_BLOCCK", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 5 }
   },

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -219,7 +219,7 @@
     "heat_per_shot": 6,
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "ALLOWS_BODY_BLOCCK", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "flags": [ "ALLOWS_BODY_BLOCK", "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 5 }
   },


### PR DESCRIPTION
#### Summary
Category "Brief description"

This PR aims to fix some inconsistent behaviour, as well as add new behaviour to rifles/shotguns.

#### Purpose of change
Uh-
Worm wanted rifles to have fire_twohand flag, and ALL pistols and SMGs to have ALLOWS_BODY_BLOCK flags.
I added fire_twohand to shotguns as well since that made sense.

#### Describe the solution

Added the flags, reused inherited flags to make it more consistent and easier to do these changes in the future.
Added flags to the classes so they should be applied on a wider scope.

#### Describe alternatives you've considered

Hard coding the flags is a little bad as if you want to make a large sweep of changes into a item class it makes it take a long time longer to actually do that.
We also saw the problem that lead to this PR, being SW_610 acting like a handgun rather than a revolver because the flag "ALLOWS_BODY_BLOCK" was added without the rest of the revolver flags.

#### Testing

Game loads, Looking at the debug spawn menu, items seem to be much greater consistency in apply flags.

#### Additional context

This took me 7 hours
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
