### PR TITLE
Add json flags to lever action for reloading

### DIFF
--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -500,7 +500,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 10, "38": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -544,7 +544,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 10, "38": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -588,7 +588,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 8, "38": 8 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -544,7 +544,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "357mag": 10, "38": 10 } } ],
     "melee_damage": { "bash": 12 }
   },

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -302,7 +302,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 8 } } ],
     "melee_damage": { "bash": 12 }
   },

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -74,7 +74,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 10 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -302,7 +302,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE" "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 8 } } ],
     "melee_damage": { "bash": 12 }
   },
@@ -346,7 +346,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "44": 10 } } ],
     "melee_damage": { "bash": 12 }
   }

--- a/data/json/items/gun/500.json
+++ b/data/json/items/gun/500.json
@@ -45,6 +45,7 @@
       [ "rail mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
+    "flags": [ "FIRE_TWOHAND", "RELOAD_ONE", "NO_TURRET" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "500": 7 } } ],
     "melee_damage": { "bash": 12 }
   },


### PR DESCRIPTION
#### Summary
Category "Lever Action Reload Flags"

#### Purpose of change

Make it more consistent between lever actions

#### Describe the solution

adds "RELOAD_ONE" flag to lever actions that were missing it.

#### Describe alternatives you've considered

#### Testing

Game runs, items now behave

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
