### PR TITLE
Backport 77941 - EOCs can compare more than one string

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -63,7 +63,7 @@
       { "math": [ "u_glass_health_arm_r", "=", "u_hp('arm_r')" ] },
       { "math": [ "u_glass_health_leg_l", "=", "u_hp('leg_l')" ] },
       { "math": [ "u_glass_health_leg_r", "=", "u_hp('leg_r')" ] },
-      { "math": [ "u_glass_sleepiness", "=", "u_val('sleepiness')" ] },
+      { "math": [ "u_glass_fatigue", "=", "u_val('fatigue')" ] },
       {
         "u_location_variable": { "global_val": "vitrified_farm_ground" },
         "target_params": { "om_terrain": "unvitrified_farm_0", "search_range": 100, "min_distance": 0, "z": 0 },

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -20,8 +20,14 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_vitrified_farm_entry_event",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
+    "effect": [ { "run_eocs": "EOC_vitrified_farm_entry" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_vitrified_farm_entry",
-    "recurrence": "1 seconds",
     "condition": {
       "and": [
         { "or": [ { "u_at_om_location": "unvitrified_farm_0" }, { "u_at_om_location": "unvitrified_orchard" } ] },
@@ -38,174 +44,147 @@
         }
       ]
     },
-    "effect": {
-      "run_eocs": [
-        {
-          "id": "EOC_vitrified_confuse",
-          "effect": [
-            {
-              "place_override": { "global_val": "place_name", "default_str": "Quiet Farmhouse" },
-              "length": "1 day",
-              "key": "vitrified_farm_escape_key"
-            },
-            { "custom_light_level": 70, "length": "1 day", "key": "vitrified_farm_escape_key" }
-          ]
-        },
-        {
-          "id": "EOC_vitrified_entry_state",
-          "effect": [
-            { "math": [ "u_glass_health_head", "=", "u_hp('head')" ] },
-            { "math": [ "u_glass_health_torso", "=", "u_hp('torso')" ] },
-            { "math": [ "u_glass_health_arm_l", "=", "u_hp('arm_l')" ] },
-            { "math": [ "u_glass_health_arm_r", "=", "u_hp('arm_r')" ] },
-            { "math": [ "u_glass_health_leg_l", "=", "u_hp('leg_l')" ] },
-            { "math": [ "u_glass_health_leg_r", "=", "u_hp('leg_r')" ] },
-            { "math": [ "u_glass_fatigue", "=", "u_val('fatigue')" ] }
-          ]
-        },
-        {
-          "id": "EOC_setup_vitrified_farm",
-          "effect": [
-            {
-              "u_location_variable": { "global_val": "vitrified_farm_ground" },
-              "target_params": { "om_terrain": "unvitrified_farm_0", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 6,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_farm_upper" },
-              "target_params": { "om_terrain": "unvitrified_farm_1", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 7,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_farm_basement" },
-              "target_params": { "om_terrain": "unvitrified_farm_neg_1", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 5,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_farm_roof" },
-              "target_params": { "om_terrain": "unvitrified_farm_2", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 8,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_sky_1" },
-              "target_params": { "om_terrain": "unvitrified_farm_2", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 9,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_apples" },
-              "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 6,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_apples_sky_lower" },
-              "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 7,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_apples_sky_upper" },
-              "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 8,
-              "z_override": true
-            },
-            {
-              "u_location_variable": { "global_val": "vitrified_sky_2" },
-              "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
-              "z_adjust": 9,
-              "z_override": true
-            },
-            {
-              "revert_location": { "global_val": "vitrified_farm_ground" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_farm_upper" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_farm_basement" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_farm_roof" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_sky_1" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_apples" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_apples_sky_lower" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_apples_sky_upper" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            {
-              "revert_location": { "global_val": "vitrified_sky_2" },
-              "time_in_future": "infinite",
-              "key": "vitrified_farm_escape_key"
-            },
-            { "mapgen_update": "vitrified_farm_0", "target_var": { "global_val": "vitrified_farm_ground" } },
-            { "mapgen_update": "vitrified_farm_1", "target_var": { "global_val": "vitrified_farm_upper" } },
-            { "mapgen_update": "vitrified_farm_-1", "target_var": { "global_val": "vitrified_farm_basement" } },
-            { "mapgen_update": "vitrified_farm_2", "target_var": { "global_val": "vitrified_farm_roof" } },
-            { "mapgen_update": "vitrified_sky", "target_var": { "global_val": "vitrified_sky_1" } },
-            { "mapgen_update": "vitrified_orchard", "target_var": { "global_val": "vitrified_apples" } },
-            { "mapgen_update": "vitrified_orchard_sky", "target_var": { "global_val": "vitrified_apples_sky_lower" } },
-            { "mapgen_update": "vitrified_orchard_sky", "target_var": { "global_val": "vitrified_apples_sky_upper" } },
-            { "mapgen_update": "vitrified_sky", "target_var": { "global_val": "vitrified_sky_2" } }
-          ]
-        },
-        {
-          "id": "EOC_entry_tp",
-          "effect": [
-            { "u_location_variable": { "u_val": "vitrifaction_entry" }, "x_adjust": 0, "y_adjust": 0, "z_adjust": 6 },
-            { "u_teleport": { "u_val": "vitrifaction_entry" }, "fail_message": "Oops!", "force": true }
-          ]
-        },
-        {
-          "id": "EOC_vitrifiaction_entry_message",
-          "effect": {
-            "u_message": "You arrive at the farmhouse, after what feels like an eternity.  It's not quite what you were expecting, but it's very peaceful.",
-            "type": "good",
-            "popup": true
-          }
-        },
-        {
-          "id": "EOC_enter_vitrify_effect",
-          "effect": [
-            { "math": [ "u_vitri_vitrified", "=", "1" ] },
-            { "math": [ "u_vitri_glassed", "=", "0" ] },
-            { "math": [ "u_vitri_glass_entered", "=", "2" ] },
-            {
-              "u_add_effect": "VITRIFYING",
-              "duration": "PERMANENT",
-              "intensity": { "math": [ "u_vitri_vitrified" ] }
-            }
-          ]
-        }
-      ]
-    }
+    "false_effect": [
+      {
+        "if": { "not": { "u_has_trait": "NOT_GLASS" } },
+        "then": { "run_eocs": [ "EOC_vitrified_farm_entry" ], "time_in_future": "1 seconds" }
+      }
+    ],
+    "effect": [
+      {
+        "place_override": { "global_val": "place_name", "default_str": "Quiet Farmhouse" },
+        "length": "1 day",
+        "key": "vitrified_farm_escape_key"
+      },
+      { "custom_light_level": 70, "length": "1 day", "key": "vitrified_farm_escape_key" },
+      { "math": [ "u_glass_health_head", "=", "u_hp('head')" ] },
+      { "math": [ "u_glass_health_torso", "=", "u_hp('torso')" ] },
+      { "math": [ "u_glass_health_arm_l", "=", "u_hp('arm_l')" ] },
+      { "math": [ "u_glass_health_arm_r", "=", "u_hp('arm_r')" ] },
+      { "math": [ "u_glass_health_leg_l", "=", "u_hp('leg_l')" ] },
+      { "math": [ "u_glass_health_leg_r", "=", "u_hp('leg_r')" ] },
+      { "math": [ "u_glass_sleepiness", "=", "u_val('sleepiness')" ] },
+      {
+        "u_location_variable": { "global_val": "vitrified_farm_ground" },
+        "target_params": { "om_terrain": "unvitrified_farm_0", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 6,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_farm_upper" },
+        "target_params": { "om_terrain": "unvitrified_farm_1", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 7,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_farm_basement" },
+        "target_params": { "om_terrain": "unvitrified_farm_neg_1", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 5,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_farm_roof" },
+        "target_params": { "om_terrain": "unvitrified_farm_2", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 8,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_sky_1" },
+        "target_params": { "om_terrain": "unvitrified_farm_2", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 9,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_apples" },
+        "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 6,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_apples_sky_lower" },
+        "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 7,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_apples_sky_upper" },
+        "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 8,
+        "z_override": true
+      },
+      {
+        "u_location_variable": { "global_val": "vitrified_sky_2" },
+        "target_params": { "om_terrain": "unvitrified_orchard", "search_range": 100, "min_distance": 0, "z": 0 },
+        "z_adjust": 9,
+        "z_override": true
+      },
+      {
+        "revert_location": { "global_val": "vitrified_farm_ground" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_farm_upper" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_farm_basement" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_farm_roof" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_sky_1" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_apples" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_apples_sky_lower" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_apples_sky_upper" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      {
+        "revert_location": { "global_val": "vitrified_sky_2" },
+        "time_in_future": "infinite",
+        "key": "vitrified_farm_escape_key"
+      },
+      { "mapgen_update": "vitrified_farm_0", "target_var": { "global_val": "vitrified_farm_ground" } },
+      { "mapgen_update": "vitrified_farm_1", "target_var": { "global_val": "vitrified_farm_upper" } },
+      { "mapgen_update": "vitrified_farm_-1", "target_var": { "global_val": "vitrified_farm_basement" } },
+      { "mapgen_update": "vitrified_farm_2", "target_var": { "global_val": "vitrified_farm_roof" } },
+      { "mapgen_update": "vitrified_sky", "target_var": { "global_val": "vitrified_sky_1" } },
+      { "mapgen_update": "vitrified_orchard", "target_var": { "global_val": "vitrified_apples" } },
+      { "mapgen_update": "vitrified_orchard_sky", "target_var": { "global_val": "vitrified_apples_sky_lower" } },
+      { "mapgen_update": "vitrified_orchard_sky", "target_var": { "global_val": "vitrified_apples_sky_upper" } },
+      { "mapgen_update": "vitrified_sky", "target_var": { "global_val": "vitrified_sky_2" } },
+      { "u_location_variable": { "u_val": "vitrifaction_entry" }, "z_adjust": 6 },
+      { "u_teleport": { "u_val": "vitrifaction_entry" }, "fail_message": "Oops!", "force": true },
+      {
+        "u_message": "You arrive at the farmhouse, after what feels like an eternity.  It's not quite what you were expecting, but it's very peaceful.",
+        "type": "good",
+        "popup": true
+      },
+      { "math": [ "u_vitri_vitrified", "=", "1" ] },
+      { "math": [ "u_vitri_glassed", "=", "0" ] },
+      { "math": [ "u_vitri_glass_entered", "=", "2" ] },
+      { "u_add_effect": "VITRIFYING", "duration": "PERMANENT", "intensity": { "math": [ "u_vitri_vitrified" ] } },
+      { "run_eocs": "EOC_vitrified_farm_explore", "time_in_future": "1 minutes" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -391,6 +391,11 @@
         "if": { "u_has_effect": "boomered" },
         "then": [ { "u_message": "The bile is washed away from your face.", "type": "good" }, { "u_lose_effect": "boomered" } ]
       },
+
+      {
+        "if": { "u_has_effect": "glowing" },
+        "then": [ { "u_message": "The glowing goo is washed away.", "type": "good" }, { "u_lose_effect": "glowing" } ]
+      },
       {
         "if": { "u_has_effect": "corroding" },
         "then": [ { "u_message": "The acid is washed away from your body.", "type": "good" }, { "u_lose_effect": "corroding" } ]

--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -389,11 +389,11 @@
       },
       {
         "if": { "u_has_effect": "boomered" },
-        "then": [ { "u_message": "You wash the bile from your face.", "type": "good" }, { "u_lose_effect": "boomered" } ]
+        "then": [ { "u_message": "The bile is washed away from your face.", "type": "good" }, { "u_lose_effect": "boomered" } ]
       },
       {
         "if": { "u_has_effect": "corroding" },
-        "then": [ { "u_message": "You wash the acid from your body.", "type": "good" }, { "u_lose_effect": "corroding" } ]
+        "then": [ { "u_message": "The acid is washed away from your body.", "type": "good" }, { "u_lose_effect": "corroding" } ]
       }
     ]
   }

--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -378,20 +378,23 @@
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
     "condition": "u_is_underwater",
+    "//": "I would assume that Mycus spores are a bit sticky to keep them from coming off, so this has a chance to be removed instead of a guarantee.",
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_REMOVE_HARD_THINGS_CHECK",
-          "global": false,
-          "eoc_type": "EVENT",
-          "required_event": "avatar_moves",
-          "condition": { "x_in_y_chance": { "x": 1, "y": 10 } },
-          "//": "I would assume that Mycus spores are a bit sticky to keep them from coming off, so this has a chance to be removed instead of a garuntee.",
-          "effect": [ { "u_lose_effect": "spores" } ]
-        }
+        "if": { "and": [ { "u_has_effect": "spores" }, { "x_in_y_chance": { "x": 1, "y": 10 } } ] },
+        "then": [
+          { "u_message": "You scrub your body extensively, and spores are finally gone.", "type": "good" },
+          { "u_lose_effect": "spores" }
+        ]
       },
-      { "u_lose_effect": "boomered" },
-      { "u_lose_effect": "corroding" }
+      {
+        "if": { "u_has_effect": "boomered" },
+        "then": [ { "u_message": "You wash the bile from your face.", "type": "good" }, { "u_lose_effect": "boomered" } ]
+      },
+      {
+        "if": { "u_has_effect": "corroding" },
+        "then": [ { "u_message": "You wash the acid from your body.", "type": "good" }, { "u_lose_effect": "corroding" } ]
+      }
     ]
   }
 ]

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -163,5 +163,48 @@
       { "set_string_var": "mixin fail alpha", "target_var": { "global_val": "alpha_name" } },
       { "set_string_var": "mixin fail beta", "target_var": { "global_val": "beta_name" } }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_compare_string_test",
+    "effect": [
+      { "if": { "compare_string": [ "yes", "yes" ] }, "then": { "math": [ "eoc_compare_string_test_1", "++" ] } },
+      { "if": { "compare_string": [ "yes", "no" ] }, "else": { "math": [ "eoc_compare_string_test_2", "++" ] } },
+      {
+        "if": { "compare_string": [ "yes", "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_test_3", "++" ] }
+      },
+      {
+        "if": { "compare_string": [ "yes", "yes", "no" ] },
+        "then": { "math": [ "eoc_compare_string_test_4", "++" ] }
+      },
+      { "if": { "compare_string": [ "yes", "no", "eh" ] }, "else": { "math": [ "eoc_compare_string_test_5", "++" ] } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_compare_string_match_all_test",
+    "effect": [
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_match_all_test_1", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "no" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_2", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes", "yes" ] },
+        "then": { "math": [ "eoc_compare_string_match_all_test_3", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "yes", "no" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_4", "++" ] }
+      },
+      {
+        "if": { "compare_string_match_all": [ "yes", "no", "eh" ] },
+        "else": { "math": [ "eoc_compare_string_match_all_test_5", "++" ] }
+      }
+    ]
   }
 ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -549,8 +549,8 @@ checks this var exists
 ```
 
 ### `compare_string`
-- type: pair of strings or [variable objects](##variable-object)
-- Compare two strings, and return true if strings are equal
+- type: array of strings or [variable objects](#variable-object)
+- Compare all strings, and return true if at least two of them match
 
 #### Examples
 checks if `victim_type` is `mon_zombie_phase_shrike`
@@ -561,6 +561,42 @@ checks if `victim_type` is `mon_zombie_phase_shrike`
 checks is `victim_type` has `zombie` faction
 ```json
 { "compare_string": [ "zombie", { "mutator": "mon_faction", "mtype_id": { "context_val": "victim_type" } } ] }
+```
+
+Check if victim_type is any in the list
+```json
+"compare_string": [
+  { "context_val": "victim_type" },
+  "mon_hound_tindalos",
+  "mon_darkman",
+  "mon_zombie_phase_shrike",
+  "mon_swarm_structure",
+  "mon_better_half",
+  "mon_hallucinator",
+  "mon_archunk_strong",
+  "mon_void_spider",
+  "mon_XEDRA_officer",
+  "mon_eigenspectre_3",
+  "mon_eigenspectre_4",
+  "mon_living_vector"
+]
+```
+
+Check if `map_cache` contain value `has`, `lack` or `read`
+```json
+{ "compare_string": [ { "npc_val": "map_cache" }, "has", "lack", "read" ] }
+```
+
+### `compare_string_match_all`
+- type: array of strings or [variable objects](#variable-object)
+- Compare all strings, and return true if all of them match
+- For two strings the check is same as compare_string
+
+#### Examples
+
+Check if two variables are `yes`
+```json
+"compare_string": [ "yes", { "context_val": "some_context_should_be_yes" }, { "context_val": "some_another_context_also_should_be_yes" } ]
 ```
 
 ### `u_profession`
@@ -1350,7 +1386,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | activates_mininuke | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE |
 | administers_mutagen |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE |
 | angers_amigara_horrors | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE |
-| avatar_enters_omt |  | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
+| avatar_enters_omt | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
 | avatar_moves |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE |
 | avatar_dies |  | NONE | avatar / NONE |
 | awakes_dark_wyrms | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE |

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -68,7 +68,6 @@ static const character_modifier_id
 character_modifier_melee_stamina_cost_mod( "melee_stamina_cost_mod" );
 
 static const efftype_id effect_amigara( "amigara" );
-static const efftype_id effect_glowing( "glowing" );
 static const efftype_id effect_grabbing( "grabbing" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_harnessed( "harnessed" );
@@ -653,11 +652,6 @@ void avatar_action::swim( map &m, avatar &you, const tripoint &p )
             }
         }
     }
-    if( you.has_effect( effect_glowing ) ) {
-        add_msg( _( "The water washes off the glowing goo!" ) );
-        you.remove_effect( effect_glowing );
-    }
-
     g->water_affect_items( you );
 
     int movecost = you.swim_speed();

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1851,26 +1851,42 @@ conditional_t::func f_has_faction_trust( const JsonObject &jo, std::string_view 
 
 conditional_t::func f_compare_string( const JsonObject &jo, std::string_view member )
 {
-    str_or_var first;
-    str_or_var second;
-    JsonArray objects = jo.get_array( member );
-    if( objects.size() != 2 ) {
-        jo.throw_error( "incorrect number of values.  Expected 2 in " + jo.str() );
+    // return true if at least two strings match, OR
+
+    std::vector<str_or_var> values;
+    for( JsonValue jv : jo.get_array( member ) ) {
+        values.emplace_back( get_str_or_var( jv, member ) );
     }
 
-    if( objects.has_object( 0 ) ) {
-        first = get_str_or_var( objects.next_value(), member, true );
-    } else {
-        first.str_val = objects.next_string();
-    }
-    if( objects.has_object( 1 ) ) {
-        second = get_str_or_var( objects.next_value(), member, true );
-    } else {
-        second.str_val = objects.next_string();
+    return [values]( const_dialogue const & d ) {
+        std::unordered_set<std::string> seen_values;
+        for( const str_or_var &val : values ) { 
+            std::string evaluated_value = val.evaluate( d );
+            if( seen_values.count( evaluated_value ) > 0 ) {
+                return true;
+            }
+            seen_values.insert( evaluated_value );
+        }
+        return false;
+    };
+}
+
+conditional_t::func f_compare_string_match_all( const JsonObject &jo, std::string_view member )
+{
+    // return true if all strings match, AND
+    std::vector<str_or_var> values;
+    for( JsonValue jv : jo.get_array( member ) ) {
+        values.emplace_back( get_str_or_var( jv, member ) );
     }
 
-    return [first, second]( const_dialogue const & d ) {
-        return first.evaluate( d ) == second.evaluate( d );
+    return [values]( const_dialogue const & d ) {
+        std::string first_value = values[0].evaluate( d );
+        for( size_t i = 1; i < values.size(); ++i ) {
+            if( values[i].evaluate( d ) != first_value ) {
+                return false;
+            }
+        }
+        return true;
     };
 }
 
@@ -2650,6 +2666,7 @@ parsers = {
     {"u_has_faction_trust", jarg::member | jarg::array, &conditional_fun::f_has_faction_trust },
     {"math", jarg::member, &conditional_fun::f_math },
     {"compare_string", jarg::member, &conditional_fun::f_compare_string },
+    {"compare_string_match_all", jarg::member, &conditional_fun::f_compare_string_match_all },
     {"get_condition", jarg::member, &conditional_fun::f_get_condition },
     {"test_eoc", jarg::member, &conditional_fun::f_test_eoc },
 };

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1860,7 +1860,7 @@ conditional_t::func f_compare_string( const JsonObject &jo, std::string_view mem
 
     return [values]( const_dialogue const & d ) {
         std::unordered_set<std::string> seen_values;
-        for( const str_or_var &val : values ) { 
+        for( const str_or_var &val : values ) {
             std::string evaluated_value = val.evaluate( d );
             if( seen_values.count( evaluated_value ) > 0 ) {
                 return true;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -34,9 +34,9 @@ static const effect_on_condition_id effect_on_condition_EOC_attack_test( "EOC_at
 static const effect_on_condition_id
 effect_on_condition_EOC_combat_mutator_test( "EOC_combat_mutator_test" );
 static const effect_on_condition_id
-effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
-static const effect_on_condition_id
 effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
+static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_increment_var_var( "EOC_increment_var_var" );
 static const effect_on_condition_id

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -34,6 +34,10 @@ static const effect_on_condition_id effect_on_condition_EOC_attack_test( "EOC_at
 static const effect_on_condition_id
 effect_on_condition_EOC_combat_mutator_test( "EOC_combat_mutator_test" );
 static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
+static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
+static const effect_on_condition_id
 effect_on_condition_EOC_increment_var_var( "EOC_increment_var_var" );
 static const effect_on_condition_id
 effect_on_condition_EOC_item_activate_test( "EOC_item_activate_test" );
@@ -1378,6 +1382,49 @@ TEST_CASE( "EOC_string_test", "[eoc]" )
     CHECK( get_avatar().get_value( "npctalk_var_key1" ) == "nest2" );
     CHECK( get_avatar().get_value( "npctalk_var_key2" ) == "nest3" );
     CHECK( get_avatar().get_value( "npctalk_var_key3" ) == "nest4" );
+}
+
+TEST_CASE( "EOC_compare_string_test", "[eoc]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_1" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_2" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_3" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_4" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_test_5" ).empty() );
+
+    CHECK( effect_on_condition_EOC_compare_string_test->activate( d ) );
+
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_1" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_2" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_3" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_4" ) ) == Approx( 1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_test_5" ) ) == Approx( 1 ) );
+
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_1" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_2" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_3" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_4" ).empty() );
+    REQUIRE( globvars.get_global_value( "eoc_compare_string_match_all_test_5" ).empty() );
+
+    CHECK( effect_on_condition_EOC_compare_string_match_all_test->activate( d ) );
+
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_1" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_2" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_3" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_4" ) ) == Approx(
+               1 ) );
+    CHECK( std::stod( globvars.get_global_value( "eoc_compare_string_match_all_test_5" ) ) == Approx(
+               1 ) );
 }
 
 TEST_CASE( "EOC_run_eocs", "[eoc]" )

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -34,9 +34,9 @@ static const effect_on_condition_id effect_on_condition_EOC_attack_test( "EOC_at
 static const effect_on_condition_id
 effect_on_condition_EOC_combat_mutator_test( "EOC_combat_mutator_test" );
 static const effect_on_condition_id
-effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
-static const effect_on_condition_id
 effect_on_condition_EOC_compare_string_test( "EOC_compare_string_test" );
+static const effect_on_condition_id
+effect_on_condition_EOC_compare_string_match_all_test( "EOC_compare_string_match_all_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_increment_var_var( "EOC_increment_var_var" );
 static const effect_on_condition_id


### PR DESCRIPTION
#### Summary
Backport 77941 - EOCs can compare more than one string

#### Purpose of change
Infrastructure, move the hardcoded thing where water washes off the glowing effect to EOC

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
