### PR TITLE
Make craft range checks more permissive and fix woodcutting

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2196,9 +2196,7 @@ void inventory_selector::add_nearby_items( int radius )
                 add_vehicle_items( pos );
                 continue;
             }
-            int dist = ( radius <= 1 ) ?
-                       square_dist( center, pos ) :
-                       static_cast<int>( trig_dist_z_adjust( center, pos ) );
+            int dist = static_cast<int>( std::ceil( trig_dist_z_adjust( center, pos ) ) );
             if( !here.clear_path( center, pos, dist, 1, 100 ) ) {
                 continue;
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4631,16 +4631,18 @@ std::optional<int> iuse::lumber( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     map &here = get_map();
-    // Check if player is standing on any lumber
-    for( item &i : here.i_at( p->pos_bub() ) ) {
-        if( i.typeId() == itype_log ) {
-            here.i_rem( p->pos_bub(), &i );
-            cut_log_into_planks( *p );
-            return 1;
+    // Check if player is standing on or adjacent to any lumber
+    for( tripoint_bub_ms lumberpos : here.points_in_radius( p->pos_bub(), 1 ) ) {
+        for( item &i : here.i_at( lumberpos ) ) {
+            if( i.typeId() == itype_log ) {
+                here.i_rem( lumberpos, &i );
+                cut_log_into_planks( *p );
+                return 1;
+            }
         }
     }
 
-    // If the player is not standing on a log, check inventory
+    // If there are no logs around, check our inventory.
     avatar *you = p->as_avatar();
     item_location loc;
     auto filter = []( const item & it ) {
@@ -4727,10 +4729,6 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
-        return std::nullopt;
-    }
-    if( !p->is_wielding( *it ) && !p->is_worn( *it ) ) {
-        p->add_msg_if_player( _( "You need to be wielding the %s to use it." ), it->tname() );
         return std::nullopt;
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8367,9 +8367,10 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     }
 
     // Ugly `if` for now
+    // TODO: Why is it even like this?
     if( f.z() == t.z() ) {
         if( ( range >= 0 &&
-              range < trig_dist( f.raw(), t.raw() ) ) ||
+              range < static_cast<int>( std::ceil( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) ) ||
             !inbounds( t ) ) {
             return false; // Out of range!
         }
@@ -8392,7 +8393,7 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     }
 
     // Handle direct vertical neighbor (1 tile away, different Z)
-    if( trig_dist_z_adjust( f.raw(), t.raw() ) == 1 && f.z() != t.z() ) {
+    if(  static_cast<int>( std::ceil( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) == 1 && f.z() != t.z() ) {
         const bool going_up = t.z() > f.z();
         const tripoint_bub_ms &lower = going_up ? f : t;
         const tripoint_bub_ms &upper = going_up ? t : f;
@@ -8413,7 +8414,7 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     }
 
     // 3D path check
-    if( ( range >= 0 && range < trig_dist_z_adjust( f.raw(), t.raw() ) ) ||
+    if( ( range >= 0 && range <  static_cast<int>( std::ceil( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) ) ||
         !inbounds( t ) ) {
         return false;
     }


### PR DESCRIPTION
#### Summary
Make craft range checks more permissive and fix woodcutting

#### Purpose of change
- Craft range checks were failing because of some float-int conversions causing a mismatch. The easiest fix is to just make it always round the trig distance up. This might extend the craft range by 1 in some cases, but whatever.

#### Describe the solution
- Round up all the trig_dist_z_adjust checks.

#### Describe alternatives you've considered
- Do proper rounding.

#### Testing
Seems to work. Will it break anything else? idk

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
