### PR TITLE
Small wasps hit and run, nerf dodge penalty

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -1898,6 +1898,7 @@
       "GROUP_MORALE",
       "CANPLAY",
       "PATH_AVOID_DANGER",
+      "HIT_AND_RUN", 
       "HARDTOSHOOT",
       "EATS",
       "SMALL_HIDER"
@@ -1930,6 +1931,7 @@
     "dissect": "dissect_insect_sample_large",
     "stomach_size": 800,
     "reproduction": { "baby_egg": "egg_wasp", "baby_count": 2, "baby_timer": 5 },
+    "delete": { "flags": [ "HIT_AND_RUN" ] },
     "upgrades": { "age_grow": 30, "into": "mon_wasp_mega" },
     "fungalize_into": "mon_wasp_queen_fungus",
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3848,7 +3848,9 @@ float monster::speed_rating() const
 
 void monster::on_dodge( Creature *, float, float )
 {
+    if( one_in( 2 ) ) {
     add_effect( effect_monster_dodged, 1_seconds, false );
+    }
 }
 
 void monster::on_hit( Creature *source, bodypart_id,


### PR DESCRIPTION
#### Summary
Small wasps hit and run, nerf dodge penalty

#### Purpose of change
The stacking dodge penalty introduced recently was a bit too harsh, and wasps couldn't put up much of a fight.

#### Describe the solution
Now it only has a 50% chance to proc on monster dodge. Smaller wasps do hit and run tactics, making them as profoundly annoying as all other flying insects, but also keeping them from getting swarmed too quickly and maybe giving the player a chance to duck inside or something if targeted.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
