### PR TITLE
Improve eye level/cover calculations with vehicles

### DIFF
--- a/data/json/vehicleparts/alternator.json
+++ b/data/json/vehicleparts/alternator.json
@@ -7,7 +7,7 @@
     "broken_color": "red",
     "categories": [ "energy" ],
     "description": "An alternator.",
-    "flags": [ "ALTERNATOR" ],
+    "flags": [ "ALTERNATOR", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "#" } ]
   },
   {

--- a/data/json/vehicleparts/armor.json
+++ b/data/json/vehicleparts/armor.json
@@ -16,7 +16,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "7 m", "using": [ [ "repair_welding_rebar", 1 ] ] }
     },
-    "flags": [ "ARMOR" ],
+    "flags": [ "ARMOR", "NO_COVER" ],
     "damage_reduction": { "all": 10, "cut": 45, "stab": 45 },
     "variants": [ { "symbols": "X", "symbols_broken": "*" } ]
   },
@@ -31,7 +31,7 @@
     "broken_color": "dark_gray",
     "durability": 340,
     "bonus": 50,
-    "description": "A system of springs and pads, intended to cushion the effects of collisions on the interior of your vehicle.",
+    "description": "A system of springs and pads, intended to cushion the effects of driving over rough terrain.",
     "//": "1 m x 1 m sq metal plate + 3 9 cm springs ~= 400 cm weld or so, 50 cm per damage quadrant to repair",
     "breaks_into": [ { "item": "scrap", "count": [ 1, 5 ] }, { "item": "spring", "count": [ 0, 4 ] } ],
     "requirements": {
@@ -39,8 +39,239 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 5 ] ] }
     },
-    "flags": [ "SHOCK_ABSORBER" ],
+    "flags": [ "SHOCK_ABSORBER", "NO_COVER" ],
     "damage_reduction": { "all": 25 },
     "variants": [ { "symbols": "X", "symbols_broken": "*" } ]
+  },
+  
+  {
+    "type": "vehicle_part",
+    "id": "plating_wood",
+    "name": { "str": "wooden armor" },
+    "categories": [ "warfare" ],
+    "color": "brown",
+    "broken_color": "brown",
+    "durability": 250,
+    "item": "wood_plate",
+    "location": "armor",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
+    },
+    "flags": [ "ARMOR" ],
+    "breaks_into": [
+      { "item": "splinter", "count": [ 4, 8 ] },
+      { "item": "string_36", "count": [ 2, 3 ] },
+      { "item": "string_6", "count": [ 3, 6 ] },
+      { "item": "nail", "charges": [ 1, 3 ] }
+    ],
+    "damage_reduction": { "all": 16, "cut": 8, "stab": 8 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_steel",
+    "name": { "str": "steel plating" },
+    "categories": [ "warfare" ],
+    "color": "light_cyan",
+    "broken_color": "light_cyan",
+    "durability": 660,
+    "item": "steel_plate",
+    "location": "armor",
+    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "50 m",
+        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+    },
+    "flags": [ "ARMOR" ],
+    "breaks_into": "ig_vp_steel_plate",
+    "damage_reduction": { "all": 56 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_superalloy",
+    "name": { "str": "superalloy plating" },
+    "categories": [ "warfare" ],
+    "color": "dark_gray",
+    "broken_color": "dark_gray",
+    "durability": 600,
+    "item": "alloy_plate",
+    "location": "armor",
+    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "50 m",
+        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      },
+      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+    },
+    "flags": [ "ARMOR" ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 4, 6 ] },
+      { "item": "steel_chunk", "count": [ 4, 6 ] },
+      { "item": "scrap", "charges": [ 4, 6 ] }
+    ],
+    "damage_reduction": { "all": 56 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_spiked",
+    "name": { "str": "spiked plating" },
+    "categories": [ "warfare" ],
+    "color": "red",
+    "broken_color": "red",
+    "damage_modifier": 150,
+    "durability": 620,
+    "description": "A spiked plate that will increase the damage delivered to someone else in collisions.",
+    "item": "spiked_plate",
+    "location": "armor",
+    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "50 m",
+        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      },
+      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
+    },
+    "flags": [ "ARMOR", "SHARP" ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 5, 8 ] },
+      { "item": "spike", "count": [ 1, 2 ] }
+    ],
+    "damage_reduction": { "all": 48 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_hard",
+    "name": { "str": "hard plating" },
+    "categories": [ "warfare" ],
+    "color": "cyan",
+    "broken_color": "cyan",
+    "durability": 780,
+    "item": "hard_plate",
+    "location": "armor",
+    "//": "300 cm weld to install, 80 cm weld per damage quadrant",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      },
+      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 8 ] ] }
+    },
+    "flags": [ "ARMOR" ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 4, 6 ] },
+      { "item": "steel_chunk", "count": [ 5, 8 ] },
+      { "item": "scrap", "charges": [ 6, 12 ] }
+    ],
+    "damage_reduction": { "all": 70 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_military",
+    "name": { "str": "military composite armor plating" },
+    "categories": [ "warfare" ],
+    "color": "green",
+    "broken_color": "green",
+    "durability": 700,
+    "item": "mil_plate",
+    "location": "armor",
+    "//": "300 cm weld to install",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 6 ] ],
+        "time": "60 m",
+        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      }
+    },
+    "flags": [ "ARMOR", "NO_REPAIR" ],
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 4, 6 ] },
+      { "item": "steel_chunk", "count": [ 4, 6 ] },
+      { "item": "scrap", "charges": [ 4, 6 ] },
+      { "item": "ceramic_armor", "count": [ 0, 4 ] }
+    ],
+    "damage_reduction": { "all": 60, "bullet": 105 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_chitin",
+    "name": { "str": "chitin plating" },
+    "categories": [ "warfare" ],
+    "color": "yellow",
+    "durability": 200,
+    "item": "chitin_plate",
+    "location": "armor",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m" },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m" },
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
+    },
+    "flags": [ "ARMOR" ],
+    "breaks_into": [
+      { "item": "chitin_piece", "count": [ 4, 8 ] },
+      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "rope_6", "prob": 75 },
+      { "item": "string_36", "count": [ 2, 4 ] },
+      { "item": "string_6", "count": [ 7, 14 ] }
+    ],
+    "damage_reduction": { "all": 20 },
+    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plating_acidchitin",
+    "copy-from": "plating_chitin",
+    "name": { "str": "biosilicified chitin plating" },
+    "proportional": { "durability": 1.1 },
+    "item": "acidchitin_plate",
+    "breaks_into": [
+      { "item": "acidchitin_piece", "count": [ 6, 19 ] },
+      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
+      { "item": "rope_6", "prob": 75 },
+      { "item": "string_36", "count": [ 2, 4 ] },
+      { "item": "string_6", "count": [ 7, 14 ] }
+    ],
+    "damage_reduction": { "all": 24 }
   }
 ]

--- a/data/json/vehicleparts/battery.json
+++ b/data/json/vehicleparts/battery.json
@@ -22,7 +22,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "600 s", "using": [ [ "soldering_standard", 5 ] ] }
     },
     "damage_reduction": { "bash": 10 },
-    "flags": [ "BATTERY" ],
+    "flags": [ "BATTERY", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
   {
@@ -133,7 +133,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": "vehicle_weld_removal" }
     },
     "damage_reduction": { "bash": 10 },
-    "flags": [ "BATTERY" ],
+    "flags": [ "BATTERY", "NO_COVER" ],
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
   {
@@ -163,7 +163,7 @@
     "durability": 10,
     "folded_volume": "10 ml",
     "breaks_into": [ { "item": "e_scrap", "prob": 10 } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_light_battery_cell",
@@ -179,7 +179,7 @@
     "durability": 20,
     "folded_volume": "25 ml",
     "breaks_into": [ { "item": "e_scrap", "prob": 10 } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_light_plus_battery_cell",
@@ -195,7 +195,7 @@
     "durability": 20,
     "folded_volume": "35 ml",
     "breaks_into": [ { "item": "e_scrap", "prob": 10 } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_medium_battery_cell",
@@ -211,7 +211,7 @@
     "durability": 30,
     "folded_volume": "450 ml",
     "breaks_into": [ { "item": "light_battery_cell", "count": [ 0, 3 ] }, { "item": "scrap", "count": [ 1, 4 ] } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_medium_plus_battery_cell",
@@ -227,7 +227,7 @@
     "durability": 30,
     "folded_volume": "525 ml",
     "breaks_into": [ { "item": "light_plus_battery_cell", "count": [ 0, 3 ] }, { "item": "scrap", "count": [ 1, 4 ] } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_heavy_battery_cell",
@@ -243,7 +243,7 @@
     "durability": 40,
     "folded_volume": "1225 ml",
     "breaks_into": [ { "item": "medium_battery_cell", "count": [ 0, 1 ] }, { "item": "scrap", "count": [ 1, 4 ] } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   },
   {
     "id": "car_heavy_plus_battery_cell",
@@ -259,6 +259,6 @@
     "durability": 40,
     "folded_volume": "1500 ml",
     "breaks_into": [ { "item": "medium_battery_cell", "count": [ 0, 1 ] }, { "item": "scrap", "count": [ 1, 4 ] } ],
-    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR" ]
+    "flags": [ "BATTERY", "NEEDS_HANDHELD_BATTERY_MOUNT", "NO_REPAIR", "NO_COVER" ]
   }
 ]

--- a/data/json/vehicleparts/boards.json
+++ b/data/json/vehicleparts/boards.json
@@ -115,6 +115,7 @@
     "name": { "str": "quarterpanel" },
     "description": "A half-height metal wall.  Keeps zombies outside the vehicle but allows people to see over it.",
     "proportional": { "durability": 0.8 },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] }
   },
   {
@@ -152,6 +153,7 @@
     "name": { "str": "cloth quarterpanel" },
     "description": "A half-height cloth wall.  Keeps zombies outside the vehicle but allows people to see over it.",
     "proportional": { "durability": 0.8 },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] }
   },
   {
@@ -223,6 +225,7 @@
     "name": { "str": "heavy-duty quarterpanel" },
     "description": "A half-height strong metal wall.  Keeps zombies outside the vehicle but allows people to see over it.",
     "proportional": { "durability": 0.8 },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] }
   },
   {
@@ -256,6 +259,7 @@
     "name": { "str": "wooden quarterpanel" },
     "description": "A half-height wooden wall.  Keeps zombies outside the vehicle but allows people to see over it.",
     "proportional": { "durability": 0.8 },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] }
   },
   {
@@ -278,6 +282,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] },
     "damage_reduction": { "all": 5 }
   },
@@ -299,6 +304,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
     "damage_reduction": { "all": 20 },
+    "delete": { "flags": [ "OPAQUE" ] },
     "extend": { "flags": [ "HALF_BOARD" ] }
   }
 ]

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -16,7 +16,7 @@
       "removal": { "skills": [ [ "fabrication", 2 ] ], "time": "5 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "CARGO", "BOARDABLE", "COVERED", "CARGO_PASSABLE" ],
+    "flags": [ "CARGO", "BOARDABLE", "COVERED", "CARGO_PASSABLE", "NO_COVER" ],
     "breaks_into": "ig_vp_cloth",
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -36,7 +36,7 @@
       "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "repair": { "skills": [ [ "fabrication", 2 ], [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 5 ] ] }
     },
-    "flags": [ "CARGO", "BOARDABLE", "CARGO_PASSABLE", "FLAT_SURF" ],
+    "flags": [ "CARGO", "BOARDABLE", "CARGO_PASSABLE", "FLAT_SURF", "NO_COVER" ],
     "breaks_into": "ig_vp_sheet_metal",
     "variants": [ { "symbols": "T", "symbols_broken": "#" } ]
   },
@@ -63,7 +63,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ], [ "fabrication", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE" ],
+    "flags": [ "CARGO", "OBSTACLE", "NO_COVER" ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -94,7 +94,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "CARGO_PASSABLE" ],
+    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "CARGO_PASSABLE", "NO_COVER" ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -118,7 +118,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ], [ "fabrication", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "CARGO", "OBSTACLE" ],
+    "flags": [ "CARGO", "OBSTACLE", "NO_COVER" ],
     "damage_reduction": { "all": 4 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -142,7 +142,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ], [ "fabrication", 1 ] ], "time": "2 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "CARGO", "CARGO_PASSABLE" ],
+    "flags": [ "CARGO", "CARGO_PASSABLE", "NO_COVER" ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -173,7 +173,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "2 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "CARGO_PASSABLE" ],
+    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "CARGO_PASSABLE", "NO_COVER" ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   },
@@ -229,7 +229,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "6 m", "using": [ [ "repair_welding_standard", 5 ] ] }
     },
-    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "COVERED", "BOARDABLE", "HUGE_OK", "CARGO_PASSABLE" ],
+    "flags": [ "UNMOUNT_ON_DAMAGE", "CARGO", "PROTRUSION", "COVERED", "BOARDABLE", "HUGE_OK", "CARGO_PASSABLE", "NO_COVER" ],
     "damage_reduction": { "all": 26 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
   },
@@ -254,7 +254,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE" ],
+    "flags": [ "BIKE_RACK_VEH", "MULTISQUARE", "NO_COVER" ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "=", "symbols_broken": "#" } ]
   },
@@ -273,7 +273,7 @@
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] }
     },
-    "flags": [ "UNMOUNT_ON_DAMAGE", "PROTRUSION", "CARGO_PASSABLE" ],
+    "flags": [ "UNMOUNT_ON_DAMAGE", "PROTRUSION", "CARGO_PASSABLE", "NO_COVER" ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "o", "symbols_broken": "#" } ]
   }

--- a/data/json/vehicleparts/combustion.json
+++ b/data/json/vehicleparts/combustion.json
@@ -170,6 +170,7 @@
     "power": "7370 W",
     "energy_consumption": "18425 W",
     "folded_volume": "12 L",
+    "extend": { "flags": [ "NO_COVER" ] },
     "breaks_into": [
       { "item": "steel_lump", "count": [ 1, 2 ] },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
@@ -196,6 +197,7 @@
     "power": "21000 W",
     "energy_consumption": "49800 W",
     "folded_volume": "42 L",
+    "extend": { "flags": [ "NO_COVER" ] },
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 8 ] },
       { "item": "steel_chunk", "count": [ 4, 8 ] },
@@ -222,6 +224,7 @@
     "power": "22000 W",
     "energy_consumption": "55000 W",
     "folded_volume": "42 L",
+    "extend": { "flags": [ "NO_COVER" ] },
     "breaks_into": [
       { "item": "steel_lump", "count": [ 4, 8 ] },
       { "item": "steel_chunk", "count": [ 4, 8 ] },
@@ -248,6 +251,7 @@
     "power": "3728 W",
     "energy_consumption": "9320 W",
     "folded_volume": "6 L",
+    "extend": { "flags": [ "NO_COVER" ] },
     "breaks_into": [
       { "item": "steel_lump", "count": [ 0, 1 ] },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
@@ -493,6 +497,7 @@
     "item": "steam_triple_small",
     "durability": 200,
     "power": "93250 W",
+    "extend": { "flags": [ "NO_COVER" ] },
     "energy_consumption": "186500 W",
     "breaks_into": [
       { "item": "steel_lump", "count": [ 30, 60 ] },

--- a/data/json/vehicleparts/engineering.json
+++ b/data/json/vehicleparts/engineering.json
@@ -81,7 +81,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "PROTRUSION" ],
+    "flags": [ "PROTRUSION", "NO_COVER" ],
     "damage_reduction": { "all": 40 },
     "variants": [ { "symbols": "=", "symbols_broken": "*" } ]
   },
@@ -116,7 +116,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "CARGO", "PROTRUSION" ],
+    "flags": [ "CARGO", "PROTRUSION", "NO_COVER" ],
     "pseudo_tools": [ { "id": "crane_pseudo_item" } ],
     "damage_reduction": { "all": 42 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
@@ -183,7 +183,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "PROTRUSION", "SELF_JACK" ],
+    "flags": [ "PROTRUSION", "SELF_JACK", "NO_COVER" ],
     "damage_reduction": { "all": 36 },
     "variants": [ { "symbols": "[", "symbols_broken": "/" } ]
   },
@@ -204,7 +204,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "SELF_JACK" ],
+    "flags": [ "SELF_JACK", "NO_COVER" ],
     "damage_reduction": { "all": 5 },
     "variants": [ { "symbols": "[", "symbols_broken": "/" } ]
   }

--- a/data/json/vehicleparts/frames.json
+++ b/data/json/vehicleparts/frames.json
@@ -12,7 +12,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "MOUNTABLE", "INITIAL_PART" ],
+    "flags": [ "MOUNTABLE", "INITIAL_PART", "NO_COVER" ],
     "categories": [ "hull" ],
     "damage_reduction": { "all": 20 },
     "variants": [

--- a/data/json/vehicleparts/lights.json
+++ b/data/json/vehicleparts/lights.json
@@ -18,7 +18,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
-    "flags": [ "AISLE_LIGHT", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "AISLE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -39,7 +39,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 5 ] ] }
     },
-    "flags": [ "ATOMIC_LIGHT", "LEAK_DAM", "RADIOACTIVE" ],
+    "flags": [ "ATOMIC_LIGHT", "LEAK_DAM", "RADIOACTIVE", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -77,7 +77,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
-    "flags": [ "CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "-" } ]
   },
   {
@@ -89,7 +89,7 @@
     "description": "A very bright, directed light that illuminates a half-circular area outside the vehicle when turned on.  During installation, you can choose what direction to point the light.",
     "//": "8000 lm 100 W LED floodlight",
     "epower": "-55 W",
-    "flags": [ "HALF_CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER" ]
+    "flags": [ "HALF_CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ]
   },
   {
     "id": "headlight",
@@ -111,7 +111,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
-    "flags": [ "CONE_LIGHT", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "CONE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -134,7 +134,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "CONE_LIGHT", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "CONE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
   {
@@ -145,7 +145,7 @@
     "copy-from": "headlight",
     "description": "A bright light that illuminates a wide cone outside the vehicle when turned on.  During installation, you can choose what direction to point the light, so multiple headlights can illuminate the sides or rear, as well as the front.",
     "epower": "-150 W",
-    "flags": [ "WIDE_CONE_LIGHT", "ENABLED_DRAINS_EPOWER" ]
+    "flags": [ "WIDE_CONE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ]
   },
   {
     "id": "headlight_reinforced",
@@ -191,7 +191,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "200 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
-    "flags": [ "CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "CIRCLE_LIGHT", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "damage_reduction": { "all": 6 },
     "variants": [ { "symbols": "*", "symbols_broken": "-" } ]
   },

--- a/data/json/vehicleparts/manual.json
+++ b/data/json/vehicleparts/manual.json
@@ -10,7 +10,7 @@
     "noise_factor": 5,
     "m2c": 45,
     "exclusions": [ "manual" ],
-    "flags": [ "ENGINE", "E_STARTS_INSTANTLY", "E_ALTERNATOR" ],
+    "flags": [ "ENGINE", "E_STARTS_INSTANTLY", "E_ALTERNATOR", "NO_COVER" ],
     "variants": [ { "symbols": "*", "symbols_broken": "#" } ]
   },
   {
@@ -91,7 +91,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "3 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "6 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "CONTROL_ANIMAL" ],
+    "flags": [ "CONTROL_ANIMAL", "NO_COVER" ],
     "breaks_into": [ { "item": "leather", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "W", "symbols_broken": "X" } ]
   }

--- a/data/json/vehicleparts/mirrors.json
+++ b/data/json/vehicleparts/mirrors.json
@@ -17,7 +17,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "VISION", "PROTRUSION", "UNMOUNT_ON_DAMAGE" ],
+    "flags": [ "VISION", "PROTRUSION", "UNMOUNT_ON_DAMAGE", "NO_COVER" ],
     "breaks_into": [ { "item": "glass_shard", "charges": [ 0, 8 ] } ],
     "variants": [
       { "id": "left", "label": "Left", "symbols": "o", "symbols_broken": "*" },
@@ -42,7 +42,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "100 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "VISION" ],
+    "flags": [ "VISION", "NO_COVER" ],
     "breaks_into": [ { "item": "glass_shard", "charges": [ 0, 8 ] } ],
     "variants": [ { "symbols": "o", "symbols_broken": "*" } ]
   }

--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -9,6 +9,7 @@
     "price": "400 USD",
     "price_postapoc": "20 USD",
     "material": [ "steel" ],
+    "flags": [ "NO_COVER" ],
     "symbol": "&",
     "color": "light_cyan"
   },
@@ -97,7 +98,7 @@
     "damage_reduction": { "all": 30 },
     "durability": 80,
     "size": "50 L",
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "VEH_TOOLS" ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "VEH_TOOLS", "NO_COVER" ],
     "//": "allow tools common for both kitchen unit and workshop; unpowered or low-power and no fume hood required",
     "allowed_tools": [
       "aluminum_pan",

--- a/data/json/vehicleparts/motor.json
+++ b/data/json/vehicleparts/motor.json
@@ -28,6 +28,7 @@
     "energy_consumption": "2 kW",
     "damage_modifier": 80,
     "folded_volume": "750 ml",
+    "extend": { "flags": [ "NO_COVER" ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
@@ -51,6 +52,7 @@
     "energy_consumption": "8 kW",
     "damage_modifier": 80,
     "folded_volume": "6 L",
+    "extend": { "flags": [ "NO_COVER" ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "60 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -245,7 +245,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 6 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
-    "extend": { "flags": [ "SHARP", "UNMOUNT_ON_DAMAGE" ] },
+    "extend": { "flags": [ "SHARP", "UNMOUNT_ON_DAMAGE", "NO_COVER" ] },
     "delete": { "flags": [ "OBSTACLE" ] },
     "damage_reduction": { "all": 40 },
     "variants": [ { "symbols": "*", "symbols_broken": "x" } ]
@@ -265,7 +265,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "extend": { "flags": [ "SHARP" ] },
+    "extend": { "flags": [ "SHARP", "NO_COVER" ] },
     "delete": { "flags": [ "OBSTACLE" ] },
     "breaks_into": [ { "item": "steel_chunk", "prob": 50 } ]
   },
@@ -277,6 +277,7 @@
     "damage_modifier": 300,
     "durability": 250,
     "color": "white",
+    "extend": { "flags": [ "NO_COVER" ] },
     "broken_color": "white",
     "description": "A metal spike, welded to the vehicle, to increase injury when crashing into things.",
     "item": "spike",

--- a/data/json/vehicleparts/rotor.json
+++ b/data/json/vehicleparts/rotor.json
@@ -5,7 +5,7 @@
     "categories": [ "movement" ],
     "location": "on_roof",
     "color": "light_blue",
-    "flags": [ "ROTOR", "NO_INSTALL_PLAYER", "NO_REPAIR", "SMASH_REMOVE" ],
+    "flags": [ "ROTOR", "NO_INSTALL_PLAYER", "NO_REPAIR", "SMASH_REMOVE", "NO_COVER" ],
     "description": "A set of aerofoil helicopter rotors, when spun at high speed, they generate thrust via lift.",
     "variants": [ { "symbols": "X", "symbols_broken": "O" } ],
     "control_requirements": { "air": { "proficiencies": [ "prof_helicopter_pilot" ] } }

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -140,7 +140,7 @@
     },
     "breaks_into": [ { "item": "leather", "prob": 50 }, { "item": "scrap", "count": [ 1, 2 ] } ],
     "size": "0 ml",
-    "extend": { "flags": [ "NONBELTABLE" ] },
+    "extend": { "flags": [ "NONBELTABLE", "NO_COVER" ] },
     "delete": { "flags": [ "BELTABLE", "CARGO" ] },
     "variants_bases": [  ],
     "variants": [
@@ -175,6 +175,7 @@
     "description": "A steel bench with ankle and wrist restraints built in.  It looks very uncomfortable.",
     "durability": 450,
     "item": "steel_plate",
+    "extend": { "flags": [ "NO_COVER" ] },
     "//": "more metal here so bigger weld cost - 20 cm weld per damage quadrant",
     "name": { "str": "steel bench" },
     "requirements": {

--- a/data/json/vehicleparts/tanks.json
+++ b/data/json/vehicleparts/tanks.json
@@ -22,7 +22,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "FLUIDTANK" ],
+    "flags": [ "FLUIDTANK", "NO_COVER" ],
     "damage_reduction": { "all": 26, "stab": 8 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
@@ -47,7 +47,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": [ [ "soldering_standard", 5 ] ] }
     },
-    "flags": [ "FLUIDTANK" ],
+    "flags": [ "FLUIDTANK", "NO_COVER" ],
     "damage_reduction": { "all": 9, "stab": 0 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
@@ -77,7 +77,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "22 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "8 m", "using": [ [ "repair_welding_standard", 4 ] ] }
     },
-    "flags": [ "FLUIDTANK" ],
+    "flags": [ "FLUIDTANK", "NO_COVER" ],
     "damage_reduction": { "all": 28, "stab": 10 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },
@@ -362,7 +362,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "45 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "GASTANK" ],
+    "flags": [ "GASTANK", "NO_COVER" ],
     "damage_reduction": { "all": 28, "stab": 12 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
   },

--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -126,7 +126,7 @@
     "item": "binoculars",
     "location": "internal",
     "folded_volume": "500 ml",
-    "flags": [ "ENHANCED_VISION", "SIMPLE_PART" ],
+    "flags": [ "ENHANCED_VISION", "SIMPLE_PART", "NO_COVER" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "6 m", "using": [ [ "vehicle_screw", 1 ], [ "adhesive", 2 ] ] },
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "3 m", "using": [ [ "vehicle_screw", 1 ] ] },

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -122,7 +122,8 @@
       "UNMOUNT_ON_DAMAGE",
       "UNSTABLE_WHEEL",
       "WHEEL",
-      "HUGE_OK"
+      "HUGE_OK",
+      "NO_COVER"
     ],
     "damage_reduction": { "all": 2 },
     "variants": [ { "symbols": "H", "symbols_broken": "M" } ]
@@ -167,7 +168,8 @@
       "UNMOUNT_ON_DAMAGE",
       "UNSTABLE_WHEEL",
       "WHEEL",
-      "HUGE_OK"
+      "HUGE_OK",
+      "NO_COVER"
     ],
     "damage_reduction": { "all": 20 },
     "variants": [ { "symbols": "H", "symbols_broken": "M" } ]
@@ -202,7 +204,8 @@
       "HARNESS_human",
       "STEERABLE",
       "UNMOUNT_ON_DAMAGE",
-      "HUGE_OK"
+      "HUGE_OK",
+      "NO_COVER"
     ],
     "damage_reduction": { "all": 2 },
     "variants": [ { "symbols": "-", "symbols_broken": "~" } ]
@@ -263,7 +266,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "MOUNTABLE" ],
+    "flags": [ "MOUNTABLE", "NO_COVER" ],
     "breaks_into": [ { "item": "steel_chunk", "count": [ 0, 1 ] }, { "item": "scrap", "charges": [ 3, 7 ] } ],
     "damage_reduction": { "all": 5 },
     "variants": [ { "symbols": "^", "symbols_broken": "#" } ]
@@ -279,6 +282,7 @@
     "durability": 150,
     "description": "A pair of handles.  You can mount other items on top of it.",
     "item": "frame_wood",
+    "flags": [ "NO_COVER" ],
     "location": "structure",
     "requirements": {
       "install": { "skills": [ [ "fabrication", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
@@ -301,6 +305,7 @@
     "description": "A pair of handles.  You can mount other items on top of it.",
     "item": "frame_wood_light",
     "location": "structure",
+    "flags": [ "NO_COVER" ],
     "breaks_into": [
       { "item": "splinter", "count": [ 5, 8 ] },
       { "item": "string_36", "count": [ 1, 3 ] },
@@ -508,7 +513,7 @@
     "item": "programmable_autopilot",
     "looks_like": "cam_control",
     "epower": "-15 W",
-    "flags": [ "ENABLED_DRAINS_EPOWER", "AUTOPILOT" ],
+    "flags": [ "ENABLED_DRAINS_EPOWER", "AUTOPILOT", "NO_COVER" ],
     "requirements": {
       "install": {
         "time": "12 m",
@@ -555,7 +560,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "BATTERY_MOUNT" ],
+    "flags": [ "BATTERY_MOUNT", "NO_COVER" ],
     "breaks_into": [
       { "item": "steel_lump", "prob": 50 },
       { "item": "steel_chunk", "count": [ 1, 2 ] },
@@ -581,7 +586,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "HANDHELD_BATTERY_MOUNT" ],
+    "flags": [ "HANDHELD_BATTERY_MOUNT", "NO_COVER" ],
     "breaks_into": [ { "item": "power_supply", "prob": 50 }, { "item": "scrap", "charges": [ 1, 4 ] } ],
     "damage_reduction": { "all": 4, "bash": 5 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
@@ -595,7 +600,7 @@
     "durability": 400,
     "categories": [ "other" ],
     "broken_color": "dark_gray",
-    "flags": [ "NO_REPAIR" ],
+    "flags": [ "NO_REPAIR", "NO_COVER" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 2 ] ], "qualities": [ { "id": "SCREW", "level": 3 }, { "id": "WRENCH", "level": 3 } ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "using": [ [ "vehicle_screw", 1 ] ] }
@@ -855,7 +860,7 @@
     "size": "75 L",
     "item": "frame_wood_light",
     "location": "center",
-    "flags": [ "CARGO", "BOARDABLE", "COVERED", "HUGE_OK", "CARGO_PASSABLE" ],
+    "flags": [ "CARGO", "BOARDABLE", "COVERED", "HUGE_OK", "CARGO_PASSABLE", "NO_COVER" ],
     "breaks_into": [
       { "item": "splinter", "count": [ 5, 8 ] },
       { "item": "string_36", "count": [ 1, 3 ] },
@@ -1085,7 +1090,7 @@
       "removal": { "skills": [ [ "fabrication", 1 ] ], "time": "15 m", "qualities": [ { "id": "CUT", "level": 2 } ] },
       "repair": { "skills": [ [ "fabrication", 2 ] ], "time": "15 m", "using": [ [ "rope_natural_short", 1 ] ] }
     },
-    "flags": [ "FLOATS" ],
+    "flags": [ "FLOATS", "NO_COVER" ],
     "breaks_into": [ { "item": "splinter", "count": [ 10, 20 ] } ],
     "damage_reduction": { "all": 5 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
@@ -1107,7 +1112,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 3 ] ] }
     },
-    "flags": [ "FLOATS" ],
+    "flags": [ "FLOATS", "NO_COVER" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
     "damage_reduction": { "all": 12, "stab": 4, "cut": 4 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
@@ -1138,7 +1143,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
-    "flags": [ "FLOATS" ],
+    "flags": [ "FLOATS", "NO_COVER" ],
     "breaks_into": "ig_vp_sheet_metal",
     "damage_reduction": { "all": 28 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
@@ -1160,7 +1165,7 @@
       "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 7 ] ], "time": "60 m", "using": [ [ "adhesive", 3 ] ] }
     },
-    "flags": [ "FLOATS", "BOARDABLE" ],
+    "flags": [ "FLOATS", "BOARDABLE", "NO_COVER" ],
     "breaks_into": [ { "item": "rigid_kevlar_plate", "count": [ 1, 3 ] } ],
     "damage_reduction": { "all": 14 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
@@ -1185,7 +1190,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "MOUNTABLE", "BOARDABLE", "CARGO", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
+    "flags": [ "MOUNTABLE", "BOARDABLE", "CARGO", "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "NO_COVER" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
     "damage_reduction": { "bash": 10 },
     "variants": [ { "symbols": "O", "symbols_broken": "#" } ]
@@ -1209,7 +1214,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "adhesive_rubber", 2 ], [ "tire_rubber", 2 ] ] }
     },
-    "flags": [ "FLOATS", "VARIABLE_SIZE", "NO_INSTALL_HIDDEN", "NO_UNINSTALL" ],
+    "flags": [ "FLOATS", "VARIABLE_SIZE", "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "NO_COVER" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 10, 20 ] } ],
     "damage_reduction": { "bash": 10 },
     "variants": [ { "symbols": "O", "symbols_broken": "x" } ]
@@ -1278,7 +1283,7 @@
         "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 8 ], [ "vehicle_wrench_1", 1 ], [ "vehicle_screw", 1 ] ]
       }
     },
-    "flags": [ "CONTROLS", "NEED_LEG", "INOPERABLE_SMALL" ],
+    "flags": [ "CONTROLS", "NEED_LEG", "INOPERABLE_SMALL", "NO_COVER" ],
     "breaks_into": [
       { "item": "steel_lump" },
       { "item": "steel_chunk", "count": [ 1, 3 ] },
@@ -1299,7 +1304,7 @@
     "bonus": 10,
     "folded_volume": "740 ml",
     "item": "hand_controls",
-    "flags": [ "IGNORE_LEG_REQUIREMENT", "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
+    "flags": [ "IGNORE_LEG_REQUIREMENT", "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "count": [ 0, 2 ] }, { "item": "pipe", "count": [ 0, 1 ] } ],
     "variants": [ { "symbols": "/", "symbols_broken": "/" } ]
   },
@@ -1314,7 +1319,7 @@
     "bonus": 10,
     "folded_volume": "2 L",
     "item": "pedal_extenders",
-    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
+    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS", "NO_COVER" ],
     "breaks_into": [
       { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
       { "item": "rubber_tire_chunk", "count": [ 0, 8 ] },
@@ -1334,7 +1339,7 @@
     "bonus": 10,
     "folded_volume": "2 L",
     "item": "pedal_extenders_makeshift",
-    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS" ],
+    "flags": [ "IGNORE_HEIGHT_REQUIREMENT", "ON_CONTROLS", "NO_COVER" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "350 s", "components": [ [ [ "duct_tape", 25 ] ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ] ] }
@@ -1424,7 +1429,7 @@
   {
     "id": "integrated_heater_small",
     "copy-from": "mountable_heater_small",
-    "description": "Set of tubes, that move heat from the engine into the vehicle cabin, heating it up.",
+    "description": "A set of tubes that move heat from the engine into the vehicle cabin, heating it up.",
     "item": "pipe",
     "type": "vehicle_part",
     "location": "",
@@ -1471,7 +1476,7 @@
     "type": "vehicle_part",
     "location": "",
     "name": { "str": "small integrated cooler" },
-    "description": "Small set of mechanisms, that cool the vehicle out when turned on.",
+    "description": "A small set of mechanisms that cool the vehicle when turned on.",
     "item": "integrated_cooler",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 4 ], [ "electronics", 1 ] ], "time": "3 h", "using": [ [ "vehicle_screw", 1 ] ] },
@@ -1498,7 +1503,7 @@
       "removal": { "skills": [ [ "mechanics", 3 ] ], "time": "350 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "80 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 10 ] ] }
     },
-    "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "CABLE_PORTS" ],
+    "flags": [ "CTRL_ELECTRONIC", "DOME_LIGHT", "ENABLED_DRAINS_EPOWER", "CABLE_PORTS", "NO_COVER" ],
     "breaks_into": [
       { "item": "cable", "charges": [ 0, 1 ] },
       { "item": "plastic_chunk", "count": [ 2, 4 ] },
@@ -1531,7 +1536,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "MUFFLER" ],
+    "flags": [ "MUFFLER", "NO_COVER" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 1, 3 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
@@ -1558,7 +1563,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "SEATBELT", "SIMPLE_PART" ],
+    "flags": [ "SEATBELT", "SIMPLE_PART", "NO_COVER" ],
     "damage_reduction": { "bash": 15 },
     "variants": [ { "symbols": ",", "symbols_broken": "," } ]
   },
@@ -1589,7 +1594,7 @@
         "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
       }
     },
-    "flags": [ "ON_CONTROLS", "SECURITY", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "ON_CONTROLS", "SECURITY", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "variants": [ { "symbols": ",", "symbols_broken": "," } ]
   },
@@ -1617,7 +1622,7 @@
         "qualities": [ { "id": "SCREW_FINE", "level": 1 } ]
       }
     },
-    "flags": [ "ON_CONTROLS", "ENABLED_DRAINS_EPOWER", "SMART_ENGINE_CONTROLLER" ],
+    "flags": [ "ON_CONTROLS", "ENABLED_DRAINS_EPOWER", "SMART_ENGINE_CONTROLLER", "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "variants": [ { "symbols": "'", "symbols_broken": "'" } ]
   },
@@ -1639,7 +1644,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "SEATBELT", "SIMPLE_PART" ],
+    "flags": [ "SEATBELT", "SIMPLE_PART", "NO_COVER" ],
     "damage_reduction": { "bash": 15 },
     "variants": [ { "symbols": ",", "symbols_broken": "," } ]
   },
@@ -1966,6 +1971,7 @@
     "pseudo_tools": [ { "id": "water_faucet" } ],
     "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] } ],
     "damage_reduction": { "all": 6 },
+    "flags": [ "NO_COVER" ],
     "variants": [ { "symbols": "u", "symbols_broken": "-" } ]
   },
   {
@@ -1980,6 +1986,7 @@
     "durability": 45,
     "folded_volume": "2500 ml",
     "//": "10 cm weld per damage quadrant",
+    "flags": [ "NO_COVER" ],
     "item": "towel_hanger",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
@@ -1989,195 +1996,6 @@
     "pseudo_tools": [ { "id": "towel", "hotkey": "t" } ],
     "breaks_into": [ { "item": "scrap", "charges": [ 1, 3 ] }, { "item": "cotton_patchwork", "count": [ 1, 6 ] } ],
     "variants": [ { "symbols": "h", "symbols_broken": "-" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_wood",
-    "name": { "str": "wooden armor" },
-    "categories": [ "warfare" ],
-    "color": "brown",
-    "broken_color": "brown",
-    "durability": 250,
-    "item": "wood_plate",
-    "location": "armor",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 2 ] ] }
-    },
-    "flags": [ "ARMOR" ],
-    "breaks_into": [
-      { "item": "splinter", "count": [ 4, 8 ] },
-      { "item": "string_36", "count": [ 2, 3 ] },
-      { "item": "string_6", "count": [ 3, 6 ] },
-      { "item": "nail", "charges": [ 1, 3 ] }
-    ],
-    "damage_reduction": { "all": 16, "cut": 8, "stab": 8 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_steel",
-    "name": { "str": "steel plating" },
-    "categories": [ "warfare" ],
-    "color": "light_cyan",
-    "broken_color": "light_cyan",
-    "durability": 660,
-    "item": "steel_plate",
-    "location": "armor",
-    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
-      },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
-    },
-    "flags": [ "ARMOR" ],
-    "breaks_into": "ig_vp_steel_plate",
-    "damage_reduction": { "all": 56 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_superalloy",
-    "name": { "str": "superalloy plating" },
-    "categories": [ "warfare" ],
-    "color": "dark_gray",
-    "broken_color": "dark_gray",
-    "durability": 600,
-    "item": "alloy_plate",
-    "location": "armor",
-    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
-      },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
-    },
-    "flags": [ "ARMOR" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "charges": [ 4, 6 ] }
-    ],
-    "damage_reduction": { "all": 56 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_spiked",
-    "name": { "str": "spiked plating" },
-    "categories": [ "warfare" ],
-    "color": "red",
-    "broken_color": "red",
-    "damage_modifier": 150,
-    "durability": 620,
-    "description": "A spiked plate that will increase the damage delivered to someone else in collisions.",
-    "item": "spiked_plate",
-    "location": "armor",
-    "//": "240 cm weld to install, 60 cm weld per damage quadrant",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "50 m",
-        "using": [ [ "welding_standard", 240 ], [ "vehicle_bolt_install", 3 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
-      },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
-    },
-    "flags": [ "ARMOR", "SHARP" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "charges": [ 5, 8 ] },
-      { "item": "spike", "count": [ 1, 2 ] }
-    ],
-    "damage_reduction": { "all": 48 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_hard",
-    "name": { "str": "hard plating" },
-    "categories": [ "warfare" ],
-    "color": "cyan",
-    "broken_color": "cyan",
-    "durability": 780,
-    "item": "hard_plate",
-    "location": "armor",
-    "//": "300 cm weld to install, 80 cm weld per damage quadrant",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "60 m",
-        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 2 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
-      },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 8 ] ] }
-    },
-    "flags": [ "ARMOR" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 5, 8 ] },
-      { "item": "scrap", "charges": [ 6, 12 ] }
-    ],
-    "damage_reduction": { "all": 70 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_military",
-    "name": { "str": "military composite armor plating" },
-    "categories": [ "warfare" ],
-    "color": "green",
-    "broken_color": "green",
-    "durability": 700,
-    "item": "mil_plate",
-    "location": "armor",
-    "//": "300 cm weld to install",
-    "requirements": {
-      "install": {
-        "skills": [ [ "mechanics", 6 ] ],
-        "time": "60 m",
-        "using": [ [ "welding_standard", 300 ], [ "vehicle_bolt_install", 4 ] ]
-      },
-      "removal": {
-        "skills": [ [ "mechanics", 4 ] ],
-        "time": "30 m",
-        "using": [ [ "vehicle_weld_removal_cut_resistant", 1 ], [ "vehicle_wrench_2", 1 ] ]
-      }
-    },
-    "flags": [ "ARMOR", "NO_REPAIR" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 6 ] },
-      { "item": "steel_chunk", "count": [ 4, 6 ] },
-      { "item": "scrap", "charges": [ 4, 6 ] },
-      { "item": "ceramic_armor", "count": [ 0, 4 ] }
-    ],
-    "damage_reduction": { "all": 60, "bullet": 105 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
   },
   {
     "type": "vehicle_part",
@@ -2196,7 +2014,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "HORN" ],
+    "flags": [ "HORN", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap_aluminum", "prob": 10 }, { "item": "plastic_chunk", "prob": 35 } ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
@@ -2216,7 +2034,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
     },
-    "flags": [ "HORN" ],
+    "flags": [ "HORN", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "charges": [ 0, 2 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
@@ -2236,7 +2054,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 2 ] ] }
     },
-    "flags": [ "HORN" ],
+    "flags": [ "HORN", "NO_COVER" ],
     "breaks_into": [
       { "item": "steel_chunk", "prob": 50 },
       { "item": "scrap", "charges": [ 0, 2 ] },
@@ -2261,7 +2079,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
     },
-    "flags": [ "BEEPER", "ODDTURN" ],
+    "flags": [ "BEEPER", "ODDTURN", "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "variants": [ { "symbols": "*", "symbols_broken": "*" } ]
   },
@@ -2345,7 +2163,7 @@
     "copy-from": "livestock_stall",
     "name": { "str": "animal compartment" },
     "durability": 125,
-    "description": "A large locker for transporting smaller animals.  'e'xamine it to capture an animal next to you, or to release the animal currently contained.  When selecting an animal to capture, choose its tile relative to you, not the part.",
+    "description": "A locker for transporting smaller animals.  'e'xamine it to capture an animal next to you, or to release the animal currently contained.  When selecting an animal to capture, choose its tile relative to you, not the part.",
     "size": "50 L",
     "item": "animal_locker",
     "flags": [ "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "OBSTACLE" ],
@@ -2370,7 +2188,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 8 ] ] }
     },
-    "flags": [ "INTERNAL", "RECHARGE" ],
+    "flags": [ "INTERNAL", "RECHARGE", "NO_COVER" ],
     "folded_volume": "2 L",
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 0, 2 ] },
@@ -2395,6 +2213,7 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
     "folded_volume": "250 ml",
+    "flags": [ "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "copy-from": "recharge_station"
   },
@@ -2416,7 +2235,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "STEREO", "ENABLED_DRAINS_EPOWER", "SIMPLE_PART" ],
+    "flags": [ "STEREO", "ENABLED_DRAINS_EPOWER", "SIMPLE_PART", "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "variants": [ { "symbols": "&", "symbols_broken": "&" } ]
   },
@@ -2436,7 +2255,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 1 ] ] }
     },
-    "flags": [ "CHIMES", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "CHIMES", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "location": "on_roof",
     "breaks_into": [
       { "item": "scrap", "charges": [ 3, 5 ] },
@@ -2461,7 +2280,7 @@
     "description": "Thick copper cable with leads on either end.  Attach one end to one vehicle and the other to another, and you can transfer electrical power between the two.",
     "item": "jumper_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER", "NO_COVER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 10, 30 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
@@ -2479,7 +2298,7 @@
     "description": "A long orange extension cord for connecting appliances.  Currently plugged in.",
     "item": "extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER", "NO_COVER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 45, 90 ] }, { "item": "plastic_chunk", "count": [ 2, 3 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
@@ -2497,7 +2316,7 @@
     "description": "An extra long 30 m orange extension cord for connecting outdoor appliances.  Currently plugged in.",
     "item": "long_extension_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER", "NO_COVER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 135, 270 ] }, { "item": "plastic_chunk", "count": [ 4, 6 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
@@ -2515,7 +2334,7 @@
     "//": "Epower for POWER_TRANSFER stuff is how much percentage-wise loss there is in transmission",
     "item": "jumper_cable_heavy",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER", "NO_COVER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 97, 195 ] }, { "item": "plastic_chunk", "count": [ 4, 8 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
@@ -2531,7 +2350,7 @@
     "description": "A heavy-duty tow cable, if the other end was attached to another vehicle, it could pull it.",
     "item": "hd_tow_cable",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "TOW_CABLE", "NO_COVER" ],
     "breaks_into": [
       { "item": "steel_lump", "count": [ 5, 10 ] },
       { "item": "steel_chunk", "count": [ 7, 14 ] },
@@ -2553,7 +2372,7 @@
     "durability": 120,
     "item": "jumper_cable_debug",
     "requirements": { "removal": { "time": "5 s" } },
-    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
+    "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER", "NO_COVER" ],
     "breaks_into": [ { "item": "jumper_cable_debug" } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
@@ -2575,7 +2394,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "qualities": [ { "id": "CUT", "level": 2 } ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "rope_natural_short", 1 ] ] }
     },
-    "flags": [ "SEAT", "BOARDABLE", "BELTABLE" ],
+    "flags": [ "SEAT", "BOARDABLE" ],
     "breaks_into": [
       { "item": "splinter", "count": [ 4, 7 ] },
       { "item": "string_36", "count": [ 3, 6 ] },
@@ -2640,47 +2459,6 @@
   },
   {
     "type": "vehicle_part",
-    "id": "plating_chitin",
-    "name": { "str": "chitin plating" },
-    "categories": [ "warfare" ],
-    "color": "yellow",
-    "durability": 200,
-    "item": "chitin_plate",
-    "location": "armor",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m" },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m" },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive", 1 ] ] }
-    },
-    "flags": [ "ARMOR" ],
-    "breaks_into": [
-      { "item": "chitin_piece", "count": [ 4, 8 ] },
-      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
-      { "item": "rope_6", "prob": 75 },
-      { "item": "string_36", "count": [ 2, 4 ] },
-      { "item": "string_6", "count": [ 7, 14 ] }
-    ],
-    "damage_reduction": { "all": 20 },
-    "variants": [ { "symbols": ")", "symbols_broken": ")" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "plating_acidchitin",
-    "copy-from": "plating_chitin",
-    "name": { "str": "biosilicified chitin plating" },
-    "proportional": { "durability": 1.1 },
-    "item": "acidchitin_plate",
-    "breaks_into": [
-      { "item": "acidchitin_piece", "count": [ 6, 19 ] },
-      { "item": "meal_chitin_piece", "count": [ 2, 6 ] },
-      { "item": "rope_6", "prob": 75 },
-      { "item": "string_36", "count": [ 2, 4 ] },
-      { "item": "string_6", "count": [ 7, 14 ] }
-    ],
-    "damage_reduction": { "all": 24 }
-  },
-  {
-    "type": "vehicle_part",
     "id": "door_motor",
     "name": { "str": "door motor" },
     "categories": [ "other" ],
@@ -2695,7 +2473,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "BOARD_INTERNAL", "DOOR_MOTOR", "UNMOUNT_ON_DAMAGE" ],
+    "flags": [ "BOARD_INTERNAL", "DOOR_MOTOR", "UNMOUNT_ON_DAMAGE", "NO_COVER" ],
     "breaks_into": [
       { "item": "scrap", "charges": [ 1, 3 ] },
       { "item": "cable", "charges": [ 3, 7 ] },
@@ -2735,7 +2513,7 @@
         "using": [ [ "repair_welding_standard", 6 ], [ "soldering_standard", 5 ] ]
       }
     },
-    "flags": [ "CONTROLS", "REMOTE_CONTROLS" ],
+    "flags": [ "CONTROLS", "REMOTE_CONTROLS", "NO_COVER" ],
     "breaks_into": [ { "item": "motor_tiny" }, { "item": "steel_chunk", "count": [ 1, 3 ] }, { "item": "scrap", "count": [ 1, 3 ] } ],
     "variants": [ { "symbols": "$", "symbols_broken": "$" } ]
   },
@@ -2786,7 +2564,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "breaks_into": [
       { "item": "e_scrap", "count": [ 3, 7 ] },
       { "item": "cable", "charges": [ 3, 7 ] },
@@ -2809,7 +2587,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
-    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER" ],
+    "flags": [ "VISION", "CAMERA", "ENABLED_DRAINS_EPOWER", "NO_COVER" ],
     "breaks_into": [
       { "item": "e_scrap", "count": [ 3, 7 ] },
       { "item": "cable", "charges": [ 3, 7 ] },
@@ -2849,7 +2627,7 @@
         "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 3 ] ]
       }
     },
-    "flags": [ "REMOTE_CONTROLS", "OBSTACLE", "CABLE_PORTS" ],
+    "flags": [ "REMOTE_CONTROLS", "OBSTACLE", "CABLE_PORTS", "NO_COVER" ],
     "breaks_into": [
       { "item": "motor_tiny", "count": [ 1, 3 ] },
       { "item": "steel_chunk", "count": [ 1, 3 ] },
@@ -2872,7 +2650,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "20 s", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "WATCH", "ALARMCLOCK", "SIMPLE_PART" ],
+    "flags": [ "WATCH", "ALARMCLOCK", "SIMPLE_PART", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "prob": 50 } ],
     "damage_reduction": { "bash": 5 },
     "variants": [ { "symbols": ":", "symbols_broken": ";" } ]
@@ -3290,7 +3068,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "12 m", "using": [ [ "vehicle_screw", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "adhesive", 1 ] ] }
     },
-    "flags": [ "CARGO_LOCKING", "INTERNAL", "SIMPLE_PART" ],
+    "flags": [ "CARGO_LOCKING", "INTERNAL", "SIMPLE_PART", "NO_COVER" ],
     "breaks_into": [ { "item": "clockworks", "prob": 15 }, { "item": "scrap", "prob": 75 } ],
     "damage_reduction": { "all": 60 },
     "variants": [ { "symbols": "+", "symbols_broken": "+" } ]
@@ -3348,7 +3126,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "24 m", "qualities": [ { "id": "SCREW", "level": 1 } ] },
       "repair": { "skills": [ [ "mechanics", 2 ], [ "traps", 1 ] ], "time": "12 m", "using": [ [ "soldering_standard", 3 ] ] }
     },
-    "flags": [ "BOARD_INTERNAL", "DOOR_LOCKING", "UNMOUNT_ON_DAMAGE", "SIMPLE_PART" ],
+    "flags": [ "BOARD_INTERNAL", "DOOR_LOCKING", "UNMOUNT_ON_DAMAGE", "SIMPLE_PART", "NO_COVER" ],
     "breaks_into": [ { "item": "clockworks", "prob": 30 }, { "item": "scrap", "prob": 75 } ],
     "damage_reduction": { "all": 60 }
   },
@@ -3404,7 +3182,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_alloys", 6 ] ] }
     },
-    "flags": [ "FLOATS" ],
+    "flags": [ "FLOATS", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap_aluminum", "count": [ 6, 14 ] } ],
     "damage_reduction": { "all": 18 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -708,5 +708,18 @@
     "id": "WATER_ONLY",
     "info": "This part can only power a vehicle on water.",
     "type": "json_flag"
+  },
+  {
+    "id": "NO_COVER",
+    "info": "This part does not provide any coverage or concealment.",
+    "type": "json_flag"
+  },
+  {
+    "id": "MEDIUM_HIDE",
+    "type": "json_flag"
+  },
+  {
+    "id": "SMALL_HIDE",
+    "type": "json_flag"
   }
 ]

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -16,7 +16,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "adhesive", 2 ] ] }
     },
-    "flags": [ "WHEEL_MOUNT_LIGHT", "NEEDS_JACKING" ],
+    "flags": [ "WHEEL_MOUNT_LIGHT", "NEEDS_JACKING", "NO_COVER" ],
     "breaks_into": [ { "item": "2x4", "count": [ 2, 5 ] } ],
     "damage_reduction": { "all": 8 },
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
@@ -45,7 +45,7 @@
       "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m", "using": [ [ "vehicle_weld_removal", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 1 ] ], "time": "4 m", "using": [ [ "repair_welding_standard", 1 ] ] }
     },
-    "flags": [ "WHEEL_MOUNT_LIGHT", "NEEDS_JACKING" ],
+    "flags": [ "WHEEL_MOUNT_LIGHT", "NEEDS_JACKING", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "count": [ 0, 1 ] } ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
@@ -81,7 +81,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "WHEEL_MOUNT_MEDIUM", "NEEDS_JACKING" ],
+    "flags": [ "WHEEL_MOUNT_MEDIUM", "NEEDS_JACKING", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "count": [ 1, 4 ] }, { "item": "steel_chunk", "count": [ 2, 5 ] } ],
     "damage_reduction": { "all": 30 },
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
@@ -117,7 +117,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "8 m", "using": [ [ "repair_welding_standard", 4 ] ] }
     },
-    "flags": [ "WHEEL_MOUNT_HEAVY", "NEEDS_JACKING" ],
+    "flags": [ "WHEEL_MOUNT_HEAVY", "NEEDS_JACKING", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "count": [ 1, 4 ] }, { "item": "steel_chunk", "count": [ 3, 7 ] } ],
     "damage_reduction": { "all": 40 },
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
@@ -149,7 +149,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "RAIL" ],
+    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "RAIL", "NO_COVER" ],
     "damage_reduction": { "all": 66 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
@@ -297,7 +297,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "damage_reduction": { "bash": 10 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
@@ -326,7 +326,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "damage_reduction": { "bash": 6 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
@@ -365,7 +365,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 5 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -390,7 +390,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 6 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -415,7 +415,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "1 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] },
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "1 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] }
     },
-    "flags": [ "WHEEL", "NEEDS_WHEEL_MOUNT_SKATEBOARD", "STABLE", "STEERABLE" ],
+    "flags": [ "WHEEL", "NEEDS_WHEEL_MOUNT_SKATEBOARD", "STABLE", "STEERABLE", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -431,7 +431,7 @@
     "unfolding_time": "0 seconds",
     "durability": 120,
     "description": "A pair of skateboard trucks, for attaching wheels to.",
-    "flags": [ "WHEEL_MOUNT_SKATEBOARD" ],
+    "flags": [ "WHEEL_MOUNT_SKATEBOARD", "NO_COVER" ],
     "requirements": {
       "removal": {
         "skills": [ [ "mechanics", 0 ] ],
@@ -474,7 +474,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -543,7 +543,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "variants_bases": [ { "id": "scooter", "label": "Scooter" } ],
     "variants": [
       { "id": "front", "label": "Front", "symbols": "o", "symbols_broken": "x" },
@@ -570,7 +570,7 @@
     "rolling_resistance": 10.0,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 10,
-    "flags": [ "STABLE", "STEERABLE", "WHEEL", "NEEDS_JACKING" ],
+    "flags": [ "STABLE", "STEERABLE", "WHEEL", "NEEDS_JACKING", "NO_COVER" ],
     "damage_reduction": { "bash": 8 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
@@ -600,7 +600,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "damage_reduction": { "bash": 8 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
@@ -631,7 +631,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "damage_reduction": { "bash": 6 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
@@ -727,7 +727,7 @@
     "durability": 240,
     "description": "A set of two small wheel mounts from a concrete mixer.",
     "item": "wheel_mount_concrete_mix",
-    "flags": [ "WHEEL_MOUNT_CONCRETE_MIX", "NEEDS_JACKING", "NO_INSTALL_HIDDEN" ],
+    "flags": [ "WHEEL_MOUNT_CONCRETE_MIX", "NEEDS_JACKING", "NO_INSTALL_HIDDEN", "NO_COVER" ],
     "breaks_into": [ { "item": "scrap", "count": [ 1, 8 ] } ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
@@ -750,7 +750,7 @@
     "wheel_offroad_rating": 0.3,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
     "contact_area": 60,
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_CONCRETE_MIX", "NO_INSTALL_HIDDEN" ],
+    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_CONCRETE_MIX", "NO_INSTALL_HIDDEN", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1407,6 +1407,30 @@ int Character::eye_level() const
     }
 
     map &here = get_map();
+
+    if( const optional_vpart_position vp = here.veh_at( pos_bub() ) ) {
+        const bool is_aisle = vp->part_with_feature( VPFLAG_AISLE, true ).has_value();
+        const vehicle &veh = vp->vehicle();
+        const point rel = vp->mount();
+        bool all_no_cover = true;
+        for( int idx : veh.parts_at_relative( rel, true, true ) ) {
+            const vehicle_part &vp_here = veh.part( idx );
+            const vpart_info &vpi_here = vp_here.info();
+            if( !vpi_here.has_flag( "NO_COVER" ) && vpi_here.location != "on_roof" &&
+                vpi_here.location != "roof" ) {
+                all_no_cover = false;
+                break; // Early exit since at least one part provides cover.
+            }
+        }
+        if( all_no_cover ) {
+            eye_level += 0;
+        } else if( !is_aisle ) {
+            // Non-aisle non-obstacle parts typically give 45 cover. We get less than that as we're inside the vehicle, not atop it.
+            // Return here to ensure we aren't stacking vehicle and furniture bonuses.
+            return eye_level += 20;
+        }
+    }
+
     const furn_id viewer_furn = here.furn( pos_bub() );
     const furn_t &furn = viewer_furn.obj();
     if( !furn.id ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -73,6 +73,7 @@
 #include "units.h"
 #include "value_ptr.h"
 #include "vehicle.h"
+#include "veh_type.h"
 #include "vpart_position.h"
 
 struct mutation_branch;
@@ -606,8 +607,8 @@ bool Creature::sees( const Creature &critter ) const
         return false;
     }
 
-    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub() ) &&
-        critter.get_size() < creature_size::huge ) {
+    if( ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub() ) ) &&
+               critter.get_size() < creature_size::large ) {
         return false;
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3142,7 +3142,8 @@ talk_effect_fun_t::func f_add_trait( const JsonObject &jo, std::string_view memb
         const trait_id trait = trait_id( new_trait.evaluate( d ) );
         const mutation_variant *variant = trait->variant( new_variant.evaluate( d ) );
         d.actor( is_npc )->set_mutation( trait, variant );
-        get_event_bus().send<event_type::gains_mutation>( d.actor( is_npc )->get_character()->getID(), trait_id( new_trait.evaluate( d ) ) );
+        get_event_bus().send<event_type::gains_mutation>( d.actor( is_npc )->get_character()->getID(),
+                trait_id( new_trait.evaluate( d ) ) );
     };
 }
 
@@ -3170,7 +3171,8 @@ talk_effect_fun_t::func f_remove_trait( const JsonObject &jo, std::string_view m
     str_or_var old_trait = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, old_trait]( dialogue const & d ) {
         d.actor( is_npc )->unset_mutation( trait_id( old_trait.evaluate( d ) ) );
-        get_event_bus().send<event_type::loses_mutation>( d.actor( is_npc )->get_character()->getID(), trait_id( old_trait.evaluate( d ) ) );
+        get_event_bus().send<event_type::loses_mutation>( d.actor( is_npc )->get_character()->getID(),
+                trait_id( old_trait.evaluate( d ) ) );
     };
 }
 


### PR DESCRIPTION
#### Summary
Improve eye level/cover calculations with vehicles

#### Purpose of change
- Bicycles were opaque to small characters.
- Vehicle parts weren't boosting your line of sight like furniture does.

#### Describe the solution
- Give a lot of vehicle parts the NO_COVER flag. These parts offer no coverage or concealment. If a vehicle tile is composed entirely of parts with this flag, it is transparent for everyone at all times.
- Make vehicle seats and other parts boost you up in the same way standing on a chair does.

#### Describe alternatives you've considered
- We still need car seats for mouse mutants.
- Mouse mutants can ride bicycles. This is partially intended as they need to be able to drive the little tricycles and those use the same seat/pedal as a bike. Not exactly sure yet of a proper fix that wouldn't just be installable on a regular bike.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
