### PR TITLE
Zombie deer can bash

### DIFF
--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -31,7 +31,7 @@
     "special_attacks": [ { "id": "bite_grab", "attack_upper": false, "cooldown": 5 }, { "id": "scratch_grab_required", "max_mul": 1.5 } ],
     "death_drops": "mon_dog_death_drops",
     "upgrades": { "half_life": 42, "into": "mon_dog_skeleton_brute" },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "POISON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "POISON", "FILTHY", "BASHES" ],
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 12, "electric": 1 }
   },
   {
@@ -208,7 +208,7 @@
     "vision_night": 3,
     "harvest": "puppy_bones",
     "upgrades": { "half_life": 42, "into": "mon_dog_skeleton_brute" },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "POISON", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "POISON", "FILTHY", "BASHES" ],
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 12, "electric": 3 }
   },
   {

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -718,6 +718,7 @@
       "POISON",
       "NO_BREATHE",
       "REVIVES",
+      "BASHES",
       "FILTHY",
       "KEENNOSE",
       "GOODHEARING"
@@ -763,6 +764,7 @@
       "NO_BREATHE",
       "REVIVES",
       "FILTHY",
+      "BASHES",
       "KEENNOSE",
       "GOODHEARING"
     ],


### PR DESCRIPTION
#### Summary
Zombie deer can bash

#### Purpose of change
Zombie deer couldn't bash. This was unintended, all zombies should have the same sort of behavior unless they're special.

#### Describe the solution
Give them BASHES. I didn't give them GROUP_BASH as it looks like that's only meant to be applied to either adult human zombies or especially big animals, I guess to account for their differing anatomy making it harder to pack lots of them together and trample effectively or something. It's probably due for a review.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
