### PR TITLE
Remove tainted hide from leather ingredients

### DIFF
--- a/data/json/monstergroups/mutant_upgrades.json
+++ b/data/json/monstergroups/mutant_upgrades.json
@@ -7,9 +7,13 @@
   {
     "name": "GROUP_CENTIPEDE_ADULT",
     "type": "monstergroup",
-    "monsters": [ { "monster": "mon_centipede_giant", "weight": 85 }, { "monster": "mon_centipede_mom", "weight": 10 }, { "group": "GROUP_EMPTY", "weight": 5 } ]
+    "monsters": [
+      { "monster": "mon_centipede_giant", "weight": 85 },
+      { "monster": "mon_centipede_mom", "weight": 10 },
+      { "group": "GROUP_EMPTY", "weight": 5 }
+    ]
   },
-    {
+  {
     "name": "GROUP_BULLFROG_UPGRADE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_bullfrog", "weight": 25 }, { "monster": "mon_big_bullfrog", "weight": 75 } ]
@@ -17,12 +21,20 @@
   {
     "name": "GROUP_BIG_BULLFROG_UPGRADE",
     "type": "monstergroup",
-    "monsters": [ { "monster": "mon_big_bullfrog", "weight": 20 }, { "monster": "mon_giant_frog", "weight": 75 }, { "group": "GROUP_EMPTY", "weight": 5 } ]
+    "monsters": [
+      { "monster": "mon_big_bullfrog", "weight": 20 },
+      { "monster": "mon_giant_frog", "weight": 75 },
+      { "group": "GROUP_EMPTY", "weight": 5 }
+    ]
   },
   {
     "name": "GROUP_GIANT_FROG_UPGRADE",
     "type": "monstergroup",
-    "monsters": [ { "monster": "mon_giant_frog", "weight": 40 }, { "monster": "mon_megafrog", "weight": 55 }, { "group": "GROUP_EMPTY", "weight": 5 } ]
+    "monsters": [
+      { "monster": "mon_giant_frog", "weight": 40 },
+      { "monster": "mon_megafrog", "weight": 55 },
+      { "group": "GROUP_EMPTY", "weight": 5 }
+    ]
   },
   {
     "name": "GROUP_CENTIPEDE_GIANT",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1956,7 +1956,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
       [ [ "salt_water", 1 ], [ "saline", 2 ], [ "salt", 2 ] ],
-      [ [ "raw_leather", 1 ], [ "raw_tainted_leather", 1 ], [ "raw_hleather", 1 ], [ "raw_demihumanleather", 1 ] ]
+      [ [ "raw_leather", 1 ], [ "raw_hleather", 1 ] ]
     ]
   },
   {
@@ -2014,7 +2014,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
       [ [ "salt_water", 1 ], [ "saline", 2 ], [ "salt", 2 ] ],
-      [ [ "raw_fur", 1 ], [ "raw_hfur", 1 ], [ "raw_tainted_fur", 1 ] ]
+      [ [ "raw_fur", 1 ], [ "raw_hfur", 1 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Remove tainted hide from leather ingredients

#### Purpose of change
You're not supposed to be able to make much of anything useful out of zombies. They're already rotten and after death their tissue is supposed to break down faster than a normal human's would, even the bones.

#### Describe the solution
Remove tainted hide and fur from the curing hide and pelt recipes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
