### PR TITLE
Minor overmap adjustments

### DIFF
--- a/data/json/furniture_and_terrain/terrain-bridges-docks.json
+++ b/data/json/furniture_and_terrain/terrain-bridges-docks.json
@@ -242,10 +242,7 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
     "connect_groups": "WATER",
-    "deconstruct": {
-      "ter_set": "t_water_sh",
-      "items": [ { "item": "scrap", "count": [ 3, 6 ] }, { "item": "sheet_metal", "count": 2 } ]
-    },
+    "deconstruct": { "ter_set": "t_water_sh", "items": [ { "item": "scrap", "count": [ 3, 6 ] }, { "item": "sheet_metal", "count": 2 } ] },
     "bash": {
       "str_min": 20,
       "str_max": 80,

--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -34,9 +34,7 @@
       ],
       "palettes": [ "farm_dairy_palette" ],
       "monsters": { ".": { "monster": "GROUP_ZOMBIE_BOVINE", "chance": 2, "density": 0.0005 } },
-      "nested": {
-      "$": { "chunks": [ [ "1x1_bash", 2 ], [ "null", 98 ] ] }
-      },
+      "nested": { "$": { "chunks": [ [ "1x1_bash", 2 ], [ "null", 98 ] ] } },
       "place_monsters": [
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.1 },
         { "monster": "GROUP_COWS_DAIRY", "x": [ 25, 33 ], "y": [ 1, 11 ], "density": 0.1 },

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2967,9 +2967,9 @@
     ],
     "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field" ],
-    "city_distance": [ 5, -1 ],
-    "occurrences": [ 0, 3 ],
-    "flags": [ "CLASSIC", "FARM", "MAN_MADE" ]
+    "city_distance": [ 6, -1 ],
+    "occurrences": [ 1, 5 ],
+    "flags": [ "CLASSIC", "FARM", "MAN_MADE", "OVERMAP_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -3058,7 +3058,7 @@
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 85, 100 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "OVERMAP_UNIQUE", "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3107,7 +3107,7 @@
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
     "city_distance": [ 15, 50 ],
-    "occurrences": [ 60, 100 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "OVERMAP_UNIQUE", "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3157,7 +3157,7 @@
     "locations": [ "land" ],
     "city_distance": [ 0, 10 ],
     "city_sizes": [ 6, -1 ],
-    "occurrences": [ 70, 100 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "OVERMAP_UNIQUE", "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3253,8 +3253,8 @@
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
-    "city_distance": [ 20, 60 ],
-    "occurrences": [ 15, 100 ],
+    "city_distance": [ 15, 60 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "OVERMAP_UNIQUE", "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -3531,8 +3531,8 @@
     ],
     "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "forest", "field" ],
-    "city_distance": [ 5, 50 ],
-    "occurrences": [ 0, 3 ],
+    "city_distance": [ 8, 50 ],
+    "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {
@@ -4355,8 +4355,8 @@
     "city_distance": [ 5, 40 ],
     "city_sizes": [ 6, -1 ],
     "occurrences": [ 70, 100 ],
-    "//": "Inflated chance, effective rate ~40%",
-    "flags": [ "CLASSIC", "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "//": "Incredibly rare, there are actually no food irradiation plants in New England IRL.",
+    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -4428,7 +4428,7 @@
       { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road" }
     ],
     "locations": [ "land" ],
-    "city_distance": [ 5, -1 ],
+    "city_distance": [ 10, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
@@ -6118,7 +6118,7 @@
       { "point": [ 3, 2, 1 ], "overmap": "fort_4c_1_north" }
     ],
     "locations": [ "field", "forest_without_trail" ],
-    "city_distance": [ 0, 100 ],
+    "city_distance": [ 2, 100 ],
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 5, 100 ],
     "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE", "WILDERNESS" ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -43,15 +43,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "solar_farm",
-    "vision_levels": "blends_till_outlines",
-    "name": "solar farm",
-    "sym": "#",
-    "color": "i_yellow",
-    "see_cost": "medium"
-  },
-  {
-    "type": "overmap_terrain",
     "id": "pwr_sub_s",
     "name": "small power substation",
     "sym": "H",


### PR DESCRIPTION
#### Summary
Minor overmap adjustments

#### Purpose of change
Some overmap specials were spawning too often, some not enough.

#### Describe the solution
Make all kinds of mansions roughly equally common, with the boarded up variant slightly more likely than the others. Tweak some probabilities, make dairy farms have to be farther from towns and keep multiples from spawning on the same overmap.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
