### PR TITLE
Reduce monster movement messaging spam

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1906,13 +1906,14 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         ) && here.is_divable( destination );
 
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
-        //Birds and other flying creatures flying over the deep water terrain
-        if( was_water && flies() ) {
+        // Birds and other flying creatures flying over the deep water terrain
+        Character &player_character == get_player_character();
+        if( was_water && flies() && sees( player_character ) && attitude_to( player_character ) == Attitude::HOSTILE ) {
             if( one_in( 4 ) ) {
                 add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),
                                         name(), here.tername( pos_bub() ) );
             }
-        } else if( was_water && !will_be_water ) {
+        } else if( was_water && sees( player_character ) && !will_be_water && attitude_to( player_character ) == Attitude::HOSTILE ) {
             // Use more dramatic messages for swimming monsters
             add_msg_if_player_sees( *this, m_warning,
                                     //~ Message when a monster emerges from water
@@ -1920,7 +1921,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
                                     pgettext( "monster movement", "A %1$s %2$s from the %3$s!" ),
                                     name(), swims() ||
                                     has_flag( mon_flag_AQUATIC ) ? _( "leaps" ) : _( "emerges" ), here.tername( pos_bub() ) );
-        } else if( !was_water && will_be_water ) {
+        } else if( !was_water && sees( player_character ) && will_be_water && attitude_to( player_character ) == Attitude::HOSTILE ) {
             add_msg_if_player_sees( *this, m_warning, pgettext( "monster movement",
                                     //~ Message when a monster enters water
                                     //~ %1$s: monster name, %2$s: dives/sinks, %3$s: terrain name


### PR DESCRIPTION
#### Summary
Reduce monster movement messaging spam

#### Purpose of change
A trout dives under the water! A trout emerges from the water! how about you shut up

#### Describe the solution
- Disable these messages entirely unless the target is hostile and can see you.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
