### PR TITLE
Fix name, description, of jeweler's blowtorch and blow lamp

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -582,9 +582,9 @@
   {
     "id": "clay_blowtorch",
     "type": "TOOL",
-    "name": { "str": "Blow Lamp" },
+    "name": { "str": "blow lamp" },
     "//": "the Earilest form of Blowtorch that was essentially a very short clay pitcher with a wick and a copper tube to blow through. was capable of melting tin and copper",
-    "description": "a Very Early version of a Blow torch, made with a Clay bowl that holds a wick as well as a Metal Tube to blow through. Altough it takes some practice the precise flame is hot enough to weld softer metals like copper and gold, making it suited for jewelry ",
+    "description": "A very early version of a blow torch. Made with a clay bowl that holds a wick and metal tube, it is used by blowing through it to create a precise flame hot enough to weld soft metals like copper and gold. Mainly used for jewelry.",
     "weight": "225 g",
     "volume": "1 L",
     "price": "200 USD",
@@ -604,8 +604,8 @@
   {
     "id": "fine_blowtorch",
     "type": "TOOL",
-    "name": { "str": "Jeweler's blowtorch" },
-    "description": "a small butane blow torch with a pipe to blow into. used by jeweler's too weld soft metals like gold and copper together.",
+    "name": { "str": "jeweler's blowtorch" },
+    "description": "A small butane blow torch with a pipe to blow into. Used by jewelers to weld soft metals like gold and copper together.",
     "weight": "350 g",
     "volume": " 500 ml",
     "price": "800 USD",


### PR DESCRIPTION

#### Summary
Changes the description and name of the jeweler's blowtorch and blow lamp. Also changes the capitalization of the tool quality to be in line with the rest of the tools

#### Purpose of change
Fix the odd grammar and capitalization which probably resulted from a translation
#### Describe the solution
I went in and changed the description and capitalizations to make more sense
#### Describe alternatives you've considered
Leaving it looking odd
#### Testing
Going to load on my computer as soon as I finish.
#### Additional context
https://discord.com/channels/1341953719889170594/1398064176441720884
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
