### PR TITLE
Fix two minor old lab bugs

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1314,7 +1314,6 @@
     "symbol": "[",
     "color": "light_gray",
     "name": { "str": "phase immersion suit" },
-    "looks_like": "rm13_armor",
     "description": "Covered in interlocking plates of reflective metal, this advanced suit resembles both plate armor and an astronaut's spacesuit.  Designed to protect its wearer during extradimensional excursions, it offers unparalleled environmental protection, both in this Earth and beyond.  Use it to turn it on.",
     "price": "1500 USD",
     "price_postapoc": "150 USD",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -121,7 +121,7 @@ static const itype_id itype_diesel( "diesel" );
 static const itype_id itype_gasoline( "gasoline" );
 static const itype_id itype_jp8( "jp8" );
 
-static const mongroup_id GROUP_FUNGI_FLOWER( "GROUP_FUNGI_FLOWER" );
+static const mongroup_id GROUP_FUNGI_FLOWERS( "GROUP_FUNGI_FLOWERS" );
 static const mongroup_id GROUP_FUNGI_ZOMBIE( "GROUP_FUNGI_ZOMBIE" );
 static const mongroup_id GROUP_LAB( "GROUP_LAB" );
 static const mongroup_id GROUP_LAB_CYBORG( "GROUP_LAB_CYBORG" );
@@ -6184,7 +6184,7 @@ void map::draw_lab( mapgendata &dat )
                     ter_set( center.xy(), ter_t_fungus_floor_in );
                     furn_set( center.xy(), furn_str_id::NULL_ID() );
                     trap_set( center, tr_portal );
-                    place_spawns( GROUP_FUNGI_FLOWER, 1, center.xy() + point( -2, -2 ),
+                    place_spawns( GROUP_FUNGI_FLOWERS, 1, center.xy() + point( -2, -2 ),
                                   center.xy() + point( 2, 2 ), center.z(), 1, true );
 
                     break;
@@ -6325,7 +6325,6 @@ void map::draw_lab( mapgendata &dat )
                             spawn_item( point_bub_ms( SEEX, SEEY ), "recipe_atomic_battery" );
                             spawn_item( point_bub_ms( SEEX + 1, SEEY ), "plut_cell", rng( 8, 20 ) );
                         }  else { // loot_variant between 90 and 96.
-                            spawn_item( point_bub_ms( SEEX - 1, SEEY - 1 ), "rm13_armor" );
                             spawn_item( point_bub_ms( SEEX, SEEY - 1 ), "plut_cell" );
                             spawn_item( point_bub_ms( SEEX - 1, SEEY ), "plut_cell" );
                             spawn_item( point_bub_ms( SEEX, SEEY ), "recipe_caseless" );


### PR DESCRIPTION
#### Summary
Fix two minor old lab bugs

#### Purpose of change
- GROUP_FUNGAL_FLOWER was throwing an error message due to a hardcoded lab spawn. This group was deleted along with fungalouds, but GROUP_FUNGAL_FLOWERS exists. Let's see how that goes.
- Two lingering references to rm13_armor were found and excised

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
