### PR TITLE
Nerf tear gas sprayer and fire extinguisher, buff stun guns

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -844,7 +844,7 @@
     "has_fume": true,
     "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
     "priority": 8,
-    "half_life": "5 minutes",
+    "half_life": "1 minutes",
     "phase": "gas",
     "display_items": false,
     "display_field": true,

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -652,7 +652,7 @@
     "id": "rubber_spray_can",
     "type": "TOOL",
     "name": { "str": "rubber sealant spray" },
-    "description": "An aerosol spray can that contains (if there's any left) quick-drying liquid butyl rubber, which can be sprayed onto fabric and other materials to make them waterproof.",
+    "description": "An aerosol spray can that contains (if there's any left) quick-drying liquid butyl rubber, which can be sprayed onto fabric and other materials to make them waterproof, or onto surfaces like spraypaint.",
     "weight": "340 g",
     "volume": "250 ml",
     "longest_side": "21 cm",
@@ -661,6 +661,7 @@
     "material": [ "aluminum" ],
     "symbol": ";",
     "color": "light_gray",
+    "use_action": [ "SPRAY_CAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "liquid_rubber_spray": 10 }, "watertight": true, "rigid": true } ],
     "flags": [ "NO_RELOAD", "NO_UNLOAD" ]
   },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1945,6 +1945,10 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint & 
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
+    if( !p->is_wielding( *it ) ) {
+        p->add_msg_if_player( _( "You need to be wielding the %s to use it." ), it->tname() );
+        return std::nullopt;
+    }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
     const std::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );
@@ -1953,20 +1957,18 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint & 
     }
     tripoint_bub_ms dest = tripoint_bub_ms( *dest_ );
 
-    p->mod_moves( -to_moves<int>( 2_seconds ) );
-
     map &here = get_map();
     // Reduce the strength of fire (if any) in the target tile.
     here.add_field( dest, fd_extinguisher, 3, 10_turns );
 
+    p->mod_moves( -to_moves<int>( 2_seconds ) );
     // Also spray monsters in that tile.
     if( monster *const mon_ptr = get_creature_tracker().creature_at<monster>( dest, true ) ) {
         monster &critter = *mon_ptr;
-        critter.mod_moves( -to_moves<int>( 2_seconds ) );
         bool blind = false;
         if( one_in( 2 ) && critter.has_flag( mon_flag_SEES ) ) {
             blind = true;
-            critter.add_effect( effect_blind, rng( 1_minutes, 2_minutes ) );
+            critter.add_effect( effect_blind, rng( 3_seconds, 6_seconds ) );
         }
         viewer &player_view = get_player_view();
         if( player_view.sees( critter ) ) {
@@ -2322,6 +2324,10 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint & )
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
+    if( !p->is_wielding( *it ) ) {
+        p->add_msg_if_player( _( "You need to be wielding the %s to use it." ), it->tname() );
+        return std::nullopt;
+    }
     // If anyone other than the player wants to use one of these,
     // they're going to need to figure out how to aim it.
     const std::optional<tripoint> dest_ = choose_adjacent( _( "Spray where?" ) );
@@ -2330,34 +2336,10 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint & )
     }
     tripoint_bub_ms dest = tripoint_bub_ms( *dest_ );
 
-    p->mod_moves( -to_moves<int>( 2_seconds ) );
-
     map &here = get_map();
     here.add_field( dest, fd_tear_gas, 2, 3_turns );
 
-    // Also spray monsters in that tile.
-    if( monster *const mon_ptr = get_creature_tracker().creature_at<monster>( dest, true ) ) {
-        monster &critter = *mon_ptr;
-        critter.mod_moves( -to_moves<int>( 2_seconds ) );
-        bool blind = false;
-        if( one_in( 2 ) && critter.has_flag( mon_flag_SEES ) ) {
-            blind = true;
-            critter.add_effect( effect_blind, rng( 1_minutes, 2_minutes ) );
-        }
-        // even if it's not blinded getting maced hurts a lot and stuns it
-        if( !critter.has_flag( mon_flag_NO_BREATHE ) ) {
-            critter.mod_moves( -to_moves<int>( 3_seconds ) );
-            p->add_msg_if_player( _( "The %s recoils in pain!" ), critter.name() );
-        }
-        viewer &player_view = get_player_view();
-        if( player_view.sees( critter ) ) {
-            p->add_msg_if_player( _( "The %s is sprayed!" ), critter.name() );
-            if( blind ) {
-                p->add_msg_if_player( _( "The %s looks blinded." ), critter.name() );
-            }
-        }
-    }
-
+    p->mod_moves( -to_moves<int>( 1_seconds ) );
     return 1;
 }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -110,6 +110,8 @@ static const ter_str_id ter_t_pit( "t_pit" );
 static const ter_str_id ter_t_rock_floor( "t_rock_floor" );
 
 static const trait_id trait_ACIDPROOF( "ACIDPROOF" );
+static const trait_id trait_COMPOUND_EYES( "COMPOUND_EYES" );
+static const trait_id trait_EYESTALKS_RIGID( "EYESTALKS_RIGID" );
 static const trait_id trait_GASTROPOD_FOOT( "GASTROPOD_FOOT" );
 static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_M_SKIN2( "M_SKIN2" );
@@ -1673,6 +1675,7 @@ void map::player_in_field( Character &you )
             }
             // Prevent stacking ridiculous amounts of blindness.
             if( cur.get_field_intensity() > 1 && ( !inside || one_in( 3 ) ) &&
+                !you.has_trait( trait_COMPOUND_EYES ) && !you.has_trait( trait_EYESTALKS_RIGID ) &&
                 ( !you.has_effect( effect_blind ) || you.get_effect_dur( effect_blind ) < 30_seconds ) ) {
                 you.add_env_effect( effect_blind, bodypart_id( "eyes" ), 1, cur.get_field_intensity() * 2_seconds );
             }
@@ -1993,11 +1996,12 @@ void map::monster_in_field( monster &z )
                 }
             }
             // Cyborg monsters ignore it because of the protective lenses CBM.
+            // Zombies ignore pain but might still be blinded by inflammation and swelling.
             if( z.has_flag( mon_flag_SEES ) && z.made_of_any( Creature::cmat_flesh ) &&
                 !z.in_species( species_INSECT ) &&
                 !z.in_species( species_INSECT_FLYING ) && !z.in_species( species_CENTIPEDE ) &&
                 !z.in_species( species_SPIDER ) && !z.in_species( species_CYBORG ) &&
-                !z.has_effect( effect_blind ) ) {
+                !z.has_effect( effect_blind ) && ( !z.in_species( species_ZOMBIE ) || one_in( z.enum_size() ) ) ) {
                 z.add_effect( effect_blind, cur.get_field_intensity() * rng( 1_turns, 4_turns ) );
                 if( z.type->has_fear_trigger( mon_trigger::HURT ) ) {
                     z.morale -= ( 2 * cur.get_field_intensity() );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -703,11 +703,11 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
     const int skill_training_cap = t.is_monster() ? t.as_monster()->type->melee_training_cap :
                                    MAX_SKILL;
-    // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, if the monster is 
+    // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, if the monster is
     // flagged to not train, if it's a weakened NPC, or if the creature has already trained someone an excessive number of times.
     const bool can_train_melee = !has_active_bionic( bio_cqb ) &&
                                  !t.is_hallucination() &&
-                                 ( t.is_monster() || ( !t.is_monster() && !t.as_character()->is_prone() ) ) && 
+                                 ( t.is_monster() || ( !t.is_monster() && !t.as_character()->is_prone() ) ) &&
                                  !t.has_flag( mon_flag_NO_TRAIN ) &&
                                  !t.has_effect_with_flag( json_flag_PREVENT_TRAINING ) &&
                                  t.times_combatted_player <= 50;
@@ -750,7 +750,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
         if( can_train_melee ) {
             t.times_combatted_player++;
-            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null, reach_attacking );
+            melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_vector_null,
+                         reach_attacking );
         }
 
         // Cap stumble penalty, heavy weapons are quite weak already


### PR DESCRIPTION
#### Summary
Nerf tear gas sprayer and fire extinguisher, buff stun guns

#### Purpose of change
- Fire extinguishers were blinding anything that was capable of being blinded for several minutes.
- Tear gas sprayers and fire extinguishers could be used without wielding them.
- Tear gas was lasting way too long on the map.
- Characters with compound eyes were not immune to tear gas.
- Zombies were a bit too vulnerable to tear gas.
- Stun guns were a bit too weak.
- Cameras were able to blind stuff without appropriate checks, and for way too long.
- Everything was raw RNG

#### Describe the solution
- Stun guns are now more likely to make monsters release grabs.
- Zombies have a chance to not be blinded by tear gas, based on their size.
- Tear gas sprayers and fire extinguishers must be wielded to be used.
- Tear gas sprayers and fire extinguishers will make NPCs mad if used directly on them. This comes with a prompt so you don't accidentally do it. Fire extinguishers won't anger NPCs if they are on or in fire. They won't care either way unless you spray it right in their face.
- Removed the explicit blind/movecost effect that was being applied on direct hits with tear gas. The field effect is entirely sufficient!
- Extinguishers no longer do massive damage to liquid monsters. ????
- Extinguisher blinding now works on characters as well as monsters.
- Movecost for extinguisher and tear gas sprayer reduced to 1 second and moved to the end of the function.
- Spraypaint and rubber sealant spray can now be used to blind monsters. This lasts slightly longer when used on robots. This uses your melee vs their dodge. They must be wielded to use, as with the other items.
- Extinguishers now also use your melee vs target's dodge for the blinding effect.

#### Testing
Sprayed stuff and blinded it. Made friendlies mad.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
