### PR TITLE
Buff skates

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10666,9 +10666,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     if( worn_with_flag( flag_ROLLER_INLINE ) ) {
         if( on_road ) {
             if( is_running() ) {
-                run_cost_effect_mul( 0.5f, _( "Inline Skates" ) );
+                run_cost_effect_mul( 0.65f, _( "Inline Skates" ) );
             } else if( is_walking() ) {
-                run_cost_effect_mul( 0.85f, _( "Inline Skates" ) );
+                run_cost_effect_mul( 0.65f, _( "Inline Skates" ) );
             }
         } else {
             run_cost_effect_mul( 1.5f, _( "Inline Skates" ) );
@@ -10680,9 +10680,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     if( worn_with_flag( flag_ROLLER_QUAD ) ) {
         if( on_road ) {
             if( is_running() ) {
-                run_cost_effect_mul( 0.7f, _( "Roller Skates" ) );
+                run_cost_effect_mul( 0.75f, _( "Roller Skates" ) );
             } else if( is_walking() ) {
-                run_cost_effect_mul( 0.85f, _( "Roller Skates" ) );
+                run_cost_effect_mul( 0.75f, _( "Roller Skates" ) );
             }
         } else {
             run_cost_effect_mul( 1.3f, _( "Roller Skates" ) );
@@ -10694,9 +10694,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     if( worn_with_flag( flag_ROLLER_ONE ) ) {
         if( on_road ) {
             if( is_running() ) {
-                run_cost_effect_mul( 0.85f, _( "Heelys" ) );
+                run_cost_effect_mul( 0.8f, _( "Heelys" ) );
             } else if( is_walking() ) {
-                run_cost_effect_mul( 0.9f, _( "Heelys" ) );
+                run_cost_effect_mul( 0.8f, _( "Heelys" ) );
             }
         } else {
             run_cost_effect_mul( 1.1f, _( "Heelys" ) );


### PR DESCRIPTION
#### Summary
Buff skates

#### Purpose of change
Skates have high encumbrance which was sort of taking their effectiveness. They were also giving an inordinate run buff compared to their walk buff.

#### Describe the solution
Normalize the movespeed buff and make it higher than it was for walking in all cases (heelys, rollerskates, rollerblades).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
