### PR TITLE
It's not an "alien bomb"

### DIFF
--- a/data/json/mapgen/crater.json
+++ b/data/json/mapgen/crater.json
@@ -13,7 +13,7 @@
     "id": "crater_bomb",
     "type": "TOOL",
     "category": "weapons",
-    "name": { "str": "active alien bomb" },
+    "name": { "str": "AGM-114 Hellfire missile" },
     "description": "This item is used to make a hole for a crater.  It should not otherwise appear in game.",
     "weight": "4400 g",
     "volume": "10 L",


### PR DESCRIPTION
#### Summary
It's not an "alien bomb"

#### Purpose of change
The name "active alien bomb" for the item that generates mapgen craters was confusing people. It wasn't really supposed to be something you can see. It's not an alien bomb, it's some kind of weapon the US military launched, or maybe a particularly powerful IED. Why did they do it? Maybe there was something bad there, or maybe they're feral and still have air superiority.

#### Describe the solution
active alien bomb->AGM-114 Hellfire missile.

The Hellfire's a good candidate for this because it's a missile designed for precise strikes and not something that would level a city block. That doesn't mean every explosion you see is from one of these, but it's less silly than "alien bomb".

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
