### PR TITLE
Mutant QoL updates

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -330,7 +330,8 @@
         "duration": 1,
         "duration_dmg_scaling": 0.5
       }
-    ]
+    ],
+    "similar_bodyparts": [ "eyes_frog" ]
   },
   {
     "id": "mouth",
@@ -611,7 +612,7 @@
     "heading_multiple": "legs",
     "hp_bar_ui_text": "L LEG",
     "encumbrance_text": "Running and swimming are slowed.",
-    "encumbrance_threshold": 6,
+    "encumbrance_threshold": 8,
     "main_part": "leg_l",
     "connected_to": "torso",
     "opposite_part": "leg_r",
@@ -705,7 +706,7 @@
     "heading_multiple": "legs",
     "hp_bar_ui_text": "R LEG",
     "encumbrance_text": "Running and swimming are slowed.",
-    "encumbrance_threshold": 6,
+    "encumbrance_threshold": 8,
     "main_part": "leg_r",
     "connected_to": "torso",
     "opposite_part": "leg_l",
@@ -1259,7 +1260,8 @@
     "side": 1,
     "opposite": "eyes_right",
     "name_multiple": "eyes",
-    "name": "left eye"
+    "name": "left eye",
+    "similar_bodyparts": [ "eyes_frog_left" ]
   },
   {
     "id": "eyes_right",
@@ -1269,7 +1271,8 @@
     "side": 2,
     "opposite": "eyes_left",
     "name_multiple": "eyes",
-    "name": "right eye"
+    "name": "right eye",
+    "similar_bodyparts": [ "eyes_frog_right" ]
   },
   {
     "id": "mouth_lips",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1469,9 +1469,9 @@
   {
     "type": "effect_type",
     "id": "mutagen_lizard",
-    "name": [ "Lizard Mutation", "Lizard Transformation", "Lizard Metamorphosis" ],
+    "name": [ "Reptilian Mutation", "Reptilian Transformation", "Reptilian Metamorphosis" ],
     "desc": [
-      "You consumed lizard mutagen.",
+      "You consumed reptilian mutagen.",
       "Your skin feels dry and too small.  You'll have to molt soon.",
       "Your limbs slump, almost ready to tear right out of their sockets."
     ],
@@ -1489,14 +1489,15 @@
     },
     "scaling_mods": { "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Lizard Mutagen"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Reptilian Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_lupine",
-    "name": [ "Canine Mutation", "Canine Transformation", "Canine Metamorphosis" ],
+    "name": [ "Lupine Mutation", "Lupine Transformation", "Lupine Metamorphosis" ],
     "desc": [
-      "You consumed canine mutagen.",
+      "You consumed lupine mutagen.",
       "Where's your pack?  How will you survive without them?",
       "You pant, unable to stop pacing and full of hunger."
     ],

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -146,6 +146,49 @@
   },
   {
     "type": "enchantment",
+    "id": "THERMAL_VISION_REPTILIAN_IR",
+    "special_vision": [
+      {
+        "condition": { "and": [ "u_see_npc_loc", "npc_is_warm" ] },
+        "distance": 14,
+        "precise": true,
+        "descriptions": [
+          {
+            "id": "infrared_creature_tiny",
+            "text_condition": { "math": [ "n_val('size') == 1" ] },
+            "symbol": ".",
+            "text": "You see a tiny figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_small",
+            "text_condition": { "math": [ "n_val('size') == 2" ] },
+            "symbol": ",",
+            "text": "You see a small figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_medium",
+            "text_condition": { "math": [ "n_val('size') == 3" ] },
+            "symbol": "o",
+            "text": "You see a medium figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_large",
+            "text_condition": { "math": [ "n_val('size') == 4" ] },
+            "symbol": "O",
+            "text": "You see a large figure radiating heat."
+          },
+          {
+            "id": "infrared_creature_huge",
+            "text_condition": { "math": [ "n_val('size') == 5" ] },
+            "symbol": "&",
+            "text": "You see a huge figure radiating heat."
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "enchantment",
     "id": "ELECTRIC_VISION",
     "condition": "ALWAYS",
     "special_vision": [
@@ -288,6 +331,12 @@
       { "gain": "wing_bird_l" },
       { "gain": "wing_bird_r" }
     ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ench_eyes_frog",
+    "condition": "ALWAYS",
+    "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_frog" } ]
   },
   {
     "type": "enchantment",

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -494,7 +494,6 @@
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3 } ],
         "covers": [ "head" ],
         "coverage": 100,
-        "cover_vitals": 65,
         "encumbrance": 1,
         "specifically_covers": [ "head_throat" ]
       }
@@ -1546,9 +1545,36 @@
         ],
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 1,
-        "rigid_layer_only": true,
-        "cover_vitals": 90
+        "encumbrance": 5,
+        "rigid_layer_only": true
+      }
+    ]
+  },
+  {
+    "id": "integrated_lidless_eyes",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "ocular scales" },
+    "description": "Transparent scales seal the corneas behind a firm but flexible lens.  It's enough to keep water and most irritants at bay, and it would be very difficult to sneak up on one who sleeps with their eyes open.",
+    "weight": "50 g",
+    "volume": "25 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "to_hit": -2,
+    "material": [ "scales" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "warmth": 0,
+    "material_thickness": 0.2,
+    "environmental_protection": 10,
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "NO_REPAIR", "PADDED", "SWIM_GOGGLES", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [ { "type": "scales", "covered_by_mat": 100, "thickness": 0.2 } ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 0,
+        "rigid_layer_only": true
       }
     ]
   },
@@ -1646,7 +1672,7 @@
       "PROVIDES_TECHNIQUES",
       "NATURAL_WEAPON"
     ],
-    "techniques": [ "TEC_CLAW" ],
+    "techniques": [ "TEC_CLAW", "tec_paws_large_claw" ],
     "armor": [
       {
         "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 2 } ],
@@ -1685,7 +1711,7 @@
       "NATURAL_WEAPON",
       "CONDUCTIVE"
     ],
-    "techniques": [ "TEC_CLAW" ],
+    "techniques": [ "TEC_CLAW", "tec_paws_large_claw" ],
     "armor": [
       {
         "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 0.4 } ],
@@ -1723,7 +1749,7 @@
       "PROVIDES_TECHNIQUES",
       "NATURAL_WEAPON"
     ],
-    "techniques": [ "TEC_CLAW" ],
+    "techniques": [ "TEC_CLAW", "tec_paws_large_claw" ],
     "armor": [
       {
         "material": [ { "type": "keratin", "covered_by_mat": 100, "thickness": 3 } ],

--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -1,5 +1,62 @@
 [
   {
+    "id": "eyes_frog",
+    "type": "body_part",
+    "name": "eyes",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "eyes" },
+    "heading": "eyes",
+    "heading_multiple": "eyes",
+    "encumbrance_text": "Ranged combat is hampered.",
+    "encumbrance_limit": 60,
+    "main_part": "head",
+    "opposite_part": "eyes_frog",
+    "hit_size": 0.55,
+    "hit_difficulty": 1.1,
+    "limb_type": "sensor",
+    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.1 ], [ "reaction", 0.8 ] ],
+    "side": "both",
+    "stylish_bonus": 2,
+    "squeamish_penalty": 8,
+    "base_hp": 62,
+    "drench_capacity": 0,
+    "flags": [ "IGNORE_TEMP", "LIMB_UPPER" ],
+    "smash_message": "You headbutt the %s.",
+    "smash_efficiency": 0.25,
+    "bionic_slots": 4,
+    "sub_parts": [ "eyes_frog_left", "eyes_frog_right" ],
+    "effects_on_hit": [
+      {
+        "id": "blind",
+        "dmg_threshold": 3,
+        "dmg_scale_increment": 3,
+        "chance": 50,
+        "chance_dmg_scaling": 5,
+        "duration": 1,
+        "duration_dmg_scaling": 0.5
+      }
+    ]
+  },
+    {
+    "id": "eyes_frog_left",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_frog",
+    "side": 1,
+    "opposite": "eyes_frog_right",
+    "name_multiple": "eyes",
+    "name": "left eye"
+  },
+  {
+    "id": "eyes_frog_right",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_frog",
+    "side": 2,
+    "opposite": "eyes_frog_left",
+    "name_multiple": "eyes",
+    "name": "right eye"
+  },
+  {
     "id": "wing_bird_l",
     "type": "body_part",
     "name": "left wing",

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -591,7 +591,6 @@
     "messages": [ "You maul %s", "<npcname> mauls %s" ],
     "unarmed_allowed": true,
     "basic": true,
-    "weighting": -2,
     "reach_ok": false,
     "crit_ok": true,
     "attack_vectors": [ "vector_bite" ],
@@ -1469,9 +1468,19 @@
     "messages": [ "You claw %s", "<npcname> claws %s" ],
     "unarmed_allowed": true,
     "basic": true,
-    "weighting": -4,
+    "weighting": -2,
     "reach_ok": false,
     "crit_ok": true,
+    "condition": { "not": { "and": [
+        { "u_has_trait": "PAWS_LARGE" },
+        {
+          "and": [
+            { "math": [ "u_val('size') >= n_val('size')" ] },
+            { "not": { "npc_has_effect": "downed" } },
+            { "not": { "and": [ { "npc_bodytype": "blob" }, { "npc_bodytype": "snake" } ] } }
+          ]
+        }
+      ] } },
     "attack_vectors": [ "vector_claw" ]
   },
   {
@@ -1607,5 +1616,33 @@
     "messages": [ "You gore %s", "<npcname> gores %s" ],
     "description": "Headbutt using a pair of horns or antlers",
     "attack_vectors": [ "vector_horns" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_paws_large_claw",
+    "name": "Bear Claw",
+    "melee_allowed": false,
+    "messages": [ "You claw %s", "<npcname> claws %s" ],
+    "unarmed_allowed": true,
+    "basic": true,
+    "reach_ok": false,
+    "crit_ok": true,
+    "attack_vectors": [ "vector_claw" ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "PAWS_LARGE" },
+        {
+          "and": [
+            { "math": [ "u_val('size') >= n_val('size')" ] },
+            { "not": { "npc_has_effect": "downed" } },
+            { "not": { "and": [ { "npc_bodytype": "blob" }, { "npc_bodytype": "snake" } ] } }
+          ]
+        }
+      ]
+    },
+    "tech_effects": [
+      { "id": "downed", "chance": 70, "duration": 150, "on_damage": true, "message": "The attack knocks %s down!" }
+    ],
+    "flat_bonuses": [ { "stat": "damage", "type": "bash", "scale": 4 } ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -961,7 +961,6 @@
     "starting_trait": false,
     "enchantments": [ { "values": [ { "value": "VOMIT_MUL", "multiply": 0.5 } ] } ],
     "//": "Create an effect on condition that reduces nausea quickly whenever it occurs by one intensity per vomit?",
-    "types": [ "CONSTITUTION" ],
     "category": [ "BATRACHIAN" ],
     "threshreq": [ "THRESH_BATRACHIAN" ]
   },
@@ -1347,6 +1346,7 @@
     "description": "Your wounds heal a little slower than most.  Your HP whilst asleep, as well as your broken limbs, heal at 75% of the regular rate.",
     "starting_trait": true,
     "types": [ "HEALING" ],
+    "category": [ "LIZARD" ],
     "enchantments": [ { "values": [ { "value": "MENDING_MODIFIER", "multiply": -0.25 }, { "value": "REGEN_HP", "multiply": -0.25 } ] } ]
   },
   {
@@ -2176,9 +2176,9 @@
     "id": "MESOPIC",
     "name": { "str": "Mesopic" },
     "points": -1,
-    "description": "You find it difficult to see very far in bright light.  On its own, this doesn't necessarily make you any better in the dark.",
+    "description": "You find it difficult to see very far in bright light.  On its own, this doesn't make you any better at seeing in the dark.",
     "cancels": [ "MYOPIC" ],
-    "category": [ "CHIROPTERAN", "TROGLOBITE", "URSINE" ],
+    "category": [ "CHIROPTERAN", "TROGLOBITE", "CATTLE" ],
     "flags": [ "MYOPIC_IN_LIGHT" ]
   },
   {
@@ -2252,7 +2252,7 @@
     "name": { "str": "Reptilian IR" },
     "points": 5,
     "description": "Your optic nerves and brain have mutated to catch up with your eyes, allowing you to see in the infrared spectrum.",
-    "enchantments": [ "THERMAL_VISION_GOOD_PASSIVE" ],
+    "enchantments": [ "THERMAL_VISION_REPTILIAN_IR" ],
     "types": [ "VISION" ],
     "prereqs": [ "LIZ_EYE" ],
     "category": [ "LIZARD" ]
@@ -2301,15 +2301,17 @@
     "type": "mutation",
     "id": "REGEN_LIZ",
     "name": { "str": "Reptilian Healing" },
-    "points": 5,
+    "points": 4,
     "purifiable": false,
-    "description": "Your broken limbs mend themselves without significant difficulty in addition to your already-quick healing.  You do not require splints for broken limbs.",
+    "description": "Your rate of healing speeds up dramatically so long as your body is kept at or above room temperature, allowing even broken limbs to recover in record time.",
     "cancels": [ "ROT1", "ROT2", "ROT3" ],
-    "prereqs": [ "FASTHEALER" ],
+    "prereqs": [ "SLOWHEALER" ],
+    "prereqs2": [ "COLDBLOOD2", "COLDBLOOD3", "COLDBLOOD4" ],
     "threshreq": [ "THRESH_LIZARD" ],
     "category": [ "LIZARD" ],
     "enchantments": [
       {
+        "condition": "u_body_temp > 290",
         "values": [
           { "value": "MENDING_MODIFIER", "multiply": 19 },
           { "value": "REGEN_HP", "multiply": 0.5 },
@@ -2365,7 +2367,7 @@
     "visibility": 1,
     "ugliness": 2,
     "description": "You have a set of clear lenses which lower over your eyes while underwater, allowing you to see as though you were wearing goggles.  Slightly decreases wet penalties.",
-    "category": [ "LIZARD", "FISH" ],
+    "category": [ "URSINE" ],
     "flags": [ "EYE_MEMBRANE" ],
     "wet_protection": [ { "part": "eyes", "neutral": 1 } ]
   },
@@ -2376,16 +2378,17 @@
     "points": 1,
     "visibility": 8,
     "ugliness": 4,
-    "description": "Your eyes bulge noticeably out of your face, and you are able to move them much more freely than before.  You can see movement and close objects clearly, but you have trouble picking up distant details in the light.  Instead of eyelids they are covered by a translucent, protective membrane that blocks irritants and water.  It allows you to sleep with your eyes open!  Activate to cause the approach of hostile creatures to wake you up.",
+    "description": "Your huge, bulging eyes are great at tracking movement even underwater, and you have a transparent third eyelid that allows you to sleep with your eyes open.",
     "prereqs": [ "EYEBULGE" ],
+    "prereqs2": [ "MESOPIC", "NIGHTVISION" ],
     "category": [ "BATRACHIAN" ],
-    "flags": [ "EYE_MEMBRANE", "SEESLEEP", "MYOPIC_IN_LIGHT" ],
-    "types": [ "EYES" ],
-    "cancels": [ "MEMBRANE", "MYOPIC", "MESOPIC" ],
+    "flags": [ "EYE_MEMBRANE", "SEESLEEP" ],
+    "types": [ "EYES", "VISION" ],
+    "cancels": [ "MEMBRANE", "MYOPIC", "MESOPIC", "HYPEROPIC" ],
+    "enchantments": [ "ench_eyes_frog" ],
     "threshreq": [ "THRESH_BATRACHIAN" ],
-    "wet_protection": [ { "part": "eyes", "neutral": 1 } ],
-    "armor": [ { "parts": "eyes", "cut": 3, "bash": 1 } ],
-    "active": true
+    "wet_protection": [ { "part": "eyes_frog", "neutral": 1 } ],
+    "armor": [ { "parts": "eyes_frog", "cut": 3, "bash": 1 } ]
   },
   {
     "type": "mutation",
@@ -4411,6 +4414,17 @@
     "active": true,
     "cost": 0
   },
+    {
+    "type": "mutation",
+    "id": "EATPOISON_WEAK",
+    "name": { "str": "Intestinal Fortitude" },
+    "points": 2,
+    "description": "While it is by no means pleasant, your body has adapted to handle the toxic contaminants in mutant meat a little better.  You can eat a bit more of the stuff before suffering ill effects.",
+    "types": [ "CONSTITUTION" ],
+    "prereqs": [ "CARNIVORE" ],
+    "vitamins_absorb_multi": [ [ "all", [ [ "mutant_toxin", 0.75 ] ] ] ],
+    "category": [ "SPIDER", "FELINE", "BEAST", "LIZARD" ]
+  },
   {
     "type": "mutation",
     "id": "EATPOISON",
@@ -4427,6 +4441,7 @@
       "THRESH_CHIMERA",
       "THRESH_RAPTOR",
       "THRESH_RAT",
+      "THRESH_SPIDER",
       "THRESH_MOUSE",
       "THRESH_BATRACHIAN",
       "THRESH_CRUSTACEAN"
@@ -5154,7 +5169,7 @@
     "social_modifiers": { "intimidate": 4 },
     "purifiable": false,
     "types": [ "PREDATION" ],
-    "prereqs": [ "CARNIVORE" ],
+    "prereqs": [ "CARNIVORE_FAKE" ],
     "prereqs2": [ "PRED3" ],
     "threshreq": [ "THRESH_LUPINE" ],
     "category": [ "LUPINE" ],
@@ -6317,7 +6332,6 @@
     "ugliness": 4,
     "types": [ "EYES" ],
     "description": "Your eyes bulge out several inches from your skull.  This does not affect your vision in any way.",
-    "leads_to": [ "MEMBRANE" ],
     "changes_to": [ "COMPOUND_EYES", "EYESTALKS1", "FROG_EYES" ],
     "category": [ "BATRACHIAN", "INSECT", "GASTROPOD", "FISH", "CRUSTACEAN" ]
   },
@@ -7344,7 +7358,7 @@
     "description": "Your body's ability to digest fruits, vegetables, grains and nuts is severely hampered.  You've largely lost your taste for everything but meat, but your nutritional needs have largely adjusted to suit your new lifestyle.",
     "types": [ "DIET" ],
     "cancels": [ "VEGAN" ],
-    "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "FELINE", "BATRACHIAN", "BEAST", "LUPINE" ],
+    "category": [ "LIZARD", "SPIDER", "CHIMERA", "RAPTOR", "FELINE", "BATRACHIAN", "BEAST" ],
     "vitamin_rates": [ [ "vitC", 900 ] ]
   },
   {
@@ -8459,12 +8473,11 @@
     "points": 2,
     "visibility": 3,
     "ugliness": 4,
-    "description": "Like a true fish, your eyes lack eyelids, and are instead covered by a translucent, protective membrane that blocks irritants and water, and provides minor armor.  It also allows you to sleep with your eyes open!  Activate to cause the approach of hostile creatures to wake you up.",
-    "category": [ "FISH" ],
-    "threshreq": [ "THRESH_FISH" ],
-    "armor": [ { "parts": "eyes", "cut": 3, "bash": 1 } ],
-    "flags": [ "EYE_MEMBRANE", "SEESLEEP" ],
-    "active": true
+    "description": "Your eyes lack lids and are instead protected by a translucent scale that shuts out irritants.  This will make it much easier to see underwater, and to spot danger approaching even while you rest.",
+    "category": [ "FISH", "LIZARD" ],
+    "threshreq": [ "THRESH_FISH", "THRESH_LIZARD" ],
+    "integrated_armor": [ "integrated_lidless_eyes" ],
+    "flags": [ "EYE_MEMBRANE", "SEESLEEP" ]
   },
   {
     "type": "mutation",
@@ -9343,8 +9356,8 @@
     "name": { "str": "Imitation Carnivore" },
     "points": 0,
     "description": "Fake mutation to allow post-threshold Ursine mutants access to mutations normally gated behind Carnivore.  This is not meant to be visible in-game.",
-    "category": [ "URSINE" ],
-    "threshreq": [ "THRESH_URSINE" ],
+    "category": [ "URSINE", "LUPINE" ],
+    "threshreq": [ "THRESH_URSINE", "THRESH_LUPINE" ],
     "player_display": false
   },
   {


### PR DESCRIPTION
#### Summary
Mutant QoL updates

#### Purpose of change
Stuff I've been meaning to do based on how IRL animals work and also some gameplay concerns.

#### Describe the solution
- Ursines lose mesopic, bovoids gain it
- Ursines gain Nictitating Membrane, allowing them to see underwater.
- All carnivores that don't get EATPOISON (aranean, reptilian, feline, beast) instead get EATPOISON_WEAK which allows them to eat 25% more mutant meat/day without getting sick. This should make it a bit easier to keep those mutants alive, especially early game.
- Lupines are no longer carnivores. They get the CARNIVORE_FAKE mutation like Ursine which still lets them get all the cool predator mutations, but they can eat anything.
- Ursine's Broad Paws mutation grants a bitch slap from hell if you have mutated or bionic claws of any kind and make an unarmed attack. This attack has a good chance to knock opponents down. Downed opponents can trigger your maul attack which is a powerful bite. So now you can finally do the thing from that one movie where Leonardo DiCaprio got ate by a bear.
- Reptilian IR range drops from 60 tiles to 14 tiles. Sorry, pit vipers are cool, but it's not the same thing as wearing high tech goggles.
- Frog Eyes are an actual body part now. They have mesopic as before, but now have a higher reaction and night vision score than human eyes. This is a dodge/block buff for Batrachian, though frog eyes are slightly easier to hit.
- Reptilians gain Lidless Eyes, and Reptilians and Piscines now get an integrated bodypart from this to represent the protective scale over their eye. It should keep bile, smoke, water, some physical attacks, and acid out, but they'll still need some sort of eye protection when poison gas gets its eye effects added. This integrated item is on the PERSONAL layer and has no encumbrance, so it's a straight up bonus.
- Reptilians lose Fast Healing and Reptilian Healing no longer grants you super regeneration at all times. Instead, Reptilians get Slow Healing, and Reptilian Healing's effects only kick in if the temperature in the character's tile is at or above room temperature (~70 F, ~21 C).
- Encumbrance threshold for the legs (all legs) is getting bumped up from 6 to 8. That means you essentially have 2 more free points of encumbrance to work with on the legs.
- Regular claw attacks from mutations or bionics are now twice as likely to occur. These don't need a strong negative weighting since if you're fighting barehanded without gloves, it's safe to assume you want to use them.
- Fixed an issue where reptilian mutagen wasn't triggering mutations.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
