### PR TITLE
Option to center the cam while looking around

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3334,6 +3334,13 @@
   },
   {
     "type": "keybinding",
+    "id": "CENTER_ON_LOOK",
+    "name": "Center camera on currently viewed tile",
+    "category": "LOOK",
+    "bindings": [ { "input_method": "keyboard_any", "key": ":" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",


### PR DESCRIPTION


#### Summary
- Added a new keybind ":" used to center the player camera with the currently viewed tile, inside of the "look_around" function context. If the user uses the keybind, it exits the look around context with the camera changed.
- Added a hint for the keybind to its UI.

#### Purpose of change
Need of more options to change the camera, HJKL to move it manually is tiresome.

#### Describe alternatives you've considered
Pass time while looking/peeking.

#### Testing
- Tested without debug options, basic testing.
- UI not tested in other devices.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
