### PR TITLE
Add antlers to more zeds and animals

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1549,6 +1549,23 @@
     ]
   },
   {
+    "id": "zombie_antler",
+    "//": "Any zombie that might drop 0 to 2 antlers.",
+    "type": "harvest",
+    "message": "<zombie_animal_generic_harvest>",
+    "entries": [
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
+      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
+      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
+      { "drop": "antler", "type": "bone", "base_num": [ 0, 2 ], "max": 2 },
+      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
+      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "raw_tainted_leather", "type": "skin", "mass_ratio": 0.02 }
+    ]
+  },
+  {
     "id": "zombie_fur",
     "//": "any zombie that might drop fur. mostly animals.",
     "type": "harvest",
@@ -1937,6 +1954,21 @@
     ]
   },
   {
+    "id": "zombie_thorny_antler",
+    "//": "Mix of animal and plant. Also drops 0 to 2 antlers.",
+    "type": "harvest",
+    "entries": [
+      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.2 },
+      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.05 },
+      { "drop": "antler", "type": "bone", "base_num": [ 0, 2 ], "max": 2 },
+      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.08 },
+      { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
+      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
+      { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.1 }
+    ]
+  },
+  {
     "id": "zombie_thorny",
     "//": "mix of animal and plant",
     "type": "harvest",
@@ -2139,6 +2171,24 @@
       { "drop": "demihuman_marrow", "type": "bone", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
       { "drop": "raw_demihumanleather", "type": "skin", "mass_ratio": 0.01 }
+    ]
+  },
+  {
+    "id": "mutant_human_antler",
+    "//": "Used for the ungulate mutant, but broadly appropriate for any formerly human mutant with fur and antlers.",
+    "type": "harvest",
+    "entries": [
+      { "drop": "skull_human", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
+      { "drop": "mutant_human_flesh", "type": "flesh", "mass_ratio": 0.19 },
+      { "drop": "mutant_human_blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "mutant_human_heart", "type": "offal", "mass_ratio": 0.01 },
+      { "drop": "antler", "type": "bone", "base_num": [ 0, 2 ], "max": 2 },
+      { "drop": "hstomach", "scale_num": [ 1, 1 ], "max": 1, "type": "offal" },
+      { "drop": "mutant_human_fat", "type": "flesh", "mass_ratio": 0.1 },
+      { "drop": "bone_human", "type": "bone", "mass_ratio": 0.12 },
+      { "drop": "mutant_human_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 },
+      { "drop": "raw_hfur", "type": "skin", "mass_ratio": 0.02 }
     ]
   },
   {

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -199,7 +199,10 @@
     "container-item": "quiver",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] } ]
+    "entries": [
+      { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] },
+      { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] }
+    ]
   },
   {
     "type": "item_group",
@@ -207,7 +210,10 @@
     "container-item": "quiver_large",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 2, 3 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 2, 3 ] } ]
+    "entries": [
+      { "group": "archery_ammo", "prob": 80, "count": [ 2, 3 ] },
+      { "group": "crossbow_bolts", "prob": 20, "count": [ 2, 3 ] }
+    ]
   },
   {
     "type": "item_group",
@@ -215,7 +221,10 @@
     "container-item": "nylon_quiver",
     "on_overflow": "discard",
     "subtype": "distribution",
-    "entries": [ { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] }, { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] } ]
+    "entries": [
+      { "group": "archery_ammo", "prob": 80, "count": [ 1, 2 ] },
+      { "group": "crossbow_bolts", "prob": 20, "count": [ 1, 2 ] }
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -557,7 +557,7 @@
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 6, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
-    {
+  {
     "id": "quiver_denim",
     "type": "ARMOR",
     "name": { "str": "denim quiver" },

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -843,7 +843,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
     "extend": { "special_attacks": [ [ "LUNGE", 5 ] ] },
-    "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_CLOSE" ],
+    "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_CLOSE", "SOUND" ],
     "petfood": {
       "food": [ "DOGFOOD" ],
       "feed": "The %s seems to like you!  It lets you pat its head and seems friendly.",
@@ -2100,7 +2100,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
     "dodge": 4,
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
-    "harvest": "mammal_fur",
+    "harvest": "deer_with_skull",
     "dissect": "dissect_cattle_sample_single",
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
     "upgrades": { "age_grow": 500, "into": "mon_reindeer" },

--- a/data/json/monsters/mutant.json
+++ b/data/json/monsters/mutant.json
@@ -164,12 +164,11 @@
     "stomach_size": 1500,
     "path_settings": { "max_dist": 20, "avoid_sharp": true, "avoid_traps": true, "avoid_dangerous_fields": true },
     "families": [ "prof_intro_biology", "prof_physiology" ],
-    "harvest": "mutant_human",
+    "harvest": "mutant_human_antler",
     "dissect": "dissect_cattle_sample_large",
     "death_drops": "mon_mutant_experimental_death_drops",
     "anger_triggers": [ "HOSTILE_SEEN", "PLAYER_CLOSE", "FRIEND_ATTACKED" ],
     "fear_triggers": [ "HURT", "FIRE" ],
-    "zombify_into": "mon_meat_cocoon_med",
     "flags": [
       "SEES",
       "HEARS",
@@ -361,9 +360,8 @@
     "stomach_size": 1100,
     "harvest": "mutant_human",
     "dissect": "dissect_gastropod_sample_large",
-    "zombify_into": "mon_meat_cocoon_large",
     "delete": { "flags": [ "HIT_AND_RUN" ], "fear_triggers": [ "FIRE" ] },
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF", "NOHEAD", "STUN_IMMUNE", "PATH_AVOID_FIRE" ] },
-    "armor": { "bash": 22, "cut": 45, "stab": 30, "heat": 20, "bullet": 70, "electric": 6 }
+    "armor": { "bash": 22, "cut": 45, "stab": 30, "heat": 8, "bullet": 70, "electric": 6, "acid": 3 }
   }
 ]

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -394,7 +394,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
     "bleed_rate": 20,
     "vision_night": 7,
-    "harvest": "zombie_thorny",
+    "harvest": "zombie_thorny_antler",
     "attack_effs": [ { "id": "paralyzepoison", "duration": 33 } ],
     "//grab": "Let's say the thorns make it half again as grabby",
     "grab_strength": 45,

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -408,7 +408,7 @@
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "vision_day": 30,
     "vision_night": 5,
-    "harvest": "zombie_leather",
+    "harvest": "zombie_antler",
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "upgrades": { "half_life": 42, "into_group": "GROUP_ZOOSE_UPGRADE" },
     "fungalize_into": "mon_zoose_fungus",
@@ -707,7 +707,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "vision_night": 12,
-    "harvest": "zombie_leather",
+    "harvest": "zombie_antler",
     "fungalize_into": "mon_zeer_fungus",
     "flags": [
       "SEES",
@@ -751,7 +751,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "vision_night": 12,
-    "harvest": "zombie_leather",
+    "harvest": "zombie_antler",
     "fungalize_into": "mon_zeindeer_fungus",
     "flags": [
       "SEES",


### PR DESCRIPTION
#### Summary
Add antlers to more zeds and animals

#### Purpose of change
Zombie deer and mooses didn't have antlers! That's no good. Neither did the ungulate mutant.

#### Describe the solution
Give all the zombie deer, moose, reindeer etc. antlers in their harvestry lists. You want to butcher them to get these.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
