### PR TITLE
Backport DDA 77770 - Enchantify special vision 1/2

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -961,7 +961,7 @@
     "description": "Your range of vision extends into the infrared, allowing you to see warm-blooded creatures in the dark or through smoke.",
     "occupied_bodyparts": [ [ "eyes", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "active_flags": [ "INFRARED" ],
+    "enchantments": [ "THERMAL_VISION_GOOD" ],
     "act_cost": "5 J",
     "react_cost": "5 J",
     "time": "1 s"

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -667,6 +667,14 @@
   },
   {
     "type": "effect_type",
+    "id": "mech_recon_vision",
+    "//": "is applied when you ride a mech. Ideally should be jsonified in some way",
+    "name": [ "" ],
+    "desc": [ "." ],
+    "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE", "nvg_great_mech" ]
+  },
+  {
+    "type": "effect_type",
     "id": "onfire",
     "name": [ "On Fire" ],
     "desc": [ "Loss of health - Entire Body\nYour clothing and other equipment may be consumed by the flames." ],

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -35,6 +35,127 @@
   },
   {
     "type": "enchantment",
+    "id": "THERMAL_VISION_GOOD",
+    "condition": "ACTIVE",
+    "has": "WORN",
+    "special_vision": [
+      {
+        "condition": { "and": [ "u_see_npc_loc", "npc_is_warm" ] },
+        "distance": 60,
+        "descriptions": [
+          {
+            "id": "infrared_creature_tiny",
+            "text_condition": { "math": [ "n_val('size') == 1" ] },
+            "text": "You see a tiny figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_small",
+            "text_condition": { "math": [ "n_val('size') == 2" ] },
+            "text": "You see a small figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "n_val('size') == 3" ] },
+            "text": "You see a medium figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_large",
+            "text_condition": { "math": [ "n_val('size') == 4" ] },
+            "text": "You see a large figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_huge",
+            "text_condition": { "math": [ "n_val('size') == 5" ] },
+            "text": "You see a huge figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "true" ] },
+            "text": "You see a figure radiating heat."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "THERMAL_VISION_GOOD_PASSIVE",
+    "condition": "ALWAYS",
+    "special_vision": [
+      {
+        "condition": { "and": [ "u_see_npc_loc", "npc_is_warm" ] },
+        "distance": 60,
+        "descriptions": [
+          {
+            "id": "infrared_creature_tiny",
+            "text_condition": { "math": [ "n_val('size') == 1" ] },
+            "text": "You see a tiny figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_small",
+            "text_condition": { "math": [ "n_val('size') == 2" ] },
+            "text": "You see a small figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "n_val('size') == 3" ] },
+            "text": "You see a medium figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_large",
+            "text_condition": { "math": [ "n_val('size') == 4" ] },
+            "text": "You see a large figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_huge",
+            "text_condition": { "math": [ "n_val('size') == 5" ] },
+            "text": "You see a huge figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "true" ] },
+            "text": "You see a figure radiating heat."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "THERMAL_VISION_LEAFNOSE",
+    "condition": {
+      "not": {
+        "or": [
+          { "u_has_effect": "smoke", "bodypart": "mouth" },
+          { "u_has_effect": "asthma" },
+          { "u_has_effect": "tpollen" },
+          { "u_has_effect": "hay_fever" },
+          "u_is_underwater"
+        ]
+      }
+    },
+    "special_vision": [
+      {
+        "condition": { "and": [ "u_see_npc_loc", "npc_is_warm" ] },
+        "distance": 10,
+        "descriptions": [
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "true" ] },
+            "text": "You sense a creature with your thermal nostrils."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
+    "id": "nvg_great_mech",
+    "condition": "ALWAYS",
+    "values": [ { "value": "NIGHT_VIS", "add": 14 } ]
+  },
+  {
+    "type": "enchantment",
     "id": "nvg_great",
     "name": { "str": "Night Vision Goggles" },
     "description": "You are wearing night vision goggles which allow you to see very well in the dark, though at the cost of some detail.",

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -365,7 +365,7 @@
         "default_magazine": "medium_plus_battery_cell"
       }
     ],
-    "relic_data": { "passive_effects": [ { "id": "nvg_good" } ] },
+    "relic_data": { "passive_effects": [ { "id": "nvg_good" }, { "id": "THERMAL_VISION_GOOD" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
@@ -384,7 +384,7 @@
     "name": { "str_sp": "enhanced night vision goggles (on)" },
     "description": "New and rare high-resolution thermal NVG device, designed to be mounted on a compatible helmet.  Lets you see in the dark, and detects heat signatures emitted by (un)living organisms.  It is turned on, and continually draining batteries.  Use it to turn it off.",
     "//": "AN/PSQ-42",
-    "extend": { "flags": [ "NVG_GREEN", "IR_EFFECT" ] },
+    "extend": { "flags": [ "NVG_GREEN" ] },
     "power_draw": "320 mW",
     "revert_to": "enhanced_nvg",
     "use_action": {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2259,6 +2259,7 @@
     "warmth": 10,
     "environmental_protection": 3,
     "material_thickness": 2,
+    "relic_data": { "passive_effects": [ { "id": "THERMAL_VISION_GOOD" } ] },
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -2276,7 +2277,7 @@
     "name": { "str": "pair of infrared goggles (on)", "str_pl": "pairs of infrared goggles (on)" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
-    "flags": [ "IR_EFFECT", "FRAGILE", "TRADER_AVOID", "OUTER", "ELECTRONIC" ],
+    "flags": [ "FRAGILE", "TRADER_AVOID", "OUTER", "ELECTRONIC" ],
     "power_draw": "1 W",
     "revert_to": "goggles_ir",
     "use_action": { "ammo_scale": 0, "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "goggles_ir" },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -520,29 +520,10 @@
     "name": { "str": "Leaf Nose" },
     "points": 2,
     "prereqs": [ "SLIT_NOSTRILS", "BLOODFEEDER" ],
-    "flags": [ "INFRARED" ],
     "category": [ "CHIROPTERAN" ],
     "ugliness": 3,
     "description": "Your nose is upturned, ridged and flared out into a leaf shape that humans will likely find unsightly.  On the plus side, thermoreceptors in your nostrils allow you to smell heat as long as you can breathe.",
-    "triggers": [
-      [
-        {
-          "condition": {
-            "not": {
-              "or": [
-                { "u_has_effect": "smoke", "bodypart": "mouth" },
-                { "u_has_effect": "asthma" },
-                { "u_has_effect": "tpollen" },
-                { "u_has_effect": "asthma" },
-                { "u_has_effect": "hay_fever" },
-                "u_is_underwater"
-              ]
-            }
-          },
-          "msg_on": { "text": "", "rating": "good" }
-        }
-      ]
-    ]
+    "enchantments": [ "THERMAL_VISION_LEAFNOSE" ]
   },
   {
     "type": "mutation",
@@ -2220,7 +2201,7 @@
     "name": { "str": "Infrared Vision" },
     "points": 5,
     "description": "Your eyes have mutated to pick up radiation in the infrared spectrum.",
-    "flags": [ "INFRARED" ],
+    "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE" ],
     "prereqs": [ "NIGHTVISION3" ],
     "cancels": [ "LIZ_IR" ],
     "category": [ "INSECT", "TROGLOBITE", "SPIDER" ],
@@ -2245,7 +2226,7 @@
     "name": { "str": "Reptilian IR" },
     "points": 5,
     "description": "Your optic nerves and brain have mutated to catch up with your eyes, allowing you to see in the infrared spectrum.",
-    "flags": [ "INFRARED" ],
+    "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE" ],
     "types": [ "VISION" ],
     "prereqs": [ "LIZ_EYE" ],
     "category": [ "LIZARD", "RAPTOR" ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1108,6 +1108,23 @@ NPC is dead
 ```json
 { "not": "npc_is_alive" }
 ```
+
+### `u_is_warm`, `npc_is_warm`
+- type: simple string
+- return true if alpha or beta talker is warm-blooded (does it have WARM flag)
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ |
+
+#### Examples
+
+```json
+"npc_is_warm"
+```
+
 ### `u_exists`, `npc_exists`
 - type: simple string
 - return true if alpha or beta talker is not null
@@ -1343,6 +1360,78 @@ You can see selected location.
     "then": { "u_message": "You can see <context_val:pos>." },
     "else": { "u_message": "You cant see <context_val:pos>." }
   }
+}
+```
+
+### `u_see_npc`, `npc_see_you`
+- type: simple string
+- return true if alpha talker can see beta talker, or vice versa
+- require both talkers to be presented
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ |
+
+#### Examples
+
+```json
+"u_see_npc"
+```
+
+```json
+{ "not": "npc_see_you" }
+```
+
+### `u_see_npc_loc`, `npc_see_you_loc`
+- type: simple string
+- return true if beta talker' position is visible from the alpha talker position, and vice versa
+- doesn't check vision condition, can return true even if one or other is blind or it is a night
+- require both talkers to be presented
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ |
+
+#### Examples
+
+```json
+"u_see_npc_loc"
+```
+
+```json
+{ "not": "npc_see_you_loc" }
+```
+
+### `line_of_sight`
+- Checks if two points are visible to each other
+- Works at night
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- | 
+| "line_of_sight" | **mandatory** | int,  or [variable object](#variable-object) | Distance that would be checked |
+| "loc_1" | **mandatory** | [variable object](#variable-object) | One of two points of the line |
+| "loc_2" | **mandatory** | [variable object](#variable-object) | Second of two points of the line |
+| "with_fields" | optional | bool | If false, ignores opaque fields. Default true |
+
+#### Examples
+
+```json
+{
+  "type": "effect_on_condition",
+  "id": "EOC_line_check",
+  "effect": [
+      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "loc_1" } },
+      { "set_string_var": { "mutator": "npc_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "loc_2" } },
+      {
+        "if": { "line_of_sight": 60, "loc_1": { "context_val": "loc_1" }, "loc_2": { "context_val": "loc_2" } },
+        "then": { "u_message": "Can see each other" },
+        "else": { "u_message": "Cannot see each other" }
+      }
+  ]
 }
 ```
 

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -667,6 +667,45 @@ There are two possible syntaxes.  The first is by defining an enchantment object
         }
       ]
     }
+    "special_vision": [   // defines creatures (monsters or NPC) you can see in some irregular ways, mainly thermal or supernatural
+      {
+        "condition": { "and": [ { "npc_has_flag": "ELECTRIC" }, "u_see_npc" ] },   // this need to return true to see the critter; u is character, npc is critter being watched
+        "distance": 20, // how far special_vision is applied. for technical reasons special_vision do not stack, having multiple special_visions of the same nature will not result in special_visions of bigger distance
+        "descriptions": [ // if condition is true, this will assign a dedicated id (used for tiles) and text, depending on text_condition
+          { 
+            "id": "infrared_creature_tiny", 
+            "text_condition": { "math": [ "n_val('size') == 1" ] }, // be sure to not use condition that can change in between moves (like any math with random result, `rand(1)` etc); 
+                        // while text with tags is stored and re-evaluated only when cursor changes its position, tiles are re-evaluated every frame, even on pause
+            "text": "Message 1."
+          },
+          {
+            "id": "infrared_creature_small",
+            "text_condition": { "math": [ "n_val('size') == 2" ] },
+            "text": "Message 2."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "n_val('size') == 3" ] },
+            "text": "Message 3. <fuck_you>" // tags are also supported
+          },
+          {
+            "id": "infrared_creature_large",
+            "text_condition": { "math": [ "n_val('size') == 4" ] },
+            "text": "Message 4."
+          },
+          {
+            "id": "infrared_creature_huge",
+            "text_condition": { "math": [ "n_val('size') == 5" ] },
+            "text": "Message 5."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "true" ] }, // descriptions are read in order they are in json, adding dummy condition that always return true can be used as a fallback if none previous condition matches;
+            "text": "Last message." // otherwise default description is `You sense a creature here.`, and default id is `infrared_creature`
+          }
+        ]
+      }
+    ]
   }
 ```
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1347,6 +1347,13 @@ conditional_t::func f_is_alive( bool is_npc )
     };
 }
 
+conditional_t::func f_is_warm( bool is_npc )
+{
+    return [is_npc]( const_dialogue const & d ) {
+        return d.const_actor( is_npc )->is_warm();
+    };
+}
+
 conditional_t::func f_exists( bool is_npc )
 {
     return [is_npc]( const_dialogue const & d ) {
@@ -1408,6 +1415,36 @@ conditional_t::func f_player_see( bool is_npc )
             return get_player_view().sees( *c );
         } else {
             return get_player_view().sees( d.const_actor( is_npc )->pos() );
+        }
+    };
+}
+
+conditional_t::func f_see_opposite( bool is_npc )
+{
+    return [is_npc]( const_dialogue const & d ) {
+        if( d.const_actor( is_npc )->get_const_creature() &&
+            d.const_actor( !is_npc )->get_const_creature() ) {
+            return d.const_actor( is_npc )->get_const_creature()->sees(
+                       *d.const_actor( !is_npc )->get_const_creature() );
+        } else {
+            return false;
+        }
+    };
+}
+
+conditional_t::func f_see_opposite_coordinates( bool is_npc )
+{
+    return [is_npc]( const_dialogue const & d ) {
+        if( d.const_actor( is_npc )->get_const_creature() &&
+            d.const_actor( !is_npc )->get_const_creature() ) {
+            tripoint_bub_ms alpha_pos = d.const_actor( is_npc )->get_const_creature()->pos_bub();
+            tripoint_bub_ms beta_pos = d.const_actor( !is_npc )->get_const_creature()->pos_bub();
+            int alpha_vision =
+                500; // function is made specifically to bypass light level, and the only way to pick the creature vision distance is affected by light level
+
+            return get_map().sees( alpha_pos, beta_pos, alpha_vision );
+        } else {
+            return false;
         }
     };
 }
@@ -1677,6 +1714,23 @@ conditional_t::func f_one_in_chance( const JsonObject &jo, std::string_view memb
     dbl_or_var dov = get_dbl_or_var( jo, member );
     return [dov]( const_dialogue const & d ) {
         return one_in( dov.evaluate( d ) );
+    };
+}
+
+conditional_t::func f_line_of_sight( const JsonObject &jo, std::string_view member )
+{
+    dbl_or_var range = get_dbl_or_var( jo, member );
+    var_info loc_var_1 = read_var_info( jo.get_object( "loc_1" ) );
+    var_info loc_var_2 = read_var_info( jo.get_object( "loc_2" ) );
+    bool with_fields = true;
+    if( jo.has_bool( "with_fields" ) ) {
+        with_fields = jo.get_bool( "with_fields" );
+    }
+    return [range, loc_var_1, loc_var_2, with_fields]( const_dialogue const & d ) {
+        tripoint_bub_ms loc_1 = get_map().bub_from_abs( get_tripoint_from_var( loc_var_1, d, false ) );
+        tripoint_bub_ms loc_2 = get_map().bub_from_abs( get_tripoint_from_var( loc_var_2, d, false ) );
+
+        return get_map().sees( loc_1, loc_2, range.evaluate( d ), with_fields );
     };
 }
 
@@ -2557,6 +2611,7 @@ parsers = {
     {"u_know_recipe", jarg::member, &conditional_fun::f_u_know_recipe },
     {"one_in_chance", jarg::member | jarg::array, &conditional_fun::f_one_in_chance },
     {"x_in_y_chance", jarg::object, &conditional_fun::f_x_in_y_chance },
+    {"line_of_sight", jarg::member, &conditional_fun::f_line_of_sight },
     {"u_has_worn_with_flag", "npc_has_worn_with_flag", jarg::member, &conditional_fun::f_has_worn_with_flag },
     {"u_has_wielded_with_flag", "npc_has_wielded_with_flag", jarg::member, &conditional_fun::f_has_wielded_with_flag },
     {"u_has_wielded_with_weapon_category", "npc_has_wielded_with_weapon_category", jarg::member, &conditional_fun::f_has_wielded_with_weapon_category },
@@ -2639,6 +2694,7 @@ parsers_simple = {
     {"u_can_see", "npc_can_see", &conditional_fun::f_can_see },
     {"u_is_deaf", "npc_is_deaf", &conditional_fun::f_is_deaf },
     {"u_is_alive", "npc_is_alive", &conditional_fun::f_is_alive },
+    {"u_is_warm", "npc_is_warm", &conditional_fun::f_is_warm },
     {"u_exists", "npc_exists", &conditional_fun::f_exists },
     {"u_is_avatar", "npc_is_avatar", &conditional_fun::f_is_avatar },
     {"u_is_npc", "npc_is_npc", &conditional_fun::f_is_npc },
@@ -2648,6 +2704,8 @@ parsers_simple = {
     {"u_is_furniture", "npc_is_furniture", &conditional_fun::f_is_furniture },
     {"has_ammo", &conditional_fun::f_has_ammo },
     {"player_see_u", "player_see_npc", &conditional_fun::f_player_see },
+    {"u_see_npc", "npc_see_u", &conditional_fun::f_see_opposite },
+    {"u_see_npc_loc", "npc_see_u_loc", &conditional_fun::f_see_opposite_coordinates },
     {"has_alpha", &conditional_fun::f_has_alpha },
     {"has_beta", &conditional_fun::f_has_beta },
 };

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3524,39 +3524,6 @@ void Creature::load_hit_range( const JsonObject &jo )
     }
 }
 
-void Creature::describe_infrared( std::vector<std::string> &buf ) const
-{
-    std::string size_str;
-    switch( get_size() ) {
-        case creature_size::tiny:
-            size_str = pgettext( "infrared size", "tiny" );
-            break;
-        case creature_size::small:
-            size_str = pgettext( "infrared size", "small" );
-            break;
-        case creature_size::medium:
-            size_str = pgettext( "infrared size", "medium" );
-            break;
-        case creature_size::large:
-            size_str = pgettext( "infrared size", "large" );
-            break;
-        case creature_size::huge:
-            size_str = pgettext( "infrared size", "huge" );
-            break;
-        case creature_size::num_sizes:
-            debugmsg( "Creature has invalid size class." );
-            size_str = "invalid";
-            break;
-    }
-    buf.emplace_back( _( "You see a figure radiating heat." ) );
-    buf.push_back( string_format( _( "It is %s in size." ), size_str ) );
-}
-
-void Creature::describe_specials( std::vector<std::string> &buf ) const
-{
-    buf.emplace_back( _( "You sense a creature here." ) );
-}
-
 tripoint_abs_ms Creature::get_location() const
 {
     return location;

--- a/src/creature.h
+++ b/src/creature.h
@@ -985,12 +985,6 @@ class Creature : public viewer
          */
         virtual int print_info( const catacurses::window &w, int vStart, int vLines, int column ) const = 0;
 
-        /** Describe this creature as seen by the avatar via infrared vision. */
-        void describe_infrared( std::vector<std::string> &buf ) const;
-
-        /** Describe this creature as detected by the avatar's special senses. */
-        void describe_specials( std::vector<std::string> &buf ) const;
-
         // Message related stuff
         // These functions print to the sidebar message log. Unlike add_msg which prints messages
         // unconditionally, these only print messages when invoked for certain creature types:

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -173,7 +173,6 @@ const flag_id flag_INTEGRATED( "INTEGRATED" );
 const flag_id flag_IN_CBM( "IN_CBM" );
 const flag_id flag_IRRADIATED( "IRRADIATED" );
 const flag_id flag_IRREMOVABLE( "IRREMOVABLE" );
-const flag_id flag_IR_EFFECT( "IR_EFFECT" );
 const flag_id flag_IS_ARMOR( "IS_ARMOR" );
 const flag_id flag_IS_PET_ARMOR( "IS_PET_ARMOR" );
 const flag_id flag_IS_UPS( "IS_UPS" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -181,7 +181,6 @@ extern const flag_id flag_IN_CBM;
 extern const flag_id flag_INTEGRATED;
 extern const flag_id flag_IRRADIATED;
 extern const flag_id flag_IRREMOVABLE;
-extern const flag_id flag_IR_EFFECT;
 extern const flag_id flag_IS_ARMOR;
 extern const flag_id flag_IS_PET_ARMOR;
 extern const flag_id flag_IS_UPS;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4180,7 +4180,7 @@ void game::draw_critter( const Creature &critter, const tripoint &center )
         return;
     }
 
-    if( u.sees_with_infrared( critter ) || u.sees_with_specials( critter ) ) {
+    if( u.sees_with_specials( critter ) ) {
         mvwputch( w_terrain, point( mx, my ), c_red, '?' );
     }
 }
@@ -6358,16 +6358,20 @@ void game::print_all_tile_info( const tripoint &lp, const catacurses::window &w_
         case visibility_type::HIDDEN:
             print_visibility_info( w_look, column, line, visibility );
 
+            static std::string raw_description;
+            static std::string parsed_description;
             if( creature != nullptr ) {
-                std::vector<std::string> buf;
-                if( u.sees_with_infrared( *creature ) ) {
-                    creature->describe_infrared( buf );
-                } else if( u.sees_with_specials( *creature ) ) {
-                    creature->describe_specials( buf );
+                if( u.sees_with_specials( *creature ) ) {
+                    // handling against re-evaluation and snippet replacement on redraw
+                    if( raw_description.empty() ) {
+                        raw_description = u.enchantment_cache->get_vision_description( *u.as_character(), *creature );
+                        parse_tags( raw_description, *u.as_character(), *creature );
+                        parsed_description = raw_description;
+                    }
+                    mvwprintw( w_look, point( 1, ++line ), parsed_description );
                 }
-                for( const std::string &s : buf ) {
-                    mvwprintw( w_look, point( 1, ++line ), s );
-                }
+            } else {
+                raw_description.clear();
             }
             break;
     }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -475,6 +475,24 @@ void enchantment::load( const JsonObject &jo, const std::string_view,
     load_add_and_multiply<damage_type_id>( jo, is_child, "melee_damage_bonus", "type",
                                            damage_values_add, damage_values_multiply );
 
+    if( !is_child && jo.has_array( "special_vision" ) ) {
+        for( const JsonObject vision_obj : jo.get_array( "special_vision" ) ) {
+            special_vision foo;
+            special_vision_descriptions _desc;
+            if( vision_obj.has_array( "descriptions" ) ) {
+                for( const JsonObject descriptions_obj : vision_obj.get_array( "descriptions" ) ) {
+                    mandatory( descriptions_obj, was_loaded, "id", _desc.id );
+                    mandatory( descriptions_obj, was_loaded, "text", _desc.description );
+                    read_condition( descriptions_obj, "text_condition", _desc.condition, false );
+                    foo.special_vision_descriptions_vector.emplace_back( _desc );
+                }
+            }
+
+            foo.range = get_dbl_or_var( vision_obj, "distance", false );
+            read_condition( vision_obj, "condition", foo.condition, false );
+            special_vision_vector.emplace_back( foo );
+        }
+    }
 }
 
 void enchant_cache::load( const JsonObject &jo, const std::string_view,
@@ -543,6 +561,25 @@ void enchant_cache::load( const JsonObject &jo, const std::string_view,
             if( mult != 0.0 ) {
                 damage_values_multiply.emplace( value, static_cast<int>( mult ) );
             }
+        }
+    }
+
+    if( jo.has_array( "special_vision" ) ) {
+        for( const JsonObject vision_obj : jo.get_array( "special_vision" ) ) {
+            special_vision foo;
+            special_vision_descriptions _desc;
+            if( vision_obj.has_array( "descriptions" ) ) {
+                for( const JsonObject descriptions_obj : vision_obj.get_array( "descriptions" ) ) {
+                    mandatory( descriptions_obj, was_loaded, "id", _desc.id );
+                    mandatory( descriptions_obj, was_loaded, "text", _desc.description );
+                    read_condition( descriptions_obj, "text_condition", _desc.condition, false );
+                    foo.special_vision_descriptions_vector.emplace_back( _desc );
+                }
+            }
+
+            foo.range = vision_obj.get_float( "distance", 0.0 );
+            read_condition( vision_obj, "condition", foo.condition, false );
+            special_vision_vector.emplace_back( foo );
         }
     }
 }
@@ -646,6 +683,24 @@ void enchant_cache::serialize( JsonOut &jsout ) const
     }
     jsout.end_array();
 
+    jsout.member( "special_vision" );
+    jsout.start_array();
+    for( const special_vision &struc : special_vision_vector ) {
+        jsout.start_object();
+        // jsout.member( "condition", struc.condition );
+        jsout.member( "distance", struc.range );
+        jsout.member( "descriptions" );
+        jsout.start_array();
+        for( const special_vision_descriptions &struc_desc : struc.special_vision_descriptions_vector ) {
+            jsout.start_object();
+            jsout.member( "id", struc_desc.id );
+            // jsout.member( "text_condition", struc_desc.condition );
+            jsout.member( "text", struc_desc.description );
+            jsout.end_object();
+        }
+        jsout.end_object();
+    }
+    jsout.end_array();
 
     jsout.end_object();
 }
@@ -706,6 +761,11 @@ void enchant_cache::force_add( const enchant_cache &rhs )
         damage_values_multiply[pair_values.first] += pair_values.second;
     }
 
+    // from cache to cache?
+    for( const special_vision &struc : rhs.special_vision_vector ) {
+        special_vision_vector.emplace_back( special_vision{ struc.special_vision_descriptions_vector, struc.condition, struc.range } );
+    }
+
     hit_me_effect.insert( hit_me_effect.end(), rhs.hit_me_effect.begin(), rhs.hit_me_effect.end() );
 
     hit_you_effect.insert( hit_you_effect.end(), rhs.hit_you_effect.begin(), rhs.hit_you_effect.end() );
@@ -764,6 +824,11 @@ void enchant_cache::force_add( const enchantment &rhs, const Character &guy )
     for( const std::pair<const damage_type_id, dbl_or_var> &pair_values :
          rhs.damage_values_multiply ) {
         damage_values_multiply[pair_values.first] += pair_values.second.evaluate( d );
+    }
+
+    // from eval to cache, for char
+    for( const enchantment::special_vision &struc : rhs.special_vision_vector ) {
+        special_vision_vector.emplace_back( special_vision{ struc.special_vision_descriptions_vector, struc.condition, struc.range.evaluate( d ) } );
     }
 
     hit_me_effect.insert( hit_me_effect.end(), rhs.hit_me_effect.begin(), rhs.hit_me_effect.end() );
@@ -828,6 +893,11 @@ void enchant_cache::force_add( const enchantment &rhs, const monster &mon )
         damage_values_multiply[pair_values.first] += pair_values.second.evaluate( d );
     }
 
+    // from eval to cache, for monster
+    for( const enchantment::special_vision &struc : rhs.special_vision_vector ) {
+        special_vision_vector.emplace_back( special_vision{ struc.special_vision_descriptions_vector, struc.condition, struc.range.evaluate( d ) } );
+    }
+
     hit_me_effect.insert( hit_me_effect.end(), rhs.hit_me_effect.begin(), rhs.hit_me_effect.end() );
 
     hit_you_effect.insert( hit_you_effect.end(), rhs.hit_you_effect.begin(), rhs.hit_you_effect.end() );
@@ -887,6 +957,11 @@ void enchant_cache::force_add( const enchantment &rhs )
     for( const std::pair<const damage_type_id, dbl_or_var> &pair_values :
          rhs.damage_values_multiply ) {
         damage_values_multiply[pair_values.first] += pair_values.second.constant();
+    }
+
+    // from eval to cache, with constant
+    for( const enchantment::special_vision &struc : rhs.special_vision_vector ) {
+        special_vision_vector.emplace_back( special_vision{ struc.special_vision_descriptions_vector, struc.condition, struc.range.constant() } );
     }
 
     hit_me_effect.insert( hit_me_effect.end(), rhs.hit_me_effect.begin(), rhs.hit_me_effect.end() );
@@ -962,6 +1037,67 @@ double enchantment::get_value_multiply( const enchant_vals::mod value, const Cha
     return found->second.evaluate( d );
 }
 
+bool enchantment::get_vision_distance( const Character &guy, const Creature &critter ) const
+{
+    if( special_vision_vector.empty() ) {
+        return false;
+    }
+
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+
+    for( const special_vision &struc : special_vision_vector ) {
+        if( struc.range.evaluate( d ) >= distance && struc.condition( d ) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::string enchantment::get_vision_description( const Character &guy,
+        const Creature &critter ) const
+{
+
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+
+    for( const special_vision &struc : special_vision_vector ) {
+        if( struc.range.evaluate( d ) >= distance && struc.condition( d ) ) {
+            for( const enchantment::special_vision_descriptions &desc :
+                 struc.special_vision_descriptions_vector ) {
+                if( desc.condition( d ) ) {
+                    return desc.description;
+                }
+            }
+            return "You sense a creature here.";
+        }
+    }
+
+    return "";
+}
+
+std::string enchantment::get_vision_tile( const Character &guy, const Creature &critter ) const
+{
+
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+
+    for( const special_vision &struc : special_vision_vector ) {
+        if( struc.range.evaluate( d ) >= distance && struc.condition( d ) ) {
+            for( const enchantment::special_vision_descriptions &desc :
+                 struc.special_vision_descriptions_vector ) {
+                if( desc.condition( d ) ) {
+                    return desc.id;
+                }
+            }
+            return "infrared_creature";
+        }
+    }
+
+    return "";
+}
+
 double enchant_cache::get_value_add( const enchant_vals::mod value ) const
 {
     const auto found = values_add.find( value );
@@ -996,6 +1132,65 @@ double enchant_cache::get_value_multiply( const enchant_vals::mod value ) const
         return 0;
     }
     return found->second;
+}
+
+bool enchant_cache::get_vision_distance( const Character &guy, const Creature &critter ) const
+{
+    if( special_vision_vector.empty() ) {
+        return false;
+    }
+
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+
+    for( const special_vision &struc : special_vision_vector ) {
+        if( struc.range >= distance && struc.condition( d ) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::string enchant_cache::get_vision_description( const Character &guy,
+        const Creature &critter ) const
+{
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+
+    for( const  special_vision &struc : special_vision_vector ) {
+        if( struc.range >= distance && struc.condition( d ) ) {
+            for( const enchantment::special_vision_descriptions  &desc :
+                 struc.special_vision_descriptions_vector ) {
+                if( desc.condition( d ) ) {
+                    return desc.description;
+                }
+            }
+            return "You sense a creature here.";
+        }
+    }
+
+    return "";
+}
+
+std::string enchant_cache::get_vision_tile( const Character &guy, const Creature &critter ) const
+{
+    const_dialogue d( get_const_talker_for( guy ), get_const_talker_for( critter ) );
+    const double distance = rl_dist_exact( guy.pos(), critter.pos() );
+
+    for( const special_vision &struc : special_vision_vector ) {
+        if( struc.range >= distance && struc.condition( d ) ) {
+            for( const enchantment::special_vision_descriptions &desc :
+                 struc.special_vision_descriptions_vector ) {
+                if( desc.condition( d ) ) {
+                    return desc.id;
+                }
+            }
+            return "infrared_creature";
+        }
+    }
+
+    return "";
 }
 
 double enchant_cache::get_skill_value_multiply( const skill_id &value ) const
@@ -1199,6 +1394,7 @@ void enchant_cache::clear()
     skill_values_multiply.clear();
     damage_values_add.clear();
     damage_values_multiply.clear();
+    special_vision_vector.clear();
     hit_me_effect.clear();
     hit_you_effect.clear();
     ench_effects.clear();

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -232,6 +232,10 @@ class enchantment
         double get_value_add( enchant_vals::mod value, const Character &guy ) const;
         double get_value_multiply( enchant_vals::mod value, const Character &guy ) const;
 
+        bool get_vision_distance( const Character &guy, const Creature &critter ) const;
+        std::string get_vision_description( const Character &guy, const Creature &critter ) const;
+        std::string get_vision_tile( const Character &guy, const Creature &critter ) const;
+
         body_part_set modify_bodyparts( const body_part_set &unmodified ) const;
         // does the enchantment modify bodyparts?
         bool modifies_bodyparts() const;
@@ -271,6 +275,22 @@ class enchantment
         std::vector<fake_spell> hit_me_effect;
         std::vector<fake_spell> hit_you_effect;
 
+        struct special_vision_descriptions {
+            std::string id;
+            std::string description;
+            std::function<bool( const_dialogue const & )> condition;
+        };
+
+        struct special_vision {
+            std::vector<special_vision_descriptions> special_vision_descriptions_vector;
+            std::function<bool( const_dialogue const & )> condition;
+            dbl_or_var range;
+            // todo: add boolean to see/not see with aiming the gun, in cata_tiles::draw_critter_at(), sees_with_specials block
+            // and boolean for precision to be used in calculate_aim_cap()
+        };
+
+        std::vector<special_vision> special_vision_vector;
+
         std::map<time_duration, std::vector<fake_spell>> intermittent_activation;
 
         std::pair<has, condition> active_conditions;
@@ -307,6 +327,9 @@ class enchant_cache : public enchantment
 
         int get_skill_value_add( const skill_id &value ) const;
         int get_damage_add( const damage_type_id &value ) const;
+        bool get_vision_distance( const Character &guy, const Creature &critter ) const;
+        std::string get_vision_description( const Character &guy, const Creature &critter ) const;
+        std::string get_vision_tile( const Character &guy, const Creature &critter ) const;
         double get_skill_value_multiply( const skill_id &value ) const;
         double get_damage_multiply( const damage_type_id &value ) const;
         int skill_mult_bonus( const skill_id &value_type, int base_value ) const;
@@ -353,6 +376,15 @@ class enchant_cache : public enchantment
         std::map<damage_type_id, double> damage_values_add; // NOLINT(cata-serialize)
         std::map<damage_type_id, double> damage_values_multiply; // NOLINT(cata-serialize)
 
+        using special_vision_descriptions = enchantment::special_vision_descriptions;
+
+        struct special_vision {
+            std::vector<special_vision_descriptions> special_vision_descriptions_vector;
+            std::function<bool( const_dialogue const & )> condition;
+            double range;
+        };
+
+        std::vector<special_vision> special_vision_vector;
 };
 
 template <typename E> struct enum_traits;

--- a/src/npc.h
+++ b/src/npc.h
@@ -85,10 +85,10 @@ using overmap_location_str_id = string_id<overmap_location>;
 using drop_location = std::pair<item_location, int>;
 using drop_locations = std::list<drop_location>;
 
-void parse_tags( std::string &phrase, const Character &u, const Character &me,
+void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const itype_id &item_type = itype_id::NULL_ID() );
 
-void parse_tags( std::string &phrase, const Character &u, const Character &me,
+void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const_dialogue const &d, const itype_id &item_type = itype_id::NULL_ID() );
 
 void parse_tags( std::string &phrase, const_talker const &u, const_talker const &me,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2214,14 +2214,14 @@ int topic_category( const talk_topic &the_topic )
     return -1; // Not grouped with other topics
 }
 
-void parse_tags( std::string &phrase, const Character &u, const Character &me,
+void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const itype_id &item_type )
 {
     const_dialogue d( get_const_talker_for( u ), get_const_talker_for( me ) );
     parse_tags( phrase, u, me, d, item_type );
 }
 
-void parse_tags( std::string &phrase, const Character &u, const Character &me,
+void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const_dialogue const &d,
                  const itype_id &item_type )
 {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1299,7 +1299,7 @@ double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
     const Creature *victim = get_creature_tracker().creature_at( target, true );
     // No p.sees_with_specials() here because special senses are not precise enough
     // to give creature's exact size & position, only which tile it occupies
-    if( victim == nullptr || ( !you.sees( *victim ) && !you.sees_with_infrared( *victim ) ) ) {
+    if( victim == nullptr || ( !you.sees( *victim ) && !you.sees_with_specials( *victim ) ) ) {
         const int range = trig_dist_z_adjust( you.pos(), target.raw() );
         // Get angle of triangle that spans the target square.
         const double angle = 2 * atan2( 0.5, range );
@@ -2149,7 +2149,7 @@ static int print_throwforce( const catacurses::window &w, int line_number, float
 static bool pl_sees( const Creature &cr )
 {
     Character &u = get_player_character();
-    return u.sees( cr ) || u.sees_with_infrared( cr ) || u.sees_with_specials( cr );
+    return u.sees( cr ) || u.sees_with_specials( cr );
 }
 
 static int print_aim( const target_ui &ui, Character &you, const catacurses::window &w,
@@ -4288,10 +4288,17 @@ void target_ui::panel_target_info( int &text_y, bool fill_with_blank_if_no_targe
             text_y += max_lines;
         } else {
             std::vector<std::string> buf;
-            if( you->sees_with_infrared( *dst_critter ) ) {
-                dst_critter->describe_infrared( buf );
-            } else if( you->sees_with_specials( *dst_critter ) ) {
-                dst_critter->describe_specials( buf );
+            static std::string raw_description;
+            static std::string critter_name;
+            if( you->sees_with_specials( *dst_critter ) ) {
+                // handling against re-evaluation and snippet replacement on redraw
+                if( critter_name != dst_critter->get_name() ) {
+                    raw_description = you->enchantment_cache->get_vision_description( *you->as_character(),
+                                      *dst_critter );
+                    parse_tags( raw_description, *you->as_character(), *dst_critter );
+                    critter_name = dst_critter->get_name();
+                }
+                buf.emplace_back( raw_description );
             }
             for( size_t i = 0; i < static_cast<size_t>( max_lines ); i++, text_y++ ) {
                 if( i >= buf.size() ) {

--- a/src/talker.h
+++ b/src/talker.h
@@ -139,6 +139,9 @@ class const_talker
             return false;
         }
 
+        virtual bool is_warm() const {
+            return false;
+        }
         // stats, skills, traits, bionics, and magic
         virtual int str_cur() const {
             return 0;

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1305,6 +1305,11 @@ bool talker_character_const::get_is_alive() const
     return !me_chr_const->is_dead_state();
 }
 
+bool talker_character_const::is_warm() const
+{
+    return me_chr_const->is_warm();
+}
+
 void talker_character::die()
 {
     me_chr->die( nullptr );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -185,6 +185,7 @@ class talker_character_const: virtual public const_talker
         int get_part_hp_cur( const bodypart_id &id ) const override;
         int get_part_hp_max( const bodypart_id &id ) const override;
         bool get_is_alive() const override;
+        bool is_warm() const override;
 
         bool can_see() const override;
         bool can_see_location( const tripoint &pos ) const override;

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -190,6 +190,11 @@ int talker_monster_const::get_weight() const
     return units::to_milligram( me_mon_const->get_weight() );
 }
 
+bool talker_monster_const::is_warm() const
+{
+    return me_mon_const->is_warm();
+}
+
 void talker_monster::set_friendly( int new_val )
 {
     me_mon->friendly = new_val;

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -81,6 +81,7 @@ class talker_monster_const: public const_talker_cloner<talker_monster_const>
         bool can_see_location( const tripoint &pos ) const override;
         int get_volume() const override;
         int get_weight() const override;
+        bool is_warm() const override;
 
     private:
         const monster *me_mon_const{};


### PR DESCRIPTION
#### Summary
Backport DDA 77770 - Enchantify special vision 1/2

#### Purpose of change
Standardize and de-hardcode special vision, and fix some ongoing issues with it. Make variable special vision tiles due to creature size a tileset thing and not a dynamic scaling thing.

#### Testing
Loads, runs, tiles work.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
