### PR TITLE
Cap animal birth

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -116,7 +116,7 @@
     "color": "dark_gray",
     "stomach_size": 30,
     "special_attacks": [ [ "EAT_CARRION", 40 ], [ "EAT_FOOD", 120 ] ],
-    "reproduction": { "baby_egg": "egg_crow", "baby_count": 4, "baby_timer": 18 },
+    "reproduction": { "baby_egg": "egg_crow", "baby_count": 3, "baby_timer": 18 },
     "extend": { "flags": [ "EATS" ] }
   },
   {
@@ -130,7 +130,7 @@
     "color": "dark_gray",
     "stomach_size": 50,
     "special_attacks": [ [ "EAT_CARRION", 40 ], [ "EAT_FOOD", 120 ] ],
-    "reproduction": { "baby_egg": "egg_raven", "baby_count": 5, "baby_timer": 18 },
+    "reproduction": { "baby_egg": "egg_raven", "baby_count": 4, "baby_timer": 18 },
     "extend": { "flags": [ "EATS" ] }
   },
   {
@@ -142,7 +142,7 @@
     "volume": "120 ml",
     "weight": "90 g",
     "color": "light_blue",
-    "reproduction": { "baby_egg": "egg_bluejay", "baby_count": 5, "baby_timer": 18 }
+    "reproduction": { "baby_egg": "egg_bluejay", "baby_count": 3, "baby_timer": 18 }
   },
   {
     "id": "mon_cardinal",
@@ -164,7 +164,7 @@
     "volume": "103 ml",
     "weight": "77 g",
     "color": "brown",
-    "reproduction": { "baby_egg": "egg_robin", "baby_count": 5, "baby_timer": 16 }
+    "reproduction": { "baby_egg": "egg_robin", "baby_count": 4, "baby_timer": 16 }
   },
   {
     "id": "mon_sparrow",
@@ -174,7 +174,7 @@
     "copy-from": "mon_bird_flying_base",
     "volume": "40 ml",
     "weight": "30 g",
-    "reproduction": { "baby_egg": "egg_sparrow", "baby_count": 5, "baby_timer": 16 }
+    "reproduction": { "baby_egg": "egg_sparrow", "baby_count": 4, "baby_timer": 16 }
   },
   {
     "id": "mon_duck",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1510,7 +1510,7 @@ int Character::overmap_modified_sight_range( float light_level ) const
     if( sight == 0 ) {
         return 0;
     }
-    
+
     return std::max( sight, 3 );
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1980,20 +1980,6 @@ bool mattack::fungus( monster *z )
     return true;
 }
 
-bool mattack::fungus_corporate( monster *z )
-{
-    if( x_in_y( 1, 20 ) ) {
-        sounds::sound( z->pos(), 10, sounds::sound_t::speech, _( "\"Buy SpOreos™ now!\"" ) );
-        if( get_player_view().sees( *z ) ) {
-            add_msg( m_warning, _( "Delicious snacks are released from the %s!" ), z->name() );
-            get_map().add_item( z->pos_bub(), item( "sporeos" ) );
-        } // only spawns SpOreos if the player is near; can't have the COMMONERS stealing our product from good customers
-        return true;
-    } else {
-        return fungus( z );
-    }
-}
-
 bool mattack::fungus_haze( monster *z )
 {
     //~ That spore sound again

--- a/src/monattack.h
+++ b/src/monattack.h
@@ -37,7 +37,6 @@ bool vine( monster *z );
 bool spit_sap( monster *z );
 bool triffid_heartbeat( monster *z );
 bool fungus( monster *z );            // Generic fungal spore-launch
-bool fungus_corporate( monster *z );   // Used by Crazy Cataclysm; spawns SpOreos(tm).
 bool fungus_haze( monster *z );       // Broadly scatter aerobics
 bool fungus_big_blossom( monster *z ); // Aerobic & anaerobic, as needed
 bool fungus_inject( monster *z );     // Directly inject the spores

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -563,10 +563,16 @@ void monster::try_reproduce()
     if( !type->baby_timer ) {
         return;
     }
+    // Failsafe to prevent comically exponential monster growth.
+    if( g->num_creatures() > 100 ) {
+        return;
+    }
+    if( has_effect( effect_critter_underfed ) ) {
+        return;
+    }
 
-    if( !baby_timer && amount_eaten >= stomach_size ) {
+    if( !baby_timer ) {
         // Assume this is a freshly spawned monster (because baby_timer is not set yet), set the point when it reproduce to somewhere in the future.
-        // Monsters need to have eaten eat to start their pregnancy timer, but that's all.
         baby_timer.emplace( calendar::turn + *type->baby_timer );
     }
 
@@ -602,9 +608,6 @@ void monster::try_reproduce()
         }
 
         chance += 2;
-        if( has_flag( mon_flag_EATS ) && has_effect( effect_critter_underfed ) ) {
-            chance += 1; //Reduce the chances but don't prevent birth if the animal is not eating.
-        }
         if( season_match && female && one_in( chance ) ) {
             int spawn_cnt = rng( 1, type->baby_count );
             if( type->baby_monster ) {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -615,7 +615,6 @@ void MonsterGenerator::init_attack()
     add_hardcoded_attack( "SPIT_SAP", mattack::spit_sap );
     add_hardcoded_attack( "TRIFFID_HEARTBEAT", mattack::triffid_heartbeat );
     add_hardcoded_attack( "FUNGUS", mattack::fungus );
-    add_hardcoded_attack( "FUNGUS_CORPORATE", mattack::fungus_corporate );
     add_hardcoded_attack( "FUNGUS_HAZE", mattack::fungus_haze );
     add_hardcoded_attack( "FUNGUS_BIG_BLOSSOM", mattack::fungus_big_blossom );
     add_hardcoded_attack( "FUNGUS_INJECT", mattack::fungus_inject );


### PR DESCRIPTION
#### Summary
Cap animal birth

#### Purpose of change
fixes #841 sort of. It's not a sufficient fix, but it'll help. Backporting DDA 76266 will also help.

#### Describe the solution
Underfed creatures don't give birth. Creatures also check the reality bubble and won't give birth if there are already 100 creatures in the reality bubble. This isn't super ideal, but like, look at #841. Come on.

#### Testing
Compiles and runs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
