### PR TITLE
Shut the fuck up I did not fail to put a item in a pouch

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2397,13 +2397,8 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint & )
         return 0;
     }
 
-    const int success = round( p->get_skill_level( skill_firstaid ) ) - rng( 0, 6 );
-    if( success > 0 ) {
-        p->add_msg_if_player( m_good, _( "You carefully prepare the CBM for sterilization." ) );
-        bionic.get_item()->unset_flag( flag_NO_PACKED );
-    } else {
-        p->add_msg_if_player( m_bad, _( "You fail to properly prepare the CBM." ) );
-    }
+    p->add_msg_if_player( m_good, _( "You carefully prepare the CBM for sterilization." ) );
+    bionic.get_item()->unset_flag( flag_NO_PACKED );
 
     std::vector<item_comp> comps;
     comps.emplace_back( it->typeId(), 1 );


### PR DESCRIPTION
#### Summary
Shut the fuck up I did not fail to put a item in a pouch

#### Purpose of change
- Autoclave pouches were rolling 1d6 and subtracting that from your medical skill. If it got zero, you wasted your pouch and failed to pack it. That is not only annoying, it's quite confusing. 6 is a lot of medical skill, you're telling me skilled professionals still accidentally rip 1/6th of their pouches in half?

#### Describe the solution
- Delete it. If we want to add a skill thing later it'd be related to infection chance or something.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
