### PR TITLE
Update bouldering status per turn

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7033,11 +7033,7 @@
       [
         {
           "condition": {
-            "and": [
-              { "u_has_move_mode": "crouch" },
-              { "not": "u_can_drop_weapon" },
-              { "not": { "u_has_flag": "QUADRUPED_RUN" } }
-            ]
+            "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "not": { "u_has_flag": "QUADRUPED_RUN" } } ]
           },
           "msg_on": { "text": "Your paws make it easier to crawl on all fours." }
         }
@@ -9162,7 +9158,12 @@
         }
       ]
     ],
-    "enchantments": [ "ench_quadruped_movement_bipedal", "ench_quadruped_movement_full_crouch", "ench_quadruped_movement_full_run", { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] } ]
+    "enchantments": [
+      "ench_quadruped_movement_bipedal",
+      "ench_quadruped_movement_full_crouch",
+      "ench_quadruped_movement_full_run",
+      { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.2 } ] }
+    ]
   },
   {
     "type": "mutation",
@@ -9193,11 +9194,7 @@
       [
         {
           "condition": {
-            "and": [
-              { "u_has_move_mode": "crouch" },
-              { "not": "u_can_drop_weapon" },
-              { "not": { "u_has_flag": "QUADRUPED_RUN" } }
-            ]
+            "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "not": { "u_has_flag": "QUADRUPED_RUN" } } ]
           },
           "msg_on": { "text": "Your paws make it easier to crawl on all fours." }
         }

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -349,61 +349,63 @@ static void strip_trailing_nulls( std::string &str )
 #endif
 #if defined(__ANDROID__)
 // Android-specific UTF-8 to UTF-32 conversion
-static std::wstring utf8_to_wstr_android(const std::string &utf8) {
+static std::wstring utf8_to_wstr_android( const std::string &utf8 )
+{
     std::wstring wstr;
-    wstr.reserve(utf8.size()); // worst case
-    
+    wstr.reserve( utf8.size() ); // worst case
+
     const char *ptr = utf8.data();
     int len = utf8.size();
-    while (len > 0) {
-        uint32_t ch = UTF8_getch(&ptr, &len);
-        if (ch == UNKNOWN_UNICODE) {
+    while( len > 0 ) {
+        uint32_t ch = UTF8_getch( &ptr, &len );
+        if( ch == UNKNOWN_UNICODE ) {
             continue;
         }
-        if (ch <= 0xFFFF) {
-            wstr.push_back(static_cast<wchar_t>(ch));
+        if( ch <= 0xFFFF ) {
+            wstr.push_back( static_cast<wchar_t>( ch ) );
         } else {
             // Handle surrogate pairs for UTF-16
             ch -= 0x10000;
-            wstr.push_back(static_cast<wchar_t>(0xD800 + (ch >> 10)));
-            wstr.push_back(static_cast<wchar_t>(0xDC00 + (ch & 0x3FF)));
+            wstr.push_back( static_cast<wchar_t>( 0xD800 + ( ch >> 10 ) ) );
+            wstr.push_back( static_cast<wchar_t>( 0xDC00 + ( ch & 0x3FF ) ) );
         }
     }
     return wstr;
 }
 
 // Android-specific UTF-32 to UTF-8 conversion
-static std::string wstr_to_utf8_android(const std::wstring &wstr) {
+static std::string wstr_to_utf8_android( const std::wstring &wstr )
+{
     std::string utf8;
-    utf8.reserve(wstr.size() * 4); // worst case
-    
-    for (size_t i = 0; i < wstr.size(); ) {
+    utf8.reserve( wstr.size() * 4 ); // worst case
+
+    for( size_t i = 0; i < wstr.size(); ) {
         uint32_t ch;
-        if (wstr[i] >= 0xD800 && wstr[i] <= 0xDBFF && i + 1 < wstr.size() && 
-            wstr[i+1] >= 0xDC00 && wstr[i+1] <= 0xDFFF) {
+        if( wstr[i] >= 0xD800 && wstr[i] <= 0xDBFF && i + 1 < wstr.size() &&
+            wstr[i + 1] >= 0xDC00 && wstr[i + 1] <= 0xDFFF ) {
             // Surrogate pair
-            ch = 0x10000 + ((wstr[i] - 0xD800) << 10) + (wstr[i+1] - 0xDC00);
+            ch = 0x10000 + ( ( wstr[i] - 0xD800 ) << 10 ) + ( wstr[i + 1] - 0xDC00 );
             i += 2;
         } else {
-            ch = static_cast<uint32_t>(wstr[i]);
+            ch = static_cast<uint32_t>( wstr[i] );
             i += 1;
         }
-        
+
         // Convert to UTF-8
-        if (ch <= 0x7F) {
-            utf8.push_back(static_cast<char>(ch));
-        } else if (ch <= 0x7FF) {
-            utf8.push_back(static_cast<char>(0xC0 | (ch >> 6)));
-            utf8.push_back(static_cast<char>(0x80 | (ch & 0x3F)));
-        } else if (ch <= 0xFFFF) {
-            utf8.push_back(static_cast<char>(0xE0 | (ch >> 12)));
-            utf8.push_back(static_cast<char>(0x80 | ((ch >> 6) & 0x3F)));
-            utf8.push_back(static_cast<char>(0x80 | (ch & 0x3F)));
+        if( ch <= 0x7F ) {
+            utf8.push_back( static_cast<char>( ch ) );
+        } else if( ch <= 0x7FF ) {
+            utf8.push_back( static_cast<char>( 0xC0 | ( ch >> 6 ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ch & 0x3F ) ) );
+        } else if( ch <= 0xFFFF ) {
+            utf8.push_back( static_cast<char>( 0xE0 | ( ch >> 12 ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ( ch >> 6 ) & 0x3F ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ch & 0x3F ) ) );
         } else {
-            utf8.push_back(static_cast<char>(0xF0 | (ch >> 18)));
-            utf8.push_back(static_cast<char>(0x80 | ((ch >> 12) & 0x3F)));
-            utf8.push_back(static_cast<char>(0x80 | ((ch >> 6) & 0x3F)));
-            utf8.push_back(static_cast<char>(0x80 | (ch & 0x3F)));
+            utf8.push_back( static_cast<char>( 0xF0 | ( ch >> 18 ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ( ch >> 12 ) & 0x3F ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ( ch >> 6 ) & 0x3F ) ) );
+            utf8.push_back( static_cast<char>( 0x80 | ( ch & 0x3F ) ) );
         }
     }
     return utf8;
@@ -424,7 +426,7 @@ std::wstring utf8_to_wstr( const std::string &utf8 )
     return wstr;
 
 #elif defined(__ANDROID__)
-    return utf8_to_wstr_android(utf8);
+    return utf8_to_wstr_android( utf8 );
 
 #else
     iconv_t cd = iconv_open( "UTF-32LE", "UTF-8" );
@@ -467,7 +469,7 @@ std::string wstr_to_utf8( const std::wstring &wstr )
     return str;
 
 #elif defined(__ANDROID__)
-    return wstr_to_utf8_android(wstr);
+    return wstr_to_utf8_android( wstr );
 
 #else
     iconv_t cd = iconv_open( "UTF-8", "UTF-32LE" );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8329,7 +8329,8 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     const optional_vpart_position veh_part = here.veh_at( pos_bub() );
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
-    if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() && !has_effect_with_flag( json_flag_LEVITATION ) ) {
+    if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() &&
+        !has_effect_with_flag( json_flag_LEVITATION ) ) {
         int rolls = 4;
         if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
             rolls += 2;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2540,6 +2540,12 @@ void Character::process_turn()
         }
     }
 
+    // TODO: Maybe a unified function for terrain effects?
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
+        !here.has_vehicle_floor( pos_bub() ) ) {
+        add_effect( effect_bouldering, 1_turns, true );
+    }
+
     for( const trait_id &mut : get_mutations() ) {
         mutation_reflex_trigger( mut );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -327,6 +327,7 @@ static const json_character_flag json_flag_INFRARED( "INFRARED" );
 static const json_character_flag json_flag_INSECTBLOOD( "INSECTBLOOD" );
 static const json_character_flag json_flag_INVERTEBRATEBLOOD( "INVERTEBRATEBLOOD" );
 static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
+static const json_character_flag json_flag_LEVITATION( "LEVITATION" );
 static const json_character_flag json_flag_MYOPIC( "MYOPIC" );
 static const json_character_flag json_flag_MYOPIC_IN_LIGHT( "MYOPIC_IN_LIGHT" );
 static const json_character_flag json_flag_NIGHT_BLINDNESS( "NIGHT_BLINDNESS" );
@@ -2541,8 +2542,9 @@ void Character::process_turn()
     }
 
     // TODO: Maybe a unified function for terrain effects?
+    map &here = get_map();
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
-        !here.has_vehicle_floor( pos_bub() ) ) {
+        !here.has_vehicle_floor( pos_bub() ) && !has_effect( effect_bouldering ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     }
 
@@ -8327,7 +8329,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
     const optional_vpart_position veh_part = here.veh_at( pos_bub() );
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
-    if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() )  {
+    if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() && !has_effect_with_flag( json_flag_LEVITATION ) ) {
         int rolls = 4;
         if( worn_with_flag( flag_ROLLER_ONE ) && !in_skater_vehicle ) {
             rolls += 2;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2791,7 +2791,8 @@ void monster::process_turn()
     }
 
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
-        !here.has_vehicle_floor( pos_bub() ) && !flies() && !climbs() && !has_effect( effect_bouldering ) ) {
+        !here.has_vehicle_floor( pos_bub() ) && !flies() && !climbs() &&
+        !has_effect( effect_bouldering ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2790,6 +2790,11 @@ void monster::process_turn()
         }
     }
 
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
+        !here.has_vehicle_floor( pos_bub() ) && !flies() && !climbs() ) {
+        add_effect( effect_bouldering, 1_turns, true );
+    }
+
     // Special attack cooldowns are updated here.
     // Loop through the monster's special attacks, same as monster::move.
     for( const auto &sp_type : type->special_attacks ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2791,7 +2791,7 @@ void monster::process_turn()
     }
 
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
-        !here.has_vehicle_floor( pos_bub() ) && !flies() && !climbs() ) {
+        !here.has_vehicle_floor( pos_bub() ) && !flies() && !climbs() && !has_effect( effect_bouldering ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1087,7 +1087,7 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
         delete[] n_enabled;
         if( j_ret == -1 ) {
             ret = UILIST_CANCEL;
-        } else if( j_ret >= 0 && static_cast<size_t>(j_ret) < entries.size() ) {
+        } else if( j_ret >= 0 && static_cast<size_t>( j_ret ) < entries.size() ) {
             ret = entries[j_ret].retval;
         } else {
             ret = UILIST_ERROR;


### PR DESCRIPTION
#### Summary
Update bouldering status per turn

#### Purpose of change
The bouldering effect was not applying when you climbed somewhere, only when you moved. Given that you generally get it while climbing, that needed fixing.

#### Describe the solution
Add a per-turn check for both monsters and characters in process_turn() that applies bouldering if you're up a tree or something.

#### Testing
Went up a tree. Good.

Put a turret up a tree. Good.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
