### PR TITLE
Remove pointless/old/debug keybinds

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2849,51 +2849,6 @@
   },
   {
     "type": "keybinding",
-    "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
-    "name": "Toggle debug dialogue dynamic_line conditionals",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+C" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
-    ]
-  },
-  {
-    "type": "keybinding",
-    "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
-    "name": "Toggle debug dialogue response conditionals",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+D" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
-    ]
-  },
-  {
-    "type": "keybinding",
-    "id": "DEBUG_DIALOGUE_DL_EFFECT",
-    "name": "Toggle debug dialogue dynamic_line effects",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+T" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
-    ]
-  },
-  {
-    "type": "keybinding",
-    "id": "DEBUG_DIALOGUE_RESP_EFFECT",
-    "name": "Toggle debug dialogue response effects",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+Y" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
-    ]
-  },
-  {
-    "type": "keybinding",
-    "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
-    "name": "Toggle debug dialogue show hidden responses ",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+R" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
-    ]
-  },
-  {
-    "type": "keybinding",
     "id": "RESET",
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",
@@ -2902,69 +2857,6 @@
       { "input_method": "keyboard_char", "key": "R" },
       { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
-  },
-  {
-    "type": "keybinding",
-    "name": "View scent map",
-    "category": "DEFAULTMODE",
-    "id": "debug_scent"
-  },
-  {
-    "type": "keybinding",
-    "name": "View scent type",
-    "category": "DEFAULTMODE",
-    "id": "debug_scent_type"
-  },
-  {
-    "type": "keybinding",
-    "name": "View temperature map (using Map font)",
-    "category": "DEFAULTMODE",
-    "id": "debug_temp"
-  },
-  {
-    "type": "keybinding",
-    "name": "View visibility map",
-    "category": "DEFAULTMODE",
-    "id": "debug_visibility"
-  },
-  {
-    "type": "keybinding",
-    "name": "View lighting map",
-    "category": "DEFAULTMODE",
-    "id": "debug_lighting"
-  },
-  {
-    "type": "keybinding",
-    "name": "View radiation map",
-    "category": "DEFAULTMODE",
-    "id": "debug_radiation"
-  },
-  {
-    "type": "keybinding",
-    "name": "Toggle hour timer",
-    "category": "DEFAULTMODE",
-    "id": "debug_hour_timer"
-  },
-  {
-    "type": "keybinding",
-    "category": "DEBUG_SPELLS",
-    "id": "TOGGLE_ALL_SPELL",
-    "name": "Toggle all spells",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
-  },
-  {
-    "type": "keybinding",
-    "category": "DEBUG_SPELLS",
-    "id": "UNLEARN_SPELL",
-    "name": "Unlearn a spell",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
-  },
-  {
-    "type": "keybinding",
-    "category": "DEBUG_SPELLS",
-    "id": "SHOW_ONLY_LEARNED",
-    "name": "Show only learned",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2674,13 +2674,6 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "open_color" );
     ctxt.register_action( "open_world_mods" );
     ctxt.register_action( "debug" );
-    ctxt.register_action( "debug_scent" );
-    ctxt.register_action( "debug_scent_type" );
-    ctxt.register_action( "debug_temp" );
-    ctxt.register_action( "debug_visibility" );
-    ctxt.register_action( "debug_lighting" );
-    ctxt.register_action( "debug_radiation" );
-    ctxt.register_action( "debug_hour_timer" );
     ctxt.register_action( "debug_mode" );
     ctxt.register_action( "zoom_out" );
     ctxt.register_action( "zoom_in" );


### PR DESCRIPTION
#### Summary
Remove pointless/old/debug keybinds

#### Purpose of change
Several debug features, like the scent map and creature visibility view, had options for keybinds. These are debugging tools, and putting them in the keybind menu makes players think they're meant to be using them for normal gameplay. Since I am the only developer and I do not need them as keybinds, there is no reason for them to be there.

#### Describe the solution
Remove the keybinds for all debug features. You can still access these by opening the debug menu and hitting the button.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
