### PR TITLE
A fun combat balance pass

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5116,5 +5116,24 @@
     "desc": [ "You are especially adept at climbing and can scale most vertical surfaces with ease." ],
     "flags": [ "WALL_CLING" ],
     "rating": "good"
+  },
+  {
+    "type": "effect_type",
+    "id": "monster_dodged",
+    "name": [ "Dodged" ],
+    "desc": [ "Monster effect used to penalize subsequent dodges.  This is a bug if you have it." ],
+    "max_intensity": 2,
+    "int_add_val": 1,
+    "max_duration": "1 s",
+    "base_mods": { "dodge_mod": [ -1 ] },
+    "scaling_mods": { "dodge_mod": [ -1.0 ] }
+  },
+  {
+    "type": "effect_type",
+    "id": "maimed_armor_migo",
+    "name": [ "Cracked Carapace" ],
+    "show_in_info": true,
+    "max_duration": "100000 s",
+    "desc": [ "Monster effect used to enable a weakpoint.  This is a bug if you have it." ]
   }
 ]

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -246,7 +246,6 @@
     "volume": "2110 ml",
     "longest_side": "377 mm",
     "barrel_length": "116 mm",
-    "skill": "smg",
     "range": 1,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "dispersion": 270,

--- a/data/json/monster_weakpoints/migo_weakpoints.json
+++ b/data/json/monster_weakpoints/migo_weakpoints.json
@@ -84,6 +84,46 @@
             "damage_required": [ 51, 100 ]
           }
         ]
+      },
+      {
+        "id": "armour_carapace",
+        "name": "the carapace",
+        "is_good": false,
+        "armor_mult": { "cut": 1.3, "stab": 1.15, "bullet": 1.2 },
+        "coverage_mult": { "bash": 2.0, "point": 0.3 },
+        "condition": { "not": { "npc_has_any_effect": [ "maimed_armor_migo" ] } },
+        "effects": [
+          {
+            "effect": "maimed_armor_migo",
+            "chance": 15,
+            "message": "The carapace is cracked!",
+            "damage_required": [ 0, 10 ],
+            "duration": [ 10, 1000 ]
+          },
+          {
+            "effect": "maimed_armor_migo",
+            "chance": 20,
+            "message": "The carapace is badly cracked!",
+            "damage_required": [ 11, 20 ],
+            "duration": [ 100, 10000 ]
+          },
+          {
+            "effect": "maimed_armor_migo",
+            "chance": 25,
+            "message": "The carapace is broken open!",
+            "damage_required": [ 21, 200 ],
+            "duration": [ 1000, 100000 ]
+          }
+        ],
+        "coverage": 5
+      },
+      {
+        "id": "armour_shattered",
+        "name": "a crack in the carapace",
+        "armor_mult": { "all": 0.25 },
+        "coverage_mult": { "ranged": 0.8 },
+        "coverage": 20,
+        "condition": { "npc_has_any_effect": [ "maimed_armor_migo" ] }
       }
     ]
   }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -108,6 +108,7 @@ static const efftype_id effect_foamcrete_slow( "foamcrete_slow" );
 static const efftype_id effect_invisibility( "invisibility" );
 static const efftype_id effect_knockdown( "knockdown" );
 static const efftype_id effect_lying_down( "lying_down" );
+static const efftype_id effect_monster_dodged( "monster_dodged" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
 static const efftype_id effect_onfire( "onfire" );
@@ -876,15 +877,15 @@ int Creature::size_melee_penalty() const
 {
     switch( get_size() ) {
         case creature_size::tiny:
-            return 30;
+            return rng( 10, 30 );
         case creature_size::small:
-            return 15;
+            return rng( 5, 15 );
         case creature_size::medium:
             return 0;
         case creature_size::large:
-            return -10;
+            return rng( -5, -15 );
         case creature_size::huge:
-            return -20;
+            return rng( -10, -30 );
         case creature_size::num_sizes:
             debugmsg( "ERROR: Creature has invalid size class." );
             return 0;
@@ -1664,7 +1665,6 @@ bool Creature::dodge_check( float hit_roll, bool force_try, float )
     if( uncanny_dodge() ) {
         return true;
     }
-
     const float dodge_ability = dodge_roll();
     // center is 5 - 0 / 2
     // stddev is 5 - 0 / 4

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -110,6 +110,7 @@ static const efftype_id effect_leashed( "leashed" );
 static const efftype_id effect_lightsnare( "lightsnare" );
 static const efftype_id effect_maimed_arm( "maimed_arm" );
 static const efftype_id effect_monster_armor( "monster_armor" );
+static const efftype_id effect_monster_dodged( "monster_dodged" );
 static const efftype_id effect_monster_saddled( "monster_saddled" );
 static const efftype_id effect_natures_commune( "natures_commune" );
 static const efftype_id effect_nemesis_buff( "nemesis_buff" );
@@ -3547,7 +3548,7 @@ void monster::process_effects()
 
     // Slip on bile, or not.
     if( has_effect( effect_slippery_terrain ) && !is_immune_effect( effect_downed ) && !flies() &&
-        !digging() && !has_effect( effect_downed ) ) {
+        !digging() && !has_effect( effect_downed ) && !type->in_species( species_ROBOT ) ) {
         map &here = get_map();
         if( here.has_flag( ter_furn_flag::TFLAG_FLAT, pos() ) &&
             !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos() ) ) {
@@ -3577,7 +3578,9 @@ void monster::process_effects()
             remove_effect( effect_cramped_space );
         }
     }
-
+    if( has_effect( effect_monster_dodged ) ) {
+        remove_effect( effect_monster_dodged );
+    }
     Creature::process_effects();
 }
 
@@ -3845,7 +3848,7 @@ float monster::speed_rating() const
 
 void monster::on_dodge( Creature *, float, float )
 {
-    // Currently does nothing, later should handle faction relations
+    add_effect( effect_monster_dodged, 1_seconds, false );
 }
 
 void monster::on_hit( Creature *source, bodypart_id,

--- a/src/monster.h
+++ b/src/monster.h
@@ -409,11 +409,11 @@ class monster : public Creature
         float get_hit_base() const override;
         float get_dodge_base() const override;
 
-        float  get_dodge( bool critfail = true ) const
+        float get_dodge( bool critfail = true ) const
         override;       // Natural dodge, or 0 if we're occupied
-        float  get_melee() const override; // For determining attack skill when awarding dodge practice.
-        float  hit_roll() const override;  // For the purposes of comparing to player::dodge_roll()
-        float  dodge_roll() const override;  // For the purposes of comparing to player::hit_roll()
+        float get_melee() const override; // For determining attack skill when awarding dodge practice.
+        float hit_roll() const override;  // For the purposes of comparing to player::dodge_roll()
+        float dodge_roll() const override;  
 
         bool can_attack_high() const override; // Can we attack upper limbs?
         int get_grab_strength() const; // intensity of grabbed effect
@@ -434,7 +434,7 @@ class monster : public Creature
         bool has_grab_break_tec() const override;
 
         float stability_roll() const override;
-        // We just dodged an attack from something
+        // We just dodged an attack from something. Penalize further dodge attempts for the rest of this second.
         void on_dodge( Creature *source, float difficulty, float training_level = 0.0 ) override;
         void on_try_dodge() override {}
         // Something hit us (possibly null source)

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -604,7 +604,7 @@ double occupied_tile_fraction( creature_size target_size )
 {
     switch( target_size ) {
         case creature_size::tiny:
-            return 0.2;
+            return 0.25;
         case creature_size::small:
             return 0.35;
         case creature_size::medium:
@@ -612,12 +612,11 @@ double occupied_tile_fraction( creature_size target_size )
         case creature_size::large:
             return 0.65;
         case creature_size::huge:
-            return 0.8;
+            return 0.85;
         case creature_size::num_sizes:
-            debugmsg( "ERROR: Invalid Creature size class." );
             break;
     }
-
+    debugmsg( "ERROR: occupied_tile_fraction found invalid creature size." );
     return 0.5;
 }
 
@@ -638,22 +637,9 @@ double Creature::ranged_target_size() const
         }
     }
     if( has_flag( mon_flag_HARDTOSHOOT ) ) {
-        switch( get_size() ) {
-            case creature_size::tiny:
-            case creature_size::small:
-                return stance_factor * occupied_tile_fraction( creature_size::tiny );
-            case creature_size::medium:
-                return stance_factor * occupied_tile_fraction( creature_size::small );
-            case creature_size::large:
-                return stance_factor * occupied_tile_fraction( creature_size::medium );
-            case creature_size::huge:
-                return stance_factor * occupied_tile_fraction( creature_size::large );
-            case creature_size::num_sizes:
-                debugmsg( "ERROR: Invalid Creature size class." );
-                break;
-        }
+        stance_factor -= 0.25;
     }
-    return stance_factor * occupied_tile_fraction( get_size() );
+    return std::clamp( ( stance_factor * occupied_tile_fraction( get_size() ) ), 0.1, 1.0 );
 }
 
 int range_with_even_chance_of_good_hit( int dispersion )


### PR DESCRIPTION
#### Summary
A fun combat balance pass

#### Purpose of change
- Creatures are easier or harder to hit in melee based on their size. These numbers were very inflated for tiny and huge creatures, and they were not standardized.
- Mi-go and wasps had an easy time clearing dozens or hundreds of zombies due to how dodge rolls and armor work.
- There were some ongoing issues with HARDTOSHOOT and occupied_tile_fraction.

#### Describe the solution
- Melee to-hit penalties/bonuses for size are standardized, clamped a bit, and slightly randomized.
- Adjusted HARDTOSHOOT, making both tiny and huge creatures slightly easier to hit. HARDTOSHOOT is now equivalent to crouching (a -25% multiplier to your occupied_tile_fraction).
- Clamped occupied_tile_size at 0.1 to 0.9 for sanity's sake.
- Added a monster-only on_dodge() effect which grants stacking penalties to the monster's dodge score for each dodge it has made this turn. This effect is manually cleared at the end of process_effects so it should never persist between turns. Currently this effect stacks up to 2 times.
- Gave mi-go (all types) a weakpoint with a 5% base proc (10% for bash attacks, 1.5% for bullets and stabs) which grants a 15% chance to crack their armor. Mi-go with cracked armor suffer a 75% penalty to all armor values. This is a temporary effect, as their carapaces regrow like the mi-go ballistic plate. While the player can exploit this in battle, the chances are low. The intent is that mi-go are unlikely to get cracked carapaces except when mobbed by zombies. This means they will be far worse at clearing out towns, but not all that less dangerous to the player.

#### Describe alternatives you've considered
Crowd crush for monsters.

#### Testing
Oversized wasps can kill a few zombies before succumbing. Mi-go can kill 15 or more, but will eventually go down.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
