### PR TITLE
Upgrade old lab containment glass to ballistic

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -72,17 +72,51 @@
     "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "BLOCK_WIND", "SUPPORTS_ROOF" ],
     "open": "t_ballistic_door_glass_o",
     "bash": {
-      "str_min": 200,
-      "str_max": 400,
+      "str_min": 25,
+      "str_max": 90,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] } ]
     },
     "shoot": {
-      "reduce_damage": [ 30, 60 ],
+      "reduce_damage": [ 5, 20 ],
+      "reduce_damage_laser": [ 0, 10 ],
+      "destroy_damage": [ 80, 200 ],
+      "no_laser_destroy": true
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_ballistic_door_glass_lab_c",
+    "name": "closed ballistic glass door",
+    "description": "A ballistic glass door, consisting of layers of laminated glass.",
+    "symbol": "+",
+    "color": "light_cyan",
+    "move_cost": 0,
+    "coverage": 100,
+    "concealment": 0,
+    "looks_like": "t_reinforced_door_glass_c",
+    "roof": "t_flat_roof",
+    "connect_groups": "WALL",
+    "connects_to": "WALL",
+    "rotates_to": "INDOORFLOOR",
+    "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "SUPPORTS_ROOF" ],
+    "open": "t_ballistic_door_glass_lab_o",
+    "bash": {
+      "str_min": 25,
+      "str_max": 90,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "sound_vol": 20,
+      "sound_fail_vol": 14,
+      "ter_set": "t_mdoor_frame",
+      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] } ]
+    },
+    "shoot": {
+      "reduce_damage": [ 5, 20 ],
       "reduce_damage_laser": [ 0, 10 ],
       "destroy_damage": [ 80, 200 ],
       "no_laser_destroy": true
@@ -104,14 +138,40 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
     "close": "t_ballistic_door_glass_c",
     "bash": {
-      "str_min": 200,
-      "str_max": 400,
+      "str_min": 25,
+      "str_max": 90,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
       "sound_fail_vol": 14,
       "ter_set": "t_mdoor_frame",
-      "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "scrap", "count": [ 3, 5 ] } ]
+      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_ballistic_door_glass_lab_o",
+    "name": "open ballistic glass door",
+    "description": "A ballistic glass door, consisting of layers of laminated glass.  It's open.",
+    "symbol": "'",
+    "color": "light_cyan",
+    "move_cost": 2,
+    "looks_like": "t_reinforced_door_glass_o",
+    "coverage": 10,
+    "roof": "t_flat_roof",
+    "connect_groups": "WALL",
+    "connects_to": "WALL",
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
+    "close": "t_ballistic_door_glass_lab_c",
+    "bash": {
+      "str_min": 25,
+      "str_max": 90,
+      "sound": "glass breaking!",
+      "sound_fail": "whack!",
+      "sound_vol": 20,
+      "sound_fail_vol": 14,
+      "ter_set": "t_mdoor_frame",
+      "items": [ { "item": "glass_shard", "count": [ 20, 44 ] } ]
     }
   },
   {

--- a/data/json/mapgen/lab/lab_floorplans.json
+++ b/data/json/mapgen/lab/lab_floorplans.json
@@ -676,7 +676,13 @@
       ],
       "palettes": [ "lab_palette" ],
       "furniture": { "7": "f_console", "C": "f_centrifuge" },
-      "terrain": { "C": "t_floor_blue", "7": "t_floor_blue", ",": "t_floor_blue" },
+      "terrain": {
+        "g": "t_ballistic_glass",
+        "G": "t_ballistic_door_glass_lab_c",
+        "C": "t_floor_blue",
+        "7": "t_floor_blue",
+        ",": "t_floor_blue"
+      },
       "mapping": {
         "c": { "items": [ { "item": "office", "chance": 30 }, { "item": "tools_science", "chance": 15 } ] },
         "l": { "items": [ { "item": "science", "chance": 60 } ] },

--- a/data/json/mapgen/lab/lab_floorplans_1side.json
+++ b/data/json/mapgen/lab/lab_floorplans_1side.json
@@ -257,6 +257,7 @@
         "|---|-|----|----|-|----|"
       ],
       "palettes": [ "lab_palette" ],
+      "terrain": { "g": "t_ballistic_glass", "G": "t_ballistic_door_glass_lab_c" },
       "place_monster": [
         { "monster": "mon_zombie_shrieker", "x": [ 19, 22 ], "y": [ 20, 22 ] },
         { "monster": "mon_zombie_brute", "x": [ 12, 15 ], "y": [ 20, 22 ] },

--- a/data/json/mapgen/lab/lab_rooms.json
+++ b/data/json/mapgen/lab/lab_rooms.json
@@ -405,7 +405,7 @@
         "ggGgg"
       ],
       "palettes": [ "lab_palette" ],
-      "terrain": { ",": "t_floor_blue" },
+      "terrain": { "g": "t_ballistic_glass", "G": "t_ballistic_door_glass_lab_c", ",": "t_floor_blue" },
       "place_monster": [
         {
           "monster": [ "mon_zombie_brute", "mon_zombie_screecher", "mon_zombie_hollow", "mon_zombie_master", "mon_zombie_necro" ],
@@ -431,7 +431,7 @@
         "ggggg"
       ],
       "palettes": [ "lab_palette" ],
-      "terrain": { ",": "t_floor_blue" },
+      "terrain": { "g": "t_ballistic_glass", "G": "t_ballistic_door_glass_lab_c", ",": "t_floor_blue" },
       "place_monster": [
         {
           "monster": [ "mon_zombie_pig", "mon_zombear", "mon_zoose", "mon_zolf", "mon_zombie_dog" ],

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -126,6 +126,7 @@ static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_rad_platform( "t_rad_platform" );
 static const ter_str_id ter_t_radio_tower( "t_radio_tower" );
 static const ter_str_id ter_t_reinforced_glass( "t_reinforced_glass" );
+static const ter_str_id ter_t_ballistic_glass( "t_ballistic_glass" );
 static const ter_str_id ter_t_reinforced_glass_shutter( "t_reinforced_glass_shutter" );
 static const ter_str_id ter_t_reinforced_glass_shutter_open( "t_reinforced_glass_shutter_open" );
 static const ter_str_id ter_t_sewage( "t_sewage" );
@@ -387,7 +388,8 @@ bool computer_session::can_activate( computer_action action )
 
         case COMPACT_RELEASE:
         case COMPACT_RELEASE_DISARM:
-            return get_map().has_nearby_ter( get_player_character().pos_bub(), ter_t_reinforced_glass, 25 );
+            return get_map().has_nearby_ter( get_player_character().pos_bub(), ter_t_ballistic_glass, 25 )
+              || get_map().has_nearby_ter( get_player_character().pos_bub(), ter_t_reinforced_glass, 25 );
 
         case COMPACT_RELEASE_BIONICS:
             return get_map().has_nearby_ter( get_player_character().pos_bub(), ter_t_reinforced_glass, 3 );
@@ -402,7 +404,12 @@ bool computer_session::can_activate( computer_action action )
                 }
                 const ter_id &t_north = here.ter( p + tripoint::north );
                 const ter_id &t_south = here.ter( p + tripoint::south );
-                if( ( t_north == ter_t_reinforced_glass &&
+                // Support legacy reinforced glass from pre-existing labs
+                if( ( t_north == ter_t_ballistic_glass &&
+                      t_south == ter_t_concrete_wall ) ||
+                    ( t_south == ter_t_ballistic_glass &&
+                      t_north == ter_t_concrete_wall ) ||
+                    ( t_north == ter_t_reinforced_glass &&
                       t_south == ter_t_concrete_wall ) ||
                     ( t_south == ter_t_reinforced_glass &&
                       t_north == ter_t_concrete_wall ) ) {
@@ -549,6 +556,9 @@ void computer_session::action_release()
     get_map().translate_radius( ter_t_reinforced_glass, ter_t_thconc_floor, 25.0,
                                 player_character.pos_bub(),
                                 true );
+    get_map().translate_radius( ter_t_ballistic_glass, ter_t_thconc_floor, 25.0,
+                                player_character.pos_bub(),
+                                true );
     query_any( _( "Containment shields opened.  Press any key…" ) );
 }
 
@@ -584,7 +594,12 @@ void computer_session::action_terminate()
         }
         const ter_id &t_north = here.ter( p + tripoint::north );
         const ter_id &t_south = here.ter( p + tripoint::south );
-        if( ( t_north == ter_t_reinforced_glass &&
+        // Support legacy reinforced glass from pre-existing labs
+        if( ( t_north == ter_t_ballistic_glass &&
+              t_south == ter_t_concrete_wall ) ||
+            ( t_south == ter_t_ballistic_glass &&
+              t_north == ter_t_concrete_wall ) ||
+            ( t_north == ter_t_reinforced_glass &&
               t_south == ter_t_concrete_wall ) ||
             ( t_south == ter_t_reinforced_glass &&
               t_north == ter_t_concrete_wall ) ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -177,6 +177,7 @@ static const ter_str_id ter_t_marloss( "t_marloss" );
 static const ter_str_id ter_t_radio_tower( "t_radio_tower" );
 static const ter_str_id ter_t_reinforced_door_glass_c( "t_reinforced_door_glass_c" );
 static const ter_str_id ter_t_reinforced_glass( "t_reinforced_glass" );
+static const ter_str_id ter_t_ballistic_glass( "t_ballistic_glass" );
 static const ter_str_id ter_t_rock_floor( "t_rock_floor" );
 static const ter_str_id ter_t_sewage( "t_sewage" );
 static const ter_str_id ter_t_stairs_down( "t_stairs_down" );
@@ -6355,7 +6356,7 @@ void map::draw_lab( mapgendata &dat )
                                     if( ( i - lw ) % 2 == 0 ) {
                                         ter_set( point( i, j ), ter_t_concrete_wall );
                                     } else {
-                                        ter_set( point( i, j ), ter_t_reinforced_glass );
+                                        ter_set( point( i, j ), ter_t_ballistic_glass );
                                     }
                                 } else if( ( i - lw ) % 2 == 0 || j == tw + 2 ) {
                                     ter_set( point( i, j ), ter_t_concrete_wall );


### PR DESCRIPTION
#### Summary
Updates old labs to use ballistic glass instead of reinforced glass when containing monsters.

#### Purpose of change
Mi-gos and zombie brutes are natural spawns in various cells in old labs, but they are able to break through reinforced glass.
This is mostly intended to fix the overly common example of a room with a mi-go which immediately breaks the glass in its room in a direct line to a shoggoth spawn, leading to two loose shoggoths.

#### Describe the solution
Switches reinforced glass for ballistic glass for prisoner containment, nether creature containment, alien containment, and glass monster cage rooms. As a result, brutes and mi-gos are no longer able to break their glass while a brute that evolves into a hulk can.
Updates computer_session.cpp to support reinforced or ballistic glass for the netherworld access lab finale for backwards compatibility.

#### Describe alternatives you've considered
Updating all lab glass to be ballistic instead of reinforced, or more selectively doing so based on logic/hack difficulty.
For example, adding ballistic glass to military bunkers, bionics finales, weapons testing finales, portal finales, and possibly autodoc rooms (due to the difficulty of their hack).

#### Testing
Newly generated labs use ballistic glass instead of reinforced glass.
Able to open reinforced glass chambers from pre-existing labs.
Able to open ballistic glass chambers from new labs.
Mi-gos and brutes are unable to break through new glass.
Hulks are able to break the new glass (and old).

#### Additional context
When creating ballistic glass lab doors, I updated (and then copied) the regular ballistic glass doors to have values that match ballistic glass, similar to how reinforced glass doors match the TLG values for reinforced glass.

This fixes issue #1091 using worm girl's suggestion of using ballistic glass instead of reinforced glass.