### PR TITLE
Nerf garage loot, add monsters

### DIFF
--- a/data/json/mapgen/garage.json
+++ b/data/json/mapgen/garage.json
@@ -72,15 +72,15 @@
       },
       "items": {
         "L": { "item": "clothing_work_set", "chance": 55 },
-        "c": { "item": "mechanics", "chance": 60 },
-        "S": { "item": "mechanics", "chance": 80, "repeat": [ 1, 6 ] },
-        "x": { "item": "SUS_welding_gear", "chance": 80, "repeat": [ 1, 2 ] }
+        "c": { "item": "mechanics", "chance": 30 },
+        "S": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] },
+        "x": { "item": "SUS_welding_gear", "chance": 60, "repeat": [ 1, 2 ] }
       },
       "place_vehicles": [
         { "vehicle": "garage", "x": [ 8, 8 ], "y": [ 9, 10 ], "chance": 25, "rotation": 90 },
         { "vehicle": "garage", "x": [ 18, 18 ], "y": [ 9, 10 ], "chance": 25, "rotation": 90 }
       ],
-      "place_monsters": [ { "monster": "GROUP_FERROUS", "x": [ 5, 20 ], "y": [ 7, 15 ], "chance": 10 } ]
+      "place_monsters": [ { "monster": "GROUP_FERROUS", "x": [ 5, 20 ], "y": [ 7, 15 ], "chance": 15 } ]
     }
   },
   {
@@ -191,15 +191,16 @@
       },
       "items": {
         "L": { "item": "clothing_work_set", "chance": 55 },
-        "c": { "item": "mechanics", "chance": 60 },
-        "S": { "item": "mechanics", "chance": 80, "repeat": [ 1, 6 ] },
-        "x": { "item": "mechanics", "chance": 80, "repeat": [ 1, 3 ] }
+        "c": { "item": "mechanics", "chance": 50 },
+        "S": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] },
+        "x": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] }
       },
       "place_vehicles": [
         { "vehicle": "garage", "x": [ 8, 8 ], "y": [ 9, 10 ], "chance": 25, "rotation": 90 },
         { "vehicle": "garage", "x": [ 18, 18 ], "y": [ 9, 10 ], "chance": 25, "rotation": 90 }
       ],
-      "place_loot": [ { "group": "cash_register_random", "x": [ 19, 20 ], "y": 14 } ]
+      "place_loot": [ { "group": "cash_register_random", "x": [ 19, 20 ], "y": 14 } ],
+      "place_monsters": [ { "monster": "GROUP_FERROUS", "x": [ 5, 20 ], "y": [ 7, 15 ], "chance": 15 } ]
     }
   },
   {
@@ -318,14 +319,15 @@
       "items": {
         "L": { "item": "clothing_work_set", "chance": 55 },
         "c": { "item": "mechanics", "chance": 60 },
-        "S": { "item": "mechanics", "chance": 80, "repeat": [ 1, 6 ] },
-        "x": { "item": "mechanics", "chance": 80, "repeat": [ 1, 6 ] },
-        "w": { "item": "SUS_welding_gear", "chance": 80, "repeat": [ 1, 2 ] },
-        "f": { "item": "office", "chance": 70, "repeat": [ 1, 6 ] },
-        "d": { "item": "office", "chance": 70, "repeat": [ 1, 6 ] },
-        "T": { "item": "cleaning", "chance": 70, "repeat": [ 1, 6 ] }
+        "S": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] },
+        "x": { "item": "mechanics", "chance": 60, "repeat": [ 1, 2 ] },
+        "w": { "item": "SUS_welding_gear", "chance": 60, "repeat": [ 1, 2 ] },
+        "f": { "item": "office", "chance": 60, "repeat": [ 1, 4 ] },
+        "d": { "item": "office", "chance": 60, "repeat": [ 1, 4 ] },
+        "T": { "item": "cleaning", "chance": 70, "repeat": [ 1, 4 ] }
       },
-      "place_vehicles": [ { "vehicle": "garage", "x": [ 8, 8 ], "y": [ 9, 10 ], "chance": 95, "rotation": 90 } ]
+      "place_vehicles": [ { "vehicle": "garage", "x": [ 8, 8 ], "y": [ 9, 10 ], "chance": 95, "rotation": 90 } ],
+      "place_monsters": [ { "monster": "GROUP_FERROUS", "x": [ 5, 20 ], "y": [ 7, 15 ], "chance": 15 } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Nerf garage loot, add monsters

#### Purpose of change
Garages were like always empty and at least one of them had gobs of loot.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
