### PR TITLE
Delete hardcoded leg tentacle bracing effect

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10802,21 +10802,6 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
             }
         }
     }
-    if( !u.is_mounted() && u.has_trait( trait_LEG_TENT_BRACE ) &&
-        u.is_barefoot() ) {
-        // DX and IN are long suits for Cephalopods,
-        // so this shouldn't cause too much hardship
-        // Presumed that if it's swimmable, they're
-        // swimming and won't stick
-        ///\EFFECT_DEX decreases chance of tentacles getting stuck to the ground
-
-        ///\EFFECT_INT decreases chance of tentacles getting stuck to the ground
-        if( !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest_loc ) &&
-            one_in( 80 + u.dex_cur + u.int_cur ) ) {
-            add_msg( _( "Your tentacles stick to the ground, but you pull them free." ) );
-            u.mod_fatigue( 1 );
-        }
-    }
 
     u.make_footstep_noise();
 


### PR DESCRIPTION
#### Summary
Delete hardcoded leg tentacle bracing effect

#### Purpose of change
There's a stupid hardcoded effect that checks dex and int and can make you randomly stick to the ground when walking around as a cephalopod, with an accompanying spammy message. Cephalopods are already slow as hell, if they need to be slower (and they don't) that could be managed without this bespoke hardcoded thing.

#### Describe the solution
Sinmply,,delet it;

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
