### PR TITLE
Fix EOC teleportation

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -385,11 +385,10 @@ str_translation_or_var get_str_translation_or_var(
 tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
                                        bool is_npc )
 {
-    tripoint_abs_ms target_pos = get_map().getglobal( d.const_actor( is_npc )->pos_bub() );
     if( var.has_value() ) {
         std::string value = read_var_value( var.value(), d );
         if( !value.empty() ) {
-            target_pos = tripoint_abs_ms( tripoint::from_string( value ) );
+            return tripoint_abs_ms( tripoint::from_string( value ) );
         }
     }
     if( !d.has_actor( is_npc ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6852,9 +6852,9 @@ talk_effect_fun_t::func f_closest_city( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view member,
-                                    const std::string_view, bool is_npc )
+                                    std::string_view, bool is_npc )
 {
-    std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
+    var_info target_var = read_var_info( jo.get_object( member ) );
     translation_or_var fail_message;
     if( jo.has_member( "fail_message" ) ) {
         fail_message = get_translation_or_var( jo.get_member( "fail_message" ), "fail_message",

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -57,6 +57,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                                   bool add_teleglow, bool display_message, bool force, bool force_safe )
 {
     if( critter.pos_bub() == target ) {
+        critter.add_msg_if_player( m_warning, _( "You feel a strange inward pressure, but nothing more." ) );
         return false;
     }
     Character *const p = critter.as_character();
@@ -73,7 +74,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                                         p->has_effect_with_flag( json_flag_DIMENSIONAL_ANCHOR ) ||
                                         p->has_effect_with_flag( json_flag_TELEPORT_LOCK ) ) ) {
         if( display_message ) {
-            p->add_msg_if_player( m_warning, _( "You feel a strange, inwards force." ) );
+            p->add_msg_if_player( m_warning, _( "You feel a strange inward pressure, but nothing more." ) );
         }
         return false;
     }
@@ -119,7 +120,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 get_event_bus().send<event_type::teleports_into_wall>( p->getID(),
                         dest->obstacle_name( dest_target ) );
                 if( display_message ) {
-                    add_msg( m_bad, _( "You die after teleporting into a solid." ) );
+                    add_msg( m_bad, _( "Your body is torn apart as it is teleported into a solid obstacle." ) );
                 }
             }
             critter.check_dead_state();
@@ -160,6 +161,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 } else if( !c_is_u && p != nullptr ) {
                     add_msg( m_bad, _( "%s flickers but remains exactly where they are." ), p->get_name() );
                 }
+                            add_msg( _( "failure: unsafe (force safe is on, !found_new_spot" ) );
                 return false;
             }
         }


### PR DESCRIPTION
#### Summary
Fix EOC teleportation

#### Purpose of change
Backports broke EOC teleportation, which caused all kinds of problems, in the base game and especially with mods.

#### Describe the solution
Make the value passed to teleport.cpp from npctalk.cpp non-optional. Improve the messaging somewhat.

#### Testing
Storing variables works. Teleporting to variables (as with MoM's loci teleport) works. It's possible the Hub 01 mercs will continue to misbehave, but I sort of doubt it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
