### PR TITLE
Stop drawing fake size 20 hordes everywhere.

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -451,14 +451,13 @@ int overmapbuffer::get_horde_size( const tripoint_abs_omt &p )
     int horde_size = 0;
     for( mongroup * const &m : overmap_buffer.monsters_at( p ) ) {
         if( m->horde ) {
+            // Monstergroups which have not yet spawned in will not display. This is fine.
+            // Map visibility being iffy means that we probably wouldn't be able to see such
+            // groups anyway, and unspawned groups all have a horde_size of 10 which looks
+            // weird when you get close and it's like 3 guys and the size 10 horde disappears
+            // from your map.
             if( !m->monsters.empty() ) {
                 horde_size += m->monsters.size();
-            } else {
-                // We don't know how large this will actually be, because
-                // population "1" can still result in a zombie pack.
-                // So we double the population as an estimate to make
-                // hordes more likely to be visible on the overmap.
-                horde_size += m->population * 2;
             }
         }
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -992,7 +992,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     }
                 }
                 if( showhordes && los ) {
-                    const int horde_size = overmap_buffer.get_horde_size( omp );
+                    const int horde_size = std::min( 10, overmap_buffer.get_horde_size( omp ) );
                     if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                         // a little bit of hardcoded fallbacks for hordes
                         if( find_tile_with_season( id ) ) {


### PR DESCRIPTION
#### Summary
Stop drawing fake size 20 hordes everywhere.

#### Purpose of change
The map screen was showing size 10 to 20 hordes all over the place, which was incorrectly displaying zombie masters and stuff on the screen. This was leading people to erroneously believe that those enemies were actually in those places.

What was really happening was that unspawned mosntergroups were all size 10 and the code was then doubling their size to "ensure their visibility". This logic might (though I doubt it) have made sense a long time ago before obscured map vision, but it certainly doesn't now. It was misleading. What appeared to be a size 20 horde could easily turn out to be like 3 monsters.

#### Describe the solution
Remove the fallback display for unspawned hordes. Cap displayed horde size at 10. Now if you see a horde on your map, you know for sure it represents a roaming group of zombies which will respond to noise etc.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
