### PR TITLE
Fix build and update quarterstaffs

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -506,7 +506,7 @@
     "symbol": "/",
     "material": [ "wood" ],
     "techniques": [ "WBLOCK_1", "PRECISE" ],
-    "weapon_category": [ "BLUDGEONS", "KARATE_WEAPONS" ],
+    "weapon_category": [ "BLUDGEONS" ],
     "volume": "1100 ml",
     "longest_side": "65 cm",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },
@@ -674,10 +674,10 @@
     "color": "brown",
     "looks_like": "q_staff",
     "name": { "str": "ironshod quarterstaff", "str_pl": "ironshod quarterstaves" },
-    "description": "A long wooden staff reinforced with metal bands and caps.",
+    "description": "A long wooden staff reinforced with steel langets and ferrules.",
     "price": "60 USD",
     "price_postapoc": "15 USD",
-    "material": [ "wood", "iron" ],
+    "material": [ "wood", "steel" ],
     "techniques": [ "WBLOCK_2", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND", "DURABLE_MELEE" ],
     "weapon_category": [ "QUARTERSTAVES" ],
@@ -687,7 +687,7 @@
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "neutral" },
     "category": "weapons",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 27 }
+    "melee_damage": { "bash": 25 }
   },
   {
     "type": "GENERIC",
@@ -1138,7 +1138,7 @@
     "price": "80 USD",
     "price_postapoc": "20 USD",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "neutral" },
-    "material": [ "wood", "iron" ],
+    "material": [ "wood", "steel", "plastic" ],
     "symbol": "/",
     "color": "brown",
     "ammo": [ "battery" ],
@@ -1156,7 +1156,7 @@
         "default_magazine": "medium_battery_cell"
       }
     ],
-    "melee_damage": { "bash": 27 }
+    "melee_damage": { "bash": 24 }
   },
   {
     "id": "shocktonfa_off",

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -882,28 +882,11 @@
     "time": "24 m",
     "autolearn": true,
     "book_learn": [ [ "textbook_weapwest", 2 ], [ "recipe_melee", 3 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "qualities": [ { "id": "DRILL", "level": 1 } ],
     "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
+      { "proficiency": "prof_metalworking" }
     ],
-    "components": [ [ [ "bo", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "result": "i_staff",
-    "id_suffix": "with sheet metal",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 2,
-    "time": "30 m",
-    "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
-    "components": [ [ [ "sheet_metal_small", 6 ] ], [ [ "nuts_bolts", 4 ] ], [ [ "bo", 1 ] ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 }, { "id": "DRILL", "level": 2 } ]
+    "components": [ [ [ "q_staff", 1 ] ], [ [ "pipe_fittings", 2 ] ], [ [ "scrap", 4 ] ], [ [ "nuts_bolts", 8 ], [ "nail", 8 ] ] ]
   },
   {
     "result": "knuckle_impact",

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1907,7 +1907,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
 
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         // Birds and other flying creatures flying over the deep water terrain
-        Character &player_character == get_player_character();
+        Character &player_character = get_player_character();
         if( was_water && flies() && sees( player_character ) && attitude_to( player_character ) == Attitude::HOSTILE ) {
             if( one_in( 4 ) ) {
                 add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),


### PR DESCRIPTION
#### Summary
Fix build and update quarterstaffs

#### Purpose of change
- Build was squirrely because of a == instead of a =
- Ironshod quarterstaff recipe needed fixin

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
