### PR TITLE
Reptilian Thermal Vision requires Carnivore

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2249,12 +2249,13 @@
   {
     "type": "mutation",
     "id": "LIZ_IR",
-    "name": { "str": "Reptilian IR" },
+    "name": { "str": "Thermal Vision" },
     "points": 5,
     "description": "Your optic nerves and brain have mutated to catch up with your eyes, allowing you to see in the infrared spectrum.",
     "enchantments": [ "THERMAL_VISION_REPTILIAN_IR" ],
     "types": [ "VISION" ],
     "prereqs": [ "LIZ_EYE" ],
+    "prereqs2": [ "CARNIVORE" ],
     "category": [ "LIZARD" ]
   },
   {


### PR DESCRIPTION
#### Summary
Reptilian Thermal Vision requires Carnivore

#### Purpose of change
- Reptilian IR vision was too easy to grab on a dip, and very valuable.
- Carnivore is too much of a penalty and should have things that rely on it so it's less undesirable.

#### Describe the solution
- Change it from Reptilian IR to Thermal Vision.
- Make it require Carnivore. This makes sense as it's for tracking prey.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
