### PR TITLE
Remove link from smart lamp for now

### DIFF
--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -966,8 +966,7 @@
         "msg": "Your smart lamp turned off.",
         "menu_text": "Turn off",
         "type": "transform"
-      },
-      { "type": "link_up", "cable_length": 3, "charge_rate": "6 W" }
+      }
     ],
     "flags": [
       "ALLOWS_REMOTE_USE",


### PR DESCRIPTION
#### Summary
Remove link from smart lamp for now

#### Purpose of change
There's some weird stuff going on with this item that DDA hasn't solved, and the error messages are annoying.

#### Describe the solution
Remove the link action.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
