### PR TITLE
PTR is SMG

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -246,7 +246,7 @@
     "volume": "2110 ml",
     "longest_side": "377 mm",
     "barrel_length": "116 mm",
-    "skill": "pistol",
+    "skill": "smg",
     "range": 1,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "dispersion": 270,


### PR DESCRIPTION
#### Summary
PTR is SMG

#### Purpose of change
The PTR 603 was not accepting straps because it was flagged as a pistol. It's a semi auto mp5 clone, so ehhhh.

#### Describe the solution
Switch it to smg for now. This'll be fixed by the skill rework anyway.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
