### PR TITLE
Bokken saya, leather && plastic, and spawn points as well as recipe for leather sheath

### DIFF
--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -463,6 +463,80 @@
     ]
   },
   {
+    "id": "bokken_scabbard",
+    "type": "ARMOR",
+    "name": { "str": "bokken saya" },
+    "description": "A large, adjustable plastic sheath for holding a bokken.  Activate to sheathe/draw a weapon.",
+    "weight": "150 g",
+    "volume": "2000 ml",
+    "price": "60 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "plastic" ],
+    "symbol": "[",
+    "looks_like": "holster",
+    "color": "black",
+    "sided": true,
+    "material_thickness": 1,
+    "pocket_data": [
+      {
+        "magazine_well": "1800 ml",
+        "max_contains_volume": "2 L",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "100 cm",
+        "holster": true,
+        "moves": 30,
+        "item_restriction": [ "bokken" ]
+      }
+    ],
+    "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "encumbrance": [ 3, 4 ],
+        "coverage": 15,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_r", "leg_hip_l" ]
+      }
+    ]
+  },
+	{
+    "id": "bokken_scabbard_leather",
+    "type": "ARMOR",
+    "name": { "str": "leather bokken saya" },
+    "description": "A large, adjustable leather sheath for holding a bokken.  Activate to sheathe/draw a weapon.",
+    "weight": "150 g",
+    "volume": "2000 ml",
+    "price": "60 USD",
+    "price_postapoc": "5 USD",
+    "material": [ "leather", "wood" ],
+    "symbol": "[",
+    "looks_like": "holster",
+    "color": "brown",
+    "sided": true,
+    "material_thickness": 1,
+    "pocket_data": [
+      {
+        "magazine_well": "1800 ml",
+        "max_contains_volume": "2 L",
+        "max_contains_weight": "4 kg",
+        "max_item_length": "100 cm",
+        "holster": true,
+        "moves": 30,
+        "item_restriction": [ "bokken" ]
+      }
+    ],
+    "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "encumbrance": [ 3, 4 ],
+        "coverage": 15,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_r", "leg_hip_l" ]
+      }
+    ]
+  },
+  {
     "id": "sheath",
     "type": "ARMOR",
     "name": { "str": "sheath", "str_pl": "sheathes" },


### PR DESCRIPTION
#### Summary
adds the bokken saya and leather bokken saya, as well as making them spawn with bokkens rarely

#### Purpose of change
adds something that exists in real life and could be easily made by a survivor with some tailoring skill, as well as making it so it can be found. Balance-wise it adds an option other than a rope, belt loop, or baldric for carrying a bokken
#### Describe the solution
added the (plastic) bokken saya which spawns with the bokken rarely and also added a handmade leather bokken saya
#### Describe alternatives you've considered
Not much, I just asked WG if it's something I should PR and then here we are.
#### Testing
Once everything is written I will test on my PC on latest. 
#### Additional context
https://discord.com/channels/1341953719889170594/1396029875995017257
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
