### PR TITLE
Favor natural attack vectors and fix talons

### DIFF
--- a/data/json/attack_vectors.json
+++ b/data/json/attack_vectors.json
@@ -129,6 +129,14 @@
   },
   {
     "type": "attack_vector",
+    "id": "vector_talon",
+    "limbs": [ "foot_l", "foot_r" ],
+    "contact_area": [ "foot_toes_l", "foot_toes_r", "foot_heel_l", "foot_heel_r" ],
+    "limb_req": [ [ "leg", 2 ] ],
+    "natural_attack": true
+  },
+  {
+    "type": "attack_vector",
     "id": "vector_hoof_toe",
     "limbs": [ "hoof_l", "hoof_r" ],
     "contact_area": [ "hoof_toe_l", "hoof_toe_r" ],

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -48,7 +48,15 @@
     "unarmed_allowed": true,
     "messages": [ "You kick %s", "<npcname> kicks %s" ],
     "description": "A basic kick",
-    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_shin", "vector_knee", "vector_hoof_toe", "vector_hoof_sole" ]
+    "attack_vectors": [
+      "vector_foot_toes",
+      "vector_talon",
+      "vector_foot_sole",
+      "vector_shin",
+      "vector_knee",
+      "vector_hoof_toe",
+      "vector_hoof_sole"
+    ]
   },
   {
     "type": "technique",
@@ -1038,7 +1046,7 @@
       { "stat": "damage", "type": "cut", "scale": 0.66 },
       { "stat": "damage", "type": "stab", "scale": 0.66 }
     ],
-    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_talon", "vector_hoof_toe" ]
   },
   {
     "type": "technique",
@@ -1096,7 +1104,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.25 },
       { "stat": "damage", "type": "stab", "scale": 1.25 }
     ],
-    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_talon", "vector_hoof_toe" ]
   },
   {
     "type": "technique",
@@ -1192,7 +1200,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.2 },
       { "stat": "damage", "type": "stab", "scale": 1.2 }
     ],
-    "attack_vectors": [ "vector_foot_heel", "vector_hoof_sole" ]
+    "attack_vectors": [ "vector_foot_heel", "vector_hoof_sole", "vector_talon" ]
   },
   {
     "type": "technique",
@@ -1676,7 +1684,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.2 },
       { "stat": "damage", "type": "stab", "scale": 1.2 }
     ],
-    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_talon", "vector_hoof_toe" ]
   },
   {
     "type": "technique",
@@ -1824,7 +1832,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.4 },
       { "stat": "damage", "type": "stab", "scale": 1.4 }
     ],
-    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_talon", "vector_hoof_toe" ]
   },
   {
     "type": "technique",
@@ -1904,6 +1912,7 @@
       "vector_punch",
       "vector_elbow",
       "vector_foot_toes",
+      "vector_talon",
       "vector_shin",
       "vector_knee",
       "vector_hoof_toe",
@@ -2184,7 +2193,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.4 },
       { "stat": "damage", "type": "stab", "scale": 1.4 }
     ],
-    "attack_vectors": [ "vector_shin", "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_shin", "vector_foot_toes", "vector_talon", "vector_hoof_toe" ]
   },
   {
     "type": "technique",
@@ -2288,6 +2297,7 @@
       "vector_punch",
       "vector_elbow",
       "vector_foot_toes",
+      "vector_talon",
       "vector_shin",
       "vector_hoof_toe",
       "vector_hoof_sole"
@@ -2311,6 +2321,7 @@
       "vector_punch",
       "vector_elbow",
       "vector_foot_toes",
+      "vector_talon",
       "vector_shin",
       "vector_hoof_toe",
       "vector_hoof_sole"
@@ -2454,6 +2465,7 @@
       "vector_punch",
       "vector_elbow",
       "vector_foot_heel",
+      "vector_talon",
       "vector_shin",
       "vector_hoof_toe",
       "vector_hoof_sole"
@@ -2913,7 +2925,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.5 },
       { "stat": "damage", "type": "stab", "scale": 1.5 }
     ],
-    "attack_vectors": [ "vector_foot_heel", "vector_hoof_sole" ]
+    "attack_vectors": [ "vector_foot_heel", "vector_talon", "vector_hoof_sole" ]
   },
   {
     "type": "technique",
@@ -2968,7 +2980,7 @@
     },
     "condition_desc": "* Only works on a <info>non-downed</info> target of <info>similar or smaller</info> size incapable of flight",
     "down_dur": 1,
-    "attack_vectors": [ "vector_foot_toes", "vector_shin", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_shin", "vector_hoof_toe", "vector_talon" ]
   },
   {
     "type": "technique",
@@ -2982,7 +2994,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.2 },
       { "stat": "damage", "type": "stab", "scale": 1.2 }
     ],
-    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_foot_toes", "vector_hoof_toe", "vector_talon" ]
   },
   {
     "type": "technique",
@@ -3400,7 +3412,7 @@
       { "stat": "damage", "type": "cut", "scale": 1.3 },
       { "stat": "damage", "type": "stab", "scale": 1.3 }
     ],
-    "attack_vectors": [ "vector_claw", "vector_claw_right", "vector_punch", "vector_foot_toes", "vector_hoof_toe" ]
+    "attack_vectors": [ "vector_claw", "vector_claw_right", "vector_punch", "vector_foot_toes", "vector_hoof_toe", "vector_talon" ]
   },
   {
     "type": "technique",

--- a/data/mods/innawood/recipes/recipe_others.json
+++ b/data/mods/innawood/recipes/recipe_others.json
@@ -63,13 +63,7 @@
     "difficulty": 1,
     "time": "2 m",
     "autolearn": true,
-    "components": [
-      [
-        [ "wire", 2 ],
-        [ "cable", 2 ]
-      ],
-      [ [ "yarn", 1 ], [ "cotton_ball", 1 ], [ "wool_staple", 1 ] ]
-    ]
+    "components": [ [ [ "wire", 2 ], [ "cable", 2 ] ], [ [ "yarn", 1 ], [ "cotton_ball", 1 ], [ "wool_staple", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1908,12 +1908,14 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         // Birds and other flying creatures flying over the deep water terrain
         Character &player_character = get_player_character();
-        if( was_water && flies() && sees( player_character ) && attitude_to( player_character ) == Attitude::HOSTILE ) {
+        if( was_water && flies() && sees( player_character ) &&
+            attitude_to( player_character ) == Attitude::HOSTILE ) {
             if( one_in( 4 ) ) {
                 add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),
                                         name(), here.tername( pos_bub() ) );
             }
-        } else if( was_water && sees( player_character ) && !will_be_water && attitude_to( player_character ) == Attitude::HOSTILE ) {
+        } else if( was_water && sees( player_character ) && !will_be_water &&
+                   attitude_to( player_character ) == Attitude::HOSTILE ) {
             // Use more dramatic messages for swimming monsters
             add_msg_if_player_sees( *this, m_warning,
                                     //~ Message when a monster emerges from water
@@ -1921,7 +1923,8 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
                                     pgettext( "monster movement", "A %1$s %2$s from the %3$s!" ),
                                     name(), swims() ||
                                     has_flag( mon_flag_AQUATIC ) ? _( "leaps" ) : _( "emerges" ), here.tername( pos_bub() ) );
-        } else if( !was_water && sees( player_character ) && will_be_water && attitude_to( player_character ) == Attitude::HOSTILE ) {
+        } else if( !was_water && sees( player_character ) && will_be_water &&
+                   attitude_to( player_character ) == Attitude::HOSTILE ) {
             add_msg_if_player_sees( *this, m_warning, pgettext( "monster movement",
                                     //~ Message when a monster enters water
                                     //~ %1$s: monster name, %2$s: dives/sinks, %3$s: terrain name


### PR DESCRIPTION
#### Summary
Favor natural attack vectors and fix talons

#### Purpose of change
- Talons weren't working properly
- I wanted to make natural attack vectors favored over other ones if available

#### Describe the solution
- Add a vector for talons, mapped to foot_toes and foot_heel
- Add a 75% chance to favor a natural attack if one is available

#### Describe alternatives you've considered
It looks like avian legs and toe talons need to be limbified, which is a lot of json overhead I was hoping to avoid, but I can't think of a better solution. This will do in the meantime, but that will produce better behavior overall.

#### Testing
Mutated talons. Kicked a guy, saw talons were the selected vector. Put on XL boots. Saw that toes were the selected vector.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
