### PR TITLE
Backport DDA 76968 - move volume and weight vals to math

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -109,8 +109,8 @@
     "type": "effect_on_condition",
     "id": "EOC_variable_weight_volume_test1",
     "effect": [
-      { "math": [ "u_weight_test", "=", "u_val('weight')" ] },
-      { "math": [ "u_volume_test", "=", "u_val('volume')" ] },
+      { "math": [ "u_weight_test", "=", "u_weight()" ] },
+      { "math": [ "u_volume_test", "=", "u_volume()" ] },
       { "u_message": "<u_name> weight: <u_val:weight_test> volume: <u_val:volume_test>" }
     ]
   },
@@ -118,8 +118,8 @@
     "type": "effect_on_condition",
     "id": "EOC_variable_weight_volume_test2",
     "effect": [
-      { "math": [ "u_weight_test", "=", "n_val('weight')" ] },
-      { "math": [ "u_volume_test", "=", "n_val('volume')" ] },
+      { "math": [ "u_weight_test", "=", "n_weight()" ] },
+      { "math": [ "u_volume_test", "=", "n_volume()" ] },
       { "u_message": "<npc_name> weight: <u_val:weight_test> volume: <u_val:volume_test>" }
     ]
   },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1382,6 +1382,8 @@ _some functions support array arguments or kwargs, denoted with square brackets 
 | npc_fear()    |  ✅   |  ✅   | u, n  | Return NPC fear toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_fear()", "<", "2" ] }`|
 | npc_trust()    |  ✅   |  ✅   | u, n  | Return NPC trust toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_trust()", "=", "2" ] }`|
 | npc_value()    |  ✅   |  ✅   | u, n  | Return NPC value toward opposite talker. <br/><br/>Example:<br/> `{ "math": [ "n_npc_value()", "+=", "2" ] }`|
+| weight()    |  ✅   |  ❌   | u, n  | Return creature or item weight, in miligrams. <br/><br/>Example:<br/> `{ "math": [ "u_weight()", "<", "1000000" ] }`|
+| volume()    |  ✅   |  ❌   | u, n  | Return creature or item volume, in mililiters. <br/><br/>Example:<br/> `{ "math": [ "u_volume()", "<", "1000" ] }`|
 | vitamin(`s`/`v`)    |  ✅   |   ✅  | u, n  | Return or set the characters vitamin level.<br/>Argument is vitamin ID.<br/><br/>Example:<br/>`{ "math": [ "u_vitamin('mutagen')", "=", "0" ] }`|
 | warmth(`s`/`v`)    |  ✅   |   ❌  | u, n  | Return the characters warmth on a body part.<br/>Argument is bodypart ID.<br/><br/>Example:<br/> The value displayed in-game is calculated as follows.<br/> `"{ "math": [ "u_warmth_in_game", "=", "(u_warmth('torso') / 100) * 2 - 100"] }`|
 | vision_range()    |  ✅   |   ❌  | u, n  | Return the character's or monsters visual range, adjusted by their mutations, effects, and other issues.<br/><br/>Example:<br/> `"{ "math": [ "n_vision_range()", "<", "30"] }`|

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2192,8 +2192,6 @@ std::unordered_map<std::string_view, int ( talker::* )() const> const f_get_vals
     { "strength_bonus", &talker::get_str_bonus },
     { "strength", &talker::str_cur },
     { "thirst", &talker::get_thirst },
-    { "volume", &talker::get_volume },
-    { "weight", &talker::get_weight },
     { "count", &talker::get_count }
 };
 } // namespace

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1618,6 +1618,38 @@ std::function<void( dialogue &, double )> calories_ass( char scope,
     };
 }
 
+std::function<double( dialogue & )> weight_eval( char scope,
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+{
+    return[beta = is_beta( scope )]( dialogue const & d ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+            return d.actor( beta )->get_weight();
+        }
+        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        if( it && *it ) {
+            return static_cast<int>( to_milligram( it->get_item()->weight() ) );
+        }
+        debugmsg( "For weight(), talker is not character nor item" );
+        return 0;
+    };
+}
+
+std::function<double( dialogue & )> volume_eval( char scope,
+        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+{
+    return[beta = is_beta( scope )]( dialogue const & d ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+            return d.actor( beta )->get_volume();
+        }
+        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        if( it && *it ) {
+            return to_milliliter( it->get_item()->volume() );
+        }
+        debugmsg( "For volume(), talker is not character nor item" );
+        return 0;
+    };
+}
+
 std::function<double( dialogue & )> vitamin_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
@@ -1799,6 +1831,8 @@ std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
     { "vision_range", { "un", 0, vision_range_eval } },
     { "vitamin", { "un", 1, vitamin_eval } },
     { "calories", { "un", 0, calories_eval } },
+    { "weight", { "un", 0, weight_eval } },
+    { "volume", { "un", 0, volume_eval } },
     { "warmth", { "un", 1, warmth_eval } },
     { "weather", { "g", 1, weather_eval } },
     { "climate_control_str_heat", { "un", 0, climate_control_str_heat_eval } },

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -999,6 +999,11 @@ int talker_character_const::get_weight() const
     return units::to_milligram( me_chr_const->get_weight() );
 }
 
+int talker_character_const::get_volume() const
+{
+    return units::to_milliliter( me_chr_const->get_total_character_volume() );
+}
+
 void talker_character::set_height( int amount )
 {
     me_chr->set_base_height( amount );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -199,6 +199,7 @@ class talker_character_const: public talker_cloner<talker_character_const>
         int get_height() const override;
         int get_bmi_permil() const override;
         int get_weight() const override;
+        int get_volume() const override;
         const move_mode_id &get_move_mode() const override;
         int get_fine_detail_vision_mod() const override;
         int get_health() const override;


### PR DESCRIPTION
#### Summary
Backport DDA 76968 - move volume and weight vals to math

#### Purpose of change
u_weight() and u_volume() are now valid math conditions. u_volume() currently only checks height, creature size, and wielded item volume, not body fat, muscle, worn items, etc.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
