### PR TITLE
Stews are liquid

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -706,6 +706,8 @@
     "material": [ "flesh", "wheat", "mushroom" ],
     "volume": "250 ml",
     "flags": [ "EATEN_HOT" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 9,
     "vitamins": [ [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -858,6 +860,8 @@
     "material": [ "flesh", "vegetable", "bean", "tomato" ],
     "volume": "250 ml",
     "flags": [ "EATEN_HOT" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 5,
     "vitamins": [ [ "vitC", 7 ], [ "calcium", 7 ], [ "iron", 27 ], [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ]
   },
@@ -1000,6 +1004,8 @@
     "material": [ "flesh", "milk" ],
     "volume": "250 ml",
     "flags": [ "EATEN_HOT" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 6,
     "vitamins": [ [ "vitC", 14 ], [ "calcium", 7 ], [ "iron", 16 ], [ "meat_allergen", 1 ], [ "milk_allergen", 1 ] ]
   },
@@ -1021,6 +1027,8 @@
     "volume": "500 ml",
     "//": "One beans + one protein = 2 servings",
     "flags": [ "EATEN_HOT" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 4,
     "vitamins": [ [ "vitC", 10 ], [ "calcium", 6 ], [ "iron", 51 ], [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ]
   },

--- a/data/json/items/comestibles/mre.json
+++ b/data/json/items/comestibles/mre.json
@@ -112,6 +112,8 @@
     "calories": 211,
     "description": "The beef stew entree from an MRE.",
     "material": [ "flesh", "vegetable" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 0,
     "vitamins": [ [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ]
   },
@@ -123,6 +125,9 @@
     "calories": 280,
     "description": "The chili & macaroni entree from an MRE.",
     "material": [ "wheat", "vegetable" ],
+    "phase": "liquid",
+    "comestible_type": "DRINK",
+    "charges": 1,
     "fun": 1,
     "vitamins": [ [ "vegetable_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -198,6 +203,8 @@
     "calories": 214,
     "description": "The Mexican chicken stew entree from an MRE.",
     "material": [ "tomato", "vegetable", "flesh", "bean" ],
+    "phase": "liquid",
+    "charges": 1,
     "fun": 1,
     "vitamins": [ [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ]
   },

--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -289,7 +289,7 @@
     "color": "brown",
     "spoils_in": "5 days",
     "container": "can_medium",
-    "comestible_type": "DRINK",
+    "comestible_type": "FOOD",
     "symbol": "o",
     "quench": 2,
     "calories": 504,


### PR DESCRIPTION
#### Summary
Stews are liquid

#### Purpose of change
#655 

#### Describe the solution
Made a few of these items liquids. The delineation between solid and liquid starts to get a little fuzzy. I guess we'll go with the spaghetti test. You could put spaghetti in your pocket and it would make a mess but you'd still be able to eat most of it. If you put beef stew in your pocket, much of it would wind up running down your pant leg. So that's the test.

#### Testing
Made hellfire stew and ate it. Put it in some bowls and used sorting zones. All good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
