### PR TITLE
December Backports

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -54,6 +54,7 @@ jobs:
       id: get-vars
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$(echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
 
     - name: ccache cache files
@@ -78,7 +79,7 @@ jobs:
         export EM_CONFIG=$EMSDK/.emscripten
         export CCACHE_COMPILERCHECK=string:3.1.51
         ccache --zero-stats
-        ccache -M 5G
+        ccache -M 20G
         ccache --show-stats
 
         ./build-scripts/build-emscripten.sh
@@ -88,7 +89,11 @@ jobs:
         emsdk activate ccache-git-emscripten-64bit
         export PATH="${PATH%%:*}/../../ccache/git-emscripten_64bit/bin":$PATH
         ccache --show-stats
-        ccache -M 5G
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        ccache --evict-older-than ${DELTA}s
+        ccache --show-stats
+        ccache -M 1G
         ccache -c
         ccache --show-stats
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -110,8 +110,7 @@ jobs:
             sound: 1
             localize: 1
             title: Clang 14, macOS 12, Tiles, Sound, x64 and arm64 Universal Binary
-            # cache size ??? to be observed
-            ccache_limit: 4G
+            ccache_limit: 10G
             ccache_key: macos-llvm-14-universal-break1
 
           - compiler: g++-9
@@ -127,10 +126,7 @@ jobs:
             native: linux64
             pch: 1
             title: GCC 9, Curses, LTO
-            # ~850MB in a clean build
-            # ~370MB compressed
-            # observed usage: 4.0GB -> 1.5GB
-            ccache_limit: 3G
+            ccache_limit: 7.5G
             ccache_key: linux-gcc-9-lto
 
           - compiler: clang++-12
@@ -147,10 +143,7 @@ jobs:
             mods: --mods=magiclysm
             dont_skip_data_only_changes: 1
             title: Clang 12, Ubuntu, Tiles, ASan
-            # ~390MB in a clean build
-            # ~50MB compressed
-            # observed usage: 4.0GB -> 400MB
-            ccache_limit: 3G
+            ccache_limit: 6G
             ccache_key: linux-llvm-12-asan
 
           - compiler: g++-11
@@ -164,10 +157,7 @@ jobs:
             pch: 1
             sanitize: address
             title: GCC 11, Ubuntu, Curses, ASan
-            # ~480MB in a clean build
-            # ~50MB compressed
-            # observed usage: 4.4GB -> 400MB
-            ccache_limit: 4G
+            ccache_limit: 6.5G
             ccache_key: linux-gcc-11-asan
 
           - compiler: g++
@@ -200,10 +190,7 @@ jobs:
             native: linux64
             pch: 1
             title: GCC 9, Ubuntu, Tiles, Sound, CMake
-            # ~180MB in a clean build
-            # ~25MB compressed
-            # observed usage: 3.0GB -> 300MB
-            ccache_limit: 2G
+            ccache_limit: 1G
             ccache_key: linux-gcc-9-cmake
 
           # Reserving space for msvc ccache & vcpkg cache
@@ -267,11 +254,12 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 }}
       run: |
           sudo apt-get install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev
-    - name: install recent ccache on ubuntu 20.04
-      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.os == 'ubuntu-22.04' }}
+    - name: install recent ccache on ubuntu
+      if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}
       run: |
+          ccache --version
           sudo apt-get remove --purge -y ccache
-          curl -sL https://github.com/ccache/ccache/releases/download/v4.8.3/ccache-4.8.3-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.8.3-linux-x86_64/ccache
+          curl -sL https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.10.2-linux-x86_64/ccache
           ccache --version
     - name: install Clang 12 (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-12') }}
@@ -310,6 +298,7 @@ jobs:
       if: ${{ env.SKIP == 'false' }}
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$([ "$RUNNER_OS" = "macOS" ] && echo '/Users/runner/Library/Caches/ccache' || echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
       shell: bash
     - name: ccache cache files
@@ -328,6 +317,10 @@ jobs:
     - name: post-build ccache manipulation
       if: ${{ env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
       run: |
+        ccache --show-stats --verbose
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        ccache --evict-older-than ${DELTA}s
         ccache --show-stats --verbose
         ccache -M ${{ env.CCACHE_LIMIT }}
         ccache -c

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -111,6 +111,7 @@ jobs:
       id: get-vars
       run: |
         echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
         echo "ccache-path=$(echo "$APPDATA\\ccache")" >> $GITHUB_OUTPUT
       shell: bash
 
@@ -139,13 +140,23 @@ jobs:
           msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static" msvc-full-features/Cataclysm-vcpkg-static.sln
      #     msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-stati;JsonFormatter-vcpkg-static" msvc-full-features/Cataclysm-vcpkg-static.sln
 
+    - name: Get ccache cache age cutoff
+      id: get-cache-age
+      run: |
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        echo "ccache-age=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
-        ${{ env.CTLG_CCACHE_PATH }}\ccache.exe -s -v
-        ${{ env.CTLG_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
-        ${{ env.CTLG_CCACHE_PATH }}\ccache.exe -c
-        ${{ env.CTLG_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-ccache-age.outputs.ccache-age }}
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -c
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
 
     - name: clear ccache on PRs
       if: ${{ github.ref_name != 'master' }}

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -40,7 +40,7 @@ fi
 
 ccache --zero-stats
 # Increase cache size because debug builds generate large object files
-ccache -M 10G
+ccache -M 20G
 ccache --show-stats --verbose
 
 function run_test

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -40,7 +40,7 @@ fi
 
 ccache --zero-stats
 # Increase cache size because debug builds generate large object files
-ccache -M 10G
+ccache -M 20G
 ccache --show-stats --verbose
 
 if [ "$CMAKE" = "1" ]

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -1224,7 +1224,8 @@
     "description": "A normal and healthy purple eggplant.  Needs to be disassembled before being useful for cooking.",
     "healthy": -1,
     "symbol": "e",
-    "flags": [ "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
+    "flags": [ "RAW", "SMOKABLE", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
+    "smoking_result": "dry_vegetable",
     "vitamins": [ [ "vitC", "12100 μg" ], [ "iron", "1300 μg" ], [ "calcium", "49300 μg" ], [ "vegetable_allergen", 1 ] ],
     "fun": -8
   },
@@ -1245,7 +1246,8 @@
     "healthy": -1,
     "symbol": "e",
     "looks_like": "eggplant",
-    "flags": [ "RAW" ],
+    "flags": [ "RAW", "SMOKABLE", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
+    "smoking_result": "dry_vegetable",
     "vitamins": [ [ "vitC", "60500 μg" ], [ "iron", "650 μg" ], [ "calcium", "24650 μg" ], [ "vegetable_allergen", 1 ] ],
     "fun": -5
   },

--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1121,6 +1121,8 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "corn_kernels", "name": { "str_sp": "%s, corn kernels" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "cucumber", "name": { "str_sp": "%s, cucumber" } },
       { "type": "COMPONENT_ID", "condition": "dandelion_cooked", "name": { "str_sp": "%s, cooked dandelion greens" } },
+      { "type": "COMPONENT_ID", "condition": "eggplant", "name": { "str_sp": "%s, eggplant" } },
+      { "type": "COMPONENT_ID", "condition": "eggplant_cut", "name": { "str_sp": "%s, cut eggplant" } },
       { "type": "COMPONENT_ID", "condition": "grape_leaves", "name": { "str_sp": "%s, grape leaves" } },
       { "type": "COMPONENT_ID", "condition": "groundnut_prepared", "name": { "str_sp": "%s, ground nuts" } },
       { "type": "COMPONENT_ID", "condition": "horseradish_greens", "name": { "str_sp": "%s, horseradish greens" } },

--- a/data/json/mapgen/map_extras/jabberwock.json
+++ b/data/json/mapgen/map_extras/jabberwock.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_jabberwock",
+    "object": { "place_monster": [ { "monster": "mon_jabberwock", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100 } ] }
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -249,7 +249,7 @@
     "type": "map_extra",
     "name": { "str": "Jabberwock" },
     "description": "Jabberwock is nearby.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_jabberwock" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_jabberwock" },
     "min_max_zlevel": [ -2, 5 ],
     "sym": "J",
     "autonote": false,

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -101,7 +101,21 @@
     "flags": [ "NO_MORALE_OK" ],
     "//": "See pur_tablets item definition for documentation and discussion",
     "autolearn": true,
-    "components": [ [ [ "water", 4 ] ], [ [ "pur_tablets", 1 ] ] ]
+    "components": [ [ [ "water_murky", 4 ] ], [ [ "pur_tablets", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "water",
+    "charges": 10,
+    "category": "CC_FOOD",
+    "id_suffix": "using_water_filter_sand",
+    "subcategory": "CSC_FOOD_DRINKS",
+    "skill_used": "survival",
+    "time": "15 m",
+    "autolearn": true,
+    "tools": [ [ "water_filter_sand" ] ],
+    "components": [ [ [ "water_murky", 10 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -8752,6 +8752,7 @@
         [ "seed_rose", 3 ],
         [ "seed_cattail", 3 ],
         [ "seed_dahlia", 3 ],
+        [ "seed_eggplant", 3 ],
         [ "seed_flower", 3 ],
         [ "seed_cactus", 3 ],
         [ "seed_hops", 3 ],

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -605,6 +605,7 @@
           "mx_portal": 3,
           "mx_portal_in": 3,
           "mx_helicopter": 1,
+          "mx_jabberwock": 2,
           "mx_beehive_natural": 20
         }
       },
@@ -770,13 +771,13 @@
       "research_facility_interior": {
         "chance": 2,
         "extras": {
-          "mx_jabberwock": 1,
-          "mx_military": 5,
-          "mx_portal": 100,
-          "mx_crater": 300,
-          "mx_portal_in": 40,
-          "mx_point_burned_ground": 125,
-          "mx_casings": 30
+          "mx_crater": 15000,
+          "mx_portal": 5000,
+          "mx_point_burned_ground": 6250,
+          "mx_portal_in": 2000,
+          "mx_casings": 1500,
+          "mx_military": 250,
+          "mx_jabberwock": 1
         }
       },
       "river": { "chance": 1, "extras": { "mx_null": 66, "mx_riverside_boat": 1, "mx_reed": 33 } },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3120,6 +3120,7 @@ See [MUTATIONS.md](MUTATIONS.md)
     "funnel_radius": 200, // millimeters. The higher the more rain it will capture.
     "comfort": 0, // Same property affecting furniture and terrain
     "floor_bedding_warmth": -500, // Same property affecting furniture and terrain. Also affects how comfortable a resting place this is(affects healing). Vanilla values should not exceed 1000.
+    "eocs": [ "EOC_COOL_EOC_TRAP" ], // array of eocs to trigger, only usable with "action": "eocs". The alpha talker is the creature that triggered the trap and the trap's location is passed as a context variable trap_location for use with ranged traps. Items can't currently trigger eoc traps.
     "spell_data": { "id": "bear_trap" }, // data required for trapfunc::spell()
     "trigger_weight": "200 g", // If an item with this weight or more is thrown onto the trap, it triggers. Defaults to 500 grams.
     "drops": [ "beartrap" ], // ID of item spawned when disassembled

--- a/doc/MONSTERS.md
+++ b/doc/MONSTERS.md
@@ -348,7 +348,7 @@ Field              | Description
 `coverage`         | base percentage chance of hitting the weakpoint. (e.g. A coverage of 5 means a 5% base chance of hitting the weakpoint)
 `is_good`          | marks mutation, that is beneficial for you to hit (like headshot); false means it is a bad weakpoint for you to hit (like thick piece of armor); default true; 
 `coverage_mult`    | object mapping weapon types to constant coverage multipliers.
-`difficulty`       | object mapping weapon types to difficulty values. Difficulty acts as soft "gate" on the attacker's skill. If the the attacker has skill equal to the difficulty, coverage is reduced to 50%.
+`difficulty`       | object mapping weapon types to difficulty values. Difficulty acts as soft "gate" on the attacker's skill. If the the attacker has skill equal to the difficulty, coverage is reduced to 50%. For bad weakpoint, attacker's skill will reduce the chance of hitting it.
 `armor_mult`       | object mapping damage types to multipliers on the monster's base protection, when hitting the weakpoint.
 `armor_penalty`    | object mapping damage types to flat penalties on the monster's protection, applied after the multiplier.
 `damage_mult`      | object mapping damage types to multipliers on the post-armor damage, when hitting the weakpoint.

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1189,7 +1189,13 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
 
 std::optional<tripoint> choose_adjacent( const std::string &message, const bool allow_vertical )
 {
-    return choose_adjacent( get_player_character().pos(), message, allow_vertical );
+    const std::optional<tripoint_bub_ms> temp = choose_adjacent( get_player_character().pos_bub(),
+            message, allow_vertical );
+    std::optional<tripoint> result;
+    if( temp.has_value() ) {
+        result = temp.value().raw();
+    }
+    return result;
 }
 
 std::optional<tripoint_bub_ms> choose_adjacent_bub( const std::string &message,
@@ -1247,17 +1253,7 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
     }
 }
 
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, const action_id action,
-        const bool allow_vertical, const bool allow_autoselect )
-{
-    const std::function<bool( const tripoint & )> f = [&action]( const tripoint & p ) {
-        return can_interact_at( action, tripoint_bub_ms( p ) );
-    };
-    return choose_adjacent_highlight( message, failure_message, f, allow_vertical, allow_autoselect );
-}
-
-std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const action_id action,
         const bool allow_vertical, const bool allow_autoselect )
 {
@@ -1267,61 +1263,12 @@ std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::stri
     return choose_adjacent_highlight( message, failure_message, f, allow_vertical, allow_autoselect );
 }
 
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, const std::function<bool ( const tripoint & )> &allowed,
-        const bool allow_vertical, const bool allow_autoselect )
-{
-    return choose_adjacent_highlight( get_avatar().pos(), message, failure_message, allowed,
-                                      allow_vertical, allow_autoselect );
-}
-
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         const bool allow_vertical, const bool allow_autoselect )
 {
     return choose_adjacent_highlight( get_avatar().pos_bub(), message, failure_message, allowed,
                                       allow_vertical, allow_autoselect );
-}
-
-std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
-        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
-        bool allow_vertical, bool allow_autoselect )
-{
-    std::vector<tripoint_bub_ms> valid;
-    map &here = get_map();
-    if( allowed ) {
-        for( const tripoint_bub_ms &pos : here.points_in_radius( tripoint_bub_ms( pos ), 1 ) ) {
-            if( allowed( pos.raw() ) ) {
-                valid.emplace_back( pos );
-            }
-        }
-    }
-
-    const bool auto_select = allow_autoselect && get_option<bool>( "AUTOSELECT_SINGLE_VALID_TARGET" );
-    if( valid.empty() && auto_select ) {
-        add_msg( failure_message );
-        return std::nullopt;
-    } else if( valid.size() == 1 && auto_select ) {
-        return valid.back().raw();
-    }
-
-    shared_ptr_fast<game::draw_callback_t> hilite_cb;
-    if( !valid.empty() ) {
-        hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
-            for( const tripoint_bub_ms &pos : valid ) {
-                here.drawsq( g->w_terrain, pos, drawsq_params().highlight( true ) );
-            }
-        } );
-        g->add_draw_callback( hilite_cb );
-    }
-
-    const std::optional<tripoint_bub_ms> chosen = choose_adjacent( tripoint_bub_ms( pos ), message,
-            allow_vertical );
-    if( std::find( valid.begin(), valid.end(), chosen ) != valid.end() ) {
-        return std::optional<tripoint>( chosen.value().raw() );
-    }
-
-    return std::nullopt;
 }
 
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,

--- a/src/action.h
+++ b/src/action.h
@@ -529,11 +529,7 @@ std::optional<tripoint_rel_ms> choose_direction_rel_ms( const std::string &messa
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-// TODO: Get rid of untyped version and change name of typed one.
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, action_id action,
-        bool allow_vertical = false, bool allow_autoselect = true );
-std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, action_id action,
         bool allow_vertical = false, bool allow_autoselect = true );
 
@@ -554,16 +550,8 @@ std::optional<tripoint_bub_ms> choose_adjacent_highlight_bub_ms( const std::stri
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-// TODO: Get rid of untyped overload.
-std::optional<tripoint> choose_adjacent_highlight( const std::string &message,
-        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
-        bool allow_vertical = false, bool allow_autoselect = true );
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
-        bool allow_vertical = false, bool allow_autoselect = true );
-// TODO: Get rid of untyped overload.
-std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const std::string &message,
-        const std::string &failure_message, const std::function<bool( const tripoint & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
 std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
         const std::string &message,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6558,7 +6558,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
         }
     }
 
-    here.cut_down_tree( pos, direction.xy().raw() );
+    here.cut_down_tree( pos, direction.xy() );
 
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
     // sound of falling tree

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3953,7 +3953,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
             }
 
             if( spell_being_cast.has_flag( spell_flag::VERBAL ) && !you->has_flag( json_flag_SILENT_SPELL ) ) {
-                sounds::sound( you->pos(), you->get_shout_volume() / 2, sounds::sound_t::speech,
+                sounds::sound( you->pos_bub(), you->get_shout_volume() / 2, sounds::sound_t::speech,
                                _( "cast a spell" ),
                                false );
             }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1600,7 +1600,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
         liquid.charges = std::min( charges_per_second, liquid.charges );
         const int original_charges = liquid.charges;
         if( liquid.has_temperature() && units::to_joule_per_gram( liquid.specific_energy ) < 0 ) {
-            liquid.set_item_temperature( std::max( get_weather().get_temperature( you->pos() ),
+            liquid.set_item_temperature( std::max( get_weather().get_temperature( you->pos_bub() ),
                                                    temperatures::cold ) );
         }
 

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -173,7 +173,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
 
         const trap &tr = here.tr_at( pt );
         if( tr.triggered_by_item( dropped_item ) ) {
-            tr.trigger( pt.raw(), dropped_item );
+            tr.trigger( pt, dropped_item );
         }
     }
 }
@@ -314,7 +314,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
 
         if( first ) {
             sfx::play_variant_sound( "bullet_hit", "hit_wall", sfx::get_heard_volume( target ),
-                                     sfx::get_heard_angle( target.raw() ) );
+                                     sfx::get_heard_angle( target ) );
         }
         // TODO: Z dispersion
     }
@@ -555,7 +555,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg,
             z.add_effect( effect_bounced, 1_turns );
             projectile_attack( proj, tp, z.pos_bub(), dispersion, origin, in_veh );
             sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
-                                     sfx::get_heard_volume( z.pos() ), sfx::get_heard_angle( z.pos() ) );
+                                     sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
         }
     }
 

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -46,20 +46,20 @@
 
 static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 
-const std::map<point, base_camps::direction_data> base_camps::all_directions = {
+const std::map<point_rel_omt, base_camps::direction_data> base_camps::all_directions = {
     // direction, direction id, tab order, direction abbreviation with bracket, direction tab title
     { base_camps::base_dir, { "[B]", base_camps::TAB_MAIN, to_translation( "base camp: base", "[B]" ), to_translation( "base camp: base", " MAIN " ) } },
-    { point::north, { "[N]", base_camps::TAB_N, to_translation( "base camp: north", "[N]" ), to_translation( "base camp: north", "  [N] " ) } },
-    { point::north_east, { "[NE]", base_camps::TAB_NE, to_translation( "base camp: northeast", "[NE]" ), to_translation( "base camp: northeast", " [NE] " ) } },
-    { point::east, { "[E]", base_camps::TAB_E, to_translation( "base camp: east", "[E]" ), to_translation( "base camp: east", "  [E] " ) } },
-    { point::south_east, { "[SE]", base_camps::TAB_SE, to_translation( "base camp: southeast", "[SE]" ), to_translation( "base camp: southeast", " [SE] " ) } },
-    { point::south, { "[S]", base_camps::TAB_S, to_translation( "base camp: south", "[S]" ), to_translation( "base camp: south", "  [S] " ) } },
-    { point::south_west, { "[SW]", base_camps::TAB_SW, to_translation( "base camp: southwest", "[SW]" ), to_translation( "base camp: southwest", " [SW] " ) } },
-    { point::west, { "[W]", base_camps::TAB_W, to_translation( "base camp: west", "[W]" ), to_translation( "base camp: west", "  [W] " ) } },
-    { point::north_west, { "[NW]", base_camps::TAB_NW, to_translation( "base camp: northwest", "[NW]" ), to_translation( "base camp: northwest", " [NW] " ) } },
+    { point_rel_omt::north, { "[N]", base_camps::TAB_N, to_translation( "base camp: north", "[N]" ), to_translation( "base camp: north", "  [N] " ) } },
+    { point_rel_omt::north_east, { "[NE]", base_camps::TAB_NE, to_translation( "base camp: northeast", "[NE]" ), to_translation( "base camp: northeast", " [NE] " ) } },
+    { point_rel_omt::east, { "[E]", base_camps::TAB_E, to_translation( "base camp: east", "[E]" ), to_translation( "base camp: east", "  [E] " ) } },
+    { point_rel_omt::south_east, { "[SE]", base_camps::TAB_SE, to_translation( "base camp: southeast", "[SE]" ), to_translation( "base camp: southeast", " [SE] " ) } },
+    { point_rel_omt::south, { "[S]", base_camps::TAB_S, to_translation( "base camp: south", "[S]" ), to_translation( "base camp: south", "  [S] " ) } },
+    { point_rel_omt::south_west, { "[SW]", base_camps::TAB_SW, to_translation( "base camp: southwest", "[SW]" ), to_translation( "base camp: southwest", " [SW] " ) } },
+    { point_rel_omt::west, { "[W]", base_camps::TAB_W, to_translation( "base camp: west", "[W]" ), to_translation( "base camp: west", "  [W] " ) } },
+    { point_rel_omt::north_west, { "[NW]", base_camps::TAB_NW, to_translation( "base camp: northwest", "[NW]" ), to_translation( "base camp: northwest", " [NW] " ) } },
 };
 
-point base_camps::direction_from_id( const std::string &id )
+point_rel_omt base_camps::direction_from_id( const std::string &id )
 {
     for( const auto &dir : all_directions ) {
         if( dir.second.id == id ) {
@@ -131,9 +131,9 @@ basecamp::basecamp( const std::string &name_, const tripoint_abs_omt &omt_pos_ )
 {
 }
 
-basecamp::basecamp( const std::string &name_, const tripoint &bb_pos_,
-                    const std::vector<point> &directions_,
-                    const std::map<point, expansion_data> &expansions_ )
+basecamp::basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
+                    const std::vector<point_rel_omt> &directions_,
+                    const std::map<point_rel_omt, expansion_data> &expansions_ )
     : directions( directions_ ), name( name_ ), bb_pos( bb_pos_ ), expansions( expansions_ )
 {
 }
@@ -170,14 +170,14 @@ void basecamp::add_expansion( const std::string &terrain, const tripoint_abs_omt
         return;
     }
 
-    const point dir = talk_function::om_simple_dir( omt_pos, new_pos );
+    const point_rel_omt dir = talk_function::om_simple_dir( omt_pos, new_pos );
     expansions[ dir ] = parse_expansion( terrain, new_pos );
     update_provides( terrain, expansions[ dir ] );
     directions.push_back( dir );
 }
 
 void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                              const point &dir )
+                              const point_rel_omt &dir )
 {
     expansion_data e;
     e.type = base_camps::faction_decode( bldg );
@@ -269,7 +269,7 @@ std::string basecamp::om_upgrade_description( const std::string &bldg, const map
 
 // upgrade levels
 // legacy next upgrade
-std::string basecamp::next_upgrade( const point &dir, const int offset ) const
+std::string basecamp::next_upgrade( const point_rel_omt &dir, const int offset ) const
 {
     const auto &e = expansions.find( dir );
     if( e == expansions.end() ) {
@@ -302,7 +302,7 @@ bool basecamp::has_provides( const std::string &req, const expansion_data &e_dat
     return false;
 }
 
-bool basecamp::has_provides( const std::string &req, const std::optional<point> &dir,
+bool basecamp::has_provides( const std::string &req, const std::optional<point_rel_omt> &dir,
                              int level ) const
 {
     if( !dir ) {
@@ -344,7 +344,7 @@ bool basecamp::allowed_access_by( Character &guy, bool water_request ) const
     return false;
 }
 
-std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
+std::vector<basecamp_upgrade> basecamp::available_upgrades( const point_rel_omt &dir )
 {
     std::vector<basecamp_upgrade> ret_data;
     auto e = expansions.find( dir );
@@ -410,7 +410,7 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( const point &dir )
 }
 
 // recipes and craft support functions
-std::map<recipe_id, translation> basecamp::recipe_deck( const point &dir ) const
+std::map<recipe_id, translation> basecamp::recipe_deck( const point_rel_omt &dir ) const
 {
     std::map<recipe_id, translation> recipes;
     const auto &e = expansions.find( dir );
@@ -467,7 +467,7 @@ void basecamp::update_provides( const std::string &bldg, expansion_data &e_data 
     }
 }
 
-void basecamp::update_in_progress( const std::string &bldg, const point &dir )
+void basecamp::update_in_progress( const std::string &bldg, const point_rel_omt &dir )
 {
     if( !recipe_id( bldg ).is_valid() ) {
         return;
@@ -920,7 +920,7 @@ void basecamp::form_crafting_inventory()
 }
 
 // display names
-std::string basecamp::expansion_tab( const point &dir ) const
+std::string basecamp::expansion_tab( const point_rel_omt &dir ) const
 {
     if( dir == base_camps::base_dir ) {
         return _( "Base Missions" );

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -96,11 +96,11 @@ struct direction_data {
 };
 
 // base_dir and the eight directional points
-extern const std::map<point, direction_data> all_directions;
+extern const std::map<point_rel_omt, direction_data> all_directions;
 
-point direction_from_id( const std::string &id );
+point_rel_omt direction_from_id( const std::string &id );
 
-constexpr point base_dir;
+constexpr point_rel_omt base_dir;
 const std::string prefix = "faction_base_";
 const std::string id = "FACTION_CAMP";
 const int prefix_len = 13;
@@ -139,8 +139,8 @@ struct expansion_salt_water_pipe_segment {
 };
 
 struct expansion_salt_water_pipe {
-    point expansion;
-    point connection_direction;
+    point_rel_omt expansion;
+    point_rel_omt connection_direction;
     std::vector<expansion_salt_water_pipe_segment> segments;
 };
 
@@ -160,9 +160,9 @@ class basecamp
     public:
         basecamp();
         basecamp( const std::string &name_, const tripoint_abs_omt &omt_pos );
-        basecamp( const std::string &name_, const tripoint &bb_pos_,
-                  const std::vector<point> &directions_,
-                  const std::map<point, expansion_data> &expansions_ );
+        basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
+                  const std::vector<point_rel_omt> &directions_,
+                  const std::map<point_rel_omt, expansion_data> &expansions_ );
         inline bool is_valid() const {
             return !name.empty() && omt_pos != tripoint_abs_omt();
         }
@@ -178,8 +178,8 @@ class basecamp
         inline const std::string &camp_name() const {
             return name;
         }
-        tripoint get_bb_pos() const {
-            return bb_pos.raw();
+        tripoint_abs_ms get_bb_pos() const {
+            return bb_pos;
         }
         tripoint_abs_ms get_bb_pos_abs() const {
             return bb_pos;
@@ -195,7 +195,7 @@ class basecamp
         void set_by_radio( bool access_by_radio );
 
         std::string board_name() const;
-        std::vector<point> directions; // NOLINT(cata-serialize)
+        std::vector<point_rel_omt> directions; // NOLINT(cata-serialize)
         std::vector<std::vector<ui_mission_id>> hidden_missions;
         std::vector<tripoint_abs_omt> fortifications;
         std::vector<expansion_salt_water_pipe *> salt_water_pipes;
@@ -209,25 +209,25 @@ class basecamp
         void scan_pseudo_items();
         void add_expansion( const std::string &terrain, const tripoint_abs_omt &new_pos );
         void add_expansion( const std::string &bldg, const tripoint_abs_omt &new_pos,
-                            const point &dir );
+                            const point_rel_omt &dir );
         void define_camp( const tripoint_abs_omt &p, std::string_view camp_type,
                           bool player_founded = true );
 
-        std::string expansion_tab( const point &dir ) const;
+        std::string expansion_tab( const point_rel_omt &dir ) const;
         // check whether the point is the part of camp
         bool point_within_camp( const tripoint_abs_omt &p ) const;
         // upgrade levels
         bool has_provides( const std::string &req, const expansion_data &e_data, int level = 0 ) const;
-        bool has_provides( const std::string &req, const std::optional<point> &dir = std::nullopt,
+        bool has_provides( const std::string &req, const std::optional<point_rel_omt> &dir = std::nullopt,
                            int level = 0 ) const;
         void update_resources( const std::string &bldg );
         void update_provides( const std::string &bldg, expansion_data &e_data );
-        void update_in_progress( const std::string &bldg, const point &dir );
+        void update_in_progress( const std::string &bldg, const point_rel_omt &dir );
 
         /// Returns the name of the building the current building @ref dir upgrades into,
         /// "null" if there isn't one
-        std::string next_upgrade( const point &dir, int offset = 1 ) const;
-        std::vector<basecamp_upgrade> available_upgrades( const point &dir );
+        std::string next_upgrade( const point_rel_omt &dir, int offset = 1 ) const;
+        std::vector<basecamp_upgrade> available_upgrades( const point_rel_omt &dir );
 
         // camp utility functions
         int recruit_evaluation() const;
@@ -261,8 +261,8 @@ class basecamp
         /// food_supply
         bool distribute_food( bool player_command = true );
         std::string name_display_of( const mission_id &miss_id );
-        void handle_hide_mission( const point &dir );
-        void handle_reveal_mission( const point &dir );
+        void handle_hide_mission( const point_rel_omt &dir );
+        void handle_reveal_mission( const point_rel_omt &dir );
         bool has_water() const;
         /// The number of days the current camp supplies lasts at the given exertion level.
         int camp_food_supply_days( float exertion_level ) const;
@@ -281,7 +281,7 @@ class basecamp
         void handle_takeover_by( faction_id new_owner, bool violent_takeover );
         // recipes, gathering, and craft support functions
         // from a direction
-        std::map<recipe_id, translation> recipe_deck( const point &dir ) const;
+        std::map<recipe_id, translation> recipe_deck( const point_rel_omt &dir ) const;
         // from a building
         std::map<recipe_id, translation> recipe_deck( const std::string &bldg ) const;
         int recipe_batch_max( const recipe &making ) const;
@@ -331,7 +331,7 @@ class basecamp
         void place_results( const item &result );
 
         // mission description functions
-        void add_available_recipes( mission_data &mission_key, mission_kind kind, const point &dir,
+        void add_available_recipes( mission_data &mission_key, mission_kind kind, const point_rel_omt &dir,
                                     const std::map<recipe_id, translation> &craft_recipes );
 
         std::string recruit_description( int npc_count ) const;
@@ -340,7 +340,7 @@ class basecamp
         std::string gathering_description();
         /// Returns a string for the number of plants that are harvestable, plots ready to plant,
         /// and ground that needs tilling
-        std::string farm_description( const point &dir, size_t &plots_count,
+        std::string farm_description( const point_rel_omt &dir, size_t &plots_count,
                                       farm_ops operation );
         /// Returns the description of a camp crafting options. converts fire charges to charcoal,
         /// allows dark crafting
@@ -348,7 +348,7 @@ class basecamp
 
         // main mission description collection
         void get_available_missions( mission_data &mission_key, map &here );
-        void get_available_missions_by_dir( mission_data &mission_key, const point &dir );
+        void get_available_missions_by_dir( mission_data &mission_key, const point_rel_omt &dir );
         void choose_new_leader();
         // available companion list manipulation
         void reset_camp_workers();
@@ -396,7 +396,7 @@ class basecamp
         void start_salt_water_pipe( const mission_id &miss_id );
         void continue_salt_water_pipe( const mission_id &miss_id );
         void start_combat_mission( const mission_id &miss_id, float exertion_level );
-        void start_farm_op( const point &dir, const mission_id &miss_id,
+        void start_farm_op( const point_rel_omt &dir, const mission_id &miss_id,
                             float exertion_level );
         ///Display items listed in @ref equipment to let the player pick what to give the departing
         ///NPC, loops until quit or empty.
@@ -405,7 +405,7 @@ class basecamp
         drop_locations give_equipment( Character *pc, const inventory_filter_preset &preset,
                                        const std::string &msg, const std::string &title, units::volume &total_volume,
                                        units::mass &total_mass );
-        drop_locations get_equipment( tinymap *target_bay, const tripoint &target, Character *pc,
+        drop_locations get_equipment( tinymap *target_bay, const tripoint_omt_ms &target, Character *pc,
                                       const inventory_filter_preset &preset,
                                       const std::string &msg, const std::string &title, units::volume &total_volume,
                                       units::mass &total_mass );
@@ -446,8 +446,8 @@ class basecamp
         * @param omt_tgt the overmap pos3 of the farm_ops
         * @param op whether to plow, plant, or harvest
         */
-        bool farm_return( const mission_id &miss_id, const point &dir );
-        std::pair<size_t, std::string> farm_action( const point &dir, farm_ops op,
+        bool farm_return( const mission_id &miss_id, const point_rel_omt &dir );
+        std::pair<size_t, std::string> farm_action( const point_rel_omt &dir, farm_ops op,
                 const npc_ptr &comp = nullptr );
         void fortifications_return( const mission_id &miss_id );
         bool salt_water_pipe_swamp_return( const mission_id &miss_id,
@@ -493,7 +493,7 @@ class basecamp
         std::vector<npc_ptr> assigned_npcs; // NOLINT(cata-serialize)
         // location of associated bulletin board
         tripoint_abs_ms bb_pos;
-        std::map<point, expansion_data> expansions;
+        std::map<point_rel_omt, expansion_data> expansions;
         comp_list camp_workers; // NOLINT(cata-serialize)
         basecamp_map camp_map; // NOLINT(cata-serialize)
         // dumping spot in absolute co-ords

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -903,7 +903,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
     } else if( bio.id == bio_resonator ) {
         add_msg_activate();
         //~Sound of a bionic sonic-resonator shaking the area
-        sounds::sound( pos(), 30, sounds::sound_t::combat, _( "VRRRRMP!" ), false, "bionic",
+        sounds::sound( pos_bub(), 30, sounds::sound_t::combat, _( "VRRRRMP!" ), false, "bionic",
                        static_cast<std::string>( bio_resonator ) );
         for( const tripoint_bub_ms &bashpoint : here.points_in_radius( pos_bub(), 1 ) ) {
             here.bash( bashpoint, 110 );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -716,7 +716,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             if( is_armed() ) {
                 stow_item( *weapon );
             }
-            add_msg_if_player_sees( pos(), m_info, _( "%s activates their %s." ),
+            add_msg_if_player_sees( pos_bub(), m_info, _( "%s activates their %s." ),
                                     disp_name(), bio.info().name );
 
             set_wielded_item( cbm_weapon );
@@ -1153,7 +1153,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         const oter_id &cur_om_ter = overmap_buffer.ter( global_omt_location() );
         /* cache g->get_temperature( player location ) since it is used twice. No reason to recalc */
         weather_manager &weather = get_weather();
-        const units::temperature player_local_temp = weather.get_temperature( player_character.pos() );
+        const units::temperature player_local_temp = weather.get_temperature( player_character.pos_bub() );
         const int windpower = get_local_windpower( weather.windspeed + vehwindspeed,
                               cur_om_ter, get_location(), weather.winddirection, g->is_sheltered( pos_bub() ) );
         add_msg_if_player( m_info, _( "Temperature: %s." ), print_temperature( player_local_temp ) );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1303,7 +1303,7 @@ static std::map<tripoint_bub_ms, int> display_npc_attack_potential()
     return effectiveness_map;
 }
 
-void cata_tiles::draw( const point &dest, const tripoint &center, int width, int height,
+void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int width, int height,
                        std::multimap<point, formatted_text> &overlay_strings,
                        color_block_overlay_container &color_blocks )
 {
@@ -1335,7 +1335,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     map &here = get_map();
     const visibility_variables &cache = here.get_visibility_variables_cache();
 
-    o = is_isometric() ? center.xy() : center.xy() - point( POSX, POSY );
+    o = is_isometric() ? center.xy().raw() : center.xy().raw() - point( POSX, POSY );
 
     op = dest;
     screentile_width = s.x;
@@ -1366,7 +1366,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                              ( you.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
     const int draw_min_z = std::max( you.posz() - max_draw_depth, -OVERMAP_DEPTH );
 
-    const level_cache &ch = here.access_cache( center.z );
+    const level_cache &ch = here.access_cache( center.z() );
 
     // Map memory should be at least the size of the view range
     // so that new tiles can be memorized, and at least the size of the display
@@ -1419,8 +1419,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     here.prev_o = o;
 
     you.prepare_map_memory_region(
-        here.getglobal( tripoint_bub_ms( min_mm_reg.x, min_mm_reg.y, center.z ) ),
-        here.getglobal( tripoint_bub_ms( max_mm_reg.x, max_mm_reg.y, center.z ) )
+        here.getglobal( tripoint_bub_ms( min_mm_reg.x, min_mm_reg.y, center.z() ) ),
+        here.getglobal( tripoint_bub_ms( max_mm_reg.x, max_mm_reg.y, center.z() ) )
     );
 
     //set up a default tile for the edges outside the render area
@@ -1487,7 +1487,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         creature_tracker &creatures = get_creature_tracker();
         for( int row = min_row; row < max_row; row ++ ) {
             // Reserve columns on each row
-            for( int zlevel = center.z; zlevel >= draw_min_z; zlevel -- ) {
+            for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel -- ) {
                 here.draw_points_cache[zlevel][row].reserve( std::max( 0, max_col - min_col ) );
             }
             for( int col = min_col; col < max_col; col ++ ) {
@@ -1495,13 +1495,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 if( !temp.has_value() ) {
                     continue;
                 }
-                for( int zlevel = center.z; zlevel >= draw_min_z; zlevel -- ) {
+                for( int zlevel = center.z(); zlevel >= draw_min_z; zlevel -- ) {
                     // todo: conversion slightly simplified, a couple of calls already use pos as tripoint_bub_ms
                     const tripoint_bub_ms pos( point_bub_ms( temp.value() ), zlevel );
                     const tripoint_abs_ms pos_global = here.getglobal( pos );
                     const int &x = pos.x();
                     const int &y = pos.y();
-                    const bool is_center_z = zlevel == center.z;
+                    const bool is_center_z = zlevel == center.z();
                     const level_cache &ch2 = here.access_cache( zlevel );
 
                     // light level is used for choosing between grayscale filter and normal lit tiles.
@@ -1514,7 +1514,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         if( has_memory_at( pos_global ) ) {
                             ll = lit_level::MEMORIZED;
                             invisible[0] = true;
-                        } else if( has_draw_override( pos.raw() ) ) {
+                        } else if( has_draw_override( pos ) ) {
                             ll = lit_level::DARK;
                             invisible[0] = true;
                         } else {
@@ -1552,7 +1552,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
 
                         if( g->display_overlay_state( ACTION_DISPLAY_RADIATION ) ) {
-                            const auto rad_override = radiation_override.find( tripoint_bub_ms( pos ) );
+                            const auto rad_override = radiation_override.find( pos );
                             const bool rad_overridden = rad_override != radiation_override.end();
                             if( rad_overridden || !invisible[0] ) {
                                 const int rad_value = rad_overridden ? rad_override->second :
@@ -1570,8 +1570,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
 
                         if( g->display_overlay_state( ACTION_DISPLAY_NPC_ATTACK_POTENTIAL ) ) {
-                            if( npc_attack_rating_map.count( tripoint_bub_ms( pos ) ) ) {
-                                const int val = npc_attack_rating_map.at( tripoint_bub_ms( pos ) );
+                            if( npc_attack_rating_map.count( pos ) ) {
+                                const int val = npc_attack_rating_map.at( pos );
                                 short color;
                                 if( val <= 0 ) {
                                     color = catacurses::red;
@@ -1589,7 +1589,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         // Add temperature value to the overlay_strings list for every visible tile when
                         // displaying temperature
                         if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invisible[0] ) {
-                            const units::temperature temp_value = get_weather().get_temperature( pos.raw() );
+                            const units::temperature temp_value = get_weather().get_temperature( pos );
                             const float celsius_temp_value = units::to_celsius( temp_value );
                             short color;
                             const short bold = 8;
@@ -1662,7 +1662,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
                         if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
                             if( g->displaying_lighting_condition == 0 ) {
-                                const float light = here.ambient_light_at( {x, y, center.z} );
+                                const float light = here.ambient_light_at( {x, y, center.z()} );
                                 // note: lighting will be constrained in the [1.0, 11.0] range.
                                 int intensity =
                                     static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
@@ -1671,7 +1671,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
 
                         if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
-                            const float tr = here.light_transparency( tripoint_bub_ms{x, y, center.z} );
+                            const float tr = here.light_transparency( tripoint_bub_ms{x, y, center.z()} );
                             int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
                                              ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
                             draw_debug_tile( intensity, string_format( "%.2f", tr ) );
@@ -1682,7 +1682,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         const visibility_type vis_type = here.get_visibility( ll, cache );
                         if( would_apply_vision_effects( vis_type ) ) {
                             const Creature *critter = creatures.creature_at( pos, true );
-                            if( has_draw_override( pos.raw() ) || has_memory_at( pos_global ) ||
+                            if( has_draw_override( pos ) || has_memory_at( pos_global ) ||
                                 ( critter &&
                                   ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
                                     || you.sees_with_specials( *critter ) ) ) ) {
@@ -1743,7 +1743,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // Legacy draw mode
         for( int row = min_row; row < max_row; row ++ ) {
             for( auto f : drawing_layers_legacy ) {
-                for( tile_render_info &p : here.draw_points_cache[center.z][row] ) {
+                for( tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
                     if( const tile_render_info::vision_effect * const
                         var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                         if( f == &cata_tiles::draw_terrain ) {
@@ -1761,14 +1761,14 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // Start drawing from the lowest visible z-level (some off-screen tiles
         // are considered visible here to simplify the logic.)
         int cur_zlevel = draw_min_z;
-        while( cur_zlevel <= center.z ) {
+        while( cur_zlevel <= center.z() ) {
             const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
-                    ? z_any_tile_range[center.z - cur_zlevel] : top_any_tile_range;
+                    ? z_any_tile_range[center.z() - cur_zlevel] : top_any_tile_range;
             // For each row
             for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
                 // Set base height for each tile
                 for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
-                    p.com.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
+                    p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
                 }
                 // For each layer
                 for( auto f : drawing_layers ) {
@@ -1789,7 +1789,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
                                 int temp_height_3d = p.com.height_3d;
                                 // Reset height_3d to base when drawing vehicles
-                                p.com.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
+                                p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
                                 // Draw
                                 if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) ) {
                                     // If no vpart drawn, revert height_3d changes
@@ -1798,7 +1798,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             } else if( f == &cata_tiles::draw_critter_at ) {
                                 // Draw
                                 if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow &&
-                                    here.dont_draw_lower_floor( tripoint_bub_ms( p.com.pos ) ) ) {
+                                    here.dont_draw_lower_floor( p.com.pos ) ) {
                                     // Draw shadow of flying critters on bottom-most tile if no other critter drawn
                                     draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
                                 }
@@ -1816,13 +1816,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     // display number of monsters to spawn in mapgen preview
     for( int row = top_any_tile_range.p_min.y; row < top_any_tile_range.p_max.y; row ++ ) {
-        for( const tile_render_info &p : here.draw_points_cache[center.z][row] ) {
+        for( const tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
             const tile_render_info::sprite *const
             var = std::get_if<tile_render_info::sprite>( &p.var );
             if( !var ) {
                 continue;
             }
-            const auto mon_override = monster_override.find( tripoint_bub_ms( p.com.pos ) );
+            const auto mon_override = monster_override.find( p.com.pos );
             if( mon_override != monster_override.end() ) {
                 const int count = std::get<1>( mon_override->second );
                 const bool more = std::get<2>( mon_override->second );
@@ -1831,7 +1831,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     if( more ) {
                         text += "+";
                     }
-                    overlay_strings.emplace( player_to_screen( p.com.pos.xy() ) + half_tile,
+                    overlay_strings.emplace( player_to_screen( p.com.pos.xy().raw() ) + half_tile,
                                              formatted_text( text, catacurses::red,
                                                      direction::NORTH ) );
                 }
@@ -1860,7 +1860,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             if( is_isometric() && top_any_tile_range.contains( colrow ) ) {
                 continue;
             }
-            const tripoint_bub_ms p( mem_x, mem_y, center.z );
+            const tripoint_bub_ms p( mem_x, mem_y, center.z() );
             lit_level lighting = ch.visibility_cache[p.x()][p.y()];
             // `apply_vision_effects` does not memorize anything so we only need
             // to call `would_apply_vision_effects` here.
@@ -1876,14 +1876,14 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             }
             //calling draw to memorize (and only memorize) everything.
             //bypass cache check in case we learn something new about the terrain's connections
-            draw_terrain( p.raw(), lighting, height_3d, invisible, true );
+            draw_terrain( p, lighting, height_3d, invisible, true );
             if( here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_clear_decoration( here.getglobal( p ), "" );
-                draw_furniture( p.raw(), lighting, height_3d, invisible, true );
-                draw_trap( p.raw(), lighting, height_3d, invisible, true );
-                draw_part_con( p.raw(), lighting, height_3d, invisible, true );
-                draw_vpart_no_roof( p.raw(), lighting, height_3d, invisible, true );
-                draw_vpart_roof( p.raw(), lighting, height_3d, invisible, true );
+                draw_furniture( p, lighting, height_3d, invisible, true );
+                draw_trap( p, lighting, height_3d, invisible, true );
+                draw_part_con( p, lighting, height_3d, invisible, true );
+                draw_vpart_no_roof( p, lighting, height_3d, invisible, true );
+                draw_vpart_roof( p, lighting, height_3d, invisible, true );
                 here.memory_cache_dec_set_dirty( p, false );
             }
         }
@@ -1939,7 +1939,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     } else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle ) {
         // check to see if player is located at ter
         draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
-                             tripoint( g->ter_view_p.raw().xy(), center.z ), 0, 0, lit_level::LIT,
+                             tripoint( g->ter_view_p.raw().xy(), center.z() ), 0, 0, lit_level::LIT,
                              false );
     }
     if( you.controlling_vehicle ) {
@@ -1947,7 +1947,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         if( indicator_offset ) {
             draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
                                  indicator_offset->raw().xy() +
-                                 tripoint( you.posx(), you.posy(), center.z ),
+                                 tripoint( you.posx(), you.posy(), center.z() ),
                                  0, 0, lit_level::LIT, false );
         }
     }
@@ -1961,7 +1961,8 @@ void cata_tiles::set_draw_cache_dirty()
     get_map().draw_points_cache_dirty = true;
 }
 
-void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int width, int height )
+void cata_tiles::draw_minimap( const point &dest, const tripoint_bub_ms &center, int width,
+                               int height )
 {
     minimap->set_type( is_isometric() ? pixel_minimap_type::iso : pixel_minimap_type::ortho );
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
@@ -2598,7 +2599,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
     if( !tt ) {
         // Use occlusion overlay as fallback for transparent terrain
         if( category == TILE_CATEGORY::TERRAIN && !here.dont_draw_lower_floor( tripoint_bub_ms( pos ) ) ) {
-            draw_zlevel_overlay( pos, ll, height_3d );
+            draw_zlevel_overlay( tripoint_bub_ms( pos ), ll, height_3d );
 
             // t_open_air is plentiful at high z-levels
             // Skipping the rest of the fallback code will significantly improve performance
@@ -3168,7 +3169,7 @@ bool cata_tiles::would_apply_vision_effects( const visibility_type visibility ) 
     return visibility != visibility_type::CLEAR;
 }
 
-bool cata_tiles::apply_vision_effects( const tripoint &pos,
+bool cata_tiles::apply_vision_effects( const tripoint_bub_ms &pos,
                                        const visibility_type visibility,
                                        int &height_3d )
 {
@@ -3198,7 +3199,7 @@ bool cata_tiles::apply_vision_effects( const tripoint &pos,
     }
 
     // lighting is never rotated, though, could possibly add in random rotation?
-    draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos, 0, 0,
+    draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos.raw(), 0, 0,
                          lit_level::LIT, false, height_3d, 1.0f, 1.0f );
 
     return true;
@@ -3283,7 +3284,7 @@ void cata_tiles::draw_square_below( const point &p, const nc_color &col, const i
     geometry->rect( renderer, sdlrect, sdlcol );
 }
 
-bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
+bool cata_tiles::draw_terrain_below( const tripoint_bub_ms &p, const lit_level, int &,
                                      const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -3291,14 +3292,14 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
     }
 
     map &here = get_map();
-    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
+    const auto low_override = draw_below_override.find( p );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second :
-        ( invisible[0] || here.dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
+        ( invisible[0] || here.dont_draw_lower_floor( p ) ) ) {
         return false;
     }
 
-    tripoint_bub_ms pbelow = tripoint_bub_ms( p + tripoint::below );
+    tripoint_bub_ms pbelow = p + tripoint::below;
     nc_color col = c_dark_gray;
 
     const ter_t &curr_ter = here.ter( pbelow ).obj();
@@ -3327,16 +3328,16 @@ bool cata_tiles::draw_terrain_below( const tripoint &p, const lit_level, int &,
     return true;
 }
 
-bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                                const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     map &here = get_map();
-    const auto override = terrain_override.find( tripoint_bub_ms( p ) );
+    const auto override = terrain_override.find( p );
     const bool overridden = override != terrain_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( terrain_override.find( tripoint_bub_ms( p + dir ) ) != terrain_override.end() ) {
+            if( terrain_override.find( p + dir ) != terrain_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3356,11 +3357,11 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         const std::bitset<NUM_TERCONN> &rotate_group = t.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_connect_values( tripoint_bub_ms( p ), subtile, rotation, connect_group, rotate_group, {} );
+            get_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
             // re-memorize previously seen terrain in case new connections have been seen
             here.memory_cache_ter_set_dirty( p, true );
         } else {
-            get_terrain_orientation( tripoint_bub_ms( p ), rotation, subtile, {}, invisible, rotate_group );
+            get_terrain_orientation( p, rotation, subtile, {}, invisible, rotate_group );
             // do something to get other terrain orientation values
         }
         if( here.memory_cache_ter_is_dirty( p ) ) {
@@ -3370,7 +3371,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
+                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p.raw(), subtile,
                                           rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
@@ -3386,10 +3387,10 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             const std::bitset<NUM_TERCONN> &rotate_group = t2.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_connect_values( tripoint_bub_ms( p ), subtile, rotation, connect_group, rotate_group,
+                get_connect_values( p, subtile, rotation, connect_group, rotate_group,
                                     terrain_override );
             } else {
-                get_terrain_orientation( tripoint_bub_ms( p ), rotation, subtile, terrain_override, invisible,
+                get_terrain_orientation( p, rotation, subtile, terrain_override, invisible,
                                          rotate_group );
             }
             const std::string &tname = t2.id().str();
@@ -3399,7 +3400,7 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
+                   : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p.raw(), subtile,
                                           rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
@@ -3409,23 +3410,23 @@ bool cata_tiles::draw_terrain( const tripoint &p, const lit_level ll, int &heigh
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
+                       mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p.raw(), mt.get_ter_subtile(),
                        mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
 }
 
-bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     avatar &you = get_avatar();
-    const auto override = furniture_override.find( tripoint_bub_ms( p ) );
+    const auto override = furniture_override.find( p );
     const bool overridden = override != furniture_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( furniture_override.find( tripoint_bub_ms( p + dir ) ) != furniture_override.end() ) {
+            if( furniture_override.find( p + dir ) != furniture_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3447,13 +3448,13 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
         if( connect_group.any() ) {
-            get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+            get_furn_connect_values( p.raw(), subtile, rotation, connect_group, rotate_group, {} );
         } else {
-            get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
+            get_tile_values_with_ter( p.raw(), f.to_i(), neighborhood, subtile, rotation, rotate_group );
         }
         const std::string &fname = f.id().str();
         if( !( you.get_grab_type() == object_type::FURNITURE
-               && tripoint_bub_ms( p ) == you.pos_bub() + you.grab_point )
+               && p == you.pos_bub() + you.grab_point )
             && here.memory_cache_dec_is_dirty( p ) ) {
             you.memorize_decoration( here.getglobal( p ), fname, subtile, rotation );
         }
@@ -3461,7 +3462,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
+                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p.raw(), subtile,
                                           rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
@@ -3471,8 +3472,8 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
         if( f2 ) {
             // both the current and neighboring overrides may change the appearance
             // of the tile, so always re-calculate it.
-            const auto furn = [&]( const tripoint & q, const bool invis ) -> furn_id {
-                const auto it = furniture_override.find( tripoint_bub_ms( q ) );
+            const auto furn = [&]( const tripoint_bub_ms & q, const bool invis ) -> furn_id {
+                const auto it = furniture_override.find( q );
                 return it != furniture_override.end() ? it->second :
                 ( !overridden || !invis ) ? here.furn( q ) : furn_str_id::NULL_ID().id();
             };
@@ -3488,11 +3489,11 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             const std::bitset<NUM_TERCONN> &rotate_group = f.obj().rotate_to_groups;
 
             if( connect_group.any() ) {
-                get_furn_connect_values( p, subtile, rotation, connect_group, rotate_group, {} );
+                get_furn_connect_values( p.raw(), subtile, rotation, connect_group, rotate_group, {} );
             } else {
-                get_tile_values_with_ter( p, f.to_i(), neighborhood, subtile, rotation, rotate_group );
+                get_tile_values_with_ter( p.raw(), f.to_i(), neighborhood, subtile, rotation, rotate_group );
             }
-            get_tile_values_with_ter( p, f2.to_i(), neighborhood, subtile, rotation, 0 );
+            get_tile_values_with_ter( p.raw(), f2.to_i(), neighborhood, subtile, rotation, 0 );
             const std::string &fname = f2.id().str();
             // tile overrides are never memorized
             // tile overrides are always shown with full visibility
@@ -3500,7 +3501,7 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
+                   : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p.raw(), subtile,
                                           rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
@@ -3510,22 +3511,22 @@ bool cata_tiles::draw_furniture( const tripoint &p, const lit_level ll, int &hei
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
+                       mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p.raw(), mt.get_dec_subtile(),
                        mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
 }
 
-bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, const bool memorize_only )
 {
-    const auto override = trap_override.find( tripoint_bub_ms( p ) );
+    const auto override = trap_override.find( p );
     const bool overridden = override != trap_override.end();
     bool neighborhood_overridden = overridden;
     if( !neighborhood_overridden ) {
         for( const point &dir : neighborhood ) {
-            if( trap_override.find( tripoint_bub_ms( p + dir ) ) != trap_override.end() ) {
+            if( trap_override.find( p + dir ) != trap_override.end() ) {
                 neighborhood_overridden = true;
                 break;
             }
@@ -3554,7 +3555,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         if( !neighborhood_overridden ) {
             return memorize_only
                    ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
+                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), subtile,
                                           rotation, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
@@ -3565,8 +3566,8 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
         if( tr2 ) {
             // both the current and neighboring overrides may change the appearance
             // of the tile, so always re-calculate it.
-            const auto tr_at = [&]( const tripoint & q, const bool invis ) -> trap_id {
-                const auto it = trap_override.find( tripoint_bub_ms( q ) );
+            const auto tr_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> trap_id {
+                const auto it = trap_override.find( q );
                 return it != trap_override.end() ? it->second :
                 ( !overridden || !invis ) ? here.tr_at( q ).loadid : tr_null;
             };
@@ -3586,7 +3587,7 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             const bool nv = overridden ? false : nv_goggles_activated;
             return memorize_only
                    ? false
-                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
+                   : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), subtile,
                                           rotation, lit, nv, height_3d, 1.0f, 1.0f );
         }
     } else if( invisible[0] ) {
@@ -3596,19 +3597,20 @@ bool cata_tiles::draw_trap( const tripoint &p, const lit_level ll, int &height_3
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(), mt.get_dec_rotation(),
+                       mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p.raw(), mt.get_dec_subtile(),
+                       mt.get_dec_rotation(),
                        lit_level::MEMORIZED, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
     return false;
 }
 
-bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                                 const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     map &here = get_map();
     // FIXME: fix tripoint type
-    if( here.partial_con_at( tripoint_bub_ms( p ) ) != nullptr && !invisible[0] ) {
+    if( here.partial_con_at( p ) != nullptr && !invisible[0] ) {
         avatar &you = get_avatar();
         std::string const &trname = tr_unfinished_construction.str();;
         if( here.memory_cache_dec_is_dirty( p ) ) {
@@ -3616,13 +3618,13 @@ bool cata_tiles::draw_part_con( const tripoint &p, const lit_level ll, int &heig
         }
         return memorize_only
                ? false
-               : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
+               : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p.raw(), 0,
                                       0, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
     }
     return false;
 }
 
-bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_graffiti( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                                 const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -3630,7 +3632,7 @@ bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &heig
     }
 
     map &here = get_map();
-    const auto override = graffiti_override.find( tripoint_bub_ms( p ) );
+    const auto override = graffiti_override.find( p );
     const bool overridden = override != graffiti_override.end();
     if( overridden ? !override->second : ( invisible[0] || !here.has_graffiti_at( p ) ) ) {
         return false;
@@ -3641,17 +3643,17 @@ bool cata_tiles::draw_graffiti( const tripoint &p, const lit_level ll, int &heig
                              to_upper_case( string_replace( remove_punctuations( here.graffiti_at( p ) ), " ",
                                             "_" ) ).substr( 0, 32 );
     return draw_from_id_string( tileset_ptr->find_tile_type( tile ) ? tile : "graffiti",
-                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, false, height_3d, 1.0f, 1.0f );
+                                TILE_CATEGORY::NONE, empty_string, p.raw(), 0, rotation, lit, false, height_3d, 1.0f, 1.0f );
 }
 
-bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int &height_3d,
+bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
                                      const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
         return false;
     }
 
-    const auto fld_override = field_override.find( tripoint_bub_ms( p ) );
+    const auto fld_override = field_override.find( p );
     const bool fld_overridden = fld_override != field_override.end();
     map &here = get_map();
     const field &f = here.field_at( p );
@@ -3675,7 +3677,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
 
                     // get the sprite to draw
                     // roll is based on the maptile seed to keep visuals consistent
-                    int roll = simple_point_hash( p.xy() ) % layer_var.total_weight;
+                    int roll = simple_point_hash( p.xy().raw() ) % layer_var.total_weight;
                     std::string sprite_to_draw;
                     for( const auto &sprite_list : layer_var.sprite ) {
                         roll = roll - sprite_list.second;
@@ -3686,7 +3688,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                     }
 
                     // if we have found info on the item go through and draw its stuff
-                    ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p,
+                    ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p.raw(),
                                                           subtile, rotation, ll, nv, height_3d, fe.get_field_intensity(), "", layer_var.offset );
                     break;
                 }
@@ -3732,7 +3734,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                             variant += layer_var.append_suffix;
                         }
                         // if we have found info on the item go through and draw its stuff
-                        draw_from_id_string( sprite_to_draw, TILE_CATEGORY::ITEM, layer_it_category, p, 0,
+                        draw_from_id_string( sprite_to_draw, TILE_CATEGORY::ITEM, layer_it_category, p.raw(), 0,
                                              0, layer_lit, layer_nv, height_3d, 0, variant, layer_var.offset );
 
                         // if the top item is already being layered don't draw it later
@@ -3758,7 +3760,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             if( !invisible[0] && fld.obj().display_field ) {
                 const lit_level lit = ll;
 
-                auto has_field = [&]( field_type_id fld, const tripoint & q, const bool invis ) -> field_type_id {
+                auto has_field = [&]( field_type_id fld, const tripoint_bub_ms & q,
+                const bool invis ) -> field_type_id {
                     // go through the fields and see if they are equal
                     field_type_id found = fd_null;
                     for( std::pair<const field_type_id, field_entry> &this_fld : here.field_at( q ) )
@@ -3767,7 +3770,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                             found = fld;
                         }
                     }
-                    const auto it = field_override.find( tripoint_bub_ms( q ) );
+                    const auto it = field_override.find( q );
                     return it != field_override.end() ? it->second :
                            ( !fld_overridden || !invis ) ?  found : fd_null;
                 };
@@ -3796,7 +3799,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 }
                 if( !has_drawn_field ) {
                     draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                         p, subtile, rotation, ll, nv_goggles_activated, height_3d, intensity );
+                                         p.raw(), subtile, rotation, ll, nv_goggles_activated, height_3d, intensity );
                 }
             }
         }
@@ -3806,8 +3809,8 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
         if( fld.obj().display_field ) {
             const lit_level lit = lit_level::LIT;
 
-            auto field_at = [&]( const tripoint & q, const bool invis ) -> field_type_id {
-                const auto it = field_override.find( tripoint_bub_ms( q ) );
+            auto field_at = [&]( const tripoint_bub_ms & q, const bool invis ) -> field_type_id {
+                const auto it = field_override.find( q );
                 return it != field_override.end() ? it->second :
                 ( !fld_overridden || !invis ) ? here.field_at( q ).displayed_field_type() : fd_null;
             };
@@ -3826,12 +3829,12 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
             //get field intensity
             int intensity = fld_overridden ? 0 : here.field_at( p ).displayed_intensity();
             ret_draw_field = draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                                  p, subtile, rotation, lit, false, height_3d, intensity );
+                                                  p.raw(), subtile, rotation, lit, false, height_3d, intensity );
         }
     }
 
     if( fld.obj().display_items ) {
-        const auto it_override = item_override.find( tripoint_bub_ms( p ) );
+        const auto it_override = item_override.find( p );
         const bool it_overridden = it_override != item_override.end();
 
         itype_id it_id;
@@ -3889,7 +3892,7 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
                 const lit_level lit = it_overridden ? lit_level::LIT : ll;
                 const bool nv = it_overridden ? false : nv_goggles_activated;
 
-                ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p, 0,
+                ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p.raw(), 0,
                                                       0, lit, nv, height_3d, 0, variant );
                 if( ret_draw_items && hilite ) {
                     draw_item_highlight( p, height_3d );
@@ -3904,20 +3907,21 @@ bool cata_tiles::draw_field_or_item( const tripoint &p, const lit_level ll, int 
     return ret_draw_field && ret_draw_items;
 }
 
-bool cata_tiles::draw_vpart_below( const tripoint &p, const lit_level /*ll*/, int &/*height_3d*/,
+bool cata_tiles::draw_vpart_below( const tripoint_bub_ms &p, const lit_level /*ll*/,
+                                   int &/*height_3d*/,
                                    const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
         return false;
     }
 
-    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
+    const auto low_override = draw_below_override.find( p );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
+            get_map().dont_draw_lower_floor( p ) ) ) {
         return false;
     }
-    tripoint pbelow( p.xy(), p.z - 1 );
+    tripoint_bub_ms pbelow( p + tripoint::below );
     int height_3d_below = 0;
     std::array<bool, 5> below_invisible;
     std::fill( below_invisible.begin(), below_invisible.end(), false );
@@ -3925,22 +3929,22 @@ bool cata_tiles::draw_vpart_below( const tripoint &p, const lit_level /*ll*/, in
                                memorize_only );
 }
 
-bool cata_tiles::draw_vpart_no_roof( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_vpart_no_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                      const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     return draw_vpart( p, ll, height_3d, invisible, false, memorize_only );
 }
 
-bool cata_tiles::draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     return draw_vpart( p, ll, height_3d, invisible, true, memorize_only );
 }
 
-bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool roof, const bool memorize_only )
 {
-    const auto override = vpart_override.find( tripoint_bub_ms( p ) );
+    const auto override = vpart_override.find( p );
     const bool overridden = override != vpart_override.end();
     map &here = get_map();
     // first memorize the actual vpart
@@ -3963,7 +3967,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
                 const bool ret = memorize_only
                                  ? false
                                  : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
-                                                        empty_string, p, subtile, rotation, ll,
+                                                        empty_string, p.raw(), subtile, rotation, ll,
                                                         nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
                 if( ret && vd.has_cargo ) {
                     draw_item_highlight( p, height_3d_temp );
@@ -3990,7 +3994,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             int height_3d_temp = height_3d;
             const bool ret = memorize_only
                              ? false
-                             : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
+                             : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p.raw(), subtile,
                                                     rotation, lit_level::LIT, false, height_3d_temp, 1.0f, 1.0f );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p, height_3d_temp );
@@ -4015,7 +4019,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
             return memorize_only
                    ? false
                    : draw_from_id_string(
-                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
+                       std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p.raw(), t.get_dec_subtile(),
                        t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
                        std::string( tvar ) );
         }
@@ -4023,7 +4027,7 @@ bool cata_tiles::draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
     return false;
 }
 
-bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int &,
+bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_level, int &,
                                         const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -4031,14 +4035,14 @@ bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int 
     }
 
     // Check if we even need to draw below. If not, bail.
-    const auto low_override = draw_below_override.find( tripoint_bub_ms( p ) );
+    const auto low_override = draw_below_override.find( p );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( tripoint_bub_ms( p ) ) ) ) {
+            get_map().dont_draw_lower_floor( p ) ) ) {
         return false;
     }
 
-    tripoint pbelow( p.xy(), p.z - 1 );
+    tripoint_bub_ms pbelow( p + tripoint::below );
 
     // Get the critter at the location below. If there isn't one,
     // we can bail.
@@ -4055,12 +4059,12 @@ bool cata_tiles::draw_critter_at_below( const tripoint &p, const lit_level, int 
         return false;
     }
 
-    draw_square_below( pbelow.xy(), c_red, 2 );
+    draw_square_below( pbelow.xy().raw(), c_red, 2 );
 
     return true;
 }
 
-bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -4074,7 +4078,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
     Character &you = get_player_character();
     const Creature *pcritter = get_creature_tracker().creature_at( p, true );
     const bool always_visible = pcritter && pcritter->has_flag( mon_flag_ALWAYS_VISIBLE );
-    const auto override = monster_override.find( tripoint_bub_ms( p ) );
+    const auto override = monster_override.find( p );
     if( override != monster_override.end() ) {
         const mtype_id id = std::get<0>( override->second );
         if( !id ) {
@@ -4086,7 +4090,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
         const std::string &chosen_id = id.str();
         const std::string &ent_subcategory = id.obj().species.empty() ?
                                              empty_string : id.obj().species.begin()->str();
-        result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p,
+        result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p.raw(),
                                       corner, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
     } else if( !invisible[0] || always_visible ) {
         if( pcritter == nullptr ) {
@@ -4100,7 +4104,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             if( !sees_with_special.is_empty() ) {
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
-                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
+                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
                                             lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             }
             return false;
@@ -4140,7 +4144,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
                         chosen_id = ridden_id;
                     }
                 }
-                result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
+                result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p.raw(),
                                               subtile, rot_facing, ll, false, height_3d, 1.0f, 1.0f );
                 sees_player = m->sees( you );
                 attitude = m->attitude_to( you );
@@ -4197,7 +4201,7 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             if( !scope_is_blocking ) {
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
-                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p,
+                return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p.raw(),
                                             0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             } else {
                 return false;
@@ -4213,14 +4217,14 @@ bool cata_tiles::draw_critter_at( const tripoint &p, lit_level ll, int &height_3
             draw_id += "_sees_player";
         }
         if( tileset_ptr->find_tile_type( draw_id ) ) {
-            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
+            draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
                                  lit_level::LIT, false, height_3d, 1.0f, 1.0f );
         }
     }
     return result;
 }
 
-bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                      const std::array<bool, 5> &invisible )
 {
     if( invisible[0] ) {
@@ -4246,9 +4250,8 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
     const Creature &critter = *pcritter;
 
     // Draw shadow
-    if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() &&
-        you.sees( critter ) ) {
+    if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p.raw(),
+                             0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() && you.sees( critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;
@@ -4279,7 +4282,7 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
                 draw_id += "_sees_player";
             }
             if( tileset_ptr->find_tile_type( draw_id ) ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p.raw(), 0, 0,
                                      lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             }
         }
@@ -4289,7 +4292,7 @@ bool cata_tiles::draw_critter_above( const tripoint &p, lit_level ll, int &heigh
     }
 }
 
-bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
+bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -4312,7 +4315,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
         const mark_option *option = dynamic_cast<const mark_option *>( &zone->get_options() );
 
         if( option && !option->get_mark().empty() ) {
-            return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p,
+            return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p.raw(),
                                         0, 0, ll, nv_goggles_activated, height_3d, 1.0f, 1.0f );
         }
     }
@@ -4320,7 +4323,7 @@ bool cata_tiles::draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d
     return false;
 }
 
-bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_level /*ll*/,
+bool cata_tiles::draw_zombie_revival_indicators( const tripoint_bub_ms &pos, const lit_level /*ll*/,
         int &height_3d, const std::array<bool, 5> &invisible, const bool memorize_only )
 {
     if( memorize_only ) {
@@ -4329,23 +4332,23 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint &pos, const lit_
 
     map &here = get_map();
     if( tileset_ptr->find_tile_type( ZOMBIE_REVIVAL_INDICATOR ) && !invisible[0] &&
-        item_override.find( tripoint_bub_ms( pos ) ) == item_override.end() &&
+        item_override.find( pos ) == item_override.end() &&
         here.could_see_items( pos, get_player_character() ) ) {
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, TILE_CATEGORY::NONE,
-                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                            empty_string, pos.raw(), 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
             }
         }
     }
     return false;
 }
 
-void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int &height_3d )
+void cata_tiles::draw_zlevel_overlay( const tripoint_bub_ms &p, const lit_level ll, int &height_3d )
 {
     // Draws zlevel occlusion using geometry renderer
     // Slower than sprites so only use as fallback when sprite missing
-    const point screen = player_to_screen( p.xy() );
+    const point screen = player_to_screen( p.xy().raw() );
     SDL_Rect draw_rect;
     if( is_isometric() ) {
         // See comments in get_window_base_tile_counts for an explanation of tile width
@@ -4389,7 +4392,8 @@ void cata_tiles::draw_zlevel_overlay( const tripoint &p, const lit_level ll, int
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
 }
 
-void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
+void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p,
+        lit_level ll,
         int &height_3d, float scale_x, float scale_y )
 {
     std::vector<trait_id> override_look_muts = ch.get_functioning_mutations( true,
@@ -4409,10 +4413,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
         }
         // depending on the toggle flip sprite left or right
         if( ch.facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, 0, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p.raw(), corner, 0, ll, false,
                                  height_3d, scale_x, scale_y );
         } else if( ch.facing == FacingDirection::LEFT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, -1, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p.raw(), corner, -1, ll, false,
                                  height_3d, scale_x, scale_y );
         }
     } else {
@@ -4426,10 +4430,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
             category = TILE_CATEGORY::NONE;
         }
         if( ch.facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( override_look.id, category, "", p, corner, 0, ll, false,
+            draw_from_id_string( override_look.id, category, "", p.raw(), corner, 0, ll, false,
                                  height_3d, scale_x, scale_y );
         } else if( ch.facing == FacingDirection::LEFT ) {
-            draw_from_id_string( override_look.id, category, "", p, corner, -1, ll, false,
+            draw_from_id_string( override_look.id, category, "", p.raw(), corner, -1, ll, false,
                                  height_3d, scale_x, scale_y );
         }
     }
@@ -4442,10 +4446,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
         if( find_overlay_looks_like( ch.male, overlay.first, overlay.second, draw_id ) ) {
             int overlay_height_3d = prev_height_3d;
             if( ch.facing == FacingDirection::RIGHT ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ 0, ll,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p.raw(), corner, /*rota:*/ 0, ll,
                                      false, overlay_height_3d, scale_x, scale_y );
             } else if( ch.facing == FacingDirection::LEFT ) {
-                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ -1, ll,
+                draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p.raw(), corner, /*rota:*/ -1, ll,
                                      false, overlay_height_3d, scale_x, scale_y );
             }
             // the tallest height-having overlay is the one that counts
@@ -4454,9 +4458,9 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint 
     }
 }
 
-bool cata_tiles::draw_item_highlight( const tripoint &pos, int &height_3d )
+bool cata_tiles::draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d )
 {
-    return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos, 0, 0,
+    return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos.raw(), 0, 0,
                                 lit_level::LIT, false, height_3d, 1.0f, 1.0f );
 }
 
@@ -4717,18 +4721,18 @@ void cata_tiles::void_monster_override()
     monster_override.clear();
 }
 
-bool cata_tiles::has_draw_override( const tripoint &p ) const
+bool cata_tiles::has_draw_override( const tripoint_bub_ms &p ) const
 {
-    return radiation_override.find( tripoint_bub_ms( p ) ) != radiation_override.end() ||
-           terrain_override.find( tripoint_bub_ms( p ) ) != terrain_override.end() ||
-           furniture_override.find( tripoint_bub_ms( p ) ) != furniture_override.end() ||
-           graffiti_override.find( tripoint_bub_ms( p ) ) != graffiti_override.end() ||
-           trap_override.find( tripoint_bub_ms( p ) ) != trap_override.end() ||
-           field_override.find( tripoint_bub_ms( p ) ) != field_override.end() ||
-           item_override.find( tripoint_bub_ms( p ) ) != item_override.end() ||
-           vpart_override.find( tripoint_bub_ms( p ) ) != vpart_override.end() ||
-           draw_below_override.find( tripoint_bub_ms( p ) ) != draw_below_override.end() ||
-           monster_override.find( tripoint_bub_ms( p ) ) != monster_override.end();
+    return radiation_override.find( p ) != radiation_override.end() ||
+           terrain_override.find( p ) != terrain_override.end() ||
+           furniture_override.find( p ) != furniture_override.end() ||
+           graffiti_override.find( p ) != graffiti_override.end() ||
+           trap_override.find( p ) != trap_override.end() ||
+           field_override.find( p ) != field_override.end() ||
+           item_override.find( p ) != item_override.end() ||
+           vpart_override.find( p ) != vpart_override.end() ||
+           draw_below_override.find( p ) != draw_below_override.end() ||
+           monster_override.find( p ) != monster_override.end();
 }
 
 /* -- Animation Renders */
@@ -4910,7 +4914,7 @@ void cata_tiles::draw_weather_frame()
 void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_strings )
 {
     const bool use_font = get_option<bool>( "ANIMATION_SCT_USE_FONT" );
-    tripoint player_pos = get_player_character().pos();
+    tripoint_bub_ms player_pos = get_player_character().pos_bub();
 
     for( const scrollingcombattext::cSCT &sct : SCT.vSCT ) {
         const point iD( sct.getPosX(), sct.getPosY() );
@@ -4939,7 +4943,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, TILE_CATEGORY::NONE, empty_string,
-                                             iD + tripoint( iOffset, player_pos.z ),
+                                             iD + tripoint( iOffset, player_pos.z() ),
                                              0, 0, lit_level::LIT, false );
                     }
 
@@ -4955,11 +4959,11 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
 
 void cata_tiles::draw_zones_frame()
 {
-    tripoint player_pos = get_player_character().pos();
+    tripoint_bub_ms player_pos = get_player_character().pos_bub();
     for( int iY = zone_start.y(); iY <= zone_end.y(); ++ iY ) {
         for( int iX = zone_start.x(); iX <= zone_end.x(); ++iX ) {
             draw_from_id_string( "highlight", TILE_CATEGORY::NONE, empty_string,
-                                 zone_offset.xy() + tripoint( iX, iY, player_pos.z ),
+                                 zone_offset.xy() + tripoint( iX, iY, player_pos.z() ),
                                  0, 0, lit_level::LIT, false );
         }
     }
@@ -4980,7 +4984,7 @@ void cata_tiles::draw_async_anim()
     }
 }
 
-void cata_tiles::draw_footsteps_frame( const tripoint &center )
+void cata_tiles::draw_footsteps_frame( const tripoint_bub_ms &center )
 {
     static const std::string id_footstep = "footstep";
     static const std::string id_footstep_above = "footstep_above";
@@ -4989,13 +4993,13 @@ void cata_tiles::draw_footsteps_frame( const tripoint &center )
     const tile_type *tl_above = tileset_ptr->find_tile_type( id_footstep_above );
     const tile_type *tl_below = tileset_ptr->find_tile_type( id_footstep_below );
 
-    for( const tripoint &pos : sounds::get_footstep_markers() ) {
-        if( pos.z > center.z && tl_above ) {
-            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, false );
-        } else if( pos.z < center.z && tl_below ) {
-            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, false );
+    for( const tripoint_bub_ms &pos : sounds::get_footstep_markers() ) {
+        if( pos.z() > center.z() && tl_above ) {
+            draw_from_id_string( id_footstep_above, pos.raw(), 0, 0, lit_level::LIT, false );
+        } else if( pos.z() < center.z() && tl_below ) {
+            draw_from_id_string( id_footstep_below, pos.raw(), 0, 0, lit_level::LIT, false );
         } else {
-            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep, pos.raw(), 0, 0, lit_level::LIT, false );
         }
     }
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -439,13 +439,13 @@ class cata_tiles
         }
 
         /** Draw to screen */
-        void draw( const point &dest, const tripoint &center, int width, int height,
+        void draw( const point &dest, const tripoint_bub_ms &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
         void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 
         /** Minimap functionality */
-        void draw_minimap( const point &dest, const tripoint &center, int width, int height );
+        void draw_minimap( const point &dest, const tripoint_bub_ms &center, int width, int height );
 
     protected:
         /** How many rows and columns of tiles fit into given dimensions, fully
@@ -556,45 +556,45 @@ class cata_tiles
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;
-        bool apply_vision_effects( const tripoint &pos, visibility_type visibility, int &height_3d );
+        bool apply_vision_effects( const tripoint_bub_ms &pos, visibility_type visibility, int &height_3d );
         void draw_square_below( const point &p, const nc_color &col, int sizefactor );
-        bool draw_terrain( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_terrain( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                            const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_terrain_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_terrain_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_furniture( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_furniture( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_graffiti( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_graffiti( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_trap( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_trap( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                         const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_part_con( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_part_con( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                             const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_field_or_item( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_field_or_item( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                          const std::array<bool, 5> &invisible, bool roof, bool memorize_only );
-        bool draw_vpart_no_roof( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_no_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart_roof( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_roof( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_vpart_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_vpart_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_at( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                               const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_at_below( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_at_below( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                     const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_critter_above( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                  const std::array<bool, 5> &invisible );
-        bool draw_zone_mark( const tripoint &p, lit_level ll, int &height_3d,
+        bool draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                              const std::array<bool, 5> &invisible, bool memorize_only );
-        bool draw_zombie_revival_indicators( const tripoint &pos, lit_level ll, int &height_3d,
+        bool draw_zombie_revival_indicators( const tripoint_bub_ms &pos, lit_level ll, int &height_3d,
                                              const std::array<bool, 5> &invisible, bool memorize_only );
-        void draw_zlevel_overlay( const tripoint &p, lit_level ll, int &height_3d );
-        void draw_entity_with_overlays( const Character &ch, const tripoint &p, lit_level ll,
+        void draw_zlevel_overlay( const tripoint_bub_ms &p, lit_level ll, int &height_3d );
+        void draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p, lit_level ll,
                                         int &height_3d, float scale_x, float scale_y );
 
-        bool draw_item_highlight( const tripoint &pos, int &height_3d );
+        bool draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d );
 
     public:
         // Animation layers
@@ -614,7 +614,7 @@ class cata_tiles
         void draw_hit_frame();
         void void_hit();
 
-        void draw_footsteps_frame( const tripoint &center );
+        void draw_footsteps_frame( const tripoint_bub_ms &center );
 
         // pseudo-animated layer, not really though.
         void init_draw_line( const tripoint_bub_ms &p, std::vector<tripoint_bub_ms> trajectory,
@@ -680,7 +680,7 @@ class cata_tiles
                                          bool more, Creature::Attitude att );
         void void_monster_override();
 
-        bool has_draw_override( const tripoint &p ) const;
+        bool has_draw_override( const tripoint_bub_ms &p ) const;
 
         void set_disable_occlusion( bool val );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8201,6 +8201,9 @@ void Character::did_hit( Creature &target )
 
 ret_val<void> Character::can_wield( const item &it ) const
 {
+    if( it.has_flag( flag_INTEGRATED ) ) {
+        return ret_val<void>::make_failure( _( "You can't wield a part of your body." ) );
+    }
     if( has_effect( effect_incorporeal ) ) {
         return ret_val<void>::make_failure( _( "You can't wield anything while incorporeal." ) );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2483,11 +2483,11 @@ void Character::make_footstep_noise() const
         return;
     }
     if( is_mounted() ) {
-        sounds::sound( pos(), volume, sounds::sound_t::movement,
+        sounds::sound( pos_bub(), volume, sounds::sound_t::movement,
                        mounted_creature.get()->type->get_footsteps(),
                        false, "none", "none" );
     } else {
-        sounds::sound( pos(), volume, sounds::sound_t::movement, _( "footsteps" ), true,
+        sounds::sound( pos_bub(), volume, sounds::sound_t::movement, _( "footsteps" ), true,
                        "none", "none" );    // Sound of footsteps may awaken nearby monsters
     }
     sfx::do_footstep();
@@ -2500,7 +2500,7 @@ void Character::make_clatter_sound() const
     if( volume <= 0 ) {
         return;
     }
-    sounds::sound( pos(), volume, sounds::sound_t::movement, _( "clattering equipment" ), true,
+    sounds::sound( pos_bub(), volume, sounds::sound_t::movement, _( "clattering equipment" ), true,
                    "none", "none" );   // Sound of footsteps may awaken nearby monsters
 }
 
@@ -7636,7 +7636,7 @@ void Character::cough( bool harmful, int loudness )
     if( !is_npc() ) {
         add_msg( m_bad, _( "You cough heavily." ) );
     }
-    sounds::sound( pos(), loudness, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
+    sounds::sound( pos_bub(), loudness, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
                    "cough" );
 
     mod_moves( -get_speed() * 0.8 );
@@ -7755,7 +7755,7 @@ void Character::shout( std::string msg, bool order )
         add_msg_if_player( m_warning, _( "The sound of your voice is significantly muffled!" ) );
     }
 
-    sounds::sound( pos(), noise, order ? sounds::sound_t::order : sounds::sound_t::alert, msg, false,
+    sounds::sound( pos_bub(), noise, order ? sounds::sound_t::order : sounds::sound_t::alert, msg, false,
                    "shout", shout );
 }
 
@@ -8924,7 +8924,7 @@ void Character::spores()
     map &here = get_map();
     fungal_effects fe;
     //~spore-release sound
-    sounds::sound( pos(), 10, sounds::sound_t::combat, _( "Pouf!" ), false, "misc", "puff" );
+    sounds::sound( pos_bub(), 10, sounds::sound_t::combat, _( "Pouf!" ), false, "misc", "puff" );
     for( const tripoint_bub_ms &sporep : here.points_in_radius( pos_bub(), 1 ) ) {
         if( sporep == pos_bub() ) {
             continue;
@@ -8936,7 +8936,7 @@ void Character::spores()
 void Character::blossoms()
 {
     // Player blossoms are shorter-ranged, but you can fire much more frequently if you like.
-    sounds::sound( pos(), 10, sounds::sound_t::combat, _( "Pouf!" ), false, "misc", "puff" );
+    sounds::sound( pos_bub(), 10, sounds::sound_t::combat, _( "Pouf!" ), false, "misc", "puff" );
     map &here = get_map();
     for( const tripoint_bub_ms &tmp : here.points_in_radius( pos_bub(), 2 ) ) {
         here.add_field( tmp, fd_fungal_haze, rng( 1, 2 ) );
@@ -10924,13 +10924,13 @@ void Character::echo_pulse()
     // Sound travels farther underwater
     if( has_effect( effect_subaquatic_sonar ) && is_underwater() ) {
         pulse_range = 20;
-        sounds::sound( this->pos(), 5, sounds::sound_t::movement, _( "boop." ), true,
+        sounds::sound( this->pos_bub(), 5, sounds::sound_t::movement, _( "boop." ), true,
                        "none", "none" );
     } else if( !has_effect( effect_subaquatic_sonar ) && is_underwater() ) {
         add_msg_if_player( m_warning, _( "You can't echolocate underwater!" ) );
         return;
     } else {
-        sounds::sound( this->pos(), 5, sounds::sound_t::movement, _( "chirp." ), true,
+        sounds::sound( this->pos_bub(), 5, sounds::sound_t::movement, _( "chirp." ), true,
                        "none", "none" );
     }
     for( tripoint_bub_ms origin : points_in_radius( pos_bub(), pulse_range ) ) {
@@ -12443,7 +12443,7 @@ void Character::invalidate_pseudo_items()
     pseudo_items_valid = false;
 }
 
-bool Character::avoid_trap( const tripoint &pos, const trap &tr ) const
+bool Character::avoid_trap( const tripoint_bub_ms &pos, const trap &tr ) const
 {
     /** @EFFECT_DEX increases chance to avoid traps */
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5622,7 +5622,7 @@ needs_rates Character::calc_needs_rates() const
     if( has_trait( trait_TRANSPIRATION ) ) {
         // Transpiration, the act of moving nutrients with evaporating water, can take a very heavy toll on your thirst when it's really hot.
         rates.thirst *= ( ( units::to_fahrenheit( get_weather().get_temperature(
-                                pos() ) ) - 32.5f ) / 40.0f );
+                                pos_bub() ) ) - 32.5f ) / 40.0f );
     }
 
     rates.hunger = enchantment_cache->modify_value( enchant_vals::mod::HUNGER, rates.hunger );
@@ -13438,7 +13438,7 @@ void Character::search_surroundings()
             continue;
         }
         // Chance to detect traps we haven't yet seen.
-        if( tr.detect_trap( tp.raw(), *this ) ) {
+        if( tr.detect_trap( tp, *this ) ) {
             if( !tr.is_trivial_to_spot() ) {
                 // Only bug player about traps that aren't trivial to spot.
                 const std::string direction = direction_name(

--- a/src/character.h
+++ b/src/character.h
@@ -2578,7 +2578,7 @@ class Character : public Creature, public visitable
         bool cast_spell( spell &sp, bool fake_spell, const std::optional<tripoint_bub_ms> &target );
 
         /** Called when a player triggers a trap, returns true if they don't set it off */
-        bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
+        bool avoid_trap( const tripoint_bub_ms &pos, const trap &tr ) const override;
 
         //returns true if the warning is now beyond final and results in hostility.
         bool add_faction_warning( const faction_id &id ) const;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -444,7 +444,7 @@ void Character::update_bodytemp()
     }
     weather_manager &weather_man = get_weather();
     /* Cache calls to g->get_temperature( player position ), used in several places in function */
-    const units::temperature player_local_temp = weather_man.get_temperature( pos() );
+    const units::temperature player_local_temp = weather_man.get_temperature( pos_bub() );
     const w_point weather = *weather_man.weather_precise;
     int vehwindspeed = 0;
     map &here = get_map();
@@ -890,7 +890,7 @@ void Character::update_frostbite( const bodypart_id &bp, const int FBwindPower,
     Less than -35F, more than 10 mp
     **/
 
-    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
+    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos_bub() ) );
     const units::temperature temp_after = get_part_temp_cur( bp );
     const time_duration cooldown = 1900_seconds;
     const time_duration cooldown_danger = 300_seconds;
@@ -1437,7 +1437,7 @@ void Character::update_heartrate_index()
     // The following code was adapted from the heartrate function, which will now probably need to be rewritten to be based on the heartrate index.
 
     //COLDBLOOD dependencies, works almost same way as temperature effect for speed.
-    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos() ) );
+    const float player_local_temp = units::to_fahrenheit( get_weather().get_temperature( pos_bub() ) );
     float temperature_modifier = 0.0f;
     if( has_flag( json_flag_COLDBLOOD ) ) {
         temperature_modifier = 0.002f;

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -348,7 +348,7 @@ climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
 
     auto detect_ter_furn_flag = [&you, &here, &fall]( condition & cond ) {
         tripoint_bub_ms pos = fall.pos_furniture_or_floor();
-        cond.range = fall.pos_top().z - pos.z;
+        cond.range = fall.pos_top().z() - pos.z();
         bool furn_ok = false;
         if( here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, pos ) ||
             here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, pos ) ) {

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -327,7 +327,7 @@ static void detect_conditions_sub( climbing_aid::condition_list &list,
 }
 
 climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
-        const tripoint &examp )
+        const tripoint_bub_ms &examp )
 {
     condition_list list;
 
@@ -347,7 +347,7 @@ climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
     };
 
     auto detect_ter_furn_flag = [&you, &here, &fall]( condition & cond ) {
-        tripoint pos = fall.pos_furniture_or_floor();
+        tripoint_bub_ms pos = fall.pos_furniture_or_floor();
         cond.range = fall.pos_top().z - pos.z;
         bool furn_ok = false;
         if( here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, pos ) ||
@@ -377,7 +377,7 @@ climbing_aid::condition_list climbing_aid::detect_conditions( Character &you,
     return list;
 }
 
-climbing_aid::fall_scan::fall_scan( const tripoint &examp )
+climbing_aid::fall_scan::fall_scan( const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "coordinates.h"
 #include "point.h"
 #include "translation.h"
 #include "type_id.h"
@@ -73,7 +74,7 @@ class climbing_aid
         bool was_loaded = false;
 
 
-        static condition_list detect_conditions( Character &you, const tripoint &examp );
+        static condition_list detect_conditions( Character &you, const tripoint_bub_ms &examp );
 
         static aid_list list( const condition_list &cond );
         static aid_list list_all( const condition_list &cond );
@@ -88,9 +89,9 @@ class climbing_aid
         class fall_scan
         {
             public:
-                explicit fall_scan( const tripoint &examp );
+                explicit fall_scan( const tripoint_bub_ms &examp );
 
-                tripoint examp; // Initial position of scan (usually a ledge / open air tile)
+                tripoint_bub_ms examp; // Initial position of scan (usually a ledge / open air tile)
                 int height; // Z-levels to "ground" based on here.valid_move
                 int height_until_creature; // Z-levels below that are free of creatures
                 int height_until_furniture; // Z-levels below that are free of furniture
@@ -101,22 +102,22 @@ class climbing_aid
                     return height != 0;
                 }
 
-                tripoint pos_top() const {
+                tripoint_bub_ms pos_top() const {
                     return examp;
                 }
-                tripoint pos_bottom() const {
-                    tripoint ret = examp;
-                    ret.z -= height;
+                tripoint_bub_ms pos_bottom() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= height;
                     return ret;
                 }
-                tripoint pos_just_below() const {
-                    tripoint ret = examp;
-                    ret.z -= 1;
+                tripoint_bub_ms pos_just_below() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= 1;
                     return ret;
                 }
-                tripoint pos_furniture_or_floor() const {
-                    tripoint ret = examp;
-                    ret.z -= std::min( height, height_until_furniture + 1 );
+                tripoint_bub_ms pos_furniture_or_floor() const {
+                    tripoint_bub_ms ret = examp;
+                    ret.z() -= std::min( height, height_until_furniture + 1 );
                     return ret;
                 }
 

--- a/src/computer.cpp
+++ b/src/computer.cpp
@@ -63,7 +63,7 @@ void computer_failure::deserialize( const JsonObject &jo )
     type = jo.get_enum_value<computer_failure_type>( "action" );
 }
 
-computer::computer( const std::string &new_name, int new_security, tripoint new_loc )
+computer::computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc )
     : name( new_name ), mission_id( -1 ), security( new_security ), alerts( 0 ),
       next_attempt( calendar::before_time_starts ),
       access_denied( _( "ERROR!  Access denied!" ) )

--- a/src/computer.h
+++ b/src/computer.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
 
@@ -118,7 +119,7 @@ struct computer_failure {
 class computer
 {
     public:
-        computer( const std::string &new_name, int new_security, tripoint new_loc );
+        computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc );
 
         // Initialization
         void set_security( int Security );
@@ -136,7 +137,7 @@ class computer
         void deserialize( const JsonValue &jv );
 
         friend class computer_session;
-        tripoint loc;
+        tripoint_bub_ms loc;
         // "Jon's Computer", "Lab 6E77-B Terminal Omega"
         std::string name;
         // Linked to a mission?

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -497,7 +497,7 @@ void computer_session::action_toll()
         reset_terminal();
     } else {
         comp.next_attempt = calendar::turn + 1_minutes;
-        sounds::sound( get_player_character().pos(), 120, sounds::sound_t::alarm,
+        sounds::sound( get_player_character().pos_bub(), 120, sounds::sound_t::alarm,
                        //~ the sound of a church bell ringing
                        _( "Bohm…  Bohm…  Bohm…" ), true, "environment", "church_bells" );
 
@@ -542,7 +542,7 @@ void computer_session::action_release()
 {
     get_event_bus().send<event_type::releases_subspace_specimens>();
     Character &player_character = get_player_character();
-    sounds::sound( player_character.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+    sounds::sound( player_character.pos_bub(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
                    "environment",
                    "alarm" );
     get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 25.0,
@@ -560,7 +560,7 @@ void computer_session::action_release_disarm()
 void computer_session::action_release_bionics()
 {
     Character &player_character = get_player_character();
-    sounds::sound( player_character.pos(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+    sounds::sound( player_character.pos_bub(), 40, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
                    "environment",
                    "alarm" );
     get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 3.0,
@@ -1294,7 +1294,7 @@ void computer_session::action_irradiator()
                         print_error( _( "  >> Radiation spike detected!\n" ) );
                         print_error( _( "WARNING [912]: Catastrophic malfunction!  Contamination detected!" ) );
                         print_error( _( "EMERGENCY PROCEDURE [1]:  Evacuate.  Evacuate.  Evacuate.\n" ) );
-                        sounds::sound( player_character.pos(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+                        sounds::sound( player_character.pos_bub(), 30, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
                                        "environment",
                                        "alarm" );
                         here.i_rem( dest, it );
@@ -1564,7 +1564,7 @@ void computer_session::failure_alarm()
 {
     Character &player_character = get_player_character();
     get_event_bus().send<event_type::triggers_alarm>( player_character.getID() );
-    sounds::sound( player_character.pos(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
+    sounds::sound( player_character.pos_bub(), 60, sounds::sound_t::alarm, _( "an alarm sound!" ), false,
                    "environment",
                    "alarm" );
 }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2180,7 +2180,7 @@ conditional_t::func f_can_see_location( const JsonObject &jo, std::string_view m
     str_or_var target = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, target]( const_dialogue const & d ) {
         tripoint_abs_ms target_pos = tripoint_abs_ms( tripoint::from_string( target.evaluate( d ) ) );
-        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ).raw() );
+        return d.const_actor( is_npc )->can_see_location( get_map().bub_from_abs( target_pos ) );
     };
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2099,11 +2099,11 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
     // TODO: fix point types
-    sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p.raw() ) );
+    sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p ) );
     if( calendar::once_every( 1_minutes ) ) {
         // TODO: fix point types
         //~ Sound of a shovel digging a pit at work!
-        sounds::sound( p.raw(), 10, sounds::sound_t::activity, _( "hsh!" ) );
+        sounds::sound( p, 10, sounds::sound_t::activity, _( "hsh!" ) );
     }
     if( !who.knows_trap( p ) ) {
         get_map().maybe_trigger_trap( p, who, true );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -143,7 +143,7 @@ void craft_command::execute( bool only_cache_comps )
 
     bool need_selections = true;
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
 
     if( has_cached_selections() ) {
         std::vector<comp_selection<item_comp>> missing_items = check_item_components_missing( map_inv );
@@ -455,7 +455,7 @@ item craft_command::create_in_progress_craft()
     }
 
     inventory map_inv;
-    map_inv.form_from_map( crafter->pos(), PICKUP_RANGE, crafter );
+    map_inv.form_from_map( crafter->pos_bub(), PICKUP_RANGE, crafter );
 
     if( !check_item_components_missing( map_inv ).empty() ) {
         debugmsg( "Aborting crafting: couldn't find cached components" );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -133,7 +133,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         if( p.is_avatar() ) {
             add_msg( m_info, _( "Your morale is too low to craft such a difficult thing…" ) );
         } else {
-            add_msg_if_player_sees( p.pos(), m_info,
+            add_msg_if_player_sees( p.pos_bub(), m_info,
                                     _( "%s's morale is too low to craft such a difficult thing…" ),
                                     p.get_name() );
         }
@@ -144,7 +144,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         if( p.is_avatar() ) {
             add_msg( m_info, _( "You can't see to craft!" ) );
         } else {
-            add_msg_if_player_sees( p.pos(), m_info, _( "%s can't see to craft!" ),
+            add_msg_if_player_sees( p.pos_bub(), m_info, _( "%s can't see to craft!" ),
                                     p.get_name() );
         }
         return false;
@@ -652,7 +652,7 @@ const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, 
     }
     crafting_cache.crafting_inventory->clear();
     if( radius >= 0 ) {
-        crafting_cache.crafting_inventory->form_from_map( inv_pos.raw(), radius, this, false, clear_path );
+        crafting_cache.crafting_inventory->form_from_map( inv_pos, radius, this, false, clear_path );
     }
 
     std::map<itype_id, int> tmp_liq_list;
@@ -996,14 +996,14 @@ bool Character::craft_skill_gain( const item &craft, const int &num_practice_tic
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s assists with crafting…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
                 }
             }
             if( batch_size == 1 && one_in( 300 ) ) {
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s could assist you with a batch…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%1s could assist %2s with a batch…" ),
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s could assist %2s with a batch…" ),
                                             helper->get_name(), get_name() );
                 }
             }
@@ -1014,7 +1014,7 @@ bool Character::craft_skill_gain( const item &craft, const int &num_practice_tic
                 if( is_avatar() ) {
                     add_msg( m_info, _( "%s watches you craft…" ), helper->get_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
                                             get_name() );
                 }
             }
@@ -1543,7 +1543,7 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
                     add_msg( m_good, _( "You memorized the recipe for %s!" ),
                              making.result_name() );
                 } else {
-                    add_msg_if_player_sees( pos(), m_good, _( "%1s memorized the recipe for %2s!" ),
+                    add_msg_if_player_sees( pos_bub(), m_good, _( "%1s memorized the recipe for %2s!" ),
                                             get_name(), making.result_name() );
                 }
             }
@@ -1640,7 +1640,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
         auto filter = [&]( const item & it ) {
             return std_filter( it ) &&
@@ -1658,7 +1658,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
                 if( this->is_avatar() ) {
                     add_msg( _( "You stop crafting." ) );
                 } else {
-                    add_msg_if_player_sees( pos(), _( "%s stops crafting." ), get_name() );
+                    add_msg_if_player_sees( pos_bub(), _( "%s stops crafting." ), get_name() );
                 }
                 return false;
             }
@@ -1708,7 +1708,7 @@ bool Character::can_continue_craft( item &craft, const requirement_data &continu
         }
 
         inventory map_inv;
-        map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+        map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
         std::vector<comp_selection<tool_comp>> new_tool_selections;
         for( const std::vector<tool_comp> &alternatives : tool_reqs ) {
@@ -2170,7 +2170,7 @@ std::list<item> Character::consume_items( const std::vector<item_comp> &componen
         const std::function<bool( const itype_id & )> &select_ind )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
     comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, false, filter );
     return consume_items( sel, batch, filter, select_ind( sel.comp.type ) );
 }
@@ -2360,7 +2360,7 @@ bool Character::craft_consume_tools( item &craft, int multiplier, bool start_cra
                 craft.get_cached_tool_selections();
 
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
 
     for( const comp_selection<tool_comp> &tool_sel : cached_tool_selections ) {
         itype_id type = tool_sel.comp.type;
@@ -2481,7 +2481,7 @@ to consume_tools */
 void Character::consume_tools( const std::vector<tool_comp> &tools, int batch )
 {
     inventory map_inv;
-    map_inv.form_from_map( pos(), PICKUP_RANGE, this );
+    map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
     consume_tools( select_tool_component( tools, batch, map_inv ), batch );
 }
 
@@ -2930,7 +2930,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
 
             if( act_item.has_temperature() ) {
                 // TODO: fix point types
-                act_item.set_item_temperature( get_weather().get_temperature( loc.raw() ) );
+                act_item.set_item_temperature( get_weather().get_temperature( loc ) );
             }
 
             // Refitted clothing disassembles into refitted components (when applicable)

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1573,7 +1573,7 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
         c->move_to( tripoint_abs_ms( line_to( get_location().raw(), c->get_location().raw(), 0,
                                               0 ).front() ) );
         c->add_effect( effect_stunned, 1_seconds );
-        sounds::sound( c->pos(), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
+        sounds::sound( c->pos_bub(), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
     } else {
         add_msg_if_player( m_bad, _( "%s weight makes it difficult to pull towards you." ),
                            c->disp_name( true, true ) );

--- a/src/creature.h
+++ b/src/creature.h
@@ -387,7 +387,7 @@ class Creature : public viewer
          * @param tr is the trap that was triggered.
          * @param pos is the location of the trap (not necessarily of the creature) in the main map.
          */
-        virtual bool avoid_trap( const tripoint &pos, const trap &tr ) const = 0;
+        virtual bool avoid_trap( const tripoint_bub_ms &pos, const trap &tr ) const = 0;
 
         /** Gets the relevant eye_level() function from either monster or Character. */
         int eye_level() const;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3511,13 +3511,13 @@ static void show_sound()
             player_character.view_offset.xy().raw() + point( POSX - player_character.posx(), POSY - player_character.posy() )
         };
         wattron( g->w_terrain, c_yellow );
-        for( const tripoint &sound : sounds_to_draw.first ) {
-            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
+        for( const tripoint_bub_ms &sound : sounds_to_draw.first ) {
+            mvwaddch( g->w_terrain, sound.xy().raw() + offset, '?' );
         }
         wattroff( g->w_terrain, c_yellow );
         wattron( g->w_terrain, c_red );
-        for( const tripoint &sound : sounds_to_draw.second ) {
-            mvwaddch( g->w_terrain, offset + sound.xy(), '?' );
+        for( const tripoint_bub_ms &sound : sounds_to_draw.second ) {
+            mvwaddch( g->w_terrain, sound.xy().raw() + offset, '?' );
         }
         wattroff( g->w_terrain, c_red );
     } );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -140,7 +140,7 @@ std::string display::get_temp( const Character &u )
     std::string temp;
     if( u.cache_has_item_with( json_flag_THERMOMETER ) ||
         u.has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) ) ) {
-        temp = print_temperature( get_weather().get_temperature( u.pos() ) );
+        temp = print_temperature( get_weather().get_temperature( u.pos_bub() ) );
     }
     if( temp.empty() ) {
         return "-";

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3198,8 +3198,8 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
 
         for( int i = -max_salt_water_pipe_distance; i <= max_salt_water_pipe_distance; i++ ) {
             for( int k = -max_salt_water_pipe_distance; k <= max_salt_water_pipe_distance; k++ ) {
-                tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x + i,
-                                        omt_pos.y() + dir.y + connection_dir.y + k, omt_pos.z() );
+                tripoint_abs_omt tile = tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x() + i,
+                                        omt_pos.y() + dir.y()+ connection_dir.y() + k, omt_pos.z() );
                 const oter_id &omt_ref = overmap_buffer.ter( tile );
                 bool match = false;
                 for( const std::string &pos_om : allowed_locations ) {
@@ -3216,8 +3216,8 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                     path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] = salt_pipe_illegal;
                 }
                 //  if this is an expansion tile, forbid it. Only allocated ones have their type changed.
-                if( i >= -dir.x - connection_dir.x - 1 && i <= -dir.x - connection_dir.x + 1 &&
-                    k >= -dir.y - connection_dir.y - 1 && k <= -dir.y - connection_dir.y + 1 ) {
+                if( i >= -dir.x() - connection_dir.x() - 1 && i <= -dir.x() - connection_dir.x() + 1 &&
+                    k >= -dir.y() - connection_dir.y() - 1 && k <= -dir.y() - connection_dir.y() + 1 ) {
                     path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] = salt_pipe_illegal;
                 }
             }
@@ -3252,13 +3252,13 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                     for( int k = -dist; k <= dist; k++ ) {
                         if( path_map[max_salt_water_pipe_distance + i][max_salt_water_pipe_distance + k] >
                             0.0 ) { // Tile has been assigned a distance and isn't a swamp
-                            point temp = check_salt_pipe_neighbors( path_map, { i, k } );
+                            point_rel_omt temp = check_salt_pipe_neighbors( path_map, { i, k } );
                             if( !temp.is_invalid() ) {
-                                if( path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance + temp.y] >
+                                if( path_map[max_salt_water_pipe_distance + temp.x()][max_salt_water_pipe_distance + temp.y()] >
                                     destination_cost ) {
-                                    destination_cost = path_map[max_salt_water_pipe_distance + temp.x][max_salt_water_pipe_distance +
-                                                       temp.y];
-                                    destination = temp;
+                                    destination_cost = path_map[max_salt_water_pipe_distance + temp.x()][max_salt_water_pipe_distance +
+                                                       temp.y()];
+                                    destination = temp.raw();
                                     path_found = true;
                                 }
                             }
@@ -3286,7 +3286,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
                     destination.y];
 
         while( destination != point::zero ) {
-            pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x + destination.x, omt_pos.y() + dir.y + connection_dir.y + destination.y, omt_pos.z() ), false, false } );
+            pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x() + destination.x, omt_pos.y() + dir.y() + connection_dir.y() + destination.y, omt_pos.z() ), false, false } );
             path_found = false;  //  Reuse of existing variable after its original usability has been passed.
             for( int i = -1; i <= 1; i++ ) {
                 for( int k = -1; k <= 1; k++ ) {
@@ -3317,7 +3317,7 @@ void basecamp::start_salt_water_pipe( const mission_id &miss_id )
             destination = candidate;
         }
 
-        pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x + connection_dir.x, omt_pos.y() + dir.y + connection_dir.y, omt_pos.z() ), false, false } );
+        pipe->segments.push_back( { tripoint_abs_omt( omt_pos.x() + dir.x() + connection_dir.x(), omt_pos.y() + dir.y() + connection_dir.y(), omt_pos.z() ), false, false } );
     }
 
     if( common_salt_water_pipe_construction( miss_id, pipe, 0 ) ) {

--- a/src/faction_camp.h
+++ b/src/faction_camp.h
@@ -50,6 +50,6 @@ std::string name_mission_tabs( const tripoint_abs_omt &omt_pos, const std::strin
 std::vector<std::pair<std::string, tripoint_abs_omt>> om_building_region(
             const tripoint_abs_omt &omt_pos, int range, bool purge = false );
 /// Returns the x and y coordinates of ( omt_tar - omt_pos ), clamped to [-1, 1]
-point om_simple_dir( const tripoint_abs_omt &omt_pos, const tripoint_abs_omt &omt_tar );
+point_rel_omt om_simple_dir( const tripoint_abs_omt &omt_pos, const tripoint_abs_omt &omt_tar );
 } // namespace talk_function
 #endif // CATA_SRC_FACTION_CAMP_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13837,7 +13837,7 @@ void game::climb_down_menu_gen( const tripoint_bub_ms &examp, uilist &cmenu )
     }
 
     // Scan the height of the drop and what's in the way.
-    const climbing_aid::fall_scan fall( examp.raw() );
+    const climbing_aid::fall_scan fall( examp );
 
     add_msg_debug( debugmode::DF_IEXAMINE, "Ledge height %d", fall.height );
     if( fall.height == 0 ) {
@@ -13848,7 +13848,7 @@ void game::climb_down_menu_gen( const tripoint_bub_ms &examp, uilist &cmenu )
     // This is used to mention object names.  TODO make this more flexible.
     std::string target_disp_name = m.disp_name( fall.pos_furniture_or_floor() );
 
-    climbing_aid::condition_list conditions = climbing_aid::detect_conditions( you, examp.raw() );
+    climbing_aid::condition_list conditions = climbing_aid::detect_conditions( you, examp );
 
     climbing_aid::aid_list aids = climbing_aid::list( conditions );
 
@@ -13944,7 +13944,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
     }
 
     // Scan the height of the drop and what's in the way.
-    const climbing_aid::fall_scan fall( examp.raw() );
+    const climbing_aid::fall_scan fall( examp );
 
     int estimated_climb_cost = you.climbing_cost( tripoint_bub_ms( fall.pos_bottom() ), examp );
     const float fall_mod = you.fall_damage_mod();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3852,13 +3852,13 @@ void game::disp_NPCs()
 static void draw_footsteps( const catacurses::window &window, const tripoint_rel_ms &offset )
 {
     wattron( window, c_yellow );
-    for( const tripoint &footstep : sounds::get_footstep_markers() ) {
+    for( const tripoint_bub_ms &footstep : sounds::get_footstep_markers() ) {
         char glyph = '?';
-        if( footstep.z != offset.z() ) { // Here z isn't an offset, but a coordinate
-            glyph = footstep.z > offset.z() ? '^' : 'v';
+        if( footstep.z() != offset.z() ) { // Here z isn't an offset, but a coordinate
+            glyph = footstep.z() > offset.z() ? '^' : 'v';
         }
 
-        mvwaddch( window, footstep.xy() + offset.raw().xy(), glyph );
+        mvwaddch( window, footstep.raw().xy() + offset.raw().xy(), glyph );
     }
     wattroff( window, c_yellow );
 }
@@ -6000,14 +6000,14 @@ void game::examine( bool with_pickup )
     std::optional<tripoint_bub_ms> examp;
     if( with_pickup ) {
         // Examine and/or pick up items
-        examp = choose_adjacent_highlight_bub_ms( _( "Examine terrain, furniture, or items where?" ),
-                _( "There is nothing that can be examined nearby." ),
-                ACTION_EXAMINE_AND_PICKUP, false );
+        examp = choose_adjacent_highlight( _( "Examine terrain, furniture, or items where?" ),
+                                           _( "There is nothing that can be examined nearby." ),
+                                           ACTION_EXAMINE_AND_PICKUP, false );
     } else {
         // Examine but do not pick up items
-        examp = choose_adjacent_highlight_bub_ms( _( "Examine terrain or furniture where?" ),
-                _( "There is nothing that can be examined nearby." ),
-                ACTION_EXAMINE, false );
+        examp = choose_adjacent_highlight( _( "Examine terrain or furniture where?" ),
+                                           _( "There is nothing that can be examined nearby." ),
+                                           ACTION_EXAMINE, false );
     }
 
     if( !examp ) {
@@ -6266,7 +6266,7 @@ bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
 void game::pickup()
 {
     // Prompt for which adjacent/current tile to pick up items from
-    const std::optional<tripoint_bub_ms> where_ = choose_adjacent_highlight_bub_ms(
+    const std::optional<tripoint_bub_ms> where_ = choose_adjacent_highlight(
                 _( "Pick up items where?" ),
                 _( "There is nothing to pick up nearby." ),
                 ACTION_PICKUP, false );
@@ -6476,7 +6476,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
     }
     const int max_width = getmaxx( w_look ) - column - 1;
 
-    std::string this_sound = sounds::sound_at( lp.raw() );
+    std::string this_sound = sounds::sound_at( lp );
     if( !this_sound.empty() ) {
         const int lines = fold_and_print( w_look, point( 1, ++line ), max_width, c_light_gray,
                                           _( "From here you heard %s" ),
@@ -6490,7 +6490,7 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
                 continue;
             }
 
-            std::string zlev_sound = sounds::sound_at( tmp.raw() );
+            std::string zlev_sound = sounds::sound_at( tmp );
             if( !zlev_sound.empty() ) {
                 const int lines = fold_and_print( w_look, point( 1, ++line ), max_width, c_light_gray,
                                                   tmp.z() > lp.z() ?
@@ -9201,7 +9201,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
 
         if( iActive >= 0 && static_cast<size_t>( iActive ) < monster_list.size() ) {
             cCurMon = monster_list[iActive];
-            iActivePos = cCurMon->pos() - u.pos();
+            iActivePos = ( cCurMon->pos_bub() - u.pos_bub() ).raw();
             centerlistview( iActivePos, width );
             trail_start = u.pos_bub();
             trail_end = cCurMon->pos_bub();
@@ -11854,13 +11854,13 @@ void game::water_affect_items( Character &ch ) const
         }
         // check flag first because its cheaper
         if( loc->has_flag( flag_WATER_DISSOLVE ) && !loc.protected_from_liquids() ) {
-            add_msg_if_player_sees( ch.pos(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
+            add_msg_if_player_sees( ch.pos_bub(), m_bad, _( "%1$s %2$s dissolved in the water!" ),
                                     ch.disp_name( true, true ), loc->display_name() );
             loc.remove_item();
         } else if( loc->has_flag( flag_WATER_BREAK ) && !loc->is_broken()
                    && !loc.protected_from_liquids() ) {
 
-            add_msg_if_player_sees( ch.pos(), m_bad, _( "The water destroyed %1$s %2$s!" ),
+            add_msg_if_player_sees( ch.pos_bub(), m_bad, _( "The water destroyed %1$s %2$s!" ),
                                     ch.disp_name( true ), loc->display_name() );
             loc->deactivate();
             // TODO: Maybe different types of wet faults? But I can't think of any.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1105,7 +1105,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
                 if( glass_portion && rng( 0, vol + 3 ) < vol ) {
                     add_msg( m_bad, _( "Your %s shatters!" ), weapon->tname() );
                     weapon->spill_contents( pos_bub() );
-                    sounds::sound( pos(), 24, sounds::sound_t::combat, "CRACK!", true, "smash",
+                    sounds::sound( pos_bub(), 24, sounds::sound_t::combat, "CRACK!", true, "smash",
                                    "glass" );
                     deal_damage( nullptr, bodypart_id( "hand_r" ), damage_instance( damage_cut,
                                  rng( 0,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -498,14 +498,14 @@ static void pldrive( point d )
 static void open()
 {
     avatar &player_character = get_avatar();
-    const std::optional<tripoint> openp_ = choose_adjacent_highlight( _( "Open where?" ),
-                                           pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
-                                           ACTION_OPEN, false );
+    const std::optional<tripoint_bub_ms> openp_ = choose_adjacent_highlight( _( "Open where?" ),
+            pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
+            ACTION_OPEN, false );
 
     if( !openp_ ) {
         return;
     }
-    const tripoint_bub_ms openp = tripoint_bub_ms( *openp_ );
+    const tripoint_bub_ms openp = *openp_;
     map &here = get_map();
 
     player_character.mod_moves( -to_moves<int>( 1_seconds ) );
@@ -583,7 +583,7 @@ static void open()
 
 static void close()
 {
-    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight_bub_ms(
+    if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight(
                 _( "Close where?" ),
                 pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
                 ACTION_CLOSE, false ) ) {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -154,7 +154,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
     if( test_mode ) {
         switch( test_mode_spilling_action ) {
             case test_mode_spilling_action_t::spill_all:
-                target.pos = player_character.pos();
+                target.pos = player_character.pos_bub().raw();
                 target.dest_opt = LD_GROUND;
                 return true;
             case test_mode_spilling_action_t::cancel_spill:

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -171,8 +171,6 @@ static const itype_id itype_fake_milling_item( "fake_milling_item" );
 static const itype_id itype_fake_smoke_plume( "fake_smoke_plume" );
 static const itype_id itype_fertilizer( "fertilizer" );
 static const itype_id itype_fire( "fire" );
-static const itype_id itype_foodperson_mask( "foodperson_mask" );
-static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
 static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_hickory_root( "hickory_root" );
 static const itype_id itype_id_science( "id_science" );
@@ -1433,55 +1431,6 @@ void iexamine::cardreader_robofac( Character &you, const tripoint_bub_ms &examp 
         intercom( you, examp );
     } else {
         add_msg( _( "You have never seen this card reader model before.  Hacking it seems impossible." ) );
-    }
-}
-
-void iexamine::cardreader_foodplace( Character &you, const tripoint_bub_ms &examp )
-{
-    bool open = false;
-    if( ( you.is_wearing( itype_foodperson_mask ) ||
-          you.is_wearing( itype_foodperson_mask_on ) ) &&
-        query_yn( _( "Press mask on the reader?" ) ) ) {
-        you.mod_moves( -100 );
-        map &here = get_map();
-        for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( examp ), 3 ) ) {
-            if( here.ter( tmp ) == ter_t_door_metal_locked ) {
-                here.ter_set( tmp, ter_t_door_metal_c );
-                open = true;
-            }
-        }
-        if( open ) {
-            add_msg( _( "You press your face on the reader." ) );
-            add_msg( m_good, _( "The nearby doors are unlocked." ) );
-            sounds::sound( examp, 6, sounds::sound_t::electronic_speech,
-                           _( "\"Hello Foodperson.  Welcome home.\"" ), true, "speech", "welcome" );
-        } else {
-            add_msg( _( "The nearby doors are already unlocked." ) );
-            if( query_yn( _( "Lock doors?" ) ) ) {
-                for( const tripoint_bub_ms &tmp : here.points_in_radius( tripoint_bub_ms( examp ), 3 ) ) {
-                    const ter_id &t = here.ter( tmp );
-                    if( t == ter_t_door_metal_o || t == ter_t_door_metal_c ) {
-                        if( you.pos_bub() == tmp ) {
-                            you.add_msg_if_player( m_bad, _( "You are in the way of the door, move before trying again." ) );
-                        } else {
-                            here.ter_set( tmp, ter_t_door_metal_locked );
-                        }
-                    }
-                }
-            }
-        }
-    } else if( you.has_amount( itype_foodperson_mask, 1 ) ||
-               you.has_amount( itype_foodperson_mask_on, 1 ) ) {
-        sounds::sound( examp, 6, sounds::sound_t::electronic_speech,
-                       _( "\"FOODPERSON DETECTED.  Please make yourself presentable.\"" ), true,
-                       "speech", "welcome" );
-    } else {
-        sounds::sound( examp, 6, sounds::sound_t::electronic_speech,
-                       _( "\"Your face is inadequate.  Please go away.\"" ), true,
-                       "speech", "welcome" );
-        if( can_hack( you ) && query_yn( _( "Attempt to hack this card-reader?" ) ) ) {
-            try_start_hacking( you, tripoint_bub_ms( examp ) );
-        }
     }
 }
 
@@ -5305,7 +5254,7 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
             return;
         }
 
-        sounds::sound( you.pos(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
+        sounds::sound( you.pos_bub(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
                        "gaspump" );
 
         int cost = liters * pricePerUnit;
@@ -5335,7 +5284,7 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
             popup( _( "Unable to refund, no fuel in pump." ) );
             return;
         }
-        sounds::sound( you.pos(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
+        sounds::sound( you.pos_bub(), 6, sounds::sound_t::activity, _( "Glug Glug Glug" ), true, "tool",
                        "gaspump" );
 
         // getGasPricePerLiter( platinum_discount) min price to avoid exploit
@@ -7348,7 +7297,6 @@ iexamine_functions iexamine_functions_from_string( const std::string &function_n
             { "elevator", &iexamine::elevator },
             { "controls_gate", &iexamine::controls_gate },
             { "cardreader_robofac", &iexamine::cardreader_robofac },
-            { "cardreader_fp", &iexamine::cardreader_foodplace },
             { "intercom", &iexamine::intercom },
             { "rubble", &iexamine::rubble },
             { "chainfence", &iexamine::chainfence },

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2183,7 +2183,7 @@ void iexamine_helper::handle_harvest( Character &you, const std::string &itemid,
 {
     item harvest = item( itemid );
     if( harvest.has_temperature() ) {
-        harvest.set_item_temperature( get_weather().get_temperature( you.pos() ) );
+        harvest.set_item_temperature( get_weather().get_temperature( you.pos_bub() ) );
     }
     if( !force_drop && you.can_pickVolume( harvest, true ) &&
         you.can_pickWeight( harvest, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
@@ -4519,7 +4519,7 @@ void iexamine::shrub_wildveggies( Character &you, const tripoint_bub_ms &examp )
     you.activity.auto_resume = true;
 }
 
-void trap::examine( const tripoint &examp ) const
+void trap::examine( const tripoint_bub_ms &examp ) const
 {
     avatar &player_character = get_avatar();
     map &here = get_map();
@@ -4610,11 +4610,6 @@ void trap::examine( const tripoint &examp ) const
 
         return;
     }
-}
-
-void trap::examine( const tripoint_bub_ms &examp ) const
-{
-    trap::examine( examp.raw() );
 }
 
 void iexamine::part_con( Character &you, tripoint_bub_ms const &examp )
@@ -6719,7 +6714,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
 
     Character &player_character = get_player_character();
     // select from where to get the items from and place them
-    inv.form_from_map( player_character.pos(), PICKUP_RANGE, &player_character );
+    inv.form_from_map( player_character.pos_bub(), PICKUP_RANGE, &player_character );
     inv.remove_items_with( []( const item & it ) {
         return it.rotten();
     } );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -51,7 +51,7 @@ bool can_hack( Character &you );
 
 bool try_start_hacking( Character &you, const tripoint_bub_ms &examp );
 
-void egg_sack_generic( Character &you, const tripoint &examp, const mtype_id &montype );
+void egg_sack_generic( Character &you, const tripoint_bub_ms &examp, const mtype_id &montype );
 
 void none( Character &you, const tripoint_bub_ms &examp );
 
@@ -91,11 +91,11 @@ void locked_object_pickable( Character &you, const tripoint_bub_ms &examp );
 void bulletin_board( Character &you, const tripoint_bub_ms &examp );
 void pedestal_wyrm( Character &you, const tripoint_bub_ms &examp );
 void door_peephole( Character &you, const tripoint_bub_ms &examp );
-void flower_tulip( Character &you, const tripoint &examp );
-void flower_spurge( Character &you, const tripoint &examp );
+void flower_tulip( Character &you, const tripoint_bub_ms &examp );
+void flower_spurge( Character &you, const tripoint_bub_ms &examp );
 void flower_poppy( Character &you, const tripoint_bub_ms &examp );
 void flower_cactus( Character &you, const tripoint_bub_ms &examp );
-void flower_bluebell( Character &you, const tripoint &examp );
+void flower_bluebell( Character &you, const tripoint_bub_ms &examp );
 void flower_dahlia( Character &you, const tripoint_bub_ms &examp );
 void flower_marloss( Character &you, const tripoint_bub_ms &examp );
 void fungus( Character &you, const tripoint_bub_ms &examp );
@@ -107,8 +107,6 @@ void tree_maple_tapped( Character &you, const tripoint_bub_ms &examp );
 void shrub_marloss( Character &you, const tripoint_bub_ms &examp );
 void tree_marloss( Character &you, const tripoint_bub_ms &examp );
 void shrub_wildveggies( Character &you, const tripoint_bub_ms &examp );
-// TODO: Get rid of untyped overload.
-void part_con( Character &you, const tripoint &examp );
 void part_con( Character &you, const tripoint_bub_ms &examp );
 void water_source( Character &, const tripoint_bub_ms &examp );
 void finite_water_source( Character &, const tripoint_bub_ms &examp );
@@ -134,9 +132,9 @@ void ledge( Character &you, const tripoint_bub_ms &examp );
 void autodoc( Character &you, const tripoint_bub_ms &examp );
 void attunement_altar( Character &you, const tripoint_bub_ms &examp );
 void translocator( Character &you, const tripoint_bub_ms &examp );
-void on_smoke_out( const tripoint &examp,
+void on_smoke_out( const tripoint_bub_ms &examp,
                    const time_point &start_time ); //activates end of smoking effects
-void mill_finalize( Character &, const tripoint &examp );
+void mill_finalize( Character &, const tripoint_bub_ms &examp );
 void quern_examine( Character &you, const tripoint_bub_ms &examp );
 void smoker_options( Character &you, const tripoint_bub_ms &examp );
 void open_safe( Character &you, const tripoint_bub_ms &examp );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -68,7 +68,6 @@ void nanofab( Character &you, const tripoint_bub_ms &examp );
 void controls_gate( Character &you, const tripoint_bub_ms &examp );
 void cardreader( Character &you, const tripoint_bub_ms &examp );
 void cardreader_robofac( Character &you, const tripoint_bub_ms &examp );
-void cardreader_foodplace( Character &you, const tripoint_bub_ms &examp );
 void intercom( Character &you, const tripoint_bub_ms &examp );
 void cvdmachine( Character &you, const tripoint_bub_ms &examp );
 void change_appearance( Character &you, const tripoint_bub_ms &examp );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -480,7 +480,7 @@ static int count_charges_in_list( const ammotype *ammotype, const map_stack &ite
     return 0;
 }
 
-void inventory::form_from_map( const tripoint &origin, int range, const Character *pl,
+void inventory::form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl,
                                bool assign_invlet,
                                bool clear_path )
 {
@@ -490,40 +490,41 @@ void inventory::form_from_map( const tripoint &origin, int range, const Characte
 void inventory::form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zone_pts,
                                 const Character *pl, bool assign_invlet )
 {
-    std::vector<tripoint> pts;
+    std::vector<tripoint_bub_ms> pts;
     pts.reserve( zone_pts.size() );
     for( const tripoint_abs_ms &elem : zone_pts ) {
-        pts.push_back( m.bub_from_abs( elem ).raw() );
+        pts.push_back( m.bub_from_abs( elem ) );
     }
     form_from_map( m, pts, pl, assign_invlet );
 }
 
-void inventory::form_from_map( map &m, const tripoint &origin, int range, const Character *pl,
+void inventory::form_from_map( map &m, const tripoint_bub_ms &origin, int range,
+                               const Character *pl,
                                bool assign_invlet,
                                bool clear_path )
 {
     // populate a grid of spots that can be reached
-    std::vector<tripoint> reachable_pts = {};
+    std::vector<tripoint_bub_ms> reachable_pts = {};
     // If we need a clear path we care about the reachability of points
     if( clear_path ) {
         m.reachable_flood_steps( reachable_pts, origin, range, 1, 100 );
     } else {
         // Fill reachable points with points_in_radius
-        tripoint_range<tripoint> in_radius = m.points_in_radius( origin, range );
-        for( const tripoint &p : in_radius ) {
+        tripoint_range<tripoint_bub_ms> in_radius = m.points_in_radius( origin, range );
+        for( const tripoint_bub_ms &p : in_radius ) {
             reachable_pts.emplace_back( p );
         }
     }
     form_from_map( m, reachable_pts, pl, assign_invlet );
 }
 
-void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Character *pl,
+void inventory::form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                                bool assign_invlet )
 {
     items.clear();
     provisioned_pseudo_tools.clear();
 
-    for( const tripoint &p : pts ) {
+    for( const tripoint_bub_ms &p : pts ) {
         const ter_id &t = m.ter( p );
         // a temporary hack while trees are terrain
         if( t->has_flag( ter_furn_flag::TFLAG_TREE ) ) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -155,13 +155,13 @@ class inventory : public visitable
         void restack( Character &p );
         void form_from_zone( map &m, std::unordered_set<tripoint_abs_ms> &zone_pts,
                              const Character *pl = nullptr, bool assign_invlet = true );
-        void form_from_map( const tripoint &origin, int range, const Character *pl = nullptr,
+        void form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
-        void form_from_map( map &m, const tripoint &origin, int range, const Character *pl = nullptr,
+        void form_from_map( map &m, const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
-        void form_from_map( map &m, std::vector<tripoint> pts, const Character *pl,
+        void form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                             bool assign_invlet = true );
         /**
          * Remove a specific item from the inventory. The item is compared

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1875,10 +1875,10 @@ const item_category *inventory_selector::naturalize_category( const item_categor
         return iter != categories.end() ? &*iter : nullptr;
     };
 
-    const int dist = rl_dist( u.pos(), pos );
+    const int dist = rl_dist( u.pos_bub().raw(), pos );
 
     if( dist != 0 ) {
-        const std::string suffix = direction_suffix( u.pos(), pos );
+        const std::string suffix = direction_suffix( u.pos_bub().raw(), pos );
         const item_category_id id = item_category_id( string_format( "%s_%s", category.get_id().c_str(),
                                     suffix.c_str() ) );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10053,7 +10053,21 @@ bool item::is_funnel_container( units::volume &bigger_than ) const
 
 bool item::is_emissive() const
 {
-    return light.luminance > 0 || type->light_emission > 0;
+    if( light.luminance > 0 || type->light_emission > 0 ) {
+        return true;
+    }
+
+    for( const item_pocket *pkt : get_all_contained_pockets() ) {
+        if( pkt->transparent() ) {
+            for( const item *it : pkt->all_items_top() ) {
+                if( it->is_emissive() ) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
 }
 
 bool item::is_deployable() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13289,7 +13289,7 @@ bool item::process_fake_mill( map &here, Character * /*carrier*/, const tripoint
         return true; //destroy fake mill
     }
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::mill_finalize( get_avatar(), pos.raw() ); //activate effects when timers goes to zero
+        iexamine::mill_finalize( get_avatar(), pos ); //activate effects when timers goes to zero
         return true; //destroy fake mill item
     }
 
@@ -13306,7 +13306,7 @@ bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoin
     }
 
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::on_smoke_out( pos.raw(), birthday() ); //activate effects when timers goes to zero
+        iexamine::on_smoke_out( pos, birthday() ); //activate effects when timers goes to zero
         return true; //destroy fake smoke when it 'burns out'
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12850,7 +12850,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
         return false;
     }
 
-    units::temperature temp = get_weather().get_temperature( pos.raw() );
+    units::temperature temp = get_weather().get_temperature( pos );
 
     switch( flag ) {
         case temperature_flag::NORMAL:
@@ -12917,7 +12917,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
             // Use weather if above ground, use map temp if below
             units::temperature env_temperature;
             if( pos.z() >= 0 && flag != temperature_flag::ROOT_CELLAR ) {
-                env_temperature = wgen.get_weather_temperature( pos.raw(), time, seed );
+                env_temperature = wgen.get_weather_temperature( get_map().getglobal( pos ), time, seed );
             } else {
                 env_temperature = AVERAGE_ANNUAL_TEMPERATURE;
             }
@@ -13789,7 +13789,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     // Handle links to items in the inventory.
     if( link().source == link_state::solarpack ) {
         if( carrier == nullptr || !carrier->worn_with_flag( flag_SOLARPACK_ON ) ) {
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s has come loose from the solar pack." ),
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the solar pack." ),
                                     link_name() );
             reset_link( true, carrier );
             return false;
@@ -13800,7 +13800,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     };
     if( link().source == link_state::ups ) {
         if( carrier == nullptr || !carrier->cache_has_item_with( flag_IS_UPS, used_ups ) ) {
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s has come loose from the UPS." ), link_name() );
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the UPS." ), link_name() );
             reset_link( true, carrier );
             return false;
         }
@@ -13830,7 +13830,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
             if( carrier != nullptr ) {
                 carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
             } else {
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "Your %s breaks loose!" ), cable_name );
+                add_msg_if_player_sees( pos, m_bad, _( "Your %s breaks loose!" ), cable_name );
             }
             return true;
         } else if( link().length + M_SQRT2 >= link().max_length + 1 && carrier != nullptr ) {
@@ -13910,7 +13910,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     }
 
     if( link().last_processed <= t_veh->part( link_vp_index ).last_disconnected ) {
-        add_msg_if_player_sees( pos.raw(), m_warning, string_format( _( "You detached the %s." ),
+        add_msg_if_player_sees( pos, m_warning, string_format( _( "You detached the %s." ),
                                 type_name() ) );
         return reset_link( true, carrier, -2 );
     }
@@ -14059,7 +14059,7 @@ bool item::reset_link( bool unspool_if_too_long, Character *p, int vpart_index,
         if( p != nullptr ) {
             p->add_msg_if_player( m_warning, _( "Your %s has come loose." ), link_name() );
         } else {
-            add_msg_if_player_sees( cable_position.raw(), m_warning, _( "The %s has come loose." ),
+            add_msg_if_player_sees( cable_position, m_warning, _( "The %s has come loose." ),
                                     link_name() );
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1760,7 +1760,8 @@ static void move_to_parent_pocket_recursive( const tripoint &pos, item &it,
         carrier->add_msg_player_or_npc( m_bad, _( "Your %s falls to the ground." ),
                                         _( "<npcname>'s %s falls to the ground." ), it.display_name() );
     } else {
-        add_msg_if_player_sees( pos, m_bad, _( "The %s falls to the ground." ), it.display_name() );
+        add_msg_if_player_sees( tripoint_bub_ms( pos ), m_bad, _( "The %s falls to the ground." ),
+                                it.display_name() );
     }
     here.add_item_or_charges( pos, it );
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5312,7 +5312,7 @@ std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint_bu
     p->add_msg_if_player( m_neutral, _( "You press a button on the doll to make it talk." ) );
     const SpeechBubble speech = get_speech( it->typeId().str() );
 
-    sounds::sound( p->pos(), speech.volume, sounds::sound_t::electronic_speech,
+    sounds::sound( p->pos_bub(), speech.volume, sounds::sound_t::electronic_speech,
                    speech.text.translated(), true, "speech", it->typeId().str() );
 
     return 1;
@@ -5359,7 +5359,7 @@ std::optional<int> gun_repair( Character *p, item *, item_location &loc )
         return std::nullopt;
     }
     const std::string startdurability = fix.durability_indicator( true );
-    sounds::sound( p->pos(), 8, sounds::sound_t::activity, "crunch", true, "tool", "repair_kit" );
+    sounds::sound( p->pos_bub(), 8, sounds::sound_t::activity, "crunch", true, "tool", "repair_kit" );
     p->practice( skill_mechanics, 10 );
     p->mod_moves( -to_moves<int>( 20_seconds ) );
 
@@ -5468,7 +5468,7 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_
 std::optional<int> iuse::bell( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( it->typeId() == itype_cow_bell ) {
-        sounds::sound( p->pos(), 12, sounds::sound_t::music, _( "Clank!  Clank!" ), true, "misc",
+        sounds::sound( p->pos_bub(), 12, sounds::sound_t::music, _( "Clank!  Clank!" ), true, "misc",
                        "cow_bell" );
         if( !p->is_deaf() ) {
             auto cattle_level =
@@ -5480,7 +5480,7 @@ std::optional<int> iuse::bell( Character *p, item *it, const tripoint_bub_ms & )
             }
         }
     } else {
-        sounds::sound( p->pos(), 4, sounds::sound_t::music, _( "Ring!  Ring!" ), true, "misc", "bell" );
+        sounds::sound( p->pos_bub(), 4, sounds::sound_t::music, _( "Ring!  Ring!" ), true, "misc", "bell" );
     }
     return 1;
 }
@@ -6755,7 +6755,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
         trajectory.push_back( aim_point );
 
         p->mod_moves( -to_moves<int>( 1_seconds ) * 0.5 );
-        sounds::sound( p->pos(), 8, sounds::sound_t::activity, _( "Click." ), true, "tool",
+        sounds::sound( p->pos_bub(), 8, sounds::sound_t::activity, _( "Click." ), true, "tool",
                        "camera_shutter" );
 
         for( std::vector<tripoint_bub_ms>::iterator point_it = trajectory.begin();
@@ -7219,7 +7219,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
     for( const tripoint_bub_ms &loc : here.points_in_radius( p.pos_bub(), 60 ) ) {
         for( item &it : here.i_at( loc ) ) {
             if( it.has_flag( flag_RADIO_ACTIVATION ) && it.has_flag( signal ) ) {
-                sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
+                sounds::sound( p.pos_bub(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
                 if( it.has_flag( flag_RADIO_INVOKE_PROC ) ) {
                     // Invoke to transform a radio-modded explosive into its active form
                     // The item activation may have all kinds of requirements. Like requiring item to be wielded.
@@ -7240,7 +7240,7 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                 } );
 
                 if( itm != nullptr ) {
-                    sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
+                    sounds::sound( p.pos_bub(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
                     // Invoke to transform a radio-modded explosive into its active form
                     if( itm->has_flag( flag_RADIO_INVOKE_PROC ) ) {
                         itm->type->invoke( &p, *itm, loc.raw() );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -747,7 +747,7 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms 
                 if( monster *const mon_ptr = creatures.creature_at<monster>( dest ) ) {
                     monster &critter = *mon_ptr;
                     if( !critter.type->in_species( species_FUNGUS ) ) {
-                        add_msg_if_player_sees( dest.raw(), m_warning, _( "The %s is covered in tiny spores!" ),
+                        add_msg_if_player_sees( dest, m_warning, _( "The %s is covered in tiny spores!" ),
                                                 critter.name() );
                     }
                     if( !critter.make_fungus() ) {
@@ -3347,7 +3347,7 @@ std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint_bub_ms 
             found = here.passable( goop ) && here.tr_at( goop ).is_null();
         } while( !found && tries < 10 );
         if( found ) {
-            add_msg_if_player_sees( goop.raw(), m_warning,
+            add_msg_if_player_sees( goop, m_warning,
                                     _( "A nearby splatter of goo forms into a goo pit." ) );
             here.trap_set( goop, tr_goo );
         } else {
@@ -7916,7 +7916,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
             meal.heat_up();
         } else {
             meal.set_item_temperature( std::max( temperatures::cold,
-                                                 get_weather().get_temperature( pos.raw() ) ) );
+                                                 get_weather().get_temperature( pos ) ) );
         }
 
         it->active = false;
@@ -7948,7 +7948,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     const w_point weatherPoint = *weather.weather_precise;
 
     /* Possibly used twice. Worth spending the time to precalculate. */
-    const units::temperature player_local_temp = weather.get_temperature( p->pos_bub().raw() );
+    const units::temperature player_local_temp = weather.get_temperature( p->pos_bub() );
 
     if( it->typeId() == itype_weather_reader ) {
         p->add_msg_if_player( m_neutral, _( "The %s's monitor slowly outputs the data…" ),
@@ -8270,8 +8270,8 @@ heating_requirements heating_requirements_for_weight( const units::mass &frozen,
 
 static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( Character *p )
 {
-    const std::optional<tripoint> pt = choose_adjacent_highlight( _( "Select an appliance." ),
-                                       _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
+    const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( _( "Select an appliance." ),
+            _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
     if( !pt ) {
         p->add_msg_if_player( m_info, _( "You haven't selected any appliance." ) );
         return std::nullopt;
@@ -8303,7 +8303,7 @@ static std::optional<std::pair<tripoint, itype_id>> appliance_heater_selector( C
                     p->add_msg_if_player( m_info, _( "You haven't selected any heater." ) );
                     return std::nullopt;
                 } else {
-                    return std::make_pair( pt.value(), pseudo_tools[app_menu.ret] );
+                    return std::make_pair( pt.value().raw(), pseudo_tools[app_menu.ret] );
                 }
 
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2036,7 +2036,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
     p->mod_moves( -moves );
     if( rng( 0, 10 ) - it.damage_level() > success_chance && !p->is_underwater() ) {
         if( noise > 0 ) {
-            sounds::sound( p->pos(), noise, sounds::sound_t::combat, success_message );
+            sounds::sound( p->pos_bub(), noise, sounds::sound_t::combat, success_message );
         } else {
             p->add_msg_if_player( "%s", success_message );
         }
@@ -2132,7 +2132,7 @@ std::optional<int> manualnoise_actor::use( Character *p, item &, const tripoint_
     // Uses the moves specified by iuse_actor's definition
     p->mod_moves( -moves );
     if( noise > 0 ) {
-        sounds::sound( p->pos(), noise, sounds::sound_t::activity,
+        sounds::sound( p->pos_bub(), noise, sounds::sound_t::activity,
                        noise_message.empty() ? _( "Hsss" ) : noise_message.translated(), true, noise_id, noise_variant );
     }
     p->add_msg_if_player( "%s", use_message );
@@ -2316,10 +2316,10 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     if( morale_effect >= 0 ) {
-        sounds::sound( p->pos(), volume, sounds::sound_t::music, desc, true, "musical_instrument",
+        sounds::sound( p->pos_bub(), volume, sounds::sound_t::music, desc, true, "musical_instrument",
                        it.typeId().str() );
     } else {
-        sounds::sound( p->pos(), volume, sounds::sound_t::music, desc, true, "musical_instrument_bad",
+        sounds::sound( p->pos_bub(), volume, sounds::sound_t::music, desc, true, "musical_instrument_bad",
                        it.typeId().str() );
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -405,7 +405,7 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
 
     std::map<quality_id, int> unmet_reqs;
     inventory inv;
-    inv.form_from_map( p.pos(), 1, &p, true, true );
+    inv.form_from_map( p.pos_bub(), 1, &p, true, true );
     for( const auto &quality : qualities_needed ) {
         if( !p.has_quality( quality.first, quality.second ) &&
             !inv.has_quality( quality.first, quality.second ) ) {
@@ -3925,7 +3925,7 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
                                  name );
         } else {
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
-            existing_trap.trigger( pos.raw(), p );
+            existing_trap.trigger( pos, p );
         }
         return false;
     }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -68,19 +68,32 @@ std::string four_quadrants::to_string() const
                           ( *this )[quadrant::SW], ( *this )[quadrant::NW] );
 }
 
+void map::add_item_light_recursive( const tripoint_bub_ms &p, const item &it )
+{
+    float ilum = 0.0f; // brightness
+    units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
+    units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
+    if( it.getlight( ilum, iwidth, idir ) ) {
+        if( iwidth > 0_degrees ) {
+            apply_light_arc( p, idir, ilum, iwidth );
+        } else {
+            add_light_source( p, ilum );
+        }
+    }
+
+    for( const item_pocket *pkt : it.get_all_contained_pockets() ) {
+        if( pkt->transparent() ) {
+            for( const item *cont : pkt->all_items_top() ) {
+                add_item_light_recursive( p, *cont );
+            }
+        }
+    }
+}
+
 void map::add_light_from_items( const tripoint_bub_ms &p, const item_stack &items )
 {
     for( const item &it : items ) {
-        float ilum = 0.0f; // brightness
-        units::angle iwidth = 0_degrees; // 0-360 degrees. 0 is a circular light_source
-        units::angle idir = 0_degrees;   // otherwise, it's a light_arc pointed in this direction
-        if( it.getlight( ilum, iwidth, idir ) ) {
-            if( iwidth > 0_degrees ) {
-                apply_light_arc( p, idir, ilum, iwidth );
-            } else {
-                add_light_source( p, ilum );
-            }
-        }
+        add_item_light_recursive( p, it );
     }
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1315,7 +1315,7 @@ void spell::use_components( Character &guy ) const
     const requirement_data &spell_components = type->spell_components.obj();
     // if we're here, we're assuming the Character has the correct components (using can_cast())
     inventory map_inv;
-    map_inv.form_from_map( guy.pos(), 0, &guy, true, false );
+    map_inv.form_from_map( guy.pos_bub(), 0, &guy, true, false );
     for( const std::vector<item_comp> &comp_vec : spell_components.get_components() ) {
         guy.consume_items( guy.select_item_component( comp_vec, 1, map_inv ), 1 );
     }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -747,6 +747,7 @@ void enchant_cache::serialize( JsonOut &jsout ) const
             jsout.member( "id", struc_desc.id );
             jsout.end_object();
         }
+        jsout.end_array();
         jsout.end_object();
     }
     jsout.end_array();

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -318,11 +318,15 @@ bool enchantment::is_active( const Character &guy, const bool active ) const
 bool enchantment::is_active( const monster &mon ) const
 {
     //This is very limited at the moment. Basically, we can't use any conditions except "ALWAYS"
-    if( active_conditions.second == condition::ALWAYS && !mon.is_fake() ) {
+    if( active_conditions.second == condition::ALWAYS ) {
         return true;
     }
-    // Dialogue conditions for monsters seems like overkill.
-    // Definitely not an excuse for not knowing how to add them. Nope! Sure isn't!
+
+    if( active_conditions.second == condition::DIALOG_CONDITION ) {
+        const_dialogue d( get_const_talker_for( mon ), nullptr );
+        return dialog_condition( d );
+    }
+
     return false;
 }
 

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1448,12 +1448,19 @@ void enchant_cache::clear()
     skill_values_multiply.clear();
     damage_values_add.clear();
     damage_values_multiply.clear();
+    armor_values_add.clear();
+    armor_values_multiply.clear();
+    extra_damage_add.clear();
+    extra_damage_multiply.clear();
     special_vision_vector.clear();
     hit_me_effect.clear();
     hit_you_effect.clear();
     ench_effects.clear();
+    emitter.reset();
     mutations.clear();
     modified_bodyparts.clear();
+    intermittent_activation.clear();
+    details.clear();
 }
 
 bool enchant_cache::operator==( const enchant_cache &rhs ) const

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -721,7 +721,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             }
         } else if( sp.damage( caster ) < 0 ) {
             sp.heal( target, caster );
-            add_msg_if_player_sees( cr->pos(), m_good, _( "%s wounds are closing up!" ),
+            add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );
         }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -619,7 +619,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                     cr->add_msg_player_or_npc( "You dodge out of the way!", "%s dodges out of the way!" );
                 } else {
                     if( !cr->has_effect( effect_invisibility ) ) {
-                        add_msg_if_player_sees( cr->pos(), m_bad, _( "%1$s dodges out of the way!" ),
+                        add_msg_if_player_sees( cr->pos_bub(), m_bad, _( "%1$s dodges out of the way!" ),
                                                 cr->disp_name( false, true ) );
                     }
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9358,7 +9358,7 @@ void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since
     }
 }
 
-void map::cut_down_tree( tripoint_bub_ms p, point dir )
+void map::cut_down_tree( tripoint_bub_ms p, point_rel_ms dir )
 {
     if( !zlevels ) {
         debugmsg( "Call to cut_down_tree from a map that doesn't support zlevels." );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10787,7 +10787,7 @@ void map::maybe_trigger_prox_trap( const tripoint_bub_ms &pos, Creature &c,
         return;
     }
 
-    if( !tr.has_flag( json_flag_UNDODGEABLE ) && may_avoid && c.avoid_trap( pos.raw(), tr ) ) {
+    if( !tr.has_flag( json_flag_UNDODGEABLE ) && may_avoid && c.avoid_trap( pos, tr ) ) {
         Character *const pl = c.as_character();
         if( !tr.is_always_invisible() && pl && !pl->knows_trap( pos ) ) {
             pl->add_msg_if_player( _( "You've spotted a %1$s!" ), tr.name() );
@@ -10951,7 +10951,7 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
         return;
     }
 
-    if( !tr.has_flag( json_flag_UNDODGEABLE ) && may_avoid && c.avoid_trap( pos.raw(), tr ) ) {
+    if( !tr.has_flag( json_flag_UNDODGEABLE ) && may_avoid && c.avoid_trap( pos, tr ) ) {
         Character *const pl = c.as_character();
         if( !tr.is_always_invisible() && pl && !pl->knows_trap( pos ) ) {
             pl->add_msg_if_player( _( "You've spotted a %1$s!" ), tr.name() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3146,7 +3146,7 @@ void map::drop_items( const tripoint_bub_ms &p )
             } else if( creature_hit_chance < 100 ) {
                 hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::leg );
             } else {
-                add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s misses %2$s!" ), i.tname(),
+                add_msg_if_player_sees( creature_below->pos_bub(), _( "Falling %1$s misses %2$s!" ), i.tname(),
                                         creature_below->disp_name() );
             }
             // Did we hit at all? Then run the message.
@@ -3154,10 +3154,10 @@ void map::drop_items( const tripoint_bub_ms &p )
                 if( hit_part.is_valid() && !creature_below->is_monster() ) {
                     //~First positional argument: Item name. Second: Name of a person (e.g. "Jane") or player (e.g. "you"). Third: Body part name, accusative.
                     const std::string msg = _( "Falling %1$s hits %2$s on the %3$s for %4$i damage!" );
-                    add_msg_if_player_sees( creature_below->pos(), msg,
+                    add_msg_if_player_sees( creature_below->pos_bub(), msg,
                                             i.tname(), creature_below->disp_name(), hit_part->accusative, static_cast<int>( damage ) );
                 } else {
-                    add_msg_if_player_sees( creature_below->pos(), _( "Falling %1$s hits %2$s for %3$i damage!" ),
+                    add_msg_if_player_sees( creature_below->pos_bub(), _( "Falling %1$s hits %2$s for %3$i damage!" ),
                                             i.tname(), creature_below->disp_name(), static_cast<int>( damage ) );
                 }
                 // FIXME: Hardcoded damage type!
@@ -4280,16 +4280,16 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
 
     // Let the player know that the item was damaged if they can see it.
     if( items_destroyed > 1 ) {
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s destroys several items!" ), cause_message );
+        add_msg_if_player_sees( p, m_bad, _( "The %s destroys several items!" ), cause_message );
     } else if( items_destroyed == 1 && items_damaged == 1 ) {
         //~ %1$s: the cause of destruction, %2$s: destroyed item name
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
+        add_msg_if_player_sees( p, m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %s damages several items." ), cause_message );
+        add_msg_if_player_sees( p, m_bad, _( "The %s damages several items." ), cause_message );
     } else if( items_damaged == 1 ) {
         //~ %1$s: the cause of damage, %2$s: damaged item name
-        add_msg_if_player_sees( p.raw(), m_bad, _( "The %1$s damages the %2$s." ), cause_message,
+        add_msg_if_player_sees( p, m_bad, _( "The %1$s damages the %2$s." ), cause_message,
                                 damaged_item_name );
     }
 
@@ -5095,7 +5095,7 @@ bool map::hit_with_acid( const tripoint_bub_ms &p )
                t == ter_t_bars ||
                t == ter_t_reb_cage ) {
         ter_set( p, ter_t_floor );
-        add_msg_if_player_sees( p.raw(), m_warning, _( "The metal bars melt!" ) );
+        add_msg_if_player_sees( p, m_warning, _( "The metal bars melt!" ) );
     } else if( t == ter_t_door_b ) {
         if( one_in( 4 ) ) {
             ter_set( p, ter_t_door_frame );
@@ -5885,7 +5885,7 @@ item map::liquid_from( const tripoint_bub_ms &p ) const
         source_terrain.liquid_source_count == std::make_pair( 0, 0 ) ) {
 
         item ret( source_terrain.liquid_source_item_id, calendar::turn, item::INFINITE_CHARGES );
-        ret.set_item_temperature( std::max( weather.get_temperature( p.raw() ),
+        ret.set_item_temperature( std::max( weather.get_temperature( p ),
                                             units::from_celsius( source_terrain.liquid_source_min_temp ) ) );
         return ret;
     }
@@ -7437,7 +7437,7 @@ void map::update_visibility_cache( const int zlev )
 {
     Character &player_character = get_player_character();
     if( !visibility_variables_cache.visibility_cache_dirty &&
-        player_character.pos_bub().raw() == visibility_variables_cache.last_pos ) {
+        player_character.pos_bub() == visibility_variables_cache.last_pos ) {
         return;
     }
 
@@ -7492,7 +7492,7 @@ void map::update_visibility_cache( const int zlev )
     }
 #endif
 
-    visibility_variables_cache.last_pos = player_character.pos();
+    visibility_variables_cache.last_pos = player_character.pos_bub();
     visibility_variables_cache.visibility_cache_dirty = false;
 }
 
@@ -9336,7 +9336,7 @@ void map::produce_sap( const tripoint_bub_ms &p, const time_duration &time_since
 
     item sap( "maple_sap", calendar::turn );
 
-    sap.set_item_temperature( get_weather().get_temperature( p.raw() ) );
+    sap.set_item_temperature( get_weather().get_temperature( p ) );
     sap.charges = new_charges;
 
     // Is there a proper container?
@@ -10800,7 +10800,7 @@ void map::maybe_trigger_prox_trap( const tripoint_bub_ms &pos, Creature &c,
         c.add_msg_player_or_npc( m_bad, tr.get_trigger_message_u(), tr.get_trigger_message_npc(),
                                  tr.name() );
     }
-    tr.trigger( pos.raw(), c );
+    tr.trigger( pos, c );
 }
 
 // TODO: Should be moved to submap or Creature?
@@ -10964,7 +10964,7 @@ void map::maybe_trigger_trap( const tripoint_bub_ms &pos, Creature &c, const boo
         c.add_msg_player_or_npc( m_bad, tr.get_trigger_message_u(), tr.get_trigger_message_npc(),
                                  tr.name() );
     }
-    tr.trigger( c.pos(), c );
+    tr.trigger( c.pos_bub(), c );
 }
 
 template<typename Functor>

--- a/src/map.h
+++ b/src/map.h
@@ -133,7 +133,7 @@ struct visibility_variables {
     int u_clairvoyance = 0;
     float vision_threshold = 0.0f;
     std::optional<field_type_id> clairvoyance_field;
-    tripoint last_pos;
+    tripoint_bub_ms last_pos;
 };
 
 struct bash_params {
@@ -304,7 +304,7 @@ struct drawsq_params {
 
 struct tile_render_info {
     struct common {
-        const tripoint pos;
+        const tripoint_bub_ms pos;
         // accumulator for 3d tallness of sprites rendered here so far;
         int height_3d = 0;
 

--- a/src/map.h
+++ b/src/map.h
@@ -2226,7 +2226,7 @@ class map
         * Removes the tree at 'p' and produces a trunk_yield length line of trunks in the 'dir'
         * direction from 'p', leaving a stump behind at 'p'.
         */
-        void cut_down_tree( tripoint_bub_ms p, point dir );
+        void cut_down_tree( tripoint_bub_ms p, point_rel_ms dir );
     protected:
         /**
          * Radiation-related plant (and fungus?) death.
@@ -2636,7 +2636,7 @@ class tinymap : private map
         tinymap( int mapsize, bool zlev ) : map( mapsize, zlev ) {};
 
         // This operation cannot be used with tinymap due to a lack of zlevel support, but are carried through for use by smallmap.
-        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+        void cut_down_tree( tripoint_omt_ms p, point_rel_ms dir ) {
             map::cut_down_tree( rebase_bub( p ), dir );
         };
 
@@ -2942,7 +2942,7 @@ class smallmap : public tinymap
     public:
         smallmap() : tinymap( 2, true ) {}
 
-        void cut_down_tree( tripoint_omt_ms p, point dir ) {
+        void cut_down_tree( tripoint_omt_ms p, point_rel_ms dir ) {
             tinymap::cut_down_tree( p, dir );
         };
 };

--- a/src/map.h
+++ b/src/map.h
@@ -2419,6 +2419,7 @@ class map
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
                               const tripoint &s, const tripoint &e, float luminance );
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack &items );
+        void add_item_light_recursive( const tripoint_bub_ms &p, const item &it );
         std::unique_ptr<vehicle> add_vehicle_to_map( std::unique_ptr<vehicle> veh, bool merge_wrecks );
 
         // Internal methods used to bash just the selected features

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -129,7 +129,6 @@ static const map_extra_id map_extra_mx_corpses( "mx_corpses" );
 static const map_extra_id map_extra_mx_fungal_zone( "mx_fungal_zone" );
 static const map_extra_id map_extra_mx_grove( "mx_grove" );
 static const map_extra_id map_extra_mx_helicopter( "mx_helicopter" );
-static const map_extra_id map_extra_mx_jabberwock( "mx_jabberwock" );
 static const map_extra_id map_extra_mx_looters( "mx_looters" );
 static const map_extra_id map_extra_mx_minefield( "mx_minefield" );
 static const map_extra_id map_extra_mx_null( "mx_null" );
@@ -144,7 +143,6 @@ static const map_extra_id map_extra_mx_shrubbery( "mx_shrubbery" );
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 static const mongroup_id GROUP_FUNGI_FLOWERS( "GROUP_FUNGI_FLOWERS" );
 static const mongroup_id GROUP_FUNGI_ZOMBIE( "GROUP_FUNGI_ZOMBIE" );
-static const mongroup_id GROUP_JABBERWOCK( "GROUP_JABBERWOCK" );
 static const mongroup_id GROUP_MIL_PASSENGER( "GROUP_MIL_PASSENGER" );
 static const mongroup_id GROUP_MIL_PILOT( "GROUP_MIL_PILOT" );
 static const mongroup_id GROUP_MIL_WEAK( "GROUP_MIL_WEAK" );
@@ -1166,22 +1164,6 @@ static bool mx_portal_in( map &m, const tripoint &abs_sub )
     }
 
     return true;
-}
-
-static bool mx_jabberwock( map &m, const tripoint &/*loc*/ )
-{
-    // A rare chance to spawn a jabberwock. This was extracted from the hardcoded forest mapgen
-    // and moved into a map extra. It still has a one_in chance of spawning because otherwise
-    // the rarity skewed the values for all the other extras too much. I considered moving it
-    // into the monster group, but again the hardcoded rarity it had in the forest mapgen was
-    // not easily replicated there.
-    if( one_in( 50 ) ) {
-        m.place_spawns( GROUP_JABBERWOCK, 1, point_bub_ms::zero, { SEEX * 2, SEEY * 2 },
-                        m.get_abs_sub().z(), 1, true );
-        return true;
-    }
-
-    return false;
 }
 
 static bool mx_grove( map &m, const tripoint &abs_sub )
@@ -2214,7 +2196,6 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_minefield, mx_minefield },
     { map_extra_mx_helicopter, mx_helicopter },
     { map_extra_mx_portal_in, mx_portal_in },
-    { map_extra_mx_jabberwock, mx_jabberwock },
     { map_extra_mx_grove, mx_grove },
     { map_extra_mx_shrubbery, mx_shrubbery },
     { map_extra_mx_pond, mx_pond },

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7008,10 +7008,10 @@ computer *map::add_computer( const tripoint_bub_ms &p, const std::string &name, 
     submap *const place_on_submap = get_submap_at( p, l );
     if( place_on_submap == nullptr ) {
         debugmsg( "Tried to add computer at (%d,%d) but the submap is not loaded", l.x(), l.y() );
-        static computer null_computer = computer( name, security, p.raw() );
+        static computer null_computer = computer( name, security, p );
         return &null_computer;
     }
-    place_on_submap->set_computer( l, computer( name, security, p.raw() ) );
+    place_on_submap->set_computer( l, computer( name, security, p ) );
     return place_on_submap->get_computer( l );
 }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3120,7 +3120,7 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
             if( is_boring_wall || act_trap == apply_action::act_erase ) {
                 dat.m.remove_trap( p );
             } else if( act_trap == apply_action::act_dismantle ) {
-                dat.m.tr_at( p ).on_disarmed( dat.m, p.raw() );
+                dat.m.tr_at( p ).on_disarmed( dat.m, p );
             }
 
             if( is_boring_wall || act_item == apply_action::act_erase ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3508,8 +3508,8 @@ class jmapgen_remove_vehicles : public jmapgen_piece
     public:
         std::vector<vproto_id> vehicles_to_remove;
         jmapgen_remove_vehicles( const JsonObject &jo, const std::string_view/*context*/ ) {
-            for( std::string item_id : jo.get_string_array( "vehicles" ) ) {
-                vehicles_to_remove.emplace_back( item_id );
+            for( std::string vehicle_prototype_id : jo.get_string_array( "vehicles" ) ) {
+                vehicles_to_remove.emplace_back( vehicle_prototype_id );
             }
         }
         mapgen_phase phase() const override {
@@ -3517,18 +3517,17 @@ class jmapgen_remove_vehicles : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &/*context*/ ) const override {
-
             const tripoint_bub_ms start( int( x.val ), int( y.val ), dat.zlevel() + z.get() );
             const tripoint_bub_ms end( int( x.valmax ), int( y.valmax ), dat.zlevel() + z.get() );
             const tripoint_range<tripoint_bub_ms> range = tripoint_range<tripoint_bub_ms>( start, end );
+            auto is_in_vehicles_to_remove = [&]( vproto_id & vproto ) -> bool {
+                return std::find( vehicles_to_remove.begin(), vehicles_to_remove.end(), vproto ) != vehicles_to_remove.end();
+            };
             for( const tripoint_bub_ms &p : range ) {
-                if( optional_vpart_position vp = dat.m.veh_at( p ) ) {
-                    const auto rit = std::find( vehicles_to_remove.begin(), vehicles_to_remove.end(),
-                                                vp->vehicle().type );
-                    if( rit != vehicles_to_remove.end() ) {
-                        get_map().remove_vehicle_from_cache( &vp->vehicle(), start.z(), end.z() );
-                        dat.m.destroy_vehicle( &vp->vehicle() );
-                    }
+                optional_vpart_position vp = dat.m.veh_at( p );
+                if( vp && ( vehicles_to_remove.empty() || is_in_vehicles_to_remove( vp->vehicle().type ) ) ) {
+                    get_map().remove_vehicle_from_cache( &vp->vehicle(), start.z(), end.z() );
+                    dat.m.destroy_vehicle( &vp->vehicle() );
                 }
             }
         }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1206,7 +1206,7 @@ bool gun_actor::try_target( monster &z, Creature &target ) const
 
     if( not_targeted || not_laser_locked ) {
         if( targeting_volume > 0 && !targeting_sound.empty() ) {
-            sounds::sound( z.pos(), targeting_volume, sounds::sound_t::alarm,
+            sounds::sound( z.pos_bub(), targeting_volume, sounds::sound_t::alarm,
                            targeting_sound );
         }
         if( not_targeted ) {
@@ -1271,7 +1271,7 @@ bool gun_actor::shoot( monster &z, const tripoint_bub_ms &target, const gun_mode
 
     if( !gun.ammo_sufficient( nullptr ) ) {
         if( !no_ammo_sound.empty() ) {
-            sounds::sound( z.pos(), 10, sounds::sound_t::combat, no_ammo_sound );
+            sounds::sound( z.pos_bub(), 10, sounds::sound_t::combat, no_ammo_sound );
         }
         return false;
     }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -307,7 +307,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
         target_name = target_monster->disp_name();
     }
 
-    add_msg_if_player_sees( target.raw(), spell_instance.message(), mon.disp_name(),
+    add_msg_if_player_sees( target, spell_instance.message(), mon.disp_name(),
                             spell_instance.name(), target_name );
 
     avatar fake_player;
@@ -732,8 +732,8 @@ bool melee_actor::call( monster &z ) const
 
     if( uncanny_dodgeable && target->uncanny_dodge() ) {
         game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
-        sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+        sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                        z.name(), body_part_name_accusative( bp_id ) );
@@ -742,8 +742,8 @@ bool melee_actor::call( monster &z ) const
 
     if( dodgeable ) {
         if( hitspread < 0 ) {
-            sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
-                                     sfx::get_heard_angle( z.pos() ) );
+            sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
+                                     sfx::get_heard_angle( z.pos_bub() ) );
             target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                            get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                            mon_name, body_part_name_accusative( bp_id ) );
@@ -877,8 +877,8 @@ bool melee_actor::call( monster &z ) const
     if( damage_total > 0 ) {
         on_damage( z, *target, dealt_damage );
     } else {
-        sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+        sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos_bub() ),
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, no_dmg_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : translation(),
                                        mon_name, body_part_name_accusative( grabbed_bp_id.value_or( bp_id ) ) );
@@ -944,7 +944,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
 {
     if( target.is_avatar() ) {
         sfx::play_variant_sound( "mon_bite", "bite_hit", sfx::get_heard_volume( z.pos_bub() ),
-                                 sfx::get_heard_angle( z.pos() ) );
+                                 sfx::get_heard_angle( z.pos_bub() ) );
         sfx::do_player_death_hurt( dynamic_cast<Character &>( target ), false );
     }
     game_message_type msg_type = target.attitude_to( get_player_character() ) ==

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -950,7 +950,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             if( !is_quiet() ) { // check martial arts silence
                 //sound generated later
                 int volume = enchantment_cache->modify_value( enchant_vals::mod::ATTACK_NOISE, 8 );
-                sounds::sound( pos(), volume, sounds::sound_t::combat, _( "whack!" ) );
+                sounds::sound( pos_bub(), volume, sounds::sound_t::combat, _( "whack!" ) );
             }
             std::string material = "flesh";
             if( t.is_monster() ) {
@@ -1952,7 +1952,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
         // if the weapon needs ammo we now expend it
         cur_weapon.get_item()->ammo_consume( 1, pos_bub(), this );
         // thing going off should be as loud as the ammo
-        sounds::sound( pos(), current_ammo->ammo->loudness, sounds::sound_t::combat, _( "Crack!" ), true );
+        sounds::sound( pos_bub(), current_ammo->ammo->loudness, sounds::sound_t::combat, _( "Crack!" ), true );
         const itype_id casing = *current_ammo->ammo->casing;
         if( cur_weapon.get_item()->has_flag( flag_RELOAD_EJECT ) ) {
             cur_weapon.get_item()->force_insert_item( item( casing ).set_flag( flag_CASING ),
@@ -2457,7 +2457,7 @@ std::string Character::melee_special_effects( Creature &t, damage_instance &d, i
                                    weap.tname() );
         }
 
-        sounds::sound( pos(), 16, sounds::sound_t::combat, "Crack!", true, "smash_success",
+        sounds::sound( pos_bub(), 16, sounds::sound_t::combat, "Crack!", true, "smash_success",
                        "smash_glass_contents" );
         // Dump its contents on the ground
         weap.spill_contents( pos_bub() );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -687,7 +687,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );
-        sfx::generate_melee_sound( pos(), t.pos(), false, false );
+        sfx::generate_melee_sound( pos_bub(), t.pos_bub(), false, false );
 
         const ma_technique miss_recovery = martial_arts_data->get_miss_recovery( *this );
 
@@ -959,7 +959,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                     material = "steel";
                 }
             }
-            sfx::generate_melee_sound( pos(), t.pos(), true, t.is_monster(), material );
+            sfx::generate_melee_sound( pos_bub(), t.pos_bub(), true, t.is_monster(), material );
             int dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1001,11 +1001,6 @@ void add_msg( const game_message_params &params, std::string msg )
     Messages::add_msg( params, std::move( msg ) );
 }
 
-void add_msg_if_player_sees( const tripoint &target, std::string msg )
-{
-    add_msg_if_player_sees( tripoint_bub_ms( target ), std::move( msg ) );
-}
-
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
     if( get_player_view().sees( target ) ) {
@@ -1018,12 +1013,6 @@ void add_msg_if_player_sees( const Creature &target, std::string msg )
     if( get_player_view().sees( target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
-}
-
-void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
-                             std::string msg )
-{
-    add_msg_if_player_sees( tripoint_bub_ms( target ), params, std::move( msg ) );
 }
 
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,

--- a/src/messages.h
+++ b/src/messages.h
@@ -78,12 +78,10 @@ inline void add_msg( const game_message_params &params, const char *const msg, A
     return add_msg( params, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-// TODO: Get rid of untyped overload
-void add_msg_if_player_sees( const tripoint &target, std::string msg );
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg );
 void add_msg_if_player_sees( const Creature &target, std::string msg );
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const std::string &msg,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target, const std::string &msg,
                                     Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
@@ -91,11 +89,6 @@ inline void add_msg_if_player_sees( const tripoint &target, const std::string &m
 template<typename ...Args>
 inline void add_msg_if_player_sees( const Creature &target, const std::string &msg,
                                     Args &&... args )
-{
-    return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
-}
-template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const char *const msg, Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
@@ -111,7 +104,7 @@ inline void add_msg_if_player_sees( const Creature &target, const char *const ms
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const translation &msg,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target, const translation &msg,
                                     Args &&... args )
 {
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
@@ -123,15 +116,13 @@ inline void add_msg_if_player_sees( const Creature &target, const translation &m
     return add_msg_if_player_sees( target, string_format( msg, std::forward<Args>( args )... ) );
 }
 
-// TODO: Get rid of untyped overload
-void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
-                             std::string msg );
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg );
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,
                              std::string msg );
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target,
+                                    const game_message_params &params,
                                     const std::string &msg, Args &&... args )
 {
     if( params.type == m_debug && !debug_mode ) {
@@ -151,7 +142,8 @@ inline void add_msg_if_player_sees( const Creature &target, const game_message_p
                                    std::forward<Args>( args )... ) );
 }
 template<typename ...Args>
-inline void add_msg_if_player_sees( const tripoint &target, const game_message_params &params,
+inline void add_msg_if_player_sees( const tripoint_bub_ms &target,
+                                    const game_message_params &params,
                                     const char *const msg, Args &&... args )
 {
     if( params.type == m_debug && !debug_mode ) {

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2913,7 +2913,7 @@ void mission_data::add( const ui_mission_id &id, const std::string &name_display
     if( !possible ) {
         entries[10].push_back( miss );
     }
-    const point direction = id.id.dir ? *id.id.dir : base_camps::base_dir;
+    const point_rel_omt direction = id.id.dir ? *id.id.dir : base_camps::base_dir;
     const int tab_order = base_camps::all_directions.at( direction ).tab_order;
     entries[tab_order + 1].emplace_back( miss );
 }

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -103,7 +103,7 @@ struct mission_id {
     mission_kind id = No_Mission;
     std::string parameters;
     mapgen_arguments mapgen_args;
-    std::optional<point> dir;
+    std::optional<point_rel_omt> dir;
 
     void serialize( JsonOut & ) const;
     void deserialize( const JsonValue & );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4951,7 +4951,7 @@ bool mattack::kamikaze( monster *z )
     */
     // END HORRIBLE HACK
 
-    add_msg_if_player_sees( z->pos(), m_bad, _( "The %s lights up menacingly." ), z->name() );
+    add_msg_if_player_sees( z->pos_bub(), m_bad, _( "The %s lights up menacingly." ), z->name() );
 
     return true;
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -637,7 +637,7 @@ bool mattack::shriek( monster *z )
 
     // It takes a while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 2.4 );
-    sounds::sound( z->pos(), 50, sounds::sound_t::alert, _( "a terrible shriek!" ), false, "shout",
+    sounds::sound( z->pos_bub(), 50, sounds::sound_t::alert, _( "a terrible shriek!" ), false, "shout",
                    "shriek" );
     return true;
 }
@@ -656,7 +656,7 @@ bool mattack::shriek_alert( monster *z )
     }
     add_msg_if_player_sees( *z, _( "The %s begins shrieking!" ), z->name() );
     z->mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );
-    sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
+    sounds::sound( z->pos_bub(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
                    "wail" );
     z->add_effect( effect_shrieking, 1_minutes );
 
@@ -722,7 +722,7 @@ bool mattack::howl( monster *z )
 
     // It takes a while
     z->mod_moves( -to_moves<int>( 2_seconds ) );
-    sounds::sound( z->pos(), 35, sounds::sound_t::alert, _( "an ear-piercing howl!" ), false, "shout",
+    sounds::sound( z->pos_bub(), 35, sounds::sound_t::alert, _( "an ear-piercing howl!" ), false, "shout",
                    "howl" );
 
     // TODO: Make this use mon's faction when those are in
@@ -756,7 +756,7 @@ bool mattack::rattle( monster *z )
 
     // It takes a very short while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 0.2 );
-    sounds::sound( z->pos(), 10, sounds::sound_t::alarm, _( "a sibilant rattling sound!" ), false,
+    sounds::sound( z->pos_bub(), 10, sounds::sound_t::alarm, _( "a sibilant rattling sound!" ), false,
                    "misc", "rattling" );
 
     return true;
@@ -781,7 +781,7 @@ bool mattack::acid( monster *z )
     }
     // It takes a while
     z->mod_moves( -to_moves<int>( 3_seconds ) );
-    sounds::sound( z->pos(), 4, sounds::sound_t::combat, _( "a spitting noise." ), false, "misc",
+    sounds::sound( z->pos_bub(), 4, sounds::sound_t::combat, _( "a spitting noise." ), false, "misc",
                    "spitting" );
 
     projectile proj;
@@ -949,7 +949,7 @@ bool mattack::shockstorm( monster *z )
         add_msg( msg_type, _( "A bolt of electricity arcs towards %s!" ), target->disp_name() );
     }
     if( !player_character.is_deaf() ) {
-        sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->pos() ) );
+        sfx::play_variant_sound( "fire_gun", "bio_lightning", sfx::get_heard_volume( z->pos_bub() ) );
     }
     tripoint_bub_ms tarp( target->posx() + rng( -1, 1 ) + rng( -1, 1 ),
                           target->posy() + rng( -1, 1 ) + rng( -1, 1 ),
@@ -1871,7 +1871,7 @@ bool mattack::spit_sap( monster *z )
 
 bool mattack::triffid_heartbeat( monster *z )
 {
-    sounds::sound( z->pos(), 14, sounds::sound_t::movement, _( "thu-THUMP." ), true, "misc",
+    sounds::sound( z->pos_bub(), 14, sounds::sound_t::movement, _( "thu-THUMP." ), true, "misc",
                    "heartbeat" );
     z->mod_moves( -to_moves<int>( 3_seconds ) );
     if( z->friendly != 0 ) {
@@ -2012,13 +2012,13 @@ bool mattack::fungus_big_blossom( monster *z )
             add_msg( m_warning, _( "The %s suddenly inhales!" ), z->name() );
         }
         //~Sound of a giant fungal blossom inhaling
-        sounds::sound( z->pos(), 20, sounds::sound_t::combat, _( "WOOOSH!" ), true, "misc", "inhale" );
+        sounds::sound( z->pos_bub(), 20, sounds::sound_t::combat, _( "WOOOSH!" ), true, "misc", "inhale" );
         if( u_see ) {
             add_msg( m_bad, _( "The %s discharges an immense flow of spores, smothering the flames!" ),
                      z->name() );
         }
         //~Sound of a giant fungal blossom blowing out the dangerous fire!
-        sounds::sound( z->pos(), 20, sounds::sound_t::combat, _( "POUFF!" ), true, "misc", "exhale" );
+        sounds::sound( z->pos_bub(), 20, sounds::sound_t::combat, _( "POUFF!" ), true, "misc", "exhale" );
         return true;
     } else {
         // No fire detected, routine haze-emission
@@ -2614,17 +2614,17 @@ bool mattack::nurse_check_up( monster *z )
 
         // First we offer the check up then we wait to the player to come close
         if( !z->has_effect( effect_countdown ) ) {
-            sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                            string_format(
                                _( "a soft robotic voice say, \"Come here and stand still for a few minutes, I'll give you a check-up.\"" ) ) );
             z->add_effect( effect_countdown, 30_minutes );
         } else if( rl_dist( target->pos(), z->pos() ) > 1 ) {
             // Giving them some encouragement
-            sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                            string_format(
                                _( "a soft robotic voice say, \"Come on.  I don't bite, I promise it won't hurt one bit.\"" ) ) );
         } else {
-            sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                            string_format(
                                _( "a soft robotic voice say, \"Here we go.  Just hold still.\"" ) ) );
             if( target->is_avatar() ) {
@@ -2666,7 +2666,7 @@ bool mattack::nurse_assist( monster *z )
     if( found_target ) {
         if( target->is_wearing( itype_badge_doctor ) ||
             z->attitude_to( *target ) == Creature::Attitude::FRIENDLY ) {
-            sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                            SNIPPET.expand( target->male
                                            ? _( "a soft robotic voice say, \"Welcome doctor <male_full_name>.  I'll be your assistant today.\"" )
                                            : _( "a soft robotic voice say, \"Welcome doctor <female_full_name>.  I'll be your assistant today.\"" ) ) );
@@ -2752,13 +2752,13 @@ bool mattack::nurse_operate( monster *z )
                 monster *mon = dynamic_cast<monster *>( critter );
                 if( mon != nullptr && mon != z ) {
                     if( mon->type->id != mon_nursebot_defective ) {
-                        sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+                        sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                                        string_format(
                                            _( "a soft robotic voice say, \"Unhand this patient immediately!  If you keep interfering with the procedure I'll be forced to call law enforcement.\"" ) ) );
                         // Try to push the perpetrator away
                         z->push_to( mon->pos(), 6, 0 );
                     } else {
-                        sounds::sound( z->pos(), 8, sounds::sound_t::electronic_speech,
+                        sounds::sound( z->pos_bub(), 8, sounds::sound_t::electronic_speech,
                                        string_format(
                                            _( "a soft robotic voice say, \"Greetings, nurse.  Please take good care of this patient.\"" ) ) );
                         z->anger = 0;
@@ -2803,7 +2803,7 @@ bool mattack::check_money_left( monster *z )
             }
 
             const SpeechBubble &speech_no_time = get_speech( "mon_grocerybot_friendship_done" );
-            sounds::sound( z->pos(), speech_no_time.volume,
+            sounds::sound( z->pos_bub(), speech_no_time.volume,
                            sounds::sound_t::electronic_speech, speech_no_time.text );
             z->remove_effect( effect_paid );
             return true;
@@ -2813,7 +2813,7 @@ bool mattack::check_money_left( monster *z )
         if( time_left < 1_minutes ) {
             if( calendar::once_every( 20_seconds ) ) {
                 const SpeechBubble &speech_time_low = get_speech( "mon_grocerybot_running_out_of_friendship" );
-                sounds::sound( z->pos(), speech_time_low.volume,
+                sounds::sound( z->pos_bub(), speech_time_low.volume,
                                sounds::sound_t::electronic_speech, speech_time_low.text );
             }
         }
@@ -2821,7 +2821,7 @@ bool mattack::check_money_left( monster *z )
     if( z->friendly == -1 && !z->has_effect( effect_paid ) ) {
         if( calendar::once_every( 3_hours ) ) {
             const SpeechBubble &speech_override_start = get_speech( "mon_grocerybot_hacked" );
-            sounds::sound( z->pos(), speech_override_start.volume,
+            sounds::sound( z->pos_bub(), speech_override_start.volume,
                            sounds::sound_t::electronic_speech, speech_override_start.text );
         }
     }
@@ -2926,15 +2926,15 @@ bool mattack::photograph( monster *z )
     } else {
         msg = _( "a robotic voice boom, \"Citizen… database connection lost!\"" );
     }
-    sounds::sound( z->pos(), 15, sounds::sound_t::alert, msg, false, "speech", z->type->id.str() );
+    sounds::sound( z->pos_bub(), 15, sounds::sound_t::alert, msg, false, "speech", z->type->id.str() );
 
     if( player_character.is_armed() ) {
         std::string msg = string_format( _( "\"Drop your %s!  Now!\"" ),
                                          weapon->is_gun() ? _( "gun" ) : _( "weapon" ) );
-        sounds::sound( z->pos(), 15, sounds::sound_t::alert, msg );
+        sounds::sound( z->pos_bub(), 15, sounds::sound_t::alert, msg );
     }
     const SpeechBubble &speech = get_speech( z->type->id.str() );
-    sounds::sound( z->pos(), speech.volume, sounds::sound_t::alert, speech.text.translated() );
+    sounds::sound( z->pos_bub(), speech.volume, sounds::sound_t::alert, speech.text.translated() );
 
     const effect &depleted = z->get_effect( effect_eyebot_depleted );
     const effect &assisted = z->get_effect( effect_eyebot_assisted );
@@ -3030,7 +3030,7 @@ void mattack::rifle( monster *z, Creature *target )
 
     if( target && target->is_avatar() ) {
         if( !z->has_effect( effect_targeted ) ) {
-            sounds::sound( z->pos(), 8, sounds::sound_t::alarm, _( "beep-beep." ), false, "misc", "beep" );
+            sounds::sound( z->pos_bub(), 8, sounds::sound_t::alarm, _( "beep-beep." ), false, "misc", "beep" );
             z->add_effect( effect_targeted, 8_turns );
             z->mod_moves( -to_moves<int>( 1_seconds ) );
             return;
@@ -3041,9 +3041,9 @@ void mattack::rifle( monster *z, Creature *target )
 
     if( z->ammo[ammo_type] <= 0 ) {
         if( one_in( 3 ) ) {
-            sounds::sound( z->pos(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
         } else if( one_in( 4 ) ) {
-            sounds::sound( z->pos(), 6, sounds::sound_t::combat,  _( "boop!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 6, sounds::sound_t::combat,  _( "boop!" ), false, "fire_gun", "empty" );
         }
         return;
     }
@@ -3083,7 +3083,7 @@ void mattack::frag( monster *z, Creature *target ) // This is for the bots, not 
             }
             // Effect removed in game.cpp, duration doesn't much matter
             player_character.add_effect( effect_laserlocked, 3_turns );
-            sounds::sound( z->pos(), 10, sounds::sound_t::electronic_speech, _( "Targeting." ),
+            sounds::sound( z->pos_bub(), 10, sounds::sound_t::electronic_speech, _( "Targeting." ),
                            false, "speech", z->type->id.str() );
             z->add_effect( effect_targeted, 5_turns );
             z->mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );
@@ -3102,9 +3102,9 @@ void mattack::frag( monster *z, Creature *target ) // This is for the bots, not 
 
     if( z->ammo[ammo_type] <= 0 ) {
         if( one_in( 3 ) ) {
-            sounds::sound( z->pos(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
         } else if( one_in( 4 ) ) {
-            sounds::sound( z->pos(), 6, sounds::sound_t::combat, _( "boop!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 6, sounds::sound_t::combat, _( "boop!" ), false, "fire_gun", "empty" );
         }
         return;
     }
@@ -3140,7 +3140,7 @@ void mattack::tankgun( monster *z, Creature *target )
         //~ There will be a 120mm HEAT shell sent at high speed to your location next turn.
         target->add_msg_if_player( m_warning, _( "You're not sure why you've got a laser dot on you…" ) );
         //~ Sound of a tank turret swiveling into place
-        sounds::sound( z->pos(), 10, sounds::sound_t::combat, _( "whirrrrrclick." ), false, "misc",
+        sounds::sound( z->pos_bub(), 10, sounds::sound_t::combat, _( "whirrrrrclick." ), false, "misc",
                        "servomotor" );
         z->add_effect( effect_targeted, 1_minutes );
         target->add_effect( effect_laserlocked, 1_minutes );
@@ -3161,9 +3161,9 @@ void mattack::tankgun( monster *z, Creature *target )
 
     if( z->ammo[ammo_type] <= 0 ) {
         if( one_in( 3 ) ) {
-            sounds::sound( z->pos(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 2, sounds::sound_t::combat, _( "a chk!" ), false, "fire_gun", "empty" );
         } else if( one_in( 4 ) ) {
-            sounds::sound( z->pos(), 6, sounds::sound_t::combat, _( "clank!" ), false, "fire_gun", "empty" );
+            sounds::sound( z->pos_bub(), 6, sounds::sound_t::combat, _( "clank!" ), false, "fire_gun", "empty" );
         }
         return;
     }
@@ -3488,18 +3488,18 @@ bool mattack::copbot( monster *z )
         if( one_in( 3 ) ) {
             if( sees_u ) {
                 if( foe->unarmed_attack() ) {
-                    sounds::sound( z->pos(), 18, sounds::sound_t::alert,
+                    sounds::sound( z->pos_bub(), 18, sounds::sound_t::alert,
                                    _( "a robotic voice boom, \"Citizen, Halt!\"" ), false, "speech", z->type->id.str() );
                 } else if( !cuffed ) {
-                    sounds::sound( z->pos(), 18, sounds::sound_t::alert,
+                    sounds::sound( z->pos_bub(), 18, sounds::sound_t::alert,
                                    _( "a robotic voice boom, \"Please put down your weapon.\"" ), false, "speech", z->type->id.str() );
                 }
             } else {
-                sounds::sound( z->pos(), 18, sounds::sound_t::alert,
+                sounds::sound( z->pos_bub(), 18, sounds::sound_t::alert,
                                _( "a robotic voice boom, \"Come out with your hands up!\"" ), false, "speech", z->type->id.str() );
             }
         } else {
-            sounds::sound( z->pos(), 18, sounds::sound_t::alarm,
+            sounds::sound( z->pos_bub(), 18, sounds::sound_t::alarm,
                            _( "a police siren, whoop WHOOP" ), false, "environment", "police_siren" );
         }
         return true;
@@ -3717,7 +3717,7 @@ bool mattack::ratking( monster *z )
 
 bool mattack::generator( monster *z )
 {
-    sounds::sound( z->pos(), 100, sounds::sound_t::activity, "hmmmm" );
+    sounds::sound( z->pos_bub(), 100, sounds::sound_t::activity, "hmmmm" );
     if( calendar::once_every( 1_minutes ) && z->get_hp() < z->get_hp_max() ) {
         z->heal( 1 );
     }
@@ -3804,7 +3804,7 @@ bool mattack::flesh_golem( monster *z )
         if( one_in( 12 ) ) {
             z->mod_moves( -to_moves<int>( 2_seconds ) );
             // It doesn't "nearly deafen you" when it roars from the other side of bubble
-            sounds::sound( z->pos(), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false, "shout",
+            sounds::sound( z->pos_bub(), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false, "shout",
                            "roar" );
             return true;
         }
@@ -3985,7 +3985,7 @@ bool mattack::blow_whistle( monster *z )
         return false;
     }
     add_msg_if_player_sees( *z, m_warning, _( "The %1$s loudly blows their whistle!" ), z->name() );
-    sounds::sound( z->pos(), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc", "whistle" );
+    sounds::sound( z->pos_bub(), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc", "whistle" );
 
     return true;
 }
@@ -3995,14 +3995,14 @@ static void parrot_common( monster *parrot )
     // It takes a while
     parrot->mod_moves( -to_moves<int>( 1_seconds ) );
     const SpeechBubble &speech = get_speech( parrot->type->id.str() );
-    sounds::sound( parrot->pos(), speech.volume, sounds::sound_t::speech, speech.text.translated(),
+    sounds::sound( parrot->pos_bub(), speech.volume, sounds::sound_t::speech, speech.text.translated(),
                    false, "speech", parrot->type->id.str() );
 }
 
 bool mattack::parrot( monster *z )
 {
     if( z->has_effect( effect_shrieking ) ) {
-        sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
+        sounds::sound( z->pos_bub(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
                        "wail" );
         z->mod_moves( -to_moves<int>( 1_seconds ) * 0.4 );
         return false;
@@ -4165,7 +4165,7 @@ bool mattack::riotbot( monster *z )
             z->anger = 0;
 
             if( calendar::once_every( 25_turns ) ) {
-                sounds::sound( z->pos(), 10, sounds::sound_t::electronic_speech,
+                sounds::sound( z->pos_bub(), 10, sounds::sound_t::electronic_speech,
                                _( "Halt and submit to arrest, citizen!  The police will be here any moment." ), false, "speech",
                                z->type->id.str() );
             }
@@ -4184,7 +4184,7 @@ bool mattack::riotbot( monster *z )
     // We need empty hands to arrest
     if( foe && foe->is_avatar() && !foe->is_armed() ) {
 
-        sounds::sound( z->pos(), 15, sounds::sound_t::electronic_speech,
+        sounds::sound( z->pos_bub(), 15, sounds::sound_t::electronic_speech,
                        _( "Please stay in place, citizen, do not make any movements!" ), false, "speech",
                        z->type->id.str() );
 
@@ -4251,14 +4251,14 @@ bool mattack::riotbot( monster *z )
                 add_msg( m_bad, _( "The robot puts handcuffs on you." ) );
             }
 
-            sounds::sound( z->pos(), 5, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 5, sounds::sound_t::electronic_speech,
                            _( "You are under arrest, citizen.  You have the right to remain silent.  If you do not remain silent, anything you say may be used against you in a court of law." ),
                            false, "speech", z->type->id.str() );
-            sounds::sound( z->pos(), 5, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 5, sounds::sound_t::electronic_speech,
                            _( "You have the right to an attorney.  If you cannot afford an attorney, one will be provided at no cost to you.  You may have your attorney present during any questioning." ) );
-            sounds::sound( z->pos(), 5, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 5, sounds::sound_t::electronic_speech,
                            _( "If you do not understand these rights, an officer will explain them in greater detail when taking you into custody." ) );
-            sounds::sound( z->pos(), 5, sounds::sound_t::electronic_speech,
+            sounds::sound( z->pos_bub(), 5, sounds::sound_t::electronic_speech,
                            _( "Do not attempt to flee or to remove the handcuffs, citizen.  That can be dangerous to your health." ) );
 
             z->mod_moves( -to_moves<int>( 3_seconds ) );
@@ -4305,7 +4305,7 @@ bool mattack::riotbot( monster *z )
     }
 
     if( calendar::once_every( 5_turns ) ) {
-        sounds::sound( z->pos(), 25, sounds::sound_t::electronic_speech,
+        sounds::sound( z->pos_bub(), 25, sounds::sound_t::electronic_speech,
                        _( "Empty your hands and hold your position, citizen!" ), false, "speech", z->type->id.str() );
     }
 
@@ -4325,7 +4325,7 @@ bool mattack::riotbot( monster *z )
                               target->posz() );
 
         //~ Sound of a riot control bot using its blinding flash
-        sounds::sound( z->pos(), 3, sounds::sound_t::combat, _( "fzzzzzt" ), false, "misc", "flash" );
+        sounds::sound( z->pos_bub(), 3, sounds::sound_t::combat, _( "fzzzzzt" ), false, "misc", "flash" );
 
         std::vector<tripoint_bub_ms> traj = line_to( z->pos_bub(), dest, 0, 0 );
         for( tripoint_bub_ms &elem : traj ) {
@@ -4463,7 +4463,7 @@ bool mattack::flesh_tendril( monster *z )
         if( one_in( 70 ) ) {
             add_msg( _( "The floor trembles underneath your feet." ) );
             z->mod_moves( -to_moves<int>( 2_seconds ) );
-            sounds::sound( z->pos(), 60, sounds::sound_t::alert, _( "a deafening roar!" ), false, "shout",
+            sounds::sound( z->pos_bub(), 60, sounds::sound_t::alert, _( "a deafening roar!" ), false, "shout",
                            "roar" );
         }
         return false;
@@ -4491,7 +4491,7 @@ bool mattack::flesh_tendril( monster *z )
         //it pulls you towards itself and then knocks you away
         bool pulled = z->type->special_attacks.at( "ranged_pull" )->call( *z );
         if( pulled && one_in( 4 ) ) {
-            sounds::sound( z->pos(), 60, sounds::sound_t::alarm, _( "a deafening roar!" ), false, "shout",
+            sounds::sound( z->pos_bub(), 60, sounds::sound_t::alarm, _( "a deafening roar!" ), false, "shout",
                            "roar" );
         }
         return pulled;
@@ -5236,14 +5236,14 @@ bool mattack::doot( monster *z )
             continue;
         }
     }
-    sounds::sound( z->pos(), 200, sounds::sound_t::music, _( "DOOT." ), false, "music_instrument",
+    sounds::sound( z->pos_bub(), 200, sounds::sound_t::music, _( "DOOT." ), false, "music_instrument",
                    "trumpet" );
     return true;
 }
 
 bool mattack::speaker( monster *z )
 {
-    sounds::sound( z->pos(), 60, sounds::sound_t::order,
+    sounds::sound( z->pos_bub(), 60, sounds::sound_t::order,
                    SNIPPET.random_from_category( "speaker_warning" ).value_or( translation() ) );
     return true;
 }
@@ -5323,7 +5323,7 @@ bool mattack::dsa_drone_scan( monster *z )
         warning_signal = _( "a high-pitched shriek" );
     }
     warning_signal = string_format( _( "%s from the %s." ), warning_signal, z->name() );
-    sounds::sound( z->pos(), 15 + 10 * weapons_count, sounds::sound_t::alarm, warning_signal );
+    sounds::sound( z->pos_bub(), 15 + 10 * weapons_count, sounds::sound_t::alarm, warning_signal );
     if( summon_reinforcements ) {
         get_timed_events().add( timed_event_type::DSA_ALRP_SUMMON,
                                 calendar::turn + rng( 5_turns, 10_turns ),

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -213,7 +213,7 @@ item_location mdeath::splatter( monster &z )
 void mdeath::disappear( monster &z )
 {
     if( !z.type->has_flag( mon_flag_SILENT_DISAPPEAR ) ) {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s disappears." ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s disappears." ), z.name() );
     }
 }
 
@@ -275,9 +275,9 @@ void mdeath::broken( monster &z )
 
     // TODO: make mdeath::splatter work for robots
     if( broken_mon.damage() >= broken_mon.max_damage() ) {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s is destroyed!" ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s is destroyed!" ), z.name() );
     } else {
-        add_msg_if_player_sees( z.pos(), m_good, _( "The %s collapses!" ), z.name() );
+        add_msg_if_player_sees( z.pos_bub(), m_good, _( "The %s collapses!" ), z.name() );
     }
 }
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -63,7 +63,7 @@ item_location mdeath::normal( monster &z )
 
     if( !z.quiet_death && !z.has_flag( mon_flag_QUIETDEATH ) ) {
         if( z.type->in_species( species_ZOMBIE ) ) {
-            sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos() ) );
+            sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos_bub() ) );
         }
 
         //Currently it is possible to get multiple messages that a monster died.

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -186,7 +186,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
 
     for( const std::pair<const std::string, mtype_special_attack> &attack : m.type->special_attacks ) {
         if( attack.second->id == "gun" ) {
-            sounds::sound( m.pos(), 50, sounds::sound_t::alert,
+            sounds::sound( m.pos_bub(), 50, sounds::sound_t::alert,
                            _( "Detected shots from unseen attacker, return fire mode engaged." ) );
             const gun_actor *gunactor = dynamic_cast<const gun_actor *>( attack.second.get() );
             if( gunactor->get_max_range() < distance_to_source ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1430,7 +1430,7 @@ void monster::footsteps( const tripoint &p )
     if( volume == 0 ) {
         return;
     }
-    int dist = rl_dist( p, get_player_character().pos() );
+    int dist = rl_dist( p, get_player_character().pos_bub() );
     sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
 }
 
@@ -2464,7 +2464,7 @@ void monster::shove_vehicle( const tripoint_bub_ms &remote_destination,
                 if( !this->has_effect( effect_invisibility ) ) {
                     monster_name = this->disp_name( false, true );
                 }
-                add_msg_if_player_sees( this->pos(), m_bad, _( "%1$s shoves %2$s out of the way!" ),
+                add_msg_if_player_sees( this->pos_bub(), m_bad, _( "%1$s shoves %2$s out of the way!" ),
                                         monster_name,
                                         veh.disp_name() );
                 int shove_moves = shove_veh_mass_moves_factor * veh_mass / 10_kilogram;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -795,7 +795,7 @@ bool monster::is_aquatic_danger( const tripoint &at_pos ) const
 bool monster::die_if_drowning( const tripoint &at_pos, const int chance )
 {
     if( is_aquatic_danger( at_pos ) && one_in( chance ) ) {
-        add_msg_if_player_sees( at_pos, _( "The %s drowns!" ), name() );
+        add_msg_if_player_sees( pos_bub(), _( "The %s drowns!" ), name() );
         die( nullptr );
         return true;
     }
@@ -1345,7 +1345,7 @@ void monster::nursebot_operate( Character *dragged_foe )
             add_effect( effect_countdown, 2_turns );
             add_msg( m_bad, _( "The %s produces a syringe full of some translucent liquid." ), name() );
         } else if( creatures.creature_at( get_dest() ) != nullptr && has_effect( effect_dragging ) ) {
-            sounds::sound( pos(), 8, sounds::sound_t::electronic_speech,
+            sounds::sound( pos_bub(), 8, sounds::sound_t::electronic_speech,
                            string_format(
                                _( "a soft robotic voice say, \"Please step away from the Autodoc, this patient needs immediate care.\"" ) ) );
             // TODO: Make it able to push NPC/player
@@ -1387,7 +1387,7 @@ void monster::nursebot_operate( Character *dragged_foe )
 
 // footsteps will determine how loud a monster's normal movement is
 // and create a sound in the monsters location when they move
-void monster::footsteps( const tripoint &p )
+void monster::footsteps( const tripoint_bub_ms &p )
 {
     if( is_hallucination() ) {
         return;
@@ -1430,7 +1430,7 @@ void monster::footsteps( const tripoint &p )
     if( volume == 0 ) {
         return;
     }
-    int dist = rl_dist( p, get_player_character().pos_bub() );
+    int dist = rl_dist( p.raw(), get_player_character().pos() );
     sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
 }
 
@@ -1944,7 +1944,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     }
 
     setpos( destination );
-    footsteps( destination.raw() );
+    footsteps( destination );
     underwater = will_be_water;
     optional_vpart_position vp_dest = here.veh_at( destination );
     if( vp_dest ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1187,7 +1187,7 @@ nc_color monster::color_with_effects() const
     return ret;
 }
 
-bool monster::avoid_trap( const tripoint & /* pos */, const trap &tr ) const
+bool monster::avoid_trap( const tripoint_bub_ms & /* pos */, const trap &tr ) const
 {
     // The trap position is not used, monsters are to stupid to remember traps. Actually, they do
     // not even see them.
@@ -2054,7 +2054,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
         if( u_see_my_spot ) {
             if( target.is_avatar() ) {
                 sfx::play_variant_sound( "melee_attack", "monster_melee_hit",
-                                         sfx::get_heard_volume( target.pos() ) );
+                                         sfx::get_heard_volume( target.pos_bub() ) );
                 // don't make a pain yelp if our limb is a bionic
                 if( !dealt_dam.bp_hit->has_flag( json_flag_BIONIC_LIMB ) ) {
                     sfx::do_player_death_hurt( dynamic_cast<Character &>( target ), false );
@@ -2847,7 +2847,7 @@ void monster::process_turn()
     if( has_flag( mon_flag_ELECTRIC_FIELD ) && !is_hallucination() ) {
         if( has_effect( effect_emp ) ) {
             if( calendar::once_every( 10_turns ) ) {
-                sounds::sound( pos(), 5, sounds::sound_t::combat, _( "hummmmm." ), false, "humming", "electric" );
+                sounds::sound( pos_bub(), 5, sounds::sound_t::combat, _( "hummmmm." ), false, "humming", "electric" );
             }
         } else {
             weather_manager &weather = get_weather();
@@ -2856,7 +2856,7 @@ void monster::process_turn()
                 for( const item &item : items ) {
                     if( item.made_of( phase_id::LIQUID ) && item.flammable() ) { // start a fire!
                         here.add_field( zap, fd_fire, 2, 1_minutes );
-                        sounds::sound( pos(), 30, sounds::sound_t::combat,  _( "fwoosh!" ), false, "fire", "ignition" );
+                        sounds::sound( pos_bub(), 30, sounds::sound_t::combat,  _( "fwoosh!" ), false, "fire", "ignition" );
                         break;
                     }
                 }
@@ -2879,9 +2879,9 @@ void monster::process_turn()
             if( weather.lightning_active && !has_effect( effect_supercharged ) &&
                 here.is_outside( pos_bub() ) ) {
                 weather.lightning_active = false; // only one supercharge per strike
-                sounds::sound( pos(), 300, sounds::sound_t::combat, _( "BOOOOOOOM!!!" ), false, "environment",
+                sounds::sound( pos_bub(), 300, sounds::sound_t::combat, _( "BOOOOOOOM!!!" ), false, "environment",
                                "thunder_near" );
-                sounds::sound( pos(), 20, sounds::sound_t::combat, _( "vrrrRRRUUMMMMMMMM!" ), false, "explosion",
+                sounds::sound( pos_bub(), 20, sounds::sound_t::combat, _( "vrrrRRRUUMMMMMMMM!" ), false, "explosion",
                                "default" );
                 Character &player_character = get_player_character();
                 if( player_character.sees( pos_bub() ) ) {
@@ -2891,7 +2891,7 @@ void monster::process_turn()
                 }
                 add_effect( effect_supercharged, 12_hours );
             } else if( has_effect( effect_supercharged ) && calendar::once_every( 5_turns ) ) {
-                sounds::sound( pos(), 20, sounds::sound_t::combat, _( "VMMMMMMMMM!" ), false, "humming",
+                sounds::sound( pos_bub(), 20, sounds::sound_t::combat, _( "VMMMMMMMMM!" ), false, "humming",
                                "electric" );
             }
         }
@@ -3350,7 +3350,7 @@ void monster::process_one_effect( effect &it, bool is_new )
         }
     } else if( id == effect_fake_common_cold ) {
         if( calendar::once_every( time_duration::from_seconds( rng( 30, 3000 ) ) ) && one_in( 4 ) ) {
-            sounds::sound( pos(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc", "cough" );
+            sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc", "cough" );
         }
 
         avatar &you = get_avatar(); // No NPCs for now.
@@ -3360,7 +3360,7 @@ void monster::process_one_effect( effect &it, bool is_new )
     } else if( id == effect_fake_flu ) {
         // Need to define the two separately because it's theoretically (and realistically) possible to have both flu and cold at once, both for players and monsters.
         if( calendar::once_every( time_duration::from_seconds( rng( 30, 3000 ) ) ) && one_in( 4 ) ) {
-            sounds::sound( pos(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc", "cough" );
+            sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc", "cough" );
         }
 
         avatar &you = get_avatar(); // No NPCs for now.
@@ -3559,7 +3559,7 @@ void monster::process_effects()
             int slipchance = ( round( get_speed() / 50 ) - get_dodge() / 2 );
             if( intensity + slipchance > dice( 1, 12 ) ) {
                 add_effect( effect_downed, rng( 1_turns, 2_turns ) );
-                add_msg_if_player_sees( pos(), m_info, _( "The %1s slips and falls!" ),
+                add_msg_if_player_sees( pos_bub(), m_info, _( "The %1s slips and falls!" ),
                                         name() );
             }
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2867,10 +2867,10 @@ void monster::process_turn()
                 if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                     if( one_in( 4 ) ) {
                         explosion_handler::explosion( this, pos_bub(), 40, 0.8, true );
-                        add_msg_if_player_sees( zap.raw(), m_warning, _( "The %s explodes in a fiery inferno!" ),
+                        add_msg_if_player_sees( zap, m_warning, _( "The %s explodes in a fiery inferno!" ),
                                                 here.tername( zap ) );
                     } else {
-                        add_msg_if_player_sees( zap.raw(), m_warning, _( "Lightning from %1$s engulfs the %2$s!" ),
+                        add_msg_if_player_sees( zap, m_warning, _( "Lightning from %1$s engulfs the %2$s!" ),
                                                 name(), here.tername( zap ) );
                         here.add_field( zap, fd_fire, 1, 2_turns );
                     }
@@ -3601,7 +3601,7 @@ bool monster::make_fungus()
     const std::string old_name = name();
     poly( type->fungalize_into );
 
-    add_msg_if_player_sees( pos(), m_info, _( "The spores transform %1$s into a %2$s!" ),
+    add_msg_if_player_sees( pos_bub(), m_info, _( "The spores transform %1$s into a %2$s!" ),
                             old_name, name() );
 
     return true;

--- a/src/monster.h
+++ b/src/monster.h
@@ -192,7 +192,7 @@ class monster : public Creature
         bool is_pet_follow() const;
         bool has_intelligence() const;
 
-        bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
+        bool avoid_trap( const tripoint_bub_ms &pos, const trap &tr ) const override;
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );
@@ -257,7 +257,7 @@ class monster : public Creature
         // will change mon_plan::dist
         void anger_cub_threatened( monster_plan &mon_plan );
         void move(); // Actual movement
-        void footsteps( const tripoint &p ); // noise made by movement
+        void footsteps( const tripoint_bub_ms &p ); // noise made by movement
         void shove_vehicle( const tripoint_bub_ms &remote_destination,
                             const tripoint_bub_ms &nearby_destination ); // shove vehicles out of the way
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -378,8 +378,8 @@ void Character::unset_mutation( const trait_id &trait_ )
         cached_mutations.erase( trait_ );
         if( !mut.enchantments.empty() ) {
             recalculate_enchantment_cache();
-            mutation_loss_effect( trait );
         }
+        mutation_loss_effect( trait );
     }
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1917,11 +1917,11 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
 
     // Sound happens even if we can't hear it
     if( spriority == sounds::sound_t::order || spriority == sounds::sound_t::alert ) {
-        sounds::sound( pos(), get_shout_volume(), spriority, sound, false, "speech",
+        sounds::sound( pos_bub(), get_shout_volume(), spriority, sound, false, "speech",
                        male ? "NPC_m" : "NPC_f" );
     } else {
         // Always shouting when in danger or short time since being in danger
-        sounds::sound( pos(), danger_assessment() > NPC_DANGER_VERY_LOW ?
+        sounds::sound( pos_bub(), danger_assessment() > NPC_DANGER_VERY_LOW ?
                        get_shout_volume() : indoor_voice(),
                        sounds::sound_t::speech,
                        sound, false, "speech",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1398,7 +1398,7 @@ void npc::do_npc_read( bool ebook )
 
     book = book.obtain( *npc_character );
     if( can_read( *book, fail_reasons ) ) {
-        add_msg_if_player_sees( pos(), _( "%s starts reading." ), disp_name() );
+        add_msg_if_player_sees( pos_bub(), _( "%s starts reading." ), disp_name() );
 
         // NPCs can't read to other NPCs yet
         const time_duration time_taken = time_to_read( *book, *this );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4817,7 +4817,7 @@ void npc::reach_omt_destination()
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 ) {
                 if( player_character.cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) &&
                     cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) ) {
-                    add_msg_if_player_sees( pos(), m_info, _( "From your two-way radio you hear %s reporting in, "
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "From your two-way radio you hear %s reporting in, "
                                             "'I've arrived, boss!'" ), disp_name() );
                 }
             }
@@ -5389,8 +5389,8 @@ void npc::do_reload( const item_location &it )
 
     if( get_player_view().sees( *this ) ) {
         add_msg( _( "%1$s reloads their %2$s." ), get_name(), it->tname() );
-        sfx::play_variant_sound( "reload", it->typeId().str(), sfx::get_heard_volume( pos() ),
-                                 sfx::get_heard_angle( pos() ) );
+        sfx::play_variant_sound( "reload", it->typeId().str(), sfx::get_heard_volume( pos_bub() ),
+                                 sfx::get_heard_angle( pos_bub() ) );
     }
 
     // Otherwise the NPC may not equip the weapon until they see danger

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4107,22 +4107,24 @@ item *npc::evaluate_best_weapon() const
 
     //Now check through the NPC's inventory for melee weapons, guns, or holstered items
     visit_items( [this, can_use_gun, use_silent, &weap, &best_value, &best]( item * node, item * ) {
-        double weapon_value = 0.0;
-        bool using_same_type_bionic_weapon = is_using_bionic_weapon()
+        if( can_wield( *node ).success() ) {
+            double weapon_value = 0.0;
+            bool using_same_type_bionic_weapon = is_using_bionic_weapon()
                                              && node != &weap
                                              && node->type->get_id() == weap.type->get_id();
 
-        if( ( node->is_melee() || node->is_gun() ) && ( !node->has_flag( flag_INTEGRATED ) &&
+            if( ( node->is_melee() || node->is_gun() ) && ( !node->has_flag( flag_INTEGRATED ) &&
                 !is_worn( *node ) ) ) {
             weapon_value = evaluate_weapon( *node, can_use_gun, use_silent );
-            if( weapon_value > best_value && !using_same_type_bionic_weapon ) {
+                if( weapon_value > best_value && !using_same_type_bionic_weapon ) {
                 best = const_cast<item *>( node );
                 best_value = weapon_value;
-            }
+                }
             return VisitResponse::SKIP;
-        } else if( node->get_use( "holster" ) && !node->empty() ) {
-            // we just recur to the next farther down
-            return VisitResponse::NEXT;
+            } else if( node->get_use( "holster" ) && !node->empty() ) {
+                // We just recur to the next farther down,
+                return VisitResponse::NEXT;
+            }
         }
         return VisitResponse::SKIP;
     } );

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -570,7 +570,7 @@ void pixel_minimap::render_critters( const tripoint &center )
 }
 
 //the main call for drawing the pixel minimap to the screen
-void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint &center )
+void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center )
 {
     if( !g ) {
         return;
@@ -581,8 +581,8 @@ void pixel_minimap::draw( const SDL_Rect &screen_rect, const tripoint &center )
     }
 
     set_screen_rect( screen_rect );
-    process_cache( center );
-    render( center );
+    process_cache( center.raw() );
+    render( center.raw() );
 }
 
 void pixel_minimap::draw_beacon( const SDL_Rect &rect, const SDL_Color &color )

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 
+#include "coords_fwd.h"
 #include "point.h"
 #include "sdl_wrappers.h"
 #include "sdl_geometry.h"
@@ -40,7 +41,7 @@ class pixel_minimap
         void set_type( pixel_minimap_type type );
         void set_settings( const pixel_minimap_settings &settings );
 
-        void draw( const SDL_Rect &screen_rect, const tripoint &center );
+        void draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center );
 
     private:
         struct submap_cache;

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1239,7 +1239,7 @@ void Character::hardcoded_effects( effect &it )
                          body_part_name_accusative( bp ) );
             } else {
                 //~ 1$s is NPC name, 2$s is bodypart in accusative.
-                add_msg_if_player_sees( pos(), _( "%1$s starts scratching their %2$s!" ), get_name(),
+                add_msg_if_player_sees( pos_bub(), _( "%1$s starts scratching their %2$s!" ), get_name(),
                                         body_part_name_accusative( bp ) );
             }
             mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -431,7 +431,7 @@ static void eff_fun_hallu( Character &u, effect &it )
             int loudness = 20 + u.str_cur - u.int_cur;
             loudness = ( loudness > 5 ? loudness : 5 );
             loudness = ( loudness < 30 ? loudness : 30 );
-            sounds::sound( u.pos(), loudness, sounds::sound_t::speech, _( random_entry_ref( npc_hallu ) ),
+            sounds::sound( u.pos_bub(), loudness, sounds::sound_t::speech, _( random_entry_ref( npc_hallu ) ),
                            false, "speech",
                            loudness < 15 ? ( u.male ? "NPC_m" : "NPC_f" ) : ( u.male ? "NPC_m_loud" : "NPC_f_loud" ) );
         }
@@ -1235,11 +1235,11 @@ void Character::hardcoded_effects( effect &it )
         if( x_in_y( intense, 600 + 300 * get_int() ) && !has_effect( effect_narcosis ) ) {
             if( !is_npc() ) {
                 //~ %s is bodypart in accusative.
-                add_msg( m_warning, _( "You start scratching your %s!" ),
+                add_msg( m_warning, _( "You start scratching your %s." ),
                          body_part_name_accusative( bp ) );
             } else {
                 //~ 1$s is NPC name, 2$s is bodypart in accusative.
-                add_msg_if_player_sees( pos_bub(), _( "%1$s starts scratching their %2$s!" ), get_name(),
+                add_msg_if_player_sees( pos_bub(), _( "%1$s starts scratching their %2$s." ), get_name(),
                                         body_part_name_accusative( bp ) );
             }
             mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );
@@ -1564,14 +1564,14 @@ void Character::hardcoded_effects( effect &it )
                     it.mod_duration( 10_minutes );
                 } else if( dur == 2_turns ) {
                     // let the sound code handle the wake-up part
-                    sounds::sound( pos(), 16, sounds::sound_t::alarm, _( "beep-beep-beep!" ), false, "tool",
+                    sounds::sound( pos_bub(), 16, sounds::sound_t::alarm, _( "beep-beep-beep!" ), false, "tool",
                                    "alarm_clock" );
                 }
             }
         } else {
             if( dur == 1_turns ) {
                 if( player_character.has_alarm_clock() ) {
-                    sounds::sound( player_character.pos(), 16, sounds::sound_t::alarm,
+                    sounds::sound( player_character.pos_bub(), 16, sounds::sound_t::alarm,
                                    _( "beep-beep-beep!" ), false, "tool", "alarm_clock" );
                     const std::string alarm = _( "Your alarm is going off." );
                     g->cancel_activity_or_ignore_query( distraction_type::noise, alarm );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2460,7 +2460,7 @@ void make_gun_sound_effect( const Character &p, bool burst, item *weapon )
 {
     const item::sound_data data = weapon->gun_noise( burst );
     if( data.volume > 0 ) {
-        sounds::sound( p.pos(), data.volume, sounds::sound_t::combat,
+        sounds::sound( p.pos_bub(), data.volume, sounds::sound_t::combat,
                        data.sound.empty() ? _( "Bang!" ) : data.sound );
     }
     tname::segment_bitset segs( tname::unprefixed_tname );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2409,7 +2409,7 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos 
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint & e ) {
         return !here.passable( e );
     } ), tiles.end() );
-    tripoint eject = tiles.empty() ? pos : random_entry( tiles );
+    tripoint_bub_ms eject{ tiles.empty() ? pos : random_entry( tiles ) };
 
     // for turrets try and drop casings or linkages directly to any CARGO part on the same tile
     const std::optional<vpart_reference> ovp_cargo = weap.has_flag( flag_VEHICLE )

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4398,7 +4398,7 @@ void basecamp::deserialize( const JsonObject &data )
     for( JsonObject edata : data.get_array( "expansions" ) ) {
         edata.allow_omitted_members();
         expansion_data e;
-        point dir;
+        point_rel_omt dir;
         if( edata.has_string( "dir" ) ) {
             // old save compatibility
             const std::string dir_id = edata.get_string( "dir" );
@@ -5244,7 +5244,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 point loc;
                 computers_json.next_value().read( loc );
                 auto new_comp_it = computers.emplace( loc, computer( "BUGGED_COMPUTER", -100,
-                                                      tripoint::zero ) ).first;
+                                                      tripoint_bub_ms::zero ) ).first;
                 computers_json.next_value().read( new_comp_it->second );
             }
         }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1107,12 +1107,14 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         const tripoint_abs_omt &guy_loc = guy->global_omt_location();
         if( guy_loc.z() == center_pos.z() && ( has_debug_vision ||
                                                overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) ) {
-            draw_entity_with_overlays( *guy, global_omt_to_draw_position( guy_loc ), lit_level::LIT,
+            draw_entity_with_overlays( *guy, tripoint_bub_ms( global_omt_to_draw_position( guy_loc ) ),
+                                       lit_level::LIT,
                                        height_3d, 1.0f, 1.0f );
         }
     }
 
-    draw_entity_with_overlays( get_player_character(), global_omt_to_draw_position( avatar_pos ),
+    draw_entity_with_overlays( get_player_character(),
+                               tripoint_bub_ms( global_omt_to_draw_position( avatar_pos ) ),
                                lit_level::LIT, height_3d, 1.0f, 1.0f );
     if( !fast_traveling ) {
         draw_from_id_string( "cursor", global_omt_to_draw_position( center_pos ), 0, 0, lit_level::LIT,
@@ -1519,7 +1521,7 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         // skip the normal drawing code for it.
         tilecontext->draw(
             point( win->pos.x * fontwidth, win->pos.y * fontheight ),
-            g->ter_view_p.raw(),
+            g->ter_view_p,
             TERRAIN_WINDOW_TERM_WIDTH * font->width,
             TERRAIN_WINDOW_TERM_HEIGHT * font->height,
             overlay_strings,
@@ -1633,8 +1635,8 @@ void cata_cursesport::curses_drawwindow( const catacurses::window &w )
         clear_window_area( w );
         tilecontext->draw_minimap(
             point( win->pos.x * fontwidth, win->pos.y * fontheight ),
-            tripoint( get_player_character().pos_bub().raw().xy(), g->ter_view_p.z() ),
-            win->width * font->width, win->height * font->height );
+        { get_player_character().pos_bub().xy(), g->ter_view_p.z() },
+        win->width * font->width, win->height * font->height );
         update = true;
 
     } else {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -239,11 +239,11 @@ std::string enum_to_string<sounds::sound_t>( sounds::sound_t data )
 
 // Static globals tracking sounds events of various kinds.
 // The sound events since the last monster turn.
-static std::vector<std::pair<tripoint, monster_sound_event>> recent_sounds;
+static std::vector<std::pair<tripoint_bub_ms, monster_sound_event>> recent_sounds;
 // The sound events since the last interactive player turn. (doesn't count sleep etc)
-static std::vector<std::pair<tripoint, sound_event>> sounds_since_last_turn;
+static std::vector<std::pair<tripoint_bub_ms, sound_event>> sounds_since_last_turn;
 // The sound events currently displayed to the player.
-static std::unordered_map<tripoint, sound_event> sound_markers;
+static std::unordered_map<tripoint_bub_ms, sound_event> sound_markers;
 
 // This is an attempt to handle attenuation of sound for underground areas.
 // The main issue it addresses is that you can hear activity
@@ -251,10 +251,10 @@ static std::unordered_map<tripoint, sound_event> sound_markers;
 // My research indicates that attenuation through soil-like materials is as
 // high as 100x the attenuation through air, plus vertical distances are
 // roughly five times as large as horizontal ones.
-static int sound_distance( const tripoint &source, const tripoint &sink )
+static int sound_distance( const tripoint_bub_ms &source, const tripoint_bub_ms &sink )
 {
-    const int lower_z = std::min( source.z, sink.z );
-    const int upper_z = std::max( source.z, sink.z );
+    const int lower_z = std::min( source.z(), sink.z() );
+    const int upper_z = std::max( source.z(), sink.z() );
     const int vertical_displacement = upper_z - lower_z;
     int vertical_attenuation = vertical_displacement;
     if( lower_z < 0 && vertical_displacement > 0 ) {
@@ -309,19 +309,14 @@ static bool is_provocative( sounds::sound_t category )
     cata_fatal( "Invalid sound_t category" );
 }
 
-void sounds::ambient_sound( const tripoint &p, int vol, sound_t category,
+void sounds::ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
                             const std::string &description )
 {
     sound( p, vol, category, description, true );
 }
 
-void sounds::ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
-                            const std::string &description )
-{
-    sounds::ambient_sound( p.raw(), vol, category, description );
-}
-
-void sounds::sound( const tripoint &p, int vol, sound_t category, const std::string &description,
+void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
+                    const std::string &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
     if( vol < 0 ) {
@@ -331,37 +326,24 @@ void sounds::sound( const tripoint &p, int vol, sound_t category, const std::str
     }
     // Description is not an optional parameter
     if( description.empty() ) {
-        debugmsg( "Sound at %d:%d has no description!", p.x, p.y );
+        debugmsg( "Sound at %d:%d has no description!", p.x(), p.y() );
     }
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     recent_sounds.emplace_back( p, monster_sound_event{ vol, is_provocative( category ) } );
     sounds_since_last_turn.emplace_back( p,
-                                         sound_event { vol, category, description, ambient,
+                                         sound_event{ vol, category, description, ambient,
                                                  false, id, variant, seas_str } );
-}
-
-void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
-                    const std::string &description,
-                    bool ambient, const std::string &id, const std::string &variant )
-{
-    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
-}
-
-void sounds::sound( const tripoint &p, int vol, sound_t category, const translation &description,
-                    bool ambient, const std::string &id, const std::string &variant )
-{
-    sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
 }
 
 void sounds::sound( const tripoint_bub_ms &p, int vol, sound_t category,
                     const translation &description,
                     bool ambient, const std::string &id, const std::string &variant )
 {
-    sounds::sound( p.raw(), vol, category, description, ambient, id, variant );
+    sounds::sound( p, vol, category, description.translated(), ambient, id, variant );
 }
 
-void sounds::add_footstep( const tripoint &p, int volume, int, monster *,
+void sounds::add_footstep( const tripoint_bub_ms &p, int volume, int, monster *,
                            const std::string &footstep )
 {
     const season_type seas = season_of_year( calendar::turn );
@@ -381,8 +363,9 @@ static void vector_quick_remove( std::vector<C> &source, int index )
     source.pop_back();
 }
 
-static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, monster_sound_event>>
-        input_sounds )
+static std::vector<centroid> cluster_sounds(
+    std::vector<std::pair<tripoint_bub_ms, monster_sound_event>>
+    input_sounds )
 {
     // If there are too many monsters and too many noise sources (which can be monsters, go figure),
     // applying sound events to monsters can dominate processing time for the whole game,
@@ -396,8 +379,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         std::max( std::min( input_sounds.size(), static_cast<size_t>( 10 ) ),
                   static_cast<size_t>( std::log( input_sounds.size() ) ) );
     const size_t stopping_point = input_sounds.size() - num_seed_clusters;
-    const size_t max_map_distance = sound_distance( tripoint( point::zero, OVERMAP_DEPTH ),
-                                    tripoint( MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT ) );
+    const size_t max_map_distance = sound_distance( { point_bub_ms::zero, OVERMAP_DEPTH },
+    { MAPSIZE_X, MAPSIZE_Y, OVERMAP_HEIGHT } );
     // Randomly choose cluster seeds.
     for( size_t i = input_sounds.size(); i > stopping_point; i-- ) {
         size_t index = rng( 0, i - 1 );
@@ -405,8 +388,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         sound_clusters.push_back(
             // Assure the compiler that these int->float conversions are safe.
         {
-            static_cast<float>( input_sounds[index].first.x ), static_cast<float>( input_sounds[index].first.y ),
-            static_cast<float>( input_sounds[index].first.z ),
+            static_cast<float>( input_sounds[index].first.x() ), static_cast<float>( input_sounds[index].first.y() ),
+            static_cast<float>( input_sounds[index].first.z() ),
             static_cast<float>( input_sounds[index].second.volume ), static_cast<float>( input_sounds[index].second.volume ),
             input_sounds[index].second.provocative
         } );
@@ -419,8 +402,8 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         for( auto centroid_iter = sound_clusters.begin(); centroid_iter != cluster_end;
              ++centroid_iter ) {
             // Scale the distance between the two by the max possible distance.
-            tripoint centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
-            const int dist = sound_distance( sound_event_pair.first, centroid_pos );
+            tripoint_bub_ms centroid_pos { static_cast<int>( centroid_iter->x ), static_cast<int>( centroid_iter->y ), static_cast<int>( centroid_iter->z ) };
+            const int dist = sound_distance( tripoint_bub_ms( sound_event_pair.first ), centroid_pos );
             if( dist * dist < dist_factor ) {
                 found_centroid = centroid_iter;
                 dist_factor = dist * dist;
@@ -429,13 +412,13 @@ static std::vector<centroid> cluster_sounds( std::vector<std::pair<tripoint, mon
         const float volume_sum = static_cast<float>( sound_event_pair.second.volume ) +
                                  found_centroid->weight;
         // Set the centroid location to the average of the two locations, weighted by volume.
-        found_centroid->x = static_cast<float>( ( sound_event_pair.first.x *
+        found_centroid->x = static_cast<float>( ( sound_event_pair.first.x() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->x * found_centroid->weight ) ) / volume_sum;
-        found_centroid->y = static_cast<float>( ( sound_event_pair.first.y *
+        found_centroid->y = static_cast<float>( ( sound_event_pair.first.y() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->y * found_centroid->weight ) ) / volume_sum;
-        found_centroid->z = static_cast<float>( ( sound_event_pair.first.z *
+        found_centroid->z = static_cast<float>( ( sound_event_pair.first.z() *
                                                 sound_event_pair.second.volume ) +
                                                 ( found_centroid->z * found_centroid->weight ) ) / volume_sum;
         // Set the centroid volume to the larger of the volumes.
@@ -496,7 +479,7 @@ void sounds::process_sounds()
         // Alert all monsters (that can hear) to the sound.
         for( monster &critter : g->all_monsters() ) {
             // TODO: Generalize this to Creature::hear_sound
-            const int dist = sound_distance( source, critter.pos() );
+            const int dist = sound_distance( source, critter.pos_bub() );
             if( vol * 2 > dist && critter.has_flag( mon_flag_HEARS ) && !critter.has_effect( effect_deaf ) ) {
                 // Exclude monsters that certainly won't hear the sound
                 critter.hear_sound( source, vol, dist, this_centroid.provocative );
@@ -516,12 +499,12 @@ void sounds::process_sounds()
         // Trigger sound-triggered traps and ensure they are still valid
         for( const trap *trapType : trap::get_sound_triggered_traps() ) {
             for( const tripoint_bub_ms &tp : get_map().trap_locations( trapType->id ) ) {
-                const int dist = sound_distance( source, tp.raw() );
+                const int dist = sound_distance( source, tp );
                 const trap &tr = get_map().tr_at( tp );
                 // Exclude traps that certainly won't hear the sound
                 if( vol * 2 > dist ) {
                     if( tr.triggered_by_sound( vol, dist ) ) {
-                        tr.trigger( tp.raw() );
+                        tr.trigger( tp );
                     }
                 }
             }
@@ -592,7 +575,7 @@ void sounds::process_sound_markers( Character *you )
         // so the references may become invalid after the vector enlarged its internal buffer
         const tripoint_bub_ms pos = tripoint_bub_ms( sounds_since_last_turn[i].first );
         const sound_event sound = sounds_since_last_turn[i].second;
-        const int distance_to_sound = sound_distance( you->pos_bub().raw(), pos.raw() );
+        const int distance_to_sound = sound_distance( you->pos_bub(), pos );
         const int raw_volume = sound.volume;
 
         // The felt volume of a sound is not affected by negative multipliers, such as already
@@ -779,10 +762,10 @@ void sounds::process_sound_markers( Character *you )
         // Enumerate the valid points the player *cannot* see.
         // Unless the source is on a different z-level, then any point is fine
         // Also show sensory sounds like SONAR even if we can see the point.
-        std::vector<tripoint> unseen_points;
+        std::vector<tripoint_bub_ms> unseen_points;
         for( const tripoint_bub_ms &newp : get_map().points_in_radius( pos, err_offset ) ) {
             if( diff_z || sound.category == sound_t::sensory || !you->sees( newp ) ) {
-                unseen_points.emplace_back( newp.raw() );
+                unseen_points.emplace_back( newp );
             }
         }
 
@@ -808,10 +791,10 @@ void sounds::reset_markers()
     sound_markers.clear();
 }
 
-std::vector<tripoint> sounds::get_footstep_markers()
+std::vector<tripoint_bub_ms> sounds::get_footstep_markers()
 {
     // Optimization, make this static and clear it in reset_markers?
-    std::vector<tripoint> footsteps;
+    std::vector<tripoint_bub_ms> footsteps;
     footsteps.reserve( sound_markers.size() );
     for( const auto &mark : sound_markers ) {
         footsteps.push_back( mark.first );
@@ -819,15 +802,15 @@ std::vector<tripoint> sounds::get_footstep_markers()
     return footsteps;
 }
 
-std::pair<std::vector<tripoint>, std::vector<tripoint>> sounds::get_monster_sounds()
+std::pair<std::vector<tripoint_bub_ms>, std::vector<tripoint_bub_ms>> sounds::get_monster_sounds()
 {
     auto sound_clusters = cluster_sounds( recent_sounds );
-    std::vector<tripoint> sound_locations;
+    std::vector<tripoint_bub_ms> sound_locations;
     sound_locations.reserve( recent_sounds.size() );
     for( const auto &sound : recent_sounds ) {
         sound_locations.push_back( sound.first );
     }
-    std::vector<tripoint> cluster_centroids;
+    std::vector<tripoint_bub_ms> cluster_centroids;
     cluster_centroids.reserve( sound_clusters.size() );
     for( const centroid &sound : sound_clusters ) {
         cluster_centroids.emplace_back( static_cast<int>( sound.x ), static_cast<int>( sound.y ),
@@ -836,7 +819,7 @@ std::pair<std::vector<tripoint>, std::vector<tripoint>> sounds::get_monster_soun
     return { sound_locations, cluster_centroids };
 }
 
-std::string sounds::sound_at( const tripoint &location )
+std::string sounds::sound_at( const tripoint_bub_ms &location )
 {
     auto this_sound = sound_markers.find( location );
     if( this_sound == sound_markers.end() ) {
@@ -1035,7 +1018,7 @@ void sfx::do_vehicle_engine_sfx()
         add_msg_debug( debugmode::DF_SOUND, "STOP speed %d =/= %d", current_speed, previous_speed );
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night,
-                                    sfx::get_heard_volume( player_character.pos() ), ch, 1000, pitch );
+                                    sfx::get_heard_volume( player_character.pos_bub() ), ch, 1000, pitch );
         add_msg_debug( debugmode::DF_SOUND, "PITCH %f", pitch );
     }
     previous_speed = current_speed;
@@ -1073,10 +1056,10 @@ void sfx::do_vehicle_exterior_engine_sfx()
     for( wrapped_vehicle vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
-            sound_distance( player_character.pos_bub().raw(), vehicle.v->pos_bub().raw() ) > noise_factor ) {
+            sound_distance( player_character.pos_bub(), vehicle.v->pos_bub() ) > noise_factor ) {
 
-            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub().raw(),
-                           vehicle.v->pos_bub().raw() );
+            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub(),
+                           vehicle.v->pos_bub() );
             veh = vehicle.v;
         }
     }
@@ -1115,7 +1098,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol,
                            Mix_Volume( ch_int, -1 ) );
@@ -1125,7 +1108,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
             add_msg_debug( debugmode::DF_SOUND, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                         seas_str, indoors, night, 128, ch, 0 );
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound %s %s vol: %d",
                            id_and_variant.first,
@@ -1136,7 +1119,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night, 128, ch, 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub().raw() ) ), 0 );
+        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub() ) ), 0 );
         add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
         set_channel_volume( ch, vol );
         add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d",
@@ -1337,7 +1320,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() < 80 ) {
         return;
     }
-    const tripoint source = source_arg.pos();
+    const tripoint_bub_ms source = source_arg.pos_bub();
     int heard_volume = get_heard_volume( source );
     if( heard_volume <= 30 ) {
         heard_volume = 30;
@@ -1353,7 +1336,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
     const bool indoors = !is_creature_outside( player_character );
     const bool night = is_night( calendar::turn );
     // this does not mean p == avatar (it could be a vehicle turret)
-    if( player_character.pos() == source ) {
+    if( player_character.pos_bub() == source ) {
         selected_sound = "fire_gun";
 
         const auto mods = firing.gunmods();
@@ -1366,7 +1349,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 
     } else {
         angle = get_heard_angle( source );
-        distance = sound_distance( player_character.pos(), source );
+        distance = sound_distance( player_character.pos_bub(), source );
         if( distance <= 17 ) {
             selected_sound = "fire_gun";
         } else {
@@ -1382,7 +1365,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 namespace sfx
 {
 struct sound_thread {
-    sound_thread( const tripoint &source, const tripoint &target, bool hit, bool targ_mon,
+    sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit, bool targ_mon,
                   const std::string &material );
 
     bool hit;
@@ -1402,7 +1385,8 @@ struct sound_thread {
 };
 } // namespace sfx
 
-void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, bool hit,
+void sfx::generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+                                bool hit,
                                 bool targ_mon,
                                 const std::string &material )
 {
@@ -1427,7 +1411,8 @@ void sfx::generate_melee_sound( const tripoint &source, const tripoint &target, 
     }
 }
 
-sfx::sound_thread::sound_thread( const tripoint &source, const tripoint &target, const bool hit,
+sfx::sound_thread::sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+                                 const bool hit,
                                  const bool targ_mon, const std::string &material )
     : hit( hit )
     , targ_mon( targ_mon )
@@ -1518,8 +1503,8 @@ void sfx::do_projectile_hit( const Creature &target )
         return;
     }
 
-    const int heard_volume = sfx::get_heard_volume( target.pos() );
-    const units::angle angle = get_heard_angle( target.pos() );
+    const int heard_volume = sfx::get_heard_volume( target.pos_bub() );
+    const units::angle angle = get_heard_angle( target.pos_bub() );
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     const bool indoors = !is_creature_outside( get_player_character() );
@@ -2018,7 +2003,7 @@ void sfx::play_ambient_variant_sound( const std::string &, const std::string &, 
 void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
-void sfx::generate_melee_sound( const tripoint &, const tripoint &, bool, bool,
+void sfx::generate_melee_sound( const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,
                                 const std::string & ) { }
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }
@@ -2056,9 +2041,9 @@ void sfx::play_variant_sound( const std::string &, const std::string &, const st
 /** Functions from sfx that do not use the SDL_mixer API at all. They can be used in builds
   * without sound support. */
 /*@{*/
-int sfx::get_heard_volume( const tripoint &source )
+int sfx::get_heard_volume( const tripoint_bub_ms &source )
 {
-    int distance = sound_distance( get_player_character().pos(), source );
+    int distance = sound_distance( get_player_character().pos_bub(), source );
     // fract = -100 / 24
     const float fract = -4.166666f;
     int heard_volume = fract * distance - 1 + 100;
@@ -2069,14 +2054,9 @@ int sfx::get_heard_volume( const tripoint &source )
     return heard_volume;
 }
 
-int sfx::get_heard_volume( const tripoint_bub_ms &source )
+units::angle sfx::get_heard_angle( const tripoint_bub_ms &source )
 {
-    return sfx::get_heard_volume( source.raw() );
-}
-
-units::angle sfx::get_heard_angle( const tripoint &source )
-{
-    units::angle angle = coord_to_angle( get_player_character().pos(), source ) + 90_degrees;
+    units::angle angle = coord_to_angle( get_player_character().pos_bub(), source ) + 90_degrees;
     //add_msg(m_warning, "angle: %i", angle);
     return angle;
 }

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -53,27 +53,17 @@ enum class sound_t : int {
  * @param variant Variant of sound effect given in id
  * @returns true if the player could hear the sound.
  */
-// TODO: Get rid of untyped overload.
-void sound( const tripoint &p, int vol, sound_t category, const std::string &description,
-            bool ambient = false, const std::string &id = "",
-            const std::string &variant = "default" );
 void sound( const tripoint_bub_ms &p, int vol, sound_t category, const std::string &description,
-            bool ambient = false, const std::string &id = "",
-            const std::string &variant = "default" );
-// TODO: Get rid of untyped overload.
-void sound( const tripoint &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 void sound( const tripoint_bub_ms &p, int vol, sound_t category, const translation &description,
             bool ambient = false, const std::string &id = "",
             const std::string &variant = "default" );
 /** Functions identical to sound(..., true). */
-// TODO: Get rid of untyped overload
-void ambient_sound( const tripoint &p, int vol, sound_t category, const std::string &description );
 void ambient_sound( const tripoint_bub_ms &p, int vol, sound_t category,
                     const std::string &description );
 /** Creates a list of coordinates at which to draw footsteps. */
-void add_footstep( const tripoint &p, int volume, int distance, monster *source,
+void add_footstep( const tripoint_bub_ms &p, int volume, int distance, monster *source,
                    const std::string &footstep );
 
 /* Make sure the sounds are all reset when we start a new game. */
@@ -87,11 +77,11 @@ void process_sounds();
 void process_sound_markers( Character *you );
 
 // Return list of points that have sound events the player can hear.
-std::vector<tripoint> get_footstep_markers();
+std::vector<tripoint_bub_ms> get_footstep_markers();
 // Return list of all sounds and the list of sound cluster centroids.
-std::pair<std::vector<tripoint>, std::vector<tripoint>> get_monster_sounds();
+std::pair<std::vector<tripoint_bub_ms>, std::vector<tripoint_bub_ms>> get_monster_sounds();
 // retrieve the sound event(s?) at a location.
-std::string sound_at( const tripoint &location );
+std::string sound_at( const tripoint_bub_ms &location );
 /** Tells us if sound has been enabled in options */
 extern bool sound_enabled;
 } // namespace sounds
@@ -171,15 +161,13 @@ void play_activity_sound( const std::string &id, const std::string &variant,
                           const std::string &season, int volume );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
-void generate_melee_sound( const tripoint &source, const tripoint &target, bool hit,
+void generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,
                            bool targ_mon = false, const std::string &material = "flesh" );
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
-// TODO: Get rid of untyped overload
-int get_heard_volume( const tripoint &source );
 int get_heard_volume( const tripoint_bub_ms &source );
-units::angle get_heard_angle( const tripoint &source );
+units::angle get_heard_angle( const tripoint_bub_ms &source );
 void do_footstep();
 void do_danger_music();
 void do_ambient();

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -646,7 +646,7 @@ void suffer::from_asthma( Character &you, const int current_stim )
     map &here = get_map();
     if( you.in_sleep_state() && !you.has_effect( effect_narcosis ) ) {
         inventory map_inv;
-        map_inv.form_from_map( you.pos(), 2, &you );
+        map_inv.form_from_map( you.pos_bub(), 2, &you );
         // check if an inhaler is somewhere near
         bool nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
                           map_inv.has_charges( itype_oxygen_tank, 1 ) ||
@@ -807,7 +807,7 @@ void suffer::in_sunlight( Character &you, outfit &worn )
         const float weather_factor = std::min( incident_sun_irradiance( get_weather().weather_id,
                                                calendar::turn ) / irradiance::moderate, 1.f );
         const int player_local_temp = units::to_fahrenheit( get_weather().get_temperature(
-                                          position.raw() ) );
+                                          position ) );
         int flux = ( player_local_temp - 32 ) / 5;
         // Efficiency rapidly falls off when it's too hot due to photosynthesis being an enzymatic process.
         // Some tropical plants can overcome this with specific adaptations, but that would probably be its own mutation.

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1805,7 +1805,7 @@ void suffer::from_artifact_resonance( Character &you, int amt )
                 you.add_msg_player_or_npc( m_bad,
                                            _( "You hear a painfully loud grinding noise from your location." ),
                                            _( "A painfully loud grinding noise suddenly blares from the location of <npcname>." ) );
-                sounds::sound( you.pos(), 5000, sounds::sound_t::movement, _( "A horribly loud grinding sound!" ),
+                sounds::sound( you.pos_bub(), 5000, sounds::sound_t::movement, _( "A horribly loud grinding sound!" ),
                                true, "misc", "scraping" );
             } else if( rng_outcome == 3 ) {
                 you.add_msg_player_or_npc( m_bad,

--- a/src/talker.h
+++ b/src/talker.h
@@ -321,7 +321,7 @@ class const_talker
         virtual bool can_see() const {
             return false;
         }
-        virtual bool can_see_location( const tripoint & ) const {
+        virtual bool can_see_location( const tripoint_bub_ms & ) const {
             return false;
         }
         virtual bool is_mute() const {

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -872,7 +872,7 @@ bool talker_character_const::can_see() const
                                           me_chr_const->has_flag( json_flag_SEESLEEP ) );
 }
 
-bool talker_character_const::can_see_location( const tripoint &pos ) const
+bool talker_character_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
     return me_chr_const->sees( pos );
 }

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -190,7 +190,7 @@ class talker_character_const: virtual public const_talker
         bool is_warm() const override;
 
         bool can_see() const override;
-        bool can_see_location( const tripoint &pos ) const override;
+        bool can_see_location( const tripoint_bub_ms &pos ) const override;
         int morale_cur() const override;
         int focus_cur() const override;
         int get_rad() const override;

--- a/src/talker_furniture.cpp
+++ b/src/talker_furniture.cpp
@@ -15,27 +15,27 @@ std::string talker_furniture_const::disp_name() const
 
 int talker_furniture_const::posx() const
 {
-    return me_comp->loc.x;
+    return me_comp->loc.x();
 }
 
 int talker_furniture_const::posy() const
 {
-    return me_comp->loc.y;
+    return me_comp->loc.y();
 }
 
 int talker_furniture_const::posz() const
 {
-    return me_comp->loc.z;
+    return me_comp->loc.z();
 }
 
 tripoint talker_furniture_const::pos() const
 {
-    return me_comp->loc;
+    return me_comp->loc.raw();
 }
 
 tripoint_bub_ms talker_furniture_const::pos_bub() const
 {
-    return tripoint_bub_ms( me_comp->loc );
+    return me_comp->loc;
 }
 
 tripoint_abs_ms talker_furniture_const::global_pos() const

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -185,7 +185,7 @@ int talker_monster_const::get_grab_strength() const
     return  me_mon_const->get_grab_strength();
 }
 
-bool talker_monster_const::can_see_location( const tripoint &pos ) const
+bool talker_monster_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
     return me_mon_const->sees( pos );
 }

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -80,7 +80,7 @@ class talker_monster_const: public const_talker_cloner<talker_monster_const>
         int get_hp_max( const bodypart_id & ) const override;
         double armor_at( damage_type_id &dt, bodypart_id &bp ) const override;
 
-        bool can_see_location( const tripoint &pos ) const override;
+        bool can_see_location( const tripoint_bub_ms &pos ) const override;
         int get_volume() const override;
         int get_weight() const override;
         bool is_warm() const override;

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -125,7 +125,7 @@ void timed_event::actualize()
 
             // You could drop the flag, you know.
             if( player_character.has_amount( itype_petrified_eye, 1 ) ) {
-                sounds::sound( player_character.pos(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false,
+                sounds::sound( player_character.pos_bub(), 60, sounds::sound_t::alert, _( "a tortured scream!" ), false,
                                "shout",
                                "scream_tortured" );
                 if( !player_character.is_deaf() ) {

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -152,6 +152,14 @@ void trap::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "floor_bedding_warmth", legacy_floor_bedding_warmth, 0 );
     floor_bedding_warmth = units::from_legacy_bodypart_temp_delta( legacy_floor_bedding_warmth );
     optional( jo, was_loaded, "spell_data", spell_data );
+    if( jo.has_member( "eocs" ) ) {
+        if( act.target_type() != trap_function_from_string( "eocs" ).target_type() ) {
+            jo.throw_error_at( "eocs", R"(Can't use "eocs" without specifying "action": "eocs")" );
+        }
+        for( JsonValue jv : jo.get_array( "eocs" ) ) {
+            eocs.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        }
+    }
     assign( jo, "trigger_weight", trigger_weight );
     optional( jo, was_loaded, "sound_threshold", sound_threshold );
     for( const JsonValue entry : jo.get_array( "drops" ) ) {

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -240,7 +240,7 @@ bool trap::detected_by_echolocation() const
     return has_flag( json_flag_ECHOLOCATION_DETECTABLE );
 }
 
-bool trap::detect_trap( const tripoint &pos, const Character &p ) const
+bool trap::detect_trap( const tripoint_bub_ms &pos, const Character &p ) const
 {
     // * Buried landmines, the silent killer, have a visibility of 10.
     // Assuming no knowledge of traps or proficiencies, and average per/int (8 each),
@@ -261,7 +261,7 @@ bool trap::detect_trap( const tripoint &pos, const Character &p ) const
 
     // The further away the trap is, the harder it is to spot.
     // Subtract 1 so that we don't get an unfair penalty when not quite on top of the trap.
-    const int distance_penalty = rl_dist( p.pos(), pos ) - 1;
+    const int distance_penalty = rl_dist( p.pos_bub(), pos ) - 1;
 
     int proficiency_effect = -1;
     // Without at least a basic traps proficiency, your skill level is effectively three levels lower.
@@ -295,18 +295,6 @@ bool trap::detect_trap( const tripoint &pos, const Character &p ) const
 }
 
 // Whether or not, in the current state, the player can see the trap.
-bool trap::can_see( const tripoint &pos, const Character &p ) const
-{
-    if( is_null() ) {
-        // There is no trap at all, so logically one can not see it.
-        return false;
-    }
-    if( is_always_invisible() ) {
-        return false;
-    }
-    return visibility < 0 || p.knows_trap( tripoint_bub_ms( pos ) );
-}
-
 bool trap::can_see( const tripoint_bub_ms &pos, const Character &p ) const
 {
     if( is_null() ) {
@@ -319,7 +307,7 @@ bool trap::can_see( const tripoint_bub_ms &pos, const Character &p ) const
     return visibility < 0 || p.knows_trap( pos );
 }
 
-void trap::trigger( const tripoint &pos ) const
+void trap::trigger( const tripoint_bub_ms &pos ) const
 {
     if( is_null() ) {
         return;
@@ -327,17 +315,17 @@ void trap::trigger( const tripoint &pos ) const
     act( pos, nullptr, nullptr );
 }
 
-void trap::trigger( const tripoint &pos, Creature &creature ) const
+void trap::trigger( const tripoint_bub_ms &pos, Creature &creature ) const
 {
     return trigger( pos, &creature, nullptr );
 }
 
-void trap::trigger( const tripoint &pos, item &item ) const
+void trap::trigger( const tripoint_bub_ms &pos, item &item ) const
 {
     return trigger( pos, nullptr, &item );
 }
 
-void trap::trigger( const tripoint &pos, Creature *creature, item *item ) const
+void trap::trigger( const tripoint_bub_ms &pos, Creature *creature, item *item ) const
 {
     if( is_null() ) {
         return;
@@ -393,7 +381,7 @@ bool trap::triggered_by_sound( int vol, int dist ) const
     return !is_null() && ( rng( 0, 100 ) <= sound_chance );
 }
 
-void trap::on_disarmed( map &m, const tripoint &p ) const
+void trap::on_disarmed( map &m, const tripoint_bub_ms &p ) const
 {
     for( const auto &i : components ) {
         const itype_id &item_type = std::get<0>( i );

--- a/src/trap.h
+++ b/src/trap.h
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include "color.h"
+#include "coords_fwd.h"
+#include "effect_on_condition.h"
 #include "flat_set.h"
 #include "magic.h"
 #include "translations.h"
@@ -30,40 +32,41 @@ namespace trapfunc
 // creature is the creature that triggered the trap,
 // item is the item that triggered the trap,
 // creature and item can be nullptr.
-bool none( const tripoint &, Creature *, item * );
-bool bubble( const tripoint &p, Creature *c, item *i );
-bool glass( const tripoint &p, Creature *c, item *i );
-bool cot( const tripoint &p, Creature *c, item *i );
-bool beartrap( const tripoint &p, Creature *c, item *i );
-bool snare_light( const tripoint &p, Creature *c, item *i );
-bool snare_heavy( const tripoint &p, Creature *c, item *i );
-bool snare_species( const tripoint &p, Creature *critter, item *trap_item );
-bool board( const tripoint &p, Creature *c, item *i );
-bool caltrops( const tripoint &p, Creature *c, item *i );
-bool caltrops_glass( const tripoint &p, Creature *c, item *i );
-bool tripwire( const tripoint &p, Creature *c, item *i );
-bool crossbow( const tripoint &p, Creature *c, item *i );
-bool shotgun( const tripoint &p, Creature *c, item *i );
-bool blade( const tripoint &p, Creature *c, item *i );
-bool landmine( const tripoint &p, Creature *c, item *i );
-bool telepad( const tripoint &p, Creature *c, item *i );
-bool goo( const tripoint &p, Creature *c, item *i );
-bool dissector( const tripoint &p, Creature *c, item *i );
-bool sinkhole( const tripoint &p, Creature *c, item *i );
-bool pit( const tripoint &p, Creature *c, item *i );
-bool pit_spikes( const tripoint &p, Creature *c, item *i );
-bool pit_glass( const tripoint &p, Creature *c, item *i );
-bool lava( const tripoint &p, Creature *c, item *i );
-bool portal( const tripoint &p, Creature *c, item *i );
-bool boobytrap( const tripoint &p, Creature *c, item *i );
-bool glow( const tripoint &p, Creature *c, item *i );
-bool hum( const tripoint &p, Creature *c, item *i );
-bool shadow( const tripoint &p, Creature *c, item *i );
-bool map_regen( const tripoint &p, Creature *c, item *i );
-bool drain( const tripoint &p, Creature *c, item *i );
-bool snake( const tripoint &p, Creature *c, item *i );
-bool cast_spell( const tripoint &p, Creature *critter, item * );
-bool dummy_trap( const tripoint &p, Creature *critter, item * );
+bool none( const tripoint_bub_ms &, Creature *, item * );
+bool bubble( const tripoint_bub_ms &p, Creature *c, item *i );
+bool glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool cot( const tripoint_bub_ms &p, Creature *c, item *i );
+bool beartrap( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_light( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_heavy( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snare_species( const tripoint_bub_ms &p, Creature *critter, item *trap_item );
+bool board( const tripoint_bub_ms &p, Creature *c, item *i );
+bool caltrops( const tripoint_bub_ms &p, Creature *c, item *i );
+bool caltrops_glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool tripwire( const tripoint_bub_ms &p, Creature *c, item *i );
+bool crossbow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool shotgun( const tripoint_bub_ms &p, Creature *c, item *i );
+bool blade( const tripoint_bub_ms &p, Creature *c, item *i );
+bool landmine( const tripoint_bub_ms &p, Creature *c, item *i );
+bool telepad( const tripoint_bub_ms &p, Creature *c, item *i );
+bool goo( const tripoint_bub_ms &p, Creature *c, item *i );
+bool dissector( const tripoint_bub_ms &p, Creature *c, item *i );
+bool sinkhole( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit_spikes( const tripoint_bub_ms &p, Creature *c, item *i );
+bool pit_glass( const tripoint_bub_ms &p, Creature *c, item *i );
+bool lava( const tripoint_bub_ms &p, Creature *c, item *i );
+bool portal( const tripoint_bub_ms &p, Creature *c, item *i );
+bool boobytrap( const tripoint_bub_ms &p, Creature *c, item *i );
+bool glow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool hum( const tripoint_bub_ms &p, Creature *c, item *i );
+bool shadow( const tripoint_bub_ms &p, Creature *c, item *i );
+bool map_regen( const tripoint_bub_ms &p, Creature *c, item *i );
+bool drain( const tripoint_bub_ms &p, Creature *c, item *i );
+bool snake( const tripoint_bub_ms &p, Creature *c, item *i );
+bool cast_spell( const tripoint_bub_ms &p, Creature *critter, item * );
+bool dummy_trap( const tripoint_bub_ms &p, Creature *critter, item * );
+bool eocs( const tripoint_bub_ms &p, Creature *c, item * );
 } // namespace trapfunc
 
 struct vehicle_handle_trap_data {
@@ -82,7 +85,7 @@ struct vehicle_handle_trap_data {
     trap_str_id set_trap = trap_str_id::NULL_ID();
 };
 
-using trap_function = std::function<bool( const tripoint &, Creature *, item * )>;
+using trap_function = std::function<bool( const tripoint_bub_ms &, Creature *, item * )>;
 
 /**
  * Some traps aren't actually traps in the usual sense of the word. We use traps to implement
@@ -201,8 +204,6 @@ struct trap {
          * called on the null trap.
          */
         // Implemented for historical reasons in iexamine.cpp
-        // TODO: Get rid of untyped overload.
-        void examine( const tripoint &examp ) const;
         void examine( const tripoint_bub_ms &examp ) const;
 
         update_mapgen_id map_regen_target() const;
@@ -247,13 +248,11 @@ struct trap {
         bool detected_by_echolocation() const;
         /** Player has not yet seen the trap and returns the variable chance, at this moment,
          of whether the trap is seen or not. */
-        bool detect_trap( const tripoint &pos, const Character &p ) const;
+        bool detect_trap( const tripoint_bub_ms &pos, const Character &p ) const;
         /**
          * Can player/npc p see this kind of trap, either by their memory (they known there is
          * the trap) or by the visibility of the trap (the trap is not hidden at all)?
          */
-        // TODO: Get rid of untyped overload.
-        bool can_see( const tripoint &pos, const Character &p ) const;
         bool can_see( const tripoint_bub_ms &pos, const Character &p ) const;
 
         bool has_trigger_msg() const {
@@ -282,7 +281,7 @@ struct trap {
          * @param item The item that triggered the trap
          */
         // Don't call from outside this class. Add a wrapper like the ones below instead.
-        void trigger( const tripoint &pos, Creature *creature, item *item ) const;
+        void trigger( const tripoint_bub_ms &pos, Creature *creature, item *item ) const;
     public:
         /*@{*/
         /**
@@ -293,11 +292,11 @@ struct trap {
          * caller has already checked whether the trap should be activated
          * (e.g. the creature has had a chance to avoid the trap, but it failed).
          */
-        void trigger( const tripoint &pos, Creature &creature ) const;
-        void trigger( const tripoint &pos, item &item ) const;
+        void trigger( const tripoint_bub_ms &pos, Creature &creature ) const;
+        void trigger( const tripoint_bub_ms &pos, item &item ) const;
         /*@}*/
 
-        void trigger( const tripoint &pos ) const;
+        void trigger( const tripoint_bub_ms &pos ) const;
 
         /**
          * If the given item is throw onto the trap, does it trigger the trap?
@@ -309,7 +308,7 @@ struct trap {
          * It should spawn trap items (if any) and remove the trap from the map via
          * @ref map::remove_trap.
          */
-        void on_disarmed( map &m, const tripoint &p ) const;
+        void on_disarmed( map &m, const tripoint_bub_ms &p ) const;
         /**
          * This is used when defining area this trap occupies. A value of 0 means trap occupies exactly 1 tile.
          */

--- a/src/trap.h
+++ b/src/trap.h
@@ -164,6 +164,7 @@ struct trap {
         std::optional<itype_id> trap_item_type;
         // data required for trapfunc::spell()
         fake_spell spell_data;
+        std::vector<effect_on_condition_id> eocs;
         int comfort = 0;
         units::temperature_delta floor_bedding_warmth = 0_C_delta;
         vehicle_handle_trap_data vehicle_data;

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -194,7 +194,7 @@ bool trapfunc::beartrap( const tripoint_bub_ms &p, Creature *c, item * )
             if( c->has_effect( effect_ridden ) ) {
                 add_msg( m_warning, _( "Your %s is caught by a beartrap!" ), c->get_name() );
             } else {
-                add_msg_if_player_sees( c->pos(), _( "%s gets caught in a beartrap!" ), c->get_name() );
+                add_msg_if_player_sees( c->pos_bub(), _( "%s gets caught in a beartrap!" ), c->get_name() );
             }
         } else {
             c->add_msg_player_or_npc( m_bad,
@@ -694,7 +694,7 @@ bool trapfunc::snare_light( const tripoint_bub_ms &p, Creature *c, item * )
             if( c->has_effect( effect_ridden ) ) {
                 add_msg( m_warning, _( "Your %s is caught in a snare!" ), c->get_name() );
             } else {
-                add_msg_if_player_sees( c->pos(), _( "%s gets caught in a snare!" ), c->get_name() );
+                add_msg_if_player_sees( c->pos_bub(), _( "%s gets caught in a snare!" ), c->get_name() );
             }
         } else {
             c->add_msg_player_or_npc( m_bad, _( "A snare closes on your leg." ),
@@ -717,7 +717,7 @@ bool trapfunc::snare_heavy( const tripoint_bub_ms &p, Creature *c, item * )
         if( c->has_effect( effect_ridden ) ) {
             add_msg( m_warning, _( "Your %s is caught in a snare!" ), c->get_name() );
         } else {
-            add_msg_if_player_sees( c->pos(), _( "%s gets caught in a snare!" ), c->get_name() );
+            add_msg_if_player_sees( c->pos_bub(), _( "%s gets caught in a snare!" ), c->get_name() );
         }
     } else {
         //~ %s is bodypart name in accusative.

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -102,7 +102,7 @@ static const trap_str_id tr_shotgun_2( "tr_shotgun_2" );
 static const trap_str_id tr_temple_flood( "tr_temple_flood" );
 
 // A pit becomes less effective as it fills with corpses.
-static float pit_effectiveness( const tripoint &p )
+static float pit_effectiveness( const tripoint_bub_ms &p )
 {
     units::volume corpse_volume = 0_ml;
     for( item &pit_content : get_map().i_at( p ) ) {
@@ -117,12 +117,12 @@ static float pit_effectiveness( const tripoint &p )
     return std::max( 0.0f, 1.0f - corpse_volume / filled_volume );
 }
 
-bool trapfunc::none( const tripoint &, Creature *, item * )
+bool trapfunc::none( const tripoint_bub_ms &, Creature *, item * )
 {
     return false;
 }
 
-bool trapfunc::bubble( const tripoint &p, Creature *c, item * )
+bool trapfunc::bubble( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals don't trigger bubble wrap
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -140,7 +140,7 @@ bool trapfunc::bubble( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -164,7 +164,7 @@ bool trapfunc::glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::cot( const tripoint &, Creature *c, item * )
+bool trapfunc::cot( const tripoint_bub_ms &, Creature *c, item * )
 {
     monster *z = dynamic_cast<monster *>( c );
     if( z != nullptr ) {
@@ -176,7 +176,7 @@ bool trapfunc::cot( const tripoint &, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
+bool trapfunc::beartrap( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals don't trigger bear traps
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -223,7 +223,7 @@ bool trapfunc::beartrap( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint &p )
+static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint_bub_ms &p )
 {
     if( !z ) { // should never happen
         debugmsg( "non-monster creature passed to mount_step_on_trap_make_slow_give_msg" );
@@ -232,7 +232,7 @@ static void mount_step_on_trap_make_slow_give_msg( monster *z, const tripoint &p
     map &here = get_map();
     Character *rider = nullptr;
     for( npc &guy : g->all_npcs() ) {
-        if( guy.pos() == p && guy.pos() == z->pos() ) {
+        if( guy.pos_bub() == p && guy.pos_bub() == z->pos_bub() ) {
             rider = &guy;
             break;
         }
@@ -261,7 +261,7 @@ static void try_apply_tetanus( Character *you, int total_cut_dmg )
     }
 }
 
-bool trapfunc::board( const tripoint &p, Creature *c, item * )
+bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -301,7 +301,7 @@ bool trapfunc::board( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::caltrops( const tripoint &p, Creature *c, item * )
+bool trapfunc::caltrops( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -343,7 +343,7 @@ bool trapfunc::caltrops( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::caltrops_glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -372,7 +372,30 @@ bool trapfunc::caltrops_glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
+bool trapfunc::eocs( const tripoint_bub_ms &p, Creature *critter, item * )
+{
+    if( !critter ) {
+        //TODO: Pass the item as a talker somehow taking into account we don't have the item's tripoint in the case of ranged traps so something like get_talker_for( item_location( map_cursor( tripoint_bub_ms( p ) ), it ) ) isn't enough (and didn't work for non ranged traps on testing anyway)
+        return false;
+    }
+    map &here = get_map();
+    trap tr = here.tr_at( p );
+    const tripoint_abs_ms trap_location = get_map().getglobal( p );
+    for( const effect_on_condition_id &eoc : tr.eocs ) {
+        dialogue d( get_talker_for( critter ), nullptr );
+        write_var_value( var_type::context, "trap_location", &d, trap_location.to_string() );
+        if( eoc->type == eoc_type::ACTIVATION ) {
+            eoc->activate( d );
+        } else {
+            debugmsg( "Must use an activation eoc for activation.  If you don't want the effect_on_condition to happen on its own (without the item's involvement), remove the recurrence min and max.  Otherwise, create a non-recurring effect_on_condition for this item with its condition and effects, then have a recurring one queue it." );
+        }
+    }
+    here.remove_trap( p );
+    return true;
+}
+
+
+bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -391,8 +414,8 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
     if( z != nullptr ) {
         if( z->has_effect( effect_ridden ) ) {
             add_msg( m_bad, _( "Your %s trips over a tripwire!" ), z->get_name() );
-            std::vector<tripoint> valid;
-            for( const tripoint &jk : here.points_in_radius( p, 1 ) ) {
+            std::vector<tripoint_bub_ms> valid;
+            for( const tripoint_bub_ms &jk : here.points_in_radius( p, 1 ) ) {
                 if( g->is_empty( jk ) ) {
                     valid.push_back( jk );
                 }
@@ -411,8 +434,8 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
                             4 ) ) );
         }
     } else if( you != nullptr ) {
-        std::vector<tripoint> valid;
-        for( const tripoint &jk : here.points_in_radius( p, 1 ) ) {
+        std::vector<tripoint_bub_ms> valid;
+        for( const tripoint_bub_ms &jk : here.points_in_radius( p, 1 ) ) {
             if( g->is_empty( jk ) ) {
                 valid.push_back( jk );
             }
@@ -435,7 +458,7 @@ bool trapfunc::tripwire( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
+bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     bool add_bolt = true;
     if( c != nullptr ) {
@@ -533,7 +556,7 @@ bool trapfunc::crossbow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
+bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
 {
     map &here = get_map();
     sounds::sound( p, 60, sounds::sound_t::combat, _( "Kerblam!" ), false, "fire_gun",
@@ -635,7 +658,7 @@ bool trapfunc::shotgun( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::blade( const tripoint &, Creature *c, item * )
+bool trapfunc::blade( const tripoint_bub_ms &, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -653,7 +676,7 @@ bool trapfunc::blade( const tripoint &, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
+bool trapfunc::snare_light( const tripoint_bub_ms &p, Creature *c, item * )
 {
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
     map &here = get_map();
@@ -681,7 +704,7 @@ bool trapfunc::snare_light( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
+bool trapfunc::snare_heavy( const tripoint_bub_ms &p, Creature *c, item * )
 {
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
     get_map().remove_trap( p );
@@ -729,7 +752,7 @@ bool trapfunc::snare_heavy( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::snare_species( const tripoint &p, Creature *critter, item * )
+bool trapfunc::snare_species( const tripoint_bub_ms &p, Creature *critter, item * )
 {
     map &here = get_map();
     const trap &laid_trap = here.tr_at( p );
@@ -791,7 +814,7 @@ bool trapfunc::snare_species( const tripoint &p, Creature *critter, item * )
     return true;
 }
 
-bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
+bool trapfunc::landmine( const tripoint_bub_ms &p, Creature *c, item * )
 {
     // tiny animals are too light to trigger land mines
     if( c != nullptr && c->get_size() == creature_size::tiny ) {
@@ -801,12 +824,12 @@ bool trapfunc::landmine( const tripoint &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( c, tripoint_bub_ms( p ), 80.0f, 0.5f, false, 30, 0.2f );
+    explosion_handler::explosion( c, p, 80.0f, 0.5f, false, 30, 0.2f );
     get_map().remove_trap( p );
     return true;
 }
 
-bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
+bool trapfunc::boobytrap( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c != nullptr ) {
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
@@ -821,7 +844,7 @@ bool trapfunc::boobytrap( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::telepad( const tripoint &p, Creature *c, item * )
+bool trapfunc::telepad( const tripoint_bub_ms &p, Creature *c, item * )
 {
     //~ the sound of a telepad functioning
     sounds::sound( p, 6, sounds::sound_t::movement, _( "vvrrrRRMM*POP!*" ), false, "trap", "teleport" );
@@ -837,7 +860,7 @@ bool trapfunc::telepad( const tripoint &p, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::goo( const tripoint &p, Creature *c, item * )
+bool trapfunc::goo( const tripoint_bub_ms &p, Creature *c, item * )
 {
     get_map().remove_trap( p );
     if( c == nullptr ) {
@@ -885,7 +908,7 @@ bool trapfunc::goo( const tripoint &p, Creature *c, item * )
     cata_fatal( "c must be either a monster or a Character" );
 }
 
-bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
+bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -943,7 +966,7 @@ bool trapfunc::dissector( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -999,7 +1022,7 @@ bool trapfunc::pit( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1090,7 +1113,7 @@ bool trapfunc::pit_spikes( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
+bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1186,7 +1209,7 @@ bool trapfunc::pit_glass( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::lava( const tripoint &p, Creature *c, item * )
+bool trapfunc::lava( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1230,7 +1253,7 @@ bool trapfunc::lava( const tripoint &p, Creature *c, item * )
 }
 
 // STUB
-bool trapfunc::portal( const tripoint &p, Creature *c, item *i )
+bool trapfunc::portal( const tripoint_bub_ms &p, Creature *c, item *i )
 {
     // TODO: make this do something unique and interesting
     return telepad( p, c, i );
@@ -1242,10 +1265,10 @@ static bool query_for_item( const Character *pl, const itype_id &itemname, const
     return pl->has_amount( itemname, 1 ) && ( !pl->is_avatar() || query_yn( que ) );
 }
 
-static tripoint random_neighbor( tripoint center )
+static tripoint_bub_ms random_neighbor( tripoint_bub_ms center )
 {
-    center.x += rng( -1, 1 );
-    center.y += rng( -1, 1 );
+    center.x() += rng( -1, 1 );
+    center.y() += rng( -1, 1 );
     return center;
 }
 
@@ -1262,7 +1285,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( roll < diff ) {
         you.add_msg_if_player( m_bad, _( "You fail to attach it…" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
+        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
         return false;
     }
 
@@ -1275,7 +1298,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( safe.empty() ) {
         you.add_msg_if_player( m_bad, _( "There's nowhere to pull yourself to, and you sink!" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( tripoint_bub_ms( random_neighbor( you.pos() ) ), itemname );
+        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
         return false;
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
@@ -1289,7 +1312,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     }
 }
 
-bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
+bool trapfunc::sinkhole( const tripoint_bub_ms &p, Creature *c, item *i )
 {
     // tiny creatures don't trigger the sinkhole to collapse
     if( c == nullptr || c->get_size() == creature_size::tiny ) {
@@ -1335,7 +1358,7 @@ bool trapfunc::sinkhole( const tripoint &p, Creature *c, item *i )
     return true;
 }
 
-bool trapfunc::glow( const tripoint &p, Creature *c, item * )
+bool trapfunc::glow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr ) {
         return false;
@@ -1354,7 +1377,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
                 get_player_character().irradiate( rng( 10, 30 ) );
             } else if( one_in( 4 ) ) {
                 add_msg( m_bad, _( "A blinding flash strikes you!" ) );
-                explosion_handler::flashbang( tripoint_bub_ms( p ) );
+                explosion_handler::flashbang( p );
             } else {
                 add_msg( _( "Small flashes surround you." ) );
             }
@@ -1366,7 +1389,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
             you->irradiate( rng( 10, 30 ) );
         } else if( one_in( 4 ) ) {
             you->add_msg_if_player( m_bad, _( "A blinding flash strikes you!" ) );
-            explosion_handler::flashbang( tripoint_bub_ms( p ) );
+            explosion_handler::flashbang( p );
         } else {
             c->add_msg_if_player( _( "Small flashes surround you." ) );
         }
@@ -1375,7 +1398,7 @@ bool trapfunc::glow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::hum( const tripoint &p, Creature *, item * )
+bool trapfunc::hum( const tripoint_bub_ms &p, Creature *, item * )
 {
     int volume = rng( 1, 200 );
     std::string sfx;
@@ -1396,7 +1419,7 @@ bool trapfunc::hum( const tripoint &p, Creature *, item * )
     return true;
 }
 
-bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
+bool trapfunc::shadow( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c == nullptr || !c->is_avatar() ) {
         return false;
@@ -1406,13 +1429,13 @@ bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
     for( int tries = 0; tries < 10; tries++ ) {
         tripoint_bub_ms monp{ p };
         if( one_in( 2 ) ) {
-            monp.x() = p.x + rng( -5, +5 );
-            monp.y() = p.y + ( one_in( 2 ) ? -5 : +5 );
+            monp.x() = p.x() + rng( -5, +5 );
+            monp.y() = p.y() + ( one_in( 2 ) ? -5 : +5 );
         } else {
-            monp.x() = p.x + ( one_in( 2 ) ? -5 : +5 );
-            monp.y() = p.y + rng( -5, +5 );
+            monp.x() = p.x() + ( one_in( 2 ) ? -5 : +5 );
+            monp.y() = p.y() + rng( -5, +5 );
         }
-        if( !here.sees( monp, tripoint_bub_ms( p ), 10 ) ) {
+        if( !here.sees( monp, p, 10 ) ) {
             continue;
         }
         if( monster *const spawned = g->place_critter_at( mon_shadow, monp ) ) {
@@ -1425,7 +1448,7 @@ bool trapfunc::shadow( const tripoint &p, Creature *c, item * )
     return true;
 }
 
-bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
+bool trapfunc::map_regen( const tripoint_bub_ms &p, Creature *c, item * )
 {
     if( c ) {
         Character *you = dynamic_cast<Character *>( c );
@@ -1444,15 +1467,15 @@ bool trapfunc::map_regen( const tripoint &p, Creature *c, item * )
                 return false;
             }
             set_queued_points();
-            here.set_seen_cache_dirty( tripoint_bub_ms( p ) );
-            here.set_transparency_cache_dirty( p.z );
+            here.set_seen_cache_dirty( p );
+            here.set_transparency_cache_dirty( p.z() );
             return true;
         }
     }
     return false;
 }
 
-bool trapfunc::drain( const tripoint &, Creature *c, item * )
+bool trapfunc::drain( const tripoint_bub_ms &, Creature *c, item * )
 {
     if( c != nullptr ) {
         c->add_msg_if_player( m_bad, _( "You feel your life force sapping away." ) );
@@ -1469,7 +1492,7 @@ bool trapfunc::drain( const tripoint &, Creature *c, item * )
     return false;
 }
 
-bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
+bool trapfunc::cast_spell( const tripoint_bub_ms &p, Creature *critter, item * )
 {
     if( critter == nullptr ) {
         map &here = get_map();
@@ -1481,9 +1504,9 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         if( tr.has_flag( json_flag_PROXIMITY ) ) {
             // remove all traps in 3-3 area area
-            for( int x = p.x - 1; x <= p.x + 1; x++ ) {
-                for( int y = p.y - 1; y <= p.y + 1; y++ ) {
-                    tripoint_bub_ms pt( x, y, p.z );
+            for( int x = p.x() - 1; x <= p.x() + 1; x++ ) {
+                for( int y = p.y() - 1; y <= p.y() + 1; y++ ) {
+                    tripoint_bub_ms pt( x, y, p.z() );
                     if( here.tr_at( pt ).loadid == tr.loadid ) {
                         here.remove_trap( pt );
                     }
@@ -1491,8 +1514,8 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
             }
         }
         // we remove the trap before casting the spell because otherwise if we teleport we might be elsewhere at the end and p is no longer valid
-        trap_spell.cast_all_effects( dummy, tripoint_bub_ms( p ) );
-        trap_spell.make_sound( tripoint_bub_ms( p ), get_player_character() );
+        trap_spell.cast_all_effects( dummy, p );
+        trap_spell.make_sound( p, get_player_character() );
         return true;
     } else {
         map &here = get_map();
@@ -1504,9 +1527,9 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         if( tr.has_flag( json_flag_PROXIMITY ) ) {
             // remove all traps in 3-3 area area
-            for( int x = p.x - 1; x <= p.x + 1; x++ ) {
-                for( int y = p.y - 1; y <= p.y + 1; y++ ) {
-                    tripoint_bub_ms pt( x, y, p.z );
+            for( int x = p.x() - 1; x <= p.x() + 1; x++ ) {
+                for( int y = p.y() - 1; y <= p.y() + 1; y++ ) {
+                    tripoint_bub_ms pt( x, y, p.z() );
                     if( here.tr_at( pt ).loadid == tr.loadid ) {
                         here.remove_trap( pt );
                     }
@@ -1515,12 +1538,12 @@ bool trapfunc::cast_spell( const tripoint &p, Creature *critter, item * )
         }
         // we remove the trap before casting the spell because otherwise if we teleport we might be elsewhere at the end and p is no longer valid
         trap_spell.cast_all_effects( dummy, critter->pos_bub() );
-        trap_spell.make_sound( tripoint_bub_ms( p ), get_player_character() );
+        trap_spell.make_sound( p, get_player_character() );
         return true;
     }
 }
 
-bool trapfunc::snake( const tripoint &p, Creature *, item * )
+bool trapfunc::snake( const tripoint_bub_ms &p, Creature *, item * )
 {
     //~ the sound a snake makes
     sounds::sound( p, 10, sounds::sound_t::movement, _( "ssssssss" ), false, "misc", "snake_hiss" );
@@ -1532,13 +1555,13 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
         for( int tries = 0; tries < 10; tries++ ) {
             tripoint_bub_ms monp{ p };
             if( one_in( 2 ) ) {
-                monp.x() = p.x + rng( -5, +5 );
-                monp.y() = p.y + ( one_in( 2 ) ? -5 : +5 );
+                monp.x() = p.x() + rng( -5, +5 );
+                monp.y() = p.y() + ( one_in( 2 ) ? -5 : +5 );
             } else {
-                monp.x() = p.x + ( one_in( 2 ) ? -5 : +5 );
-                monp.y() = p.y + rng( -5, +5 );
+                monp.x() = p.x() + ( one_in( 2 ) ? -5 : +5 );
+                monp.y() = p.y() + rng( -5, +5 );
             }
-            if( !here.sees( monp, tripoint_bub_ms( p ), 10 ) ) {
+            if( !here.sees( monp, p, 10 ) ) {
                 continue;
             }
             if( monster *const spawned = g->place_critter_at( mon_shadow_snake, monp ) ) {
@@ -1552,7 +1575,7 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
     return true;
 }
 
-bool trapfunc::dummy_trap( const tripoint &, Creature *, item * )
+bool trapfunc::dummy_trap( const tripoint_bub_ms &, Creature *, item * )
 {
     return true;
 }

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -104,7 +104,7 @@ bool repair_part( vehicle &veh, vehicle_part &pt, Character &who )
     // allow NPCs to use welding rigs they can't see ( on the other side of a vehicle )
     // as they have the handicap of not being able to use the veh interaction menu
     // or able to drag a welding cart etc.
-    map_inv.form_from_map( who.pos(), PICKUP_RANGE, &who, false, !who.is_npc() );
+    map_inv.form_from_map( who.pos_bub(), PICKUP_RANGE, &who, false, !who.is_npc() );
     if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
         who.add_msg_if_player( m_info, _( "You don't meet the requirements to repair the %s." ),
                                pt.name() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6360,7 +6360,7 @@ bool vehicle::decrement_summon_timer()
             }
             vp.items.clear();
         }
-        add_msg_if_player_sees( pos_bub().raw(), m_info, _( "Your %s winks out of existence." ), name );
+        add_msg_if_player_sees( pos_bub(), m_info, _( "Your %s winks out of existence." ), name );
         get_map().destroy_vehicle( this );
         return true;
     } else {
@@ -7239,7 +7239,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, const tripoint_bub_ms
             const int max_dist = vp_loose.get_base().max_link_length();
 
             if( distance > max_dist || shed_cables == trinary::ALL ) {
-                add_msg_if_player_sees( bub_part_pos( vp_loose ).raw(), m_warning,
+                add_msg_if_player_sees( bub_part_pos( vp_loose ), m_warning,
                                         _( "The %s's %s was detached!" ), name, vp_loose.name( false ) );
                 remove_remote = true;
             } else {
@@ -7587,23 +7587,23 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
                 continue; // Ignore the frame being destroyed
             } else if( vpi_here.has_flag( "TOW_CABLE" ) ) {
                 // Tow cables - remove it in one piece, remove remote part, and remove towing data
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                         vp_here.name() );
                 invalidate_towing( true );
             } else if( vpi_here.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 // Electrical cables - remove it in one piece and remove remote part
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                         vp_here.name() );
                 here.add_item_or_charges( pos, part_to_item( vp_here ) );
                 remove_remote_part( vp_here );
             } else if( vp_here.is_broken() ) {
                 // Tearing off a broken part - break it up
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %s's %s breaks into pieces!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %s's %s breaks into pieces!" ), name,
                                         vp_here.name() );
                 scatter_parts( vp_here );
             } else {
                 // Intact (but possibly damaged) part - remove it in one piece
-                add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is torn off!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is torn off!" ), name,
                                         vp_here.name() );
                 if( !magic ) {
                     here.add_item_or_charges( pos, part_to_item( vp_here ) );
@@ -7612,25 +7612,25 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
             remove_part( vp_here, *handler_ptr );
         }
         // After clearing the frame, remove it.
-        add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+        add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
         scatter_parts( vp );
         remove_part( vp, *handler_ptr );
         find_and_split_vehicles( here, { index_of_part( &vp, /* include_removed = */ true ) } );
     } else {
         if( vpi.has_flag( "TOW_CABLE" ) ) {
             // Tow cables - remove it in one piece, remove remote part, and remove towing data
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                     vp.name() );
             invalidate_towing( true );
         } else if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
             // Electrical cables - remove it in one piece and remove remote part
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                     vp.name() );
             here.add_item_or_charges( pos, part_to_item( vp ) );
             remove_remote_part( vp );
         } else {
             //Just break it off
-            add_msg_if_player_sees( pos.raw(), m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
+            add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s is destroyed!" ), name, vp.name() );
             scatter_parts( vp );
         }
         const point_rel_ms position = vp.mount;
@@ -7771,9 +7771,9 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         } else {
             item part_as_item = part_to_item( vp );
             if( vpi.has_flag( "INITIAL_PART" ) ) {
-                add_msg_if_player_sees( vppos.raw(), m_bad, _( "The %s falls over!" ), name );
+                add_msg_if_player_sees( vppos, m_bad, _( "The %s falls over!" ), name );
             } else {
-                add_msg_if_player_sees( vppos.raw(), m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
+                add_msg_if_player_sees( vppos, m_bad, _( "The %1$s's %2$s is disconnected!" ), name,
                                         vp.name() );
             }
             if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2288,7 +2288,7 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
                                                "the power of the impact!" ), veh.name );
                 unboard_vehicle( part_pos );
             } else {
-                add_msg_if_player_sees( part_pos.raw(), m_bad,
+                add_msg_if_player_sees( part_pos, m_bad,
                                         _( "The %s is hurled from %s's by the power of the impact!" ),
                                         pet->disp_name(), veh.name );
             }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -580,7 +580,7 @@ double vehicle::engine_cold_factor( const vehicle_part &vp ) const
     }
 
     const tripoint_bub_ms pos = bub_part_pos( vp );
-    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos.raw() ) );
+    double eff_temp = units::to_fahrenheit( get_weather().get_temperature( pos ) );
     if( !vp.has_fault_flag( "BAD_COLD_START" ) ) {
         eff_temp = std::min( eff_temp, 20.0 );
     }
@@ -1583,7 +1583,8 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
         return;
     }
     creature_tracker &creatures = get_creature_tracker();
-    const std::function<bool( const tripoint & )> f = [&creatures]( const tripoint & pnt ) {
+    const std::function<bool( const tripoint_bub_ms & )> f = [&creatures](
+    const tripoint_bub_ms & pnt ) {
         monster *mon_ptr = creatures.creature_at<monster>( pnt );
         if( mon_ptr == nullptr ) {
             return false;
@@ -1593,14 +1594,14 @@ void vehicle::use_harness( int part, const tripoint_bub_ms &pos )
                                     f.has_flag( mon_flag_PET_HARNESSABLE ) );
     };
 
-    const std::optional<tripoint> pnt_ = choose_adjacent_highlight(
-            _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
-            false );
+    const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
+                _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
+                false );
     if( !pnt_ ) {
         add_msg( m_info, _( "Never mind." ) );
         return;
     }
-    const tripoint &target = *pnt_;
+    const tripoint_bub_ms &target = *pnt_;
     monster *mon_ptr = creatures.creature_at<monster>( target );
     if( mon_ptr == nullptr ) {
         add_msg( m_info, _( "No creature there." ) );

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -552,7 +552,7 @@ float weakpoint::hit_chance( const weakpoint_attack &attack ) const
     } else {
         // Use erfc if the wp does not benefit the attacker.
         diff = attack.wp_skill - std::max( difficulty.of( attack ) + 10.0f, 10.0f );
-        difficulty_mult = 0.5f * erfc( diff / ( 2.0f * sqrt( 2.0f ) ) );
+        difficulty_mult = std::max( 0.5f * erfc( diff / ( 2.0f * sqrt( 2.0f ) ) ), 0.1f );
         final_coverage = coverage;
     }
 

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -549,8 +549,7 @@ float weakpoint::hit_chance( const weakpoint_attack &attack ) const
         } else {
             final_coverage = coverage;
         }
-    }
-    else {
+    } else {
         // Use erfc if the wp does not benefit the attacker.
         diff = attack.wp_skill - std::max( difficulty.of( attack ) + 10.0f, 10.0f );
         difficulty_mult = 0.5f * erfc( diff / ( 2.0f * sqrt( 2.0f ) ) );

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -535,16 +535,25 @@ float weakpoint::hit_chance( const weakpoint_attack &attack ) const
 
     // Retrieve multipliers.
     float constant_mult = coverage_mult.of( attack );
-    // Probability of a sample from a normal distribution centered on `skill` with `SD = 2`
-    // exceeding the difficulty.
-    float diff = attack.wp_skill - difficulty.of( attack );
-    float difficulty_mult = 0.5f * ( 1.0f + erf( diff / ( 2.0f * sqrt( 2.0f ) ) ) );
+    float diff;
+    float difficulty_mult;
     float final_coverage;
-
-    if( attack.source && attack.source->as_character() && is_good ) {
-        final_coverage = attack.source->as_character()->enchantment_cache->modify_value(
-                             enchant_vals::mod::WEAKPOINT_ACCURACY, coverage );
-    } else {
+    if( is_good ) {
+        // Probability of a sample from a normal distribution centered on `skill` with `SD = 2`
+        // exceeding the difficulty.
+        diff = attack.wp_skill - difficulty.of( attack );
+        difficulty_mult = 0.5f * ( 1.0f + erf( diff / ( 2.0f * sqrt( 2.0f ) ) ) );
+        if( attack.source && attack.source->as_character() ) {
+            final_coverage = attack.source->as_character()->enchantment_cache->modify_value(
+                                 enchant_vals::mod::WEAKPOINT_ACCURACY, coverage );
+        } else {
+            final_coverage = coverage;
+        }
+    }
+    else {
+        // Use erfc if the wp does not benefit the attacker.
+        diff = attack.wp_skill - std::max( difficulty.of( attack ) + 10.0f, 10.0f );
+        difficulty_mult = 0.5f * erfc( diff / ( 2.0f * sqrt( 2.0f ) ) );
         final_coverage = coverage;
     }
 
@@ -579,12 +588,19 @@ const weakpoint *weakpoints::select_weakpoint( const weakpoint_attack &attack ) 
     float reweighed = 0.0f;
     float idx = rng_float( 0.0f, 100.0f );
     for( const weakpoint &weakpoint : weakpoint_list ) {
-        float new_base = base + weakpoint.hit_chance( attack );
+        float raw_chance = weakpoint.hit_chance( attack );
+        if( raw_chance == 0.0f ) {
+            add_msg_debug( debugmode::DF_MONSTER,
+                           "Weakpoint Selection: weakpoint %s, conditions not match",
+                           weakpoint.id );
+            continue;
+        }
+        float new_base = base + raw_chance;
         float new_reweighed = 100.0f * reweigh( new_base / 100.0f, rolls );
         float hit_chance = new_reweighed - reweighed;
         add_msg_debug( debugmode::DF_MONSTER,
-                       "Weakpoint Selection: weakpoint %s, hit_chance %.4f",
-                       weakpoint.id, hit_chance );
+                       "Weakpoint Selection: weakpoint %s, raw_chance %.4f, hit_chance %.4f",
+                       weakpoint.id, raw_chance, hit_chance );
         if( idx < hit_chance ) {
             return &weakpoint;
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -870,7 +870,7 @@ rl_vec2d convert_wind_to_coord( const int angle )
 bool warm_enough_to_plant( const tripoint_bub_ms &pos )
 {
     // semi-appropriate temperature for most plants
-    return get_weather().get_temperature( pos.raw() ) >= units::from_fahrenheit( 50 );
+    return get_weather().get_temperature( pos ) >= units::from_fahrenheit( 50 );
 }
 
 bool warm_enough_to_plant( const tripoint_abs_omt &pos )
@@ -949,7 +949,7 @@ void weather_manager::set_nextweather( time_point t )
     update_weather();
 }
 
-units::temperature weather_manager::get_temperature( const tripoint &location )
+units::temperature weather_manager::get_temperature( const tripoint_bub_ms &location )
 {
     if( forced_temperature ) {
         return *forced_temperature;
@@ -961,13 +961,13 @@ units::temperature weather_manager::get_temperature( const tripoint &location )
     }
 
     //underground temperature = average New England temperature = 43F/6C
-    units::temperature temp = location.z < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
+    units::temperature temp = location.z() < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
 
     if( !g->new_game ) {
         units::temperature_delta temp_mod;
-        temp_mod = get_heat_radiation( tripoint_bub_ms( location ) );
-        temp_mod += get_convection_temperature( tripoint_bub_ms( location ) );
-        temp_mod += get_map().get_temperature_mod( tripoint_bub_ms( location ) );
+        temp_mod = get_heat_radiation( location );
+        temp_mod += get_convection_temperature( location );
+        temp_mod += get_map().get_temperature_mod( location );
 
         temp += temp_mod;
     }

--- a/src/weather.h
+++ b/src/weather.h
@@ -223,9 +223,9 @@ class weather_manager
         // The time at which weather will shift next.
         time_point nextweather;
         /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures */
-        std::unordered_map< tripoint, units::temperature > temperature_cache;
+        std::unordered_map< tripoint_bub_ms, units::temperature > temperature_cache;
         // Returns outdoor or indoor temperature of given location
-        units::temperature get_temperature( const tripoint &location );
+        units::temperature get_temperature( const tripoint_bub_ms &location );
         // Returns outdoor or indoor temperature of given location
         units::temperature get_temperature( const tripoint_abs_omt &location ) const;
         void clear_temp_cache();

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -47,15 +47,16 @@ struct weather_gen_common {
     season_type season = season_type::SPRING;
 };
 
-static weather_gen_common get_common_data( const tripoint &location, const time_point &real_t,
+static weather_gen_common get_common_data( const tripoint_abs_ms &location,
+        const time_point &real_t,
         unsigned seed )
 {
     season_effective_time t( real_t );
     weather_gen_common result;
     // Integer x position / widening factor of the Perlin function.
-    result.x = location.x / 2000.0;
+    result.x = location.x() / 2000.0;
     // Integer y position / widening factor of the Perlin function.
-    result.y = location.y / 2000.0;
+    result.y = location.y() / 2000.0;
     // Integer turn / widening factor of the Perlin function.
     result.z = to_days<double>( real_t - calendar::turn_zero );
     // Limit the random seed during noise calculation, a large value flattens the noise generator to zero
@@ -106,7 +107,7 @@ static units::temperature weather_temperature_from_common_data( const weather_ge
 }
 
 units::temperature weather_generator::get_weather_temperature(
-    const tripoint &location, const time_point &real_t, unsigned seed ) const
+    const tripoint_abs_ms &location, const time_point &real_t, unsigned seed ) const
 {
     return weather_temperature_from_common_data( *this, get_common_data( location, real_t, seed ),
             season_effective_time( real_t ) );
@@ -115,7 +116,7 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
                                         unsigned seed ) const
 {
     season_effective_time t( real_t );
-    const weather_gen_common common = get_common_data( location.raw(), real_t, seed );
+    const weather_gen_common common = get_common_data( location, real_t, seed );
 
     const double x( common.x );
     const double y( common.y );

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -71,7 +71,8 @@ class weather_generator
         units::temperature get_water_temperature() const;
         void test_weather( unsigned seed ) const;
         void sort_weather();
-        units::temperature get_weather_temperature( const tripoint &, const time_point &, unsigned ) const;
+        units::temperature get_weather_temperature( const tripoint_abs_ms &, const time_point &,
+                unsigned ) const;
 
         static weather_generator load( const JsonObject &jo );
 };

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -166,7 +166,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         weather_manager &weather = get_weather();
         weather.temperature = units::from_fahrenheit( 0 );
         weather.clear_temp_cache();
-        REQUIRE( units::to_fahrenheit( weather.get_temperature( test_npc.pos() ) ) == Approx( 0 ) );
+        REQUIRE( units::to_fahrenheit( weather.get_temperature( test_npc.pos_bub() ) ) == Approx( 0 ) );
         test_npc.update_bodytemp();
         REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
         CHECK( npc_needs.tick( &oracle ) == "idle" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -752,7 +752,7 @@ TEST_CASE( "dialogue_copy", "[eoc]" )
 
     item hammer( "hammer" ) ;
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint::zero );
+    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
     dialogue d2( get_talker_for( hloc ), get_talker_for( comp ) );
     dialogue d2_copy( d2 );
     d2_copy.set_value( "suppress", "1" );
@@ -776,7 +776,7 @@ TEST_CASE( "EOC_meta_test", "[eoc]" )
     monster zombie( mon_zombie );
     item hammer( "hammer" ) ;
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint::zero );
+    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
 
     dialogue d_empty( std::make_unique<talker>(), std::make_unique<talker>() );
     dialogue d_avatar( get_talker_for( get_avatar() ), std::make_unique<talker>() );

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -66,19 +66,11 @@ void add_msg( const game_message_params &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }
-void add_msg_if_player_sees( const tripoint &, std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
 void add_msg_if_player_sees( const tripoint_bub_ms &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }
 void add_msg_if_player_sees( const Creature &, std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
-void add_msg_if_player_sees( const tripoint &, const game_message_params &, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -220,7 +220,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     restore_on_out_of_scope restore_temp(
         get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );
-    REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc.raw() ) ) == 21 );
+    REQUIRE( units::to_celsius( get_weather().get_temperature( test_loc ) ) == 21 );
 
     item almond_milk( "almond_milk" );
     item *bp = nullptr;


### PR DESCRIPTION
#### Summary
December Backports

#### Purpose of change
i will not stop

#### Describe the solution
78714 unhardcode mx_jabberwock
78724 fix remove_vehicles
78739 fix enchantment
78743 improve ccache (note: if build breaks this is what did it)
78745 let monsters evaluate enchantment conditions
78751 smokable eggplant
78753 typified stuff
78762 fix duplicate integrated armor
78764 fix special_vision serialization
78773 fix recipe for water purifying
78789 transparent pockets let contained items illuminate surroundings
78793 typified stuff
78797 skill avoids bad weakpoints
78810 npcs wont wield integrated armor

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
