### PR TITLE
Kid NPCs are small

### DIFF
--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -55,7 +55,7 @@
     "type": "npc_class",
     "id": "NC_godco_chloe_taylor",
     "name": { "str": "Member" },
-    "job_description": "I am a member of the New England Church Community.",
+    "job_description": "I am a member of the New England Church Community, I'm also a child.",
     "common": false,
     "bonus_str": { "rng": [ -3, -2 ] },
     "bonus_dex": { "rng": [ 0, 2 ] },
@@ -68,6 +68,7 @@
       { "group": "NPC_starting_traits" },
       { "group": "Skin_Any" },
       { "trait": "NO_BASH" },
+      { "trait": "SMALL_NATURAL" },
       { "trait": "RETURN_TO_START_POS" }
     ],
     "skills": [
@@ -464,6 +465,7 @@
       { "group": "NPC_starting_traits" },
       { "group": "Hair_Brown" },
       { "trait": "NO_BASH" },
+      { "trait": "SMALL_NATURAL" },
       { "trait": "RETURN_TO_START_POS" }
     ],
     "skills": [

--- a/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
@@ -88,7 +88,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Jeremiah_Story",
-    "dynamic_line": "I was in high school, like anyone else my age.  Then out of nowhere, my mom pulled me out of school to \"save me\".  I got packed into a bus with my parents and their old-timey friends.  We've been stuck here ever since.  Actually, it's not all that bad.  I'm studying to be a herbalist like Kostas, which is cool I guess.",
+    "dynamic_line": "I was in school, like anyone else my age.  Then out of nowhere, my mom pulled me out of school to \"save me\".  I got packed into a bus with my parents and their old-timey friends.  We've been stuck here ever since.  Actually, it's not all that bad.  I'm studying to be a herbalist like Kostas, which is cool I guess.",
     "responses": [
       { "text": "Tell me about your parents.", "topic": "TALK_GODCO_Jeremiah_Parents" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
@@ -25,7 +25,12 @@
     "worn_override": "REFUGEE_Aleesha_worn",
     "carry_override": "REFUGEE_Aleesha_carried",
     "weapon_override": "REFUGEE_Aleesha_wield",
-    "traits": [ { "group": "Appearance_African" }, { "trait": "NO_BASH" }, { "trait": "RETURN_TO_START_POS" } ]
+    "traits": [
+      { "group": "Appearance_African" },
+      { "trait": "NO_BASH" },
+      { "trait": "SMALL_NATURAL" },
+      { "trait": "RETURN_TO_START_POS" }
+    ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
#### Summary
Kid NPCs are small

#### Purpose of change
Aleesha Seward, Jeremiah Weaver, and Chloe Taylor are all kids. Aleesha's fourteen, it's not clear what age Jeremiah and Chloe are. I think fourteen ought to be the cutoff for smallness, but it's a good idea to give it to all these NPCs anyway because it's important to their story that they're kids and it clearly signposts it for the player. NPCs standing out from each other more is always nice.

#### Describe the solution
- Change Jeremiah's line about high school to school. Maybe he's a middle schooler, who knows.
- Jeremiah, Aleesha, and Chloe all have the Little trait.

#### Describe alternatives you've considered
If the game goes on long enough, maybe they ought to grow up. That's a whole other can of worms though.

#### Testing
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7d6540ec-65aa-4c2c-af84-8f6e3349782a" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d0ed9a06-1986-4d9d-b203-c60a14ef5272" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4593e46a-0105-46c9-bca5-3dfd5f3433dd" />
hahaha they're so tiny

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
