### PR TITLE
Guard against potential segfault in aim code

### DIFF
--- a/data/json/mapgen/nested/mansion_nested.json
+++ b/data/json/mapgen/nested/mansion_nested.json
@@ -42,15 +42,17 @@
         "0": "t_fungus_wall",
         "!": [ [ "t_thconc_floor", 4 ], [ "t_fungus_mound", 3 ] ]
       },
-      "furniture": { 
-        "&": "f_table", "=": "f_machinery_old",
+      "furniture": {
+        "&": "f_table",
+        "=": "f_machinery_old",
         "}": [
           [ "f_generator_broken", 35 ],
           [ "f_portable_generator", 10 ],
           [ "f_diesel_generator", 5 ],
           [ "f_12000_gasoline_generator", 5 ]
         ],
-        "!": [ "f_crate_c", "f_cardboard_box" ] },
+        "!": [ "f_crate_c", "f_cardboard_box" ]
+      },
       "items": {
         ".": { "item": "clutter_basement", "chance": 1 },
         "!": { "item": "crate_stack", "chance": 80 },

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10723,7 +10723,8 @@ float item::gun_shot_spread_multiplier() const
     float ret = 1.0f;
     for( const item *mod : gunmods() ) {
         if( !mod || !mod->type || !mod->type->gunmod ) {
-        debugmsg( "gun_shot_spread_multiplier(): invalid gunmod detected on item %s", type ? typeId().c_str() : "unknown" );
+            debugmsg( "gun_shot_spread_multiplier(): invalid gunmod detected on item %s",
+                      type ? typeId().c_str() : "unknown" );
             continue;
         }
         ret += mod->type->gunmod->shot_spread_multiplier_modifier;
@@ -10738,7 +10739,8 @@ int item::gun_range( bool with_ammo ) const
     }
     // Defensive: ensure type->gun exists
     if( !type || !type->gun ) {
-        debugmsg( "gun_range(): item claimed is_gun() but type->gun is null for %s", type ? typeId().c_str() : "unknown" );
+        debugmsg( "gun_range(): item claimed is_gun() but type->gun is null for %s",
+                  type ? typeId().c_str() : "unknown" );
         return 0;
     }
 
@@ -10755,7 +10757,8 @@ int item::gun_range( bool with_ammo ) const
     if( with_ammo && has_ammo() ) {
         const itype *ammo_info = ammo_data();
         if( !ammo_info || !ammo_info->ammo ) {
-            debugmsg( "gun_range(): has_ammo() true but ammo_data()/ammo is null for %s", type ? typeId().c_str() : "unknown" );
+            debugmsg( "gun_range(): has_ammo() true but ammo_data()/ammo is null for %s",
+                      type ? typeId().c_str() : "unknown" );
         } else {
             ret += ammo_info->ammo->range;
             range_multiplier *= ammo_info->ammo->range_multiplier;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10722,6 +10722,10 @@ float item::gun_shot_spread_multiplier() const
     }
     float ret = 1.0f;
     for( const item *mod : gunmods() ) {
+        if( !mod || !mod->type || !mod->type->gunmod ) {
+        debugmsg( "gun_shot_spread_multiplier(): invalid gunmod detected on item %s", type ? typeId().c_str() : "unknown" );
+            continue;
+        }
         ret += mod->type->gunmod->shot_spread_multiplier_modifier;
     }
     return std::max( ret, 0.0f );
@@ -10732,18 +10736,32 @@ int item::gun_range( bool with_ammo ) const
     if( !is_gun() ) {
         return 0;
     }
+    // Defensive: ensure type->gun exists
+    if( !type || !type->gun ) {
+        debugmsg( "gun_range(): item claimed is_gun() but type->gun is null for %s", type ? typeId().c_str() : "unknown" );
+        return 0;
+    }
+
     int ret = type->gun->range;
-    float range_multiplier = 1.0;
+    float range_multiplier = 1.0f;
     for( const item *mod : gunmods() ) {
+        if( !mod || !mod->type || !mod->type->gunmod ) {
+            debugmsg( "gun_range(): invalid gunmod on %s", type ? typeId().c_str() : "unknown" );
+            continue;
+        }
         ret += mod->type->gunmod->range;
         range_multiplier *= mod->type->gunmod->range_multiplier;
     }
     if( with_ammo && has_ammo() ) {
         const itype *ammo_info = ammo_data();
-        ret += ammo_info->ammo->range;
-        range_multiplier *= ammo_info->ammo->range_multiplier;
+        if( !ammo_info || !ammo_info->ammo ) {
+            debugmsg( "gun_range(): has_ammo() true but ammo_data()/ammo is null for %s", type ? typeId().c_str() : "unknown" );
+        } else {
+            ret += ammo_info->ammo->range;
+            range_multiplier *= ammo_info->ammo->range_multiplier;
+        }
     }
-    ret *= range_multiplier;
+    ret = static_cast<int>( std::floor( ret * range_multiplier ) );
     return std::min( std::max( 0, ret ), RANGE_HARD_CAP );
 }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -413,7 +413,7 @@ class monster : public Creature
         override;       // Natural dodge, or 0 if we're occupied
         float get_melee() const override; // For determining attack skill when awarding dodge practice.
         float hit_roll() const override;  // For the purposes of comparing to player::dodge_roll()
-        float dodge_roll() const override;  
+        float dodge_roll() const override;
 
         bool can_attack_high() const override; // Can we attack upper limbs?
         int get_grab_strength() const; // intensity of grabbed effect

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1832,7 +1832,7 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
     }
     bool dest_is_curs = curs == dest;
     bool path_changed = false;
-    if( !path.empty() && !player_character.omt_path.empty() && 
+    if( !path.empty() && !player_character.omt_path.empty() &&
         path.front() == player_character.omt_path.front() && path != player_character.omt_path ) {
         // the player is trying to go to their existing destination but the path has changed
         path_changed = true;


### PR DESCRIPTION
#### Summary
Guard against potential segfault in aim code

#### Purpose of change
A player on the August 5 build was experiencing a segfault when an NPC attempted to aim at a kreck.

#### Describe the solution
Add some defensive coding to the aim code. I can't reproduce the issue, so it may have been fixed by backports. Still, it's always good to keep on top of this stuff.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
