### PR TITLE
Even fewer cows

### DIFF
--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -36,13 +36,8 @@
       "monsters": { ".": { "monster": "GROUP_ZOMBIE_BOVINE", "chance": 2, "density": 0.0005 } },
       "place_monsters": [
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 11 ], "y": [ 1, 10 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 9 ], "y": [ 1, 11 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 15 ], "y": [ 1, 14 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 34 ], "y": [ 1, 9 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 36 ], "y": [ 1, 12 ], "density": 0.1 },
         { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 33 ], "y": [ 1, 11 ], "density": 0.1 },
-        { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 39 ], "y": [ 1, 12 ], "density": 0.1 }
+        { "monster": "GROUP_FARM_PESTS", "x": [ 10, 18 ], "y": [ 1, 11 ], "density": 0.1 }
       ]
     }
   },


### PR DESCRIPTION
#### Summary
Even fewer cows

#### Purpose of change
It's the apocalypse. These animals have been standing outside in a pen they cannot escape for weeks while monsters are everywhere.

#### Describe the solution
Reduce the cows, bust up the fences, add a chance for farm pests to spawn.

#### Describe alternatives you've considered
THEREARENOCOWS

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
