### PR TITLE
Backport 81921 - Can't use a monster for infinite training

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2163,7 +2163,6 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         recoil = std::min( MAX_RECOIL, recoil );
     }
 
-    // Even if we are not to train still call practice to prevent skill rust
     difficulty = std::max( difficulty, 0.0f );
 
     // If training_level is set, treat that as the difficulty instead
@@ -2171,7 +2170,10 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         difficulty = training_level;
     }
 
-    practice( skill_dodge, difficulty * 2, difficulty );
+    if( source && source->times_combatted_player <= 50 ) {
+        source->times_combatted_player++;
+        practice( skill_dodge, difficulty * 2, difficulty );
+    }
     martial_arts_data->ma_ondodge_effects( *this );
 
     // For adjacent attackers check for techniques usable upon successful dodge

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2170,7 +2170,7 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         difficulty = training_level;
     }
 
-    if( source && source->times_combatted_player <= 50 ) {
+    if( source && source->times_combatted_player <= 60 ) {
         source->times_combatted_player++;
         practice( skill_dodge, difficulty * 2, difficulty );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2170,7 +2170,7 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         difficulty = training_level;
     }
 
-    if( source && source->times_combatted_player <= 60 ) {
+    if( source && source->times_combatted_player <= 50 ) {
         source->times_combatted_player++;
         practice( skill_dodge, difficulty * 2, difficulty );
     }

--- a/src/creature.h
+++ b/src/creature.h
@@ -1285,6 +1285,9 @@ class Creature : public viewer
         // This is done this way in order to not destroy focus since `do_aim` is on a per-move basis.
         int archery_aim_counter = 0;
 
+        // This tracks how many times the creature has trained any opponent's skill in melee/weapon skill/dodging in combat.
+        short times_combatted_player = 0;
+
         // Find the body part with the biggest hitsize - we will treat this as the center of mass for targeting
         bodypart_id get_max_hitsize_bodypart() const;
         // Select a bodypart depending on the attack's hitsize/limb restrictions

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -706,9 +706,9 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     // flagged to not train, if it's a weakened NPC, or if the creature has already trained someone an excessive number of times.
     const bool can_train_melee = !has_active_bionic( bio_cqb ) &&
                                  !t.is_hallucination() &&
-                                 ( !t.is_monster() && t.as_character()->is_prone() ) && 
+                                 ( t.is_monster() || ( !t.is_monster() && !t.as_character()->is_prone() ) ) && 
                                  !t.has_flag( mon_flag_NO_TRAIN ) &&
-                                 t.times_combatted_player <= 50;
+                                 t.times_combatted_player <= 60;
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -702,6 +702,13 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
     const int skill_training_cap = t.is_monster() ? t.as_monster()->type->melee_training_cap :
                                    MAX_SKILL;
+    // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, if the monster is 
+    // flagged to not train, if it's a weakened NPC, or if the creature has already trained someone an excessive number of times.
+    const bool can_train_melee = !has_active_bionic( bio_cqb ) &&
+                                 !t.is_hallucination() &&
+                                 ( !t.is_monster() && t.as_character()->is_prone() ) && 
+                                 !t.has_flag( mon_flag_NO_TRAIN ) &&
+                                 t.times_combatted_player <= 50;
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );
@@ -739,10 +746,9 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             }
         }
 
-        // Practice melee and relevant weapon skill (if any) except when using CQB bionic
-        if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() && !t.has_flag( mon_flag_NO_TRAIN ) ) {
-            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null,
-                         reach_attacking );
+        if( can_train_melee ) {
+            t.times_combatted_player++;
+            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null, reach_attacking );
         }
 
         // Cap stumble penalty, heavy weapons are quite weak already
@@ -981,8 +987,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             int dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 
-            // Practice melee and relevant weapon skill (if any) except when using CQB bionic
-            if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() && !t.has_flag( mon_flag_NO_TRAIN ) ) {
+            if( can_train_melee ) {
+                t.times_combatted_player++;
                 melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap, vector_id, reach_attacking );
             }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -708,7 +708,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                                  !t.is_hallucination() &&
                                  ( t.is_monster() || ( !t.is_monster() && !t.as_character()->is_prone() ) ) && 
                                  !t.has_flag( mon_flag_NO_TRAIN ) &&
-                                 t.times_combatted_player <= 60;
+                                 t.times_combatted_player <= 50;
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2525,6 +2525,7 @@ void monster::load( const JsonObject &data )
     biosig_timer = time_point( data.get_int( "biosig_timer", -1 ) );
 
     data.read( "udder_timer", udder_timer );
+    data.read( "times_combatted_player", times_combatted_player );
 
     horde_attraction = static_cast<monster_horde_attraction>( data.get_int( "horde_attraction", 0 ) );
 
@@ -2611,6 +2612,7 @@ void monster::store( JsonOut &json ) const
     json.member( "biosignatures", biosignatures );
     json.member( "biosig_timer", biosig_timer );
     json.member( "udder_timer", udder_timer );
+    json.member( "times_combatted_player", times_combatted_player );
 
     if( horde_attraction > MHA_NULL && horde_attraction < NUM_MONSTER_HORDE_ATTRACTION ) {
         json.member( "horde_attraction", horde_attraction );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -318,6 +318,17 @@ TEST_CASE( "Melee_skill_training_caps", "[melee], [melee_training_cap], [skill]"
         dude.melee_attack_abstract( zed, false, matec_id( "" ) );
         CHECK( level.knowledgeExperience( true ) == prev_xp );
     }
+    SECTION( "Using a monster as a training dummy will not cause further skill gain" ) {
+        zed.times_combatted_player = 101;
+        dude.set_skill_level( skill_melee, 0 );
+        dude.set_knowledge_level( skill_melee, 0 );
+        const int prev_xp = level.knowledgeExperience( true );
+        dude.melee_attack_abstract( zed, false, matec_id( "" ) );
+        CHECK( level.knowledgeLevel() == 0 );
+        CHECK( level.level() == 0 );
+        CHECK( level.knowledgeExperience( true ) == 0 );
+        CHECK( level.knowledgeExperience( true ) == prev_xp );
+    }
 }
 
 static void check_damage_from_test_fire( const std::string &mon_id, int expected_resist,


### PR DESCRIPTION
#### Summary
Backport 81921 - Can't use a monster for infinite training

#### Purpose of change
In what I can only see as an act of self-harm, players were dragging a lone zombie to their base, waiting for it to revive, and infinitely training on it. What the fuck.

#### Describe the solution
- Backport RenechCDDA's solution from DDA, with some adjustments.
- Monsters will only train you 50 times. So, 25 attacks and 25 dodges, or 50 of one or the other, that's it. This is per individual, not species. So you can train 50 times on one zombie soldier, then kill it and train 50 times on another zombie soldier. Dying and reanimating does not reset it. 
- Characters won't train you if they're downed. I actually don't even know if they train at all, but they ought to and let's just get out ahead of that right now.
- Prevent training against creatures that have disabling effects.

#### Testing
Seems to work.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
