### PR TITLE
Grabs can pull characters off of bikes

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13105,7 +13105,6 @@ int Character::impact( const int force, const tripoint &p )
 
     int total_dealt = 0;
     if( mod * effective_force >= 5 ) {
-        add_msg( _( "effective force = %s" ), effective_force );
         int parts_affected_total = std::max( 1, effective_force / rng( 3, 30 ) );
         int parts_affected = 0;
         std::vector<bodypart_id> bps = get_all_body_parts( get_body_part_flags::only_main );

--- a/src/character.h
+++ b/src/character.h
@@ -2788,7 +2788,7 @@ class Character : public Creature, public visitable
         outfit worn;
         mutable bool nv_cached = false;
         mutable bool nv_result = false;
-        // Means player sit inside vehicle on the tile he is now
+        // Whether or not the character is in/on the vehicle on their tile
         bool in_vehicle = false;
 
         // Means player is hauling items along the ground

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -587,6 +587,16 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
                            bp_id->name );
             // Add grabbed - permanent, removal handled in try_remove_grab on move/wait
             target->add_effect( grab_data.grab_effect, 1_days, bp_id, true, eff_grab_strength );
+            const optional_vpart_position vp = here.veh_at( target->pos_bub() );
+            vehicle *const veh = veh_pointer_or_null( vp );
+
+                // TODO: Skill/speed check to escape grab and drive away safely.
+
+                if( veh && foe->in_vehicle && !vp->part_with_feature( VPFLAG_SEATBELT, true ).has_value() ) {
+                    here.unboard_vehicle( target->pos_bub() );
+                    target->add_msg_if_player( m_bad, _( "You are yanked out of your seat!" ) );
+                    target->mod_moves( -to_moves<int>( 1_seconds ) );
+                }
         } else {
             // Monsters don't have limb scores, no need to target limbs
             target->add_effect( grab_data.grab_effect, 1_days, body_part_bp_null, true, eff_grab_strength );


### PR DESCRIPTION
#### Summary
Grabs can pull characters off of bikes

#### Purpose of change
Currently if you get grabbed while driving by a zombie, you just instantly break it when the vehicle carries you away. That isn't as funny as it could be.

#### Describe the solution
If you are grabbed by an enemy who is not in your vehicle, make a driving skill/velocity check if you're not wearing a seatbelt, contested against the attacker's grab strength. On a failure, you are unboarded from the vehicle.

#### Testing
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/dc73627a-2515-462d-bb45-b66ac74e8921" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/c3a71994-da15-454c-bb98-bd4588e716a4" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/493aa3df-76ae-4c32-a395-ec89cdea5308" />
hahahahahahahahaha
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
