### PR TITLE
Fix teamster response

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -151,7 +151,7 @@
       ]
     },
     "responses": [
-      { "text": "Thanks!  <done_conversation_section>", "topic": "TALK_FREE_MERCHANT_TEAMSTER_CHAT" },
+      { "text": "Thanks!", "topic": "TALK_FREE_MERCHANT_TEAMSTER_CHAT" },
       { "text": "Thanks!  I'll see you around.", "topic": "TALK_DONE" }
     ]
   },


### PR DESCRIPTION
#### Summary
Fix teamster response

#### Purpose of change
The teamster in the refugee center was calling an accidentally backported dialogue snippet that we don't use.

#### Describe the solution
Remove

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
