### PR TITLE
Add some lifestyle penalties

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4164,7 +4164,6 @@ int Character::calc_focus_equilibrium( bool ignore_pain ) const
             eff_morale = eff_morale - perceived_pain;
         }
     }
-
     if( eff_morale < -99 ) {
         // At very low morale, focus is at it's minimum
         focus_equilibrium = 1;
@@ -7970,10 +7969,10 @@ weighted_int_list<mutation_category_id> Character::get_vitamin_weighted_categori
     return weighted_output;
 }
 
-int Character::vitamin_RDA( const vitamin_id &vitamin, int ammount ) const
+int Character::vitamin_RDA( const vitamin_id &vitamin, int amount ) const
 {
     const double multiplier = vitamin_rate( vitamin ) * 100 / 1_days;
-    return std::lround( ammount * multiplier );
+    return std::lround( amount * multiplier );
 }
 
 void Character::recalculate_bodyparts()

--- a/src/character.h
+++ b/src/character.h
@@ -4105,8 +4105,8 @@ class Character : public Creature, public visitable
         std::map<vitamin_id, int> vitamin_levels;
         /** Current quantity for each vitamin today first value is expected second value is actual (digested) in vitamin units*/
         std::map<vitamin_id, std::pair<int, int>> daily_vitamins;
-        /** Returns the % of your RDA that ammount of vitamin represents */
-        int vitamin_RDA( const vitamin_id &vitamin, int ammount ) const;
+        /** Returns the % of your RDA that amount of vitamin represents */
+        int vitamin_RDA( const vitamin_id &vitamin, int amount ) const;
 
         pimpl<player_morale> morale;
         /** Processes human-specific effects of an effect. */

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -288,6 +288,18 @@ void Character::update_body( const time_point &from, const time_point &to )
         set_value( "sleep_health_mult", "1" );
     }
     if( calendar::once_every( 1_days ) ) {
+        if( sleep_deprivation >= SLEEP_DEPRIVATION_MINOR ) {
+            mod_daily_health( -1, -100 );
+        }
+        if( sleep_deprivation >= SLEEP_DEPRIVATION_SERIOUS ) {
+            mod_daily_health( -2, -200 );
+        }
+        if( sleep_deprivation >= SLEEP_DEPRIVATION_MAJOR ) {
+            mod_daily_health( -3, -200 );
+        }
+        if( sleep_deprivation >= SLEEP_DEPRIVATION_MASSIVE ) {
+            mod_daily_health( -4, -200 );
+        }
         reset_daily_sleep();
     }
     set_value( "was_sleeping", in_sleep_state() ? "true" : "false" );
@@ -298,7 +310,7 @@ void Character::update_body( const time_point &from, const time_point &to )
     if( calendar::once_every( 1_days ) ) {
         // not getting below half stamina even once in a whole day is not healthy
         if( get_value( "got_to_half_stam" ).empty() ) {
-            mod_daily_health( -4, -200 );
+            mod_daily_health( -5, -200 );
         } else {
             remove_value( "got_to_half_stam" );
         }
@@ -319,7 +331,18 @@ void Character::update_body( const time_point &from, const time_point &to )
             }
         }
         if( cardio_accumultor >= get_cardio_acc_base() ) {
-            mod_daily_health( 2, 200 );
+            mod_daily_health( 1, 200 );
+        }
+
+        if( !get_value( "got_to_low_morale" ).empty() ) {
+            mod_daily_health( -4, -100 );
+        } else {
+            remove_value( "got_to_low_morale" );
+        }
+        if( !get_value( "got_to_very_low_morale" ).empty() ) {
+            mod_daily_health( -6, -200 );
+        } else {
+            remove_value( "got_to_very_low_morale" );
         }
     }
 
@@ -352,10 +375,26 @@ void Character::update_body( const time_point &from, const time_point &to )
             if( ( RDA > 50 ) && ( rng( 1, 115 ) <= std::min( RDA, 100 ) ) ) {
                 mod_daily_health( 1, 200 );
             }
-
-            // Once we've checked daily intake we should reset it.
-            reset_daily_vitamin( v.first );
         }
+        // Hey so it turns out no amount of poison is healthy to ingest.
+        if( calendar::once_every( 24_hours ) && v.first->type() == vitamin_type::TOXIN ) {
+            const int &toxin_quantity = get_daily_vitamin( v.first, true );
+            const int toxin_RDA = vitamin_RDA( v.first, toxin_quantity );
+            // Three chances to lose lifestyle. Once if we had any...
+            if( ( toxin_RDA >= 1 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
+                mod_daily_health( -1, -100 );
+            }
+            // Once if we've had half of our limit... 
+            if( ( toxin_RDA >= 50 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
+                mod_daily_health( -2, -200 );
+            }
+            // And once if we've gotten near the point of actual symptoms.
+            if( ( toxin_RDA >= 90 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
+                mod_daily_health( -4, -200 );
+            }
+        }
+        // Once we've checked daily intake we should reset it.
+        reset_daily_vitamin( v.first );
     }
 
     const int thirty_mins = ticks_between( from, to, 30_minutes );

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -101,6 +101,14 @@ void Character::add_morale( const morale_type &type, int bonus, int max_bonus,
                             bool capped, const itype *item_type )
 {
     morale->add( type, bonus, max_bonus, duration, decay_start, capped, item_type );
+    if( get_morale_level() <= -25 ) {
+        // These two values are used to ding your lifestyle score. Stress is bad for you!
+        set_value( "got_to_low_morale", "true" );
+    }
+    if( get_morale_level() <= -50 ) {
+        // These two values are used to ding your lifestyle score. Stress is bad for you!
+        set_value( "got_to_very_low_morale", "true" );
+    }
 }
 
 int Character::has_morale( const morale_type &type ) const


### PR DESCRIPTION
#### Summary
Add some lifestyle penalties

#### Purpose of change
There are too many lifestyle bonuses and not enough penalties.

#### Describe the solution
- If morale hits -25 in a day, you get a lifestyle penalty.
- If morale hits -50 in a day, you get a bigger lifestyle penalty.
- If you are sleep deprived, you get lifestyle penalties that scale with how bad it is.
- If you eat mutant meat, you have a chance to get up to 3 lifestyle hits, depending on how much toxin you have relative to what your own personal allowance is. This allowance is adjusted by mutations and stuff, so it's less of a problem for ie carnivore mutants.

These are fairly minor and shouldn't present a problem for most characters given how many bonuses to lifestyle are available. The intent is mostly to make it less of a sure thing that you get to thriving without conscious effort.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
