### PR TITLE
Remove some no-brainer traits

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9143,24 +9143,6 @@
   },
   {
     "type": "mutation",
-    "id": "WAYFARER",
-    "name": { "str": "Wayfarer" },
-    "points": -8,
-    "description": "Whether from personal choice or childhood trauma, traveling with vehicles is off-limits to you, even if your life depended on it.",
-    "starting_trait": true,
-    "valid": false
-  },
-  {
-    "type": "mutation",
-    "id": "BRAWLER",
-    "name": { "str": "Brawler" },
-    "points": -4,
-    "description": "Whether from personal choice or childhood trauma, using ranged weapons is off-limits to you, even if your life depended on it.",
-    "starting_trait": true,
-    "valid": false
-  },
-  {
-    "type": "mutation",
     "id": "FAST_REFLEXES",
     "name": { "str": "Fast Reflexes" },
     "points": 2,
@@ -9611,17 +9593,6 @@
     "starting_trait": false,
     "valid": false,
     "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 1 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "NO_CBM_INSTALLATION",
-    "name": { "str": "Oversensitive System" },
-    "description": "While it doesn't cause you any problems in daily life, your immune system and body chemistry are overly sensitive to foreign implants.  You cannot have any CBMs installed.",
-    "player_display": true,
-    "points": -8,
-    "starting_trait": true,
-    "valid": false,
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
   },
   {
     "type": "mutation",

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -239,5 +239,32 @@
   {
     "id": "EOC_Nunez_Travel",
     "type": "effect_on_condition"
+  },
+  {
+    "type": "mutation",
+    "id": "NO_CBM_INSTALLATION",
+    "name": { "str": "Oversensitive System" },
+    "description": "Renamed/re-IDed mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "WAYFARER",
+    "name": { "str": "Wayfarer" },
+    "description": "Removed mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
+  },
+  {
+    "type": "mutation",
+    "id": "BRAWLER",
+    "name": { "str": "Brawler" },
+    "description": "Removed mutation.",
+    "points": 0,
+    "valid": false,
+    "player_display": false
   }
 ]


### PR DESCRIPTION
#### Summary
Remove some no-brainer traits

#### Purpose of change
Wayfarer and Brawler unrealisically locked you out of entire mechanics for your whole run. Oversensitive system was just a huge pile or free points for anyone who didn't feel like they were going to get to bionics.

#### Describe the solution
Remove them. All three traits would be better handled by bonuses and penalties rather than hard cutoffs. If you want to challenge yourself to never use a gun, just...never use one.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
