### PR TITLE
Improve chainsaw chaps

### DIFF
--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -463,17 +463,17 @@
     "looks_like": "pants_leather",
     "color": "dark_gray",
     "warmth": 10,
-    "material_thickness": 2.5,
+    "material_thickness": 2,
     "flags": [ "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       {
-        "encumbrance": 3,
-        "coverage": 80,
+        "encumbrance": 7,
+        "coverage": 70,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_knee_r", "leg_knee_l" ]
       },
       { "coverage": 20, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_r", "leg_hip_l" ] },
-      { "coverage": 80, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_r", "leg_upper_l" ] }
+      { "coverage": 70, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_r", "leg_upper_l" ] }
     ]
   },
   {
@@ -482,10 +482,50 @@
     "category": "armor",
     "name": { "str_sp": "chainsaw chaps" },
     "description": "A pair of tough chaps made of Kevlar.  Chainsaw kickbacks are potentially fatal; personal protective equipment like these chaps help protect your femoral arteries.  The layered Kevlar is designed to fray on contact with the chain and bind up the tool.",
-    "weight": "1519 g",
-    "copy-from": "chaps_leather",
-    "price": "78 USD",
-    "material": [ "kevlar" ]
+    "weight": "1014 g",
+    "volume": "1150 ml",
+    "price": "210 USD",
+    "price_postapoc": "2 USD 50 cent",
+    "to_hit": -1,
+    "material": [ "nylon", "kevlar" ],
+    "symbol": "[",
+    "looks_like": "pants_leather",
+    "color": "dark_gray",
+    "warmth": 10,
+    "flags": [ "OUTER", "ALLOWS_TAIL" ],
+    "armor": [
+      {
+        "encumbrance": 7,
+        "coverage": 70,
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 2 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "material_thickness": 1,
+        "specifically_covers": [ "leg_lower_l", "leg_lower_r", "leg_knee_r", "leg_knee_l" ]
+      },
+      {
+        "coverage": 20,
+        "covers": [ "leg_l", "leg_r" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 2 }
+        ],
+        "material_thickness": 1,
+        "specifically_covers": [ "leg_hip_r", "leg_hip_l" ]
+      },
+      {
+        "coverage": 70,
+        "covers": [ "leg_l", "leg_r" ],
+        "material": [
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 1 },
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 2.5 }
+        ],
+        "material_thickness": 1,
+        "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
+      }
+    ]
   },
   {
     "id": "fencing_pants",


### PR DESCRIPTION
#### Summary
Improve chainsaw chaps

#### Purpose of change
Chainsaw chaps were using copy_from to copy the leather ones, and wound up being a bit too weak.

#### Describe the solution
- Make them a ltitle thicker, add a nylon outer layer. Slightly lowered coverage and boosted encumbrance on both chaps.
- A user asked why the leather chaps have better fire protection. That's because basic cut-proof kevlar is not going to do much to protect the wearer from flames, it's a fairly breathable fabric that isn't particularly insulating, at least in this kind of looser weave. The fabric itself is highly resistant to being burnt, so it still provides protection for itself, and from being set on fire.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
