### PR TITLE
Move weather animation to its own function and fix flicker

### DIFF
--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -31,12 +31,7 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_fail_to_feed",
-      "fault_double_feed"
-    ],
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -75,12 +70,7 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_fail_to_feed",
-      "fault_double_feed"
-    ],
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 10 }
   },
@@ -116,12 +106,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_fail_to_feed",
-      "fault_double_feed"
-    ],
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_25_mag", "8x40_10_mag" ] } ],
     "melee_damage": { "bash": 11 }
   },
@@ -155,12 +140,7 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_fail_to_feed",
-      "fault_double_feed"
-    ],
+    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_50_mag", "8x40_100_mag" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -67,7 +67,17 @@
     "reload": 0,
     "modes": [ [ "DEFAULT", "3 rd.", 3 ], [ "BURST", "5 rd.", 5 ], [ "AUTO", "high auto", 15 ] ],
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
-    "flags": [ "FIRE_TWOHAND", "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
+    "flags": [
+      "FIRE_TWOHAND",
+      "NO_UNLOAD",
+      "NEVER_JAMS",
+      "NO_UNWIELD",
+      "NO_SALVAGE",
+      "NO_REPAIR",
+      "UNBREAKABLE_MELEE",
+      "NON_FOULING",
+      "USE_UPS"
+    ],
     "overheat_threshold": 200,
     "cooling_value": 2,
     "heat_per_shot": 6,

--- a/src/game.h
+++ b/src/game.h
@@ -1275,6 +1275,10 @@ class game
         // called on map shifting
         void shift_destination_preview( const point &delta );
 
+        // Wrapper for animate_weather() that checks options and sets it all up.
+        void run_weather_animation();
+        void animate_weather();
+
         /** Passed to climbing-related functions (slip_down) to
         *   indicate the climbing action being attempted.
         */

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -284,6 +284,8 @@ input_context game::get_player_input( std::string &action )
         } );
         add_draw_callback( animation_cb );
 
+        ctxt.set_timeout( 125 );
+
         do {
             if( g->uquit == QUIT_EXIT ) {
                 break;
@@ -311,21 +313,19 @@ input_context game::get_player_input( std::string &action )
             }
 
             ui_manager::redraw_invalidated();
-        } while( handle_mouseview( ctxt, action ) && uquit != QUIT_WATCH
-                 && ( action != "TIMEOUT" || !current_turn.has_timeout_elapsed() ) );
+
+            if( handle_mouseview( ctxt, action ) ) {
+                run_weather_animation();
+            }
+
+        } while( action == "TIMEOUT" );
         ctxt.reset_timeout();
     } else {
-        ctxt.set_timeout( 125 );
-        while( handle_mouseview( ctxt, action ) ) {
-            if( action == "TIMEOUT" && current_turn.has_timeout_elapsed() ) {
-                break;
-            }
-        }
         ctxt.reset_timeout();
     }
-
     return ctxt;
 }
+
 
 
 static void rcdrive( const point &d )

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -246,235 +246,66 @@ input_context game::get_player_input( std::string &action )
     if( uquit == QUIT_WATCH ) {
         ctxt = input_context( "DEFAULTMODE", keyboard_mode::keycode );
         ctxt.set_iso( true );
-        // The list of allowed actions in death-cam mode in game::handle_action
-        // *INDENT-OFF*
         for( const action_id id : {
-            ACTION_TOGGLE_MAP_MEMORY,
-            ACTION_CENTER,
-            ACTION_SHIFT_N,
-            ACTION_SHIFT_NE,
-            ACTION_SHIFT_E,
-            ACTION_SHIFT_SE,
-            ACTION_SHIFT_S,
-            ACTION_SHIFT_SW,
-            ACTION_SHIFT_W,
-            ACTION_SHIFT_NW,
-            ACTION_LOOK,
-            ACTION_KEYBINDINGS,
-        } ) {
+                 ACTION_TOGGLE_MAP_MEMORY,
+                 ACTION_CENTER,
+                 ACTION_SHIFT_N,
+                 ACTION_SHIFT_NE,
+                 ACTION_SHIFT_E,
+                 ACTION_SHIFT_SE,
+                 ACTION_SHIFT_S,
+                 ACTION_SHIFT_SW,
+                 ACTION_SHIFT_W,
+                 ACTION_SHIFT_NW,
+                 ACTION_LOOK,
+                 ACTION_KEYBINDINGS,
+             } ) {
             ctxt.register_action( action_ident( id ) );
         }
-        // *INDENT-ON*
         ctxt.register_action( "QUIT", to_translation( "Accept your fate" ) );
     } else {
         ctxt = get_default_mode_input_context();
     }
 
     m.update_visibility_cache( u.posz() );
-    const visibility_variables &cache = m.get_visibility_variables_cache();
-    const level_cache &map_cache = m.get_cache_ref( u.posz() );
-    const auto &visibility_cache = map_cache.visibility_cache;
+
 #if defined(TILES)
-    // Mark cata_tiles draw caches as dirty
     tilecontext->set_draw_cache_dirty();
 #endif
 
     user_turn current_turn;
 
     if( get_option<bool>( "ANIMATIONS" ) ) {
-        const int TOTAL_VIEW = MAX_VIEW_DISTANCE * 2 + 1;
-        point iStart( ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_WIDTH - TOTAL_VIEW ) / 2 : 0,
-                      ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? ( TERRAIN_WINDOW_HEIGHT - TOTAL_VIEW ) / 2 :
-                      0 );
-        point iEnd( ( TERRAIN_WINDOW_WIDTH > TOTAL_VIEW ) ? TERRAIN_WINDOW_WIDTH -
-                    ( TERRAIN_WINDOW_WIDTH - TOTAL_VIEW ) /
-                    2 :
-                    TERRAIN_WINDOW_WIDTH, ( TERRAIN_WINDOW_HEIGHT > TOTAL_VIEW ) ? TERRAIN_WINDOW_HEIGHT -
-                    ( TERRAIN_WINDOW_HEIGHT - TOTAL_VIEW ) /
-                    2 : TERRAIN_WINDOW_HEIGHT );
-
-        if( fullscreen ) {
-            iStart.x = 0;
-            iStart.y = 0;
-            iEnd.x = TERMX;
-            iEnd.y = TERMY;
-        }
-
-        //x% of the Viewport, only shown on visible areas
-        const weather_animation_t weather_info = weather.weather_id->weather_animation;
-        point offset( u.view_offset.xy().raw() + point( -getmaxx( w_terrain ) / 2 + u.posx(),
-                      -getmaxy( w_terrain ) / 2 + u.posy() ) );
-
-#if defined(TILES)
-        if( g->is_tileset_isometric() ) {
-            iStart.x = 0;
-            iStart.y = 0;
-            iEnd.x = MAPSIZE_X;
-            iEnd.y = MAPSIZE_Y;
-            offset.x = 0;
-            offset.y = 0;
-        }
-#endif //TILES
-
-        // TODO: Move the weather calculations out of here.
-        const bool bWeatherEffect = weather_info.symbol != NULL_UNICODE;
-        const int dropCount = static_cast<int>( iEnd.x * iEnd.y * weather_info.factor );
-
-        weather_printable wPrint;
-        wPrint.colGlyph = weather_info.color;
-        wPrint.cGlyph = weather_info.symbol;
-        wPrint.wtype = weather.weather_id;
-        wPrint.vdrops.clear();
-
-        ctxt.set_timeout( 125 );
-
         shared_ptr_fast<game::draw_callback_t> animation_cb =
         make_shared_fast<game::draw_callback_t>( [&]() {
-            draw_weather( wPrint );
-
             if( uquit != QUIT_WATCH ) {
                 draw_sct();
             }
         } );
         add_draw_callback( animation_cb );
 
-        creature_tracker &creatures = get_creature_tracker();
         do {
             if( g->uquit == QUIT_EXIT ) {
                 break;
             }
 
-            if( bWeatherEffect && get_option<bool>( "ANIMATION_RAIN" ) ) {
-                invalidate_main_ui_adaptor();
-                wPrint.vdrops.clear();
-                wPrint.colGlyph = weather.weather_id->weather_animation.color;
-                wPrint.cGlyph = weather.weather_id->weather_animation.symbol;
-                wPrint.static_overlay = weather.weather_id->weather_animation.static_overlay;
-                wPrint.wtype = weather.weather_id;
-
-                const int width = iEnd.x + 1 - iStart.x;
-                const int height = iEnd.y + 1 - iStart.y;
-#if defined(TILES)
-                if( wPrint.static_overlay && use_tiles ) {
-                    const int max_x = width + iStart.x;
-                    const int max_y = height + iStart.y;
-
-                    for( int local_y = iStart.y; local_y <= max_y; ++local_y ) {
-                        for( int local_x = iStart.x; local_x <= max_x; ++local_x ) {
-                            const point screen_point( local_x, local_y );
-                            const point map_point = screen_point + offset;
-                            const tripoint mapp( map_point, u.posz() );
-
-                            if( !m.inbounds( mapp ) ) {
-                                continue;
-                            }
-
-                            // Cache visibility lookup results in local variables to avoid multiple map lookups
-                            const auto &vis_cache_row = visibility_cache[mapp.x];
-                            const visibility_type vis = m.get_visibility( vis_cache_row[mapp.y], cache );
-
-                            if( m.is_outside( u.pos() ) && vis != visibility_type::CLEAR ) {
-                                continue;  // While outside, everything we can see looks foggy.
-                            } else if( !m.is_outside( mapp ) || vis != visibility_type::CLEAR ) {
-                                continue;  // While inside, only draw fog outside where we can see.
-                            }
-
-                            wPrint.vdrops.emplace_back( screen_point.x, screen_point.y );
-                        }
-                    }
-                }
-#endif
-                if( !wPrint.static_overlay ) {
-                    // For rain: randomized drops, no duplicates
-                    const int grid_size = width * height;
-                    std::vector<bool> used( grid_size, false );
-                    auto get_index = [ = ]( int x, int y ) {
-                        return y * width + x;
-                    };
-                    int attempts = 0;
-                    while( static_cast<int>( wPrint.vdrops.size() ) < dropCount && attempts < dropCount * 5 ) {
-                        const int local_x = rng( 0, width - 1 );
-                        const int local_y = rng( 0, height - 1 );
-                        const int index = get_index( local_x, local_y );
-                        if( used[index] ) {
-                            ++attempts;
-                            continue;
-                        }
-
-                        const point screen_point = point( local_x + iStart.x, local_y + iStart.y );
-                        const point map_point = screen_point + offset;
-                        const tripoint mapp( map_point, u.posz() );
-
-                        if( m.inbounds( mapp ) &&
-                            m.is_outside( mapp ) &&
-                            m.get_visibility( visibility_cache[mapp.x][mapp.y], cache ) == visibility_type::CLEAR &&
-                            !creatures.creature_at( mapp, true ) ) {
-                            used[index] = true;
-                            wPrint.vdrops.emplace_back( screen_point.x, screen_point.y );
-                        }
-                        ++attempts;
-                    }
-                }
-            }
-            // don't bother calculating SCT if we won't show it
-            if( uquit != QUIT_WATCH && get_option<bool>( "ANIMATION_SCT" ) && !SCT.vSCT.empty() ) {
-                invalidate_main_ui_adaptor();
-
-                SCT.advanceAllSteps();
-
-                //Check for creatures on all drawing positions and offset if necessary
-                for( auto iter = SCT.vSCT.rbegin(); iter != SCT.vSCT.rend(); ++iter ) {
-                    const direction oCurDir = iter->getDirection();
-                    const int width = utf8_width( iter->getText() );
-                    for( int i = 0; i < width; ++i ) {
-                        tripoint tmp( iter->getPosX() + i, iter->getPosY(), get_map().get_abs_sub().z() );
-                        const Creature *critter = creatures.creature_at( tmp, true );
-
-                        if( critter != nullptr && u.sees( *critter ) ) {
-                            i = -1;
-                            int iPos = iter->getStep() + iter->getStepOffset();
-                            for( auto iter2 = iter; iter2 != SCT.vSCT.rend(); ++iter2 ) {
-                                if( iter2->getDirection() == oCurDir &&
-                                    iter2->getStep() + iter2->getStepOffset() <= iPos ) {
-                                    if( iter2->getType() == "hp" ) {
-                                        iter2->advanceStepOffset();
-                                    }
-
-                                    iter2->advanceStepOffset();
-                                    iPos = iter2->getStep() + iter2->getStepOffset();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if( pixel_minimap_option ) {
-                // TODO: more granular control to only redraw pixel minimap
-                invalidate_main_ui_adaptor();
-            }
-
-            std::unique_ptr<static_popup> deathcam_msg_popup;
             if( uquit == QUIT_WATCH ) {
-                deathcam_msg_popup = std::make_unique<static_popup>();
-                deathcam_msg_popup
-                ->wait_message( c_red, _( "Press %s to accept your fate…" ), ctxt.get_desc( "QUIT" ) )
+                static_popup deathcam_msg_popup;
+                deathcam_msg_popup.wait_message( c_red, _( "Press %s to accept your fate…" ),
+                                                 ctxt.get_desc( "QUIT" ) )
                 .on_top( true );
             }
 
-            // Remove asynchronous animations after animation delay if no input
             if( current_turn.async_anim_timeout() ) {
                 g->void_async_anim_curses();
 #if defined(TILES)
                 tilecontext->void_async_anim();
 #else
-                // Curses does not redraw itself so do it here
                 g->invalidate_main_ui_adaptor();
 #endif
             }
 
             if( g->has_blink_curses() && current_turn.blink_timeout() ) {
-                // Toggle blink phase and redraw
                 g->blink_active_phase = !g->blink_active_phase;
                 g->invalidate_main_ui_adaptor();
             }
@@ -495,6 +326,7 @@ input_context game::get_player_input( std::string &action )
 
     return ctxt;
 }
+
 
 static void rcdrive( const point &d )
 {


### PR DESCRIPTION
#### Summary
Move weather animation to its own function and fix flicker

#### Purpose of change
- Weather was being animated in handle_action, inside a ginormous function that was about waiting for player input. This meant it wouldn't animate except when the game was waiting for you to push a button.

#### Describe the solution
- Move it to its own function in game(), which is called both by draw() and during get_player_input, so it animates while idle but doesn't vanish while driving etc

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
