### PR TITLE
Fix morale and some other error messages

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -290,9 +290,9 @@
     "text": "Optimist"
   },
   {
-    "id": "morale_perm_badtemper",
+    "id": "morale_perm_pessimist",
     "type": "morale_type",
-    "text": "Bad Tempered"
+    "text": "Pessimist"
   },
   {
     "id": "morale_perm_numb",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1464,8 +1464,8 @@
   },
   {
     "type": "mutation",
-    "id": "BADTEMPER",
-    "name": { "str": "Bad Temper" },
+    "id": "PESSIMISTIC",
+    "name": { "str": "Pessimist" },
     "points": -2,
     "description": "Things just keep getting you down.  You tend to be unhappy, and it takes some doing to cheer you up.",
     "starting_trait": true,

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
@@ -20,7 +20,7 @@
       { "trait": "BGSS_Scavenger_Merc_1" },
       { "trait": "PSYCHOPATH" },
       { "trait": "TOUGH" },
-      { "trait": "BADTEMPER" },
+      { "trait": "PESSIMISTIC" },
       { "trait": "SLOWREADER" },
       { "trait": "INSOMNIA" },
       { "group": "Appearance_demographics" }

--- a/data/json/npcs/starting_traits.json
+++ b/data/json/npcs/starting_traits.json
@@ -147,7 +147,7 @@
     "type": "trait_group",
     "id": "trait_group_OPTIMISTIC",
     "subtype": "distribution",
-    "traits": [ { "trait": "OPTIMISTIC" }, { "trait": "BADTEMPER" } ]
+    "traits": [ { "trait": "OPTIMISTIC" }, { "trait": "PESSIMISTIC" } ]
   },
   {
     "type": "trait_group",

--- a/data/json/obsoletion_and_migration/migration_eocs.json
+++ b/data/json/obsoletion_and_migration/migration_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "eoc_migrate_pessimistic",
+    "recurrence": [ "1 seconds", "1 seconds" ],
+    "condition": { "and": [ { "u_has_trait": "BADTEMPER" } ] },
+    "effect": [ { "u_add_trait": "PESSIMISTIC" }, { "u_lose_trait": "BADTEMPER" } ]
+  }
+]

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -208,5 +208,32 @@
     "points": 0,
     "valid": false,
     "player_display": false
+  },
+  {
+    "id": "morale_perm_badtemper",
+    "type": "morale_type",
+    "text": "Pessimist"
+  },
+  {
+    "type": "mutation",
+    "id": "BADTEMPER",
+    "name": { "str": "Bad temper" },
+    "description": "Renamed/re-IDed mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "id": "mon_goose_canadian",
+    "type": "MONSTER",
+    "copy-from": "mon_goose",
+    "name": { "str": "goose", "str_pl": "geese" },
+    "looks_like": "mon_goose"
+  },
+  {
+    "id": "mon_goose_canadian_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_goose_chick",
+    "looks_like": "mon_goose_chick"
   }
 ]

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -18,6 +18,7 @@
 #include "enums.h"
 #include "input_context.h"
 #include "item.h"
+#include "itype.h"
 #include "localized_comparator.h"
 #include "make_static.h"
 #include "morale_types.h"
@@ -34,7 +35,7 @@ static const efftype_id effect_took_prozac_bad( "took_prozac_bad" );
 
 static const morale_type morale_cold( "morale_cold" );
 static const morale_type morale_hot( "morale_hot" );
-static const morale_type morale_perm_badtemper( "morale_perm_badtemper" );
+static const morale_type morale_perm_pessimist( "morale_perm_pessimist" );
 static const morale_type morale_perm_constrained( "morale_perm_constrained" );
 static const morale_type morale_perm_debug( "morale_perm_debug" );
 static const morale_type morale_perm_fancy( "morale_perm_fancy" );
@@ -44,7 +45,6 @@ static const morale_type morale_perm_numb( "morale_perm_numb" );
 static const morale_type morale_perm_optimist( "morale_perm_optimist" );
 static const morale_type morale_perm_radiophile( "morale_perm_radiophile" );
 
-static const trait_id trait_BADTEMPER( "BADTEMPER" );
 static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_CHLOROMORPH( "CHLOROMORPH" );
 static const trait_id trait_FLOWERS( "FLOWERS" );
@@ -53,7 +53,6 @@ static const trait_id trait_LEAVES3( "LEAVES3" );
 static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_NUMB( "NUMB" );
-static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
 static const trait_id trait_RADIOPHILE( "RADIOPHILE" );
 static const trait_id trait_ROOTS1( "ROOTS1" );
 static const trait_id trait_ROOTS2( "ROOTS2" );
@@ -68,7 +67,7 @@ bool is_permanent_morale( const morale_type &id )
 {
     static const std::set<morale_type> permanent_morale = {{
             morale_perm_optimist,
-            morale_perm_badtemper,
+            morale_perm_pessimist,
             morale_perm_numb,
             morale_perm_fancy,
             morale_perm_masochist,
@@ -118,12 +117,6 @@ static int operator *= ( int &morale, const morale_mult &mult )
 // Commonly used morale multipliers
 namespace morale_mults
 {
-// Optimistic characters focus on the good things in life,
-// and downplay the bad things.
-static const morale_mult optimist( 1.2, 0.8 );
-// Again, those grouchy Bad-Tempered folks always focus on the negative.
-// They can't handle positive things as well.  They're No Fun.  D:
-static const morale_mult badtemper( 0.8, 1.2 );
 // Numb characters have trouble feeling anything
 static const morale_mult numb( 0.25, 0.25 );
 // Prozac reduces overall negative morale by 75%.
@@ -167,7 +160,19 @@ bool player_morale::morale_point::matches( const morale_type &_type, const itype
 
 bool player_morale::morale_point::matches( const morale_point &mp ) const
 {
-    return ( type == mp.type ) && ( item_type == mp.item_type );
+    if( type != mp.type ) {
+        return false;
+    }
+
+    if( item_type == mp.item_type ) {
+        return true;
+    }
+
+    if( item_type != nullptr && mp.item_type != nullptr ) {
+        return item_type->get_id() == mp.item_type->get_id();
+    }
+
+    return false; // one is null, one is not
 }
 
 void player_morale::morale_point::add( const int new_bonus, const int new_max_bonus,
@@ -266,13 +271,6 @@ player_morale::player_morale() :
     perceived_pain( 0 ),
     radiation( 0 )
 {
-    // Cannot use 'this' because the object is copyable
-    const auto set_optimist = []( player_morale * pm, int bonus ) {
-        pm->set_permanent( morale_perm_optimist, bonus, nullptr );
-    };
-    const auto set_badtemper = []( player_morale * pm, int bonus ) {
-        pm->set_permanent( morale_perm_badtemper, bonus, nullptr );
-    };
     const auto set_numb = []( player_morale * pm, int bonus ) {
         pm->set_permanent( morale_perm_numb, bonus, nullptr );
     };
@@ -289,20 +287,6 @@ player_morale::player_morale() :
         pm->update_radiophile_bonus();
     };
 
-    mutations[trait_OPTIMISTIC] =
-    mutation_data( [set_optimist]( player_morale * pm ) {
-        return set_optimist( pm, 9 );
-    },
-    [set_optimist]( player_morale * pm ) {
-        return set_optimist( pm, 0 );
-    } );
-    mutations[trait_BADTEMPER] =
-    mutation_data( [set_badtemper]( player_morale * pm ) {
-        return set_badtemper( pm, -9 );
-    },
-    [set_badtemper]( player_morale * pm ) {
-        return set_badtemper( pm, 0 );
-    } );
     mutations[trait_NUMB] =
     mutation_data( [set_numb]( player_morale * pm ) {
         return set_numb( pm, -1 );
@@ -409,12 +393,6 @@ morale_mult player_morale::get_temper_mult() const
 {
     morale_mult mult;
 
-    if( has( morale_perm_optimist ) ) {
-        mult *= morale_mults::optimist;
-    }
-    if( has( morale_perm_badtemper ) ) {
-        mult *= morale_mults::badtemper;
-    }
     if( has( morale_perm_numb ) ) {
         mult *= morale_mults::numb;
     }
@@ -498,7 +476,6 @@ int player_morale::get_level() const
         }
 
         level = std::sqrt( sum_of_positive_squares ) - std::sqrt( sum_of_negative_squares );
-
         if( took_prozac ) {
             level *= morale_mults::prozac;
             if( took_prozac_bad ) {
@@ -838,7 +815,8 @@ bool player_morale::consistent_with( const player_morale &morale ) const
 {
     const auto test_points = []( const player_morale & lhs, const player_morale & rhs ) {
         for( const player_morale::morale_point &lhp : lhs.points ) {
-            if( !lhp.is_permanent() ) {
+            if( !lhp.is_permanent() || lhp.get_type() == morale_perm_optimist ||
+                lhp.get_type() == morale_perm_pessimist ) {
                 continue;
             }
 
@@ -847,8 +825,12 @@ bool player_morale::consistent_with( const player_morale &morale ) const
                 return lhp.matches( rhp );
             } );
 
+            // These debug messages constantly fire even though they oughtn't to
+            // because of how morale is periodically recalculated.
+            // So they're commented out for now.
+
             if( iter == rhs.points.end() || lhp.get_net_bonus() != iter->get_net_bonus() ) {
-                debugmsg( "Morale \"%s\" is inconsistent.", lhp.get_name() );
+                //     debugmsg( "Morale \"%s\" is inconsistent.", lhp.get_name() );
                 return false;
             }
         }
@@ -857,19 +839,19 @@ bool player_morale::consistent_with( const player_morale &morale ) const
     };
 
     if( took_prozac != morale.took_prozac ) {
-        debugmsg( "player_morale::took_prozac is inconsistent." );
+        //     debugmsg( "player_morale::took_prozac is inconsistent." );
         return false;
     } else if( took_prozac_bad != morale.took_prozac_bad ) {
-        debugmsg( "player_morale::took_prozac (bad) is inconsistent." );
+        //     debugmsg( "player_morale::took_prozac (bad) is inconsistent." );
         return false;
     } else if( stylish != morale.stylish ) {
-        debugmsg( "player_morale::stylish is inconsistent." );
+        //     debugmsg( "player_morale::stylish is inconsistent." );
         return false;
     } else if( perceived_pain != morale.perceived_pain ) {
-        debugmsg( "player_morale::perceived_pain is inconsistent." );
+        //     debugmsg( "player_morale::perceived_pain is inconsistent." );
         return false;
     } else if( radiation != morale.radiation ) {
-        debugmsg( "player_morale::radiation is inconsistent." );
+        //     debugmsg( "player_morale::radiation is inconsistent." );
         return false;
     }
 

--- a/src/morale.h
+++ b/src/morale.h
@@ -77,6 +77,9 @@ class player_morale
         class morale_point
         {
             public:
+                morale_type get_type() const {
+                    return type;
+                }
                 explicit morale_point(
                     const morale_type &type = morale_type::NULL_ID(),
                     const itype *item_type = nullptr,

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -132,6 +132,8 @@ static const limb_score_id limb_score_breathing( "breathing" );
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
 static const morale_type morale_feeling_good( "morale_feeling_good" );
 static const morale_type morale_moodswing( "morale_moodswing" );
+static const morale_type morale_perm_pessimist( "morale_perm_pessimist" );
+static const morale_type morale_perm_optimist( "morale_perm_optimist" );
 static const morale_type morale_pyromania_nearfire( "morale_pyromania_nearfire" );
 static const morale_type morale_pyromania_nofire( "morale_pyromania_nofire" );
 static const morale_type morale_pyromania_startfire( "morale_pyromania_startfire" );
@@ -164,7 +166,9 @@ static const trait_id trait_NO_LEFT_ARM( "NO_LEFT_ARM" );
 static const trait_id trait_NO_LEFT_LEG( "NO_LEFT_LEG" );
 static const trait_id trait_NO_RIGHT_ARM( "NO_RIGHT_ARM" );
 static const trait_id trait_NO_RIGHT_LEG( "NO_RIGHT_LEG" );
+static const trait_id trait_OPTIMISTIC( "OPTIMISTIC" );
 static const trait_id trait_PER_SLIME( "PER_SLIME" );
+static const trait_id trait_PESSIMISTIC( "PESSIMISTIC" );
 static const trait_id trait_PLANTSKIN( "PLANTSKIN" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
 static const trait_id trait_RADIOACTIVE1( "RADIOACTIVE1" );
@@ -467,6 +471,22 @@ void suffer::while_awake( Character &you, const int current_stim )
         } else {
             you.add_effect( effect_downed, 2_turns, false, 0, true );
         }
+    }
+
+    if( you.has_trait( trait_OPTIMISTIC ) && !you.has_morale( morale_perm_optimist ) ) {
+        you.add_morale( morale_perm_optimist, 10, 10, 0_seconds );
+    }
+
+    if( !you.has_trait( trait_OPTIMISTIC ) && you.has_morale( morale_perm_optimist ) ) {
+        you.rem_morale( morale_perm_optimist );
+    }
+
+    if( you.has_trait( trait_PESSIMISTIC ) && !you.has_morale( morale_perm_pessimist ) ) {
+        you.add_morale( morale_perm_pessimist, -10, -10, 0_seconds );
+    }
+
+    if( !you.has_trait( trait_PESSIMISTIC ) && you.has_morale( morale_perm_pessimist ) ) {
+        you.rem_morale( morale_perm_pessimist );
     }
 
     if( you.has_flag( json_flag_NYCTOPHOBIA ) && !you.has_effect( effect_took_xanax ) ) {


### PR DESCRIPTION
#### Summary
Fix morale and some other error messages

#### Purpose of change
- Stylish, squeamish, and a few others were giving some annoying error messages.
- Bad tempered was a bad name for the trait. Things like "Bad" "good" etc tend to pile up in the trait list.
- Somehow canada geese were still haunting the game.

#### Describe the solution
- Silence the error messages. There's no way to stop them happening because they get triggered by the morale system periodically refreshing, and they're not all that important anyway. If something weird happens with morale, the player can just look at their morale screen and make a bug report.
- Bad tempered->Pessimist
- Pessimist and optimist used to do a bunch of mood multiplication stuff that was honestly just way too overcomplicated. Now they give you a flat plus or minus ten to your mood, forever. As always, antidepressants can help with the bad mood, or you can just do good mood things to offset it.
- Add an EOC that migrates the old ID to the new.
- Add mon_goose_canadian to the migration files to silence those error messges.

#### Testing
- Got squeamish and filthy, got stylish, got optimistic and pessimistic. All seems reasonable.

#### Additional context
- The numbers in the morale screen can be off by a point or two from your actual total because of how the system works. This isn't ideal but I haven't the foggiest idea how to fix it.
- A lot of the morale code needs to go in the garbage.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
