### PR TITLE
Further map adjustments

### DIFF
--- a/data/json/mapgen/farm_dairy.json
+++ b/data/json/mapgen/farm_dairy.json
@@ -187,17 +187,17 @@
         { "item": "clothing_work_set", "x": 9, "y": 17, "chance": 90 }
       ],
       "place_item": [
-        { "item": "cattlefodder_large", "x": 37, "y": 15, "amount": [ 0, 1 ] },
-        { "item": "cattlefodder_large", "x": 38, "y": 6, "amount": [ 0, 1 ] },
-        { "item": "cattlefodder_medium", "x": 38, "y": 10, "amount": [ 0, 2 ] },
-        { "item": "cattlefodder_medium", "x": 38, "y": 13, "amount": [ 0, 2 ] },
-        { "item": "cattlefodder", "x": 39, "y": 5, "amount": [ 0, 4 ] },
-        { "item": "cattlefodder", "x": 39, "y": 8, "amount": [ 0, 4 ] },
+        { "item": "cattlefodder_large", "x": 37, "y": 15, "amount": [ 0, 2 ] },
+        { "item": "cattlefodder_large", "x": 38, "y": 6, "amount": [ 0, 2 ] },
+        { "item": "cattlefodder_medium", "x": 38, "y": 10, "amount": [ 0, 4 ] },
+        { "item": "cattlefodder_medium", "x": 38, "y": 13, "amount": [ 0, 4 ] },
+        { "item": "cattlefodder", "x": 39, "y": 5, "amount": [ 0, 6 ] },
+        { "item": "cattlefodder", "x": 39, "y": 8, "amount": [ 0, 6 ] },
         { "item": "cattlefodder_medium", "x": 39, "y": 17, "amount": [ 0, 2 ] },
         { "item": "livestock_scale", "x": 28, "y": 4 }
       ],
       "place_vehicles": [
-        { "vehicle": "cube_van_cheap", "x": 7, "y": 4, "chance": 50, "fuel": 300, "status": -1, "rotation": 0 },
+        { "vehicle": "cube_van_cheap", "x": 7, "y": 4, "chance": 40, "fuel": 300, "status": -1, "rotation": 0 },
         { "vehicle": "quad_bike", "x": 15, "y": 6, "chance": 30, "fuel": 200, "status": -1, "rotation": 0 },
         { "vehicle": "bicycle", "x": 13, "y": 8, "chance": 80, "fuel": 0, "status": 0, "rotation": 0 }
       ]

--- a/data/json/mapgen/farm_dairy_2.json
+++ b/data/json/mapgen/farm_dairy_2.json
@@ -194,7 +194,7 @@
         "M": { "field": "fd_blood", "intensity": 1, "age": 10 },
         "q": { "field": "fd_blood", "intensity": 1, "age": 10 }
       },
-      "vehicles": { "J": { "vehicle": "portable_generator", "rotation": 90, "chance": 100, "fuel": 40, "status": 1 } }
+      "vehicles": { "J": { "vehicle": "portable_generator", "rotation": 90, "chance": 80, "fuel": 40, "status": 1 } }
     }
   },
   {

--- a/data/json/mapgen/map_extras/military.json
+++ b/data/json/mapgen/map_extras/military.json
@@ -5,7 +5,7 @@
     "nested_mapgen_id": "soldier_guns_3x3",
     "object": {
       "mapgensize": [ 3, 3 ],
-      "place_items": [ { "item": "military_squad_guns", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 100 } ],
+      "place_items": [ { "item": "military_squad_guns", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 30 } ],
       "place_fields": [ { "field": "fd_blood", "x": [ 0, 2 ], "y": [ 0, 2 ] }, { "field": "fd_gibs_flesh", "x": [ 0, 2 ], "y": [ 0, 2 ] } ],
       "place_monster": [ { "group": "GROUP_MIL_EXTRA", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
     }
@@ -15,19 +15,19 @@
     "id": "military_squad_guns",
     "subtype": "distribution",
     "groups": [
-      [ "military_standard_assault_rifles", 80 ],
-      [ "military_standard_lmgs", 10 ],
-      [ "military_standard_sniper_rifles", 5 ],
-      [ "military_standard_shotguns", 5 ]
+      { "group": "military_standard_assault_rifles", "prob": 80, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_lmgs", "prob": 80, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_sniper_rifles", "prob": 80, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] },
+      { "group": "military_standard_shotguns", "prob": 80, "damage": [ 0, 2 ], "dirt": [ 1500, 7050 ] }
     ]
   },
   {
     "name": "GROUP_MIL_EXTRA",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_soldier", "weight": 76 },
+      { "monster": "mon_zombie_soldier", "weight": 72 },
       { "monster": "mon_feral_soldier", "weight": 20 },
-      { "monster": "mon_zombie_bio_op", "weight": 4 }
+      { "monster": "mon_zombie_bio_op", "weight": 8 }
     ]
   },
   {

--- a/data/json/mapgen/mine/mine_generic.json
+++ b/data/json/mapgen/mine/mine_generic.json
@@ -417,7 +417,7 @@
       "furniture": { " ": [ [ "f_null", 5 ], "f_rubble_rock" ] },
       "items": { " ": { "item": "mine_equipment", "chance": 3 } },
       "monster": { " ": { "monster": "mon_zombie_miner", "chance": 5 } },
-      "vehicles": { "o": { "vehicle": "trencher", "chance": 100, "fuel": 100, "status": 0 } },
+      "vehicles": { "o": { "vehicle": "trencher", "chance": 100, "fuel": 70, "status": 0 } },
       "nested": { " ": { "chunks": [ [ "mine_minerals_equipment", 10 ], [ "null", 100 ] ] } }
     }
   },

--- a/data/json/mapgen/movie_theater.json
+++ b/data/json/mapgen/movie_theater.json
@@ -89,10 +89,10 @@
       "toilets": { "&": {  } },
       "vendingmachines": { "v": { "item_group": "vending_drink", "lootable": true }, "F": { "item_group": "vending_food", "lootable": true } },
       "items": {
-        "&": { "item": "alcohol", "chance": 10 },
+        "&": { "item": "alcohol", "chance": 8 },
         "T": { "item": "snacks", "chance": 5 },
-        "X": { "item": "snacks", "chance": 30, "repeat": [ 6, 12 ] },
-        "g": { "item": "fridgesnacks", "chance": 70, "repeat": [ 6, 12 ] },
+        "X": { "item": "snacks", "chance": 30, "repeat": [ 1, 6 ] },
+        "g": { "item": "fridgesnacks", "chance": 70, "repeat": [ 1, 6 ] },
         "G": { "item": "trash", "chance": 20, "repeat": [ 2, 4 ] },
         "t": [
           { "item": "snacks", "chance": 3 },
@@ -122,11 +122,11 @@
         ],
         "l": [
           { "item": "softdrugs", "chance": 10 },
-          { "item": "bags", "chance": 20 },
-          { "item": "consumer_electronics", "chance": 5 },
-          { "item": "alcohol", "chance": 5 },
-          { "item": "manuals", "chance": 5 },
-          { "item": "textbooks", "chance": 5 }
+          { "item": "bags", "chance": 5 },
+          { "item": "consumer_electronics", "chance": 3 },
+          { "item": "alcohol", "chance": 3 },
+          { "item": "manuals", "chance": 1 },
+          { "item": "textbooks", "chance": 1 }
         ]
       },
       "item": { "N": { "item": "movie_poster", "chance": 100 } },
@@ -134,9 +134,9 @@
         { "chance": 35, "item": "misc_smoking", "x": 5, "y": 7 },
         { "chance": 45, "item": "toy_store", "x": 21, "y": 22 },
         { "chance": 45, "item": "toy_store", "x": 8, "y": 14 },
-        { "item": "cash_register_random", "x": 34, "y": 9, "chance": 100 },
-        { "item": "cash_register_random", "x": 36, "y": 9, "chance": 100 },
-        { "item": "cash_register_random", "x": 61, "y": [ 4, 9 ], "chance": 100 }
+        { "item": "cash_register_random", "x": 34, "y": 9, "chance": 80 },
+        { "item": "cash_register_random", "x": 36, "y": 9, "chance": 80 },
+        { "item": "cash_register_random", "x": 61, "y": [ 4, 9 ], "chance": 80 }
       ],
       "place_monsters": [
         { "density": 0.25, "monster": "GROUP_ZOMBIE", "x": 12, "y": 15 },

--- a/data/json/mapgen/radio_tower.json
+++ b/data/json/mapgen/radio_tower.json
@@ -251,8 +251,8 @@
           "chunks": [
             [ "null", 40 ],
             [ "radio_tower_2x2_map", 40 ],
-            [ "radio_tower_2x2_holdout", 10 ],
-            [ "radio_tower_2x2_sniper", 10 ],
+            [ "radio_tower_2x2_holdout", 12 ],
+            [ "radio_tower_2x2_sniper", 3 ],
             [ "radio_tower_wasp", 5 ]
           ],
           "x": 10,
@@ -285,13 +285,12 @@
     "object": {
       "mapgensize": [ 2, 2 ],
       "place_furniture": [ { "furn": "f_camp_chair", "x": 1, "y": 0 } ],
+      "place_monster": [ { "monster": "mon_zombie_soldier", "x": 1, "y": 0 } ],
       "place_loot": [
-        { "item": "corpse", "x": 1, "y": 0 },
-        { "group": "mon_zombie_soldier_death_drops", "x": 1, "y": 0 },
-        { "item": "survivor_scope", "x": 1, "y": 0, "chance": 70 },
+        { "item": "survivor_scope", "x": 1, "y": 0, "chance": 10 },
         { "item": "can_drink", "x": 1, "y": [ 0, 1 ], "chance": 70, "repeat": [ 2, 3 ] },
         { "item": "3006", "x": 1, "y": 0, "chance": 40 },
-        { "item": "remington_700", "x": 1, "y": 0, "chance": 80, "ammo": 100 }
+        { "item": "remington_700", "x": 1, "y": 0, "chance": 60, "ammo": 100 }
       ]
     }
   },

--- a/data/json/monstergroups/fungi.json
+++ b/data/json/monstergroups/fungi.json
@@ -26,13 +26,23 @@
   },
   {
     "type": "monstergroup",
-    "name": "GROUP_FUNGI_FLOWERS",
+    "name": "GROUP_FUNGI_BLOSSOM",
     "monsters": [
       { "monster": "mon_fungal_blossom", "weight": 680, "cost_multiplier": 0 },
       { "monster": "mon_zombie_fungus", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_boomer_fungus", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_zombie_child_fungus", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid_seeder", "weight": 0, "cost_multiplier": 0 }
+    ]
+  },
+    {
+    "type": "monstergroup",
+    "name": "GROUP_FUNGI_FLOWER",
+    "monsters": [
+      { "monster": "mon_fungal_blossom", "weight": 680, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_fungus", "weight": 100, "cost_multiplier": 0 },
+      { "monster": "mon_boomer_fungus", "weight": 50, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_child_fungus", "weight": 50, "cost_multiplier": 0 }
     ]
   },
   {

--- a/data/json/overmap/overmap_mutable/farm_horse_mutable.json
+++ b/data/json/overmap/overmap_mutable/farm_horse_mutable.json
@@ -4,9 +4,9 @@
     "id": "Horse Farm Mutable",
     "subtype": "mutable",
     "locations": [ "forest_without_trail", "field", "open_air" ],
-    "city_distance": [ 5, -1 ],
+    "city_distance": [ 14, -1 ],
     "city_sizes": [ 1, -1 ],
-    "occurrences": [ 80, 100 ],
+    "occurrences": [ 40, 100 ],
     "flags": [ "CLASSIC", "MAN_MADE", "FARM", "OVERMAP_UNIQUE" ],
     "check_for_locations_area": [ { "type": [ "forest_without_trail", "field" ], "from": [ -6, -2, 0 ], "to": [ 7, 9, 0 ] } ],
     "joins": [

--- a/data/json/overmap/overmap_mutable/farm_mutable.json
+++ b/data/json/overmap/overmap_mutable/farm_mutable.json
@@ -4,7 +4,7 @@
     "id": "Farm Mutable",
     "subtype": "mutable",
     "locations": [ "subterranean_empty", "land", "open_air" ],
-    "city_distance": [ 8, -1 ],
+    "city_distance": [ 18, -1 ],
     "city_sizes": [ 1, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MAN_MADE", "FARM" ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2967,7 +2967,7 @@
     ],
     "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field" ],
-    "city_distance": [ 6, -1 ],
+    "city_distance": [ 10, -1 ],
     "occurrences": [ 1, 5 ],
     "flags": [ "CLASSIC", "FARM", "MAN_MADE", "OVERMAP_UNIQUE" ]
   },


### PR DESCRIPTION
#### Summary
Further map adjustments

#### Purpose of change
Fix stuff that's always bugged me.

#### Describe the solution
- Space dairy farms and other locations out a bit more.
- Reduce food in movie theaters.
- Improve the military corpses map extra. The corpses are dirty and potentially damaged as you'd expect from guns left in the mud.
- Make the radio tower sniper nest much rarer, change it to be a zombie soldier instead of a pile of clothes.
- Reduce some various other freebies.
- Increase the fodder in farms a bit.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
