### PR TITLE
Partially backport 74162 - Character volume

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3470,7 +3470,7 @@ void Character::on_move( const tripoint_abs_ms &old_pos )
     }
 }
 
-units::volume Character::get_total_volume() const
+units::volume Character::get_total_character_volume() const
 {
     item_location wep = get_wielded_item();
     units::volume wep_volume = wep ? wep->volume() : 0_ml;
@@ -3478,17 +3478,47 @@ units::volume Character::get_total_volume() const
     return get_base_volume() + volume_carried() + wep_volume;
 }
 
-units::volume Character::get_base_volume() const
+units::volume Character::get_average_character_volume() const
 {
-    const int your_height = height(); // avg 175cm
-    // Arbitrary number picked relative to aisle (100L), not necessarily accurate
-    const units::volume avg_human_volume = 70_liter;
+    // Assuming 175cm and 75kg as the human average, we land on about 75 liters.
+    // Characters in different size categories have different proportions.
+    // See also: get_base_volume(), size_category_height_limits
+    if( enum_size() == 1 ) {
+        units::volume avg_character_volume = 8500_milliliter;
+    } else if( enum_size() == 2 ) {
+        const units::volume avg_character_volume = 23_liter;
+    } else if( enum_size() == 4 ) {
+        const units::volume avg_character_volume = 136_liter;
+    } else if( enum_size() == 2 ) {
+        const units::volume avg_character_volume = 244_liter;
+    } else {
+        const units::volume avg_character_volume = 75_liter;
+    }
+    return avg_character_volume
+}
 
-    // Very scientific video game size to metric human volume calculation. Avg height == avg_human_volume;
-    units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.5 );
-    double volume_proport = units::to_liter( your_base_volume ) / units::to_liter( avg_human_volume );
+units::volume Character::get_base_character_volume() const
+{
+    const int your_height = height();
+    // See also: get_average_volume(), size_category_height_limits
+    if( enum_size() == 1 ) {
+        units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 8.24 );
+    } else if( enum_size() == 2 ) {
+        units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 5.3 );
+    } else if( enum_size() == 4 ) {
+        units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 1.67 );
+    } else if( enum_size() == 2 ) {
+        units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 1.15 );
+    } else {
+        units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.32 );
+    }
+    
+    // TODO: This should be looking at body fat and muscle mass, tails, shells, etc.
+    units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.32 );
+    units::volume average_volume = get_average_character_volume();
+    double volume_proport = units::to_liter( your_base_volume ) / units::to_liter( average_volume );
 
-    return std::pow( volume_proport, 3.0 ) * avg_human_volume;
+    return std::pow( volume_proport, 3.0 ) * average_volume;
 }
 
 units::mass Character::weight_carried() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3470,6 +3470,27 @@ void Character::on_move( const tripoint_abs_ms &old_pos )
     }
 }
 
+units::volume Character::get_total_volume() const
+{
+    item_location wep = get_wielded_item();
+    units::volume wep_volume = wep ? wep->volume() : 0_ml;
+    // Note: Does not measure volume of worn items that do not themselves contain anything
+    return get_base_volume() + volume_carried() + wep_volume;
+}
+
+units::volume Character::get_base_volume() const
+{
+    const int your_height = height(); // avg 175cm
+    // Arbitrary number picked relative to aisle (100L), not necessarily accurate
+    const units::volume avg_human_volume = 70_liter;
+
+    // Very scientific video game size to metric human volume calculation. Avg height == avg_human_volume;
+    units::volume your_base_volume = units::from_liter( static_cast<double>( your_height ) / 2.5 );
+    double volume_proport = units::to_liter( your_base_volume ) / units::to_liter( avg_human_volume );
+
+    return std::pow( volume_proport, 3.0 ) * avg_human_volume;
+}
+
 units::mass Character::weight_carried() const
 {
     if( cached_weight_carried ) {

--- a/src/character.h
+++ b/src/character.h
@@ -2288,6 +2288,11 @@ class Character : public Creature, public visitable
         // weapon + worn (for death, etc)
         std::vector<item *> inv_dump();
         std::vector<const item *> inv_dump() const;
+
+        // TODO: Cache this like weight carried?
+        units::volume get_total_volume() const;
+        units::volume get_base_volume() const;
+
         units::mass weight_carried() const;
         units::volume volume_carried() const;
 

--- a/src/character.h
+++ b/src/character.h
@@ -2289,9 +2289,10 @@ class Character : public Creature, public visitable
         std::vector<item *> inv_dump();
         std::vector<const item *> inv_dump() const;
 
+        units::volume get_average_character_volume() const;
         // TODO: Cache this like weight carried?
-        units::volume get_total_volume() const;
-        units::volume get_base_volume() const;
+        units::volume get_total_character_volume() const;
+        units::volume get_base_character_volume() const;
 
         units::mass weight_carried() const;
         units::volume volume_carried() const;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -223,8 +223,8 @@ void Creature::setpos( const tripoint_bub_ms &p )
 static units::volume size_to_volume( creature_size size_class )
 {
     // TODO: size_to_volume and volume_to_size should be made into a single consistent function.
-    // TODO: This calculation is underestimating the size of a medium creature. They should be around 10500 ml.
-    // Large creatures should be bigger too. This would necessitate increasing vpart capacity and resizing
+    // TODO: Volume averages should be 8500, 23000, 75000, 136000, 244000
+    // TODO: This would necessitate increasing vpart capacity and resizing
     // almost every monster in the game.
     if( size_class == creature_size::tiny ) {
         return 15625_ml;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -231,6 +231,10 @@ static int calc_bash_skill( const mtype &t )
     return ret;
 }
 
+// TODO: size_to_volume and volume_to_size should be made into a single consistent function.
+// TODO: Volume max should be tiny: 10679, small: 27358, medium: 90134, large: 150299
+// TODO: This would necessitate increasing vpart capacity and resizing almost every monster in the game.
+// See Character::get_average_character_volume() etc.
 static creature_size volume_to_size( const units::volume &vol )
 {
     if( vol <= 7500_ml ) {


### PR DESCRIPTION
#### Summary
Partially backport 74162 - Character volume

#### Purpose of change
- DDA 74162 moved cramped space calculations to use dynamically derived volume. I am not satisfied with that implementation and we will continue to use size category for now, but it's still useful to be able to figure out what our volume is.
- DDA assumes that different size categories are proportionally 1:1 with medium humans. This is not the case, as children have shorter limbs and larger heads, etc. and the same goes for murine and lagomorph mutants, etc.
- DDA adds your worn equipment to your volume. This is certainly reasonable, but last I checked there were a lot of problems with the approach used, so for now let's just look at the body.

#### Describe the solution
- Use the height limits in size_category_height_limits to get average heights for size categories.
- Divide average height for that weight by 1.01 g/cm³ (average human body density) to get volume.
- Repeat for different sizes, adding a small amount of density for larger, subtracting for smaller as larger characters need proportionally larger bones to support their weight etc.
- Don't do anything else with these numbers for now.
- Add some comments to size_to_volume() and volume_to_size() to prep for monster size fixes someday.

#### Testing
Compiles and runs, no problems.

#### Additional context
- Still need to do body fat, muscle, mutations, worn items, etc.
- Should unify and fix size_to_volume() and volume_to_size()

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
