### PR TITLE
Remove wield requirement for prying for now

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2805,10 +2805,6 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
-    if( !p->is_wielding( *it ) && !p->is_worn( *it ) ) {
-        p->add_msg_if_player( _( "You need to be wielding the %s to use it." ), it->tname() );
-        return std::nullopt;
-    }
     map &here = get_map();
     const std::function<bool( const tripoint & )> f =
     [&here, p]( const tripoint & pnt ) {
@@ -2821,7 +2817,6 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint &pos )
         }
         return false;
     };
-
     const std::optional<tripoint> pnt_ = ( pos != p->pos() ) ? pos : choose_adjacent_highlight(
             _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
     if( !pnt_ ) {


### PR DESCRIPTION
#### Summary
Remove wield requirement for prying for now

#### Purpose of change
fixes #1132 

#### Describe the solution
I made it so you needed to wield or wear prying tools to use them, but that was causing some unexpected behavior because most of the prying code is done in iexamine, and it just tries to pick your best item. It's worth redoing, but for now we can just dump the requirement.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
