### PR TITLE
Scale character tiles by size

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2932,13 +2932,13 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
                 break;
             }
             // NPC
-if( string_starts_with( found_id, "npc_" ) ) {
-    if( npc *const guy = creatures.creature_at<npc>( pos ) ) {
-        seed = guy->getID().get_value();
-    }
+            if( string_starts_with( found_id, "npc_" ) ) {
+                if( npc *const guy = creatures.creature_at<npc>( pos ) ) {
+                    seed = guy->getID().get_value();
+                }
 
             }
-        }
+    }
 
     // make sure we aren't going to rotate the tile if it shouldn't be rotated
     if( !display_tile.rotates && !( category == TILE_CATEGORY::NONE )
@@ -3001,11 +3001,11 @@ if( string_starts_with( found_id, "npc_" ) ) {
 
     //draw it!
     if( newoffset != offset ) {
-    draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  nv_color_active, retract, height_3d, newoffset, scale_x, scale_y );
+        draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
+                      nv_color_active, retract, height_3d, newoffset, scale_x, scale_y );
     } else {
-    draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  nv_color_active, retract, height_3d, offset, scale_x, scale_y );
+        draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
+                      nv_color_active, retract, height_3d, offset, scale_x, scale_y );
     }
 
     return true;
@@ -3014,7 +3014,8 @@ if( string_starts_with( found_id, "npc_" ) ) {
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset, float scale_x, float scale_y )
+    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset, float scale_x,
+    float scale_y )
 {
     const std::vector<int> *picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -3089,8 +3090,10 @@ bool cata_tiles::draw_sprite_at(
                     tileset_ptr->get_tile_width() );
     destination.y = p.y + divide_round_down( ( tile_offset.y + offset.y - height_3d ) * tile_width,
                     tileset_ptr->get_tile_width() );
-destination.w = static_cast<int>( width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width() * scale_x );
-destination.h = static_cast<int>( height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height() * scale_y );
+    destination.w = static_cast<int>( width * tile_width * tile.pixelscale /
+                                      tileset_ptr->get_tile_width() * scale_x );
+    destination.h = static_cast<int>( height * tile_height * tile.pixelscale /
+                                      tileset_ptr->get_tile_height() * scale_y );
 
     if( rotate_sprite ) {
         if( rota == -1 ) {
@@ -4114,32 +4117,32 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         if( !you.sees( critter ) ) {
             if( you.sees_with_infrared( critter ) ||
                 you.sees_with_specials( critter ) ) {
-                            float scale_x = 1.0f;
-                            float scale_y = 1.0f;
-switch( critter.enum_size() ) {
+                const bool use_scaling = get_option<bool>( "CREATURE_TILE_SCALING" );
+
+                float scale_x = 1.0f;
+                float scale_y = 1.0f;
+                if( use_scaling ) {
+                    switch( critter.enum_size() ) {
                         case 1:
-                            scale_x = 0.4f;
-                            scale_y = 0.4f;
-                                                        add_msg( _( "tiny infra" ) );
+                            scale_x = 0.5f;
+                            scale_y = 0.5f;
                             break;
                         case 2:
                             scale_x = 0.6f;
                             scale_y = 0.6f;
-                                                        add_msg( _( "small infra" ) );
                             break;
                         case 4:
                             scale_x = 1.3f;
                             scale_y = 1.3f;
-                                                        add_msg( _( "large infra" ) );
                             break;
                         case 5:
-                            scale_x = 1.6f;
-                            scale_y = 1.6f;
-                            add_msg( _( "big infra boi detected" ) );
+                            scale_x = 1.5f;
+                            scale_y = 1.5f;
                             break;
                         default:
                             break;
-                        }
+                    }
+                }
                 return draw_from_id_string( "infrared_creature", TILE_CATEGORY::NONE, empty_string,
                                             p, 0, 0, lit_level::LIT, false, height_3d, scale_x, scale_y );
             }
@@ -4188,28 +4191,32 @@ switch( critter.enum_size() ) {
         }
         const Character *pl = dynamic_cast<const Character *>( &critter );
         if( pl != nullptr ) {
-                            float scale_x = 1.0f;
-                            float scale_y = 1.0f;
-            switch( pl->enum_size() ) {
-                        case 1:
-                            scale_x = 0.4f;
-                            scale_y = 0.4f;
-                            break;
-                        case 2:
-                            scale_x = 0.6f;
-                            scale_y = 0.6f;
-                            break;
-                        case 4:
-                            scale_x = 1.3f;
-                            scale_y = 1.3f;
-                            break;
-                        case 5:
-                            scale_x = 1.6f;
-                            scale_y = 1.6f;
-                            break;
-                        default:
-                            break;
-                        }
+            const bool use_scaling = get_option<bool>( "CREATURE_TILE_SCALING" );
+
+            float scale_x = 1.0f;
+            float scale_y = 1.0f;
+            if( use_scaling ) {
+                switch( pl->enum_size() ) {
+                    case 1:
+                        scale_x = 0.5f;
+                        scale_y = 0.5f;
+                        break;
+                    case 2:
+                        scale_x = 0.6f;
+                        scale_y = 0.6f;
+                        break;
+                    case 4:
+                        scale_x = 1.3f;
+                        scale_y = 1.3f;
+                        break;
+                    case 5:
+                        scale_x = 1.5f;
+                        scale_y = 1.5f;
+                        break;
+                    default:
+                        break;
+                }
+            }
             draw_entity_with_overlays( *pl, p, ll, height_3d, scale_x, scale_y );
             result = true;
             if( pl->is_avatar() ) {
@@ -4230,32 +4237,31 @@ switch( critter.enum_size() ) {
         if( sees_with_infrared || you.sees_with_specials( *pcritter ) ) {
             // try drawing infrared creature if invisible and not overridden
             // return directly without drawing overlay
-                            float scale_x = 1.0f;
-                            float scale_y = 1.0f;
-                    switch( pcritter->enum_size() ) {
-                        case 1:
-                            scale_x = 0.4f;
-                            scale_y = 0.4f;
-                                                        add_msg( _( "tiny infra" ) );
-                            break;
-                        case 2:
-                            scale_x = 0.6f;
-                            scale_y = 0.6f;
-                                                        add_msg( _( "small infra" ) );
-                            break;
-                        case 4:
-                            scale_x = 1.3f;
-                            scale_y = 1.3f;
-                                                        add_msg( _( "large infra" ) );
-                            break;
-                        case 5:
-                            scale_x = 1.6f;
-                            scale_y = 1.6f;
-                            add_msg( _( "big infra boi detected" ) );
-                            break;
-                        default:
-                            break;
-                        }
+            const bool use_scaling = get_option<bool>( "CREATURE_TILE_SCALING" );
+            float scale_x = 1.0f;
+            float scale_y = 1.0f;
+            if( use_scaling ) {
+                switch( pcritter->enum_size() ) {
+                    case 1:
+                        scale_x = 0.5f;
+                        scale_y = 0.5f;
+                        break;
+                    case 2:
+                        scale_x = 0.6f;
+                        scale_y = 0.6f;
+                        break;
+                    case 4:
+                        scale_x = 1.3f;
+                        scale_y = 1.3f;
+                        break;
+                    case 5:
+                        scale_x = 1.5f;
+                        scale_y = 1.5f;
+                        break;
+                    default:
+                        break;
+                }
+            }
             return draw_from_id_string( "infrared_creature", TILE_CATEGORY::NONE, empty_string, p,
                                         0, 0, lit_level::LIT, false, height_3d, scale_x, scale_y );
         } else {
@@ -4303,7 +4309,8 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() && you.sees( critter ) ) {
+                             0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() &&
+        you.sees( critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2257,16 +2257,16 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
                                       bool apply_night_vision_goggles, int &height_3d, int intensity )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, intensity, "", point() );
+            ll, -1, apply_night_vision_goggles, height_3d, intensity, "", point(), 1.0f, 1.0f );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d )
+                                      bool apply_night_vision_goggles, int &height_3d, float scale_x, float scale_y )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, 0, "", point() );
+            ll, -1, apply_night_vision_goggles, height_3d, 0, "", point(), scale_x, scale_y );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
@@ -2277,7 +2277,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
             ll, -1, apply_night_vision_goggles, height_3d, intensity_level,
-            variant, point() );
+            variant, point(), 1.0f, 1.0f );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
@@ -2289,7 +2289,7 @@ bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY categ
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
             ll, -1, apply_night_vision_goggles, height_3d, intensity_level,
-            variant, offset );
+            variant, offset, 1.0f, 1.0f );
 }
 bool cata_tiles::draw_from_id_string_internal( const std::string &id, const tripoint &pos,
         int subtile,
@@ -2298,7 +2298,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, const trip
 {
     return cata_tiles::draw_from_id_string_internal( id, TILE_CATEGORY::NONE, empty_string, pos,
             subtile,
-            rota, ll, retract, apply_night_vision_goggles, height_3d, 0, "", point() );
+            rota, ll, retract, apply_night_vision_goggles, height_3d, 0, "", point(), 1.0f, 1.0f );
 }
 
 std::optional<tile_lookup_res>
@@ -2535,7 +2535,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         int subtile, int rota, lit_level ll, int retract,
         bool apply_night_vision_goggles, int &height_3d,
         int intensity_level, const std::string &variant,
-        const point &offset )
+        const point &offset, float scale_x, float scale_y )
 {
     bool nv_color_active = apply_night_vision_goggles && get_option<bool>( "NV_GREEN_TOGGLE" );
     // If the ID string does not produce a drawable tile
@@ -2593,7 +2593,31 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             tt = &res -> tile();
         }
     }
-
+    point newoffset = offset;
+    if( scale_x == 0.4f ) {
+        newoffset.x += scale_x * 26;
+    }
+    if( scale_y == 0.4f ) {
+        newoffset.y += scale_y * 46;
+    }
+    if( scale_x == 0.6f ) {
+        newoffset.x += scale_x * 12;
+    }
+    if( scale_y == 0.6f ) {
+        newoffset.y += scale_y * 20;
+    }
+    if( scale_x == 1.3f ) {
+        newoffset.x -= scale_x * 4;
+    }
+    if( scale_y == 1.3f ) {
+        newoffset.y -= scale_y * 8;
+    }
+    if( scale_x == 1.6f ) {
+        newoffset.x -= scale_x * 6;
+    }
+    if( scale_y == 1.6f ) {
+        newoffset.y -= 1 + scale_y * 12;
+    }
     map &here = get_map();
     const std::string &found_id = res ? res->id() : id;
 
@@ -2823,7 +2847,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             // append subtile name to tile and re-find display_tile
             return draw_from_id_string_internal(
                        found_id + "_" + multitile_keys[subtile], category, subcategory, pos, -1, rota, ll,
-                       retract, nv_color_active, height_3d, 0, "", point() );
+                       retract, nv_color_active, height_3d, 0, "", point(), 1.0f, 1.0f );
         }
     }
 
@@ -2908,13 +2932,13 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
                 break;
             }
             // NPC
-            if( string_starts_with( found_id, "npc_" ) ) {
-                if( npc *const guy = creatures.creature_at<npc>( pos ) ) {
-                    seed = guy->getID().get_value();
-                    break;
-                }
-            }
+if( string_starts_with( found_id, "npc_" ) ) {
+    if( npc *const guy = creatures.creature_at<npc>( pos ) ) {
+        seed = guy->getID().get_value();
     }
+
+            }
+        }
 
     // make sure we aren't going to rotate the tile if it shouldn't be rotated
     if( !display_tile.rotates && !( category == TILE_CATEGORY::NONE )
@@ -2976,8 +3000,13 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
     }
 
     //draw it!
+    if( newoffset != offset ) {
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  nv_color_active, retract, height_3d, offset );
+                  nv_color_active, retract, height_3d, newoffset, scale_x, scale_y );
+    } else {
+    draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
+                  nv_color_active, retract, height_3d, offset, scale_x, scale_y );
+    }
 
     return true;
 }
@@ -2985,7 +3014,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset )
+    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset, float scale_x, float scale_y )
 {
     const std::vector<int> *picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -3054,13 +3083,14 @@ bool cata_tiles::draw_sprite_at(
                                    + ( ( tile.offset_retracted - tile.offset ) * retract ) / 100
                                  );
     SDL_Rect destination;
+
     // Using divide_round_down because the offset might be negative.
     destination.x = p.x + divide_round_down( ( tile_offset.x + offset.x ) * tile_width,
                     tileset_ptr->get_tile_width() );
     destination.y = p.y + divide_round_down( ( tile_offset.y + offset.y - height_3d ) * tile_width,
                     tileset_ptr->get_tile_width() );
-    destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
-    destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
+destination.w = static_cast<int>( width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width() * scale_x );
+destination.h = static_cast<int>( height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height() * scale_y );
 
     if( rotate_sprite ) {
         if( rota == -1 ) {
@@ -3142,13 +3172,13 @@ bool cata_tiles::draw_sprite_at(
 bool cata_tiles::draw_tile_at(
     const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
     lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
-    const point &offset )
+    const point &offset, float scale_x, float scale_y )
 {
     int fake_int = height_3d;
     draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, ll,
-                    apply_night_vision_goggles, retract, fake_int, offset );
+                    apply_night_vision_goggles, retract, fake_int, offset, scale_x, scale_y );
     draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, ll,
-                    apply_night_vision_goggles, retract, height_3d, offset );
+                    apply_night_vision_goggles, retract, height_3d, offset, scale_x, scale_y );
     return true;
 }
 
@@ -3188,7 +3218,7 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
 
     // lighting is never rotated, though, could possibly add in random rotation?
     draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos, 0, 0,
-                         lit_level::LIT, false, height_3d );
+                         lit_level::LIT, false, height_3d, 1.0f, 1.0f );
 
     return true;
 }
@@ -3360,7 +3390,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             return memorize_only
                    ? false
                    : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3389,7 +3419,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             return memorize_only
                    ? false
                    : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3399,7 +3429,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
                    ? false
                    : draw_from_id_string(
                        mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
-                       mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
@@ -3451,7 +3481,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             return memorize_only
                    ? false
                    : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3490,7 +3520,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             return memorize_only
                    ? false
                    : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3500,7 +3530,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
                    ? false
                    : draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
-                       mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
@@ -3544,7 +3574,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             return memorize_only
                    ? false
                    : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     if( overridden || ( !invisible[0] && neighborhood_overridden &&
@@ -3576,7 +3606,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             return memorize_only
                    ? false
                    : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3586,7 +3616,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
                    ? false
                    : draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(), mt.get_dec_rotation(),
-                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
@@ -3606,7 +3636,7 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
         return memorize_only
                ? false
                : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
-                                      0, ll, nv_goggles_activated, height_3d );
+                                      0, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
     }
     return false;
 }
@@ -3630,7 +3660,7 @@ bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &heig
                              to_upper_case( string_replace( remove_punctuations( here.graffiti_at( p ) ), " ",
                                             "_" ) ).substr( 0, 32 );
     return draw_from_id_string( tileset_ptr->find_tile_type( tile ) ? tile : "graffiti",
-                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, false, height_3d );
+                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, false, height_3d, 1.0f, 1.0f );
 }
 
 bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int &height_3d,
@@ -3977,7 +4007,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             const bool ret = memorize_only
                              ? false
                              : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
-                                                    rotation, lit_level::LIT, false, height_3d_temp );
+                                                    rotation, lit_level::LIT, false, height_3d_temp, 1.0f, 1.0f );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p, height_3d_temp );
             }
@@ -4074,7 +4104,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         const std::string &ent_subcategory = id.obj().species.empty() ?
                                              empty_string : id.obj().species.begin()->str();
         result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p,
-                                      corner, 0, lit_level::LIT, false, height_3d );
+                                      corner, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
     } else if( !invisible[0] || always_visible ) {
         if( pcritter == nullptr ) {
             return false;
@@ -4084,8 +4114,34 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         if( !you.sees( critter ) ) {
             if( you.sees_with_infrared( critter ) ||
                 you.sees_with_specials( critter ) ) {
+                            float scale_x = 1.0f;
+                            float scale_y = 1.0f;
+switch( critter.enum_size() ) {
+                        case 1:
+                            scale_x = 0.4f;
+                            scale_y = 0.4f;
+                                                        add_msg( _( "tiny infra" ) );
+                            break;
+                        case 2:
+                            scale_x = 0.6f;
+                            scale_y = 0.6f;
+                                                        add_msg( _( "small infra" ) );
+                            break;
+                        case 4:
+                            scale_x = 1.3f;
+                            scale_y = 1.3f;
+                                                        add_msg( _( "large infra" ) );
+                            break;
+                        case 5:
+                            scale_x = 1.6f;
+                            scale_y = 1.6f;
+                            add_msg( _( "big infra boi detected" ) );
+                            break;
+                        default:
+                            break;
+                        }
                 return draw_from_id_string( "infrared_creature", TILE_CATEGORY::NONE, empty_string,
-                                            p, 0, 0, lit_level::LIT, false, height_3d );
+                                            p, 0, 0, lit_level::LIT, false, height_3d, scale_x, scale_y );
             }
             return false;
         }
@@ -4114,7 +4170,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                 if( m->has_effect( effect_ridden ) ) {
                     int pl_under_height = 6;
                     if( m->mounted_player ) {
-                        draw_entity_with_overlays( *m->mounted_player, p, ll, pl_under_height );
+                        draw_entity_with_overlays( *m->mounted_player, p, ll, pl_under_height, 1.0f, 1.0f );
                     }
                     const std::string prefix = "rid_";
                     std::string copy_id = chosen_id;
@@ -4125,14 +4181,36 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                     }
                 }
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
-                                              subtile, rot_facing, ll, false, height_3d );
+                                              subtile, rot_facing, ll, false, height_3d, 1.0f, 1.0f );
                 sees_player = m->sees( you );
                 attitude = m->attitude_to( you );
             }
         }
         const Character *pl = dynamic_cast<const Character *>( &critter );
         if( pl != nullptr ) {
-            draw_entity_with_overlays( *pl, p, ll, height_3d );
+                            float scale_x = 1.0f;
+                            float scale_y = 1.0f;
+            switch( pl->enum_size() ) {
+                        case 1:
+                            scale_x = 0.4f;
+                            scale_y = 0.4f;
+                            break;
+                        case 2:
+                            scale_x = 0.6f;
+                            scale_y = 0.6f;
+                            break;
+                        case 4:
+                            scale_x = 1.3f;
+                            scale_y = 1.3f;
+                            break;
+                        case 5:
+                            scale_x = 1.6f;
+                            scale_y = 1.6f;
+                            break;
+                        default:
+                            break;
+                        }
+            draw_entity_with_overlays( *pl, p, ll, height_3d, scale_x, scale_y );
             result = true;
             if( pl->is_avatar() ) {
                 is_player = true;
@@ -4152,8 +4230,34 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         if( sees_with_infrared || you.sees_with_specials( *pcritter ) ) {
             // try drawing infrared creature if invisible and not overridden
             // return directly without drawing overlay
+                            float scale_x = 1.0f;
+                            float scale_y = 1.0f;
+                    switch( pcritter->enum_size() ) {
+                        case 1:
+                            scale_x = 0.4f;
+                            scale_y = 0.4f;
+                                                        add_msg( _( "tiny infra" ) );
+                            break;
+                        case 2:
+                            scale_x = 0.6f;
+                            scale_y = 0.6f;
+                                                        add_msg( _( "small infra" ) );
+                            break;
+                        case 4:
+                            scale_x = 1.3f;
+                            scale_y = 1.3f;
+                                                        add_msg( _( "large infra" ) );
+                            break;
+                        case 5:
+                            scale_x = 1.6f;
+                            scale_y = 1.6f;
+                            add_msg( _( "big infra boi detected" ) );
+                            break;
+                        default:
+                            break;
+                        }
             return draw_from_id_string( "infrared_creature", TILE_CATEGORY::NONE, empty_string, p,
-                                        0, 0, lit_level::LIT, false, height_3d );
+                                        0, 0, lit_level::LIT, false, height_3d, scale_x, scale_y );
         } else {
             return false;
         }
@@ -4166,7 +4270,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         }
         if( tileset_ptr->find_tile_type( draw_id ) ) {
             draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
-                                 lit_level::LIT, false, height_3d );
+                                 lit_level::LIT, false, height_3d, 1.0f, 1.0f );
         }
     }
     return result;
@@ -4199,7 +4303,7 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.pos_bub().z() && you.sees( critter ) ) {
+                             0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() && you.sees( critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;
@@ -4231,7 +4335,7 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
             }
             if( tileset_ptr->find_tile_type( draw_id ) ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
-                                     lit_level::LIT, false, height_3d );
+                                     lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             }
         }
         return true;
@@ -4264,7 +4368,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
 
         if( option && !option->get_mark().empty() ) {
             return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p,
-                                        0, 0, ll, nv_goggles_activated, height_3d );
+                                        0, 0, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
 
@@ -4285,7 +4389,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, TILE_CATEGORY::NONE,
-                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d );
+                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             }
         }
     }
@@ -4341,7 +4445,7 @@ void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int
 }
 
 void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
-        int &height_3d )
+        int &height_3d, float scale_x, float scale_y )
 {
     std::vector<trait_id> override_look_muts = ch.get_mutations( true,
     false, []( const mutation_branch & mut ) {
@@ -4361,10 +4465,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
         // depending on the toggle flip sprite left or right
         if( ch.facing == FacingDirection::RIGHT ) {
             draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, 0, ll, false,
-                                 height_3d );
+                                 height_3d, scale_x, scale_y );
         } else if( ch.facing == FacingDirection::LEFT ) {
             draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, -1, ll, false,
-                                 height_3d );
+                                 height_3d, scale_x, scale_y );
         }
     } else {
         mutation_branch::OverrideLook override_look = override_look_muts.at(
@@ -4378,10 +4482,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
         }
         if( ch.facing == FacingDirection::RIGHT ) {
             draw_from_id_string( override_look.id, category, "", p, corner, 0, ll, false,
-                                 height_3d );
+                                 height_3d, scale_x, scale_y );
         } else if( ch.facing == FacingDirection::LEFT ) {
             draw_from_id_string( override_look.id, category, "", p, corner, -1, ll, false,
-                                 height_3d );
+                                 height_3d, scale_x, scale_y );
         }
     }
 
@@ -4394,10 +4498,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
             int overlay_height_3d = prev_height_3d;
             if( ch.facing == FacingDirection::RIGHT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ 0, ll,
-                                     false, overlay_height_3d );
+                                     false, overlay_height_3d, scale_x, scale_y );
             } else if( ch.facing == FacingDirection::LEFT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ -1, ll,
-                                     false, overlay_height_3d );
+                                     false, overlay_height_3d, scale_x, scale_y );
             }
             // the tallest height-having overlay is the one that counts
             height_3d = std::max( height_3d, overlay_height_3d );
@@ -4408,7 +4512,7 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
 bool cata_tiles::draw_item_highlight( const tripoint &pos, int &height_3d )
 {
     return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos, 0, 0,
-                                lit_level::LIT, false, height_3d );
+                                lit_level::LIT, false, height_3d, 1.0f, 1.0f );
 }
 
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2594,8 +2594,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         }
     }
     point newoffset = offset;
-    newoffset.x += 16 * (1 - scale_x);
-    newoffset.y += 32 * (1 - scale_y);
+    newoffset.x += 16 * ( 1 - scale_x );
+    newoffset.y += 32 * ( 1 - scale_y );
     map &here = get_map();
     const std::string &found_id = res ? res->id() : id;
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2594,30 +2594,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         }
     }
     point newoffset = offset;
-    if( scale_x == 0.4f ) {
-        newoffset.x += scale_x * 26;
-    }
-    if( scale_y == 0.4f ) {
-        newoffset.y += scale_y * 46;
-    }
-    if( scale_x == 0.6f ) {
-        newoffset.x += scale_x * 12;
-    }
-    if( scale_y == 0.6f ) {
-        newoffset.y += scale_y * 20;
-    }
-    if( scale_x == 1.3f ) {
-        newoffset.x -= scale_x * 4;
-    }
-    if( scale_y == 1.3f ) {
-        newoffset.y -= scale_y * 8;
-    }
-    if( scale_x == 1.6f ) {
-        newoffset.x -= scale_x * 6;
-    }
-    if( scale_y == 1.6f ) {
-        newoffset.y -= 1 + scale_y * 12;
-    }
+    newoffset.x += 16 * (1 - scale_x);
+    newoffset.y += 32 * (1 - scale_y);
     map &here = get_map();
     const std::string &found_id = res ? res->id() : id;
 
@@ -4128,8 +4106,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                             scale_y = 0.5f;
                             break;
                         case 2:
-                            scale_x = 0.6f;
-                            scale_y = 0.6f;
+                            scale_x = 0.75f;
+                            scale_y = 0.75f;
                             break;
                         case 4:
                             scale_x = 1.3f;
@@ -4202,8 +4180,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                         scale_y = 0.5f;
                         break;
                     case 2:
-                        scale_x = 0.6f;
-                        scale_y = 0.6f;
+                        scale_x = 0.75f;
+                        scale_y = 0.75f;
                         break;
                     case 4:
                         scale_x = 1.3f;
@@ -4247,8 +4225,8 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                         scale_y = 0.5f;
                         break;
                     case 2:
-                        scale_x = 0.6f;
-                        scale_y = 0.6f;
+                        scale_x = 0.75f;
+                        scale_y = 0.75f;
                         break;
                     case 4:
                         scale_x = 1.3f;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -492,7 +492,7 @@ class cata_tiles
                                   bool apply_night_vision_goggles, int &height_3d );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, float scale_x, float scale_y );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint &pos, int subtile, int rota,
                                   lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level );
@@ -510,14 +510,16 @@ class cata_tiles
         bool draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
                                            const std::string &subcategory, const tripoint &pos, int subtile, int rota,
                                            lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
-                                           const std::string &variant, const point &offset );
+                                           const std::string &variant, const point &offset, float scale_x, float scale_y );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset );
+            bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset,
+    float scale_x, float scale_y );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
                            lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
-                           const point &offset );
+                           const point &offset,
+    float scale_x, float scale_y  );
 
         /* Tile Picking */
         void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,
@@ -589,7 +591,7 @@ class cata_tiles
                                              const std::array<bool, 5> &invisible, bool memorize_only );
         void draw_zlevel_overlay( const tripoint &p, lit_level ll, int &height_3d );
         void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
-                                        int &height_3d );
+                                        int &height_3d, float scale_x, float scale_y );
 
         bool draw_item_highlight( const tripoint &pos, int &height_3d );
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -515,11 +515,11 @@ class cata_tiles
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
             bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset,
-    float scale_x, float scale_y );
+            float scale_x, float scale_y );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
                            lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
                            const point &offset,
-    float scale_x, float scale_y  );
+                           float scale_x, float scale_y );
 
         /* Tile Picking */
         void get_tile_values( int t, const std::array<int, 4> &tn, int &subtile, int &rotation,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3825,7 +3825,8 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
 
-            } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "CREATURE_TILE_SCALING" || iter.first == "DISTANT_TILES" ||
+            } else if( iter.first == "TILES" || iter.first == "USE_TILES" ||
+                       iter.first == "CREATURE_TILE_SCALING" || iter.first == "DISTANT_TILES" ||
                        iter.first == "USE_DISTANT_TILES" || iter.first == "OVERMAP_TILES" ) {
                 used_tiles_changed = true;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2266,7 +2266,6 @@ void options_manager::add_options_graphics()
              to_translation( "If true, shows an ASCII graphic on the title screen.  If false, shows a text-only title screen." ),
              true
            );
-
         add( "SEASONAL_TITLE", page_id, to_translation( "Use seasonal title screen" ),
              to_translation( "If true, the title screen will use the art appropriate for the season." ),
              true
@@ -2377,7 +2376,11 @@ void options_manager::add_options_graphics()
              to_translation( "If true, replaces some TTF rendered text with tiles." ),
              true, COPT_CURSES_HIDE
            );
-
+        add( "CREATURE_TILE_SCALING", page_id,
+             to_translation( "Creature tile scaling" ),
+             to_translation( "If true, scales characters and certain graphics (e.g. infrared creature indicators) by creature size." ),
+             true, COPT_CURSES_HIDE
+           );
         add( "TILES", page_id, to_translation( "Choose tileset" ),
              to_translation( "Choose the tileset you want to use." ),
              build_tilesets_list(), "MshockXottoplus", COPT_CURSES_HIDE
@@ -2399,6 +2402,7 @@ void options_manager::add_options_graphics()
            ); // populate the options dynamically
 
         get_option( "TILES" ).setPrerequisite( "USE_TILES" );
+        get_option( "CREATURE_TILE_SCALING" ).setPrerequisite( "USE_TILES" );
         get_option( "USE_DISTANT_TILES" ).setPrerequisite( "USE_TILES" );
         get_option( "DISTANT_TILES" ).setPrerequisite( "USE_DISTANT_TILES" );
         get_option( "SWAP_ZOOM" ).setPrerequisite( "USE_DISTANT_TILES" );
@@ -3821,7 +3825,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                 || iter.first == "PIXEL_MINIMAP_SCALE_TO_FIT" ) {
                 pixel_minimap_changed = true;
 
-            } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "DISTANT_TILES" ||
+            } else if( iter.first == "TILES" || iter.first == "USE_TILES" || iter.first == "CREATURE_TILE_SCALING" || iter.first == "DISTANT_TILES" ||
                        iter.first == "USE_DISTANT_TILES" || iter.first == "OVERMAP_TILES" ) {
                 used_tiles_changed = true;
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -968,7 +968,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             // light level is now used for choosing between grayscale filter and normal lit tiles.
             draw_from_id_string( id, category,
                                  category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
-                                 omp.raw(), subtile, rotation, ll, false, height_3d );
+                                 omp.raw(), subtile, rotation, ll, false, height_3d, 1.0f, 1.0f );
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),
                                      0, 0, ll, false );
@@ -1106,12 +1106,12 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         if( guy_loc.z() == center_pos.z() && ( has_debug_vision ||
                                                overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) ) {
             draw_entity_with_overlays( *guy, global_omt_to_draw_position( guy_loc ), lit_level::LIT,
-                                       height_3d );
+                                       height_3d, 1.0f, 1.0f );
         }
     }
 
     draw_entity_with_overlays( get_player_character(), global_omt_to_draw_position( avatar_pos ),
-                               lit_level::LIT, height_3d );
+                               lit_level::LIT, height_3d, 1.0f, 1.0f );
     if( !fast_traveling ) {
         draw_from_id_string( "cursor", global_omt_to_draw_position( center_pos ), 0, 0, lit_level::LIT,
                              false );


### PR DESCRIPTION
#### Summary
Scale character tiles by size

#### Purpose of change
- You can be the size of a hulk or the size of a toddler in this game, but your tile is always adult human sized. No more!
- Dynamically scaling sizes makes stuff like infrared easier.
- It will probably be broadly useful to be able to dynamically scale other kinds of things too.

#### Describe the solution
- enum_size() characters in one of the nine fucking overloads that tiles are drawn from and use that to give them x/y scaling
- Do the same for infrared tiles.

#### Testing
- Seems to work for all cases I can think of. There are a few tiles in MSX that need fixing. Functionality is iffy outside of MSX, but that's why the option exists.
- A few tiles in MSX (long horns, rabbit ears, maybe one or two others) aren't properly aligned on the 32x32 png and wind up incorrectly offset. This is a tileset fix.
- Hit markers temporarily render a nude medium sized version of yourself with no mutations. Can we get rid of that?

#### Additional context
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f498b3c5-afd3-4a6f-bd6b-bed694983432" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f9572a5b-050c-49bb-bce2-57759d001c8e" />
Note: The final version scales characters slightly less dramatically, these screens are from testing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
