### PR TITLE
Backport 77485 - enforce const correctness in dialogue

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -331,8 +331,8 @@
     "id": "EOC_query_tile_test_anywhere",
     "effect": [
       {
-        "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
-        "then": { "u_message": "<context_val:pos>" },
+        "if": { "u_query_tile": "anywhere", "target_var": { "global_val": "pos" }, "message": "Select point" },
+        "then": { "u_message": "<global_val:pos>" },
         "else": { "u_message": "Canceled" }
       }
     ]
@@ -342,8 +342,8 @@
     "id": "EOC_query_tile_test_line_of_sight",
     "effect": [
       {
-        "if": { "u_query_tile": "line_of_sight", "target_var": { "context_val": "pos" }, "message": "Select point", "range": 10 },
-        "then": { "u_message": "<context_val:pos>" },
+        "if": { "u_query_tile": "line_of_sight", "target_var": { "global_val": "pos" }, "message": "Select point", "range": 10 },
+        "then": { "u_message": "<global_val:pos>" },
         "else": { "u_message": "Canceled" }
       }
     ]
@@ -353,8 +353,8 @@
     "id": "EOC_query_tile_test_around",
     "effect": [
       {
-        "if": { "u_query_tile": "around", "target_var": { "context_val": "pos" }, "message": "Choose direction" },
-        "then": { "u_message": "<context_val:pos>" },
+        "if": { "u_query_tile": "around", "target_var": { "global_val": "pos" }, "message": "Choose direction" },
+        "then": { "u_message": "<global_val:pos>" },
         "else": { "u_message": "Canceled" }
       }
     ]
@@ -381,20 +381,20 @@
     "id": "EOC_can_see_location_test",
     "effect": [
       {
-        "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point" },
+        "if": { "u_query_tile": "anywhere", "target_var": { "global_val": "pos" }, "message": "Select point" },
         "then": [
           {
-            "if": { "u_can_see_location": { "context_val": "pos" } },
-            "then": { "u_message": "You can see <context_val:pos>." },
-            "else": { "u_message": "You cant see <context_val:pos>." }
+            "if": { "u_can_see_location": { "global_val": "pos" } },
+            "then": { "u_message": "You can see <global_val:pos>." },
+            "else": { "u_message": "You can't see <global_val:pos>." }
           },
           {
             "u_run_npc_eocs": [
               {
                 "id": "EOC_can_see_location_test_nest",
-                "condition": { "u_can_see_location": { "context_val": "pos" } },
-                "effect": { "message": "<u_name> can see <context_val:pos>." },
-                "false_effect": { "message": "<u_name> cant see <context_val:pos>." }
+                "condition": { "u_can_see_location": { "global_val": "pos" } },
+                "effect": { "message": "<u_name> can see <global_val:pos>." },
+                "false_effect": { "message": "<u_name> can't see <global_val:pos>." }
               }
             ],
             "local": true
@@ -438,10 +438,10 @@
     "id": "EOC_teleport_test_other",
     "effect": [
       {
-        "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "loc" }, "message": "Select point" },
+        "if": { "u_query_tile": "anywhere", "target_var": { "global_val": "loc" }, "message": "Select point" },
         "then": {
           "run_eoc_with": { "id": "EOC_teleport_test_other_do", "effect": { "npc_teleport": { "global_val": "teleport_test_pos" } } },
-          "beta_loc": { "context_val": "loc" },
+          "beta_loc": { "global_val": "loc" },
           "false_eocs": { "id": "EOC_teleport_test_other_do_fail_msg", "effect": { "message": "Please select a creature." } }
         },
         "else": { "u_message": "Canceled" }
@@ -467,13 +467,13 @@
     "effect": [
       { "u_set_talker": { "global_val": "player_id" } },
       {
-        "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "loc" }, "message": "Select point" },
+        "if": { "u_query_tile": "anywhere", "target_var": { "global_val": "loc" }, "message": "Select point" },
         "then": {
           "run_eoc_with": {
             "id": "_EOC_control_npc_do",
             "effect": [ { "if": "npc_is_npc", "then": [ "follow", "take_control" ], "else": { "message": "Please select a NPC." } } ]
           },
-          "beta_loc": { "context_val": "loc" },
+          "beta_loc": { "global_val": "loc" },
           "false_eocs": { "id": "_EOC_control_npc_fail_msg", "effect": { "message": "Please select a NPC." } }
         },
         "else": { "u_message": "Canceled" }

--- a/src/character.h
+++ b/src/character.h
@@ -1174,12 +1174,12 @@ class Character : public Creature, public visitable
         bool handle_melee_wear( item_location shield, float wear_multiplier = 1.0f );
         /** Returns a random technique/vector/contact area set from the  possible techs */
         std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> pick_technique(
-            Creature &t, const item_location &weap,
+            Creature const &t, const item_location &weap,
             bool crit, bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist = {} )
         const;
         // Filter techniques per tech, return a tech/vector/sublimb set
         std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
-                evaluate_technique( const matec_id &tec_id, Creature &t, const item_location &weap,
+                evaluate_technique( const matec_id &tec_id, Creature const &t, const item_location &weap,
                                     std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> &fallbacks,
                                     bool crit = false, bool dodge_counter = false, bool block_counter = false ) const;
         void perform_technique( const ma_technique &technique, Creature &t, damage_instance &di,
@@ -1280,8 +1280,8 @@ class Character : public Creature, public visitable
         bool can_autolearn( const matype_id &ma_id ) const;
     private:
         /** Check if an area-of-effect technique has valid targets */
-        bool valid_aoe_technique( Creature &t, const ma_technique &technique ) const;
-        bool valid_aoe_technique( Creature &t, const ma_technique &technique,
+        bool valid_aoe_technique( Creature const &t, const ma_technique &technique ) const;
+        bool valid_aoe_technique( Creature const &t, const ma_technique &technique,
                                   std::vector<Creature *> &targets ) const;
     public:
 

--- a/src/character.h
+++ b/src/character.h
@@ -2795,7 +2795,7 @@ class Character : public Creature, public visitable
         // Items currently being hauled
         std::vector<item_location> haul_list;
 
-        tripoint_rel_ms view_offset;
+        mutable tripoint_rel_ms view_offset;
 
         player_activity stashed_outbounds_activity;
         player_activity stashed_outbounds_backlog;

--- a/src/character.h
+++ b/src/character.h
@@ -1175,12 +1175,13 @@ class Character : public Creature, public visitable
         /** Returns a random technique/vector/contact area set from the  possible techs */
         std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> pick_technique(
             Creature &t, const item_location &weap,
-            bool crit, bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist = {} );
+            bool crit, bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist = {} )
+        const;
         // Filter techniques per tech, return a tech/vector/sublimb set
         std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
                 evaluate_technique( const matec_id &tec_id, Creature &t, const item_location &weap,
                                     std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> &fallbacks,
-                                    bool crit = false, bool dodge_counter = false, bool block_counter = false );
+                                    bool crit = false, bool dodge_counter = false, bool block_counter = false ) const;
         void perform_technique( const ma_technique &technique, Creature &t, damage_instance &di,
                                 int &move_cost, item_location &cur_weapon );
 
@@ -1279,9 +1280,9 @@ class Character : public Creature, public visitable
         bool can_autolearn( const matype_id &ma_id ) const;
     private:
         /** Check if an area-of-effect technique has valid targets */
-        bool valid_aoe_technique( Creature &t, const ma_technique &technique );
+        bool valid_aoe_technique( Creature &t, const ma_technique &technique ) const;
         bool valid_aoe_technique( Creature &t, const ma_technique &technique,
-                                  std::vector<Creature *> &targets );
+                                  std::vector<Creature *> &targets ) const;
     public:
 
         /** This handles giving xp for a skill. Returns true on level-up. */

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -641,8 +641,8 @@ conditional_t::func f_has_visible_trait( const JsonObject &jo, std::string_view 
     return [trait_to_check, is_npc]( dialogue const & d ) {
         const talker *observer = d.actor( !is_npc );
         const talker *observed = d.actor( is_npc );
-        int visibility_cap = observer->get_character()->get_mutation_visibility_cap(
-                                 observed->get_character() );
+        int visibility_cap = observer->get_const_character()->get_mutation_visibility_cap(
+                                 observed->get_const_character() );
         bool observed_has = observed->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
         const mutation_branch &mut_branch = trait_id( trait_to_check.evaluate( d ) ).obj();
         bool is_visible = mut_branch.visibility > 0 && mut_branch.visibility >= visibility_cap;
@@ -1613,7 +1613,7 @@ conditional_t::func f_is_day()
 conditional_t::func f_is_outside( bool is_npc )
 {
     return [is_npc]( dialogue const & d ) {
-        return is_creature_outside( *static_cast<talker const *>( d.actor( is_npc ) )->get_creature() );
+        return is_creature_outside( *d.actor( is_npc )->get_const_creature() );
     };
 }
 
@@ -1652,7 +1652,7 @@ conditional_t::func f_query( const JsonObject &jo, std::string_view member, bool
     bool default_val = jo.get_bool( "default" );
     return [message, default_val, is_npc]( dialogue const & d ) {
         const talker *actor = d.actor( is_npc );
-        if( actor->get_character() && actor->get_character()->is_avatar() ) {
+        if( actor->get_const_character() && actor->get_const_character()->is_avatar() ) {
             std::string translated_message = message.evaluate( d );
             return query_yn( translated_message );
         } else {
@@ -2210,50 +2210,51 @@ std::function<std::string( const dialogue & )> conditional_t::get_get_string( co
 
 namespace
 {
-std::unordered_map<std::string_view, int ( talker::* )() const> const f_get_vals = {
-    { "activity_level", &talker::get_activity_level },
-    { "age", &talker::get_age },
-    { "anger", &talker::get_anger },
-    { "bmi_permil", &talker::get_bmi_permil },
-    { "cash", &talker::cash },
-    { "dexterity_base", &talker::get_dex_max },
-    { "dexterity_bonus", &talker::get_dex_bonus },
-    { "dexterity", &talker::dex_cur },
-    { "exp", &talker::get_kill_xp },
-    { "fatigue", &talker::get_fatigue },
-    { "fine_detail_vision_mod", &talker::get_fine_detail_vision_mod },
-    { "focus", &talker::focus_cur },
-    { "friendly", &talker::get_friendly },
-    { "grab_strength", &talker::get_grab_strength },
-    { "health", &talker::get_health },
-    { "height", &talker::get_height },
-    { "hunger", &talker::get_hunger },
-    { "instant_thirst", &talker::get_instant_thirst },
-    { "intelligence_base", &talker::get_int_max },
-    { "intelligence_bonus", &talker::get_int_bonus },
-    { "intelligence", &talker::int_cur },
-    { "mana_max", &talker::mana_max },
-    { "mana", &talker::mana_cur },
-    { "morale", &talker::morale_cur },
-    { "owed", &talker::debt },
-    { "perception_base", &talker::get_per_max },
-    { "perception_bonus", &talker::get_per_bonus },
-    { "perception", &talker::per_cur },
-    { "pkill", &talker::get_pkill },
-    { "pos_x", &talker::posx },
-    { "pos_y", &talker::posy },
-    { "pos_z", &talker::posz },
-    { "rad", &talker::get_rad },
-    { "size", &talker::get_size },
-    { "sleep_deprivation", &talker::get_sleep_deprivation },
-    { "sold", &talker::sold },
-    { "stamina", &talker::get_stamina },
-    { "stim", &talker::get_stim },
-    { "strength_base", &talker::get_str_max },
-    { "strength_bonus", &talker::get_str_bonus },
-    { "strength", &talker::str_cur },
-    { "thirst", &talker::get_thirst },
-    { "count", &talker::get_count }
+std::unordered_map<std::string_view, int ( const_talker::* )() const> const f_get_vals = {
+    { "activity_level", &const_talker::get_activity_level },
+    { "age", &const_talker::get_age },
+    { "anger", &const_talker::get_anger },
+    { "bmi_permil", &const_talker::get_bmi_permil },
+    { "cash", &const_talker::cash },
+    { "difficulty", &const_talker::get_difficulty },
+    { "dexterity_base", &const_talker::get_dex_max },
+    { "dexterity_bonus", &const_talker::get_dex_bonus },
+    { "dexterity", &const_talker::dex_cur },
+    { "exp", &const_talker::get_kill_xp },
+    { "sleepiness", &const_talker::get_sleepiness },
+    { "fine_detail_vision_mod", &const_talker::get_fine_detail_vision_mod },
+    { "focus", &const_talker::focus_cur },
+    { "friendly", &const_talker::get_friendly },
+    { "grab_strength", &const_talker::get_grab_strength },
+    { "health", &const_talker::get_health },
+    { "height", &const_talker::get_height },
+    { "hunger", &const_talker::get_hunger },
+    { "instant_thirst", &const_talker::get_instant_thirst },
+    { "intelligence_base", &const_talker::get_int_max },
+    { "intelligence_bonus", &const_talker::get_int_bonus },
+    { "intelligence", &const_talker::int_cur },
+    { "mana_max", &const_talker::mana_max },
+    { "mana", &const_talker::mana_cur },
+    { "morale", &const_talker::morale_cur },
+    { "owed", &const_talker::debt },
+    { "perception_base", &const_talker::get_per_max },
+    { "perception_bonus", &const_talker::get_per_bonus },
+    { "perception", &const_talker::per_cur },
+    { "pkill", &const_talker::get_pkill },
+    { "pos_x", &const_talker::posx },
+    { "pos_y", &const_talker::posy },
+    { "pos_z", &const_talker::posz },
+    { "rad", &const_talker::get_rad },
+    { "size", &const_talker::get_size },
+    { "sleep_deprivation", &const_talker::get_sleep_deprivation },
+    { "sold", &const_talker::sold },
+    { "stamina", &const_talker::get_stamina },
+    { "stim", &const_talker::get_stim },
+    { "strength_base", &const_talker::get_str_max },
+    { "strength_bonus", &const_talker::get_str_bonus },
+    { "strength", &const_talker::str_cur },
+    { "thirst", &const_talker::get_thirst },
+    { "count", &const_talker::get_count }
 };
 } // namespace
 
@@ -2277,7 +2278,7 @@ std::function<double( dialogue & )> conditional_t::get_get_dbl( std::string_view
         };
     } else if( checked_value == "dodge" ) {
         return [is_npc]( dialogue const & d ) {
-            return static_cast<talker const *>( d.actor( is_npc ) )->get_character()->get_dodge();
+            return d.actor( is_npc )->get_const_character()->get_dodge();
         };
     } else if( checked_value == "power_percentage" ) {
         return [is_npc]( dialogue const & d ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -540,6 +540,27 @@ void write_var_value( var_type type, const std::string &name, dialogue *d,
     }
 }
 
+void write_var_value( var_type type, const std::string &name, const_dialogue const &d,
+                      const std::string &value )
+{
+    switch( type ) {
+        case var_type::global:
+            get_globals().set_global_value( name, value );
+            break;
+        case var_type::context:
+        case var_type::var:
+        case var_type::u:
+        case var_type::npc:
+        case var_type::faction:
+        case var_type::party:
+            debugmsg( "Only global variables can be assigned from an eval function.\n%s", d.get_callstack() );
+            break;
+        default:
+            debugmsg( "Invalid type." );
+            break;
+    }
+}
+
 void write_var_value( var_type type, const std::string &name, dialogue *d,
                       double value )
 {
@@ -1673,6 +1694,9 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
 {
     std::string type = jo.get_string( member.data() );
     var_info target_var = read_var_info( jo.get_object( "target_var" ) );
+    if( target_var.type != var_type::global ) {
+        jo.throw_error_at( "target_var", "Only global variables can be used as targets for u_query" ) ;
+    }
     std::string message;
     if( jo.has_member( "message" ) ) {
         message = jo.get_string( "message" );
@@ -1686,7 +1710,6 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
         std::optional<tripoint> loc;
         Character const *ch = d.const_actor( is_npc )->get_const_character();
         if( ch && ch->as_avatar() ) {
-            avatar const *you = ch->as_avatar();
             if( type == "anywhere" ) {
                 if( !message.empty() ) {
                     static_popup popup;
@@ -1702,7 +1725,9 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
                     popup.on_top( true );
                     popup.message( "%s", message );
                 }
-                target_handler::trajectory traj = target_handler::mode_select_only( *you, range.evaluate( d ) );
+                avatar dummy;
+                dummy.set_location( get_avatar().get_location() );
+                target_handler::trajectory traj = target_handler::mode_select_only( dummy, range.evaluate( d ) );
                 if( !traj.empty() ) {
                     loc = traj.back().raw();
                 }
@@ -1719,7 +1744,7 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
         }
         if( loc.has_value() ) {
             tripoint_abs_ms pos_global = get_map().getglobal( *loc );
-            write_var_value( target_var.type, target_var.name, &d,
+            write_var_value( target_var.type, target_var.name, d,
                              pos_global.to_string() );
         }
         return loc.has_value();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -384,7 +384,7 @@ str_translation_or_var get_str_translation_or_var(
 tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
                                        bool is_npc )
 {
-    tripoint_abs_ms target_pos = get_map().getglobal( d.actor( is_npc )->pos() );
+    tripoint_abs_ms target_pos = get_map().getglobal( d.const_actor( is_npc )->pos() );
     if( var.has_value() ) {
         std::string value = read_var_value( var.value(), d );
         if( !value.empty() ) {
@@ -1655,15 +1655,15 @@ conditional_t::func f_is_underwater( bool is_npc )
 
 conditional_t::func f_is_on_land( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return get_map().has_floor( d.actor( is_npc )->pos() );
+    return [is_npc]( const_dialogue const & d ) {
+        return get_map().has_floor( d.const_actor( is_npc )->pos() );
     };
 }
 
 conditional_t::func f_is_on_liquid( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !get_map().is_dry( d.actor( is_npc )->pos() );
+    return [is_npc]( const_dialogue const & d ) {
+        return !get_map().is_dry( d.const_actor( is_npc )->pos() );
     };
 }
 
@@ -2130,6 +2130,7 @@ template<class T>
 static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject &jo,
         std::function<T( const std::string & )> ret_func )
 {
+    const std::string &mutator = jo.get_string( "mutator" );
     if( jo.get_string( "mutator" ) == "mon_faction" ) {
         str_or_var mtypeid = get_str_or_var( jo.get_member( "mtype_id" ), "mtype_id" );
         return [mtypeid, ret_func]( const_dialogue const & d ) {
@@ -2257,7 +2258,7 @@ std::unordered_map<std::string_view, int ( const_talker::* )() const> const f_ge
     { "dexterity_bonus", &const_talker::get_dex_bonus },
     { "dexterity", &const_talker::dex_cur },
     { "exp", &const_talker::get_kill_xp },
-    { "sleepiness", &const_talker::get_sleepiness },
+    { "fatigue", &const_talker::get_fatigue },
     { "fine_detail_vision_mod", &const_talker::get_fine_detail_vision_mod },
     { "focus", &const_talker::focus_cur },
     { "friendly", &const_talker::get_friendly },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -381,7 +381,8 @@ str_translation_or_var get_str_translation_or_var(
     return ret_val;
 }
 
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d, bool is_npc )
+tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
+                                       bool is_npc )
 {
     tripoint_abs_ms target_pos = get_map().getglobal( d.actor( is_npc )->pos() );
     if( var.has_value() ) {
@@ -390,7 +391,12 @@ tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue con
             target_pos = tripoint_abs_ms( tripoint::from_string( value ) );
         }
     }
-    return target_pos;
+    if( !d.has_actor( is_npc ) ) {
+        debugmsg( "Tried to access location of invalid %s talker.  %s", is_npc ? "beta" : "alpha",
+                  d.get_callstack() );
+        return tripoint_abs_ms( tripoint_min );
+    }
+    return get_map().getglobal( d.const_actor( is_npc )->pos() );
 }
 
 template<class T>
@@ -556,7 +562,7 @@ static bodypart_id get_bp_from_str( const std::string &ctxt )
 void read_condition( const JsonObject &jo, const std::string &member_name,
                      conditional_t::func &condition, bool default_val )
 {
-    const auto null_function = [default_val]( dialogue const & ) {
+    const auto null_function = [default_val]( const_dialogue const & ) {
         return default_val;
     };
 
@@ -565,13 +571,13 @@ void read_condition( const JsonObject &jo, const std::string &member_name,
     } else if( jo.has_string( member_name ) ) {
         const std::string type = jo.get_string( member_name );
         conditional_t sub_condition( type );
-        condition = [sub_condition]( dialogue & d ) {
+        condition = [sub_condition]( const_dialogue const & d ) {
             return sub_condition( d );
         };
     } else if( jo.has_object( member_name ) ) {
         JsonObject con_obj = jo.get_object( member_name );
         conditional_t sub_condition( con_obj );
-        condition = [sub_condition]( dialogue & d ) {
+        condition = [sub_condition]( const_dialogue const & d ) {
             return sub_condition( d );
         };
     } else {
@@ -606,8 +612,8 @@ conditional_t::func f_has_any_trait( const JsonObject &jo, std::string_view memb
     for( JsonValue jv : jo.get_array( member ) ) {
         traits_to_check.emplace_back( get_str_or_var( jv, member ) );
     }
-    return [traits_to_check, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [traits_to_check, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         for( const str_or_var &trait : traits_to_check ) {
             if( actor->has_trait( trait_id( trait.evaluate( d ) ) ) ) {
                 return true;
@@ -620,8 +626,8 @@ conditional_t::func f_has_any_trait( const JsonObject &jo, std::string_view memb
 conditional_t::func f_has_trait( const JsonObject &jo, std::string_view member, bool is_npc )
 {
     str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [trait_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
+    return [trait_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
     };
 }
 
@@ -629,8 +635,8 @@ conditional_t::func f_is_trait_purifiable( const JsonObject &jo, std::string_vie
         bool is_npc )
 {
     str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [trait_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_trait_purifiable( trait_id( trait_to_check.evaluate( d ) ) );
+    return [trait_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_trait_purifiable( trait_id( trait_to_check.evaluate( d ) ) );
     };
 }
 
@@ -638,9 +644,9 @@ conditional_t::func f_has_visible_trait( const JsonObject &jo, std::string_view 
         bool is_npc )
 {
     str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [trait_to_check, is_npc]( dialogue const & d ) {
-        const talker *observer = d.actor( !is_npc );
-        const talker *observed = d.actor( is_npc );
+    return [trait_to_check, is_npc]( const_dialogue const & d ) {
+        const_talker const *observer = d.const_actor( !is_npc );
+        const_talker const *observed = d.const_actor( is_npc );
         int visibility_cap = observer->get_const_character()->get_mutation_visibility_cap(
                                  observed->get_const_character() );
         bool observed_has = observed->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
@@ -654,8 +660,8 @@ conditional_t::func f_has_martial_art( const JsonObject &jo, std::string_view me
                                        bool is_npc )
 {
     str_or_var style_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [style_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->knows_martial_art( matype_id( style_to_check.evaluate( d ) ) );
+    return [style_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->knows_martial_art( matype_id( style_to_check.evaluate( d ) ) );
     };
 }
 
@@ -663,8 +669,8 @@ conditional_t::func f_has_flag( const JsonObject &jo, std::string_view member,
                                 bool is_npc )
 {
     str_or_var trait_flag_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [trait_flag_to_check, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [trait_flag_to_check, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         if( json_character_flag( trait_flag_to_check.evaluate( d ) ) == json_flag_MUTATION_THRESHOLD ) {
             return actor->crossed_threshold();
         }
@@ -676,8 +682,8 @@ conditional_t::func f_has_species( const JsonObject &jo, std::string_view member
                                    bool is_npc )
 {
     str_or_var species_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [species_to_check, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [species_to_check, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return actor->has_species( species_id( species_to_check.evaluate( d ) ) );
     };
 }
@@ -686,16 +692,16 @@ conditional_t::func f_bodytype( const JsonObject &jo, std::string_view member,
                                 bool is_npc )
 {
     str_or_var bt_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [bt_to_check, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [bt_to_check, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return actor->bodytype( bodytype_id( bt_to_check.evaluate( d ) ) );
     };
 }
 
 conditional_t::func f_has_activity( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_activity();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_activity();
     };
 }
 
@@ -708,15 +714,16 @@ conditional_t::func f_has_proficiency( const JsonObject &jo, std::string_view me
                                        bool is_npc )
 {
     str_or_var proficiency_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [proficiency_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->knows_proficiency( proficiency_id( proficiency_to_check.evaluate( d ) ) );
+    return [proficiency_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->knows_proficiency( proficiency_id( proficiency_to_check.evaluate(
+                    d ) ) );
     };
 }
 
 conditional_t::func f_is_riding( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_mounted();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_mounted();
     };
 }
 
@@ -729,15 +736,15 @@ conditional_t::func f_npc_has_class( const JsonObject &jo, std::string_view memb
                                      bool is_npc )
 {
     str_or_var class_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [class_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_myclass( npc_class_id( class_to_check.evaluate( d ) ) );
+    return [class_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_myclass( npc_class_id( class_to_check.evaluate( d ) ) );
     };
 }
 
 conditional_t::func f_u_has_mission( const JsonObject &jo, std::string_view member )
 {
     str_or_var u_mission = get_str_or_var( jo.get_member( member ), member, true );
-    return [u_mission]( dialogue const & d ) {
+    return [u_mission]( const_dialogue const & d ) {
         for( mission *miss_it : get_avatar().get_active_missions() ) {
             if( miss_it->mission_id() == mission_type_id( u_mission.evaluate( d ) ) ) {
                 return true;
@@ -751,7 +758,7 @@ conditional_t::func f_u_monsters_in_direction( const JsonObject &jo,
         std::string_view member )
 {
     str_or_var dir = get_str_or_var( jo.get_member( member ), member, true );
-    return [dir]( dialogue const & d ) {
+    return [dir]( const_dialogue const & d ) {
         //This string_to_enum function is defined in widget.h. Should it be moved?
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
@@ -763,7 +770,7 @@ conditional_t::func f_u_monsters_in_direction( const JsonObject &jo,
 conditional_t::func f_u_safe_mode_trigger( const JsonObject &jo, std::string_view member )
 {
     str_or_var dir = get_str_or_var( jo.get_member( member ), member, true );
-    return [dir]( dialogue const & d ) {
+    return [dir]( const_dialogue const & d ) {
         //This string_to_enum function is defined in widget.h. Should it be moved?
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
@@ -774,7 +781,7 @@ conditional_t::func f_u_safe_mode_trigger( const JsonObject &jo, std::string_vie
 conditional_t::func f_u_profession( const JsonObject &jo, std::string_view member )
 {
     str_or_var u_profession = get_str_or_var( jo.get_member( member ), member, true );
-    return [u_profession]( dialogue const & d ) {
+    return [u_profession]( const_dialogue const & d ) {
         const profession *prof = get_player_character().get_profession();
         std::set<const profession *> hobbies = get_player_character().get_hobbies();
         if( prof->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
@@ -797,8 +804,8 @@ conditional_t::func f_has_strength( const JsonObject &jo, std::string_view membe
                                     bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov, is_npc]( dialogue & d ) {
-        return d.actor( is_npc )->str_cur() >= dov.evaluate( d );
+    return [dov, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->str_cur() >= dov.evaluate( d );
     };
 }
 
@@ -806,8 +813,8 @@ conditional_t::func f_has_dexterity( const JsonObject &jo, std::string_view memb
                                      bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov, is_npc]( dialogue & d ) {
-        return d.actor( is_npc )->dex_cur() >= dov.evaluate( d );
+    return [dov, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->dex_cur() >= dov.evaluate( d );
     };
 }
 
@@ -815,8 +822,8 @@ conditional_t::func f_has_intelligence( const JsonObject &jo, std::string_view m
                                         bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov, is_npc]( dialogue & d ) {
-        return d.actor( is_npc )->int_cur() >= dov.evaluate( d );
+    return [dov, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->int_cur() >= dov.evaluate( d );
     };
 }
 
@@ -824,8 +831,8 @@ conditional_t::func f_has_perception( const JsonObject &jo, std::string_view mem
                                       bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov, is_npc]( dialogue & d ) {
-        return d.actor( is_npc )->per_cur() >= dov.evaluate( d );
+    return [dov, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->per_cur() >= dov.evaluate( d );
     };
 }
 
@@ -835,9 +842,9 @@ conditional_t::func f_has_part_temp( const JsonObject &jo, std::string_view memb
     dbl_or_var dov = get_dbl_or_var( jo, member );
     std::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    return [dov, bp, is_npc]( dialogue & d ) {
+    return [dov, bp, is_npc]( const_dialogue const & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
-        return units::to_legacy_bodypart_temp( d.actor( is_npc )->get_cur_part_temp(
+        return units::to_legacy_bodypart_temp( d.const_actor( is_npc )->get_cur_part_temp(
                 bid ) ) >= dov.evaluate( d );
     };
 }
@@ -846,16 +853,16 @@ conditional_t::func f_is_wearing( const JsonObject &jo, std::string_view member,
                                   bool is_npc )
 {
     str_or_var item_id = get_str_or_var( jo.get_member( member ), member, true );
-    return [item_id, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_wearing( itype_id( item_id.evaluate( d ) ) );
+    return [item_id, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_wearing( itype_id( item_id.evaluate( d ) ) );
     };
 }
 
 conditional_t::func f_has_item( const JsonObject &jo, std::string_view member, bool is_npc )
 {
     str_or_var item_id = get_str_or_var( jo.get_member( member ), member, true );
-    return [item_id, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [item_id, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return actor->charges_of( itype_id( item_id.evaluate( d ) ) ) > 0 ||
                actor->has_amount( itype_id( item_id.evaluate( d ) ), 1 );
     };
@@ -867,15 +874,15 @@ conditional_t::func f_has_items( const JsonObject &jo, const std::string_view me
     JsonObject has_items = jo.get_object( member );
     if( !has_items.has_member( "item" ) || ( !has_items.has_member( "count" ) &&
             !has_items.has_member( "charges" ) ) ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return false;
         };
     } else {
         str_or_var item_id = get_str_or_var( has_items.get_member( "item" ), "item", true );
         dbl_or_var count = get_dbl_or_var( has_items, "count", false );
         dbl_or_var charges = get_dbl_or_var( has_items, "charges", false );
-        return [item_id, count, charges, is_npc]( dialogue & d ) {
-            const talker *actor = d.actor( is_npc );
+        return [item_id, count, charges, is_npc]( const_dialogue const & d ) {
+            const_talker const *actor = d.const_actor( is_npc );
             itype_id id = itype_id( item_id.evaluate( d ) );
             if( charges.evaluate( d ) == 0 && item::count_by_charges( id ) ) {
                 return actor->has_charges( id, count.evaluate( d ), true );
@@ -902,7 +909,7 @@ conditional_t::func f_has_items_sum( const JsonObject &jo, const std::string_vie
         const dbl_or_var amount = get_dbl_or_var( jsobj, "amount", true, 1 );
         item_and_amount.emplace_back( item, amount );
     }
-    return [item_and_amount, is_npc]( dialogue & d ) {
+    return [item_and_amount, is_npc]( const_dialogue const & d ) {
         add_msg_debug( debugmode::DF_TALKER, "using _has_items_sum:" );
 
         itype_id item_to_find;
@@ -914,8 +921,8 @@ conditional_t::func f_has_items_sum( const JsonObject &jo, const std::string_vie
         for( const auto &pair : item_and_amount ) {
             item_to_find = itype_id( pair.first.evaluate( d ) );
             count_desired = pair.second.evaluate( d );
-            count_present = d.actor( is_npc )->get_amount( item_to_find );
-            charges_present = d.actor( is_npc )->charges_of( item_to_find );
+            count_present = d.const_actor( is_npc )->get_amount( item_to_find );
+            charges_present = d.const_actor( is_npc )->charges_of( item_to_find );
             total_present = std::max( count_present, charges_present );
             percent += total_present / count_desired;
 
@@ -935,8 +942,8 @@ conditional_t::func f_has_item_with_flag( const JsonObject &jo, std::string_view
         bool is_npc )
 {
     str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
-    return [flag, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_item_with_flag( flag_id( flag.evaluate( d ) ) );
+    return [flag, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_item_with_flag( flag_id( flag.evaluate( d ) ) );
     };
 }
 
@@ -952,8 +959,8 @@ conditional_t::func f_has_item_category( const JsonObject &jo, std::string_view 
         }
     }
 
-    return [category_id, count, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [category_id, count, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         const item_category_id cat_id = item_category_id( category_id.evaluate( d ) );
         const auto items_with = actor->const_items_with( [cat_id]( const item & it ) {
             return it.get_category_shallow().get_id() == cat_id;
@@ -966,8 +973,8 @@ conditional_t::func f_has_bionics( const JsonObject &jo, std::string_view member
                                    bool is_npc )
 {
     str_or_var bionics_id = get_str_or_var( jo.get_member( member ), member, true );
-    return [bionics_id, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [bionics_id, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         if( bionics_id.evaluate( d ) == "ANY" ) {
             return actor->num_bionics() > 0 || actor->has_max_power();
         }
@@ -989,11 +996,11 @@ conditional_t::func f_has_any_effect( const JsonObject &jo, std::string_view mem
     } else {
         bp.str_val = "";
     }
-    return [effects_to_check, intensity, bp, is_npc]( dialogue & d ) {
+    return [effects_to_check, intensity, bp, is_npc]( const_dialogue const & d ) {
         bodypart_id bid = bp.evaluate( d ).empty() ? get_bp_from_str( d.reason ) :
                           bodypart_id( bp.evaluate( d ) );
         for( const str_or_var &effect_id : effects_to_check ) {
-            effect target = d.actor( is_npc )->get_effect( efftype_id( effect_id.evaluate( d ) ), bid );
+            effect target = d.const_actor( is_npc )->get_effect( efftype_id( effect_id.evaluate( d ) ), bid );
             if( !target.is_null() && intensity.evaluate( d ) <= target.get_intensity() ) {
                 return true;
             }
@@ -1013,10 +1020,10 @@ conditional_t::func f_has_effect( const JsonObject &jo, std::string_view member,
     } else {
         bp.str_val = "";
     }
-    return [effect_id, intensity, bp, is_npc]( dialogue & d ) {
+    return [effect_id, intensity, bp, is_npc]( const_dialogue const & d ) {
         bodypart_id bid = bp.evaluate( d ).empty() ? get_bp_from_str( d.reason ) :
                           bodypart_id( bp.evaluate( d ) );
-        effect target = d.actor( is_npc )->get_effect( efftype_id( effect_id.evaluate( d ) ), bid );
+        effect target = d.const_actor( is_npc )->get_effect( efftype_id( effect_id.evaluate( d ) ), bid );
         return !target.is_null() && intensity.evaluate( d ) <= target.get_intensity();
     };
 }
@@ -1036,8 +1043,8 @@ conditional_t::func f_need( const JsonObject &jo, std::string_view member, bool 
             dov.min.dbl_val = static_cast<int>( flevel->second );
         }
     }
-    return [need, dov, is_npc]( dialogue & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [need, dov, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         int amount = dov.evaluate( d );
         return ( actor->get_fatigue() > amount && need.evaluate( d ) == "fatigue" ) ||
                ( actor->get_hunger() > amount && need.evaluate( d ) == "hunger" ) ||
@@ -1049,8 +1056,8 @@ conditional_t::func f_at_om_location( const JsonObject &jo, std::string_view mem
                                       bool is_npc )
 {
     str_or_var location = get_str_or_var( jo.get_member( member ), member, true );
-    return [location, is_npc]( dialogue const & d ) {
-        const tripoint_abs_omt omt_pos = d.actor( is_npc )->global_omt_location();
+    return [location, is_npc]( const_dialogue const & d ) {
+        const tripoint_abs_omt omt_pos = d.const_actor( is_npc )->global_omt_location();
         const oter_id &omt_ter = overmap_buffer.ter( omt_pos );
         const std::string &omt_str = omt_ter.id().str();
         std::string location_value = location.evaluate( d );
@@ -1076,8 +1083,8 @@ conditional_t::func f_near_om_location( const JsonObject &jo, std::string_view m
 {
     str_or_var location = get_str_or_var( jo.get_member( member ), member, true );
     const dbl_or_var range = get_dbl_or_var( jo, "range", false, 1 );
-    return [location, range, is_npc]( dialogue & d ) {
-        const tripoint_abs_omt omt_pos = d.actor( is_npc )->global_omt_location();
+    return [location, range, is_npc]( const_dialogue const & d ) {
+        const tripoint_abs_omt omt_pos = d.const_actor( is_npc )->global_omt_location();
         for( const tripoint_abs_omt &curr_pos : points_in_radius( omt_pos,
                 range.evaluate( d ) ) ) {
             const oter_id &omt_ter = overmap_buffer.ter( curr_pos );
@@ -1115,13 +1122,13 @@ conditional_t::func f_has_var( const JsonObject &jo, std::string_view member, bo
     const std::string &value = jo.has_member( "value" ) ? jo.get_string( "value" ) : std::string();
     if( !jo.has_member( "value" ) ) {
         jo.throw_error( R"(Missing field: "value")" );
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return false;
         };
     }
 
-    return [var_name, value, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [var_name, value, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return actor->get_value( var_name ) == value;
     };
 }
@@ -1135,7 +1142,7 @@ conditional_t::func f_expects_vars( const JsonObject &jo, std::string_view membe
         }
     }
 
-    return [to_check]( dialogue const & d ) {
+    return [to_check]( const_dialogue const & d ) {
         std::string missing_variables;
         for( const str_or_var &val : to_check ) {
             if( d.get_context().find( "npctalk_var_" + val.evaluate( d ) ) == d.get_context().end() ) {
@@ -1153,11 +1160,11 @@ conditional_t::func f_expects_vars( const JsonObject &jo, std::string_view membe
 conditional_t::func f_npc_role_nearby( const JsonObject &jo, std::string_view member )
 {
     str_or_var role = get_str_or_var( jo.get_member( member ), member, true );
-    return [role]( dialogue const & d ) {
+    return [role]( const_dialogue const & d ) {
         const std::vector<npc *> available = g->get_npcs_if( [&]( const npc & guy ) {
-            return d.actor( false )->posz() == guy.posz() &&
+            return d.const_actor( false )->posz() == guy.posz() &&
                    guy.companion_mission_role_id == role.evaluate( d ) &&
-                   ( rl_dist( d.actor( false )->pos(), guy.pos() ) <= 48 );
+                   ( rl_dist( d.const_actor( false )->pos(), guy.pos() ) <= 48 );
         } );
         return !available.empty();
     };
@@ -1165,8 +1172,8 @@ conditional_t::func f_npc_role_nearby( const JsonObject &jo, std::string_view me
 
 conditional_t::func f_npc_is_travelling( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const Character *traveller = d.actor( is_npc )->get_character();
+    return [is_npc]( const_dialogue const & d ) {
+        const Character *traveller = d.const_actor( is_npc )->get_const_character();
         if( !traveller ) {
             return false;
         }
@@ -1177,7 +1184,7 @@ conditional_t::func f_npc_is_travelling( bool is_npc )
 conditional_t::func f_npc_allies( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
+    return [dov]( const_dialogue const & d ) {
         return g->allies().size() >= static_cast<std::vector<npc *>::size_type>( dov.evaluate( d ) );
     };
 }
@@ -1185,7 +1192,7 @@ conditional_t::func f_npc_allies( const JsonObject &jo, std::string_view member 
 conditional_t::func f_npc_allies_global( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
+    return [dov]( const_dialogue const & d ) {
         const auto all_npcs = overmap_buffer.get_overmap_npcs();
         const size_t count = std::count_if( all_npcs.begin(),
         all_npcs.end(), []( const shared_ptr_fast<npc> &ptr ) {
@@ -1199,16 +1206,16 @@ conditional_t::func f_npc_allies_global( const JsonObject &jo, std::string_view 
 conditional_t::func f_u_has_cash( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
-        return d.actor( false )->cash() >= dov.evaluate( d );
+    return [dov]( const_dialogue const & d ) {
+        return d.const_actor( false )->cash() >= dov.evaluate( d );
     };
 }
 
 conditional_t::func f_u_are_owed( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
-        return d.actor( true )->debt() >= dov.evaluate( d );
+    return [dov]( const_dialogue const & d ) {
+        return d.const_actor( true )->debt() >= dov.evaluate( d );
     };
 }
 
@@ -1216,8 +1223,8 @@ conditional_t::func f_npc_aim_rule( const JsonObject &jo, std::string_view membe
                                     bool is_npc )
 {
     str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
-    return [setting, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "aim_rule", setting.evaluate( d ) );
+    return [setting, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "aim_rule", setting.evaluate( d ) );
     };
 }
 
@@ -1225,8 +1232,8 @@ conditional_t::func f_npc_engagement_rule( const JsonObject &jo, std::string_vie
         bool is_npc )
 {
     str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
-    return [setting, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "engagement_rule", setting.evaluate( d ) );
+    return [setting, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "engagement_rule", setting.evaluate( d ) );
     };
 }
 
@@ -1234,8 +1241,8 @@ conditional_t::func f_npc_cbm_reserve_rule( const JsonObject &jo, std::string_vi
         bool is_npc )
 {
     str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
-    return [setting, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "cbm_reserve_rule", setting.evaluate( d ) );
+    return [setting, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "cbm_reserve_rule", setting.evaluate( d ) );
     };
 }
 
@@ -1243,16 +1250,16 @@ conditional_t::func f_npc_cbm_recharge_rule( const JsonObject &jo, std::string_v
         bool is_npc )
 {
     str_or_var setting = get_str_or_var( jo.get_member( member ), member, true );
-    return [setting, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "cbm_recharge_rule", setting.evaluate( d ) );
+    return [setting, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "cbm_recharge_rule", setting.evaluate( d ) );
     };
 }
 
 conditional_t::func f_npc_rule( const JsonObject &jo, std::string_view member, bool is_npc )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
-    return [rule, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "ally_rule", rule.evaluate( d ) );
+    return [rule, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "ally_rule", rule.evaluate( d ) );
     };
 }
 
@@ -1260,15 +1267,15 @@ conditional_t::func f_npc_override( const JsonObject &jo, std::string_view membe
                                     bool is_npc )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
-    return [rule, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "ally_override", rule.evaluate( d ) );
+    return [rule, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "ally_override", rule.evaluate( d ) );
     };
 }
 
 conditional_t::func f_is_season( const JsonObject &jo, std::string_view member )
 {
     str_or_var season_name = get_str_or_var( jo.get_member( member ), member, true );
-    return [season_name]( dialogue const & d ) {
+    return [season_name]( const_dialogue const & d ) {
         const season_type season = season_of_year( calendar::turn );
         return ( season == SPRING && season_name.evaluate( d ) == "spring" ) ||
                ( season == SUMMER && season_name.evaluate( d ) == "summer" ) ||
@@ -1281,8 +1288,8 @@ conditional_t::func f_mission_goal( const JsonObject &jo, std::string_view membe
                                     bool is_npc )
 {
     str_or_var mission_goal_str = get_str_or_var( jo.get_member( member ), member, true );
-    return [mission_goal_str, is_npc]( dialogue const & d ) {
-        mission *miss = d.actor( is_npc )->selected_mission();
+    return [mission_goal_str, is_npc]( const_dialogue const & d ) {
+        mission *miss = d.const_actor( is_npc )->selected_mission();
         if( !miss ) {
             return false;
         }
@@ -1293,8 +1300,8 @@ conditional_t::func f_mission_goal( const JsonObject &jo, std::string_view membe
 
 conditional_t::func f_is_gender( bool is_male, bool is_npc )
 {
-    return [is_male, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_male() == is_male;
+    return [is_male, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_male() == is_male;
     };
 }
 
@@ -1309,14 +1316,14 @@ conditional_t::func f_is_female( bool is_npc )
 
 conditional_t::func f_is_alive( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_is_alive();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_is_alive();
     };
 }
 
 conditional_t::func f_exists( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
+    return [is_npc]( const_dialogue const & d ) {
         if( ( is_npc && !d.has_beta ) || ( !is_npc && !d.has_alpha ) ) {
             return false;
         } else {
@@ -1326,134 +1333,135 @@ conditional_t::func f_exists( bool is_npc )
 }
 conditional_t::func f_is_avatar( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_character() && d.actor( is_npc )->get_character()->is_avatar();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_character() &&
+               d.const_actor( is_npc )->get_const_character()->is_avatar();
     };
 }
 
 conditional_t::func f_is_npc( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_npc();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_npc();
     };
 }
 
 conditional_t::func f_is_character( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_character();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_character();
     };
 }
 
 conditional_t::func f_is_monster( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_monster();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_monster();
     };
 }
 
 conditional_t::func f_is_item( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_item();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_item();
     };
 }
 
 conditional_t::func f_is_furniture( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_computer();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_const_computer();
     };
 }
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const Creature *c = d.actor( is_npc )->get_creature();
+    return [is_npc]( const_dialogue const & d ) {
+        const Creature *c = d.const_actor( is_npc )->get_const_creature();
         if( c ) {
             return get_player_view().sees( *c );
         } else {
-            return get_player_view().sees( d.actor( is_npc )->pos() );
+            return get_player_view().sees( d.const_actor( is_npc )->pos() );
         }
     };
 }
 
 conditional_t::func f_has_alpha()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.has_alpha;
     };
 }
 
 conditional_t::func f_has_beta()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.has_beta;
     };
 }
 
 conditional_t::func f_no_assigned_mission()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.missions_assigned.empty();
     };
 }
 
 conditional_t::func f_has_assigned_mission()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.missions_assigned.size() == 1;
     };
 }
 
 conditional_t::func f_has_many_assigned_missions()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.missions_assigned.size() >= 2;
     };
 }
 
 conditional_t::func f_no_available_mission( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->available_missions().empty();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->available_missions().empty();
     };
 }
 
 conditional_t::func f_has_available_mission( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->available_missions().size() == 1;
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->available_missions().size() == 1;
     };
 }
 
 conditional_t::func f_has_many_available_missions( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->available_missions().size() >= 2;
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->available_missions().size() >= 2;
     };
 }
 
 conditional_t::func f_mission_complete( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        mission *miss = d.actor( is_npc )->selected_mission();
-        return miss && miss->is_complete( d.actor( is_npc )->getID() );
+    return [is_npc]( const_dialogue const & d ) {
+        mission *miss = d.const_actor( is_npc )->selected_mission();
+        return miss && miss->is_complete( d.const_actor( is_npc )->getID() );
     };
 }
 
 conditional_t::func f_mission_incomplete( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        mission *miss = d.actor( is_npc )->selected_mission();
-        return miss && !miss->is_complete( d.actor( is_npc )->getID() );
+    return [is_npc]( const_dialogue const & d ) {
+        mission *miss = d.const_actor( is_npc )->selected_mission();
+        return miss && !miss->is_complete( d.const_actor( is_npc )->getID() );
     };
 }
 
 conditional_t::func f_mission_failed( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        mission *miss = d.actor( is_npc )->selected_mission();
+    return [is_npc]( const_dialogue const & d ) {
+        mission *miss = d.const_actor( is_npc )->selected_mission();
         return miss && miss->has_failed();
     };
 }
@@ -1461,65 +1469,65 @@ conditional_t::func f_mission_failed( bool is_npc )
 conditional_t::func f_npc_service( const JsonObject &jo, std::string_view member, bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [is_npc, dov]( dialogue & d ) {
-        return !d.actor( is_npc )->has_effect( effect_currently_busy, bodypart_str_id::NULL_ID() ) &&
-               d.actor( false )->cash() >= dov.evaluate( d );
+    return [is_npc, dov]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->has_effect( effect_currently_busy, bodypart_str_id::NULL_ID() ) &&
+               d.const_actor( false )->cash() >= dov.evaluate( d );
     };
 }
 
 conditional_t::func f_npc_available( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !d.actor( is_npc )->has_effect( effect_currently_busy, bodypart_str_id::NULL_ID() );
+    return [is_npc]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->has_effect( effect_currently_busy, bodypart_str_id::NULL_ID() );
     };
 }
 
 conditional_t::func f_npc_following( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_following();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_following();
     };
 }
 
 conditional_t::func f_npc_friend( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_friendly( get_player_character() );
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_friendly( get_player_character() );
     };
 }
 
 conditional_t::func f_npc_hostile( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_enemy();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_enemy();
     };
 }
 
 conditional_t::func f_npc_train_skills( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !d.actor( is_npc )->skills_offered_to( *d.actor( !is_npc ) ).empty();
+    return [is_npc]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->skills_offered_to( *d.const_actor( !is_npc ) ).empty();
     };
 }
 
 conditional_t::func f_npc_train_styles( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !d.actor( is_npc )->styles_offered_to( *d.actor( !is_npc ) ).empty();
+    return [is_npc]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->styles_offered_to( *d.const_actor( !is_npc ) ).empty();
     };
 }
 
 conditional_t::func f_npc_train_spells( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !d.actor( is_npc )->spells_offered_to( *d.actor( !is_npc ) ).empty();
+    return [is_npc]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->spells_offered_to( *d.const_actor( !is_npc ) ).empty();
     };
 }
 
 conditional_t::func f_follower_present( const JsonObject &jo, std::string_view member )
 {
     const std::string &var_name = jo.get_string( std::string( member ) );
-    return [var_name]( dialogue const & d ) {
+    return [var_name]( const_dialogue const & d ) {
         npc *npc_to_check = nullptr;
         for( npc &guy : g->all_npcs() ) {
             if( guy.myclass.str() == var_name ) {
@@ -1527,7 +1535,7 @@ conditional_t::func f_follower_present( const JsonObject &jo, std::string_view m
                 break;
             }
         }
-        npc *d_npc = d.actor( true )->get_npc();
+        npc const *d_npc = d.const_actor( true )->get_const_npc();
         if( npc_to_check == nullptr || d_npc == nullptr ) {
             return false;
         }
@@ -1545,39 +1553,39 @@ conditional_t::func f_follower_present( const JsonObject &jo, std::string_view m
 
 conditional_t::func f_at_safe_space( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return overmap_buffer.is_safe( d.actor( is_npc )->global_omt_location() ) &&
-               d.actor( is_npc )->is_safe();
+    return [is_npc]( const_dialogue const & d ) {
+        return overmap_buffer.is_safe( d.const_actor( is_npc )->global_omt_location() ) &&
+               d.const_actor( is_npc )->is_safe();
     };
 }
 
 conditional_t::func f_can_stow_weapon( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return !actor->unarmed_attack() && actor->can_stash_weapon();
     };
 }
 
 conditional_t::func f_can_drop_weapon( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         return !actor->unarmed_attack() && !actor->wielded_with_flag( flag_NO_UNWIELD );
     };
 }
 
 conditional_t::func f_has_weapon( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return !d.actor( is_npc )->unarmed_attack();
+    return [is_npc]( const_dialogue const & d ) {
+        return !d.const_actor( is_npc )->unarmed_attack();
     };
 }
 
 conditional_t::func f_is_controlling_vehicle( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         if( const optional_vpart_position &vp = get_map().veh_at( actor->pos() ) ) {
             return actor->is_in_control_of( vp->vehicle() );
         }
@@ -1587,8 +1595,8 @@ conditional_t::func f_is_controlling_vehicle( bool is_npc )
 
 conditional_t::func f_is_driving( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         if( const optional_vpart_position &vp = get_map().veh_at( actor->pos() ) ) {
             return vp->vehicle().is_moving() && actor->is_in_control_of( vp->vehicle() );
         }
@@ -1598,29 +1606,29 @@ conditional_t::func f_is_driving( bool is_npc )
 
 conditional_t::func f_has_stolen_item( bool /*is_npc*/ )
 {
-    return []( dialogue const & d ) {
-        return d.actor( false )->has_stolen_item( *d.actor( true ) );
+    return []( const_dialogue const & d ) {
+        return d.const_actor( false )->has_stolen_item( *d.const_actor( true ) );
     };
 }
 
 conditional_t::func f_is_day()
 {
-    return []( dialogue const & ) {
+    return []( const_dialogue const & ) {
         return !is_night( calendar::turn );
     };
 }
 
 conditional_t::func f_is_outside( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return is_creature_outside( *d.actor( is_npc )->get_const_creature() );
+    return [is_npc]( const_dialogue const & d ) {
+        return is_creature_outside( *d.const_actor( is_npc )->get_const_creature() );
     };
 }
 
 conditional_t::func f_is_underwater( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return get_map().is_divable( d.actor( is_npc )->pos() );
+    return [is_npc]( const_dialogue const & d ) {
+        return get_map().is_divable( d.const_actor( is_npc )->pos() );
     };
 }
 
@@ -1641,7 +1649,7 @@ conditional_t::func f_is_on_liquid( bool is_npc )
 conditional_t::func f_one_in_chance( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
+    return [dov]( const_dialogue const & d ) {
         return one_in( dov.evaluate( d ) );
     };
 }
@@ -1650,8 +1658,8 @@ conditional_t::func f_query( const JsonObject &jo, std::string_view member, bool
 {
     translation_or_var message = get_translation_or_var( jo.get_member( member ), member, true );
     bool default_val = jo.get_bool( "default" );
-    return [message, default_val, is_npc]( dialogue const & d ) {
-        const talker *actor = d.actor( is_npc );
+    return [message, default_val, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
         if( actor->get_const_character() && actor->get_const_character()->is_avatar() ) {
             std::string translated_message = message.evaluate( d );
             return query_yn( translated_message );
@@ -1674,18 +1682,18 @@ conditional_t::func f_query_tile( const JsonObject &jo, std::string_view member,
         range = get_dbl_or_var( jo, "range" );
     }
     bool z_level = jo.get_bool( "z_level", false );
-    return [type, target_var, message, range, z_level, is_npc]( dialogue & d ) {
+    return [type, target_var, message, range, z_level, is_npc]( const_dialogue const & d ) {
         std::optional<tripoint> loc;
-        Character *ch = d.actor( is_npc )->get_character();
+        Character const *ch = d.const_actor( is_npc )->get_const_character();
         if( ch && ch->as_avatar() ) {
-            avatar *you = ch->as_avatar();
+            avatar const *you = ch->as_avatar();
             if( type == "anywhere" ) {
                 if( !message.empty() ) {
                     static_popup popup;
                     popup.on_top( true );
                     popup.message( "%s", message );
                 }
-                tripoint center = d.actor( is_npc )->pos();
+                tripoint center = d.const_actor( is_npc )->pos();
                 const look_around_params looka_params = { true, center, center, false, true, true, z_level };
                 loc = g->look_around( looka_params ).position;
             } else if( type == "line_of_sight" ) {
@@ -1723,7 +1731,7 @@ conditional_t::func f_x_in_y_chance( const JsonObject &jo, const std::string_vie
     const JsonObject &var_obj = jo.get_object( member );
     dbl_or_var dovx = get_dbl_or_var( var_obj, "x" );
     dbl_or_var dovy = get_dbl_or_var( var_obj, "y" );
-    return [dovx, dovy]( dialogue & d ) {
+    return [dovx, dovy]( const_dialogue const & d ) {
         return x_in_y( dovx.evaluate( d ),
                        dovy.evaluate( d ) );
     };
@@ -1732,7 +1740,7 @@ conditional_t::func f_x_in_y_chance( const JsonObject &jo, const std::string_vie
 conditional_t::func f_is_weather( const JsonObject &jo, std::string_view member )
 {
     str_or_var weather = get_str_or_var( jo.get_member( member ), member, true );
-    return [weather]( dialogue const & d ) {
+    return [weather]( const_dialogue const & d ) {
         return get_weather().weather_id == weather_type_id( weather.evaluate( d ) );
     };
 }
@@ -1747,7 +1755,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
     } else if( member == "map_furniture_with_flag" ) {
         terrain = false;
     }
-    return [terrain, furn_type, loc_var]( dialogue const & d ) {
+    return [terrain, furn_type, loc_var]( const_dialogue const & d ) {
         tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
         if( terrain ) {
             return get_map().ter( loc )->has_flag( furn_type.evaluate( d ) );
@@ -1762,7 +1770,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
     str_or_var furn_type = get_str_or_var( jo.get_member( member ), member, true );
     var_info loc_var = read_var_info( jo.get_object( "loc" ) );
 
-    return [member, furn_type, loc_var]( dialogue const & d ) {
+    return [member, furn_type, loc_var]( const_dialogue const & d ) {
         tripoint_bub_ms loc = get_map().bub_from_abs( get_tripoint_from_var( loc_var, d, false ) );
         if( member == "map_terrain_id" ) {
             return get_map().ter( loc ) == ter_id( furn_type.evaluate( d ) );
@@ -1781,7 +1789,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
 conditional_t::func f_map_in_city( const JsonObject &jo, std::string_view member )
 {
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
-    return [target]( dialogue const & d ) {
+    return [target]( const_dialogue const & d ) {
         tripoint_abs_omt target_pos = project_to<coords::omt>( tripoint_abs_ms( tripoint::from_string(
                                           target.evaluate( d ) ) ) );
 
@@ -1797,7 +1805,7 @@ conditional_t::func f_map_in_city( const JsonObject &jo, std::string_view member
 conditional_t::func f_mod_is_loaded( const JsonObject &jo, std::string_view member )
 {
     str_or_var compared_mod = get_str_or_var( jo.get_member( member ), member, true );
-    return [compared_mod]( dialogue const & d ) {
+    return [compared_mod]( const_dialogue const & d ) {
         mod_id comp_mod = mod_id( compared_mod.evaluate( d ) );
         for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
             if( comp_mod == mod ) {
@@ -1811,8 +1819,8 @@ conditional_t::func f_mod_is_loaded( const JsonObject &jo, std::string_view memb
 conditional_t::func f_has_faction_trust( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
-        return d.actor( true )->get_faction()->trusts_u >= dov.evaluate( d );
+    return [dov]( const_dialogue const & d ) {
+        return d.const_actor( true )->get_faction()->trusts_u >= dov.evaluate( d );
     };
 }
 
@@ -1823,9 +1831,6 @@ conditional_t::func f_compare_string( const JsonObject &jo, std::string_view mem
     JsonArray objects = jo.get_array( member );
     if( objects.size() != 2 ) {
         jo.throw_error( "incorrect number of values.  Expected 2 in " + jo.str() );
-        return []( dialogue const & ) {
-            return false;
-        };
     }
 
     if( objects.has_object( 0 ) ) {
@@ -1839,7 +1844,7 @@ conditional_t::func f_compare_string( const JsonObject &jo, std::string_view mem
         second.str_val = objects.next_string();
     }
 
-    return [first, second]( dialogue const & d ) {
+    return [first, second]( const_dialogue const & d ) {
         return first.evaluate( d ) == second.evaluate( d );
     };
 }
@@ -1847,7 +1852,7 @@ conditional_t::func f_compare_string( const JsonObject &jo, std::string_view mem
 conditional_t::func f_get_condition( const JsonObject &jo, std::string_view member )
 {
     str_or_var conditionalToGet = get_str_or_var( jo.get_member( member ), member, true );
-    return [conditionalToGet]( dialogue & d ) {
+    return [conditionalToGet]( const_dialogue const & d ) {
         return d.evaluate_conditional( conditionalToGet.evaluate( d ), d );
     };
 }
@@ -1855,9 +1860,10 @@ conditional_t::func f_get_condition( const JsonObject &jo, std::string_view memb
 conditional_t::func f_test_eoc( const JsonObject &jo, std::string_view member )
 {
     str_or_var eocToTest = get_str_or_var( jo.get_member( member ), member, true );
-    return [eocToTest]( dialogue & d ) {
+    return [eocToTest]( const_dialogue const & d ) -> bool {
         effect_on_condition_id tested( eocToTest.evaluate( d ) );
-        if( !tested.is_valid() ) {
+        if( !tested.is_valid() )
+        {
             debugmsg( "Invalid eoc id: %s", eocToTest.evaluate( d ) );
             return false;
         }
@@ -1867,10 +1873,10 @@ conditional_t::func f_test_eoc( const JsonObject &jo, std::string_view member )
 
 conditional_t::func f_has_ammo()
 {
-    return []( dialogue & d ) {
-        item_location *it = d.actor( true )->get_item();
+    return []( const_dialogue const & d ) {
+        item_location const *it = d.const_actor( true )->get_const_item();
         if( it ) {
-            return ( *it )->ammo_sufficient( d.actor( false )->get_character() );
+            return ( *it )->ammo_sufficient( d.const_actor( false )->get_const_character() );
         } else {
             debugmsg( "beta talker must be Item" );
             return false;
@@ -1882,14 +1888,15 @@ conditional_t::func f_math( const JsonObject &jo, const std::string_view member 
 {
     eoc_math math;
     math.from_json( jo, member, eoc_math::type_t::compare );
-    return [math = std::move( math )]( dialogue & d ) {
-        return math.act( d );
+    return [math = std::move( math )]( const_dialogue const & d ) {
+        dialogue loosey_goosey( d );
+        return math.act( loosey_goosey );
     };
 }
 
 conditional_t::func f_u_has_camp()
 {
-    return []( dialogue const & ) {
+    return []( const_dialogue const & ) {
         for( const tripoint_abs_omt &camp_tripoint : get_player_character().camps ) {
             std::optional<basecamp *> camp = overmap_buffer.find_camp( camp_tripoint.xy() );
             if( !camp ) {
@@ -1906,21 +1913,21 @@ conditional_t::func f_u_has_camp()
 
 conditional_t::func f_has_pickup_list( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->has_ai_rule( "pickup_rule", "any" );
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->has_ai_rule( "pickup_rule", "any" );
     };
 }
 
 conditional_t::func f_is_by_radio()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return d.by_radio;
     };
 }
 
 conditional_t::func f_has_reason()
 {
-    return []( dialogue const & d ) {
+    return []( const_dialogue const & d ) {
         return !d.reason.empty();
     };
 }
@@ -1930,7 +1937,7 @@ conditional_t::func f_roll_contested( const JsonObject &jo, const std::string_vi
     dbl_or_var get_check = get_dbl_or_var( jo, member );
     dbl_or_var difficulty = get_dbl_or_var( jo, "difficulty", true );
     dbl_or_var die_size = get_dbl_or_var( jo, "die_size", false, 10 );
-    return [get_check, difficulty, die_size]( dialogue & d ) {
+    return [get_check, difficulty, die_size]( const_dialogue const & d ) {
         return rng( 1, die_size.evaluate( d ) ) + get_check.evaluate( d ) >
                difficulty.evaluate( d );
     };
@@ -1939,7 +1946,7 @@ conditional_t::func f_roll_contested( const JsonObject &jo, const std::string_vi
 conditional_t::func f_u_know_recipe( const JsonObject &jo, std::string_view member )
 {
     str_or_var known_recipe_id = get_str_or_var( jo.get_member( member ), member, true );
-    return [known_recipe_id]( dialogue & d ) {
+    return [known_recipe_id]( const_dialogue const & d ) {
         const recipe &rep = recipe_id( known_recipe_id.evaluate( d ) ).obj();
         // should be a talker function but recipes aren't in Character:: yet
         return get_player_character().knows_recipe( &rep );
@@ -1948,8 +1955,8 @@ conditional_t::func f_u_know_recipe( const JsonObject &jo, std::string_view memb
 
 conditional_t::func f_mission_has_generic_rewards()
 {
-    return []( dialogue const & d ) {
-        mission *miss = d.actor( true )->selected_mission();
+    return []( const_dialogue const & d ) {
+        mission *miss = d.const_actor( true )->selected_mission();
         if( miss == nullptr ) {
             debugmsg( "mission_has_generic_rewards: mission_selected == nullptr" );
             return true;
@@ -1964,9 +1971,9 @@ conditional_t::func f_has_worn_with_flag( const JsonObject &jo, std::string_view
     str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
     std::optional<bodypart_id> bp;
     optional( jo, false, "bodypart", bp );
-    return [flag, bp, is_npc]( dialogue const & d ) {
+    return [flag, bp, is_npc]( const_dialogue const & d ) {
         bodypart_id bid = bp.value_or( get_bp_from_str( d.reason ) );
-        return d.actor( is_npc )->worn_with_flag( flag_id( flag.evaluate( d ) ), bid );
+        return d.const_actor( is_npc )->worn_with_flag( flag_id( flag.evaluate( d ) ), bid );
     };
 }
 
@@ -1974,8 +1981,8 @@ conditional_t::func f_has_wielded_with_flag( const JsonObject &jo, std::string_v
         bool is_npc )
 {
     str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
-    return [flag, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->wielded_with_flag( flag_id( flag.evaluate( d ) ) );
+    return [flag, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->wielded_with_flag( flag_id( flag.evaluate( d ) ) );
     };
 }
 
@@ -1984,8 +1991,9 @@ conditional_t::func f_has_wielded_with_weapon_category( const JsonObject &jo,
         bool is_npc )
 {
     str_or_var w_cat = get_str_or_var( jo.get_member( member ), member, true );
-    return [w_cat, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->wielded_with_weapon_category( weapon_category_id( w_cat.evaluate( d ) ) );
+    return [w_cat, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->wielded_with_weapon_category( weapon_category_id( w_cat.evaluate(
+                    d ) ) );
     };
 }
 
@@ -1995,9 +2003,9 @@ conditional_t::func f_has_wielded_with_skill( const JsonObject &jo, std::string_
     // ideally all this "u wield with X" should be moved to some mutator
     // and a single effect should check mutator applied to the item in your hands
     str_or_var w_skill = get_str_or_var( jo.get_member( member ), member, true );
-    return [w_skill, is_npc]( dialogue const & d ) {
+    return [w_skill, is_npc]( const_dialogue const & d ) {
 
-        return d.actor( is_npc )->wielded_with_weapon_skill( skill_id( w_skill.evaluate( d ) ) );
+        return d.const_actor( is_npc )->wielded_with_weapon_skill( skill_id( w_skill.evaluate( d ) ) );
     };
 }
 
@@ -2005,23 +2013,23 @@ conditional_t::func f_has_wielded_with_ammotype( const JsonObject &jo, std::stri
         bool is_npc )
 {
     str_or_var w_ammotype = get_str_or_var( jo.get_member( member ), member, true );
-    return [w_ammotype, is_npc]( dialogue const & d ) {
+    return [w_ammotype, is_npc]( const_dialogue const & d ) {
 
-        return d.actor( is_npc )->wielded_with_item_ammotype( ammotype( w_ammotype.evaluate( d ) ) );
+        return d.const_actor( is_npc )->wielded_with_item_ammotype( ammotype( w_ammotype.evaluate( d ) ) );
     };
 }
 
 conditional_t::func f_can_see( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->can_see();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->can_see();
     };
 }
 
 conditional_t::func f_is_deaf( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->is_deaf();
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_deaf();
     };
 }
 
@@ -2029,9 +2037,9 @@ conditional_t::func f_is_on_terrain( const JsonObject &jo, std::string_view memb
                                      bool is_npc )
 {
     str_or_var terrain_type = get_str_or_var( jo.get_member( member ), member, true );
-    return [terrain_type, is_npc]( dialogue const & d ) {
+    return [terrain_type, is_npc]( const_dialogue const & d ) {
         map &here = get_map();
-        return here.ter( d.actor( is_npc )->pos() ) == ter_id( terrain_type.evaluate( d ) );
+        return here.ter( d.const_actor( is_npc )->pos() ) == ter_id( terrain_type.evaluate( d ) );
     };
 }
 
@@ -2039,9 +2047,9 @@ conditional_t::func f_is_on_terrain_with_flag( const JsonObject &jo, std::string
         bool is_npc )
 {
     str_or_var terrain_type = get_str_or_var( jo.get_member( member ), member, true );
-    return [terrain_type, is_npc]( dialogue const & d ) {
+    return [terrain_type, is_npc]( const_dialogue const & d ) {
         map &here = get_map();
-        return here.ter( d.actor( is_npc )->pos() )->has_flag( terrain_type.evaluate( d ) );
+        return here.ter( d.const_actor( is_npc )->pos() )->has_flag( terrain_type.evaluate( d ) );
     };
 }
 
@@ -2049,10 +2057,10 @@ conditional_t::func f_is_in_field( const JsonObject &jo, std::string_view member
                                    bool is_npc )
 {
     str_or_var field_type = get_str_or_var( jo.get_member( member ), member, true );
-    return [field_type, is_npc]( dialogue const & d ) {
+    return [field_type, is_npc]( const_dialogue const & d ) {
         map &here = get_map();
         field_type_id ft = field_type_id( field_type.evaluate( d ) );
-        for( const std::pair<const field_type_id, field_entry> &f : here.field_at( d.actor(
+        for( const std::pair<const field_type_id, field_entry> &f : here.field_at( d.const_actor(
                     is_npc )->pos() ) ) {
             if( f.second.get_field_type() == ft ) {
                 return true;
@@ -2066,8 +2074,8 @@ conditional_t::func f_has_move_mode( const JsonObject &jo, std::string_view memb
                                      bool is_npc )
 {
     str_or_var mode = get_str_or_var( jo.get_member( member ), member, true );
-    return [mode, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->get_move_mode() == move_mode_id( mode.evaluate( d ) );
+    return [mode, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->get_move_mode() == move_mode_id( mode.evaluate( d ) );
     };
 }
 
@@ -2075,9 +2083,9 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
                                         bool is_npc )
 {
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
-    return [is_npc, target]( dialogue const & d ) {
+    return [is_npc, target]( const_dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
+        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
     };
 }
 
@@ -2085,8 +2093,8 @@ conditional_t::func f_using_martial_art( const JsonObject &jo, std::string_view 
         bool is_npc )
 {
     str_or_var style_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [style_to_check, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->using_martial_art( matype_id( style_to_check.evaluate( d ) ) );
+    return [style_to_check, is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->using_martial_art( matype_id( style_to_check.evaluate( d ) ) );
     };
 }
 
@@ -2094,17 +2102,17 @@ conditional_t::func f_using_martial_art( const JsonObject &jo, std::string_view 
 } // namespace conditional_fun
 
 template<class T>
-static std::function<T( const dialogue & )> get_get_str_( const JsonObject &jo,
+static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject &jo,
         std::function<T( const std::string & )> ret_func )
 {
     if( jo.get_string( "mutator" ) == "mon_faction" ) {
         str_or_var mtypeid = get_str_or_var( jo.get_member( "mtype_id" ), "mtype_id" );
-        return [mtypeid, ret_func]( const dialogue & d ) {
+        return [mtypeid, ret_func]( const_dialogue const & d ) {
             return ret_func( ( static_cast<mtype_id>( mtypeid.evaluate( d ) ) )->default_faction.str() );
         };
     } else if( jo.get_string( "mutator" ) == "game_option" ) {
         str_or_var option = get_str_or_var( jo.get_member( "option" ), "option" );
-        return [option, ret_func]( const dialogue & d ) {
+        return [option, ret_func]( const_dialogue const & d ) {
             return ret_func( get_option<std::string>( option.evaluate( d ) ) );
         };
     } else if( jo.get_string( "mutator" ) == "valid_technique" ) {
@@ -2119,24 +2127,26 @@ static std::function<T( const dialogue & )> get_get_str_( const JsonObject &jo,
         bool dodge_counter = jo.get_bool( "dodge_counter", false );
         bool block_counter = jo.get_bool( "block_counter", false );
 
-        return [blacklist, crit, dodge_counter, block_counter, ret_func]( const dialogue & d ) {
+        return [blacklist, crit, dodge_counter, block_counter, ret_func]( const_dialogue const & d ) {
             std::vector<matec_id> bl;
             bl.reserve( blacklist.size() );
             for( const str_or_var &sv : blacklist ) {
                 bl.emplace_back( sv.evaluate( d ) );
             }
-            return ret_func( d.actor( false )->get_random_technique( *d.actor( true )->get_creature(),
+            return ret_func( d.const_actor( false )->get_random_technique( *d.const_actor(
+                                 true )->get_const_creature(),
                              crit, dodge_counter, block_counter, bl ).str() );
         };
     } else if( jo.get_string( "mutator" ) == "loc_relative_u" ) {
         str_or_var target = get_str_or_var( jo.get_member( "target" ), "target" );
-        return [target, ret_func]( const dialogue & d ) {
-            tripoint_abs_ms char_pos = get_map().getglobal( d.actor( false )->pos() );
+        bool use_beta_talker = mutator == "npc_loc_relative";
+        return [target, use_beta_talker, ret_func]( const_dialogue const & d ) {
+            tripoint_abs_ms char_pos = get_map().getglobal( d.const_actor( use_beta_talker )->pos() );
             tripoint_abs_ms target_pos = char_pos + tripoint::from_string( target.evaluate( d ) );
             return ret_func( target_pos.to_string() );
         };
-    } else if( jo.get_string( "mutator" ) == "topic_item" ) {
-        return [ret_func]( const dialogue & d ) {
+    } else if( mutator == "topic_item" ) {
+        return [ret_func]( const_dialogue const & d ) {
             return ret_func( d.cur_item.str() );
         };
     }
@@ -2145,19 +2155,19 @@ static std::function<T( const dialogue & )> get_get_str_( const JsonObject &jo,
 }
 
 template<class T>
-static std::function<T( const dialogue & )> get_get_translation_( const JsonObject &jo,
+static std::function<T( const_dialogue const & )> get_get_translation_( const JsonObject &jo,
         std::function<T( const translation & )> ret_func )
 {
     if( jo.get_string( "mutator" ) == "ma_technique_description" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
-        return [ma, ret_func]( const dialogue & d ) {
+        return [ma, ret_func]( const_dialogue const & d ) {
             return ret_func( matec_id( ma.evaluate( d ) )->description );
         };
     } else if( jo.get_string( "mutator" ) == "ma_technique_name" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
-        return [ma, ret_func]( const dialogue & d ) {
+        return [ma, ret_func]( const_dialogue const & d ) {
             return ret_func( matec_id( ma.evaluate( d ) )->name );
         };
     }
@@ -2165,7 +2175,7 @@ static std::function<T( const dialogue & )> get_get_translation_( const JsonObje
     return nullptr;
 }
 
-std::function<translation( const dialogue & )> conditional_t::get_get_translation(
+std::function<translation( const_dialogue const & )> conditional_t::get_get_translation(
     const JsonObject &jo )
 {
     auto ret_func = get_get_str_<translation>( jo, []( const std::string & s ) {
@@ -2178,7 +2188,7 @@ std::function<translation( const dialogue & )> conditional_t::get_get_translatio
         } );
         if( !ret_func ) {
             jo.throw_error( "unrecognized string mutator in " + jo.str() );
-            return []( const dialogue & ) {
+            return []( const_dialogue const & ) {
                 return translation();
             };
         }
@@ -2187,7 +2197,8 @@ std::function<translation( const dialogue & )> conditional_t::get_get_translatio
     return ret_func;
 }
 
-std::function<std::string( const dialogue & )> conditional_t::get_get_string( const JsonObject &jo )
+std::function<std::string( const_dialogue const & )> conditional_t::get_get_string(
+    const JsonObject &jo )
 {
     auto ret_func = get_get_str_<std::string>( jo, []( const std::string & s ) {
         return s;
@@ -2199,7 +2210,7 @@ std::function<std::string( const dialogue & )> conditional_t::get_get_string( co
         } );
         if( !ret_func ) {
             jo.throw_error( "unrecognized string mutator in " + jo.str() );
-            return []( const dialogue & ) {
+            return []( const_dialogue const & ) {
                 return "INVALID";
             };
         }
@@ -2259,61 +2270,61 @@ std::unordered_map<std::string_view, int ( const_talker::* )() const> const f_ge
 } // namespace
 
 // Consider adding new, single-purpose math functions instead of feeding this monster another else-if
-std::function<double( dialogue & )> conditional_t::get_get_dbl( std::string_view checked_value,
-        char scope )
+std::function<double( const_dialogue const & )>
+conditional_t::get_get_dbl( std::string_view checked_value, char scope )
 {
     const bool is_npc = scope == 'n';
 
     if( auto iter = f_get_vals.find( checked_value ); iter != f_get_vals.end() ) {
-        return [is_npc, func = iter->second ]( dialogue & d ) {
-            return ( d.actor( is_npc )->*func )();
+        return [is_npc, func = iter->second ]( const_dialogue const & d ) {
+            return ( d.const_actor( is_npc )->*func )();
         };
 
     } else if( checked_value == "allies" ) {
         if( is_npc ) {
             throw std::invalid_argument( "Can't get allies count for NPCs" );
         }
-        return []( dialogue const & ) {
+        return []( const_dialogue const & /* d */ ) {
             return static_cast<double>( g->allies().size() );
         };
     } else if( checked_value == "dodge" ) {
-        return [is_npc]( dialogue const & d ) {
-            return d.actor( is_npc )->get_const_character()->get_dodge();
+        return [is_npc]( const_dialogue const & d ) {
+            return d.const_actor( is_npc )->get_const_character()->get_dodge();
         };
     } else if( checked_value == "power_percentage" ) {
-        return [is_npc]( dialogue const & d ) {
+        return [is_npc]( const_dialogue const & d ) {
             // Energy in milijoule
-            units::energy::value_type power_max = d.actor( is_npc )->power_max().value();
+            units::energy::value_type power_max = d.const_actor( is_npc )->power_max().value();
             if( power_max == 0 ) {
                 return 0.0; //Default value if character does not have power, avoids division with 0.
             }
-            return static_cast<double>( d.actor( is_npc )->power_cur().value() * 100.0L / power_max );
+            return static_cast<double>( d.const_actor( is_npc )->power_cur().value() * 100.0L / power_max );
         };
     } else if( checked_value == "mana_percentage" ) {
-        return [is_npc]( dialogue const & d ) {
-            int mana_max = d.actor( is_npc )->mana_max();
+        return [is_npc]( const_dialogue const & d ) {
+            int mana_max = d.const_actor( is_npc )->mana_max();
             if( mana_max == 0 ) {
                 return 0.0; //Default value if character does not have mana, avoids division with 0.
             }
-            return d.actor( is_npc )->mana_cur() * 100.0 / mana_max;
+            return d.const_actor( is_npc )->mana_cur() * 100.0 / mana_max;
         };
     } else if( checked_value == "body_temp" ) {
-        return [is_npc]( dialogue const & d ) {
-            return units::to_legacy_bodypart_temp( d.actor( is_npc )->get_body_temp() );
+        return [is_npc]( const_dialogue const & d ) {
+            return units::to_legacy_bodypart_temp( d.const_actor( is_npc )->get_body_temp() );
         };
     } else if( checked_value == "body_temp_delta" ) {
-        return [is_npc]( dialogue const & d ) {
-            return units::to_legacy_bodypart_temp_delta( d.actor( is_npc )->get_body_temp_delta() );
+        return [is_npc]( const_dialogue const & d ) {
+            return units::to_legacy_bodypart_temp_delta( d.const_actor( is_npc )->get_body_temp_delta() );
         };
     } else if( checked_value == "power" ) {
-        return [is_npc]( dialogue const & d ) {
+        return [is_npc]( const_dialogue const & d ) {
             // Energy in milijoule
-            return static_cast<double>( d.actor( is_npc )->power_cur().value() );
+            return static_cast<double>( d.const_actor( is_npc )->power_cur().value() );
         };
     } else if( checked_value == "power_max" ) {
-        return [is_npc]( dialogue const & d ) {
+        return [is_npc]( const_dialogue const & d ) {
             // Energy in milijoule
-            return static_cast<double>( d.actor( is_npc )->power_max().value() );
+            return static_cast<double>( d.const_actor( is_npc )->power_max().value() );
         };
     }
 
@@ -2707,7 +2718,7 @@ conditional_t::conditional_t( const JsonObject &jo )
     if( jo.has_array( "and" ) ) {
         std::vector<conditional_t> and_conditionals = parse_array( jo, "and" );
         found_sub_member = true;
-        condition = [acs = std::move( and_conditionals )]( dialogue & d ) {
+        condition = [acs = std::move( and_conditionals )]( const_dialogue const & d ) {
             return std::all_of( acs.begin(), acs.end(), [&d]( conditional_t const & cond ) {
                 return cond( d );
             } );
@@ -2715,7 +2726,7 @@ conditional_t::conditional_t( const JsonObject &jo )
     } else if( jo.has_array( "or" ) ) {
         std::vector<conditional_t> or_conditionals = parse_array( jo, "or" );
         found_sub_member = true;
-        condition = [ocs = std::move( or_conditionals )]( dialogue & d ) {
+        condition = [ocs = std::move( or_conditionals )]( const_dialogue const & d ) {
             return std::any_of( ocs.begin(), ocs.end(), [&d]( conditional_t const & cond ) {
                 return cond( d );
             } );
@@ -2724,13 +2735,13 @@ conditional_t::conditional_t( const JsonObject &jo )
         JsonObject cond = jo.get_object( "not" );
         const conditional_t sub_condition = conditional_t( cond );
         found_sub_member = true;
-        condition = [sub_condition]( dialogue & d ) {
+        condition = [sub_condition]( const_dialogue const & d ) {
             return !sub_condition( d );
         };
     } else if( jo.has_string( "not" ) ) {
         const conditional_t sub_condition = conditional_t( jo.get_string( "not" ) );
         found_sub_member = true;
-        condition = [sub_condition]( dialogue & d ) {
+        condition = [sub_condition]( const_dialogue const & d ) {
             return !sub_condition( d );
         };
     }
@@ -2767,7 +2778,7 @@ conditional_t::conditional_t( const JsonObject &jo )
         for( const std::string &sub_member : dialogue_data::simple_string_conds() ) {
             if( jo.has_string( sub_member ) ) {
                 const conditional_t sub_condition( jo.get_string( sub_member ) );
-                condition = [sub_condition]( dialogue & d ) {
+                condition = [sub_condition]( const_dialogue const & d ) {
                     return sub_condition( d );
                 };
                 found_sub_member = true;
@@ -2801,7 +2812,7 @@ conditional_t::conditional_t( std::string_view type )
         }
     }
     if( !found ) {
-        condition = []( dialogue const & ) {
+        condition = []( const_dialogue const & ) {
             return false;
         };
     }

--- a/src/condition.h
+++ b/src/condition.h
@@ -59,7 +59,7 @@ duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_vie
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string_view &member,
         bool required = true,
         time_duration default_val = 0_seconds );
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, dialogue const &d,
+tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
                                        bool is_npc );
 var_info read_var_info( const JsonObject &jo );
 translation_var_info read_translation_var_info( const JsonObject &jo );
@@ -73,7 +73,7 @@ std::string get_talk_var_basename( const JsonObject &jo, std::string_view member
                                    bool check_value );
 // the truly awful declaration for the conditional_t loading helper_function
 void read_condition( const JsonObject &jo, const std::string &member_name,
-                     std::function<bool( dialogue & )> &condition, bool default_val );
+                     std::function<bool( const_dialogue const & )> &condition, bool default_val );
 
 void finalize_conditions();
 
@@ -86,19 +86,20 @@ void finalize_conditions();
  */
 struct conditional_t {
     public:
-        using func = std::function<bool( dialogue & )>;
+        using func = std::function<bool( const_dialogue const & )>;
 
         conditional_t() = default;
         explicit conditional_t( std::string_view type );
         explicit conditional_t( const JsonObject &jo );
 
-        static std::function<std::string( const dialogue & )> get_get_string( const JsonObject &jo );
-        static std::function<translation( const dialogue & )> get_get_translation( const JsonObject &jo );
-        static std::function<double( dialogue & )> get_get_dbl( std::string_view checked_value,
+        static std::function<std::string( const_dialogue const & )> get_get_string( const JsonObject &jo );
+        static std::function<translation( const_dialogue const & )> get_get_translation(
+            const JsonObject &jo );
+        static std::function<double( const_dialogue const & )> get_get_dbl( std::string_view checked_value,
                 char scope );
         std::function<void( dialogue &, double )>
         static get_set_dbl( std::string_view checked_value, char scope );
-        bool operator()( dialogue &d ) const {
+        bool operator()( const_dialogue const &d ) const {
             if( !condition ) {
                 return false;
             }

--- a/src/condition.h
+++ b/src/condition.h
@@ -67,6 +67,8 @@ void write_var_value( var_type type, const std::string &name, dialogue *d,
                       const std::string &value, int call_depth = 0 );
 void write_var_value( var_type type, const std::string &name, dialogue *d,
                       double value );
+void write_var_value( var_type type, const std::string &name, const_dialogue const &d,
+                      const std::string &value );
 std::string get_talk_varname( const JsonObject &jo, std::string_view member,
                               bool check_value, dbl_or_var &default_val );
 std::string get_talk_var_basename( const JsonObject &jo, std::string_view member,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3575,22 +3575,23 @@ std::unique_ptr<talker> get_talker_for( Creature &me )
         return std::make_unique<talker_npc>( me.as_npc() );
     } else if( me.is_avatar() ) {
         return std::make_unique<talker_avatar>( me.as_avatar() );
-    } else {
-        debugmsg( "Invalid creature type %s.", me.get_name() );
-        return std::make_unique<talker>();
     }
+    debugmsg( "Invalid creature type %s.", me.get_name() );
+    return std::make_unique<talker>();
 }
 
 std::unique_ptr<const_talker> get_const_talker_for( const Creature &me )
 {
-    if( !me.is_monster() ) {
-        return std::make_unique<talker_character_const>( me.as_character() );
-    } else if( me.is_monster() ) {
+    if( me.is_monster() ) {
         return std::make_unique<talker_monster_const>( me.as_monster() );
-    } else {
-        debugmsg( "Invalid creature type %s.", me.get_name() );
-        return std::make_unique<talker>();
+    } else if( me.is_npc() ) {
+        return std::make_unique<talker_npc_const>( me.as_npc() );
+    } else if( me.is_avatar() ) {
+        return std::make_unique<talker_avatar_const>( me.as_avatar() );
     }
+
+    debugmsg( "Invalid creature type %s.", me.get_name() );
+    return std::make_unique<talker>();
 }
 
 std::unique_ptr<talker> get_talker_for( Creature *me )
@@ -3598,14 +3599,6 @@ std::unique_ptr<talker> get_talker_for( Creature *me )
     if( !me ) {
         debugmsg( "Null creature type." );
         return std::make_unique<talker>();
-    } else if( me->is_monster() ) {
-        return std::make_unique<talker_monster>( me->as_monster() );
-    } else if( me->is_npc() ) {
-        return std::make_unique<talker_npc>( me->as_npc() );
-    } else if( me->is_avatar() ) {
-        return std::make_unique<talker_avatar>( me->as_avatar() );
-    } else {
-        debugmsg( "Invalid creature type %s.", me->get_name() );
-        return std::make_unique<talker>();
     }
+    return get_talker_for( *me );
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3581,7 +3581,7 @@ std::unique_ptr<talker> get_talker_for( Creature &me )
     }
 }
 
-std::unique_ptr<talker> get_talker_for( const Creature &me )
+std::unique_ptr<const_talker> get_const_talker_for( const Creature &me )
 {
     if( !me.is_monster() ) {
         return std::make_unique<talker_character_const>( me.as_character() );

--- a/src/creature.h
+++ b/src/creature.h
@@ -50,6 +50,7 @@ class monster;
 class nc_color;
 class npc;
 class talker;
+class const_talker;
 class translation;
 namespace catacurses
 {
@@ -1368,6 +1369,6 @@ class Creature : public viewer
         void print_proj_avoid_msg( Creature *source, viewer &player_view ) const;
 };
 std::unique_ptr<talker> get_talker_for( Creature &me );
-std::unique_ptr<talker> get_talker_for( const Creature &me );
+std::unique_ptr<const_talker> get_const_talker_for( const Creature &me );
 std::unique_ptr<talker> get_talker_for( Creature *me );
 #endif // CATA_SRC_CREATURE_H

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -56,12 +56,12 @@ using trial_mod = std::pair<std::string, int>;
 struct talk_trial {
     talk_trial_type type = TALK_TRIAL_NONE;
     int difficulty = 0;
-    std::function<bool( dialogue & )> condition;
+    std::function<bool( const_dialogue const & )> condition;
 
     // If this talk_trial is skill check, this is the string ID of the skill that we check the level of.
     std::string skill_required;
 
-    int calc_chance( dialogue &d ) const;
+    int calc_chance( const_dialogue const &d ) const;
     /**
      * Returns a user-friendly representation of @ref type
      */
@@ -159,12 +159,26 @@ struct talk_response {
      */
     translation truetext;
     translation falsetext;
-    std::function<bool( dialogue & )> truefalse_condition;
+    std::function<bool( const_dialogue const & )> truefalse_condition;
 
     talk_trial trial;
     /**
      * The following values are forwarded to the chatbin of the NPC (see @ref npc_chatbin).
      */
+
+    //copy of json_talk_response::condition, optional
+    std::function<bool( const_dialogue const & )> condition;
+
+    //whether to display this response in normal gameplay even if condition is false
+    bool show_always = false;
+    //appended to response if condition fails or show_always/show_condition
+    std::string show_reason;
+    //show_always, but on show_condition being true
+    std::function<bool( const_dialogue const & )> show_condition;
+
+    //flag to hold result of show_anyways (not read from JSON)
+    bool ignore_conditionals = false;
+
     mission *mission_selected = nullptr;
     skill_id skill = skill_id();
     matype_id style = matype_id();
@@ -385,7 +399,7 @@ class json_talk_response
 {
     private:
         talk_response actual_response;
-        std::function<bool( dialogue & )> condition;
+        std::function<bool( const_dialogue const & )> condition;
         bool has_condition_ = false;
         bool is_switch = false;
         bool is_default = false;

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -3,7 +3,6 @@
 #define CATA_SRC_DIALOGUE_H
 
 #include <functional>
-#include <iosfwd>
 #include <memory>
 #include <set>
 #include <string>
@@ -14,10 +13,8 @@
 #include "cata_lazy.h"
 #include "dialogue_helpers.h"
 #include "dialogue_win.h"
-#include "global_vars.h"
 #include "npc_opinion.h"
 #include "talker.h"
-#include "translations.h"
 #include "type_id.h"
 
 class JsonArray;
@@ -185,39 +182,83 @@ struct talk_response {
     explicit talk_response( const JsonObject &, std::string_view );
 };
 
-struct dialogue {
+/**
+* A collection of talk_topics and talk_responses that make up a conversation.
+*/
+struct const_dialogue {
+        const_talker *const_actor( bool is_beta ) const;
+        bool has_actor( bool is_beta ) const;
+
+        const_dialogue() = default;
+        ~const_dialogue() = default;
+        const_dialogue( const const_dialogue & );
+        const_dialogue( const_dialogue && ) = default;
+        const_dialogue &operator=( const const_dialogue & ) = delete;
+        const_dialogue &operator=( const_dialogue && ) = default;
+        const_dialogue(
+            std::unique_ptr<const_talker> alpha_in, std::unique_ptr<const_talker> beta_in,
+            const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>> &cond = {},
+            const std::unordered_map<std::string, std::string> &ctx = {} );
+
+        bool has_beta{};
+        bool has_alpha{};
+
+        mutable itype_id cur_item;
+        mutable std::string reason;
+        /** Missions that have been assigned by this npc to the player they currently speak to. */
+        std::vector<mission *> missions_assigned;
+        /** This dialogue is happening over a radio */
+        bool by_radio = false;
+
+        // Methods for setting/getting misc key/value pairs.
+        void set_value( const std::string &key, const std::string &value );
+        void remove_value( const std::string &key );
+
+        void set_conditional( const std::string &key,
+                              const std::function<bool( const_dialogue const & )> &value );
+        std::string get_value( const std::string &key ) const;
+        std::optional<std::string> maybe_get_value( const std::string &key ) const;
+
+        bool evaluate_conditional( const std::string &key, const_dialogue const &d ) const;
+
+        const std::unordered_map<std::string, std::string> &get_context() const;
+        const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>>
+                &get_conditionals() const;
+        void amend_callstack( const std::string &value );
+        std::string get_callstack() const;
+
+    private:
+        std::unique_ptr<const_talker> alpha, beta;
+
+        lazy<std::unordered_map<std::string, std::string>> context;
+        mutable std::string callstack;
+
+        lazy<std::unordered_map<std::string, std::function<bool( const_dialogue const & )>>> conditionals;
+};
+
+struct dialogue: public const_dialogue {
         /**
          * If true, we are done talking and the dialog ends.
          */
         bool done = false;
         std::vector<talk_topic> topic_stack;
 
-        /** Missions that have been assigned by this npc to the player they currently speak to. */
-        std::vector<mission *> missions_assigned;
-
         talk_topic opt( dialogue_window &d_win, const talk_topic &topic );
         dialogue() = default;
+        ~dialogue() = default;
         dialogue( const dialogue &d );
+        explicit dialogue( const_dialogue const &d );
         dialogue( dialogue && ) = default;
         dialogue &operator=( const dialogue & );
         dialogue &operator=( dialogue && ) = default;
-        dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in );
         dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in,
-                  const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond );
-        dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in,
-                  const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
-                  const std::unordered_map<std::string, std::string> &ctx );
+                  const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>> &cond = {},
+                  const std::unordered_map<std::string, std::string> &ctx = {} );
         talker *actor( bool is_beta ) const;
-        bool has_actor( bool is_beta ) const;
-
-        mutable itype_id cur_item;
-        mutable std::string reason;
 
         std::string dynamic_line( const talk_topic &topic );
         void apply_speaker_effects( const talk_topic &the_topic );
 
-        /** This dialogue is happening over a radio */
-        bool by_radio = false;
         /**
          * Possible responses from the player character, filled in @ref gen_responses.
          */
@@ -226,22 +267,11 @@ struct dialogue {
 
         void add_topic( const std::string &topic );
         void add_topic( const talk_topic &topic );
-        bool has_beta;
-        bool has_alpha;
 
-        // Methods for setting/getting misc key/value pairs.
-        void set_value( const std::string &key, const std::string &value );
-        void remove_value( const std::string &key );
-        std::string get_value( const std::string &key ) const;
-        std::optional<std::string> maybe_get_value( const std::string &key ) const;
+        bool debug_conditionals = true;
+        bool debug_effects = true;
+        bool debug_ignore_conditionals = false;
 
-        void set_conditional( const std::string &key, const std::function<bool( dialogue & )> &value );
-        bool evaluate_conditional( const std::string &key, dialogue &d );
-
-        const std::unordered_map<std::string, std::string> &get_context() const;
-        const std::unordered_map<std::string, std::function<bool( dialogue & )>> &get_conditionals() const;
-        void amend_callstack( const std::string &value );
-        std::string get_callstack() const;
     private:
         /**
          * The talker that speaks (almost certainly representing the avatar, ie get_avatar() )
@@ -251,14 +281,6 @@ struct dialogue {
          * The talker responded to alpha, usually a talker_npc.
          */
         std::unique_ptr<talker> beta;
-
-        // dialogue specific variables that can be passed down to additional EOCs but are one way
-        lazy<std::unordered_map<std::string, std::string>> context;
-        // Weirdly unnecessarily in context.
-        std::string callstack;
-
-        // conditionals that were set at the upper level
-        lazy<std::unordered_map<std::string, std::function<bool( dialogue & )>>> conditionals;
 
         /**
          * Add a simple response that switches the topic to the new one. If first == true, force

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -8,7 +8,7 @@
 
 template<class T>
 std::optional<std::string> maybe_read_var_value(
-    const abstract_var_info<T> &info, const dialogue &d, int call_depth )
+    const abstract_var_info<T> &info, const_dialogue const &d, int call_depth )
 {
     global_variables &globvars = get_globals();
     switch( info.type ) {
@@ -17,9 +17,9 @@ std::optional<std::string> maybe_read_var_value(
         case var_type::context:
             return d.maybe_get_value( info.name );
         case var_type::u:
-            return d.actor( false )->maybe_get_value( info.name );
+            return d.const_actor( false )->maybe_get_value( info.name );
         case var_type::npc:
-            return d.actor( true )->maybe_get_value( info.name );
+            return d.const_actor( true )->maybe_get_value( info.name );
         case var_type::var: {
             std::optional<std::string> const var_val = d.maybe_get_value( info.name );
             if( call_depth > 1000 && var_val ) {
@@ -40,20 +40,19 @@ std::optional<std::string> maybe_read_var_value(
 }
 
 template
-std::optional<std::string> maybe_read_var_value( const var_info &, const dialogue &,
+std::optional<std::string> maybe_read_var_value( const var_info &, const_dialogue const &,
         int call_depth );
-template
-std::optional<std::string> maybe_read_var_value( const translation_var_info &, const dialogue &,
-        int call_depth );
+template std::optional<std::string> maybe_read_var_value( const translation_var_info &,
+        const_dialogue const &, int call_depth );
 
 template<>
-std::string read_var_value( const var_info &info, const dialogue &d )
+std::string read_var_value( const var_info &info, const_dialogue const &d )
 {
     return maybe_read_var_value( info, d ).value_or( info.default_val );
 }
 
 template<>
-std::string read_var_value( const translation_var_info &info, const dialogue &d )
+std::string read_var_value( const translation_var_info &info, const_dialogue const &d )
 {
     return maybe_read_var_value( info, d ).value_or( info.default_val.translated() );
 }
@@ -93,7 +92,7 @@ var_info process_variable( const std::string &type )
 }
 
 template<>
-std::string str_or_var::evaluate( dialogue const &d ) const
+std::string str_or_var::evaluate( const_dialogue const &d ) const
 {
     if( function.has_value() ) {
         return function.value()( d );
@@ -123,7 +122,7 @@ std::string str_or_var::evaluate( dialogue const &d ) const
 }
 
 template<>
-std::string translation_or_var::evaluate( dialogue const &d ) const
+std::string translation_or_var::evaluate( const_dialogue const &d ) const
 {
     if( function.has_value() ) {
         return function.value()( d ).translated();
@@ -152,14 +151,14 @@ std::string translation_or_var::evaluate( dialogue const &d ) const
     return "";
 }
 
-std::string str_translation_or_var::evaluate( dialogue const &d ) const
+std::string str_translation_or_var::evaluate( const_dialogue const &d ) const
 {
     return std::visit( [&d]( auto &&val ) {
         return val.evaluate( d );
     }, val );
 }
 
-double dbl_or_var_part::evaluate( dialogue &d ) const
+double dbl_or_var_part::evaluate( const_dialogue const &d ) const
 {
     if( dbl_val.has_value() ) {
         return dbl_val.value();
@@ -182,13 +181,14 @@ double dbl_or_var_part::evaluate( dialogue &d ) const
         return 0;
     }
     if( math_val ) {
-        return math_val->act( d );
+        dialogue loosey_goosey( d );
+        return math_val->act( loosey_goosey );
     }
     debugmsg( "No valid value for dbl_or_var_part.  %s", d.get_callstack() );
     return 0;
 }
 
-double dbl_or_var::evaluate( dialogue &d ) const
+double dbl_or_var::evaluate( const_dialogue const &d ) const
 {
     if( pair ) {
         return rng( min.evaluate( d ), max.evaluate( d ) );
@@ -196,7 +196,7 @@ double dbl_or_var::evaluate( dialogue &d ) const
     return min.evaluate( d );
 }
 
-time_duration duration_or_var_part::evaluate( dialogue &d ) const
+time_duration duration_or_var_part::evaluate( const_dialogue const &d ) const
 {
     if( dur_val.has_value() ) {
         return dur_val.value();
@@ -221,13 +221,14 @@ time_duration duration_or_var_part::evaluate( dialogue &d ) const
         return 0_seconds;
     }
     if( math_val ) {
-        return time_duration::from_turns( math_val->act( d ) );
+        dialogue loosey_goosey( d );
+        return time_duration::from_turns( math_val->act( loosey_goosey ) );
     }
     debugmsg( "No valid value for duration_or_var_part.  %s", d.get_callstack() );
     return 0_seconds;
 }
 
-time_duration duration_or_var::evaluate( dialogue &d ) const
+time_duration duration_or_var::evaluate( const_dialogue const &d ) const
 {
     if( pair ) {
         return rng( min.evaluate( d ), max.evaluate( d ) );

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -22,6 +22,7 @@ class JsonObject;
 class math_exp;
 class npc;
 struct dialogue;
+struct const_dialogue;
 
 using talkfunction_ptr = std::add_pointer_t<void ( npc & )>;
 using dialogue_fun_ptr = std::add_pointer_t<void( npc & )>;
@@ -49,8 +50,8 @@ struct abstract_str_or_var {
     std::optional<T> str_val;
     std::optional<abstract_var_info<T>> var_val;
     std::optional<T> default_val;
-    std::optional<std::function<T( const dialogue & )>> function;
-    std::string evaluate( dialogue const & ) const;
+    std::optional<std::function<T( const_dialogue const & )>> function;
+    std::string evaluate( const_dialogue const & ) const;
 };
 
 using str_or_var = abstract_str_or_var<std::string>;
@@ -58,7 +59,7 @@ using translation_or_var = abstract_str_or_var<translation>;
 
 struct str_translation_or_var {
     std::variant<str_or_var, translation_or_var> val;
-    std::string evaluate( dialogue const & ) const;
+    std::string evaluate( const_dialogue const & ) const;
 };
 
 struct talk_effect_fun_t {
@@ -88,10 +89,10 @@ struct talk_effect_fun_t {
 };
 
 template<class T>
-std::string read_var_value( const abstract_var_info<T> &info, const dialogue &d );
+std::string read_var_value( const abstract_var_info<T> &info, const_dialogue const &d );
 template<class T>
 std::optional<std::string> maybe_read_var_value(
-    const abstract_var_info<T> &info, const dialogue &d, int call_depth = 0 );
+    const abstract_var_info<T> &info, const_dialogue const &d, int call_depth = 0 );
 
 var_info process_variable( const std::string &type );
 
@@ -138,7 +139,7 @@ struct dbl_or_var_part {
     std::optional<var_info> var_val;
     std::optional<double> default_val;
     std::optional<eoc_math> math_val;
-    double evaluate( dialogue &d ) const;
+    double evaluate( const_dialogue const &d ) const;
 
     bool is_constant() const {
         return dbl_val.has_value();
@@ -166,7 +167,7 @@ struct dbl_or_var {
     bool pair = false;
     dbl_or_var_part min;
     dbl_or_var_part max;
-    double evaluate( dialogue &d ) const;
+    double evaluate( const_dialogue const &d ) const;
 
     bool is_constant() const {
         return !max && min.is_constant();
@@ -191,14 +192,14 @@ struct duration_or_var_part {
     std::optional<var_info> var_val;
     std::optional<time_duration> default_val;
     std::optional<eoc_math> math_val;
-    time_duration evaluate( dialogue &d ) const;
+    time_duration evaluate( const_dialogue const &d ) const;
 };
 
 struct duration_or_var {
     bool pair = false;
     duration_or_var_part min;
     duration_or_var_part max;
-    time_duration evaluate( dialogue &d ) const;
+    time_duration evaluate( const_dialogue const &d ) const;
 };
 
 #endif // CATA_SRC_DIALOGUE_HELPERS_H

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -346,7 +346,7 @@ bool effect_on_condition::activate( dialogue &d, bool require_callstack_check ) 
     return retval;
 }
 
-bool effect_on_condition::check_deactivate( dialogue &d ) const
+bool effect_on_condition::check_deactivate( const_dialogue const &d ) const
 {
     if( !has_deactivate_condition || has_false_effect ) {
         return false;
@@ -354,7 +354,7 @@ bool effect_on_condition::check_deactivate( dialogue &d ) const
     return deactivate_condition( d );
 }
 
-bool effect_on_condition::test_condition( dialogue &d ) const
+bool effect_on_condition::test_condition( const_dialogue const &d ) const
 {
     return !has_condition || condition( d );
 }

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -61,8 +61,8 @@ struct effect_on_condition {
         effect_on_condition_id id;
         std::vector<std::pair<effect_on_condition_id, mod_id>> src;
         eoc_type type;
-        std::function<bool( dialogue & )> condition;
-        std::function<bool( dialogue & )> deactivate_condition;
+        std::function<bool( const_dialogue const & )> condition;
+        std::function<bool( const_dialogue const & )> deactivate_condition;
         talk_effect_t true_effect;
         talk_effect_t false_effect;
         bool has_deactivate_condition = false;
@@ -71,8 +71,8 @@ struct effect_on_condition {
         event_type required_event;
         duration_or_var recurrence;
         bool activate( dialogue &d, bool require_callstack_check = true ) const;
-        bool check_deactivate( dialogue &d ) const;
-        bool test_condition( dialogue &d ) const;
+        bool check_deactivate( const_dialogue const &d ) const;
+        bool test_condition( const_dialogue const &d ) const;
         void apply_true_effects( dialogue &d ) const;
         void load( const JsonObject &jo, std::string_view src );
         void finalize();

--- a/src/emit.h
+++ b/src/emit.h
@@ -27,22 +27,22 @@ class emit
         bool is_valid() const;
 
         /** Type of field to emit @see emit::is_valid */
-        field_type_id field( dialogue &d ) const {
+        field_type_id field( const_dialogue const &d ) const {
             return field_type_id( field_.evaluate( d ) );
         }
 
         /** Intensity of output fields, range [1..maximum_intensity] */
-        int intensity( dialogue &d ) const {
+        int intensity( const_dialogue const &d ) const {
             return intensity_.evaluate( d );
         }
 
         /** Units of field to generate per turn subject to @ref chance */
-        int qty( dialogue &d ) const {
+        int qty( const_dialogue const &d ) const {
             return qty_.evaluate( d );
         }
 
         /** Chance to emit each turn, range [1..100] */
-        int chance( dialogue &d ) const {
+        int chance( const_dialogue const &d ) const {
             return chance_.evaluate( d );
         }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1165,7 +1165,7 @@ std::unique_ptr<talker> get_talker_for( item_location &it )
 {
     return std::make_unique<talker_item>( &it );
 }
-std::unique_ptr<talker> get_talker_for( const item_location &it )
+std::unique_ptr<const_talker> get_const_talker_for( const item_location &it )
 {
     return std::make_unique<talker_item_const>( &it );
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -16,6 +16,7 @@ class item_pocket;
 class map_cursor;
 class vehicle_cursor;
 class talker;
+class const_talker;
 struct tripoint;
 template<typename T> class ret_val;
 
@@ -170,6 +171,6 @@ class item_location
         std::shared_ptr<impl> ptr;
 };
 std::unique_ptr<talker> get_talker_for( item_location &it );
-std::unique_ptr<talker> get_talker_for( const item_location &it );
+std::unique_ptr<const_talker> get_const_talker_for( const item_location &it );
 std::unique_ptr<talker> get_talker_for( item_location *it );
 #endif // CATA_SRC_ITEM_LOCATION_H

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -877,14 +877,14 @@ int spell::accuracy( Creature &caster ) const
 
 double spell::min_leveled_dodge_training( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_dodge_training.evaluate( d ) + std::round( get_effective_level() *
             type->dodge_training_increment.evaluate( d ) );
 }
 
 float spell::dodge_training( Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_dodge_training = min_leveled_dodge_training( caster );
     if( type->min_dodge_training.evaluate( d ) >= 0 ||
         type->max_dodge_training.evaluate( d ) >= type->min_dodge_training.evaluate( d ) ) {
@@ -898,14 +898,14 @@ float spell::dodge_training( Creature &caster ) const
 
 int spell::min_leveled_liquid_volume( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_liquid_volume.evaluate( d ) + std::round( get_effective_level() *
             type->liquid_volume_increment.evaluate( d ) );
 }
 
 int spell::liquid_volume( Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_liquid_volume = min_leveled_liquid_volume( caster );
     if( type->min_liquid_volume.evaluate( d ) >= 0 ||
         type->max_liquid_volume.evaluate( d ) >= type->min_liquid_volume.evaluate( d ) ) {
@@ -2004,7 +2004,7 @@ vproto_id spell::summon_vehicle_id() const
 
 int spell::min_leveled_effect_intensity( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_effect_intensity.evaluate( d ) + std::round( get_effective_level() *
             type->effect_intensity_increment.evaluate( d ) );
 }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -790,7 +790,7 @@ skill_id spell::skill() const
 
 int spell::field_intensity( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return std::min( static_cast<int>( type->max_field_intensity.evaluate( d ) ),
                      static_cast<int>( type->min_field_intensity.evaluate( d ) + std::round( get_effective_level() *
                                        type->field_intensity_increment.evaluate( d ) ) ) );
@@ -798,7 +798,7 @@ int spell::field_intensity( const Creature &caster ) const
 
 double spell::bash_scaling( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const double leveled_scaling = type->min_bash_scaling.evaluate( d ) +  get_effective_level() *
                                    type->bash_scaling_increment.evaluate( d );
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
@@ -817,7 +817,7 @@ double spell::bash_scaling( const Creature &caster ) const
 
 int spell::min_leveled_damage( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_damage.evaluate( d ) + std::round( get_effective_level() *
             type->damage_increment.evaluate(
                 d ) );
@@ -837,7 +837,7 @@ float spell::dps( const Character &caster, const Creature & ) const
 
 int spell::damage( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_damage = min_leveled_damage( caster );
 
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
@@ -858,14 +858,14 @@ int spell::damage( const Creature &caster ) const
 
 int spell::min_leveled_accuracy( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_accuracy.evaluate( d ) + std::round( get_effective_level() *
             type->accuracy_increment.evaluate( d ) );
 }
 
 int spell::accuracy( Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_accuracy = min_leveled_accuracy( caster );
     if( type->min_accuracy.evaluate( d ) >= 0 ||
         type->max_accuracy.evaluate( d ) >= type->min_accuracy.evaluate( d ) ) {
@@ -917,14 +917,14 @@ int spell::liquid_volume( Creature &caster ) const
 
 double spell::min_leveled_dot( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_dot.evaluate( d ) + std::round( get_effective_level() *
             type->dot_increment.evaluate( d ) );
 }
 
 double spell::damage_dot( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const double leveled_dot = min_leveled_dot( caster );
     if( type->min_dot.evaluate( d ) >= 0.0 ||
         type->max_dot.evaluate( d ) >= type->min_dot.evaluate( d ) ) {
@@ -948,7 +948,7 @@ damage_over_time_data spell::damage_over_time( const std::vector<bodypart_id> &b
 std::string spell::damage_string( const Character &caster ) const
 {
     std::string damage_string;
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     if( has_flag( spell_flag::RANDOM_DAMAGE ) ) {
         damage_string = string_format( "%d-%d", min_leveled_damage( caster ),
                                        static_cast<int>( type->max_damage.evaluate( d ) ) );
@@ -1020,14 +1020,14 @@ std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
 
 int spell::min_leveled_aoe( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_aoe.evaluate( d ) + std::round( get_effective_level() *
             type->aoe_increment.evaluate( d ) );
 }
 
 int spell::aoe( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_aoe = min_leveled_aoe( caster );
     int return_value;
 
@@ -1059,7 +1059,7 @@ std::set<tripoint_bub_ms> spell::effect_area( const tripoint_bub_ms &source,
 bool spell::in_aoe( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
                     const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     if( has_flag( spell_flag::RANDOM_AOE ) ) {
         return rl_dist( source, target ) <= type->max_aoe.evaluate( d );
     } else {
@@ -1069,7 +1069,7 @@ bool spell::in_aoe( const tripoint_bub_ms &source, const tripoint_bub_ms &target
 
 std::string spell::aoe_string( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     if( has_flag( spell_flag::RANDOM_AOE ) ) {
         return string_format( "%d-%d", min_leveled_aoe( caster ), type->max_aoe.evaluate( d ) );
     } else {
@@ -1079,7 +1079,7 @@ std::string spell::aoe_string( const Creature &caster ) const
 
 int spell::range( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_range = type->min_range.evaluate( d ) + std::round( get_effective_level() *
                               type->range_increment.evaluate( d ) );
     float range;
@@ -1132,14 +1132,14 @@ std::vector<tripoint_bub_ms> spell::targetable_locations( const Character &sourc
 
 int spell::min_leveled_duration( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->min_duration.evaluate( d ) + std::round( get_effective_level() *
             type->duration_increment.evaluate( d ) );
 }
 
 int spell::duration( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int leveled_duration = min_leveled_duration( caster );
     int return_value;
     if( has_flag( spell_flag::RANDOM_DURATION ) ) {
@@ -1159,7 +1159,7 @@ int spell::duration( const Creature &caster ) const
 
 std::string spell::duration_string( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     if( has_flag( spell_flag::RANDOM_DURATION ) ) {
         return string_format( "%s - %s", moves_to_string( min_leveled_duration( caster ) ),
                               moves_to_string( type->max_duration.evaluate( d ) ) );
@@ -1200,7 +1200,7 @@ void spell::set_level( const Character &guy, int nlevel )
 
 bool spell::is_max_level( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return get_level() >= type->max_level.evaluate( d );
 }
 
@@ -1214,14 +1214,14 @@ bool spell::can_learn( const Character &guy ) const
 
 int spell::get_amount_of_projectiles( const Creature &guy ) const
 {
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     return type->multiple_projectiles.evaluate( d );
 }
 
 int spell::energy_cost( const Character &guy ) const
 {
     int cost;
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     if( type->base_energy_cost.evaluate( d ) < type->final_energy_cost.evaluate( d ) ) {
         cost = std::min( static_cast<int>( type->final_energy_cost.evaluate( d ) ),
                          static_cast<int>( std::round( type->base_energy_cost.evaluate( d ) +
@@ -1336,7 +1336,7 @@ bool spell::check_if_component_in_hand( Character &guy ) const
 
 int spell::get_difficulty( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->difficulty.evaluate( d ) + temp_difficulty_adjustment;
 }
 
@@ -1349,7 +1349,7 @@ int spell::casting_time( const Character &guy, bool ignore_encumb ) const
 {
     // casting time in moves
     int casting_time = 0;
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     if( type->base_casting_time.evaluate( d ) < type->final_casting_time.evaluate( d ) ) {
         casting_time = std::min( static_cast<int>( type->final_casting_time.evaluate( d ) ),
                                  static_cast<int>( std::round( type->base_casting_time.evaluate( d ) +
@@ -1605,7 +1605,7 @@ void spell::create_field( const tripoint_bub_ms &at, Creature &caster ) const
     if( !type->field ) {
         return;
     }
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     const int intensity = field_intensity( caster ) + rng( -type->field_intensity_variance.evaluate(
                               d ) * field_intensity( caster ),
                           type->field_intensity_variance.evaluate( d ) * field_intensity( caster ) );
@@ -1778,7 +1778,7 @@ int spell::get_effective_level() const
 
 int spell::get_max_level( const Creature &caster ) const
 {
-    dialogue d( get_talker_for( caster ), nullptr );
+    const_dialogue d( get_const_talker_for( caster ), nullptr );
     return type->max_level.evaluate( d );
 }
 
@@ -2473,7 +2473,7 @@ int known_magic::time_to_learn_spell( const Character &guy, const std::string &s
 
 int known_magic::time_to_learn_spell( const Character &guy, const spell_id &sp ) const
 {
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     const int base_time = to_moves<int>( 30_minutes );
     const double int_modifier = ( guy.get_int() - 8.0 ) / 8.0;
     const double skill_modifier = guy.get_skill_level( sp->skill ) / 10.0;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -292,7 +292,7 @@ bool enchantment::is_active( const Character &guy, const bool active ) const
     }
 
     if( active_conditions.second == condition::DIALOG_CONDITION ) {
-        dialogue d( get_talker_for( guy ), nullptr );
+        const_dialogue d( get_const_talker_for( guy ), nullptr );
         return dialog_condition( d );
     }
     return false;
@@ -681,7 +681,7 @@ void enchant_cache::force_add( const enchant_cache &rhs )
 
 void enchant_cache::force_add( const enchantment &rhs, const Character &guy )
 {
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     for( const std::pair<const enchant_vals::mod, dbl_or_var> &pair_values :
          rhs.values_add ) {
         values_add[pair_values.first] += pair_values.second.evaluate( d );
@@ -734,7 +734,7 @@ void enchant_cache::force_add( const enchantment &rhs, const Character &guy )
 
 void enchant_cache::force_add( const enchantment &rhs, const monster &mon )
 {
-    dialogue d( get_talker_for( mon ), nullptr );
+    const_dialogue d( get_const_talker_for( mon ), nullptr );
     for( const std::pair<const enchant_vals::mod, dbl_or_var> &pair_values :
          rhs.values_add ) {
         values_add[pair_values.first] += pair_values.second.evaluate( d );
@@ -868,7 +868,7 @@ double enchantment::get_value_add( const enchant_vals::mod value, const Characte
     if( found == values_add.cend() ) {
         return 0;
     }
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     return found->second.evaluate( d );
 }
 
@@ -878,7 +878,7 @@ double enchantment::get_value_multiply( const enchant_vals::mod value, const Cha
     if( found == values_multiply.cend() ) {
         return 0;
     }
-    dialogue d( get_talker_for( guy ), nullptr );
+    const_dialogue d( get_const_talker_for( guy ), nullptr );
     return found->second.evaluate( d );
 }
 

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -278,7 +278,7 @@ class enchantment
         std::map<time_duration, std::vector<fake_spell>> intermittent_activation;
 
         std::pair<has, condition> active_conditions;
-        std::function<bool( dialogue & )> dialog_condition; // NOLINT(cata-serialize)
+        std::function<bool( const_dialogue const & )> dialog_condition; // NOLINT(cata-serialize)
 
         void add_activation( const time_duration &dur, const fake_spell &fake );
 };

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -234,7 +234,7 @@ class ma_technique
         bool needs_ammo = false;    // technique only works if the item is loaded with ammo
 
         // Dialogue conditions of the attack
-        std::function<bool( dialogue & )> condition;
+        std::function<bool( const_dialogue const & )> condition;
         std::string condition_desc;
         bool has_condition = false;
 

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -180,7 +180,7 @@ bool is_assign_target( thingie const &thing )
            std::holds_alternative<func_diag_ass>( thing.data );
 }
 
-std::vector<double> _eval_params( std::vector<thingie> const &params, dialogue &d )
+std::vector<double> _eval_params( std::vector<thingie> const &params, const_dialogue const &d )
 {
     std::vector<double> elems( params.size() );
     std::transform( params.begin(), params.end(), elems.begin(),
@@ -219,17 +219,17 @@ func_jmath::func_jmath( std::vector<thingie> &&params_,
                         jmath_func_id const &id_ ) : params( params_ ),
     id( id_ ) {}
 
-double func::eval( dialogue &d ) const
+double func::eval( const_dialogue const &d ) const
 {
     return f( _eval_params( params, d ) );
 }
 
-double func_jmath::eval( dialogue &d ) const
+double func_jmath::eval( const_dialogue const &d ) const
 {
     return id->eval( d, _eval_params( params, d ) );
 }
 
-double var::eval( dialogue &d ) const
+double var::eval( const_dialogue const &d ) const
 {
     std::string const str = read_var_value( varinfo, d );
     if( str.empty() ) {
@@ -247,7 +247,7 @@ oper::oper( thingie l_, thingie r_, binary_op::f_t op_ ):
     r( std::make_shared<thingie>( std::move( r_ ) ) ),
     op( op_ ) {}
 
-double oper::eval( dialogue &d ) const
+double oper::eval( const_dialogue const &d ) const
 {
     return ( *op )( l->eval( d ), r->eval( d ) );
 }
@@ -261,7 +261,7 @@ ternary::ternary( thingie cond_, thingie mhs_, thingie rhs_ )
       mhs( std::make_shared<thingie>( std::move( mhs_ ) ) ),
       rhs( std::make_shared<thingie>( std::move( rhs_ ) ) ) {}
 
-double ternary::eval( dialogue &d ) const
+double ternary::eval( const_dialogue const &d ) const
 {
     return cond->eval( d ) > 0 ? mhs->eval( d ) : rhs->eval( d );
 }
@@ -296,7 +296,7 @@ class math_exp::math_exp_impl
             }
             return true;
         }
-        double eval( dialogue &d ) const {
+        double eval( const_dialogue const &d ) const {
             return tree.eval( d );
         }
 
@@ -860,7 +860,7 @@ math_exp::~math_exp() = default;
 math_exp::math_exp( math_exp &&/* other */ ) noexcept = default;
 math_exp &math_exp::operator=( math_exp &&/* other */ )  noexcept = default;
 
-double math_exp::eval( dialogue &d ) const
+double math_exp::eval( const_dialogue const &d ) const
 {
     return impl->eval( d );
 }

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -6,6 +6,7 @@
 #include <string_view>
 
 struct dialogue;
+struct const_dialogue;
 
 class math_exp
 {
@@ -21,7 +22,7 @@ class math_exp
         explicit math_exp( math_exp_impl impl_ );
 
         bool parse( std::string_view str, bool assignment = false, bool handle_errors = true );
-        double eval( dialogue &d ) const;
+        double eval( const_dialogue const &d ) const;
         void assign( dialogue &d, double val ) const;
 
     private:

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -766,7 +766,7 @@ std::function<double( dialogue & )> _characters_nearby_eval( char scope,
         std::vector<Character *> const targets = g->get_characters_if( [ &beta, &d, &radius,
                &loc, filter, allow_hallucinations ]( const Character & guy ) {
             talker const *const tk = d.actor( beta );
-            return _filter_character( tk->get_character(), guy, radius, loc, filter,
+            return _filter_character( tk->get_const_character(), guy, radius, loc, filter,
                                       allow_hallucinations );
         } );
         return static_cast<double>( targets.size() );
@@ -1012,7 +1012,7 @@ std::function<double( dialogue & )> get_daily_calories( char scope,
             return 0;
         }
 
-        return static_cast<talker const *>( d.actor( beta ) )->get_daily_calories( day, type );
+        return d.actor( beta )->get_daily_calories( day, type );
     };
 }
 
@@ -1467,9 +1467,9 @@ std::function<double( dialogue & )> vision_range_eval( char scope,
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
         talker const *const actor = d.actor( beta );
-        if( Character const *const chr = actor->get_character(); chr != nullptr ) {
+        if( Character const *const chr = actor->get_const_character(); chr != nullptr ) {
             return chr->unimpaired_range();
-        } else if( monster const *const mon = actor->get_monster(); mon != nullptr ) {
+        } else if( monster const *const mon = actor->get_const_monster(); mon != nullptr ) {
             map &here = get_map();
             tripoint_bub_ms tripoint = get_map().bub_from_abs( mon->get_location() );
             return mon->sight_range( here.ambient_light_at( tripoint ) );
@@ -1594,7 +1594,7 @@ std::function<double( dialogue & )> calories_eval( char scope,
             if( d.actor( beta )->get_character() ) {
                 return d.actor( beta )->get_stored_kcal();
             }
-            item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+            item_location const *it = d.actor( beta )->get_const_item();
             if( it && *it ) {
                 npc dummy;
                 return dummy.compute_effective_nutrients( *it->get_item() ).kcal();
@@ -1622,10 +1622,10 @@ std::function<double( dialogue & )> weight_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_const_monster() ) {
             return d.actor( beta )->get_weight();
         }
-        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        item_location const *it = d.actor( beta )->get_const_item();
         if( it && *it ) {
             return static_cast<int>( to_milligram( it->get_item()->weight() ) );
         }
@@ -1638,10 +1638,10 @@ std::function<double( dialogue & )> volume_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() || d.actor( beta )->get_monster() ) {
+        if( d.actor( beta )->get_character() || d.actor( beta )->get_const_monster() ) {
             return d.actor( beta )->get_volume();
         }
-        item_location const *it = static_cast<talker const *>( d.actor( beta ) )->get_item();
+        item_location const *it = d.actor( beta )->get_const_item();
         if( it && *it ) {
             return to_milliliter( it->get_item()->volume() );
         }
@@ -1655,7 +1655,7 @@ std::function<double( dialogue & )> vitamin_eval( char scope,
 {
     return[beta = is_beta( scope ), id = params[0]]( dialogue const & d ) {
         talker const *const actor = d.actor( beta );
-        if( Character const *const chr = actor->get_character(); chr != nullptr ) {
+        if( Character const *const chr = actor->get_const_character(); chr != nullptr ) {
             return chr->vitamin_get( vitamin_id( id.str( d ) ) );
         }
         debugmsg( "Tried to access vitamins of a non-Character talker" );
@@ -1748,7 +1748,7 @@ std::function<double( dialogue & )> climate_control_str_heat_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return [beta = is_beta( scope )]( dialogue const & d ) {
-        return static_cast<talker const *>( d.actor( beta ) )->climate_control_str_heat();
+        return d.actor( beta )->climate_control_str_heat();
     };
 }
 
@@ -1756,7 +1756,7 @@ std::function<double( dialogue & )> climate_control_str_chill_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d ) {
-        return static_cast<talker const *>( d.actor( beta ) )->climate_control_str_chill();
+        return d.actor( beta )->climate_control_str_chill();
     };
 }
 

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -7,6 +7,7 @@
 #include "calendar.h"
 #include "condition.h"
 #include "dialogue.h"
+#include "enums.h"
 #include "field.h"
 #include "game.h"
 #include "magic.h"
@@ -14,7 +15,6 @@
 #include "math_parser_diag_value.h"
 #include "mongroup.h"
 #include "mtype.h"
-#include "enums.h"
 #include "npc.h"
 #include "options.h"
 #include "string_input_popup.h"
@@ -27,14 +27,14 @@ General guidelines for writing dialogue functions
 
 The typical parsing function takes the form:
 
-std::function<double( dialogue & )> myfunction_eval( char scope,
+math_eval_dbl_f myfunction_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
     diag_value myval = kwargs.kwarg_or( "mykwarg", "default-value" );
 
     ...parse-time code...
 
-    return[effect_id = params[0], myval, beta = is_beta( scope )]( dialogue const & d ) {
+    return[effect_id = params[0], myval, beta = is_beta( scope )]( const_dialogue const & d ) {
         ...run-time code...
     };
 }
@@ -91,86 +91,86 @@ T _read_from_string( std::string_view s, const std::vector<std::pair<std::string
     return detail::read_from_json_string_common<T>( s, units, error );
 }
 
-std::function<double( dialogue & )> u_val( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f u_val( char scope, std::vector<diag_value> const &params,
+                       diag_kwargs const & /* kwargs */ )
 {
     return conditional_t::get_get_dbl( params[0].str(), scope );
 }
 
-std::function<void( dialogue &, double )> u_val_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f u_val_ass( char scope, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
     return conditional_t::get_set_dbl( params[0].str(), scope );
 }
 
-std::function<double( dialogue & )> option_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f option_eval( char /* scope */, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
-    return[option = params[0]]( dialogue const & d ) {
+    return[option = params[0]]( const_dialogue const & d ) {
         return get_option<float>( option.str( d ), true );
     };
 }
 
-std::function<double( dialogue & )> addiction_intensity_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f addiction_intensity_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const & /* kwargs */ )
 {
-    return[ beta = is_beta( scope ), add_value = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->get_addiction_intensity( addiction_id( add_value.str( d ) ) );
+    return[ beta = is_beta( scope ), add_value = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_addiction_intensity( addiction_id( add_value.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> addiction_turns_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f addiction_turns_eval( char scope, std::vector<diag_value> const &params,
+                                      diag_kwargs const & /* kwargs */ )
 {
-    return[ beta = is_beta( scope ), add_value = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->get_addiction_turns( addiction_id( add_value.str( d ) ) );
+    return[ beta = is_beta( scope ), add_value = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_addiction_turns( addiction_id( add_value.str( d ) ) );
     };
 }
 
-std::function<void( dialogue &, double )> addiction_turns_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f addiction_turns_ass( char scope, std::vector<diag_value> const &params,
+                                       diag_kwargs const & /* kwargs */ )
 {
     return[ beta = is_beta( scope ), add_value = params[0]]( dialogue const & d, double val ) {
         return d.actor( beta )->set_addiction_turns( addiction_id( add_value.str( d ) ), val );
     };
 }
 
-std::function<double( dialogue & )> armor_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f armor_eval( char scope, std::vector<diag_value> const &params,
+                            diag_kwargs const & /* kwargs */ )
 {
-    return[type = params[0], bpid = params[1], beta = is_beta( scope )]( dialogue const & d ) {
+    return[type = params[0], bpid = params[1], beta = is_beta( scope )]( const_dialogue const & d ) {
         damage_type_id dt( type.str( d ) );
         bodypart_id bp( bpid.str( d ) );
-        return d.actor( beta )->armor_at( dt, bp );
+        return d.const_actor( beta )->armor_at( dt, bp );
     };
 }
 
-std::function<double( dialogue & )> charge_count_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f charge_count_eval( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), item_value = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->charges_of( itype_id( item_value.str( d ) ) );
+    return[beta = is_beta( scope ), item_value = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->charges_of( itype_id( item_value.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> coverage_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f coverage_eval( char scope, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
-    return[bpid = params[0], beta = is_beta( scope )]( dialogue const & d ) {
+    return[bpid = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         bodypart_id bp( bpid.str( d ) );
-        return d.actor( beta )->coverage_at( bp );
+        return d.const_actor( beta )->coverage_at( bp );
     };
 }
 
-std::function<double( dialogue & )> distance_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f distance_eval( char scope, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
-    return[params, beta = is_beta( scope )]( dialogue const & d ) {
+    return[params, beta = is_beta( scope )]( const_dialogue const & d ) {
         const auto get_pos = [&d]( std::string_view str ) {
             if( str == "u" ) {
-                return d.actor( false )->global_pos();
+                return d.const_actor( false )->global_pos();
             } else if( str == "npc" ) {
-                return d.actor( true )->global_pos();
+                return d.const_actor( true )->global_pos();
             }
             return tripoint_abs_ms( tripoint::from_string( str.data() ) );
         };
@@ -178,11 +178,11 @@ std::function<double( dialogue & )> distance_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> damage_level_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f damage_level_eval( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return[params, beta = is_beta( scope )]( dialogue const & d ) {
-        item_location *it = d.actor( beta )->get_item();
+    return[params, beta = is_beta( scope )]( const_dialogue const & d ) {
+        item_location const *it = d.const_actor( beta )->get_const_item();
         if( !it ) {
             debugmsg( "subject of damage_level() must be an item" );
             return 0;
@@ -191,38 +191,38 @@ std::function<double( dialogue & )> damage_level_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> effect_intensity_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f effect_intensity_eval( char scope, std::vector<diag_value> const &params,
+                                       diag_kwargs const &kwargs )
 {
     diag_value bp_val = kwargs.kwarg_or( "bodypart" );
-    return[effect_id = params[0], bp_val, beta = is_beta( scope )]( dialogue const & d ) {
+    return[effect_id = params[0], bp_val, beta = is_beta( scope )]( const_dialogue const & d ) {
         std::string const bp_str = bp_val.str( d );
         bodypart_id const bp = bp_str.empty() ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
-        effect target = d.actor( beta )->get_effect( efftype_id( effect_id.str( d ) ), bp );
+        effect target = d.const_actor( beta )->get_effect( efftype_id( effect_id.str( d ) ), bp );
         return target.is_null() ? -1 : target.get_intensity();
     };
 }
 
-std::function<double( dialogue & )> encumbrance_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f encumbrance_eval( char scope, std::vector<diag_value> const &params,
+                                  diag_kwargs const & /* kwargs */ )
 {
-    return[bpid = params[0], beta = is_beta( scope )]( dialogue const & d ) {
+    return[bpid = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         bodypart_id bp( bpid.str( d ) );
-        return d.actor( beta )->encumbrance_at( bp );
+        return d.const_actor( beta )->encumbrance_at( bp );
     };
 }
 
-std::function<double( dialogue & )> faction_like_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_like_eval( char /* scope */, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->likes_u;
     };
 }
 
-std::function<void( dialogue &, double )> faction_like_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_like_ass( char /* scope */, std::vector<diag_value> const &params,
+                                    diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -230,17 +230,17 @@ std::function<void( dialogue &, double )> faction_like_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> faction_respect_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_respect_eval( char /* scope */, std::vector<diag_value> const &params,
+                                      diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->respects_u;
     };
 }
 
-std::function<void( dialogue &, double )> faction_respect_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_respect_ass( char /* scope */, std::vector<diag_value> const &params,
+                                       diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -248,17 +248,17 @@ std::function<void( dialogue &, double )> faction_respect_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> faction_trust_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_trust_eval( char /* scope */, std::vector<diag_value> const &params,
+                                    diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->trusts_u;
     };
 }
 
-std::function<void( dialogue &, double )> faction_trust_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_trust_ass( char /* scope */, std::vector<diag_value> const &params,
+                                     diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -266,16 +266,16 @@ std::function<void( dialogue &, double )> faction_trust_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> faction_food_supply_eval( char /* scope */,
+diag_eval_dbl_f faction_food_supply_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->food_supply.calories;
     };
 }
 
-std::function<void( dialogue &, double )> faction_food_supply_ass( char /* scope */,
+diag_assign_dbl_f faction_food_supply_ass( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
@@ -284,17 +284,17 @@ std::function<void( dialogue &, double )> faction_food_supply_ass( char /* scope
     };
 }
 
-std::function<double( dialogue & )> faction_wealth_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_wealth_eval( char /* scope */, std::vector<diag_value> const &params,
+                                     diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->wealth;
     };
 }
 
-std::function<void( dialogue &, double )> faction_wealth_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_wealth_ass( char /* scope */, std::vector<diag_value> const &params,
+                                      diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -302,17 +302,17 @@ std::function<void( dialogue &, double )> faction_wealth_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> faction_power_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_power_eval( char /* scope */, std::vector<diag_value> const &params,
+                                    diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->power;
     };
 }
 
-std::function<void( dialogue &, double )> faction_power_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_power_ass( char /* scope */, std::vector<diag_value> const &params,
+                                     diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -320,17 +320,17 @@ std::function<void( dialogue &, double )> faction_power_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> faction_size_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f faction_size_eval( char /* scope */, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return [fac_val = params[0]]( dialogue & d ) {
+    return [fac_val = params[0]]( const_dialogue const & d ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
         return fac->size;
     };
 }
 
-std::function<void( dialogue &, double )> faction_size_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f faction_size_ass( char /* scope */, std::vector<diag_value> const &params,
+                                    diag_kwargs const & /* kwargs */ )
 {
     return [fac_val = params[0]]( dialogue const & d, double val ) {
         faction *fac = g->faction_manager_ptr->get( faction_id( fac_val.str( d ) ) );
@@ -338,8 +338,8 @@ std::function<void( dialogue &, double )> faction_size_ass( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> field_strength_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f field_strength_eval( char scope, std::vector<diag_value> const &params,
+                                     diag_kwargs const &kwargs )
 {
     std::optional<var_info> loc_var;
     diag_value loc_val = kwargs.kwarg_or( "location" );
@@ -351,13 +351,13 @@ std::function<double( dialogue & )> field_strength_eval( char scope,
                                          R"("field_strength" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
     }
 
-    return [beta = is_beta( scope ), field_value = params[0], loc_var]( dialogue & d ) {
+    return [beta = is_beta( scope ), field_value = params[0], loc_var]( const_dialogue const & d ) {
         map &here = get_map();
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
             loc = get_tripoint_from_var( loc_var, d, beta );
         } else {
-            loc = d.actor( beta )->global_pos();
+            loc = d.const_actor( beta )->global_pos();
         }
         field_type_id ft = field_type_id( field_value.str( d ) );
         field_entry *fp = here.field_at( here.bub_from_abs( loc ) ).find_field( ft );
@@ -365,12 +365,12 @@ std::function<double( dialogue & )> field_strength_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> gun_damage_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f gun_damage_eval( char scope, std::vector<diag_value> const &params,
+                                 diag_kwargs const & /* kwargs */ )
 {
 
-    return[dt_val = params[0], beta = is_beta( scope )]( dialogue const & d )-> double {
-        item_location *it = d.actor( beta )->get_item();
+    return[dt_val = params[0], beta = is_beta( scope )]( const_dialogue const & d )-> double {
+        item_location const *it = d.const_actor( beta )->get_const_item();
         if( it == nullptr )
         {
             debugmsg( "subject of gun_damage() must be an item" );
@@ -385,21 +385,21 @@ std::function<double( dialogue & )> gun_damage_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> has_trait_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f has_trait_eval( char scope, std::vector<diag_value> const &params,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return [beta = is_beta( scope ), tid = params[0] ]( dialogue const & d ) {
-        return d.actor( beta )->has_trait( trait_id( tid.str( d ) ) );
+    return [beta = is_beta( scope ), tid = params[0] ]( const_dialogue const & d ) {
+        return d.const_actor( beta )->has_trait( trait_id( tid.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> sum_traits_of_category_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f sum_traits_of_category_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const &kwargs )
 {
 
     diag_value type = kwargs.kwarg_or( "type", "ALL" );
 
-    return [beta = is_beta( scope ), category = params[0], type]( dialogue const & d ) {
+    return [beta = is_beta( scope ), category = params[0], type]( const_dialogue const & d ) {
 
         mutation_category_id cat = mutation_category_id( category.str() );
         std::string thing = type.str( d );
@@ -416,17 +416,17 @@ std::function<double( dialogue & )> sum_traits_of_category_eval( char scope,
             return 0;
         }
 
-        return d.actor( beta )->get_total_in_category( cat, count_type );
+        return d.const_actor( beta )->get_total_in_category( cat, count_type );
     };
 }
 
-std::function<double( dialogue & )> sum_traits_of_category_char_has_eval( char scope,
+diag_eval_dbl_f sum_traits_of_category_char_has_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
 {
 
     diag_value type = kwargs.kwarg_or( "type", "ALL" );
 
-    return [beta = is_beta( scope ), category = params[0], type]( dialogue const & d ) {
+    return [beta = is_beta( scope ), category = params[0], type]( const_dialogue const & d ) {
 
         mutation_category_id cat = mutation_category_id( category.str() );
         std::string thing = type.str( d );
@@ -443,15 +443,15 @@ std::function<double( dialogue & )> sum_traits_of_category_char_has_eval( char s
             return 0;
         }
 
-        return d.actor( beta )->get_total_in_category_char_has( cat, count_type );
+        return d.const_actor( beta )->get_total_in_category_char_has( cat, count_type );
     };
 }
 
-std::function<double( dialogue & )> has_flag_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f has_flag_eval( char scope, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
-    return [beta = is_beta( scope ), fid = params[0] ]( dialogue const & d ) -> double {
-        talker const *actor = d.actor( beta );
+    return [beta = is_beta( scope ), fid = params[0] ]( const_dialogue const & d ) -> double {
+        const_talker const *actor = d.const_actor( beta );
         json_character_flag jcf( fid.str( d ) );
         if( jcf == json_flag_MUTATION_THRESHOLD )
         {
@@ -461,26 +461,26 @@ std::function<double( dialogue & )> has_flag_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> has_var_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f has_var_eval( char /* scope */, std::vector<diag_value> const &params,
+                              diag_kwargs const & /* kwargs */ )
 {
-    return [var = params[0].var() ]( dialogue const & d ) {
+    return [var = params[0].var() ]( const_dialogue const & d ) {
         return maybe_read_var_value( var, d ).has_value();
     };
 }
 
-std::function<double( dialogue & )> knows_proficiency_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f knows_proficiency_eval( char scope, std::vector<diag_value> const &params,
+                                        diag_kwargs const & /* kwargs */ )
 {
-    return [beta = is_beta( scope ), tid = params[0] ]( dialogue const & d ) {
-        return d.actor( beta )->knows_proficiency( proficiency_id( tid.str( d ) ) );
+    return [beta = is_beta( scope ), tid = params[0] ]( const_dialogue const & d ) {
+        return d.const_actor( beta )->knows_proficiency( proficiency_id( tid.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> hp_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f hp_eval( char scope, std::vector<diag_value> const &params,
+                         diag_kwargs const & /* kwargs */ )
 {
-    return[bp_val = params[0], beta = is_beta( scope )]( dialogue const & d ) {
+    return[bp_val = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         std::string const bp_str = bp_val.str( d );
         bool const major = bp_str == "ALL_MAJOR";
         bool const minor = bp_str == "ALL_MINOR";
@@ -488,18 +488,18 @@ std::function<double( dialogue & )> hp_eval( char scope,
             get_body_part_flags const parts = major ? get_body_part_flags::only_main :
                                               get_body_part_flags::only_minor;
             int ret{};
-            for( bodypart_id const &part : d.actor( beta )->get_all_body_parts( parts ) ) {
-                ret += d.actor( beta )->get_cur_hp( part );
+            for( bodypart_id const &part : d.const_actor( beta )->get_all_body_parts( parts ) ) {
+                ret += d.const_actor( beta )->get_cur_hp( part );
             }
             return ret;
         }
         bodypart_id const bp = bp_str == "ALL" ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
-        return d.actor( beta )->get_cur_hp( bp );
+        return d.const_actor( beta )->get_cur_hp( bp );
     };
 }
 
-std::function<void( dialogue &, double )> hp_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f hp_ass( char scope, std::vector<diag_value> const &params,
+                          diag_kwargs const & /* kwargs */ )
 {
     return [bp_val = params[0], beta = is_beta( scope )]( dialogue const & d, double val ) {
         std::string const bp_str = bp_val.str( d );
@@ -519,8 +519,8 @@ std::function<void( dialogue &, double )> hp_ass( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> spellcasting_adjustment_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_assign_dbl_f spellcasting_adjustment_ass( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const &kwargs )
 {
     enum spell_scope {
         scope_all,
@@ -589,40 +589,40 @@ std::function<void( dialogue &, double )> spellcasting_adjustment_ass( char scop
     };
 }
 
-std::function<double( dialogue & )> hp_max_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f hp_max_eval( char scope, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
-    return[bpid = params[0], beta = is_beta( scope )]( dialogue const & d ) {
+    return[bpid = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         bodypart_id bp( bpid.str( d ) );
-        return d.actor( beta )->get_hp_max( bp );
+        return d.const_actor( beta )->get_hp_max( bp );
     };
 }
 
-std::function<double( dialogue & )> item_count_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f item_count_eval( char scope,
+                                 std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
-    return[beta = is_beta( scope ), item_value = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->get_amount( itype_id( item_value.str( d ) ) );
+    return[beta = is_beta( scope ), item_value = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_amount( itype_id( item_value.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> item_rad_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f item_rad_eval( char scope, std::vector<diag_value> const &params,
+                               diag_kwargs const &kwargs )
 {
     diag_value agg_val  = kwargs.kwarg_or( "aggregate", "min" );
 
-    return [beta = is_beta( scope ), flag = params[0], agg_val]( dialogue const & d ) {
+    return [beta = is_beta( scope ), flag = params[0], agg_val]( const_dialogue const & d ) {
         std::optional<aggregate_type> const agg =
             io::string_to_enum_optional<aggregate_type>( agg_val.str( d ) );
-        return d.actor( beta )->item_rads( flag_id( flag.str( d ) ),
-                                           agg.value_or( aggregate_type::MIN ) );
+        return d.const_actor( beta )->item_rads( flag_id( flag.str( d ) ),
+                agg.value_or( aggregate_type::MIN ) );
     };
 }
 
-std::function<double( dialogue & )> num_input_eval( char /*scope*/,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f num_input_eval( char /*scope*/, std::vector<diag_value> const &params,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[prompt = params[0], default_val = params[1]]( dialogue const & d ) {
+    return[prompt = params[0], default_val = params[1]]( const_dialogue const & d ) {
         string_input_popup popup;
         double dv = default_val.dbl( d );
         int popup_val = dv;
@@ -638,20 +638,20 @@ std::function<double( dialogue & )> num_input_eval( char /*scope*/,
     };
 }
 
-std::function<double( dialogue & )> attack_speed_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f attack_speed_eval( char scope, std::vector<diag_value> const & /* params */,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        return d.actor( beta )->attack_speed();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        return d.const_actor( beta )->attack_speed();
     };
 }
 
-std::function<double( dialogue & )> melee_damage_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f melee_damage_eval( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
 
-    return[dt_val = params[0], beta = is_beta( scope )]( dialogue const & d ) {
-        item_location *it = d.actor( beta )->get_item();
+    return[dt_val = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
+        item_location const *it = d.const_actor( beta )->get_const_item();
         if( it == nullptr ) {
             debugmsg( "subject of melee_damage() must be an item" );
             return 0;
@@ -667,10 +667,10 @@ std::function<double( dialogue & )> melee_damage_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> mod_order_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f mod_order_eval( char /* scope */, std::vector<diag_value> const &params,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[mod_val = params[0]]( dialogue const & d ) {
+    return[mod_val = params[0]]( const_dialogue const & d ) {
         int count = 0;
         mod_id our_mod_id( mod_val.str( d ) );
         for( const mod_id &mod : world_generator->active_world->active_mod_order ) {
@@ -719,8 +719,8 @@ bool _filter_character( Character const *beta, Character const &guy, int radius,
     return false;
 }
 
-std::function<double( dialogue & )> _characters_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f _characters_nearby_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const &kwargs )
 {
     diag_value radius_val = kwargs.kwarg_or( "radius", 1000 );
     diag_value filter_val = kwargs.kwarg_or( "attitude", "any" );
@@ -736,12 +736,12 @@ std::function<double( dialogue & )> _characters_nearby_eval( char scope,
     }
 
     return [beta = is_beta( scope ), params, loc_var, filter_val, radius_val,
-         allow_hallucinations_val ]( dialogue & d ) {
+         allow_hallucinations_val ]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
             loc = get_tripoint_from_var( loc_var, d, beta );
         } else {
-            loc = d.actor( beta )->global_pos();
+            loc = d.const_actor( beta )->global_pos();
         }
 
         int const radius = static_cast<int>( radius_val.dbl( d ) );
@@ -765,7 +765,7 @@ std::function<double( dialogue & )> _characters_nearby_eval( char scope,
 
         std::vector<Character *> const targets = g->get_characters_if( [ &beta, &d, &radius,
                &loc, filter, allow_hallucinations ]( const Character & guy ) {
-            talker const *const tk = d.actor( beta );
+            const_talker const *const tk = d.const_actor( beta );
             return _filter_character( tk->get_const_character(), guy, radius, loc, filter,
                                       allow_hallucinations );
         } );
@@ -773,8 +773,8 @@ std::function<double( dialogue & )> _characters_nearby_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> characters_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f characters_nearby_eval( char scope, std::vector<diag_value> const &params,
+                                        diag_kwargs const &kwargs )
 {
     return _characters_nearby_eval( scope, params, kwargs );
 }
@@ -834,9 +834,9 @@ bool _filter_monster( Creature const &critter, std::vector<ID> const &ids, int r
     return false;
 }
 
-template<class ID>
-std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs, f_monster_match<ID> f )
+template <class ID>
+diag_eval_dbl_f _monsters_nearby_eval( char scope, std::vector<diag_value> const &params,
+                                       diag_kwargs const &kwargs, f_monster_match<ID> f )
 {
     diag_value radius_val = kwargs.kwarg_or( "radius", 1000 );
     diag_value filter_val = kwargs.kwarg_or( "attitude", "hostile" );
@@ -850,12 +850,13 @@ std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
                                          R"("monsters_nearby" needs either an actor scope (u/n) or a 'location' kwarg)" ) );
     }
 
-    return [beta = is_beta( scope ), params, loc_var, radius_val, filter_val, f]( dialogue & d ) {
+    return [beta = is_beta( scope ), params, loc_var, radius_val, filter_val,
+         f]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
             loc = get_tripoint_from_var( loc_var, d, beta );
         } else {
-            loc = d.actor( beta )->global_pos();
+            loc = d.const_actor( beta )->global_pos();
         }
 
         int const radius = static_cast<int>( radius_val.dbl( d ) );
@@ -882,43 +883,43 @@ std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> monsters_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f monsters_nearby_eval( char scope, std::vector<diag_value> const &params,
+                                      diag_kwargs const &kwargs )
 {
     return _monsters_nearby_eval( scope, params, kwargs, mon_check_id );
 }
 
-std::function<double( dialogue & )> monster_species_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f monster_species_nearby_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const &kwargs )
 {
     return _monsters_nearby_eval( scope, params, kwargs, mon_check_species );
 }
 
-std::function<double( dialogue & )> monster_groups_nearby_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f monster_groups_nearby_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const &kwargs )
 {
     return _monsters_nearby_eval( scope, params, kwargs, mon_check_group );
 }
 
-std::function<double( dialogue & )> moon_phase_eval( char /* scope */,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f moon_phase_eval( char /* scope */, std::vector<diag_value> const & /* params */,
+                                 diag_kwargs const & /* kwargs */ )
 {
-    return []( dialogue const & /* d */ ) {
+    return []( const_dialogue const & /* d */ ) {
         return static_cast<int>( get_moon_phase( calendar::turn ) );
     };
 }
 
-std::function<double( dialogue & )> pain_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_eval_dbl_f pain_eval( char scope, std::vector<diag_value> const & /* params */,
+                           diag_kwargs const &kwargs )
 {
     diag_value format_value = kwargs.kwarg_or( "type", "raw" );
 
-    return [format_value, beta = is_beta( scope )]( dialogue const & d ) {
+    return [format_value, beta = is_beta( scope )]( const_dialogue const & d ) {
         std::string format = format_value.str( d );
         if( format == "perceived" ) {
-            return d.actor( beta )->perceived_pain_cur();
+            return d.const_actor( beta )->perceived_pain_cur();
         } else if( format == "raw" ) {
-            return d.actor( beta )->pain_cur();
+            return d.const_actor( beta )->pain_cur();
         } else {
             debugmsg( R"(Unknown type "%s" for pain())", format );
             return 0;
@@ -926,8 +927,8 @@ std::function<double( dialogue & )> pain_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> pain_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_assign_dbl_f pain_ass( char scope, std::vector<diag_value> const & /* params */,
+                            diag_kwargs const &kwargs )
 {
     diag_value format_value = kwargs.kwarg_or( "type", "raw" );
 
@@ -944,29 +945,28 @@ std::function<void( dialogue &, double )> pain_ass( char scope,
     };
 }
 
-std::function<double( dialogue & )> energy_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f energy_eval( char /* scope */, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
-
-    return [val = params[0]]( dialogue const & d ) {
+    return [val = params[0]]( const_dialogue const & d ) {
         return static_cast<double>( units::to_millijoule(
                                         _read_from_string<units::energy>( val.str( d ), units::energy_units ) ) );
     };
 }
 
-std::function<double( dialogue & )> school_level_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f school_level_eval( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), school_value = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->get_spell_level( trait_id( school_value.str( d ) ) );
+    return[beta = is_beta( scope ), school_value = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_spell_level( trait_id( school_value.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> school_level_adjustment_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f school_level_adjustment_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), school_value = params[0]]( dialogue const & d ) {
-        const Character *ch = d.actor( beta )->get_character();
+    return[beta = is_beta( scope ), school_value = params[0]]( const_dialogue const & d ) {
+        const Character *ch = d.const_actor( beta )->get_const_character();
         if( ch ) {
             const trait_id school( school_value.str( d ) );
             auto it = ch->magic->caster_level_adjustment_by_school.find( school );
@@ -980,8 +980,8 @@ std::function<double( dialogue & )> school_level_adjustment_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> school_level_adjustment_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f school_level_adjustment_ass( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), school_value = params[0]]( dialogue const & d, double val ) {
         const Character *ch = d.actor( beta )->get_character();
@@ -998,13 +998,13 @@ std::function<void( dialogue &, double )> school_level_adjustment_ass( char scop
     };
 }
 
-std::function<double( dialogue & )> get_daily_calories( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_eval_dbl_f get_daily_calories( char scope, std::vector<diag_value> const & /* params */,
+                                    diag_kwargs const &kwargs )
 {
     diag_value type_val = kwargs.kwarg_or( "type", "total" );
     diag_value day_val = kwargs.kwarg_or( "day" );
 
-    return[beta = is_beta( scope ), day_val, type_val ]( dialogue const & d ) {
+    return[beta = is_beta( scope ), day_val, type_val ]( const_dialogue const & d ) {
         std::string type = type_val.str( d );
         int const day = day_val.dbl( d );
         if( day < 0 ) {
@@ -1012,44 +1012,44 @@ std::function<double( dialogue & )> get_daily_calories( char scope,
             return 0;
         }
 
-        return d.actor( beta )->get_daily_calories( day, type );
+        return d.const_actor( beta )->get_daily_calories( day, type );
     };
 }
 
-std::function<double( dialogue & )> skill_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f skill_eval( char scope, std::vector<diag_value> const &params,
+                            diag_kwargs const & /* kwargs */ )
 {
-    return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d ) {
-        return d.actor( beta )->get_skill_level( skill_id( sid.str( d ) ) );
+    return [beta = is_beta( scope ), sid = params[0] ]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_skill_level( skill_id( sid.str( d ) ) );
     };
 }
 
-std::function<void( dialogue &, double )> skill_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f skill_ass( char scope, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
     return [beta = is_beta( scope ), sid = params[0] ]( dialogue const & d, double val ) {
         return d.actor( beta )->set_skill_level( skill_id( sid.str( d ) ), val );
     };
 }
 
-std::function<double( dialogue & )> skill_exp_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f skill_exp_eval( char scope, std::vector<diag_value> const &params,
+                                diag_kwargs const &kwargs )
 {
     diag_value format_value = kwargs.kwarg_or( "format", "percentage" );
 
-    return[skill_value = params[0], format_value, beta = is_beta( scope )]( dialogue const & d ) {
+    return[skill_value = params[0], format_value, beta = is_beta( scope )]( const_dialogue const & d ) {
         skill_id skill( skill_value.str( d ) );
         std::string format = format_value.str( d );
         if( format != "raw" && format != "percentage" ) {
             debugmsg( R"(Unknown format type "%s" for skill_exp, assumning "percentage")", format );
         }
         bool raw = format == "raw";
-        return d.actor( beta )->get_skill_exp( skill, raw );
+        return d.const_actor( beta )->get_skill_exp( skill, raw );
     };
 }
 
-std::function<void( dialogue &, double )> skill_exp_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_assign_dbl_f skill_exp_ass( char scope, std::vector<diag_value> const &params,
+                                 diag_kwargs const &kwargs )
 {
     diag_value format_value = kwargs.kwarg_or( "format", "percentage" );
 
@@ -1065,71 +1065,71 @@ std::function<void( dialogue &, double )> skill_exp_ass( char scope,
     };
 }
 
-std::function<double( dialogue & )> spell_count_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_eval_dbl_f spell_count_eval( char scope, std::vector<diag_value> const & /* params */,
+                                  diag_kwargs const &kwargs )
 {
     diag_value school_value = kwargs.kwarg_or( "school" );
 
-    return[beta = is_beta( scope ), school_value]( dialogue const & d ) {
+    return[beta = is_beta( scope ), school_value]( const_dialogue const & d ) {
         std::string school_str = school_value.str( d );
         const trait_id scid = school_str.empty() ? trait_id::NULL_ID() : trait_id( school_str );
-        return d.actor( beta )->get_spell_count( scid );
+        return d.const_actor( beta )->get_spell_count( scid );
     };
 }
 
-std::function<double( dialogue & )> spell_sum_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_eval_dbl_f spell_sum_eval( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const &kwargs )
 {
     diag_value school_value = kwargs.kwarg_or( "school" );
     diag_value min_level = kwargs.kwarg_or( "level" );
 
-    return[beta = is_beta( scope ), school_value, min_level]( dialogue const & d ) {
+    return[beta = is_beta( scope ), school_value, min_level]( const_dialogue const & d ) {
         std::string school_str = school_value.str( d );
         int const min_spell_level = min_level.dbl( d );
         const trait_id scid = school_str.empty() ? trait_id::NULL_ID() : trait_id( school_str );
-        return d.actor( beta )->get_spell_sum( scid, min_spell_level );
+        return d.const_actor( beta )->get_spell_sum( scid, min_spell_level );
     };
 }
 
-std::function<double( dialogue & )> spell_exp_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f spell_exp_eval( char scope, std::vector<diag_value> const &params,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), sid = params[0]]( dialogue const & d ) {
-        return d.actor( beta )->get_spell_exp( spell_id( sid.str( d ) ) );
+    return[beta = is_beta( scope ), sid = params[0]]( const_dialogue const & d ) {
+        return d.const_actor( beta )->get_spell_exp( spell_id( sid.str( d ) ) );
     };
 }
 
-std::function<double( dialogue & )> spell_exp_for_level_eval( char /* scope */,
+diag_eval_dbl_f spell_exp_for_level_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
-    return[level = params[0]]( dialogue const & d ) -> double {
+    return[level = params[0]]( const_dialogue const & d ) -> double {
         return spell::exp_for_level( level.dbl( d ) );
     };
 }
 
-std::function<void( dialogue &, double )> spell_exp_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f spell_exp_ass( char scope, std::vector<diag_value> const &params,
+                                 diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), sid = params[0]]( dialogue const & d, double val ) {
         return d.actor( beta )->set_spell_exp( spell_id( sid.str( d ) ), val );
     };
 }
 
-std::function<double( dialogue & )> spell_level_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f spell_level_eval( char scope, std::vector<diag_value> const &params,
+                                  diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), spell_value = params[0]]( dialogue const & d ) {
+    return[beta = is_beta( scope ), spell_value = params[0]]( const_dialogue const & d ) {
         const spell_id spell( spell_value.str( d ) );
         if( spell == spell_id::NULL_ID() ) {
-            return d.actor( beta )->get_highest_spell_level();
+            return d.const_actor( beta )->get_highest_spell_level();
         } else {
-            return d.actor( beta )->get_spell_level( spell );
+            return d.const_actor( beta )->get_spell_level( spell );
         }
     };
 }
 
-std::function<void( dialogue &, double )> spell_level_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f spell_level_ass( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), spell_value = params[0]]( dialogue const & d, double val ) {
         const spell_id spell( spell_value.str( d ) );
@@ -1142,11 +1142,11 @@ std::function<void( dialogue &, double )> spell_level_ass( char scope,
     };
 }
 
-std::function<double( dialogue & )> spell_level_adjustment_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f spell_level_adjustment_eval( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), spell_value = params[0]]( dialogue const & d ) {
-        const Character *ch = d.actor( beta )->get_character();
+    return[beta = is_beta( scope ), spell_value = params[0]]( const_dialogue const & d ) {
+        const Character *ch = d.const_actor( beta )->get_const_character();
         if( ch ) {
             const spell_id spell( spell_value.str( d ) );
             if( spell == spell_id::NULL_ID() ) {
@@ -1162,8 +1162,8 @@ std::function<double( dialogue & )> spell_level_adjustment_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> spell_level_adjustment_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f spell_level_adjustment_ass( char scope, std::vector<diag_value> const &params,
+        diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), spell_value = params[0]]( dialogue const & d, double val ) {
         const Character *ch = d.actor( beta )->get_character();
@@ -1203,12 +1203,12 @@ double _time_in_unit( double time, std::string_view unit )
     return time;
 }
 
-std::function<double( dialogue & )> time_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f time_eval( char /* scope */, std::vector<diag_value> const &params,
+                           diag_kwargs const &kwargs )
 {
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
-    return [val = params[0], unit_val]( dialogue const & d ) {
+    return [val = params[0], unit_val]( const_dialogue const & d ) {
         std::string const val_str = val.str( d );
         double ret{};
         if( val_str == "now" ) {
@@ -1226,8 +1226,8 @@ std::function<double( dialogue & )> time_eval( char /* scope */,
     };
 }
 
-std::function<void( dialogue &, double )> time_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f time_ass( char /* scope */, std::vector<diag_value> const &params,
+                            diag_kwargs const & /* kwargs */ )
 {
     // intentionally duplicate check for str to avoid the `Expected str, got ...` error and get the nicer one below
     if( params[0].is_str() && params[0] == "now" ) {
@@ -1240,12 +1240,12 @@ std::function<void( dialogue &, double )> time_ass( char /* scope */,
         string_format( "Only time('now') is a valid time() assignment target" ) );
 }
 
-std::function<double( dialogue & )> time_since_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f time_since_eval( char /* scope */, std::vector<diag_value> const &params,
+                                 diag_kwargs const &kwargs )
 {
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
-    return [val = params[0], unit_val]( dialogue const & d ) {
+    return [val = params[0], unit_val]( const_dialogue const & d ) {
         double ret{};
         std::string const val_str = val.str( d );
         if( val_str == "cataclysm" ) {
@@ -1265,12 +1265,12 @@ std::function<double( dialogue & )> time_since_eval( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> time_until_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f time_until_eval( char /* scope */, std::vector<diag_value> const &params,
+                                 diag_kwargs const &kwargs )
 {
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
-    return [val = params[0], unit_val]( dialogue const & d ) {
+    return [val = params[0], unit_val]( const_dialogue const & d ) {
         double ret{};
         std::string const val_str = val.str( d );
         if( val_str == "night_time" ) {
@@ -1298,12 +1298,12 @@ std::function<double( dialogue & )> time_until_eval( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f time_until_eoc_eval( char /* scope */, std::vector<diag_value> const &params,
+                                     diag_kwargs const &kwargs )
 {
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
-    return [eoc_val = params[0], unit_val]( dialogue const & d ) -> double {
+    return [eoc_val = params[0], unit_val]( const_dialogue const & d ) -> double {
         effect_on_condition_id eoc_id( eoc_val.str( d ) );
         auto const &list = g->queued_global_effect_on_conditions.list;
         auto const it = std::find_if( list.cbegin(), list.cend(), [&eoc_id]( queued_eoc const & eoc )
@@ -1315,29 +1315,30 @@ std::function<double( dialogue & )> time_until_eoc_eval( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> effect_duration_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f effect_duration_eval( char scope, std::vector<diag_value> const &params,
+                                      diag_kwargs const &kwargs )
 {
     diag_value bp_val = kwargs.kwarg_or( "bodypart" );
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
-    return[effect_id = params[0], bp_val, unit_val, beta = is_beta( scope )]( dialogue const & d ) {
+    return[effect_id = params[0], bp_val, unit_val,
+              beta = is_beta( scope )]( const_dialogue const & d ) {
         std::string const bp_str = bp_val.str( d );
         bodypart_id const bp = bp_str.empty() ? bodypart_str_id::NULL_ID() : bodypart_id( bp_str );
-        effect target = d.actor( beta )->get_effect( efftype_id( effect_id.str( d ) ), bp );
+        effect target = d.const_actor( beta )->get_effect( efftype_id( effect_id.str( d ) ), bp );
         return target.is_null() ? -1 : _time_in_unit( to_seconds<double>( target.get_duration() ),
                 unit_val.str( d ) );
     };
 }
 
-std::function<double( dialogue & )> proficiency_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f proficiency_eval( char scope, std::vector<diag_value> const &params,
+                                  diag_kwargs const &kwargs )
 {
     diag_value fmt_val = kwargs.kwarg_or( "format", "time_spent" );
 
-    return [beta = is_beta( scope ), prof_value = params[0], fmt_val]( dialogue const & d ) {
+    return [beta = is_beta( scope ), prof_value = params[0], fmt_val]( const_dialogue const & d ) {
         proficiency_id prof( prof_value.str( d ) );
-        time_duration raw = d.actor( beta )->proficiency_practiced_time( prof );
+        time_duration raw = d.const_actor( beta )->proficiency_practiced_time( prof );
         std::string const format = fmt_val.str( d );
         if( format == "percent" ) {
             return raw * 100.0  / prof->time_to_learn();
@@ -1356,8 +1357,8 @@ std::function<double( dialogue & )> proficiency_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> proficiency_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_assign_dbl_f proficiency_ass( char scope, std::vector<diag_value> const &params,
+                                   diag_kwargs const &kwargs )
 {
     diag_value fmt_val = kwargs.kwarg_or( "format", "time_spent" );
     diag_value direct_val = kwargs.kwarg_or( "direct" );
@@ -1398,7 +1399,7 @@ std::function<void( dialogue &, double )> proficiency_ass( char scope,
     };
 }
 
-double _test_add( diag_value const &v, dialogue const &d )
+double _test_add( diag_value const &v, const_dialogue const &d )
 {
     double ret{};
     if( v.is_array() ) {
@@ -1410,7 +1411,7 @@ double _test_add( diag_value const &v, dialogue const &d )
     }
     return ret;
 }
-double _test_len( diag_value const &v, dialogue const &d )
+double _test_len( diag_value const &v, const_dialogue const &d )
 {
     double ret{};
     for( diag_value const &w : v.array( d ) ) {
@@ -1418,9 +1419,8 @@ double _test_len( diag_value const &v, dialogue const &d )
     }
     return ret;
 }
-std::function<double( dialogue & )> _test_func( std::vector<diag_value> const &params,
-        diag_kwargs const &kwargs,
-        double ( *f )( diag_value const &v, dialogue const &d ) )
+diag_eval_dbl_f _test_func( std::vector<diag_value> const &params, diag_kwargs const &kwargs,
+                            double ( *f )( diag_value const &v, const_dialogue const &d ) )
 {
     std::vector<diag_value> all_params( params );
     for( diag_kwargs::impl_t::value_type const &v : kwargs.kwargs ) {
@@ -1428,7 +1428,7 @@ std::function<double( dialogue & )> _test_func( std::vector<diag_value> const &p
             all_params.emplace_back( *v.second );
         }
     }
-    return [all_params, f]( dialogue const & d ) {
+    return [all_params, f]( const_dialogue const & d ) {
         double ret = 0;
         for( diag_value const &v : all_params ) {
             ret += f( v, d );
@@ -1437,23 +1437,23 @@ std::function<double( dialogue & )> _test_func( std::vector<diag_value> const &p
     };
 }
 
-std::function<double( dialogue & )> test_diag( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f test_diag( char /* scope */, std::vector<diag_value> const &params,
+                           diag_kwargs const &kwargs )
 {
     return _test_func( params, kwargs, _test_add );
 }
 
-std::function<double( dialogue & )> test_str_len( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+diag_eval_dbl_f test_str_len( char /* scope */, std::vector<diag_value> const &params,
+                              diag_kwargs const &kwargs )
 {
     return _test_func( params, kwargs, _test_len );
 }
 
-std::function<double( dialogue & )> value_or_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f value_or_eval( char /* scope */, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
     return[var = params[0].var(),
-        vor = params[1]]( dialogue const & d ) -> double {
+        vor = params[1]]( const_dialogue const & d ) -> double {
         if( std::optional<std::string> has = maybe_read_var_value( var, d ); has )
         {
             return diag_value{ *has }.dbl( d );
@@ -1462,11 +1462,11 @@ std::function<double( dialogue & )> value_or_eval( char /* scope */,
     };
 }
 
-std::function<double( dialogue & )> vision_range_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f vision_range_eval( char scope, std::vector<diag_value> const & /* params */,
+                                   diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        talker const *const actor = d.actor( beta );
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        const_talker const *const actor = d.const_actor( beta );
         if( Character const *const chr = actor->get_const_character(); chr != nullptr ) {
             return chr->unimpaired_range();
         } else if( monster const *const mon = actor->get_const_monster(); mon != nullptr ) {
@@ -1479,95 +1479,94 @@ std::function<double( dialogue & )> vision_range_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> npc_anger_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f npc_anger_eval( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta ) ) {
-            return d.actor( beta )->get_npc_anger();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta ) ) {
+            return d.const_actor( beta )->get_npc_anger();
         } else {
             return 0;
         }
     };
 }
 
-std::function<double( dialogue & )> npc_fear_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f npc_fear_eval( char scope, std::vector<diag_value> const & /* params */,
+                               diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta ) ) {
-            return d.actor( beta )->get_npc_fear();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta ) ) {
+            return d.const_actor( beta )->get_npc_fear();
         } else {
             return 0;
         }
     };
 }
 
-std::function<double( dialogue & )> npc_value_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f npc_value_eval( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta ) ) {
-            return d.actor( beta )->get_npc_value();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta ) ) {
+            return d.const_actor( beta )->get_npc_value();
         } else {
             return 0;
         }
     };
 }
 
-std::function<double( dialogue & )> npc_trust_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f npc_trust_eval( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta ) ) {
-            return d.actor( beta )->get_npc_trust();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta ) ) {
+            return d.const_actor( beta )->get_npc_trust();
         } else {
             return 0;
         }
     };
 }
 
-std::function<void( dialogue &, double )> npc_anger_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f npc_anger_ass( char scope, std::vector<diag_value> const & /* params */,
+                                 diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
         return d.actor( beta )->set_npc_anger( val );
     };
 }
 
-std::function<void( dialogue &, double )> npc_fear_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f npc_fear_ass( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
         return d.actor( beta )->set_npc_fear( val );
     };
 }
 
-std::function<void( dialogue &, double )> npc_value_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f npc_value_ass( char scope, std::vector<diag_value> const & /* params */,
+                                 diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
         return d.actor( beta )->set_npc_value( val );
     };
 }
 
-
-std::function<void( dialogue &, double )> npc_trust_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f npc_trust_ass( char scope, std::vector<diag_value> const & /* params */,
+                                 diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope )]( dialogue const & d, double val ) {
         return d.actor( beta )->set_npc_trust( val );
     };
 }
 
-std::function<double( dialogue & )> calories_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_eval_dbl_f calories_eval( char scope, std::vector<diag_value> const & /* params */,
+                               diag_kwargs const &kwargs )
 {
     diag_value format_value = kwargs.kwarg_or( "format", "raw" );
     // dummy kwarg, intentionally discarded!
     diag_value ignore_weariness_val = kwargs.kwarg_or( "dont_affect_weariness" );
 
-    return[format_value, beta = is_beta( scope )]( dialogue const & d ) -> double {
+    return[format_value, beta = is_beta( scope )]( const_dialogue const & d ) -> double {
         std::string format = format_value.str( d );
         if( format != "raw" && format != "percent" )
         {
@@ -1577,24 +1576,24 @@ std::function<double( dialogue & )> calories_eval( char scope,
 
         if( format == "percent" )
         {
-            if( d.actor( beta )->get_character() ) {
-                double divisor = d.actor( beta )->get_healthy_kcal() / 100.0;
+            if( d.const_actor( beta )->get_const_character() ) {
+                double divisor = d.const_actor( beta )->get_healthy_kcal() / 100.0;
                 //if no data, default to default height of 175cm
                 if( divisor == 0 ) {
                     debugmsg( "Can't get healthy amount of calories, return raw calories instead" );
-                    return d.actor( beta )->get_stored_kcal();
+                    return d.const_actor( beta )->get_stored_kcal();
                 }
-                return d.actor( beta )->get_stored_kcal() / divisor;
+                return d.const_actor( beta )->get_stored_kcal() / divisor;
             } else {
                 debugmsg( "Percent can be used only with character" );
                 return 0;
             }
         } else if( format == "raw" )
         {
-            if( d.actor( beta )->get_character() ) {
-                return d.actor( beta )->get_stored_kcal();
+            if( d.const_actor( beta )->get_const_character() ) {
+                return d.const_actor( beta )->get_stored_kcal();
             }
-            item_location const *it = d.actor( beta )->get_const_item();
+            item_location const *it = d.const_actor( beta )->get_const_item();
             if( it && *it ) {
                 npc dummy;
                 return dummy.compute_effective_nutrients( *it->get_item() ).kcal();
@@ -1605,8 +1604,8 @@ std::function<double( dialogue & )> calories_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> calories_ass( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &kwargs )
+diag_assign_dbl_f calories_ass( char scope, std::vector<diag_value> const & /* params */,
+                                diag_kwargs const &kwargs )
 {
     diag_value ignore_weariness_val = kwargs.kwarg_or( "dont_affect_weariness" );
 
@@ -1614,18 +1613,18 @@ std::function<void( dialogue &, double )> calories_ass( char scope,
         const bool ignore_weariness = is_true( ignore_weariness_val.dbl( d ) );
         int current_kcal = d.actor( beta )->get_stored_kcal();
         int difference = val - current_kcal;
-        return d.actor( beta )->mod_stored_kcal( difference, ignore_weariness );
+        d.actor( beta )->mod_stored_kcal( difference, ignore_weariness );
     };
 }
 
-std::function<double( dialogue & )> weight_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f weight_eval( char scope, std::vector<diag_value> const & /* params */,
+                             diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() || d.actor( beta )->get_const_monster() ) {
-            return d.actor( beta )->get_weight();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta )->get_const_character() || d.const_actor( beta )->get_const_monster() ) {
+            return d.const_actor( beta )->get_weight();
         }
-        item_location const *it = d.actor( beta )->get_const_item();
+        item_location const *it = d.const_actor( beta )->get_const_item();
         if( it && *it ) {
             return static_cast<int>( to_milligram( it->get_item()->weight() ) );
         }
@@ -1634,14 +1633,14 @@ std::function<double( dialogue & )> weight_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> volume_eval( char scope,
-        std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f volume_eval( char scope, std::vector<diag_value> const & /* params */,
+                             diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        if( d.actor( beta )->get_character() || d.actor( beta )->get_const_monster() ) {
-            return d.actor( beta )->get_volume();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        if( d.const_actor( beta )->get_const_character() || d.const_actor( beta )->get_const_monster() ) {
+            return d.const_actor( beta )->get_volume();
         }
-        item_location const *it = d.actor( beta )->get_const_item();
+        item_location const *it = d.const_actor( beta )->get_const_item();
         if( it && *it ) {
             return to_milliliter( it->get_item()->volume() );
         }
@@ -1650,11 +1649,11 @@ std::function<double( dialogue & )> volume_eval( char scope,
     };
 }
 
-std::function<double( dialogue & )> vitamin_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f vitamin_eval( char scope, std::vector<diag_value> const &params,
+                              diag_kwargs const & /* kwargs */ )
 {
-    return[beta = is_beta( scope ), id = params[0]]( dialogue const & d ) {
-        talker const *const actor = d.actor( beta );
+    return[beta = is_beta( scope ), id = params[0]]( const_dialogue const & d ) {
+        const_talker const *const actor = d.const_actor( beta );
         if( Character const *const chr = actor->get_const_character(); chr != nullptr ) {
             return chr->vitamin_get( vitamin_id( id.str( d ) ) );
         }
@@ -1663,8 +1662,8 @@ std::function<double( dialogue & )> vitamin_eval( char scope,
     };
 }
 
-std::function<void( dialogue &, double )> vitamin_ass( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f vitamin_ass( char scope, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
     return[beta = is_beta( scope ), id = params[0]]( dialogue const & d, double val ) {
         if( d.actor( beta )->get_character() ) {
@@ -1673,48 +1672,48 @@ std::function<void( dialogue &, double )> vitamin_ass( char scope,
     };
 }
 
-std::function<double( dialogue & )> warmth_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f warmth_eval( char scope, std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
 {
-    return[bpid = params[0], beta = is_beta( scope )]( dialogue const & d ) {
+    return[bpid = params[0], beta = is_beta( scope )]( const_dialogue const & d ) {
         bodypart_id bp( bpid.str( d ) );
-        return units::to_legacy_bodypart_temp( d.actor( beta )->get_cur_part_temp( bp ) );
+        return units::to_legacy_bodypart_temp( d.const_actor( beta )->get_cur_part_temp( bp ) );
     };
 }
 
-std::function<double( dialogue & )> weather_eval( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_eval_dbl_f weather_eval( char /* scope */, std::vector<diag_value> const &params,
+                              diag_kwargs const & /* kwargs */ )
 {
     if( params[0] == "temperature" ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return units::to_kelvin( get_weather().weather_precise->temperature );
         };
     }
     if( params[0] == "windpower" ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return get_weather().weather_precise->windpower;
         };
     }
     if( params[0] == "humidity" ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return get_weather().weather_precise->humidity;
         };
     }
     if( params[0] == "pressure" ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return get_weather().weather_precise->pressure;
         };
     }
     if( params[0] == "precipitation" ) {
-        return []( dialogue const & ) {
+        return []( const_dialogue const & ) {
             return precip_mm_per_hour( get_weather().weather_id->precip );
         };
     }
     throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
 }
 
-std::function<void( dialogue &, double )> weather_ass( char /* scope */,
-        std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
+diag_assign_dbl_f weather_ass( char /* scope */, std::vector<diag_value> const &params,
+                               diag_kwargs const & /* kwargs */ )
 {
     if( params[0] == "temperature" ) {
         return []( dialogue const &, double val ) {
@@ -1744,19 +1743,19 @@ std::function<void( dialogue &, double )> weather_ass( char /* scope */,
     throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
 }
 
-std::function<double( dialogue & )> climate_control_str_heat_eval( char scope,
+diag_eval_dbl_f climate_control_str_heat_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
-    return [beta = is_beta( scope )]( dialogue const & d ) {
-        return d.actor( beta )->climate_control_str_heat();
+    return [beta = is_beta( scope )]( const_dialogue const & d ) {
+        return d.const_actor( beta )->climate_control_str_heat();
     };
 }
 
-std::function<double( dialogue & )> climate_control_str_chill_eval( char scope,
+diag_eval_dbl_f climate_control_str_chill_eval( char scope,
         std::vector<diag_value> const &/* params */, diag_kwargs const &/* kwargs */ )
 {
-    return[beta = is_beta( scope )]( dialogue const & d ) {
-        return d.actor( beta )->climate_control_str_chill();
+    return[beta = is_beta( scope )]( const_dialogue const & d ) {
+        return d.const_actor( beta )->climate_control_str_chill();
     };
 }
 

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -10,6 +10,13 @@
 
 #include "math_parser_diag_value.h"
 
+
+struct dialogue;
+struct const_dialogue;
+
+using diag_assign_dbl_f = std::function<void( dialogue &, double )>;
+using diag_eval_dbl_f = std::function<double( const_dialogue const & )>;
+
 struct diag_kwargs {
     using impl_t = std::map<std::string, deref_diag_value>;
 
@@ -23,8 +30,6 @@ struct diag_kwargs {
         return diag_value{ default_value };
     }
 };
-
-struct dialogue;
 struct dialogue_func {
     dialogue_func( std::string_view sc_, int n_ ) :
         scopes( sc_ ), num_params( n_ ) {}
@@ -32,8 +37,8 @@ struct dialogue_func {
     int num_params{};
 };
 struct dialogue_func_eval : dialogue_func {
-    using f_t = std::function<double( dialogue & )> ( * )( char scope,
-                std::vector<diag_value> const &, diag_kwargs const & );
+    using f_t = diag_eval_dbl_f( * )( char scope, std::vector<diag_value> const &,
+                                      diag_kwargs const & );
 
     dialogue_func_eval( std::string_view sc_, int n_, f_t f_ )
         : dialogue_func( sc_, n_ ), f( f_ ) {}
@@ -42,8 +47,8 @@ struct dialogue_func_eval : dialogue_func {
 };
 
 struct dialogue_func_ass : dialogue_func {
-    using f_t = std::function<void( dialogue &, double )> ( * )( char scope,
-                std::vector<diag_value> const &, diag_kwargs const & );
+    using f_t = diag_assign_dbl_f( * )( char scope, std::vector<diag_value> const &,
+                                        diag_kwargs const & );
 
     dialogue_func_ass( std::string_view sc_, int n_, f_t f_ )
         : dialogue_func( sc_, n_ ), f( f_ ) {}

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -71,7 +71,7 @@ double diag_value::dbl() const
     return _diag_value_at_parse_time<double>( data );
 }
 
-double diag_value::dbl( dialogue const &d ) const
+double diag_value::dbl( const_dialogue const &d ) const
 {
     return std::visit( overloaded{
         []( std::monostate const &/* std */ )
@@ -101,8 +101,7 @@ double diag_value::dbl( dialogue const &d ) const
         },
         [&d]( math_exp const & v )
         {
-            // FIXME: maybe re-constify eval paths?
-            return v.eval( const_cast<dialogue &>( d ) );
+            return v.eval( d );
         },
         []( diag_array const & )
         {
@@ -123,7 +122,7 @@ std::string_view diag_value::str() const
     return _diag_value_at_parse_time<std::string, std::string_view>( data );
 }
 
-std::string diag_value::str( dialogue const &d ) const
+std::string diag_value::str( const_dialogue const &d ) const
 {
     return std::visit( overloaded{
         []( std::monostate const &/* std */ )
@@ -146,7 +145,7 @@ std::string diag_value::str( dialogue const &d ) const
         [&d]( math_exp const & v )
         {
             // NOLINTNEXTLINE(cata-translate-string-literal)
-            return string_format( "%g", v.eval( const_cast<dialogue &>( d ) ) );
+            return string_format( "%g", v.eval( d ) );
         },
         []( diag_array const & )
         {
@@ -167,7 +166,7 @@ var_info diag_value::var() const
     return _diag_value_at_parse_time<var_info>( data );
 }
 
-var_info diag_value::var( dialogue const &/* d */ ) const
+var_info diag_value::var( const_dialogue const &/* d */ ) const
 {
     return _diag_value_at_parse_time<var_info, var_info const &, true>( data );
 }
@@ -187,7 +186,7 @@ diag_array const &diag_value::array() const
     return _diag_value_at_parse_time<diag_array, diag_array const &>( data );
 }
 
-diag_array const &diag_value::array( dialogue const &/* d */ ) const
+diag_array const &diag_value::array( const_dialogue const &/* d */ ) const
 {
     return _diag_value_at_parse_time<diag_array, diag_array const &, true>( data );
 }

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -12,7 +12,7 @@
 #include "math_parser.h"
 
 class math_exp;
-struct dialogue;
+struct const_dialogue;
 struct diag_value;
 using diag_array = std::vector<diag_value>;
 
@@ -68,10 +68,10 @@ struct diag_value {
 
     // evaluate and possibly convert the parameter to this type.
     // These do not throw and they're meant to be used at runtime
-    double dbl( dialogue const &d ) const;
-    std::string str( dialogue const &d ) const;
-    var_info var( dialogue const &/* d */ ) const;
-    diag_array const &array( dialogue const &/* d */ ) const;
+    double dbl( const_dialogue const &d ) const;
+    std::string str( const_dialogue const &d ) const;
+    var_info var( const_dialogue const &/* d */ ) const;
+    diag_array const &array( const_dialogue const &/* d */ ) const;
 
     impl_t data;
 };

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -172,6 +172,7 @@ constexpr double thingie::eval( const_dialogue const &d ) const
         {
             return v;
         },
+        // NOLINTNEXTLINE(cata-use-string_view)
         []( std::string const & v )
         {
             debugmsg( "Unexpected string operand %s", v );
@@ -187,17 +188,12 @@ constexpr double thingie::eval( const_dialogue const &d ) const
             debugmsg( "Unexpected array" );
             return 0.0;
         },
-        [&d]( auto const & v ) -> double {
-            if constexpr( has_eval<decltype( v )>::value )
-            {
-                return v.eval( d );
-            } else
-            {
-                debugmsg( "thingie::eval(): unhandled type: %s", typeid( v ).name() );
-                return 0.0;
-            }
-        }
-    }, data );
+        [&d]( auto const & v ) -> double
+        {
+            return v.eval( d );
+        },
+    },
+    data );
 }
 
 using op_t =

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -62,7 +62,7 @@ struct thingie;
 struct oper {
     oper( thingie l_, thingie r_, binary_op::f_t op_ );
 
-    double eval( dialogue &d ) const;
+    double eval( const_dialogue const &d ) const;
 
     std::shared_ptr<thingie> l, r;
     binary_op::f_t op{};
@@ -70,7 +70,7 @@ struct oper {
 struct func {
     explicit func( std::vector<thingie> &&params_, math_func::f_t f_ );
 
-    double eval( dialogue &d ) const;
+    double eval( const_dialogue const &d ) const;
 
     std::vector<thingie> params;
     math_func::f_t f{};
@@ -78,27 +78,27 @@ struct func {
 struct func_jmath {
     explicit func_jmath( std::vector<thingie> &&params_, jmath_func_id const &id_ );
 
-    double eval( dialogue &d ) const;
+    double eval( const_dialogue const &d ) const;
 
     std::vector<thingie> params;
     jmath_func_id id;
 };
 
 struct func_diag_eval {
-    using eval_f = std::function<double( dialogue & )>;
+    using eval_f = diag_eval_dbl_f;
     explicit func_diag_eval( eval_f &&f_ ) : f( f_ ) {}
 
-    double eval( dialogue &d ) const {
+    double eval( const_dialogue const &d ) const {
         return f( d );
     }
 
     eval_f f;
 };
 struct func_diag_ass {
-    using ass_f = std::function<void( dialogue &, double )>;
+    using ass_f = diag_assign_dbl_f;
     explicit func_diag_ass( ass_f &&f_ ) : f( f_ ) {}
 
-    static double eval( dialogue &/* d */ )  {
+    static double eval( const_dialogue const &/* d */ )  {
         debugmsg( "eval() called on assignment function" );
         return 0;
     }
@@ -113,7 +113,7 @@ struct var {
     template<class... Args>
     explicit var( Args &&... args ) : varinfo( std::forward<Args>( args )... ) {}
 
-    double eval( dialogue &d ) const;
+    double eval( const_dialogue const &d ) const;
 
     var_info varinfo;
 };
@@ -134,7 +134,7 @@ struct ternary {
     std::shared_ptr<thingie> mhs;
     std::shared_ptr<thingie> rhs;
 
-    double eval( dialogue &d ) const;
+    double eval( const_dialogue const &d ) const;
 };
 struct thingie {
     thingie() = default;
@@ -146,7 +146,7 @@ struct thingie {
     explicit thingie( std::in_place_type_t<T> /*t*/, Args &&...args )
         : data( std::in_place_type<T>, std::forward<Args>( args )... ) {}
 
-    constexpr double eval( dialogue &d ) const;
+    constexpr double eval( const_dialogue const &d ) const;
 
     using impl_t = std::variant <
                    double,
@@ -164,12 +164,8 @@ struct thingie {
 
     impl_t data;
 };
-template<typename T, typename = void>
-struct has_eval : std::false_type {};
-template<typename T>
-struct has_eval<T, std::void_t<decltype( std::declval<const T>().eval( std::declval<dialogue &>() ) )>> :
-std::true_type {};
-constexpr double thingie::eval( dialogue &d ) const
+
+constexpr double thingie::eval( const_dialogue const &d ) const
 {
     return std::visit( overloaded{
         []( double v )

--- a/src/math_parser_jmath.cpp
+++ b/src/math_parser_jmath.cpp
@@ -69,16 +69,16 @@ void jmath_func::finalize()
     }
 }
 
-double jmath_func::eval( dialogue &d ) const
+double jmath_func::eval( const_dialogue const &d ) const
 {
     return _exp.eval( d );
 }
 
-double jmath_func::eval( dialogue &d, std::vector<double> const &params ) const
+double jmath_func::eval( const_dialogue const &d, std::vector<double> const &params ) const
 {
-    dialogue d_next( d );
+    const_dialogue d_next( d );
     for( std::vector<double>::size_type i = 0; i < params.size(); i++ ) {
-        write_var_value( var_type::context, "npctalk_var_" + std::to_string( i ), &d_next, params[i] );
+        d_next.set_value( "npctalk_var_" + std::to_string( i ), string_format( "%g", params[i] ) );
     }
 
     return eval( d_next );

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -18,8 +18,8 @@ struct jmath_func {
     bool was_loaded = false;
     int num_params{};
 
-    double eval( dialogue &d ) const;
-    double eval( dialogue &d, std::vector<double> const &params ) const;
+    double eval( const_dialogue const &d ) const;
+    double eval( const_dialogue const &d, std::vector<double> const &params ) const;
 
     void load( const JsonObject &jo, std::string_view src );
     static void load_func( const JsonObject &jo, std::string const &src );

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -31,7 +31,7 @@ class mattack_actor
         dbl_or_var cooldown;
 
         // Dialogue conditions of the attack
-        std::function<bool( dialogue & )> condition;
+        std::function<bool( const_dialogue const & )> condition;
         bool has_condition = false;
 
         void load( const JsonObject &jo, const std::string &src );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1551,7 +1551,7 @@ void Character::roll_damage( const damage_type_id &dt, bool crit, damage_instanc
 }
 std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_technique(
     Creature &t, const item_location &weap, bool crit,
-    bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist )
+    bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist ) const
 {
     const std::vector<matec_id> all = martial_arts_data->get_all_techniques( weap, *this );
 
@@ -1608,7 +1608,7 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
 std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
         Character::evaluate_technique( const matec_id &tec_id, Creature &t, const item_location &weap,
                                        std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> &fallbacks,
-                                       bool crit, bool dodge_counter, bool block_counter )
+                                       bool crit, bool dodge_counter, bool block_counter ) const
 {
     // this could be more robust but for now it should work fine
     bool is_loaded = weap && weap->is_magazine_full();
@@ -1754,14 +1754,14 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     return std::nullopt;
 }
 
-bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique )
+bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique ) const
 {
     std::vector<Creature *> dummy_targets;
     return valid_aoe_technique( t, technique, dummy_targets );
 }
 
 bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
-                                     std::vector<Creature *> &targets )
+                                     std::vector<Creature *> &targets ) const
 {
     if( technique.aoe.empty() ) {
         return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1550,7 +1550,7 @@ void Character::roll_damage( const damage_type_id &dt, bool crit, damage_instanc
     }
 }
 std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_technique(
-    Creature &t, const item_location &weap, bool crit,
+    Creature const &t, const item_location &weap, bool crit,
     bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist ) const
 {
     const std::vector<matec_id> all = martial_arts_data->get_all_techniques( weap, *this );
@@ -1606,7 +1606,7 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
     }
 }
 std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
-        Character::evaluate_technique( const matec_id &tec_id, Creature &t, const item_location &weap,
+        Character::evaluate_technique( const matec_id &tec_id, Creature const &t, const item_location &weap,
                                        std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> &fallbacks,
                                        bool crit, bool dodge_counter, bool block_counter ) const
 {
@@ -1627,7 +1627,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
 
     // Ignore this technique if we fail the dialog conditions
     if( tec_id->has_condition ) {
-        dialogue d( get_talker_for( this ), get_talker_for( t ) );
+        const_dialogue d( get_const_talker_for( *this ), get_const_talker_for( t ) );
         if( !tec_id->condition( d ) ) {
             add_msg_debug( debugmode::DF_MELEE, "Conditionals failed, attack discarded" );
             return std::nullopt;
@@ -1754,13 +1754,13 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     return std::nullopt;
 }
 
-bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique ) const
+bool Character::valid_aoe_technique( Creature const &t, const ma_technique &technique ) const
 {
     std::vector<Creature *> dummy_targets;
     return valid_aoe_technique( t, technique, dummy_targets );
 }
 
-bool Character::valid_aoe_technique( Creature &t, const ma_technique &technique,
+bool Character::valid_aoe_technique( Creature const &t, const ma_technique &technique,
                                      std::vector<Creature *> &targets ) const
 {
     if( technique.aoe.empty() ) {

--- a/src/mission.h
+++ b/src/mission.h
@@ -229,7 +229,7 @@ struct mission_type {
         std::map<std::string, translation> dialogue;
 
         // A dynamic goal condition invoked by MGOAL_CONDITION.
-        std::function<bool( struct dialogue & )> goal_condition;
+        std::function<bool( const_dialogue const & )> goal_condition;
 
         mission_type() = default;
 

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -113,7 +113,7 @@ struct mut_personality_score {
 struct reflex_activation_data {
 
     /**What variable controls the activation*/
-    std::function<bool( dialogue & )>trigger;
+    std::function<bool( const_dialogue const & )>trigger;
 
     std::pair<translation, game_message_type> msg_on;
     std::pair<translation, game_message_type> msg_off;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1823,7 +1823,7 @@ void npc::on_attacked( const Creature &attacker )
     }
 }
 
-int npc::assigned_missions_value()
+int npc::assigned_missions_value() const
 {
     int ret = 0;
     for( ::mission *m : chatbin.missions_assigned ) {

--- a/src/npc.h
+++ b/src/npc.h
@@ -89,9 +89,10 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
                  const itype_id &item_type = itype_id::NULL_ID() );
 
 void parse_tags( std::string &phrase, const Character &u, const Character &me,
-                 const dialogue &d, const itype_id &item_type = itype_id::NULL_ID() );
+                 const_dialogue const &d, const itype_id &item_type = itype_id::NULL_ID() );
 
-void parse_tags( std::string &phrase, const talker &u, const talker &me, const dialogue &d,
+void parse_tags( std::string &phrase, const_talker const &u, const_talker const &me,
+                 const_dialogue const &d,
                  const itype_id &item_type = itype_id::NULL_ID() );
 
 /*

--- a/src/npc.h
+++ b/src/npc.h
@@ -881,7 +881,7 @@ class npc : public Character
         * towards the player.
         */
         void on_attacked( const Creature &attacker );
-        int assigned_missions_value();
+        int assigned_missions_value() const;
         // State checks
         // We want to kill/mug/etc the player
         bool is_enemy() const;

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -184,7 +184,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
         if( !critter ) {
             // no critter? no damage! however, we assume fields are worth something
             if( attack_spell_id->field ) {
-                dialogue d( get_talker_for( source ), nullptr );
+                const_dialogue d( get_const_talker_for( source ), nullptr );
                 total_potential += static_cast<double>( attack_spell.field_intensity( source ) ) /
                                    static_cast<double>( attack_spell_id->field_chance.evaluate( d ) ) / 2.0;
             }

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -191,7 +191,7 @@ static distribution load_distribution( const JsonObject &jo, const std::string_v
 
 bool shopkeeper_item_group::can_sell( npc const &guy ) const
 {
-    dialogue temp( get_talker_for( get_avatar() ), get_talker_for( guy ) );
+    const_dialogue temp( get_const_talker_for( get_avatar() ), get_const_talker_for( guy ) );
     faction *const fac = guy.get_faction();
 
     return ( fac == nullptr || trust <= guy.get_faction()->trusts_u ) &&

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -15,7 +15,7 @@ class npc;
 class JsonObject;
 class Trait_group;
 
-struct dialogue;
+struct const_dialogue;
 struct faction_price_rule;
 
 namespace trait_group
@@ -52,7 +52,7 @@ struct shopkeeper_item_group {
     int trust = 0;
     bool strict = false;
     translation refusal;
-    std::function<bool( dialogue & )> condition;
+    std::function<bool( const_dialogue const & )> condition;
 
     // Rigid shopkeeper groups will be processed a single time. Default groups are not rigid, and will be processed until the shopkeeper has no more room or remaining value to populate goods with.
     bool rigid = false;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2230,8 +2230,8 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
 {
     phrase = SNIPPET.expand( phrase );
 
-    const Character *u_chr = u.get_character();
-    const Character *me_chr = me.get_character();
+    const Character *u_chr = u.get_const_character();
+    const Character *me_chr = me.get_const_character();
     size_t fa;
     size_t fb;
     size_t fa_;
@@ -4542,7 +4542,7 @@ talk_effect_fun_t::func f_message( const JsonObject &jo, std::string_view member
         if( global ) {
             target = &get_player_character();
         } else {
-            target = static_cast<talker const *>( d.actor( is_npc ) )->get_character();
+            target = d.actor( is_npc )->get_const_character();
         }
         if( !target || target->is_npc() ) {
             return;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4699,16 +4699,8 @@ talk_effect_fun_t::func f_open_dialogue( const JsonObject &jo, std::string_view 
         } else if( !actual_topic.empty() ) {
             get_avatar().talk_to( get_talker_for( std::vector<std::string> { actual_topic } ), false, false,
                                   true );
-        } else if( d.actor( true )->get_character() != nullptr ) {
-            get_avatar().talk_to( get_talker_for( d.actor( true )->get_character() ) );
-        } else if( d.actor( true )->get_creature() != nullptr ) {
-            get_avatar().talk_to( get_talker_for( d.actor( true )->get_creature() ) );
-        } else if( d.actor( true )->get_monster() != nullptr ) {
-            get_avatar().talk_to( get_talker_for( d.actor( true )->get_monster() ) );
-        } else if( d.actor( true )->get_item() != nullptr ) {
-            get_avatar().talk_to( get_talker_for( d.actor( true )->get_item() ) );
-        } else if( d.actor( true )->get_computer() != nullptr ) {
-            get_avatar().talk_to( get_talker_for( d.actor( true )->get_computer() ), false, true );
+        } else {
+            get_avatar().talk_to( d.actor( true )->clone() );
         }
         run_eoc_vector( true_eocs, d );
     };

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -185,7 +185,7 @@ struct item_search_data {
     bool wielded_only;
     bool held_only;
 
-    std::function<bool( dialogue & )> condition;
+    std::function<bool( const_dialogue const & )> condition;
     bool has_condition = false;
 
     explicit item_search_data( const JsonObject &jo ) {
@@ -256,7 +256,7 @@ struct item_search_data {
         held_only = jo.get_bool( "held_only", false );
     }
 
-    bool check( const Character *guy, const item_location &loc, const dialogue &d ) {
+    bool check( const Character *guy, const item_location &loc, const_dialogue const &d ) {
 
         bool match;
 
@@ -373,7 +373,7 @@ struct item_search_data {
         }
 
         if( has_condition ) {
-            dialogue dial( d.actor( false )->clone(), get_talker_for( loc ) );
+            const_dialogue dial( d.const_actor( false )->const_clone(), get_const_talker_for( loc ) );
             if( !condition( dial ) ) {
                 return false;
             }
@@ -1753,7 +1753,7 @@ talk_response &dialogue::add_response( const std::string &text, const std::strin
 {
     talk_response result = talk_response();
     result.truetext = no_translation( text );
-    result.truefalse_condition = []( const dialogue & ) {
+    result.truefalse_condition = []( const_dialogue const & ) {
         return true;
     };
     result.success.next_topic = talk_topic( r );
@@ -2045,13 +2045,13 @@ void dialogue::gen_responses( const talk_topic &the_topic )
     }
 }
 
-static int parse_mod( const dialogue &d, const std::string &attribute, const int factor )
+static int parse_mod( const_dialogue const &d, const std::string &attribute, const int factor )
 {
-    return d.actor( true )->parse_mod( attribute, factor ) + d.actor( false )->parse_mod( attribute,
-            factor );
+    return d.const_actor( true )->parse_mod( attribute, factor ) +
+           d.const_actor( false )->parse_mod( attribute, factor );
 }
 
-static int total_price( const talker &seller, const itype_id &item_type )
+static int total_price( const_talker const &seller, const itype_id &item_type )
 {
     int price = 0;
     item tmp( item_type );
@@ -2070,9 +2070,9 @@ static int total_price( const talker &seller, const itype_id &item_type )
     return price;
 }
 
-int talk_trial::calc_chance( dialogue &d ) const
+int talk_trial::calc_chance( const_dialogue const &d ) const
 {
-    if( d.actor( false )->has_trait( trait_DEBUG_MIND_CONTROL ) ) {
+    if( d.const_actor( false )->has_trait( trait_DEBUG_MIND_CONTROL ) ) {
         return 100;
     }
     int chance = difficulty;
@@ -2084,21 +2084,23 @@ int talk_trial::calc_chance( dialogue &d ) const
             chance = 100;
             break;
         case TALK_TRIAL_SKILL_CHECK:
-            chance = d.actor( false )->get_skill_level( skill_id( skill_required ) ) >= difficulty ? 100 : 0;
+            chance = d.const_actor( false )->get_skill_level( skill_id( skill_required ) ) >= difficulty ? 100 :
+                     0;
             break;
         case TALK_TRIAL_CONDITION:
             chance = condition( d ) ? 100 : 0;
             break;
         case TALK_TRIAL_LIE:
-            chance += d.actor( false )->trial_chance_mod( "lie" ) + d.actor( true )->trial_chance_mod( "lie" );
+            chance += d.const_actor( false )->trial_chance_mod( "lie" ) + d.const_actor(
+                          true )->trial_chance_mod( "lie" );
             break;
         case TALK_TRIAL_PERSUADE:
-            chance += d.actor( false )->trial_chance_mod( "persuade" ) +
-                      d.actor( true )->trial_chance_mod( "persuade" );
+            chance += d.const_actor( false )->trial_chance_mod( "persuade" ) +
+                      d.const_actor( true )->trial_chance_mod( "persuade" );
             break;
         case TALK_TRIAL_INTIMIDATE:
-            chance += d.actor( false )->trial_chance_mod( "intimidate" ) +
-                      d.actor( true )->trial_chance_mod( "intimidate" );
+            chance += d.const_actor( false )->trial_chance_mod( "intimidate" ) +
+                      d.const_actor( true )->trial_chance_mod( "intimidate" );
             break;
     }
     for( const auto &this_mod : modifiers ) {
@@ -2215,17 +2217,19 @@ int topic_category( const talk_topic &the_topic )
 void parse_tags( std::string &phrase, const Character &u, const Character &me,
                  const itype_id &item_type )
 {
-    dialogue d( get_talker_for( u ), get_talker_for( me ) );
+    const_dialogue d( get_const_talker_for( u ), get_const_talker_for( me ) );
     parse_tags( phrase, u, me, d, item_type );
 }
 
-void parse_tags( std::string &phrase, const Character &u, const Character &me, const dialogue &d,
+void parse_tags( std::string &phrase, const Character &u, const Character &me,
+                 const_dialogue const &d,
                  const itype_id &item_type )
 {
-    parse_tags( phrase, *get_talker_for( u ), *get_talker_for( me ), d, item_type );
+    parse_tags( phrase, *get_const_talker_for( u ), *get_const_talker_for( me ), d, item_type );
 }
 
-void parse_tags( std::string &phrase, const talker &u, const talker &me, const dialogue &d,
+void parse_tags( std::string &phrase, const_talker const &u, const_talker const &me,
+                 const_dialogue const &d,
                  const itype_id &item_type )
 {
     phrase = SNIPPET.expand( phrase );
@@ -2452,51 +2456,51 @@ void dialogue::add_topic( const talk_topic &topic )
     }
 }
 
-void dialogue::set_value( const std::string &key, const std::string &value )
+void const_dialogue::set_value( const std::string &key, const std::string &value )
 {
     context[key] = value;
 }
 
-void dialogue::remove_value( const std::string &key )
+void const_dialogue::remove_value( const std::string &key )
 {
     context->erase( key );
 }
 
-std::string dialogue::get_value( const std::string &key ) const
+std::string const_dialogue::get_value( const std::string &key ) const
 {
     return maybe_get_value( key ).value_or( std::string{} );
 }
 
-std::optional<std::string> dialogue::maybe_get_value( const std::string &key ) const
+std::optional<std::string> const_dialogue::maybe_get_value( const std::string &key ) const
 {
     auto it = context->find( key );
     return it == context->end() ? std::nullopt : std::optional<std::string> { it->second };
 }
 
-void dialogue::set_conditional( const std::string &key,
-                                const std::function<bool( dialogue & )> &value )
+void const_dialogue::set_conditional( const std::string &key,
+                                      const std::function<bool( const_dialogue const & )> &value )
 {
     conditionals[key] = value;
 }
 
-bool dialogue::evaluate_conditional( const std::string &key, dialogue &d )
+bool const_dialogue::evaluate_conditional( const std::string &key, const_dialogue const &d ) const
 {
     auto it = conditionals->find( key );
     return ( it == conditionals->end() ) ? false : it->second( d );
 }
 
-const std::unordered_map<std::string, std::string> &dialogue::get_context() const
+const std::unordered_map<std::string, std::string> &const_dialogue::get_context() const
 {
     return context;
 }
 
-const std::unordered_map<std::string, std::function<bool( dialogue & )>>
-        &dialogue::get_conditionals() const
+const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>>
+        &const_dialogue::get_conditionals() const
 {
     return conditionals;
 }
 
-void dialogue::amend_callstack( const std::string &value )
+void const_dialogue::amend_callstack( const std::string &value )
 {
     if( !callstack.empty() ) {
         callstack += " \\ " + value;
@@ -2505,12 +2509,22 @@ void dialogue::amend_callstack( const std::string &value )
     }
 }
 
-std::string dialogue::get_callstack() const
+std::string const_dialogue::get_callstack() const
 {
     if( !callstack.empty() ) {
         return "Callstack: " + callstack;
     }
     return "";
+}
+
+const_talker *const_dialogue::const_actor( bool is_beta ) const
+{
+    if( !has_beta && is_beta ) {
+        debugmsg( "Tried to use an invalid beta talker.  %s", get_callstack() );
+    } else if( !has_alpha && !is_beta ) {
+        debugmsg( "Tried to use an invalid alpha talker.  %s", get_callstack() );
+    }
+    return ( is_beta ? beta : alpha ).get();
 }
 
 talker *dialogue::actor( const bool is_beta ) const
@@ -2535,18 +2549,19 @@ talker *dialogue::actor( const bool is_beta ) const
     return ( is_beta ? beta : alpha ).get();
 }
 
-bool dialogue::has_actor( bool is_beta ) const
+bool const_dialogue::has_actor( bool is_beta ) const
 {
     return is_beta ? has_beta : has_alpha;
 }
 
-dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.has_alpha )
+const_dialogue::const_dialogue( const const_dialogue &d )
+    : has_beta( d.has_beta ), has_alpha( d.has_alpha )
 {
     if( has_alpha ) {
-        alpha = d.actor( false )->clone();
+        alpha = d.const_actor( false )->const_clone();
     }
     if( has_beta ) {
-        beta = d.actor( true )->clone();
+        beta = d.const_actor( true )->const_clone();
     }
     if( !has_alpha && !has_beta ) {
         debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
@@ -2560,40 +2575,38 @@ dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.h
     callstack = d.callstack;
 }
 
-dialogue::dialogue( std::unique_ptr<talker> alpha_in,
-                    std::unique_ptr<talker> beta_in ) : alpha( std::move( alpha_in ) ), beta( std::move( beta_in ) )
+dialogue::dialogue( const dialogue &d ) : const_dialogue( d )
 {
-    has_alpha = alpha != nullptr;
-    has_beta = beta != nullptr;
-    if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
+    if( has_alpha ) {
+        alpha = d.actor( false )->clone();
+    }
+    if( has_beta ) {
+        beta = d.actor( true )->clone();
     }
 }
 
-dialogue::dialogue( std::unique_ptr<talker> alpha_in,
-                    std::unique_ptr<talker> beta_in,
-                    const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond ) : alpha( std::move(
-                                    alpha_in ) ), beta( std::move( beta_in ) ), conditionals( cond )
+dialogue::dialogue( const_dialogue const &d ) : const_dialogue( d )
 {
-    has_alpha = alpha != nullptr;
-    has_beta = beta != nullptr;
-    if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
-    }
 }
 
-dialogue::dialogue( std::unique_ptr<talker> alpha_in,
-                    std::unique_ptr<talker> beta_in,
-                    const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
-                    const std::unordered_map<std::string, std::string> &ctx ) : alpha( std::move( alpha_in ) ),
-    beta( std::move( beta_in ) ), context( ctx ), conditionals( cond )
+const_dialogue::const_dialogue( std::unique_ptr<const_talker> alpha_in,
+                                std::unique_ptr<const_talker> beta_in,
+                                const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>> &cond,
+                                const std::unordered_map<std::string, std::string> &ctx )
+    : alpha( std::move( alpha_in ) ), beta( std::move( beta_in ) ), context( ctx ), conditionals( cond )
 {
-    has_alpha = alpha != nullptr;
-    has_beta = beta != nullptr;
+    has_alpha = static_cast<bool>( alpha );
+    has_beta = static_cast<bool>( beta );
+}
 
-    if( !has_alpha && !has_beta ) {
-        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
-    }
+dialogue::dialogue(
+    std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in,
+    const std::unordered_map<std::string, std::function<bool( const_dialogue const & )>> &cond,
+    const std::unordered_map<std::string, std::string> &ctx )
+    : const_dialogue( alpha_in ? alpha_in->const_clone() : nullptr,
+                      beta_in ? beta_in->const_clone() : nullptr, cond, ctx ),
+      alpha( std::move( alpha_in ) ), beta( std::move( beta_in ) )
+{
 }
 
 talk_data talk_response::create_option_line( dialogue &d, const input_event &hotkey,
@@ -2995,8 +3008,8 @@ static void run_item_eocs( const dialogue &d, bool is_npc, const std::vector<ite
         for( const effect_on_condition_id &eoc : eocs ) {
             // Check if item is outdated.
             if( loc.get_item() ) {
-                dialogue newDialog = dialogue( d.actor( is_npc )->clone(), get_talker_for( loc ),
-                                               d.get_conditionals(), d.get_context() );
+                dialogue newDialog( d.actor( is_npc )->clone(), get_talker_for( loc ),
+                                    d.get_conditionals(), d.get_context() );
                 eoc->activate( newDialog );
             }
         }
@@ -4998,7 +5011,7 @@ talk_effect_fun_t::func f_set_condition( const JsonObject &jo, std::string_view 
     str_or_var value;
     value = get_str_or_var( jo.get_member( member ), member );
 
-    std::function<bool( dialogue & )> cond;
+    std::function<bool( const_dialogue const & )> cond;
     read_condition( jo, "condition", cond, false );
     return [value, cond]( dialogue & d ) {
         d.set_conditional( value.evaluate( d ), cond );
@@ -5377,9 +5390,9 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
     if( jo.has_member( "iterations" ) ) {
         iterations = get_dbl_or_var( jo, "iterations" );
     }
-    std::optional<std::function<bool( dialogue & )>> cond;
+    std::optional<std::function<bool( const_dialogue const & )>> cond;
     if( jo.has_object( "condition" ) ) {
-        std::function<bool( dialogue & )> cond_;
+        std::function<bool( const_dialogue const & )> cond_;
         read_condition( jo, "condition", cond_, false );
         cond = { std::move( cond_ ) };
     }
@@ -5793,7 +5806,7 @@ talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view m
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
-    std::function<bool( dialogue & )> cond;
+    std::function<bool( const_dialogue const & )> cond;
     read_condition( jo, "condition", cond, true );
     dbl_or_var range = get_dbl_or_var( jo, "range", false, 1 );
 
@@ -5871,7 +5884,7 @@ talk_effect_fun_t::func f_weighted_list_eocs( const JsonObject &jo,
 talk_effect_fun_t::func f_if( const JsonObject &jo, std::string_view member,
                               const std::string_view src )
 {
-    std::function<bool( dialogue & )> cond;
+    std::function<bool( const_dialogue const & )> cond;
     talk_effect_t then_effect;
     talk_effect_t else_effect;
     read_condition( jo, std::string( member ), cond, false );
@@ -7133,7 +7146,7 @@ void talk_effect_t::load_effect( const JsonObject &jo, const std::string &member
 
 talk_response::talk_response()
 {
-    truefalse_condition = []( const dialogue & ) {
+    truefalse_condition = []( const_dialogue const & ) {
         return true;
     };
     mission_selected = nullptr;
@@ -7156,7 +7169,7 @@ talk_response::talk_response( const JsonObject &jo, const std::string_view src )
         truefalse_jo.read( "false", falsetext );
     } else {
         jo.read( "text", truetext );
-        truefalse_condition = []( const dialogue & ) {
+        truefalse_condition = []( const_dialogue const & ) {
             return true;
         };
     }
@@ -7483,7 +7496,7 @@ dynamic_line_t::dynamic_line_t( const JsonArray &ja )
 json_dynamic_line_effect::json_dynamic_line_effect( const JsonObject &jo,
         const std::string &id, const std::string_view src )
 {
-    std::function<bool( dialogue & )> tmp_condition;
+    std::function<bool( const_dialogue const & )> tmp_condition;
     read_condition( jo, "condition", tmp_condition, true );
     talk_effect_t tmp_effect = talk_effect_t( jo, "effect", src );
     // if the topic has a sentinel, it means implicitly add a check for the sentinel value

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -144,7 +144,7 @@ static void foamcrete_build( const tripoint_bub_ms &p )
     }
 }
 
-void apply_ammo_effects( const Creature *source, const tripoint_bub_ms &p,
+void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
                          const std::set<ammo_effect_str_id> &effects, const int dealt_damage )
 {
     map &here = get_map();

--- a/src/projectile.h
+++ b/src/projectile.h
@@ -74,7 +74,7 @@ struct dealt_projectile_attack {
     double missed_by; // Accuracy of dealt attack
 };
 
-void apply_ammo_effects( const Creature *source, const tripoint_bub_ms &p,
+void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
                          const std::set<ammo_effect_str_id> &effects, int dealt_damage );
 int max_aoe_size( const std::set<ammo_effect_str_id> &tags );
 

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -25,7 +25,7 @@ bool icg_entry::operator==( icg_entry const &rhs ) const
 
 bool icg_entry::matches( item const &it, npc const &beta ) const
 {
-    dialogue temp( get_talker_for( get_avatar() ), get_talker_for( beta ) );
+    const_dialogue temp( get_const_talker_for( get_avatar() ), get_const_talker_for( beta ) );
     return ( !condition || condition( temp ) ) &&
            ( itype.is_empty() || it.typeId() == itype ) &&
            ( category.is_empty() || it.get_category_shallow().id == category ) &&

--- a/src/shop_cons_rate.h
+++ b/src/shop_cons_rate.h
@@ -8,7 +8,7 @@
 
 class JsonObject;
 class npc;
-struct dialogue;
+struct const_dialogue;
 
 constexpr char const *SHOPKEEPER_CONSUMPTION_RATES = "shopkeeper_consumption_rates";
 constexpr char const *SHOPKEEPER_BLACKLIST = "shopkeeper_blacklist";
@@ -19,7 +19,7 @@ struct icg_entry {
     item_group_id item_group;
     translation message;
 
-    std::function<bool( dialogue & )> condition;
+    std::function<bool( const_dialogue const & )> condition;
 
     bool operator==( icg_entry const &rhs ) const;
     bool matches( item const &it, npc const &beta ) const;

--- a/src/talker.h
+++ b/src/talker.h
@@ -37,48 +37,36 @@ using bodytype_id = std::string;
  * Talker is a virtual abstract class and should never really be used.  Instead,
  * entity specific talker child classes such as character_talker should be used.
  */
-class talker
+class const_talker
 {
     public:
-        virtual ~talker() = default;
-        virtual std::unique_ptr<talker> clone() const {
-            return std::make_unique<talker>();
+        const_talker() = default;
+        const_talker( const const_talker & ) = default;
+        const_talker( const_talker && ) = delete;
+        const_talker &operator=( const const_talker & ) = default;
+        const_talker &operator=( const_talker && ) = delete;
+        virtual ~const_talker() = default;
+
+        virtual std::unique_ptr<const_talker> const_clone() const {
+            return std::make_unique<const_talker>();
         }
         // virtual member accessor functions
-        virtual Character *get_character() {
+        virtual Character const *get_const_character() const {
             return nullptr;
         }
-        virtual const Character *get_character() const {
+        virtual npc const *get_const_npc() const {
             return nullptr;
         }
-        virtual npc *get_npc() {
+        virtual item_location const *get_const_item() const {
             return nullptr;
         }
-        virtual npc *get_npc() const {
+        virtual monster const *get_const_monster() const {
             return nullptr;
         }
-        virtual item_location *get_item() {
+        virtual Creature const *get_const_creature() const {
             return nullptr;
         }
-        virtual item_location const *get_item() const {
-            return nullptr;
-        }
-        virtual monster *get_monster() {
-            return nullptr;
-        }
-        virtual const monster *get_monster() const {
-            return nullptr;
-        }
-        virtual Creature *get_creature() {
-            return nullptr;
-        }
-        virtual const Creature *get_creature() const {
-            return nullptr;
-        }
-        virtual computer *get_computer() {
-            return nullptr;
-        }
-        virtual const computer *get_computer() const {
+        virtual computer const *get_const_computer() const {
             return nullptr;
         }
         // identity and location
@@ -115,20 +103,17 @@ class talker
         virtual tripoint_abs_omt global_omt_location() const {
             return {};
         }
-        virtual void set_pos( tripoint ) {}
         virtual std::string distance_to_goal() const {
             return "";
         }
 
         // mandatory functions for starting a dialogue
-        virtual bool will_talk_to_u( const Character &, bool ) {
+        virtual bool will_talk_to_u( const Character &, bool ) const {
             return false;
         }
-        virtual std::vector<std::string> get_topics( bool ) {
+        virtual std::vector<std::string> get_topics( bool ) const {
             return {};
         }
-        virtual void check_missions() {}
-        virtual void update_missions( const std::vector<mission *> & ) {}
         virtual bool check_hostile_response( int ) const {
             return false;
         }
@@ -167,14 +152,6 @@ class talker
         virtual int per_cur() const {
             return 0;
         }
-        virtual void set_str_max( int ) {}
-        virtual void set_dex_max( int ) {}
-        virtual void set_int_max( int ) {}
-        virtual void set_per_max( int ) {}
-        virtual void set_str_bonus( int ) {}
-        virtual void set_dex_bonus( int ) {}
-        virtual void set_int_bonus( int ) {}
-        virtual void set_per_bonus( int ) {}
         virtual int get_str_max() const {
             return 0;
         }
@@ -223,10 +200,6 @@ class talker
         virtual int get_spell_sum( const trait_id &, int ) const {
             return 0;
         }
-        virtual void set_spell_level( const spell_id &, int ) {}
-        virtual void set_spell_exp( const spell_id &, int ) {}
-        virtual void set_skill_level( const skill_id &, int ) {}
-        virtual void set_skill_exp( const skill_id &, int, bool ) {}
         virtual bool has_trait( const trait_id & ) const {
             return false;
         }
@@ -243,20 +216,9 @@ class talker
         virtual bool has_recipe( const recipe_id & ) const {
             return false;
         }
-        virtual void learn_recipe( const recipe_id & ) {}
-        virtual void forget_recipe( const recipe_id & ) {}
-        virtual void mutate( const int &, const bool & ) {}
         virtual int get_daily_calories( int, std::string const & ) const {
             return 0;
         }
-        virtual void mutate_category( const mutation_category_id &, const bool & ) {}
-        virtual void mutate_towards( const trait_id &, const mutation_category_id &, const bool & ) {};
-        virtual void set_mutation( const trait_id &, const mutation_variant * = nullptr ) {}
-        virtual void unset_mutation( const trait_id & ) {}
-        virtual void activate_mutation( const trait_id & ) {}
-        virtual void deactivate_mutation( const trait_id & ) {}
-        virtual void set_trait_purifiability( const trait_id &, const bool & ) {}
-        virtual void set_fatigue( int ) {};
         virtual bool has_flag( const json_character_flag & ) const {
             return false;
         }
@@ -290,9 +252,7 @@ class talker
         virtual time_duration proficiency_practiced_time( const proficiency_id & ) const {
             return 0_seconds;
         }
-        virtual void set_proficiency_practiced_time( const proficiency_id &, int ) {}
-        virtual void train_proficiency_for( const proficiency_id &, int ) {}
-        virtual std::vector<skill_id> skills_offered_to( const talker & ) const {
+        virtual std::vector<skill_id> skills_offered_to( const_talker const & ) const {
             return {};
         }
         virtual std::vector<skill_id> skills_teacheable() const {
@@ -301,47 +261,45 @@ class talker
         virtual std::string skill_seminar_text( const skill_id & ) const {
             return {};
         }
-        virtual std::string skill_training_text( const talker &, const skill_id & ) const {
+        virtual std::string skill_training_text( const_talker const &, const skill_id & ) const {
             return {};
         }
         virtual std::vector<proficiency_id> proficiencies_teacheable() const {
             return {};
         }
-        virtual std::vector<proficiency_id> proficiencies_offered_to( const talker & ) const {
+        virtual std::vector<proficiency_id> proficiencies_offered_to( const_talker const & ) const {
             return {};
         }
         virtual std::string proficiency_seminar_text( const proficiency_id & ) const {
             return {};
         }
-        virtual std::string proficiency_training_text( const talker &, const proficiency_id & ) const {
+        virtual std::string proficiency_training_text( const_talker const &,
+                const proficiency_id & ) const {
             return {};
         }
         virtual std::vector<matype_id> styles_teacheable() const {
             return {};
         }
-        virtual std::vector<matype_id> styles_offered_to( const talker & ) const {
+        virtual std::vector<matype_id> styles_offered_to( const_talker const & ) const {
             return {};
         }
         virtual std::string style_seminar_text( const matype_id & ) const {
             return {};
         }
-        virtual std::string style_training_text( const talker &, const matype_id & ) const {
+        virtual std::string style_training_text( const_talker const &, const matype_id & ) const {
             return {};
         }
         virtual std::vector<spell_id> spells_teacheable() const {
             return {};
         }
-        virtual std::vector<spell_id> spells_offered_to( talker & ) const {
+        virtual std::vector<spell_id> spells_offered_to( const_talker const & ) const {
             return {};
         }
         virtual std::string spell_seminar_text( const spell_id & ) const {
             return {};
         }
-        virtual std::string spell_training_text( talker &, const spell_id & ) const {
+        virtual std::string spell_training_text( const_talker const &, const spell_id & ) const {
             return {};
-        }
-        virtual void store_chosen_training( const skill_id &, const matype_id &,
-                                            const spell_id &, const proficiency_id & ) {
         }
 
         // effects and values
@@ -363,19 +321,12 @@ class talker
         virtual bool is_mute() const {
             return false;
         }
-        virtual void add_effect( const efftype_id &, const time_duration &, const std::string &, bool, bool,
-                                 int ) {}
-        virtual void remove_effect( const efftype_id &, const std::string & ) {}
-        virtual void add_bionic( const bionic_id & ) {}
-        virtual void remove_bionic( const bionic_id & ) {}
         virtual std::string get_value( const std::string &key ) const {
             return maybe_get_value( key ).value_or( std::string{} );
         }
         virtual std::optional<std::string> maybe_get_value( const std::string & ) const {
             return std::nullopt;
         }
-        virtual void set_value( const std::string &, const std::string & ) {}
-        virtual void remove_value( const std::string & ) {}
 
         // inventory, buying, and selling
         virtual bool is_wearing( const itype_id & ) const {
@@ -391,21 +342,11 @@ class talker
         virtual bool has_charges( const itype_id &, int, bool ) const {
             return false;
         }
-        virtual std::list<item> use_charges( const itype_id &, int ) {
-            return {};
-        }
-        // bool = match tool containing charges of itype_id
-        virtual std::list<item> use_charges( const itype_id &, int, bool ) {
-            return {};
-        }
         virtual bool has_amount( const itype_id &, int ) const {
             return false;
         }
         virtual int get_amount( const itype_id & ) const {
             return 0;
-        }
-        virtual std::list<item> use_amount( const itype_id &, int ) {
-            return {};
         }
         virtual int value( const item & ) const {
             return 0;
@@ -416,42 +357,24 @@ class talker
         virtual int debt() const {
             return 0;
         }
-        virtual void add_debt( int ) {}
         virtual int sold() const {
             return 0;
-        }
-        virtual void add_sold( int ) {}
-        virtual std::vector<item *> items_with( const std::function<bool( const item & )> & ) const {
-            return {};
         }
         virtual std::vector<const item *> const_items_with( const std::function<bool( const item & )> & )
         const {
             return {};
         }
-        virtual void i_add( const item & ) {}
-        virtual void i_add_or_drop( item &, bool = false ) {}
-        virtual void remove_items_with( const std::function<bool( const item & )> & ) {}
         virtual bool unarmed_attack() const {
             return false;
         }
         virtual bool can_stash_weapon() const {
             return false;
         }
-        virtual bool has_stolen_item( const talker & ) const {
+        virtual bool has_stolen_item( const_talker const & ) const {
             return false;
         }
         virtual int cash_to_favor( int ) const {
             return 0;
-        }
-        virtual std::string give_item_to( bool ) {
-            return _( "Nope." );
-        }
-        virtual bool buy_from( int ) {
-            return false;
-        }
-        virtual bool buy_monster( talker &, const mtype_id &, int, int, bool,
-                                  const translation & ) {
-            return false;
         }
 
         // missions
@@ -464,17 +387,11 @@ class talker
         virtual mission *selected_mission() const {
             return nullptr;
         }
-        virtual void select_mission( mission * ) {
-        }
-        virtual void add_mission( const mission_type_id & ) {}
-        virtual void set_companion_mission( const std::string & ) {}
 
         // factions and alliances
         virtual faction *get_faction() const {
             return nullptr;
         }
-        virtual void set_fac( const faction_id & ) {}
-        virtual void add_faction_rep( int ) {}
         virtual bool is_following() const {
             return false;
         }
@@ -490,23 +407,17 @@ class talker
         virtual bool is_enemy() const {
             return false;
         }
-        virtual void make_angry() {}
 
         // ai rules
         virtual bool has_ai_rule( const std::string &, const std::string & ) const {
             return false;
         }
-        virtual void toggle_ai_rule( const std::string &, const std::string & ) {}
-        virtual void set_ai_rule( const std::string &, const std::string & ) {}
-        virtual void clear_ai_rule( const std::string &, const std::string & ) {}
-
-        virtual void set_fac_relation( const Character *, npc_factions::relationship, bool ) {}
 
         // other descriptors
         virtual std::string get_job_description() const {
             return "";
         }
-        virtual std::string evaluation_by( const talker & ) const {
+        virtual std::string evaluation_by( const_talker const & ) const {
             return "";
         }
         virtual std::string view_personality_traits() const {
@@ -524,7 +435,6 @@ class talker
         virtual bool is_myclass( const npc_class_id & ) const {
             return false;
         }
-        virtual void set_class( const npc_class_id & ) {}
         virtual int get_activity_level() const {
             return 0;
         }
@@ -558,42 +468,22 @@ class talker
         virtual int get_addiction_turns( const addiction_id & ) const {
             return 0;
         }
-        virtual void set_addiction_turns( const addiction_id &, int ) {}
-        virtual void mod_stored_kcal( int, bool ) {}
-        virtual void set_stored_kcal( int ) {}
-        virtual void set_stim( int ) {}
-        virtual void set_thirst( int ) {}
         virtual bool is_in_control_of( const vehicle & ) const {
             return false;
         }
 
-        // speaking
-        virtual void say( const std::string & ) {}
-        virtual void shout( const std::string & = "", bool = false ) {}
-
-        // miscellaneous
-        virtual bool enslave_mind() {
-            return false;
-        }
         virtual std::string opinion_text() const {
             return "";
         }
-        virtual void add_opinion( const npc_opinion & ) {}
-        virtual void set_first_topic( const std::string & ) {}
         virtual bool is_safe() const {
             return true;
         }
-        virtual void mod_pain( int ) {}
-        virtual void set_pain( int ) {}
         virtual int pain_cur() const {
             return 0;
         }
         virtual int perceived_pain_cur() const {
             return 0;
         }
-        virtual void attack_target( Creature &, bool, const matec_id &,
-                                    bool, int ) {}
-
         virtual int attack_speed() const {
             return 0;
         }
@@ -637,58 +527,45 @@ class talker
         virtual units::energy power_max() const {
             return 0_kJ;
         }
-        virtual void set_power_cur( units::energy ) {}
         virtual int mana_cur() const {
             return 0;
         }
         virtual int mana_max() const {
             return 0;
         }
-        virtual void set_mana_cur( int ) {}
-        virtual void mod_daily_health( int, int ) {}
         virtual int morale_cur() const {
             return 0;
         }
         virtual int focus_cur() const {
             return 0;
         }
-        virtual void mod_focus( int ) {}
         virtual int get_pkill() const {
             return 0;
         }
-        virtual void set_pkill( int ) {}
         virtual int get_stamina() const {
             return 0;
         }
-        virtual void set_stamina( int ) {}
         virtual int get_sleep_deprivation() const {
             return 0;
         }
-        virtual void set_sleep_deprivation( int ) {}
         virtual int get_rad() const {
             return 0;
         }
-        virtual void set_rad( int ) {}
         virtual int get_anger() const {
             return 0;
         }
-        virtual void set_anger( int ) {}
-        virtual void set_morale( int ) {}
         virtual int get_friendly() const {
             return 0;
         }
-        virtual void set_friendly( int ) {}
-        virtual void add_morale( const morale_type &, int, int, time_duration, time_duration, bool ) {}
-        virtual void remove_morale( const morale_type & ) {}
-        virtual void set_kill_xp( int ) {}
+        virtual int get_difficulty() const {
+            return 0;
+        }
         virtual int get_kill_xp() const {
             return 0;
         }
-        virtual void set_age( int ) {}
         virtual int get_age() const {
             return 0;
         }
-        virtual void set_height( int ) {}
         virtual int get_height() const {
             return 0;
         }
@@ -698,19 +575,15 @@ class talker
         virtual int get_weight() const {
             return 0;
         }
-        virtual void set_npc_trust( int ) {}
         virtual int get_npc_trust() const {
             return 0;
         }
-        virtual void set_npc_fear( int ) {}
         virtual int get_npc_fear() const {
             return 0;
         }
-        virtual void set_npc_value( int ) {}
         virtual int get_npc_value() const {
             return 0;
         }
-        virtual void set_npc_anger( int ) {}
         virtual int get_npc_anger() const {
             return 0;
         }
@@ -741,15 +614,10 @@ class talker
         virtual int get_part_hp_max( const bodypart_id & ) const {
             return 0;
         }
-        virtual void set_all_parts_hp_cur( int ) const {}
-        virtual void set_part_hp_cur( const bodypart_id &, int ) const {}
-        virtual void die() {}
-        virtual matec_id get_random_technique( Creature &, bool, bool,
+        virtual matec_id get_random_technique( Creature const &, bool, bool,
                                                bool, const std::vector<matec_id> & = {} ) const {
             return matec_id();
         }
-        virtual void learn_martial_art( const matype_id & ) const {}
-        virtual void forget_martial_art( const matype_id & ) const {}
         virtual bool knows_martial_art( const matype_id & ) const {
             return false;
         }
@@ -763,8 +631,170 @@ class talker
             return 0;
         }
 };
+
+class talker: virtual public const_talker
+{
+    public:
+        talker() = default;
+        talker( const talker & ) = default;
+        talker( talker && ) = delete;
+        talker &operator=( const talker & ) = default;
+        talker &operator=( talker && ) = delete;
+        ~talker() noexcept override = default;
+
+        virtual std::unique_ptr<talker> clone() const {
+            return std::make_unique<talker>();
+        }
+
+        virtual Character *get_character() {
+            return nullptr;
+        }
+        virtual npc *get_npc() {
+            return nullptr;
+        }
+        virtual item_location *get_item() {
+            return nullptr;
+        }
+        virtual monster *get_monster() {
+            return nullptr;
+        }
+        virtual Creature *get_creature() {
+            return nullptr;
+        }
+        virtual computer *get_computer() {
+            return nullptr;
+        }
+        virtual void set_pos( tripoint ) {}
+        virtual void update_missions( const std::vector<mission *> & ) {}
+        virtual void set_str_max( int ) {}
+        virtual void set_dex_max( int ) {}
+        virtual void set_int_max( int ) {}
+        virtual void set_per_max( int ) {}
+        virtual void set_str_bonus( int ) {}
+        virtual void set_dex_bonus( int ) {}
+        virtual void set_int_bonus( int ) {}
+        virtual void set_per_bonus( int ) {}
+        virtual void set_spell_level( const spell_id &, int ) {}
+        virtual void set_spell_exp( const spell_id &, int ) {}
+        virtual void set_skill_level( const skill_id &, int ) {}
+        virtual void set_skill_exp( const skill_id &, int, bool ) {}
+        virtual void learn_recipe( const recipe_id & ) {}
+        virtual void forget_recipe( const recipe_id & ) {}
+        virtual void mutate( const int &, const bool & ) {}
+        virtual void mutate_category( const mutation_category_id &, const bool & ) {}
+        virtual void mutate_towards( const trait_id &, const mutation_category_id &, const bool & ) {};
+        virtual void set_mutation( const trait_id &, const mutation_variant * = nullptr ) {}
+        virtual void unset_mutation( const trait_id & ) {}
+        virtual void activate_mutation( const trait_id & ) {}
+        virtual void deactivate_mutation( const trait_id & ) {}
+        virtual void set_trait_purifiability( const trait_id &, const bool & ) {}
+        virtual void set_sleepiness( int ) {};
+        virtual void set_proficiency_practiced_time( const proficiency_id &, int ) {}
+        virtual void train_proficiency_for( const proficiency_id &, int ) {}
+        virtual void store_chosen_training( const skill_id &, const matype_id &,
+                                            const spell_id &, const proficiency_id & ) {
+        }
+        virtual void add_effect( const efftype_id &, const time_duration &, const std::string &, bool, bool,
+                                 int ) {}
+        virtual void remove_effect( const efftype_id &, const std::string & ) {}
+        virtual void add_bionic( const bionic_id & ) {}
+        virtual void remove_bionic( const bionic_id & ) {}
+        virtual void set_value( const std::string &, const std::string & ) {}
+        virtual void remove_value( const std::string & ) {}
+        virtual std::list<item> use_charges( const itype_id &, int ) {
+            return {};
+        }
+        // bool = match tool containing charges of itype_id
+        virtual std::list<item> use_charges( const itype_id &, int, bool ) {
+            return {};
+        }
+        virtual std::list<item> use_amount( const itype_id &, int ) {
+            return {};
+        }
+        virtual void add_debt( int ) {}
+        virtual void i_add( const item & ) {}
+        virtual void i_add_or_drop( item &, bool = false ) {}
+        virtual void remove_items_with( const std::function<bool( const item & )> & ) {}
+        virtual std::string give_item_to( bool ) {
+            return _( "Nope." );
+        }
+        virtual bool buy_from( int ) {
+            return false;
+        }
+        virtual bool buy_monster( talker &, const mtype_id &, int, int, bool,
+                                  const translation & ) {
+            return false;
+        }
+        virtual void select_mission( mission * ) {
+        }
+        virtual void check_missions() {}
+        virtual void add_mission( const mission_type_id & ) {}
+        virtual void set_companion_mission( const std::string & ) {}
+        virtual void set_fac( const faction_id & ) {}
+        virtual void add_faction_rep( int ) {}
+        virtual void make_angry() {}
+        virtual void add_sold( int ) {}
+        virtual void toggle_ai_rule( const std::string &, const std::string & ) {}
+        virtual void set_ai_rule( const std::string &, const std::string & ) {}
+        virtual void clear_ai_rule( const std::string &, const std::string & ) {}
+        virtual void set_class( const npc_class_id & ) {}
+        virtual void set_addiction_turns( const addiction_id &, int ) {}
+        virtual void mod_stored_kcal( int, bool ) {}
+        virtual void set_stored_kcal( int ) {}
+        virtual void set_stim( int ) {}
+        virtual void set_thirst( int ) {}
+        virtual void say( const std::string & ) {}
+        virtual void shout( const std::string & = "", bool = false ) {}
+        virtual bool enslave_mind() {
+            return false;
+        }
+        virtual void add_opinion( const npc_opinion & ) {}
+        virtual void set_first_topic( const std::string & ) {}
+        virtual void mod_pain( int ) {}
+        virtual void set_pain( int ) {}
+        virtual void set_power_cur( units::energy ) {}
+        virtual void set_part_hp_cur( const bodypart_id &, int ) {}
+        virtual void set_sleep_deprivation( int ) {}
+        virtual void set_rad( int ) {}
+        virtual void set_anger( int ) {}
+        virtual void set_morale( int ) {}
+        virtual void set_friendly( int ) {}
+        virtual void add_morale( const morale_type &, int, int, time_duration, time_duration, bool ) {}
+        virtual void remove_morale( const morale_type & ) {}
+        virtual void set_kill_xp( int ) {}
+        virtual void set_age( int ) {}
+        virtual void set_height( int ) {}
+        virtual void set_npc_trust( int ) {}
+        virtual void set_npc_fear( int ) {}
+        virtual void set_npc_value( int ) {}
+        virtual void set_npc_anger( int ) {}
+        virtual void set_all_parts_hp_cur( int ) {}
+        virtual void die() {}
+        virtual void set_mana_cur( int ) {}
+        virtual void mod_daily_health( int, int ) {}
+        virtual void mod_focus( int ) {}
+        virtual void set_pkill( int ) {}
+        virtual void set_stamina( int ) {}
+        virtual void learn_martial_art( const matype_id & ) {}
+        virtual void forget_martial_art( const matype_id & ) {}
+        virtual void attack_target( Creature &, bool, const matec_id &, bool, int ) {}
+        virtual void set_fac_relation( const Character *, npc_factions::relationship, bool ) {}
+        virtual std::vector<item *> items_with( const std::function<bool( const item & )> & ) {
+            return {};
+        }
+};
+
+template <class T, class B = const_talker>
+class const_talker_cloner : virtual public B
+{
+    public:
+        std::unique_ptr<const_talker> const_clone() const override {
+            return std::make_unique<T>( static_cast<T const &>( *this ) );
+        }
+};
+
 template <class T, class B = talker>
-class talker_cloner : public B
+class talker_cloner : virtual public B
 {
     public:
         std::unique_ptr<talker> clone() const override {

--- a/src/talker.h
+++ b/src/talker.h
@@ -688,7 +688,7 @@ class talker: virtual public const_talker
         virtual void activate_mutation( const trait_id & ) {}
         virtual void deactivate_mutation( const trait_id & ) {}
         virtual void set_trait_purifiability( const trait_id &, const bool & ) {}
-        virtual void set_sleepiness( int ) {};
+        virtual void set_fatigue( int ) {};
         virtual void set_proficiency_practiced_time( const proficiency_id &, int ) {}
         virtual void train_proficiency_for( const proficiency_id &, int ) {}
         virtual void store_chosen_training( const skill_id &, const matype_id &,

--- a/src/talker_avatar.cpp
+++ b/src/talker_avatar.cpp
@@ -11,7 +11,6 @@
 #include "npc.h"
 #include "npctrade.h"
 #include "output.h"
-#include "skill.h"
 #include "talker.h"
 #include "talker_avatar.h"
 #include "translations.h"
@@ -19,19 +18,13 @@
 static const efftype_id effect_pacified( "pacified" );
 static const efftype_id effect_pet( "pet" );
 
-talker_avatar::talker_avatar( avatar *new_me )
-{
-    me_chr = new_me;
-    me_chr_const = new_me;
-}
-
-std::vector<std::string> talker_avatar::get_topics( bool )
+std::vector<std::string> talker_avatar_const::get_topics( bool ) const
 {
     std::vector<std::string> add_topics;
     return add_topics;
 }
 
-int talker_avatar::parse_mod( const std::string &attribute, const int factor ) const
+int talker_avatar_const::parse_mod( const std::string &attribute, const int factor ) const
 {
     int modifier = 0;
     if( attribute == "U_INTIMIDATE" ) {
@@ -41,7 +34,7 @@ int talker_avatar::parse_mod( const std::string &attribute, const int factor ) c
     return modifier;
 }
 
-int talker_avatar::trial_chance_mod( const std::string &trial_type ) const
+int talker_avatar_const::trial_chance_mod( const std::string &trial_type ) const
 {
     int chance = 0;
     const social_modifiers &me_mods = me_chr->get_mutation_bionic_social_mods();
@@ -55,9 +48,9 @@ int talker_avatar::trial_chance_mod( const std::string &trial_type ) const
     return chance;
 }
 
-int talker_avatar::get_daily_calories( int day, std::string const &type ) const
+int talker_avatar_const::get_daily_calories( int day, std::string const &type ) const
 {
-    return me_chr_const->as_avatar()->get_daily_calories( day, type );
+    return me_chr->get_daily_calories( day, type );
 }
 
 bool talker_avatar::buy_monster( talker &seller, const mtype_id &mtype, int cost,

--- a/src/talker_avatar.h
+++ b/src/talker_avatar.h
@@ -2,9 +2,9 @@
 #ifndef CATA_SRC_TALKER_AVATAR_H
 #define CATA_SRC_TALKER_AVATAR_H
 
-#include <iosfwd>
 #include <vector>
 
+#include "avatar.h"
 #include "talker_character.h"
 #include "type_id.h"
 
@@ -15,21 +15,45 @@ class translation;
 /*
  * Talker wrapper class for avatar.
  */
-class talker_avatar: public talker_cloner<talker_avatar, talker_character>
+class talker_avatar_const: public const_talker_cloner<talker_avatar_const, talker_character_const>
 {
     public:
-        explicit talker_avatar( avatar *new_me );
-        ~talker_avatar() override = default;
+        talker_avatar_const( const talker_avatar_const & ) = default;
+        talker_avatar_const( talker_avatar_const && ) = delete;
+        talker_avatar_const &operator=( const talker_avatar_const & ) = default;
+        talker_avatar_const &operator=( talker_avatar_const && ) = delete;
+        explicit talker_avatar_const( avatar const *new_me )
+            : talker_character_const{ new_me }, me_chr( new_me ) {};
+        ~talker_avatar_const() override = default;
 
         // mandatory functions for starting a dialogue
-        std::vector<std::string> get_topics( bool ) override;
+        std::vector<std::string> get_topics( bool ) const override;
         int parse_mod( const std::string &attribute, int factor ) const override;
         int trial_chance_mod( const std::string &trial_type ) const override;
         int get_daily_calories( int, std::string const & ) const override;
 
-        // inventory and such
+    private:
+        avatar const *me_chr{};
+};
+
+class talker_avatar: virtual public talker_avatar_const,
+    public talker_cloner<talker_avatar, talker_character>
+{
+    public:
+        talker_avatar( const talker_avatar & ) = default;
+        talker_avatar( talker_avatar && ) = delete;
+        talker_avatar &operator=( const talker_avatar & ) = default;
+        talker_avatar &operator=( talker_avatar && ) = delete;
+        explicit talker_avatar( avatar *new_me )
+            : talker_character_const( new_me ), talker_avatar_const( new_me ),
+              talker_character( new_me ), me_chr( new_me ) {};
+        ~talker_avatar() override = default;
+
         bool buy_monster( talker &seller, const mtype_id &mtype, int cost,
                           int count, bool pacified, const translation &name ) override;
+
+    private:
+        avatar *me_chr{};
 };
 #endif // CATA_SRC_TALKER_AVATAR_H
 

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -22,12 +22,6 @@ class time_duration;
 static const flag_id json_flag_FIT( "FIT" );
 static const json_character_flag json_flag_SEESLEEP( "SEESLEEP" );
 
-talker_character::talker_character( Character *new_me )
-{
-    me_chr = new_me;
-    me_chr_const = new_me;
-}
-
 std::string talker_character_const::disp_name() const
 {
     return me_chr_const->disp_name();
@@ -594,7 +588,7 @@ std::vector<const item *> talker_character_const::const_items_with( const
 }
 
 std::vector<item *> talker_character::items_with( const std::function<bool( const item & )>
-        &filter ) const
+        &filter )
 {
     return me_chr->items_with( filter );
 }
@@ -641,9 +635,9 @@ bool talker_character_const::can_stash_weapon() const
     return me_chr_const->can_pickVolume( *me_chr_const->get_wielded_item() );
 }
 
-bool talker_character_const::has_stolen_item( const talker &guy ) const
+bool talker_character_const::has_stolen_item( const_talker const &guy ) const
 {
-    const Character *owner = guy.get_character();
+    const Character *owner = guy.get_const_character();
     if( owner ) {
         for( const item *&elem : me_chr_const->inv_dump() ) {
             if( elem->is_old_owner( *owner, true ) ) {
@@ -1130,19 +1124,19 @@ std::vector<spell_id> talker_character_const::spells_teacheable() const
     return me_chr_const->spells_offered_to( nullptr );
 }
 
-std::vector<skill_id> talker_character_const::skills_offered_to( const talker &student ) const
+std::vector<skill_id> talker_character_const::skills_offered_to( const_talker const &student ) const
 {
-    if( student.get_character() ) {
-        return me_chr_const->skills_offered_to( student.get_character() );
+    if( student.get_const_character() ) {
+        return me_chr_const->skills_offered_to( student.get_const_character() );
     } else {
         return {};
     }
 }
 
-std::string talker_character_const::skill_training_text( const talker &student,
+std::string talker_character_const::skill_training_text( const_talker const &student,
         const skill_id &skill ) const
 {
-    const Character *pupil = student.get_character();
+    Character const *pupil = student.get_const_character();
     if( !pupil ) {
         return "";
     }
@@ -1163,19 +1157,19 @@ std::string talker_character_const::skill_training_text( const talker &student,
 }
 
 std::vector<proficiency_id> talker_character_const::proficiencies_offered_to(
-    const talker &student ) const
+    const_talker const &student ) const
 {
-    if( student.get_character() ) {
-        return me_chr_const->proficiencies_offered_to( student.get_character() );
+    if( student.get_const_character() ) {
+        return me_chr_const->proficiencies_offered_to( student.get_const_character() );
     } else {
         return {};
     }
 }
 
-std::string talker_character_const::proficiency_training_text( const talker &student,
+std::string talker_character_const::proficiency_training_text( const_talker const &student,
         const proficiency_id &proficiency ) const
 {
-    const Character *pupil = student.get_character();
+    Character const *pupil = student.get_const_character();
     if( !pupil ) {
         return "";
     }
@@ -1198,40 +1192,42 @@ std::string talker_character_const::proficiency_training_text( const talker &stu
     return string_format( _( "%s: (%2.0f%%) -> (%s)" ), name, pct_before, after_str );
 }
 
-std::vector<matype_id> talker_character_const::styles_offered_to( const talker &student ) const
+std::vector<matype_id> talker_character_const::styles_offered_to( const_talker const &student )
+const
 {
-    if( student.get_character() ) {
-        return me_chr_const->styles_offered_to( student.get_character() );
+    if( student.get_const_character() ) {
+        return me_chr_const->styles_offered_to( student.get_const_character() );
     } else {
         return {};
     }
 }
 
-std::string talker_character_const::style_training_text( const talker &student,
+std::string talker_character_const::style_training_text( const_talker const &student,
         const matype_id &style ) const
 {
-    if( !student.get_character() ) {
+    if( !student.get_const_character() ) {
         return "";
     } else if( !me_chr_const->is_npc() ||
-               me_chr_const->as_npc()->is_ally( *student.get_character() ) ) {
+               me_chr_const->as_npc()->is_ally( *student.get_const_character() ) ) {
         return string_format( "%s", style.obj().name );
     } else {
         return string_format( _( "%s ( cost $%d )" ), style.obj().name, 8 );
     }
 }
 
-std::vector<spell_id> talker_character_const::spells_offered_to( talker &student ) const
+std::vector<spell_id> talker_character_const::spells_offered_to( const_talker const &student ) const
 {
-    if( student.get_character() ) {
-        return me_chr_const->spells_offered_to( student.get_character() );
+    if( student.get_const_character() ) {
+        return me_chr_const->spells_offered_to( student.get_const_character() );
     } else {
         return {};
     }
 }
 
-std::string talker_character_const::spell_training_text( talker &student, const spell_id &sp ) const
+std::string talker_character_const::spell_training_text( const_talker const &student,
+        const spell_id &sp ) const
 {
-    Character *pupil = student.get_character();
+    Character const *pupil = student.get_const_character();
     if( !pupil ) {
         return "";
     }
@@ -1273,34 +1269,35 @@ std::string talker_character_const::spell_seminar_text( const spell_id &s ) cons
     return s->name.translated();
 }
 
-std::vector<bodypart_id> talker_character::get_all_body_parts( get_body_part_flags flags ) const
+std::vector<bodypart_id> talker_character_const::get_all_body_parts( get_body_part_flags flags )
+const
 {
-    return me_chr->get_all_body_parts( flags );
+    return me_chr_const->get_all_body_parts( flags );
 }
 
-int talker_character::get_part_hp_cur( const bodypart_id &id ) const
+int talker_character_const::get_part_hp_cur( const bodypart_id &id ) const
 {
-    return me_chr->get_part_hp_cur( id );
+    return me_chr_const->get_part_hp_cur( id );
 }
 
-int talker_character::get_part_hp_max( const bodypart_id &id ) const
+int talker_character_const::get_part_hp_max( const bodypart_id &id ) const
 {
-    return me_chr->get_part_hp_max( id );
+    return me_chr_const->get_part_hp_max( id );
 }
 
-void talker_character::set_part_hp_cur( const bodypart_id &id, int set ) const
+void talker_character::set_part_hp_cur( const bodypart_id &id, int set )
 {
     me_chr->set_part_hp_cur( id, set );
 }
 
-void talker_character::set_all_parts_hp_cur( int set ) const
+void talker_character::set_all_parts_hp_cur( int set )
 {
     me_chr->set_all_parts_hp_cur( set );
 }
 
-bool talker_character::get_is_alive() const
+bool talker_character_const::get_is_alive() const
 {
-    return !me_chr->is_dead_state();
+    return !me_chr_const->is_dead_state();
 }
 
 void talker_character::die()
@@ -1308,10 +1305,11 @@ void talker_character::die()
     me_chr->die( nullptr );
 }
 
-matec_id talker_character::get_random_technique( Creature &t, bool crit,
+matec_id talker_character_const::get_random_technique( Creature const &t, bool crit,
         bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist ) const
 {
-    return std::get<0>( me_chr->pick_technique( t, me_chr->used_weapon(), crit, dodge_counter,
+    return std::get<0>( me_chr_const->pick_technique( t, me_chr_const->used_weapon(), crit,
+                        dodge_counter,
                         block_counter,
                         blacklist ) );
 }
@@ -1322,12 +1320,12 @@ void talker_character::attack_target( Creature &t, bool allow_special,
     me_chr->melee_attack( t, allow_special, force_technique, allow_unarmed, forced_movecost );
 }
 
-void talker_character::learn_martial_art( const matype_id &id ) const
+void talker_character::learn_martial_art( const matype_id &id )
 {
     me_chr->martial_arts_data->add_martialart( id );
 }
 
-void talker_character::forget_martial_art( const matype_id &id ) const
+void talker_character::forget_martial_art( const matype_id &id )
 {
     me_chr->martial_arts_data->clear_style( id );
 }

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -32,24 +32,20 @@ enum class relationship : int;
  * Talker wrapper class for const Character access.
  * Should never be invoked directly.  Only talker_avatar and talker_npc are really valid.
  */
-class talker_character_const: public talker_cloner<talker_character_const>
+class talker_character_const: virtual public const_talker
 {
     public:
-        explicit talker_character_const( const Character *new_me ): me_chr_const( new_me ) {
-        }
+        talker_character_const( const talker_character_const & ) = default;
+        talker_character_const( talker_character_const && ) = delete;
+        talker_character_const &operator=( const talker_character_const & ) = default;
+        talker_character_const &operator=( talker_character_const && ) = delete;
+        explicit talker_character_const( const Character *new_me ) : me_chr_const( new_me ) {};
         ~talker_character_const() override = default;
 
-        // underlying element accessor functions
-        Character *get_character() override {
-            return nullptr;
-        }
-        const Character *get_character() const override {
+        Character const *get_const_character() const override {
             return me_chr_const;
         }
-        Creature *get_creature() override {
-            return nullptr;
-        }
-        const Creature *get_creature() const override {
+        Creature const *get_const_creature() const override {
             return me_chr_const;
         }
 
@@ -129,22 +125,22 @@ class talker_character_const: public talker_cloner<talker_character_const>
 
         // stats, skills, traits, bionics, magic, and proficiencies
         std::vector<skill_id> skills_teacheable() const override;
-        std::vector<skill_id> skills_offered_to( const talker &student ) const override;
+        std::vector<skill_id> skills_offered_to( const_talker const &student ) const override;
         std::string skill_seminar_text( const skill_id &s ) const override;
-        std::string skill_training_text( const talker &, const skill_id & ) const override;
+        std::string skill_training_text( const_talker const &, const skill_id & ) const override;
         std::vector<proficiency_id> proficiencies_teacheable() const override;
-        std::vector<proficiency_id> proficiencies_offered_to( const talker &student ) const override;
+        std::vector<proficiency_id> proficiencies_offered_to( const_talker const &student ) const override;
         std::string proficiency_seminar_text( const proficiency_id & ) const override;
-        std::string proficiency_training_text( const talker &student,
+        std::string proficiency_training_text( const_talker const &student,
                                                const proficiency_id &proficiency ) const override;
         std::vector<matype_id> styles_teacheable() const override;
-        std::vector<matype_id> styles_offered_to( const talker &student ) const override;
+        std::vector<matype_id> styles_offered_to( const_talker const &student ) const override;
         std::string style_seminar_text( const matype_id & ) const override;
-        std::string style_training_text( const talker &, const matype_id & ) const override;
+        std::string style_training_text( const_talker const &, const matype_id & ) const override;
         std::vector<spell_id> spells_teacheable() const override;
-        std::vector<spell_id> spells_offered_to( talker &student ) const override;
+        std::vector<spell_id> spells_offered_to( const_talker const &student ) const override;
         std::string spell_seminar_text( const spell_id & ) const override;
-        std::string spell_training_text( talker &, const spell_id & ) const override;
+        std::string spell_training_text( const_talker const &, const spell_id & ) const override;
 
         // inventory, buying, and selling
         bool is_wearing( const itype_id &item_id ) const override;
@@ -158,7 +154,7 @@ class talker_character_const: public talker_cloner<talker_character_const>
         const override;
         bool unarmed_attack() const override;
         bool can_stash_weapon() const override;
-        bool has_stolen_item( const talker &guy ) const override;
+        bool has_stolen_item( const_talker const &guy ) const override;
 
         // factions and alliances
         faction *get_faction() const override;
@@ -184,6 +180,11 @@ class talker_character_const: public talker_cloner<talker_character_const>
         bool wielded_with_item_ammotype( const ammotype &w_ammotype ) const override;
         bool has_item_with_flag( const flag_id &flag ) const override;
         int item_rads( const flag_id &flag, aggregate_type agg_func ) const override;
+
+        std::vector<bodypart_id> get_all_body_parts( get_body_part_flags flags ) const override;
+        int get_part_hp_cur( const bodypart_id &id ) const override;
+        int get_part_hp_max( const bodypart_id &id ) const override;
+        bool get_is_alive() const override;
 
         bool can_see() const override;
         bool can_see_location( const tripoint &pos ) const override;
@@ -211,34 +212,37 @@ class talker_character_const: public talker_cloner<talker_character_const>
         bool using_martial_art( const matype_id &id ) const override;
         int climate_control_str_heat() const override;
         int climate_control_str_chill() const override;
+        matec_id get_random_technique( Creature const &t, bool crit, bool dodge_counter,
+                                       bool block_counter,
+                                       const std::vector<matec_id> &blacklist = {} ) const override;
+
+    private:
+        const Character *me_chr_const{};
     protected:
         talker_character_const() = default;
-        const Character *me_chr_const;
 };
 
 /*
  * Talker wrapper class for mutable Character access.
  * Should never be invoked directly.  Only talker_avatar and talker_npc are really valid.
  */
-class talker_character: public talker_cloner<talker_character, talker_character_const>
+class talker_character: virtual public talker
 {
     public:
-        explicit talker_character( Character *new_me );
+        talker_character( const talker_character & ) = default;
+        talker_character( talker_character && ) = delete;
+        talker_character &operator=( const talker_character & ) = default;
+        talker_character &operator=( talker_character && ) = delete;
+        explicit talker_character( Character *new_me ) : me_chr( new_me ) {};
         ~talker_character() override = default;
 
-        // underlying element accessor functions
         Character *get_character() override {
             return me_chr;
-        }
-        const Character *get_character() const override {
-            return me_chr_const;
         }
         Creature *get_creature() override {
             return me_chr;
         }
-        const Creature *get_creature() const override {
-            return me_chr_const;
-        }
+
         void set_pos( tripoint new_pos ) override;
 
         // stats, skills, traits, bionics, and magic
@@ -277,7 +281,6 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void remove_value( const std::string &var_name ) override;
 
         // inventory, buying, and selling
-        std::vector<item *> items_with( const std::function<bool( const item & )> &filter ) const override;
         std::list<item> use_charges( const itype_id &item_name, int count ) override;
         std::list<item> use_charges( const itype_id &item_name, int count, bool in_tools ) override;
         std::list<item> use_amount( const itype_id &item_name, int count ) override;
@@ -313,22 +316,18 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void set_height( int ) override;
         void add_bionic( const bionic_id &new_bionic ) override;
         void remove_bionic( const bionic_id &old_bionic ) override;
-        std::vector<bodypart_id> get_all_body_parts( get_body_part_flags flags ) const override;
-        int get_part_hp_cur( const bodypart_id &id ) const override;
-        int get_part_hp_max( const bodypart_id &id ) const override;
-        void set_all_parts_hp_cur( int ) const override;
-        void set_part_hp_cur( const bodypart_id &id, int set ) const override;
-        bool get_is_alive() const override;
+        void set_all_parts_hp_cur( int ) override;
+        void set_part_hp_cur( const bodypart_id &id, int set ) override;
         void die() override;
         void attack_target( Creature &t, bool allow_special, const matec_id &force_technique,
                             bool allow_unarmed, int forced_movecost ) override;
-        matec_id get_random_technique( Creature &t, bool crit, bool dodge_counter, bool block_counter,
-                                       const std::vector<matec_id> &blacklist = {} )
-        const override;
-        void learn_martial_art( const matype_id &id ) const override;
-        void forget_martial_art( const matype_id &id ) const override;
+        void learn_martial_art( const matype_id &id ) override;
+        void forget_martial_art( const matype_id &id ) override;
+        std::vector<item *> items_with( const std::function<bool( const item & )> &filter ) override;
+
+    private:
+        Character *me_chr{};
     protected:
         talker_character() = default;
-        Character *me_chr;
 };
 #endif // CATA_SRC_TALKER_CHARACTER_H

--- a/src/talker_furniture.cpp
+++ b/src/talker_furniture.cpp
@@ -1,52 +1,50 @@
-#include <memory>
+#include "talker_furniture.h"
 
-#include "character_id.h"
+#include "character.h"
 #include "computer.h"
 #include "item.h"
 #include "itype.h"
 #include "magic.h"
-#include "npc.h"
-#include "pimpl.h"
 #include "point.h"
-#include "talker_furniture.h"
 #include "vehicle.h"
 
-std::string talker_furniture::disp_name() const
+std::string talker_furniture_const::disp_name() const
 {
     return me_comp->name;
 }
 
-int talker_furniture::posx() const
+int talker_furniture_const::posx() const
 {
     return me_comp->loc.x;
 }
 
-int talker_furniture::posy() const
+int talker_furniture_const::posy() const
 {
     return me_comp->loc.y;
 }
 
-int talker_furniture::posz() const
+int talker_furniture_const::posz() const
 {
     return me_comp->loc.z;
 }
 
-tripoint talker_furniture::pos() const
+tripoint talker_furniture_const::pos() const
 {
     return me_comp->loc;
 }
 
-tripoint_abs_ms talker_furniture::global_pos() const
+tripoint_abs_ms talker_furniture_const::global_pos() const
 {
     return get_map().getglobal( me_comp->loc );
 }
 
-tripoint_abs_omt talker_furniture::global_omt_location() const
+tripoint_abs_omt talker_furniture_const::global_omt_location() const
 {
     return get_player_character().global_omt_location();
 }
 
-std::optional<std::string> talker_furniture::maybe_get_value( const std::string &var_name ) const
+std::optional<std::string> talker_furniture_const::maybe_get_value( const std::string &var_name )
+const
 {
     return me_comp->maybe_get_value( var_name );
 }
@@ -61,12 +59,12 @@ void talker_furniture::remove_value( const std::string &var_name )
     me_comp->remove_value( var_name );
 }
 
-std::vector<std::string> talker_furniture::get_topics( bool )
+std::vector<std::string> talker_furniture_const::get_topics( bool ) const
 {
     return me_comp->chat_topics;
 }
 
-bool talker_furniture::will_talk_to_u( const Character &you, bool )
+bool talker_furniture_const::will_talk_to_u( const Character &you, bool ) const
 {
     return !you.is_dead_state();
 }

--- a/src/talker_furniture.h
+++ b/src/talker_furniture.h
@@ -2,14 +2,10 @@
 #ifndef CATA_SRC_TALKER_FURNITURE_H
 #define CATA_SRC_TALKER_FURNITURE_H
 
-#include <functional>
-#include <iosfwd>
-#include <list>
 #include <vector>
 
 #include "coords_fwd.h"
 #include "talker.h"
-#include "type_id.h"
 
 class computer;
 struct tripoint;
@@ -17,17 +13,18 @@ struct tripoint;
 /*
  * Talker wrapper class for furniture
  */
-class talker_furniture: public talker_cloner<talker_furniture>
+class talker_furniture_const: public const_talker_cloner<talker_furniture_const>
 {
     public:
-        explicit talker_furniture( computer *new_me ): me_comp( new_me ) {
-        }
-        ~talker_furniture() override = default;
+        explicit talker_furniture_const( computer *new_me ): me_comp( new_me ) {};
+        talker_furniture_const() = default;
+        talker_furniture_const( const talker_furniture_const & ) = default;
+        talker_furniture_const( talker_furniture_const && ) = delete;
+        talker_furniture_const &operator=( const talker_furniture_const & ) = default;
+        talker_furniture_const &operator=( talker_furniture_const && ) = delete;
+        ~talker_furniture_const() override = default;
 
-        computer *get_computer() override {
-            return me_comp;
-        }
-        computer *get_computer() const override {
+        computer const *get_const_computer() const override {
             return me_comp;
         }
         // identity and location
@@ -40,14 +37,33 @@ class talker_furniture: public talker_cloner<talker_furniture>
         tripoint_abs_omt global_omt_location() const override;
 
         std::optional<std::string> maybe_get_value( const std::string &var_name ) const override;
+
+        std::vector<std::string> get_topics( bool radio_contact ) const override;
+        bool will_talk_to_u( const Character &you, bool force ) const override;
+
+    private:
+        computer *me_comp{};
+};
+class talker_furniture: public talker_furniture_const, public talker_cloner<talker_furniture>
+{
+    public:
+        explicit talker_furniture( computer *new_me ): talker_furniture_const( new_me ),
+            me_comp( new_me ) {};
+        talker_furniture() = default;
+        talker_furniture( const talker_furniture & ) = default;
+        talker_furniture( talker_furniture && ) = delete;
+        talker_furniture &operator=( const talker_furniture & ) = default;
+        talker_furniture &operator=( talker_furniture && ) = delete;
+        ~talker_furniture() override = default;
+
+        computer *get_computer() override {
+            return me_comp;
+        }
+
         void set_value( const std::string &var_name, const std::string &value ) override;
         void remove_value( const std::string & ) override;
 
-        std::vector<std::string> get_topics( bool radio_contact ) override;
-        bool will_talk_to_u( const Character &you, bool force ) override;
-
-    protected:
-        talker_furniture() = default;
-        computer *me_comp;
+    private:
+        computer *me_comp{};
 };
 #endif // CATA_SRC_TALKER_FURNITURE_H

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -1,24 +1,15 @@
-#include <memory>
+#include "talker_item.h"
 
-#include "character_id.h"
+#include "character.h"
 #include "item.h"
 #include "itype.h"
 #include "magic.h"
-#include "npc.h"
-#include "pimpl.h"
 #include "point.h"
-#include "talker_item.h"
 #include "vehicle.h"
 
 static const ammotype ammo_battery( "battery" );
 
 static const itype_id itype_battery( "battery" );
-
-talker_item::talker_item( item_location *new_me )
-{
-    me_it = new_me;
-    me_it_const = new_me;
-}
 
 std::string talker_item_const::disp_name() const
 {
@@ -73,12 +64,12 @@ bool talker_item_const::has_flag( const flag_id &f ) const
     return me_it_const->get_item()->has_flag( f );
 }
 
-std::vector<std::string> talker_item_const::get_topics( bool )
+std::vector<std::string> talker_item_const::get_topics( bool ) const
 {
     return me_it_const->get_item()->typeId()->chat_topics;
 }
 
-bool talker_item_const::will_talk_to_u( const Character &you, bool )
+bool talker_item_const::will_talk_to_u( const Character &you, bool ) const
 {
     return !you.is_dead_state();
 }
@@ -143,10 +134,10 @@ void talker_item::remove_value( const std::string &var_name )
 void talker_item::set_power_cur( units::energy value )
 {
     me_it->get_item()->ammo_set( itype_battery, clamp( static_cast<int>( value.value() ), 0,
-                                 me_it_const->get_item()->ammo_capacity( ammo_battery ) ) );
+                                 me_it->get_item()->ammo_capacity( ammo_battery ) ) );
 }
 
-void talker_item::set_all_parts_hp_cur( int set ) const
+void talker_item::set_all_parts_hp_cur( int set )
 {
     me_it->get_item()->set_damage( me_it->get_item()->max_damage() - set );
 }

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -2,13 +2,9 @@
 #ifndef CATA_SRC_TALKER_ITEM_H
 #define CATA_SRC_TALKER_ITEM_H
 
-#include <functional>
-#include <iosfwd>
-#include <list>
 #include <vector>
 
 #include "coords_fwd.h"
-#include "npc.h"
 #include "talker.h"
 #include "type_id.h"
 
@@ -19,12 +15,20 @@ struct tripoint;
 /*
  * Talker wrapper class for item.
  */
-class talker_item_const: public talker_cloner<talker_item_const>
+class talker_item_const: public const_talker_cloner<talker_item_const>
 {
     public:
-        explicit talker_item_const( const item_location *new_me ): me_it_const( new_me ) {
-        }
+        explicit talker_item_const( const item_location *new_me ): me_it_const( new_me ) {}
+        talker_item_const() = default;
+        talker_item_const( const talker_item_const & ) = default;
+        talker_item_const( talker_item_const && ) = delete;
+        talker_item_const &operator=( const talker_item_const & ) = default;
+        talker_item_const &operator=( talker_item_const && ) = delete;
         ~talker_item_const() override = default;
+
+        item_location const *get_const_item() const override {
+            return me_it_const;
+        }
 
         // identity and location
         std::string disp_name() const override;
@@ -40,8 +44,8 @@ class talker_item_const: public talker_cloner<talker_item_const>
 
         bool has_flag( const flag_id &f ) const override;
 
-        std::vector<std::string> get_topics( bool radio_contact ) override;
-        bool will_talk_to_u( const Character &you, bool force ) override;
+        std::vector<std::string> get_topics( bool radio_contact ) const override;
+        bool will_talk_to_u( const Character &you, bool force ) const override;
 
         int get_cur_hp( const bodypart_id & ) const override;
         int get_hp_max( const bodypart_id & ) const override;
@@ -53,30 +57,24 @@ class talker_item_const: public talker_cloner<talker_item_const>
         int encumbrance_at( bodypart_id & ) const override;
         int get_volume() const override;
         int get_weight() const override;
-        item_location *get_item() override {
-            return nullptr;
 
-        }
-        item_location const *get_item() const override {
-            return me_it_const;
-
-        }
-    protected:
-        talker_item_const() = default;
-        const item_location *me_it_const;
+    private:
+        const item_location *me_it_const{};
 };
 
-class talker_item: public talker_cloner<talker_item, talker_item_const>
+class talker_item: public talker_item_const, public talker_cloner<talker_item>
 {
     public:
-        explicit talker_item( item_location *new_me );
+        explicit talker_item( item_location *new_me ) : talker_item_const( new_me ), me_it( new_me ) {};
+        talker_item() = default;
+        talker_item( const talker_item & ) = default;
+        talker_item( talker_item && ) = delete;
+        talker_item &operator=( const talker_item & ) = default;
+        talker_item &operator=( talker_item && ) = delete;
         ~talker_item() override = default;
 
         // underlying element accessor functions
         item_location *get_item() override {
-            return me_it;
-        }
-        item_location const *get_item() const override {
             return me_it;
         }
 
@@ -84,11 +82,10 @@ class talker_item: public talker_cloner<talker_item, talker_item_const>
         void remove_value( const std::string & ) override;
 
         void set_power_cur( units::energy value ) override;
-        void set_all_parts_hp_cur( int ) const override;
+        void set_all_parts_hp_cur( int ) override;
         void die() override;
 
-    protected:
-        talker_item() = default;
-        item_location *me_it;
+    private:
+        item_location *me_it{};
 };
 #endif // CATA_SRC_TALKER_ITEM_H

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -1,22 +1,15 @@
-#include <memory>
+#include "talker_monster.h"
+
 #include "character.h"
 #include "effect.h"
 #include "item.h"
 #include "magic.h"
 #include "monster.h"
 #include "mtype.h"
-#include "pimpl.h"
 #include "point.h"
-#include "talker_monster.h"
 #include "vehicle.h"
 
 class time_duration;
-
-talker_monster::talker_monster( monster *new_me )
-{
-    me_mon = new_me;
-    me_mon_const = new_me;
-}
 
 std::string talker_monster_const::disp_name() const
 {
@@ -212,7 +205,7 @@ void talker_monster::die()
     me_mon->die( nullptr );
 }
 
-void talker_monster::set_all_parts_hp_cur( int set ) const
+void talker_monster::set_all_parts_hp_cur( int set )
 {
     me_mon->set_hp( set );
 }
@@ -223,7 +216,7 @@ dealt_damage_instance talker_monster::deal_damage( Creature *source, bodypart_id
     return source->deal_damage( source, bp, dam );
 }
 
-std::vector<std::string> talker_monster_const::get_topics( bool )
+std::vector<std::string> talker_monster_const::get_topics( bool ) const
 {
     return me_mon_const->type->chat_topics;
 }
@@ -243,7 +236,7 @@ double talker_monster_const::armor_at( damage_type_id &dt, bodypart_id &bp ) con
     return me_mon_const->get_armor_type( dt, bp );
 }
 
-bool talker_monster_const::will_talk_to_u( const Character &you, bool )
+bool talker_monster_const::will_talk_to_u( const Character &you, bool ) const
 {
     return !you.is_dead_state();
 }

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -23,12 +23,23 @@ struct tripoint;
 /*
  * Talker wrapper class for monster.
  */
-class talker_monster_const: public talker_cloner<talker_monster_const>
+class talker_monster_const: public const_talker_cloner<talker_monster_const>
 {
     public:
-        explicit talker_monster_const( const monster *new_me ): me_mon_const( new_me ) {
-        }
+        explicit talker_monster_const( const monster *new_me ): me_mon_const( new_me ) {}
+        talker_monster_const() = default;
+        talker_monster_const( const talker_monster_const & ) = default;
+        talker_monster_const( talker_monster_const && ) = delete;
+        talker_monster_const &operator=( const talker_monster_const & ) = default;
+        talker_monster_const &operator=( talker_monster_const && ) = delete;
         ~talker_monster_const() override = default;
+
+        monster const *get_const_monster() const override {
+            return me_mon_const;
+        }
+        Creature const *get_const_creature() const override {
+            return me_mon_const;
+        }
 
         // identity and location
         std::string disp_name() const override;
@@ -61,8 +72,8 @@ class talker_monster_const: public talker_cloner<talker_monster_const>
         int get_friendly() const override;
         int get_size() const override;
         int get_grab_strength() const override;
-        bool will_talk_to_u( const Character &u, bool force ) override;
-        std::vector<std::string> get_topics( bool radio_contact ) override;
+        std::vector<std::string> get_topics( bool radio_contact ) const override;
+        bool will_talk_to_u( const Character &u, bool force ) const override;
         int get_cur_hp( const bodypart_id & ) const override;
         int get_hp_max( const bodypart_id & ) const override;
         double armor_at( damage_type_id &dt, bodypart_id &bp ) const override;
@@ -70,29 +81,27 @@ class talker_monster_const: public talker_cloner<talker_monster_const>
         bool can_see_location( const tripoint &pos ) const override;
         int get_volume() const override;
         int get_weight() const override;
-    protected:
-        talker_monster_const() = default;
-        const monster *me_mon_const;
+
+    private:
+        const monster *me_mon_const{};
 };
 
-class talker_monster: public talker_cloner<talker_monster, talker_monster_const>
+class talker_monster: public talker_monster_const, public talker_cloner<talker_monster>
 {
     public:
-        explicit talker_monster( monster *new_me );
+        explicit talker_monster( monster *new_me ): talker_monster_const( new_me ), me_mon( new_me ) {};
+        talker_monster() = default;
+        talker_monster( const talker_monster & ) = default;
+        talker_monster( talker_monster && ) = delete;
+        talker_monster &operator=( const talker_monster & ) = default;
+        talker_monster &operator=( talker_monster && ) = delete;
         ~talker_monster() override = default;
 
-        // underlying element accessor functions
         monster *get_monster() override {
             return me_mon;
         }
-        const monster *get_monster() const override {
-            return me_mon_const;
-        }
         Creature *get_creature() override {
             return me_mon;
-        }
-        const Creature *get_creature() const override {
-            return me_mon_const;
         }
 
         // effects and values
@@ -111,11 +120,11 @@ class talker_monster: public talker_cloner<talker_monster, talker_monster_const>
         bool get_is_alive() const override;
         void die() override;
 
-        void set_all_parts_hp_cur( int ) const override;
+        void set_all_parts_hp_cur( int ) override;
         dealt_damage_instance deal_damage( Creature *source, bodypart_id bp,
                                            const damage_instance &dam ) const override;
-    protected:
-        talker_monster() = default;
-        monster *me_mon;
+
+    private:
+        monster *me_mon{};
 };
 #endif // CATA_SRC_TALKER_MONSTER_H

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -30,7 +30,6 @@
 #include "npctrade.h"
 #include "output.h"
 #include "overmapbuffer.h"
-#include "pimpl.h"
 #include "player_activity.h"
 #include "proficiency.h"
 #include "ret_val.h"
@@ -41,7 +40,6 @@
 #include "translations.h"
 #include "units.h"
 #include "units_utility.h"
-#include "value_ptr.h"
 
 static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_narcosis( "narcosis" );
@@ -56,14 +54,7 @@ static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 
-talker_npc::talker_npc( npc *new_me )
-{
-    me_npc = new_me;
-    me_chr = new_me;
-    me_chr_const = new_me;
-}
-
-std::string talker_npc::distance_to_goal() const
+std::string talker_npc_const::distance_to_goal() const
 {
     // TODO: this ignores the z-component
     int dist = rl_dist( me_npc->global_omt_location(), me_npc->goal );
@@ -83,7 +74,7 @@ std::string talker_npc::distance_to_goal() const
     return response;
 }
 
-bool talker_npc::will_talk_to_u( const Character &you, bool force )
+bool talker_npc::will_talk_to_u( const Character &you, bool force ) const
 {
     if( you.is_dead_state() ) {
         me_npc->set_attitude( NPCATT_NULL );
@@ -109,7 +100,7 @@ bool talker_npc::will_talk_to_u( const Character &you, bool force )
     return true;
 }
 
-std::vector<std::string> talker_npc::get_topics( bool radio_contact )
+std::vector<std::string> talker_npc::get_topics( bool radio_contact ) const
 {
     avatar &player_character = get_avatar();
     std::vector<std::string> add_topics;
@@ -229,14 +220,14 @@ void talker_npc::update_missions( const std::vector<mission *> &missions_assigne
     }
 }
 
-bool talker_npc::check_hostile_response( const int anger ) const
+bool talker_npc_const::check_hostile_response( const int anger ) const
 {
     return me_npc->op_of_u.anger + anger > me_npc->hostile_anger_level();
 }
 
 // Every OWED_VAL that the NPC owes you counts as +1 towards convincing
 static constexpr int OWED_VAL = 1000;
-int talker_npc::parse_mod( const std::string &attribute, const int factor ) const
+int talker_npc_const::parse_mod( const std::string &attribute, const int factor ) const
 {
     int modifier = 0;
     if( attribute == "ANGER" ) {
@@ -270,7 +261,7 @@ int talker_npc::parse_mod( const std::string &attribute, const int factor ) cons
     return modifier;
 }
 
-int talker_npc::trial_chance_mod( const std::string &trial_type ) const
+int talker_npc_const::trial_chance_mod( const std::string &trial_type ) const
 {
     int chance = 0;
     if( trial_type == "lie" ) {
@@ -291,7 +282,7 @@ void talker_npc::store_chosen_training( const skill_id &c_skill, const matype_id
     me_npc->chatbin.store_chosen_training( c_skill, c_style, c_spell, c_proficiency );
 }
 
-int talker_npc::debt() const
+int talker_npc_const::debt() const
 {
     return me_npc->op_of_u.owed;
 }
@@ -301,7 +292,7 @@ void talker_npc::add_debt( const int cost )
     me_npc->op_of_u.owed += cost;
 }
 
-int talker_npc::sold() const
+int talker_npc_const::sold() const
 {
     return me_npc->op_of_u.sold;
 }
@@ -311,12 +302,12 @@ void talker_npc::add_sold( const int value )
     me_npc->op_of_u.sold += value;
 }
 
-int talker_npc::cash_to_favor( const int value ) const
+int talker_npc_const::cash_to_favor( const int value ) const
 {
     return npc_trading::cash_to_favor( *me_npc, value );
 }
 
-int talker_npc::value( const item &it ) const
+int talker_npc_const::value( const item &it ) const
 {
     return me_npc->value( it );
 }
@@ -520,17 +511,17 @@ bool talker_npc::buy_from( const int amount )
     return npc_trading::pay_npc( *me_npc, amount );
 }
 
-std::vector<mission *> talker_npc::available_missions() const
+std::vector<mission *> talker_npc_const::available_missions() const
 {
     return me_npc->chatbin.missions;
 }
 
-std::vector<mission *> talker_npc::assigned_missions() const
+std::vector<mission *> talker_npc_const::assigned_missions() const
 {
     return me_npc->chatbin.missions_assigned;
 }
 
-mission *talker_npc::selected_mission() const
+mission *talker_npc_const::selected_mission() const
 {
     return me_npc->chatbin.mission_selected;
 }
@@ -567,27 +558,27 @@ void talker_npc::add_faction_rep( const int rep_change )
     }
 }
 
-bool talker_npc::is_following() const
+bool talker_npc_const::is_following() const
 {
     return me_npc->is_following();
 }
 
-bool talker_npc::is_friendly( const Character &guy ) const
+bool talker_npc_const::is_friendly( const Character &guy ) const
 {
     return me_npc->is_friendly( guy );
 }
 
-bool talker_npc::is_enemy() const
+bool talker_npc_const::is_enemy() const
 {
     return me_npc->is_enemy();
 }
 
-bool talker_npc::is_player_ally()  const
+bool talker_npc_const::is_player_ally()  const
 {
     return me_npc->is_player_ally();
 }
 
-bool talker_npc::turned_hostile() const
+bool talker_npc_const::turned_hostile() const
 {
     return me_npc->turned_hostile();
 }
@@ -597,8 +588,8 @@ void talker_npc::make_angry()
     me_npc->make_angry();
 }
 
-bool talker_npc::has_ai_rule( const std::string &type,
-                              const std::string &rule ) const
+bool talker_npc_const::has_ai_rule( const std::string &type,
+                                    const std::string &rule ) const
 {
     if( type == "aim_rule" ) {
         auto rule_val = aim_rule_strs.find( rule );
@@ -697,12 +688,12 @@ void talker_npc::clear_ai_rule( const std::string &, const std::string &rule )
     me_npc->wield_better_weapon();
 }
 
-std::string talker_npc::get_job_description() const
+std::string talker_npc_const::get_job_description() const
 {
     return me_npc->describe_mission();
 }
 
-std::string talker_npc::view_personality_traits() const
+std::string talker_npc_const::view_personality_traits() const
 {
     // Special starting char so it doesn't appear as though the NPC is talking to us
     std::string assessment = "&";
@@ -730,7 +721,7 @@ std::string talker_npc::view_personality_traits() const
     return assessment;
 }
 
-std::string talker_npc::evaluation_by( const talker &alpha ) const
+std::string talker_npc_const::evaluation_by( const_talker const &alpha ) const
 {
     if( !alpha.can_see() ) {
         return _( "&You're blind and can't make anything out." );
@@ -811,12 +802,12 @@ std::string talker_npc::evaluation_by( const talker &alpha ) const
 
 }
 
-bool talker_npc::has_activity() const
+bool talker_npc_const::has_activity() const
 {
     return !me_npc->activity.is_null();
 }
 
-bool talker_npc::is_myclass( const npc_class_id &class_to_check ) const
+bool talker_npc_const::is_myclass( const npc_class_id &class_to_check ) const
 {
     return me_npc->myclass == class_to_check;
 }
@@ -831,7 +822,7 @@ void talker_npc::say( const std::string &speech )
     me_npc->say( speech );
 }
 
-std::string talker_npc::opinion_text() const
+std::string talker_npc_const::opinion_text() const
 {
     return me_npc->opinion_text();
 }
@@ -854,7 +845,7 @@ void talker_npc::set_first_topic( const std::string &chat_topic )
     me_npc->chatbin.first_topic = chat_topic;
 }
 
-bool talker_npc::is_safe() const
+bool talker_npc_const::is_safe() const
 {
     return me_npc->is_safe();
 }
@@ -873,7 +864,7 @@ void talker_npc::set_npc_trust( const int trust )
     me_npc->op_of_u.trust = trust;
 }
 
-int talker_npc::get_npc_trust() const
+int talker_npc_const::get_npc_trust() const
 {
     return me_npc->op_of_u.trust;
 }
@@ -883,7 +874,7 @@ void talker_npc::set_npc_fear( const int fear )
     me_npc->op_of_u.fear = fear;
 }
 
-int talker_npc::get_npc_fear() const
+int talker_npc_const::get_npc_fear() const
 {
     return me_npc->op_of_u.fear;
 }
@@ -893,7 +884,7 @@ void talker_npc::set_npc_value( const int value )
     me_npc->op_of_u.value = value;
 }
 
-int talker_npc::get_npc_value() const
+int talker_npc_const::get_npc_value() const
 {
     return me_npc->op_of_u.value;
 }
@@ -903,7 +894,7 @@ void talker_npc::set_npc_anger( const int anger )
     me_npc->op_of_u.anger = anger;
 }
 
-int talker_npc::get_npc_anger() const
+int talker_npc_const::get_npc_anger() const
 {
     return me_npc->op_of_u.anger;
 }

--- a/src/talker_npc.h
+++ b/src/talker_npc.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_TALKER_NPC_H
 #define CATA_SRC_TALKER_NPC_H
 
-#include <iosfwd>
 #include <vector>
 
 #include "faction.h"
@@ -17,16 +16,18 @@ class talker;
 
 /*
  */
-class talker_npc : public talker_cloner<talker_npc, talker_character>
+class talker_npc_const : public const_talker_cloner<talker_npc_const, talker_character_const>
 {
     public:
-        explicit talker_npc( npc *new_me );
-        ~talker_npc() override = default;
+        talker_npc_const( const talker_npc_const & ) = default;
+        talker_npc_const( talker_npc_const && ) = delete;
+        talker_npc_const &operator=( const talker_npc_const & ) = default;
+        talker_npc_const &operator=( talker_npc_const && ) = delete;
+        explicit talker_npc_const( npc const *new_me ) : talker_character_const( new_me ),
+            me_npc( new_me ) {};
+        ~talker_npc_const() override = default;
 
-        npc *get_npc() override {
-            return me_npc;
-        }
-        npc *get_npc() const override {
+        npc const *get_const_npc() const override {
             return me_npc;
         }
 
@@ -34,80 +35,99 @@ class talker_npc : public talker_cloner<talker_npc, talker_character>
         std::string distance_to_goal() const override;
 
         // mandatory functions for starting a dialogue
-        bool will_talk_to_u( const Character &you, bool force ) override;
-        std::vector<std::string> get_topics( bool radio_contact ) override;
-        void check_missions() override;
-        void update_missions( const std::vector<mission *> &missions_assigned ) override;
         bool check_hostile_response( int anger ) const override;
         int parse_mod( const std::string &attribute, int factor ) const override;
         int trial_chance_mod( const std::string &trial_type ) const override;
-        void store_chosen_training( const skill_id &c_skill, const matype_id &c_style,
-                                    const spell_id &c_spell, const proficiency_id &c_proficiency ) override;
 
         // inventory, buying, and selling
         int debt() const override;
-        void add_debt( int cost ) override;
         int sold() const override;
-        void add_sold( int value ) override;
         int cash_to_favor( int value ) const override;
-        std::string give_item_to( bool to_use ) override;
-        bool buy_from( int amount ) override;
         int value( const item &it ) const override;
 
         // missions
         std::vector<mission *> available_missions() const override;
         std::vector<mission *> assigned_missions() const override;
         mission *selected_mission() const override;
-        void select_mission( mission *selected ) override;
-        void add_mission( const mission_type_id &mission_id ) override;
-        void set_companion_mission( const std::string &role_id ) override;
 
         // factions and alliances
-        void set_fac( const faction_id &new_fac_name ) override;
-        void add_faction_rep( int rep_change ) override;
         bool is_following() const override;
         bool is_friendly( const Character &guy ) const override;
         bool is_enemy() const override;
         bool is_player_ally()  const override;
         bool turned_hostile() const override;
-        void make_angry() override;
 
         // ai rules
         bool has_ai_rule( const std::string &type, const std::string &rule ) const override;
-        void toggle_ai_rule( const std::string &type, const std::string &rule ) override;
-        void set_ai_rule( const std::string &type, const std::string &rule ) override;
-        void clear_ai_rule( const std::string &type, const std::string &rule ) override;
 
         // other descriptors
         std::string get_job_description() const override;
         std::string view_personality_traits() const override;
-        std::string evaluation_by( const talker &alpha ) const override;
+        std::string evaluation_by( const_talker const &alpha ) const override;
         bool has_activity() const override;
         bool is_myclass( const npc_class_id &class_to_check ) const override;
-        void set_class( const npc_class_id &new_class ) override;
-
-        // speaking
-        void say( const std::string &speech ) override;
 
         // miscellaneous
         std::string opinion_text() const override;
+        bool is_safe() const override;
+
+        // opinions
+        int get_npc_fear() const override;
+        int get_npc_trust() const override;
+        int get_npc_value() const override;
+        int get_npc_anger() const override;
+
+    private:
+        npc const *me_npc{};
+};
+
+class talker_npc : virtual public talker_npc_const,
+    public talker_cloner<talker_npc, talker_character>
+{
+    public:
+        talker_npc( const talker_npc & ) = default;
+        talker_npc( talker_npc && ) = delete;
+        talker_npc &operator=( const talker_npc & ) = default;
+        talker_npc &operator=( talker_npc && ) = delete;
+        explicit talker_npc( npc *new_me ) : talker_character_const( new_me ), talker_npc_const( new_me ),
+            talker_character( new_me ), me_npc( new_me ) {};
+        ~talker_npc() override = default;
+
+        npc *get_npc() override {
+            return me_npc;
+        }
+
+        void update_missions( const std::vector<mission *> &missions_assigned ) override;
+        void store_chosen_training( const skill_id &c_skill, const matype_id &c_style,
+                                    const spell_id &c_spell, const proficiency_id &c_proficiency ) override;
+        void add_debt( int cost ) override;
+        std::string give_item_to( bool to_use ) override;
+        bool buy_from( int amount ) override;
+        void select_mission( mission *selected ) override;
+        void check_missions() override;
+        void add_mission( const mission_type_id &mission_id ) override;
+        void set_companion_mission( const std::string &role_id ) override;
+        void set_fac( const faction_id &new_fac_name ) override;
+        void add_faction_rep( int rep_change ) override;
+        void make_angry() override;
+        void toggle_ai_rule( const std::string &type, const std::string &rule ) override;
+        void set_ai_rule( const std::string &type, const std::string &rule ) override;
+        void clear_ai_rule( const std::string &type, const std::string &rule ) override;
+        void set_class( const npc_class_id &new_class ) override;
+        void say( const std::string &speech ) override;
+        void add_sold( int value ) override;
         void add_opinion( const npc_opinion &op ) override;
         bool enslave_mind() override;
         void set_first_topic( const std::string &chat_topic ) override;
-        bool is_safe() const override;
         void die() override;
-
-        // opinions
         void set_npc_trust( int trust ) override;
-        int get_npc_trust() const override;
         void set_npc_fear( int fear ) override;
-        int get_npc_fear() const override;
         void set_npc_value( int value ) override;
-        int get_npc_value() const override;
         void set_npc_anger( int anger ) override;
-        int get_npc_anger() const override;
+        std::vector<std::string> get_topics( bool radio_contact ) const override;
+        bool will_talk_to_u( const Character &you, bool force ) const override;
 
-    protected:
-        npc *me_npc;
+    private:
+        npc *me_npc{};
 };
 #endif // CATA_SRC_TALKER_NPC_H

--- a/src/talker_topic.cpp
+++ b/src/talker_topic.cpp
@@ -1,75 +1,11 @@
 #include <memory>
 
-#include "character_id.h"
-#include "item.h"
-#include "itype.h"
-#include "magic.h"
 #include "npc.h"
-#include "pimpl.h"
-#include "point.h"
 #include "talker_topic.h"
-#include "vehicle.h"
 
-std::string talker_topic::disp_name() const
-{
-    debugmsg( "This talker doesn't have a name." );
-    return "";
-}
-
-int talker_topic::posx() const
-{
-    debugmsg( "This talker doesn't have a posx." );
-    return 0;
-}
-
-int talker_topic::posy() const
-{
-    debugmsg( "This talker doesn't have a posy." );
-    return 0;
-}
-
-int talker_topic::posz() const
-{
-    debugmsg( "This talker doesn't have a posz." );
-    return 0;
-}
-
-tripoint talker_topic::pos() const
-{
-    debugmsg( "This talker doesn't have a pos." );
-    return tripoint_zero;
-}
-
-tripoint_abs_ms talker_topic::global_pos() const
-{
-    debugmsg( "This talker doesn't have a global_pos." );
-    return tripoint_abs_ms( tripoint_zero );
-}
-
-tripoint_abs_omt talker_topic::global_omt_location() const
-{
-    debugmsg( "This talker doesn't have a global_omt_location." );
-    return tripoint_abs_omt( tripoint_zero );
-}
-
-void talker_topic::set_value( const std::string &, const std::string & )
-{
-    debugmsg( "This talker doesn't have values to set." );
-}
-
-void talker_topic::remove_value( const std::string & )
-{
-    debugmsg( "This talker doesn't have values to remove." );
-}
-
-std::vector<std::string> talker_topic::get_topics( bool )
+std::vector<std::string> talker_topic_const::get_topics( bool ) const
 {
     return topics;
-}
-
-bool talker_topic::will_talk_to_u( const Character &, bool )
-{
-    return true;
 }
 
 std::unique_ptr<talker> get_talker_for( const std::vector<std::string> &topics )

--- a/src/talker_topic.h
+++ b/src/talker_topic.h
@@ -2,46 +2,50 @@
 #ifndef CATA_SRC_TALKER_TOPIC_H
 #define CATA_SRC_TALKER_TOPIC_H
 
-#include <functional>
-#include <iosfwd>
-#include <list>
+#include <utility>
 #include <vector>
 
-#include "coords_fwd.h"
 #include "talker.h"
-#include "type_id.h"
 
 struct tripoint;
 
 /*
  * Talker wrapper class for an empty talker thats just topics
  */
-class talker_topic: public talker_cloner<talker_topic>
+class talker_topic_const: public const_talker_cloner<talker_topic_const>
 {
     public:
-        explicit talker_topic( std::vector<std::string> new_topics ) {
-            topics = std::move( new_topics );
+        explicit talker_topic_const( std::vector<std::string> new_topics )
+            : topics( std::move( new_topics ) ) {}
+        talker_topic_const() = default;
+        talker_topic_const( const talker_topic_const & ) = default;
+        talker_topic_const( talker_topic_const && ) = delete;
+        talker_topic_const &operator=( const talker_topic_const & ) = default;
+        talker_topic_const &operator=( talker_topic_const && ) = delete;
+        ~talker_topic_const() override = default;
+
+        std::vector<std::string> get_topics( bool radio_contact ) const override;
+        bool will_talk_to_u( const Character &/* you */, bool /* force */ ) const override {
+            return true;
         }
-        ~talker_topic() override = default;
 
-        // identity and location
-        std::string disp_name() const override;
-        int posx() const override;
-        int posy() const override;
-        int posz() const override;
-        tripoint pos() const override;
-        tripoint_abs_ms global_pos() const override;
-        tripoint_abs_omt global_omt_location() const override;
-
-        void set_value( const std::string &var_name, const std::string &value ) override;
-        void remove_value( const std::string & ) override;
-
-        std::vector<std::string> get_topics( bool radio_contact ) override;
-        bool will_talk_to_u( const Character &you, bool force ) override;
-
-    protected:
-        talker_topic() = default;
+    private:
         std::vector<std::string> topics;
 };
+
+class talker_topic: virtual public talker_topic_const, public talker_cloner<talker_topic>
+{
+    public:
+        explicit talker_topic( std::vector<std::string> new_topics )
+            : talker_topic_const( std::move( new_topics ) ) {}
+        talker_topic() = default;
+        talker_topic( const talker_topic & ) = default;
+        talker_topic( talker_topic && ) = delete;
+        talker_topic &operator=( const talker_topic & ) = default;
+        talker_topic &operator=( talker_topic && ) = delete;
+        ~talker_topic() override = default;
+};
+
 std::unique_ptr<talker> get_talker_for( const std::vector<std::string> &topics );
+
 #endif // CATA_SRC_TALKER_TOPIC_H

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -34,9 +34,9 @@ struct weakpoint_attack {
     };
 
     // The source of the attack.
-    const Creature *source;
+    Creature *source;
     // The target of the attack.
-    const Creature *target;
+    Creature *target;
     // The weapon used to make the attack.
     const item *weapon;
     // The type of the attack.
@@ -138,7 +138,7 @@ struct weakpoint {
     // Critical damage multipliers. Applied after armor instead of damage_mult, if the attack is a crit.
     std::unordered_map<damage_type_id, float> crit_mult;
     // Dialogue conditions of weakpoint
-    std::function<bool( dialogue & )> condition;
+    std::function<bool( const_dialogue const & )> condition;
     bool has_condition = false;
     // A list of effects that may trigger by hitting this weak point.
     std::vector<weakpoint_effect> effects;

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -19,7 +19,7 @@
 
 class JsonObject;
 template <typename E> struct enum_traits;
-struct dialogue;
+struct const_dialogue;
 template<typename T>
 class generic_factory;
 
@@ -111,7 +111,7 @@ struct weather_type {
         // if multiple weather conditions are true the higher priority wins
         int priority = 0;
         // when this weather should happen
-        std::function<bool( dialogue & )> condition;
+        std::function<bool( const_dialogue const & )> condition;
         std::vector<weather_type_id> required_weathers;
         time_duration duration_min = 0_turns;
         time_duration duration_max = 0_turns;

--- a/src/widget.h
+++ b/src/widget.h
@@ -169,7 +169,7 @@ struct widget_clause {
         bool has_condition = false;
         // Whether parse tags in this clause
         bool should_parse_tags = false;
-        std::function<bool( dialogue & )> condition;
+        std::function<bool( const_dialogue const & )> condition;
         bool meets_condition( const std::string &opt_var = "" ) const;
         bool meets_condition( const std::set<bodypart_id> &bps ) const;
 


### PR DESCRIPTION
#### Summary
Backport 77485 - enforce const correctness in dialogue

#### Purpose of change
Massive infrastructure backport.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
