### PR TITLE
Space farms out a bit more

### DIFF
--- a/data/json/overmap/overmap_mutable/farm_mutable.json
+++ b/data/json/overmap/overmap_mutable/farm_mutable.json
@@ -4,7 +4,7 @@
     "id": "Farm Mutable",
     "subtype": "mutable",
     "locations": [ "subterranean_empty", "land", "open_air" ],
-    "city_distance": [ 5, -1 ],
+    "city_distance": [ 8, -1 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MAN_MADE", "FARM" ],


### PR DESCRIPTION
#### Summary
Space farms out a bit more

#### Purpose of change
Farms are a bit too common.

#### Describe the solution
This is hard to adjust, but increasing their city distance from 6 to 8 seems to do OK.

#### Testing
Made several worlds, warped around. Isherwoods look fine. Farms are a bit less clustered.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
