### PR TITLE
Remove free guns from Hub01 ancilla bar

### DIFF
--- a/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
@@ -194,13 +194,6 @@
         "Y": "t_strconc_floor_olight"
       },
       "furniture": { "7": "f_filing_cabinet", "A": "f_sandbag_wall", "W": "f_sandbag_wall", ":": "f_small_satellite_dish" },
-      "items": {
-        "l": [
-          { "item": "NC_ANCILLA_GRUNT_worn", "chance": 50 },
-          { "item": "NC_ANCILLA_GRUNT_wield", "chance": 50 },
-          { "item": "NC_ANCILLA_GRUNT_carry", "chance": 50 }
-        ]
-      },
       "npcs": { "Q": { "class": "ancilla_hq_guard" } }
     }
   },


### PR DESCRIPTION
#### Summary
Remove free guns from Hub01 ancilla bar

#### Purpose of change
The fortress part of the Hub 01 ancilla area had some guns and stuff in the lockers. This was seemingly intended to belong to the mercs there, but it showed up on day 1 before anyone was even in the place, and it wasn't flagged as belonging to them.

#### Describe the solution
Remove it. Eventually I'll nix that whole structure and most of those NPCs will get moved elsewhere and reworked, but for now we can just delete the unaccountable free guns.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
