### PR TITLE
Fix proportional damage for fencing sword mods

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -948,7 +948,8 @@
     "looks_like": "fencing_foil",
     "name": { "str": "sharpened foil" },
     "description": "What was once a mostly-harmless fencing foil has had its electrical plunger assembly removed and has been crudely sharpened to a point.  Though it still lacks a cutting edge, it is now somewhat more lethal, yet still familiar to the practiced fencer.",
-    "relative": { "weight": "-25 g", "melee_damage": { "stab": 2 } }
+    "weight": "425 g",
+    "melee_damage": { "bash": 1, "stab": 4 }
   },
   {
     "id": "shock_foil",
@@ -997,7 +998,8 @@
     "looks_like": "fencing_epee",
     "name": { "str": "sharpened épée" },
     "description": "What was once a mostly-harmless fencing épée has had its electrical plunger assembly removed and has been crudely sharpened to a point.  Though it still lacks a cutting edge, it is now considerably more lethal, yet still familiar to the practiced fencer.",
-    "relative": { "weight": "-35 g", "melee_damage": { "stab": 5 } }
+    "weight": "615 g",
+    "melee_damage": { "bash": 3, "stab": 12 }
   },
   {
     "id": "shock_epee",
@@ -1048,7 +1050,8 @@
     "looks_like": "fencing_sabre",
     "name": { "str": "sharpened saber" },
     "description": "What was once a mostly-harmless fencing saber has had its rounded tip snapped off and has been crudely sharpened to a point.  Though it still lacks a cutting edge, it is now considerably more lethal, yet still familiar to the practiced fencer.",
-    "relative": { "weight": "-10 g", "melee_damage": { "stab": 5 } }
+    "weight": "390 g",
+    "melee_damage": { "bash": 1, "stab": 11 }
   },
   {
     "id": "shock_sabre",


### PR DESCRIPTION
#### Summary
Fix proportional damage for fencing sword mods

#### Purpose of change
Whoever made the electrified epee and its kin didn't realize that you can't daisy chain copy-from on items that already use it and relative, as relative isn't preserved.

#### Describe the solution
Explicitly define the weight and damage values for sharpened foil, rapier, and epee. These explicit values can then be inherited properly by their electrified versions.

#### Describe alternatives you've considered
This ought to be done dynamically via flags.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
