### PR TITLE
Fix a wide assortment of bugs

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -298,8 +298,8 @@
     "sided": true,
     "armor": [
       {
-        "encumbrance": 20,
-        "coverage": 0,
+        "encumbrance": 0,
+        "coverage": 20,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ]
       }

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -160,6 +160,7 @@
     "name": { "str": "tainted human skull" },
     "description": "The stained skull of what was once a human being.  It is rotted and noticeably warped from its lively form.  Carrying this around probably isn't going to win you any friends.",
     "copy-from": "skull_abstract",
+    "looks_like": "skull_human",
     "snippet_category": "skull_human_tainted_desc"
   },
   {

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -54,7 +54,7 @@
         "condition": {
           "or": [
             { "math": [ "!has_var(n_timer_teamster_directions_recycler)" ] },
-            { "math": [ "time_since(n_timer_teamster_directions_recycler)", ">=", "time('2 d')" ] }
+            { "math": [ "time_since(n_timer_teamster_directions_recycler) >= time('2 d')" ] }
           ]
         },
         "effect": [
@@ -64,26 +64,10 @@
         "switch": true
       },
       {
-        "text": "So, have your caravans seen anything interesting out there in the wasteland?",
-        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS",
-        "condition": { "math": [ "time_since(n_timer_teamster_directions_recycler)", "<", "time('2 d')" ] },
-        "switch": true
-      },
-      {
-        "text": "So, have your caravans seen anything interesting out there in the wasteland?",
-        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS",
-        "effect": [
-          { "math": [ "npc_randomize_dialogue_direction", "=", "rand(2)" ] },
-          { "math": [ "n_timer_teamster_directions_recycler", "=", "time('now')" ] }
-        ],
-        "switch": true,
-        "default": true
-      },
-      {
         "text": "Do you know anything about a trader near the New England Church Community, claims to be from here?",
         "condition": {
           "and": [
-            { "math": [ "godco_freemerch_representative_dead", "!=", "0" ] },
+            { "math": [ "godco_freemerch_representative_dead != 0" ] },
             { "u_has_var": "general_trade_u_think_suspicious_price", "value": "yes" },
             { "not": { "u_has_mission": "MISSION_INVESTIGATE_TRADER" } }
           ]
@@ -94,7 +78,7 @@
         "text": "I think I've got the evidence you were looking for.",
         "condition": {
           "and": [
-            { "math": [ "godco_freemerch_representative_dead", "!=", "0" ] },
+            { "math": [ "godco_freemerch_representative_dead != 0" ] },
             { "u_has_mission": "MISSION_INVESTIGATE_TRADER" },
             { "u_has_item": "godcotrader_accounting_records_dirty" }
           ]
@@ -105,7 +89,7 @@
         "text": "I think I've got the evidence you were looking for.",
         "condition": {
           "and": [
-            { "not": { "math": [ "godco_freemerch_representative_dead", "==", "0" ] } },
+            { "not": { "math": [ "godco_freemerch_representative_dead == 0" ] } },
             { "u_has_mission": "MISSION_INVESTIGATE_TRADER" },
             { "u_has_item": "godcotrader_accounting_records_clean" }
           ]
@@ -165,13 +149,13 @@
     "type": "talk_topic",
     "id": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS",
     "dynamic_line": {
-      "math": [ "npc_randomize_dialogue_direction", "==", "0" ],
+      "math": [ "npc_randomize_dialogue_direction == 0" ],
       "yes": "No, sorry.  Nothin' much worth notin' out there these days, just the odd scattered survivor and they usually don't want random visitors.",
       "no": {
-        "math": [ "npc_randomize_dialogue_direction", "==", "1" ],
+        "math": [ "npc_randomize_dialogue_direction == 1" ],
         "yes": "Matter of fact, yeah.  Ran into a bunch of farmers.  They don't want much to do with our caravans, but someone like you they might be OK with.",
         "no": {
-          "math": [ "npc_randomize_dialogue_direction", "==", "2" ],
+          "math": [ "npc_randomize_dialogue_direction == 2" ],
           "yes": {
             "gendered_line": "There's been rumors.  Folks talkin' about some kind of secret lab, out in the wilds, with survivors in it.  I haven't seen it myself, mind you.",
             "relevant_genders": [ "npc" ]
@@ -185,7 +169,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
+            { "math": [ "npc_randomize_dialogue_direction == 1" ] },
             { "not": { "u_has_var": "teamster_mission_directions", "value": "isherwood" } }
           ]
         },
@@ -197,7 +181,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
+            { "math": [ "npc_randomize_dialogue_direction == 2" ] },
             { "not": { "u_has_var": "teamster_mission_directions", "value": "hub01" } }
           ]
         },

--- a/data/json/obsoletion_and_migration/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration/obsolete_overmap_terrain.json
@@ -34,12 +34,7 @@
       "farm_lot_wire_turn_v_open_east": "farmland_straight_east",
       "farm_lot_wire_turn_v_open_south": "farmland_straight_south",
       "farm_lot_wire_turn_v_open_west": "farmland_straight_west",
-      "megastore_parking": "omt_obsolete"
-    }
-  },
-  {
-    "type": "oter_id_migration",
-    "oter_ids": {
+      "megastore_parking": "omt_obsolete",
       "rock": "empty_rock",
       "slimepit_top": "slimepit_z0_north",
       "slimepit_bottom": "slimepit_z-1_north",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -637,13 +637,14 @@
     "id": "patient",
     "name": "Challenge - Abandoned",
     "points": -8,
-    "description": "Sickly and frail, you have spent most of your life in the patient's ward of various hospitals.  When your current one was evacuated, you were considered a lost cause and left behind.  You awaken to the sound of movement around the hospital.",
+    "description": "Accident or illness left you under intensive care.  When your hospital was overrun, you were considered a lost cause and left behind.  You awaken to the sound of movement around the hospital.",
     "allowed_locs": [ "sloc_hospital" ],
     "start_name": "Hospital",
     "forced_traits": [ "FLIMSY2" ],
     "forbidden_traits": [ "TOUGH", "DISRESISTANT" ],
     "professions": [ "unemployed", "patient", "veteran", "bionic_patient" ],
     "requirement": "achievement_reach_hospital",
+    "reveal_locale": false,
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {

--- a/data/json/starting_missions.json
+++ b/data/json/starting_missions.json
@@ -569,7 +569,7 @@
         "om_terrain": "helipad_nw",
         "reveal_radius": 10,
         "om_special": "military helipad",
-        "search_range": 70,
+        "search_range": 120,
         "min_distance": 25,
         "z": 0
       }

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -353,7 +353,6 @@
       { "math": [ "u_val('thirst') = min( u_val('thirst'), 800)" ] },
       { "math": [ "u_vitamin('redcells') = 0" ] },
       { "math": [ "u_vitamin('blood') = 0" ] },
-      { "math": [ "u_vitamin('instability') = 0" ] },
       { "math": [ "u_pain() = 0" ] },
       { "math": [ "u_val('rad') = 0" ] },
       { "u_add_effect": "cureall", "duration": "1 s", "intensity": 1 },

--- a/data/mods/Sky_Island/obelisk_selector.json
+++ b/data/mods/Sky_Island/obelisk_selector.json
@@ -9,7 +9,7 @@
         "keys": [ "1", "2", "3", "4" ],
         "title": "Select Expedition Length",
         "descriptions": [
-          "A simple, brief expedition at the normal time limit.  Missions and exits will be close together.  A good chance to quickly gather supplies and experience.",
+          "A simple, brief expedition at the normal time limit.  Missions and exits will be close together.  A good chance to quickly gather supplies and experience.  NOTE: Due to code limitations, this may take several real-life minutes to initate for the first time during a run.",
           "A longer expedition that offers twice the time.  Missions and exits will be scattered over a wider area.  You will have more opportunity to dig deeper into surrounding points of interest, but also need more time to travel.  Missions offer extra warp shards as rewards.",
           "A very long expedition that triples the time limit.  Missions and exits will be very far away.  You will have time for extended activities, but a good deal of your time will be spent trying to reach objectives over potentially dangerous terrain.  Missions offer even more warp shards as rewards.",
           "Stay on the island for now."


### PR DESCRIPTION
#### Summary
Fix a wide assortment of bugs

#### Describe the solution
Fix gold bracelet having 0 coverage and 20 encumbrance.
Extend search radius for helicopter crash starting mission.
Reword Abandoned challenge and remove initial map reveal.
Fix teamster dialog being broken.
Gave tainted human skull looks_like skull_human
Added a warning message to the Sky Island mission selector that indicates that it will take several IRL minutes.
Removed a stray reference to instability from Sky Island
Fixed bad overmap terrain obsoletion for older saves.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
