### PR TITLE
Stop fog from flickering (again)

### DIFF
--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -179,7 +179,20 @@
     "burn_into": "mon_zombie_scorched",
     "fungalize_into": "mon_zombie_crawler_fungal",
     "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_CRAWLER_UPGRADE" },
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GRABS", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "ATTACK_LOWER", "GEN_DORMANT" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "STUMBLES",
+      "WARM",
+      "BASHES",
+      "GRABS",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "ATTACK_LOWER",
+      "GEN_DORMANT"
+    ],
     "armor": { "electric": 1 }
   },
   {
@@ -366,7 +379,20 @@
     "burn_into": "mon_zombie_scorched",
     "fungalize_into": "mon_zombie_rot_fungal",
     "upgrades": { "half_life": 43, "into": "mon_devourer" },
-    "flags": [ "SEES", "HEARS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "REVIVES", "PUSH_MON", "FILTHY", "GEN_DORMANT" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "STUMBLES",
+      "WARM",
+      "BASHES",
+      "GROUP_BASH",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "PUSH_MON",
+      "FILTHY",
+      "GEN_DORMANT"
+    ],
     "armor": { "electric": 1 }
   },
   {

--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -75,7 +75,20 @@
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_zombie_child_fungus",
     "upgrades": { "half_life": 30, "into_group": "GROUP_CHILD_ZOMBIE_UPGRADE" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "GUILT_CHILD", "GEN_DORMANT" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "STUMBLES",
+      "WARM",
+      "BASHES",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "GUILT_CHILD",
+      "GEN_DORMANT"
+    ],
     "armor": { "electric": 1 }
   },
   {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4102,7 +4102,7 @@ void game::draw( ui_adaptor &ui )
     ter_view_p.z() = ( u.pos_bub() + u.view_offset ).z();
     m.build_map_cache( ter_view_p.z() );
     m.update_visibility_cache( ter_view_p.z() );
-
+    g->run_weather_animation();
     werase( w_terrain );
     void_blink_curses();
     draw_ter();

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1269,7 +1269,8 @@ void spell_effect::directed_push( const spell &sp, Creature &caster, const tripo
     }
 }
 
-void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster, const tripoint_bub_ms &center )
+void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster,
+                                        const tripoint_bub_ms &center )
 {
     Character *character_at_target = get_creature_tracker().creature_at<Character>( center );
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -806,7 +806,8 @@ void suffer::in_sunlight( Character &you, outfit &worn )
         }
         const float weather_factor = std::min( incident_sun_irradiance( get_weather().weather_id,
                                                calendar::turn ) / irradiance::moderate, 1.f );
-        const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature( position.raw() ) );
+        const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature(
+                                          position.raw() ) );
         int flux = ( player_local_temp - 32 ) / 5;
         // Efficiency rapidly falls off when it's too hot due to photosynthesis being an enzymatic process.
         // Some tropical plants can overcome this with specific adaptations, but that would probably be its own mutation.


### PR DESCRIPTION
#### Summary
Stop fog from flickering (again)

#### Purpose of change
A backport caused a regression by deleting a single line, resulting in fog not being drawn between turns.

#### Describe the solution
Put the line back.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
