### PR TITLE
Backport 78332 - Fix ethereal item spells

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1518,7 +1518,6 @@ bool _stacks_weapon_mods( item const &lhs, item const &rhs )
 
 bool _stacks_location_hint( item const &lhs, item const &rhs )
 {
-    const tripoint_abs_omt tripoint_abs_omt::max( tripoint::max );
     static const std::string omt_loc_var = "spawn_location_omt";
     const tripoint_abs_omt this_loc( lhs.get_var( omt_loc_var, tripoint_abs_omt::max ) );
     const tripoint_abs_omt that_loc( rhs.get_var( omt_loc_var, tripoint_abs_omt::max ) );

--- a/src/magic.h
+++ b/src/magic.h
@@ -840,7 +840,7 @@ std::set<tripoint_bub_ms> spell_effect_cone( const override_parameters &params,
 std::set<tripoint_bub_ms> spell_effect_line( const override_parameters &params,
         const tripoint_bub_ms &source, const tripoint_bub_ms &target );
 
-void spawn_ethereal_item( const spell &sp, Creature &, const tripoint_bub_ms & );
+void spawn_ethereal_item( const spell &sp, Creature &, const tripoint_bub_ms &center );
 void recover_energy( const spell &sp, Creature &, const tripoint_bub_ms &target );
 void spawn_summoned_monster( const spell &sp, Creature &caster, const tripoint_bub_ms &target );
 void spawn_summoned_vehicle( const spell &sp, Creature &caster, const tripoint_bub_ms &target );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1269,13 +1269,9 @@ void spell_effect::directed_push( const spell &sp, Creature &caster, const tripo
     }
 }
 
-void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const tripoint_bub_ms & )
+void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const tripoint_bub_ms &center )
 {
-    if( !caster.is_avatar() ) {
-        debugmsg( "Spells that spawn items are only supported for the avatar, not for %s.",
-                  caster.disp_name() );
-        return;
-    }
+    Character *character_at_target = get_creature_tracker().creature_at<Character>( center );
 
     std::vector<item> granted;
 
@@ -1290,28 +1286,39 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const
         }
     }
 
-    avatar &player_character = get_avatar();
-    for( item &it : granted ) {
-        // Spawned items are ethereal unless permanent and max level. Comestibles are never ethereal.
-        if( !it.is_comestible() && !sp.has_flag( spell_flag::PERMANENT_ALL_LEVELS ) &&
-            !( sp.has_flag( spell_flag::PERMANENT ) && sp.is_max_level( caster ) ) ) {
-            it.set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
-            it.ethereal = true;
-        }
+    if( character_at_target != nullptr ) {
+        for( item &it : granted ) {
+            // Spawned items are ethereal unless permanent and max level. Comestibles are never ethereal.
+            if( !it.is_comestible() && !sp.has_flag( spell_flag::PERMANENT_ALL_LEVELS ) &&
+                !( sp.has_flag( spell_flag::PERMANENT ) && sp.is_max_level( caster ) ) ) {
+                it.set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
+                it.ethereal = true;
+            }
 
-        if( it.ethereal && player_character.is_wearing( it.typeId() ) ) {
-            // Ethereal equipment already exists so just update its duration
-            item *existing_item = player_character.item_worn_with_id( it.typeId() );
-            existing_item->set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
-        } else if( player_character.can_wear( it ).success() ) {
-            it.set_flag( json_flag_FIT );
-            player_character.wear_item( it, false );
-        } else if( !player_character.has_wield_conflicts( it ) &&
-                   !player_character.martial_arts_data->keep_hands_free && //No wield if hands free
-                   player_character.wield( it, 0 ) ) {
-            // nothing to do
-        } else {
-            player_character.i_add( it );
+            if( it.ethereal && character_at_target->is_wearing( it.typeId() ) ) {
+                // Ethereal equipment already exists so just update its duration
+                item *existing_item = character_at_target->item_worn_with_id( it.typeId() );
+                existing_item->set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
+            } else if( character_at_target->can_wear( it ).success() ) {
+                it.set_flag( json_flag_FIT );
+                character_at_target->wear_item( it, false );
+            } else if( !character_at_target->has_wield_conflicts( it ) &&
+                       !character_at_target->martial_arts_data->keep_hands_free && //No wield if hands free
+                       character_at_target->wield( it ) ) {
+                // nothing to do
+            } else {
+                character_at_target->i_add( it );
+            }
+        }
+    } else {
+        for( item &it : granted ) {
+            // Spawned items are ethereal unless permanent and max level. Comestibles are never ethereal.
+            if( !it.is_comestible() && !sp.has_flag( spell_flag::PERMANENT_ALL_LEVELS ) &&
+                !( sp.has_flag( spell_flag::PERMANENT ) && sp.is_max_level( caster ) ) ) {
+                it.set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
+                it.ethereal = true;
+            }
+            get_map().add_item_or_charges( center, it );
         }
     }
     sp.make_sound( caster.pos_bub(), caster );


### PR DESCRIPTION
#### Summary
Backport 78332 - Fix ethereal item spells


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
