### PR TITLE
Fix tile scaling, rename occlusion in comments

### DIFF
--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -260,7 +260,6 @@ class tileset
         const std::unordered_set<std::string> &get_duplicate_ids() const {
             return duplicate_ids;
         }
-
         tile_type &create_tile_type( const std::string &id, tile_type &&new_tile_type );
         const tile_type *find_tile_type( const std::string &id ) const;
 


### PR DESCRIPTION
#### Summary
Fix tile scaling, rename occlusion in comments

#### Purpose of change
Tiles are composed of sprites, that is, individual images which are overlaid atop each other to compose a tile. When tile scaling was added in #1062 I hadn't realized that some character overlays (IE long horns) have different dimensions from the character's body. We were scaling each image individually, but only correcting offsets on a tile scale, meaning that mutations like long horns would be too low if you were big and floating above your head if you were small.

#### Describe the solution
Move the offset adjustments to draw_sprite_at(), meaning they happen per-image according to their individual height and width. This seems to solve all the problems we were having.

#### Describe alternatives you've considered

#### Testing
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4dd330cd-e67a-486e-9361-ce9d3177243b" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/06eb7a37-47b0-41b1-a766-b708e1910382" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6ee6b684-6790-4aae-b0a4-645989b8dfcd" />




#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
