### PR TITLE
Fix Dino Dave and Smokes's dialog

### DIFF
--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -124,7 +124,7 @@
     "speaker_effect": [ { "effect": { "u_bulk_donate": 1 } }, { "effect": { "run_eocs": [ "EOC_BEGGAR_TEST_IF_FOOD_CANNIBAL" ] } } ],
     "responses": [
       { "text": "What are you doing here?", "topic": "TALK_REFUGEE_BEGGAR_2" },
-      { "text": "No problem.  <end_talking_bye>", "topic": "TALK_DONE" }
+      { "text": "No problem.  Bye.", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -96,7 +96,7 @@
         "success": { "effect": "start_trade", "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading" },
         "failure": { "topic": "TALK_FREE_MERCHANTS_MERCHANT_CANNIBAL_GTFO" }
       },
-      { "text": "I just wanted to look around.  <end_talking_bye>", "topic": "TALK_DONE" }
+      { "text": "I just wanted to look around.  See you.", "topic": "TALK_DONE" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix Dino Dave and Smokes's dialog

#### Purpose of change
Some snippet stuff got accidentally backported. We don't use those, so it was causing a Bad Tag error in Smokes and Dave's dialog.

#### Describe the solution
Remove.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
