### PR TITLE
Backport 77805 - Ensure crushed characters are fetched from the correct location

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4774,7 +4774,7 @@ void map::batter( const tripoint_bub_ms &p, int power, int tries, const bool sil
 void map::crush( const tripoint_bub_ms &p )
 {
     creature_tracker &creatures = get_creature_tracker();
-    Character *crushed_player = creatures.creature_at<Character>( p );
+    Character *crushed_player = creatures.creature_at<Character>( this->getglobal( p ) );
 
     if( crushed_player != nullptr ) {
         bool player_inside = false;


### PR DESCRIPTION
#### Summary
Backport 77805 - Ensure crushed characters are fetched from the correct location

#### Purpose of change
Fixes some weird messaging about getting buried under rubble or falling off ledges despite being nowhere near them.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
