### PR TITLE
Fix innawood steel type bug

### DIFF
--- a/data/mods/innawood/recipes/recipe_others.json
+++ b/data/mods/innawood/recipes/recipe_others.json
@@ -66,11 +66,6 @@
     "components": [
       [
         [ "wire", 2 ],
-        [ "lc_wire", 2 ],
-        [ "mc_wire", 2 ],
-        [ "hc_wire", 2 ],
-        [ "qt_wire", 2 ],
-        [ "ch_wire", 2 ],
         [ "cable", 2 ]
       ],
       [ [ "yarn", 1 ], [ "cotton_ball", 1 ], [ "wool_staple", 1 ] ]


### PR DESCRIPTION
#### Summary
Fix innawood steel type bug

#### Purpose of change
A recipe backported into innawood was calling for steel types, which we don't have.

#### Describe the solution
no,

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
