### PR TITLE
Monsters can leap up and down Z levels

### DIFF
--- a/data/json/monsters/bird.json
+++ b/data/json/monsters/bird.json
@@ -480,7 +480,7 @@
     "special_attacks": [
       [ "SHRIEK", 100 ],
       [ "LUNGE", 8 ],
-      { "type": "leap", "cooldown": 10, "max_range": 3 },
+      { "type": "leap", "cooldown": 10, "max_range": 4, "ignore_dest_danger": true },
       [ "EAT_CARRION", 40 ],
       [ "EAT_FOOD", 120 ]
     ],

--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -43,7 +43,7 @@
       { "id": "bite_humanoid", "cooldown": 5 },
       { "id": "grab", "cooldown": 12 },
       { "id": "scratch_humanoid" },
-      { "type": "leap", "cooldown": 10, "max_range": 5 }
+      { "type": "leap", "cooldown": 10, "max_range": 5, "ignore_dest_danger": true }
     ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
@@ -111,7 +111,7 @@
       { "id": "bite_humanoid", "damage_max_instance": [ { "damage_type": "stab", "amount": 12, "armor_multiplier": 0.7 } ] },
       { "id": "grab", "cooldown": 12 },
       { "id": "scratch_humanoid" },
-      { "type": "leap", "cooldown": 2, "max_range": 8 }
+      { "type": "leap", "cooldown": 2, "max_range": 8, "ignore_dest_danger": true }
     ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_fiend",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -34,6 +34,7 @@
         "move_cost": 0,
         "max_range": 6,
         "min_consider_range": 2,
+        "ignore_dest_danger": true,
         "condition": { "not": { "u_has_effect": "maimed_leg" } }
       },
       {
@@ -87,6 +88,7 @@
         "move_cost": 0,
         "max_range": 4,
         "min_consider_range": 2,
+        "ignore_dest_danger": true,
         "condition": { "not": { "u_has_effect": "maimed_leg" } }
       },
       {
@@ -140,7 +142,7 @@
     "harvest": "exempt",
     "grab_strength": 15,
     "special_attacks": [
-      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 4, "min_consider_range": 2 },
+      { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 4, "min_consider_range": 2, "ignore_dest_danger": true },
       { "id": "grab", "cooldown": 1 }
     ],
     "death_function": {
@@ -183,6 +185,7 @@
         "move_cost": 0,
         "max_range": 8,
         "min_consider_range": 2,
+        "ignore_dest_danger": true,
         "condition": { "not": { "u_has_effect": "maimed_leg" } }
       },
       {
@@ -946,7 +949,7 @@
     "harvest": "zombie_humanoid",
     "special_attacks": [
       { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 12 } ] },
-      { "type": "leap", "cooldown": 5, "max_range": 3 },
+      { "type": "leap", "cooldown": 5, "max_range": 4, "ignore_dest_danger": true },
       {
         "type": "bite",
         "cooldown": 10,
@@ -1292,7 +1295,14 @@
     "harvest": "zombie_humanoid",
     "path_settings": { "max_dist": 45 },
     "special_attacks": [
-      { "type": "leap", "cooldown": 10, "max_range": 5, "min_consider_range": 2, "max_consider_range": 4 },
+      {
+        "type": "leap",
+        "cooldown": 10,
+        "max_range": 5,
+        "min_consider_range": 2,
+        "max_consider_range": 4,
+        "ignore_dest_danger": true
+      },
       {
         "type": "bite",
         "cooldown": 10,

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -106,7 +106,10 @@
     "bleed_rate": 0,
     "relative": { "hp": 20, "speed": 10, "melee_skill": 1, "dodge": 1, "vision_night": 15 },
     "delete": { "upgrades": { "half_life": 45, "into": "mon_zombie_soldier_blackops_2" } },
-    "extend": { "special_attacks": [ { "type": "leap", "cooldown": 10, "max_range": 3 } ], "flags": [ "KEENNOSE" ] }
+    "extend": {
+      "special_attacks": [ { "type": "leap", "cooldown": 10, "max_range": 3, "ignore_dest_danger": true } ],
+      "flags": [ "KEENNOSE" ]
+    }
   },
   {
     "id": "mon_zombie_soldier_acid_1",

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -147,14 +147,13 @@ bool leap_actor::call( monster &z ) const
                    target.to_string_writable() );
 
     std::multimap<int, tripoint_bub_ms> candidates;
-    for( const tripoint_bub_ms &candidate : here.points_in_radius( z.pos_bub(), max_range ) ) {
+    for( const tripoint_bub_ms &candidate : here.points_in_radius( z.pos_bub(), max_range, max_range / 1.4f ) ) {
         if( candidate == z.pos_bub() ) {
             add_msg_debug( debugmode::DF_MATTACK, "Monster at coordinates %s",
                            candidate.to_string_writable() );
             continue;
         }
-        float leap_dist = trigdist ? trig_dist( z.pos_bub(), candidate ) :
-                          square_dist( z.pos_bub(), candidate );
+        float leap_dist = trig_dist( z.pos_bub(), candidate );
         add_msg_debug( debugmode::DF_MATTACK,
                        "Candidate coordinates %s, distance %.1f, min range %.1f, max range %.1f",
                        candidate.to_string_writable(), leap_dist, min_range, max_range );
@@ -163,8 +162,8 @@ bool leap_actor::call( monster &z ) const
                            "Candidate outside of allowed range, discarded" );
             continue;
         }
-        int candidate_dist = rl_dist( candidate, target );
-        if( candidate_dist >= best_float && !( prefer_leap || random_leap ) ) {
+        int candidate_dist = trig_dist( candidate, target );
+        if( candidate_dist >= best_float && !( prefer_leap || random_leap ) && ( z.pos_bub().z() != candidate.z() ) ) {
             add_msg_debug( debugmode::DF_MATTACK,
                            "Candidate farther from target than optimal path, discarded" );
             continue;


### PR DESCRIPTION
#### Summary
Monsters can leap up and down Z levels

#### Purpose of change
- Chilling out on a roof is still silly.
- Bloated corvids weren't behaving properly.

#### Describe the solution
- Give all leaping undead and the bloated corvid ignore_dest_danger, so they'll hop off of roofs if they can get to you that way.
- Gave leap attacks a vertical range equal to range / 1.4.

#### Testing
It's not quite right. They can wind up up standing on top of the player, and they still seem reluctant to actually jump up or down. The leap code is a bit odd, and the way it interacts with pathfinding is kind of hard to work with.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
