### PR TITLE
Remove zombies from mi-go sites

### DIFF
--- a/data/json/mapgen/mi-go/mi-go_nested.json
+++ b/data/json/mapgen/mi-go/mi-go_nested.json
@@ -68,7 +68,6 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "mi-go_encampment1_room4",
-    "//": "Observation room with zombies",
     "object": {
       "mapgensize": [ 7, 7 ],
       "rotation": [ 0, 3 ],
@@ -82,18 +81,6 @@
         "......."
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "place_monster": [
-        {
-          "monster": [ "mon_zombie_brute", "mon_zombie_screecher", "mon_zombie_hollow", "mon_zombie", "mon_zombie_fungus" ],
-          "x": 1,
-          "y": 2
-        },
-        {
-          "monster": [ "mon_skeleton", "mon_zombear", "mon_zombie_child", "mon_zombie", "mon_zombie_runner" ],
-          "x": 4,
-          "y": 2
-        }
-      ],
       "palettes": [ "mi-go_palette" ]
     }
   },
@@ -366,8 +353,7 @@
         "|||||;"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "palettes": [ "mi-go_palette" ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE_BRUTE", "x": [ 1, 3 ], "y": [ 3, 4 ], "repeat": [ 1, 2 ] } ]
+      "palettes": [ "mi-go_palette" ]
     }
   },
   {
@@ -428,8 +414,7 @@
         "|||||v"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "palettes": [ "mi-go_palette" ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE_BRUTE", "x": [ 1, 3 ], "y": [ 3, 4 ], "repeat": [ 1, 2 ] } ]
+      "palettes": [ "mi-go_palette" ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Remove zombies from mi-go sites

#### Purpose of change
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c43b4dc4-d76f-4ea6-95df-98ce2fd8032e" />

For some reason the mi-go towers are set to spawn like a billion hulks sometimes.

#### Describe the solution

Remove

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
