### PR TITLE
Stricter categorization for fencing weapons, rapiers aren't sturdy

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -217,7 +217,7 @@
     "color": "light_gray",
     "techniques": [ "RAPID", "WBLOCK_1", "PRECISE" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -8 ] ],
-    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
+    "flags": [ "SHEATH_SWORD" ],
     "weapon_category": [ "FENCING_WEAPONRY" ],
     "category": "weapons",
     "melee_damage": { "bash": 6, "stab": 22 }
@@ -339,7 +339,7 @@
     "techniques": [ "WBLOCK_2" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 7 ] ],
-    "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 25 }
   },
   {
@@ -1144,7 +1144,7 @@
     "techniques": [ "WBLOCK_2" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "melee_damage": { "bash": 6, "cut": 24 }
   },
   {
@@ -1184,7 +1184,7 @@
     "price_postapoc": "18 USD 75 cent",
     "material": [ { "type": "leather", "portion": 1.1 }, { "type": "steel", "portion": 112 } ],
     "repairs_with": [ "steel" ],
-    "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
+    "flags": [ "CONDUCTIVE", "SHEATH_SWORD" ],
     "techniques": [ "RAPID", "WBLOCK_2", "PRECISE" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
@@ -1707,7 +1707,7 @@
     "techniques": [ "WBLOCK_2", "BRUTAL" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 6 ] ],
     "flags": [ "DURABLE_MELEE", "CONDUCTIVE", "SHEATH_SWORD" ],
-    "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "melee_damage": { "bash": 5, "cut": 30 }
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -349,7 +349,7 @@
     "conductive": true,
     "chip_resist": 11,
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
-    "repaired_with": "scrap",
+    "repaired_with": "steel_chunk",
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",

--- a/data/json/requirements/melee.json
+++ b/data/json/requirements/melee.json
@@ -157,8 +157,8 @@
   {
     "id": "real_thrusting_swords",
     "type": "requirement",
-    "//": "Any real, quality weapon designed to be used in a thrusting fashion.  Needs to be a sword, not a spear.  This includes fencing weaponry.",
-    "tools": [ [ [ "estoc", -1 ], [ "sword_cane", -1 ], [ "rapier", -1 ], [ "talwar", -1 ], [ "jian", -1 ], [ "broadsword", -1 ] ] ]
+    "//": "Any real, quality weapon designed to be used in a thrusting fashion.  Needs to be a sword, not a spear.  This includes but is not limited to fencing weaponry.",
+    "tools": [ [ [ "estoc", -1 ], [ "sword_cane", -1 ], [ "rapier", -1 ], [ "jian", -1 ], [ "broadsword", -1 ] ] ]
   },
   {
     "id": "basic_short_swords",

--- a/data/json/weapon_categories.json
+++ b/data/json/weapon_categories.json
@@ -111,7 +111,7 @@
   {
     "type": "weapon_category",
     "id": "FENCING_WEAPONRY",
-    "//": "One-handed straight swords built for thrusting or lightly curved agile sabers.  Cutting edge optional for the former.",
+    "//": "One-handed featherlight straight swords built specifically for the sport of fencing.",
     "name": "FENCING WEAPONRY",
     "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_fencing_weapons_master" ]
   },

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -612,7 +612,7 @@ bool Creature::sees( const Creature &critter ) const
     }
 
     if( ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub() ) ) &&
-               critter.get_size() < creature_size::large ) {
+        critter.get_size() < creature_size::large ) {
         return false;
     }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -562,10 +562,12 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
         tripoint_bub_ms pos = veh.bub_part_pos( *t );
 
         int res = 0;
-        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( range, 0 ) ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( range,
+                                               0 ) ) ) );
         res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( -range,
                                                0 ) ) ) );
-        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( 0, range ) ) ) );
+        res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( 0,
+                                               range ) ) ) );
         res = std::max( res, static_cast<int>( trig_dist_z_adjust( you.pos(), pos.raw() + point( 0,
                                                -range ) ) ) );
         range_total = std::max( range_total, res );


### PR DESCRIPTION
#### Summary
Stricter categorization for fencing weapons, rapiers aren't sturdy

#### Purpose of change
- A lot of swords had the FENCING_WEAPONS category despite not being designed for the sport of fencing as it is practiced in modern times. "Fencing" in English may refer broadly to swordfighting martial arts of any kind, but in Cataclysm it refers specifically to that sport. So it goes to fencing sabers (NOT cavalry sabers, which are of the ubiquitous curved civil war kind and not the much less common pointy WW1 kind), epees, rapiers, foils, and similar, but not talwars, jian, or broadswords - these too have a name which is sometimes confused with the fencing saber, but in the context of this game they refer to broad-bladed slashing weapons, not skinny stabbers.
- Rapiers had the STURDY flag.
- The metal fencing sword was not repairable with most welding gear because of a mistake with budget steel's repair requirements. It now repairs like normal steel.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
