### PR TITLE
Reduce arrows in quivers in itemgroups

### DIFF
--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -148,12 +148,12 @@
     "id": "archery_ammo",
     "subtype": "distribution",
     "entries": [
-      { "item": "arrow_wood_broadhead", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_wood_bodkin", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_cf", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_metal", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_metal_bodkin", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_metal_target", "prob": 100, "count": [ 5, 30 ] }
+      { "item": "arrow_wood_broadhead", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_wood_bodkin", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_cf", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_metal", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_metal_bodkin", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_metal_target", "prob": 100, "count": [ 4, 8 ] }
     ]
   },
   {
@@ -162,12 +162,12 @@
     "//": "archery ammo, that can be crafted, and can be find in random survivor camps",
     "subtype": "distribution",
     "entries": [
-      { "item": "arrow_wood_crude", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_wood", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_wood_horn", "prob": 30, "count": [ 5, 30 ] },
-      { "item": "arrow_wood_tooth", "prob": 1, "count": [ 5, 10 ] },
-      { "item": "arrow_wood_broadhead", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "arrow_wood_bodkin", "prob": 100, "count": [ 5, 30 ] }
+      { "item": "arrow_wood_crude", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_wood", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_wood_horn", "prob": 30, "count": [ 4, 8 ] },
+      { "item": "arrow_wood_tooth", "prob": 1, "count": [ 4, 8 ] },
+      { "item": "arrow_wood_broadhead", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "arrow_wood_bodkin", "prob": 100, "count": [ 4, 8 ] }
     ]
   },
   {
@@ -199,7 +199,7 @@
     "container-item": "quiver",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80 }, { "group": "crossbow_bolts", "prob": 20 } ]
+    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",
@@ -207,7 +207,7 @@
     "container-item": "quiver_large",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80 }, { "group": "crossbow_bolts", "prob": 20 } ]
+    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 2, 3 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 2, 3 ] } ]
   },
   {
     "type": "item_group",
@@ -215,7 +215,7 @@
     "container-item": "nylon_quiver",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80 }, { "group": "crossbow_bolts", "prob": 20 } ]
+    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",
@@ -223,18 +223,18 @@
     "container-item": "quiver_takedown_bow",
     "on_overflow": "discard",
     "subtype": "collection",
-    "entries": [ { "group": "archery_ammo" }, { "group": "archery_mods", "prob": 20 } ]
+    "entries": [ { "group": "archery_ammo", "count": [ 1, 2 ] }, { "group": "archery_mods", "prob": 20 } ]
   },
   {
     "type": "item_group",
     "id": "crossbow_bolts",
     "subtype": "distribution",
     "entries": [
-      { "item": "bolt_wood", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "bolt_wood_bodkin", "prob": 50, "count": [ 5, 30 ] },
-      { "item": "bolt_steel", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "bolt_steel_bodkin", "prob": 100, "count": [ 5, 30 ] },
-      { "item": "bolt_cf", "prob": 100, "count": [ 5, 30 ] }
+      { "item": "bolt_wood", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_wood_bodkin", "prob": 50, "count": [ 4, 8 ] },
+      { "item": "bolt_steel", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_steel_bodkin", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_cf", "prob": 100, "count": [ 4, 8 ] }
     ]
   },
   {
@@ -242,10 +242,10 @@
     "id": "crossbow_bolts_makeshift",
     "subtype": "distribution",
     "entries": [
-      { "item": "bolt_crude", "prob": 100, "count": [ 10, 30 ] },
-      { "item": "bolt_simple_wood", "prob": 100, "count": [ 10, 30 ] },
-      { "item": "bolt_wood", "prob": 100, "count": [ 10, 30 ] },
-      { "item": "bolt_wood_bodkin", "prob": 50, "count": [ 10, 30 ] }
+      { "item": "bolt_crude", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_simple_wood", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_wood", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bolt_wood_bodkin", "prob": 50, "count": [ 4, 8 ] }
     ]
   }
 ]

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -387,7 +387,7 @@
     "color": "brown",
     "sided": true,
     "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 18, "bolt": 22 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 18, "bolt": 20 }, "moves": 20 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -414,7 +414,7 @@
     "color": "light_gray",
     "sided": true,
     "material_thickness": 0.5,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 18, "bolt": 22 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 18, "bolt": 20 }, "moves": 20 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "PALS_LARGE" ],
     "armor": [
       {
@@ -430,7 +430,7 @@
     "id": "quiver_birchbark",
     "type": "ARMOR",
     "name": { "str": "birchbark quiver" },
-    "description": "A quiver woven from strips of birch bark, worn at the waist, that can hold 15 arrows or 20 bolts.  Use insert to store arrows or bolts.",
+    "description": "A quiver woven from strips of birch bark, worn at the waist.  Use insert to store arrows or bolts.",
     "weight": "490 g",
     "volume": "500 ml",
     "price": "65 USD",
@@ -441,7 +441,7 @@
     "color": "light_gray",
     "sided": true,
     "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 15, "bolt": 20 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 16, "bolt": 18 }, "moves": 20 } ],
     "flags": [ "BELTED", "VARSIZE", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -468,7 +468,7 @@
     "color": "dark_gray",
     "sided": true,
     "material_thickness": 1.5,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 5, "bolt": 5 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 6, "bolt": 8 }, "moves": 20 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -494,7 +494,7 @@
     "looks_like": "quiver",
     "color": "brown",
     "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 25, "bolt": 30, "atlatl": 8, "fishspear": 8 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 32, "bolt": 34, "atlatl": 8, "fishspear": 8 }, "moves": 25 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 3, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 4 }
@@ -513,7 +513,7 @@
     "looks_like": "quiver_birchbark",
     "color": "light_gray",
     "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 20, "bolt": 25, "atlatl": 6, "fishspear": 6 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 28, "bolt": 30, "atlatl": 6, "fishspear": 6 }, "moves": 20 } ],
     "flags": [ "BELTED", "VARSIZE", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 14, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 4 }
@@ -533,7 +533,7 @@
     "color": "dark_gray",
     "sided": true,
     "material_thickness": 1.5,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 15, "bolt": 15 }, "moves": 30 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 18, "bolt": 20 }, "moves": 30 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 14, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 12 }
@@ -572,7 +572,7 @@
     "color": "light_blue",
     "sided": true,
     "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 8, "bolt": 10, "atlatl": 4, "fishspear": 4 }, "moves": 30 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 10, "bolt": 12, "atlatl": 4, "fishspear": 4 }, "moves": 30 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 6, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },

--- a/data/json/npcs/random_encounters/john_bailey.json
+++ b/data/json/npcs/random_encounters/john_bailey.json
@@ -135,7 +135,7 @@
     "type": "item_group",
     "id": "john_bailey_quiver",
     "subtype": "collection",
-    "entries": [ { "item": "arrow_cf", "count": 20 } ]
+    "entries": [ { "item": "arrow_cf", "count": 18 } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -354,7 +354,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_naturalist",
-    "entries": [ { "item": "arrow_wood", "count": 20 } ]
+    "entries": [ { "item": "arrow_wood", "count": 16 } ]
   },
   {
     "type": "item_group",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -1165,6 +1165,7 @@
       "nylon_quiver",
       "pipe_quiver",
       "pipe_quiver_large",
+      "quiver_denim",
       "quiver_simple_cloth"
     ],
     "difficulty": 3

--- a/data/mods/innawood/professions.json
+++ b/data/mods/innawood/professions.json
@@ -3,19 +3,19 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_bow_hunter",
-    "entries": [ { "item": "arrow_heavy_fire_hardened_fletched", "charges": 20 } ]
+    "entries": [ { "item": "arrow_heavy_fire_hardened_fletched", "charges": 16 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_crossbow_hunter",
-    "entries": [ { "item": "bolt_simple_wood", "charges": 20 } ]
+    "entries": [ { "item": "bolt_simple_wood", "charges": 16 } ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_arbalist",
-    "entries": [ { "item": "bolt_simple_wood", "charges": 60 } ]
+    "entries": [ { "item": "bolt_simple_wood", "charges": 16 } ]
   },
   {
     "type": "item_group",
@@ -617,7 +617,7 @@
           { "item": "seed_wild_rice", "count": 5 },
           { "item": "seed_bottle_gourd", "count": 1 },
           { "item": "water_clean", "charges": 8, "container-item": "bottle_gourd" },
-          { "item": "arrow_heavy_fire_hardened_fletched", "charges": 10, "container-item": "quiver_birchbark" }
+          { "item": "arrow_heavy_fire_hardened_fletched", "charges": 8, "container-item": "quiver_birchbark" }
         ]
       }
     }


### PR DESCRIPTION
#### Summary
Reduce arrows in quivers in itemgroups

#### Purpose of change
There were to much arrow,

By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
