### PR TITLE
Give bloodfeeder tag max enjoyment

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -574,6 +574,7 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
                 fun *= 1.1;
             }
         }
+        fun_max = 25;
     }
 
     // This cherry soda's just not the same...


### PR DESCRIPTION
#### Summary

Bloodfeeder enjoyment of blood gave a static +15 morale, and was easy to get +60 and even overflow the value.

#### Purpose of change

Stops giving bats ability to get max enjoyment for eating or even overflowing into -60 morale.

#### Describe the solution

Add fun_max of +25 to hemovore_fun flags.

#### Describe alternatives you've considered

Changing the position of the consumption of the enjoyment malus of eating the same thing too much, but this would cause other issues and doesn't even fix the problem.

Max value of +25 seemed fair.

#### Testing

Game compiles on linux, game opens and creates a character successfully, giving the bloodfeeder mutation and consuming blood only allows you to get to +25 morale and won't exceed that.

#### Additional context

Saw the issue of this here:
https://github.com/Cataclysm-TLG/Cataclysm-TLG/issues/606

And thought I'd give it a try to fix.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
