### PR TITLE
Fix minor rotation error

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7212,7 +7212,7 @@ void map::rotate( int turns )
                 old.y() += SEEY;
             }
             const point_bub_ms new_pos( old.raw().rotate( turns, {SEEX * 2, SEEY * 2} ) );
-            queued_points[queued_point.first] = tripoint_abs_ms( getabs( tripoint_bub_ms( new_pos,
+            queued_points[queued_point.first] = tripoint_abs_ms( getglobal( tripoint_bub_ms( new_pos,
                                                 queued_point.second.z() ) ) );
         }
     }


### PR DESCRIPTION
#### Summary
Fix minor rotation error

#### Purpose of change
We don't have the getabs function yet, it's still overloaded in getglobal, but a backport was trying to call it.

#### Testing
Compiles, runs. Mi-go map looks fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
