### PR TITLE
Fix talon kick vector

### DIFF
--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -1594,7 +1594,7 @@
     "melee_allowed": true,
     "messages": [ "You kick %s", "<npcname> kicks %s" ],
     "description": "A powerful kick with sharp talons",
-    "attack_vectors": [ "vector_foot_toes", "vector_foot_heel" ]
+    "attack_vectors": [ "vector_talon" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
#### Summary
Fix talon kick vector

#### Purpose of change
Talon kick needed its vector. Now it has it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
