### PR TITLE
Fix climbing

### DIFF
--- a/data/json/monsterdrops/zombie_technician.json
+++ b/data/json/monsterdrops/zombie_technician.json
@@ -122,7 +122,7 @@
                 "distribution": [
                   { "item": "ear_plugs", "prob": 15, "damage": [ 0, 1 ] },
                   { "group": "tools_lighting_industrial", "damage": [ 1, 3 ], "prob": 15 },
-                  { "item": "electric_lantern", "charges": [ 0, 100 ], "damage": [ 1, 3 ], "prob": 10  }
+                  { "item": "electric_lantern", "charges": [ 0, 100 ], "damage": [ 1, 3 ], "prob": 10 }
                 ]
               }
             ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13656,24 +13656,25 @@ int Character::climbing_cost( const tripoint_bub_ms &from, const tripoint_bub_ms
         return 0;
     }
 
-    bool furn_supports_weight = ( here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, from ) ||
-                                  here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) );
-    bool ter_supports_weight = ( here.has_flag_ter( ter_furn_flag::TFLAG_LADDER, from ) ||
-                                 here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, from ) );
+    bool furn_supports_weight = true;
+    bool ter_supports_weight = true;
     // Check both furn and ter. Only one needs to be climbable for us.
-    if( furn_supports_weight && get_weight() / 10000_gram > here.furn( from ).obj().bash->str_min ) {
+    if( ( here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, from ) ||
+        here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) && 
+        get_weight() / 10000_gram > here.furn( from ).obj().bash->str_min ) {
         add_msg_if_player( _( "The %s can't support your weight." ), here.furn( from ).obj().name() );
         furn_supports_weight = false;
     }
-    if( ter_supports_weight && get_weight() / 10000_gram > here.ter( from ).obj().bash->str_min ) {
+    if( ( here.has_flag_ter( ter_furn_flag::TFLAG_LADDER, from ) ||
+        here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) && 
+        get_weight() / 10000_gram > here.ter( from ).obj().bash->str_min ) {
         add_msg_if_player( _( "The %s can't support your weight." ), here.ter( from ).obj().name() );
         ter_supports_weight = false;
     }
 
-    if( !furn_supports_weight && !ter_supports_weight ) {
+    if( !furn_supports_weight || !ter_supports_weight ) {
         return 0;
     }
-
 
     return 50 + diff * 100;
     // TODO: All sorts of mutations, equipment weight etc.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13660,13 +13660,13 @@ int Character::climbing_cost( const tripoint_bub_ms &from, const tripoint_bub_ms
     bool ter_supports_weight = true;
     // Check both furn and ter. Only one needs to be climbable for us.
     if( ( here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, from ) ||
-        here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) && 
+          here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) &&
         get_weight() / 10000_gram > here.furn( from ).obj().bash->str_min ) {
         add_msg_if_player( _( "The %s can't support your weight." ), here.furn( from ).obj().name() );
         furn_supports_weight = false;
     }
     if( ( here.has_flag_ter( ter_furn_flag::TFLAG_LADDER, from ) ||
-        here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) && 
+          here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) &&
         get_weight() / 10000_gram > here.ter( from ).obj().bash->str_min ) {
         add_msg_if_player( _( "The %s can't support your weight." ), here.ter( from ).obj().name() );
         ter_supports_weight = false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12179,7 +12179,6 @@ void game::vertical_move( int movez, bool force, bool peeking )
         }
 
         const int cost = u.climbing_cost( u.pos_bub(), stairs );
-        add_msg_debug( debugmode::DF_GAME, "Climb cost %d", cost );
         const bool can_climb_here = cost > 0 ||
                                     u.has_flag( json_flag_CLIMB_NO_LADDER ) || wall_cling;
         if( !can_climb_here && !adjacent_climb ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12273,7 +12273,8 @@ void game::vertical_move( int movez, bool force, bool peeking )
         add_msg( m_info, _( "Halfway up, the way up becomes blocked off." ) );
         return;
     }
-    if( !u.move_effects( false, tripoint_bub_ms( u.pos_bub().raw() + tripoint( 0, 0, movez ) ) ) && !force ) {
+    if( !u.move_effects( false, tripoint_bub_ms( u.pos_bub().raw() + tripoint( 0, 0, movez ) ) ) &&
+        !force ) {
         // move_effects determined we could not move, waste all moves
         u.set_moves( 0 );
         return;
@@ -12290,7 +12291,8 @@ void game::vertical_move( int movez, bool force, bool peeking )
     // > and < are used for diving underwater.
     if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, u.pos_bub() ) ) {
         swimming = true;
-        const ter_id &target_ter = here.ter( tripoint_bub_ms( u.pos_bub().raw() + tripoint( 0, 0, movez ) ) );
+        const ter_id &target_ter = here.ter( tripoint_bub_ms( u.pos_bub().raw() + tripoint( 0, 0,
+                                             movez ) ) );
 
         // If we're in a water tile that has both air above and deep enough water to submerge in...
         if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, u.pos_bub() ) &&

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -61,7 +61,8 @@ static void serialize_liquid_source( player_activity &act, const vehicle &veh, c
     act.str_values.push_back( serialize( liquid ) );
 }
 
-static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms &pos, const item &liquid )
+static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms &pos,
+                                     const item &liquid )
 {
     const map_stack stack = get_map().i_at( pos );
     // Need to store the *index* of the item on the ground, but it may be a virtual item from

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2822,7 +2822,6 @@ int map::climb_difficulty( const tripoint_bub_ms &p ) const
             // TODO: Penalize spiked parts?
             best_difficulty = std::min( best_difficulty, 7 );
         }
-
         if( best_difficulty > 5 && has_flag( ter_furn_flag::TFLAG_CLIMBABLE, pt ) ) {
             best_difficulty = 5;
         }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -112,7 +112,8 @@ std::unique_ptr<mattack_actor> leap_actor::clone() const
 
 bool leap_actor::call( monster &z ) const
 {
-    if( !z.has_dest() || !z.can_act() || !z.move_effects( false, get_map().bub_from_abs( z.get_dest() ) ) ) {
+    if( !z.has_dest() || !z.can_act() ||
+        !z.move_effects( false, get_map().bub_from_abs( z.get_dest() ) ) ) {
         add_msg_debug( debugmode::DF_MATTACK, "Monster has no destination or can't act" );
         return false;
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -878,8 +878,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                                                   std::max( 1, get_arm_str() ) + stab_skill - ( weight_factor ) ) / 2.f );
                     if( x_in_y( chance_to_recover, 100 ) ) {
                         move_cost *= 1.15;
-                        add_msg_if_player( m_warning, 
-                            _( "You quickly pry your weapon free." ) );
+                        add_msg_if_player( m_warning,
+                                           _( "You quickly pry your weapon free." ) );
                     } else {
                         move_cost *= 1.3;
                         if( reach_attacking ) {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -250,7 +250,8 @@ static bool within_visual_range( monster *z, int max_range )
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
     return target != nullptr &&
-           ( z->is_adjacent( target, true ) || ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) <= range ) ) &&
+           ( z->is_adjacent( target, true ) ||
+             ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) <= range ) ) &&
            z->sees( *target );
 }
 
@@ -1228,7 +1229,8 @@ bool mattack::resurrect( monster *z )
         if( iter != sees_and_is_empty_cache.end() ) {
             return iter->second;
         }
-        sees_and_is_empty_cache[T] = here.sees( z->pos_bub().raw(), T, -1 ) && g->is_empty( tripoint_bub_ms( T ) );
+        sees_and_is_empty_cache[T] = here.sees( z->pos_bub().raw(), T, -1 ) &&
+                                     g->is_empty( tripoint_bub_ms( T ) );
         return sees_and_is_empty_cache[T];
     };
     for( item_location &location : here.get_active_items_in_radius( z->pos_bub(), range,

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3849,7 +3849,7 @@ float monster::speed_rating() const
 void monster::on_dodge( Creature *, float, float )
 {
     if( one_in( 2 ) ) {
-    add_effect( effect_monster_dodged, 1_seconds, false );
+        add_effect( effect_monster_dodged, 1_seconds, false );
     }
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4804,7 +4804,7 @@ talk_effect_fun_t::func f_message( const JsonObject &jo, std::string_view member
             } else {
                 if( store_in_lore && target->is_avatar() ) {
                     sid = SNIPPET.random_id_from_category( snip_id.evaluate( d ) ).c_str();
-                        get_avatar().add_snippet( snippet_id( sid ) );
+                    get_avatar().add_snippet( snippet_id( sid ) );
                     translated_message = SNIPPET.expand( SNIPPET.get_snippet_by_id( snippet_id( sid ) ).value_or(
                             translation() ).translated() );
                 } else {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3310,7 +3310,8 @@ void target_ui::update_target_list()
     // Get targets in range and sort them by distance (targets[0] is the closest)
     targets = you->get_targetable_creatures( range, mode == TargetMode::Reach );
     std::sort( targets.begin(), targets.end(), [&]( const Creature * lhs, const Creature * rhs ) {
-        return trig_dist_z_adjust( lhs->pos_bub(), you->pos_bub() ) < trig_dist_z_adjust( rhs->pos_bub(), you->pos_bub() );
+        return trig_dist_z_adjust( lhs->pos_bub(), you->pos_bub() ) < trig_dist_z_adjust( rhs->pos_bub(),
+                you->pos_bub() );
     } );
 }
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -57,7 +57,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                                   bool add_teleglow, bool display_message, bool force, bool force_safe )
 {
     if( critter.pos_bub() == target ) {
-        critter.add_msg_if_player( m_warning, _( "You feel a strange inward pressure, but nothing more." ) );
+        critter.add_msg_if_player( m_warning,
+                                   _( "You feel a strange inward pressure, but nothing more." ) );
         return false;
     }
     Character *const p = critter.as_character();
@@ -161,7 +162,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 } else if( !c_is_u && p != nullptr ) {
                     add_msg( m_bad, _( "%s flickers but remains exactly where they are." ), p->get_name() );
                 }
-                            add_msg( _( "failure: unsafe (force safe is on, !found_new_spot" ) );
+                add_msg( _( "failure: unsafe (force safe is on, !found_new_spot" ) );
                 return false;
             }
         }


### PR DESCRIPTION
#### Summary
Fix climbing

#### Purpose of change
Some iffy logic broke the ability to climb by using opposite walls/furniture/etc.

#### Describe the solution
Change the logic so that it checks for a downspout or something and bails out if it won't hold you up. This still isn't perfect as if you're in a spot where you should be able to climb but there happens to be a downspout that won't hold you up there, you have to break it or move to climb, but that's a more annoying thing to fix and not nearly as big of a deal.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
