### PR TITLE
Backport DDA 79814 for MoM biokinesis stuff

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -863,6 +863,7 @@ Character status value  | Description
 `MOTION_VISION_RANGE`   | Reveals all monsters as a red `?` within the specified radius.
 `MOVE_COST`             | 
 `MUT_INSTABILITY_MOD`   | Modifies your instability score, which affects the chance to get bad mutation (scales with amount of good mutations you have, capping at 67%, check `Character::roll_bad_mutation` for more information). `add: 1` would be equal to having 1 good mutation more, increasing the chance to get bad mutation, `add: -1` would be like you have one good mutation less, decreasing the chance to get bad mutation.
+`MUT_ADDITIONAL_OPTIONS`| Whenever the character mutates, they may pick from the initially rolled mutation and x additional options given by the mutation value.  These options will be clustered around the initially picked mutation based on their relative point values.  IE, if a character initially rolls a negative mutation, the additional options will likely also be negative mutations.  High enough enchantment values will allow picking from every possible mutation.
 `MOVECOST_FLATGROUND_MOD`| How many moves you spend to move 1 tile on flat ground; shown in UI
 `MOVECOST_OBSTACLE_MOD` | How many moves you spend to move 1 tile, if this tile has a movecost more than 105 moves; not shown in UI
 `MOVECOST_SWIM_MOD`     | How many moves you spend to move 1 tile in water; not shown in UI

--- a/src/character.h
+++ b/src/character.h
@@ -1699,7 +1699,11 @@ class Character : public Creature, public visitable
         /** Removes the mutation's child flag from the player's list */
         void remove_child_flag( const trait_id &flag );
         /** Try to cross The Threshold */
-        void test_crossing_threshold( const mutation_category_id &mutation_category );
+        void try_crossing_threshold( const mutation_category_id &mutation_category );
+        /** Crosses the mutation threshold of the given category */
+        void cross_threshold( const mutation_category_id &mutation_category );
+        /*** Returns if the character can cross the given threshold. */
+        bool can_cross_threshold( const mutation_category_id &mutation_category );
         /** Returns how many steps are required to reach a mutation */
         int mutation_height( const trait_id &mut ) const;
         /** Recalculates mutation_category_level[] values for the player */

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -76,6 +76,7 @@ namespace io
             case enchant_vals::mod::REGEN_HP: return "REGEN_HP";
             case enchant_vals::mod::REGEN_HP_AWAKE: return "REGEN_HP_AWAKE";
             case enchant_vals::mod::MUT_INSTABILITY_MOD: return "MUT_INSTABILITY_MOD";
+            case enchant_vals::mod::MUT_ADDITIONAL_OPTIONS: return "MUT_ADDITIONAL_OPTIONS";
             case enchant_vals::mod::RANGE_DODGE: return "RANGE_DODGE";
             case enchant_vals::mod::HUNGER: return "HUNGER";
             case enchant_vals::mod::THIRST: return "THIRST";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -49,6 +49,7 @@ enum class mod : int {
     FAT_TO_MAX_HP,
     CARDIO_MULTIPLIER,
     MUT_INSTABILITY_MOD,
+    MUT_ADDITIONAL_OPTIONS,
     RANGE_DODGE,
     MAX_HP,        // for all limbs! use with caution
     REGEN_HP,

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1137,7 +1137,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
     mutation_category_id cat;
     weighted_int_list<mutation_category_id> cat_list = get_vitamin_weighted_categories();
 
-    bool select_mutation = is_avatar() && get_option<bool>( "SHOW_MUTATION_SELECTOR" );
+    bool select_mutation = is_avatar() && ( get_option<bool>( "SHOW_MUTATION_SELECTOR" ) ||
+                                            calculate_by_enchantment( 0, enchant_vals::mod::MUT_ADDITIONAL_OPTIONS ) >= 1 );
 
     bool allow_good = false;
     bool allow_bad = false;
@@ -1328,7 +1329,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         } else {
             if( mut_vit != vitamin_id::NULL_ID() &&
                 vitamin_get( mut_vit ) >= mutation_category_trait::get_category( cat ).threshold_min ) {
-                test_crossing_threshold( cat );
+                try_crossing_threshold( cat );
             }
             if( mutate_towards( valid, cat, 2, use_vitamins ) ) {
                 add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
@@ -1471,13 +1472,95 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
             traits.push_back( trait );
         }
     }
+
+    if( can_cross_threshold( cat ) ) {
+        const mutation_category_trait &m_category = mutation_category_trait::get_category(
+                    cat );
+        const trait_id &mutation_thresh = m_category.threshold_mut;
+        traits.push_back( mutation_thresh );
+
+    }
+
+    // positive traits at start of list, negative traits at end.  Required for additional options if block.
+    std::sort( traits.begin(), traits.end(), []( const trait_id a, const trait_id b ) {
+        return a.obj().points > b.obj().points;
+    } );
+
+    int additional_options = calculate_by_enchantment( 0, enchant_vals::mod::MUT_ADDITIONAL_OPTIONS );
+    int traits_size = traits.size();
+
+    if( !get_option<bool>( "SHOW_MUTATION_SELECTOR" ) && additional_options >= 1 &&
+        additional_options < traits_size ) {
+        size_t primary_index = 0;
+        // Logic REQUIRES that traits are sorted by points
+        size_t end_index = traits.size() - 1;
+        size_t negative_edge = end_index;
+        size_t positive_edge = 0;
+        for( size_t index = end_index + 1; index -- > 0 ; ) {
+            if( traits[index].obj().points >= 0 ) {
+                break;
+            } else {
+                negative_edge = index;
+            }
+        }
+        for( size_t index = 0; index <= end_index; index++ ) {
+            if( traits[index].obj().points <= 0 ) {
+                break;
+            } else {
+                positive_edge = index;
+            }
+        }
+
+        if( roll_bad_mutation( cat ) ) {
+            if( positive_edge == end_index ) {
+                primary_index = end_index;
+            } else {
+                // choose trait that is either neutral or negative
+                primary_index = rng( positive_edge + 1, end_index );
+            }
+        } else {
+            if( negative_edge == 0 ) {
+                primary_index = 0;
+            } else {
+                // choose trait that is either positive or neutral
+                primary_index = rng( 0, negative_edge - 1 );
+            }
+        }
+        size_t below_index = primary_index;
+        size_t above_index = primary_index + 1;
+        int added_traits = 0;
+        std::vector<trait_id> selectable_traits = { traits[primary_index] };
+        while( added_traits < additional_options ) {
+            // Cannot check < 0 since size_t is unsigned.  Resolve by adding 1 to the stored value and making check off of that, and subtracting 1 when using it.
+            if( below_index >= 1 && added_traits < additional_options ) {
+                selectable_traits.insert( selectable_traits.begin(), traits[below_index - 1] );
+                below_index--;
+                added_traits++;
+            }
+            if( above_index <= end_index && added_traits < additional_options ) {
+                selectable_traits.insert( selectable_traits.end(), traits[above_index] );
+                above_index++;
+                added_traits++;
+            }
+            if( below_index < 0 && above_index > end_index ) {
+                break;
+            }
+        }
+        traits = selectable_traits;
+    }
+
+
     make_entries( traits );
 
     // Display menu and handle selection
     mmenu.query();
     if( mmenu.ret >= 0 ) {
-        if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
-            add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
+        if( traits[mmenu.ret]->threshold ) {
+            cross_threshold( cat );
+        } else {
+            if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
+                add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
+            }
         }
         return true;
     }
@@ -2299,12 +2382,28 @@ void Character::remove_child_flag( const trait_id &flag )
     }
 }
 
-void Character::test_crossing_threshold( const mutation_category_id &mutation_category )
+void Character::try_crossing_threshold( const mutation_category_id &mutation_category )
+{
+    if( can_cross_threshold( mutation_category ) ) {
+        int breach_power = mutation_category_level[mutation_category];
+        if( breach_power >= 100 || x_in_y( breach_power, 100 ) ) {
+            cross_threshold( mutation_category );
+        }
+    }
+}
+
+bool Character::can_cross_threshold( const mutation_category_id &mutation_category )
 {
     // Threshold-check.  You only get to cross once!
     if( crossed_threshold() ) {
-        add_msg_debug( debugmode::DF_MUTATION, "test_crossing_treshold failed: already post-threshold" );
-        return;
+        add_msg_debug( debugmode::DF_MUTATION, "can_cross_threshold failed: already post-threshold" );
+        return false;
+    }
+
+    if( mutation_category == mutation_category_ANY ) {
+        add_msg_debug( debugmode::DF_MUTATION,
+                       "can_cross_threshold failed: cannot cross threshold of the ANY category" );
+        return false;
     }
 
     const mutation_category_trait &m_category = mutation_category_trait::get_category(
@@ -2314,31 +2413,41 @@ void Character::test_crossing_threshold( const mutation_category_id &mutation_ca
     const trait_id &mutation_thresh = m_category.threshold_mut;
     if( mutation_thresh.is_empty() ) {
         add_msg_debug( debugmode::DF_MUTATION,
-                       "test_crossing_treshold failed: category %s has no threshold defined", m_category.id.c_str() );
-        return;
+                       "can_cross_threshold failed: category %s has no threshold defined", m_category.id.c_str() );
+        return false;
     }
 
     // Threshold-breaching
     int breach_power = mutation_category_level[mutation_category];
     add_msg_debug( debugmode::DF_MUTATION, "test_crossing_treshold: breach power %d", breach_power );
     // You're required to have hit third-stage dreams first.
-    if( breach_power >= 30 ) {
-        if( breach_power >= 100 || x_in_y( breach_power, 100 ) ) {
-            const mutation_branch &thrdata = mutation_thresh.obj();
-            if( vitamin_get( m_category.vitamin ) >= thrdata.vitamin_cost ) {
-                vitamin_mod( m_category.vitamin, -thrdata.vitamin_cost );
-                add_msg_if_player( m_good,
-                                   _( "Something strains mightily for a moment… and then… you're… FREE!" ) );
-                // Thresholds can cancel unpurifiable traits
-                for( const trait_id &canceled : thrdata.cancels ) {
-                    get_event_bus().send<event_type::loses_mutation>( getID(), canceled );
-                    unset_mutation( canceled );
-                }
-                set_mutation( mutation_thresh );
-                get_event_bus().send<event_type::crosses_mutation_threshold>( getID(), m_category.id );
-            }
-        }
+    if( breach_power >= 30 &&
+        vitamin_get( m_category.vitamin ) >= mutation_thresh.obj().vitamin_cost ) {
+        return true;
     }
+    return false;
+}
+
+void Character::cross_threshold( const mutation_category_id &mutation_category )
+{
+    if( !can_cross_threshold( mutation_category ) ) {
+        return;
+    }
+    const mutation_category_trait &m_category = mutation_category_trait::get_category(
+                mutation_category );
+    const trait_id &mutation_thresh = m_category.threshold_mut;
+
+    const mutation_branch &thrdata = mutation_thresh.obj();
+    vitamin_mod( m_category.vitamin, -thrdata.vitamin_cost );
+    add_msg_if_player( m_good,
+                       _( "Something strains mightily for a moment… and then… you're… FREE!" ) );
+    // Thresholds can cancel unpurifiable traits
+    for( const trait_id &canceled : thrdata.cancels ) {
+        get_event_bus().send<event_type::loses_mutation>( getID(), canceled );
+        unset_mutation( canceled );
+    }
+    set_mutation( mutation_thresh );
+    get_event_bus().send<event_type::crosses_mutation_threshold>( getID(), m_category.id );
 }
 
 bool are_conflicting_traits( const trait_id &trait_a, const trait_id &trait_b )

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1542,7 +1542,7 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
                 above_index++;
                 added_traits++;
             }
-            if( below_index < 0 && above_index > end_index ) {
+            if( below_index < 1 && above_index > end_index ) {
                 break;
             }
         }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -577,6 +577,4 @@ struct enum_traits<mutagen_technique> {
     static constexpr mutagen_technique last = mutagen_technique::num_mutagen_techniques;
 };
 
-void test_crossing_threshold( Character &guy, const mutation_category_trait &m_category );
-
 #endif // CATA_SRC_MUTATION_H


### PR DESCRIPTION
#### Summary
Backport DDA 79814 for MoM biokinesis stuff

#### Purpose of change
Code infrastructure for mutation selection for biokinetics. Not useful in mainline at the moment, but no reason not to add it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
