### PR TITLE
Fix Ruminant not removing some plants when eaten

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3901,10 +3901,12 @@ void catacurses::init_interface()
     color_loader<SDL_Color>().load( windowsPalette );
     init_colors();
 
+#if defined(SDL_SOUND)
     // initialize sound set
     if( sound_init_success ) {
         load_soundset();
     }
+#endif
 
     font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
             windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );


### PR DESCRIPTION
#### Summary
Fix Ruminant/Grazer mutation infinite food source exploit

#### Purpose of change
Some plants, like Japanese knotweed and wild rice, would not disappear when consumed with an active Ruminant mutation, despite giving calories. This way, one could feed forever on one plant.

The problem was code checking for the SHRUB flag on either terrain or furniture (via map::has_flag -> map::has_flag_ter_or_furn), but only removing terrain, not furniture.
Japanese knotweed is furniture with the SHRUB flag, regular shrubs (which were disappearing correctly) are terrain.

#### Describe the solution
Replace map::has_flag(flag, pos) with the more specific map::{ter,furn}(pos).obj().has_flag(flag) to figure out whether the flag was on terrain or furniture, and then use ter_set or furn_set to remove the appropriate thing.

Also fix the compilation when SDL_SOUND is not defined.

#### Describe alternatives you've considered
- Wait for the complete grazing overhaul https://github.com/Cataclysm-TLG/Cataclysm-TLG/issues/152
- Adjust flags on edible furniture (furniture with the FLOWER flag was being handled correctly)

#### Testing
Compiled, verified that Japanese knotweed, wild rice, spreading dogbane disappear when ruminated on.
Flowers and regular shrubs can still be eaten like before.

#### Additional context
There is a separate bug where, if the player is full enough that the dialog "You're full already and will be forcing yourself to eat. Y/N?" appears, the plant disappears even if the player chooses "no", without giving any calories.

This patch doesn't fix that, but this same code is probably relevant;  there is an explicit check for being engorged, and the plant does not get removed in that case, but that seems to trigger at a higher stomach-fill-level than the Y/N dialog box (you can test this by eating a bunch, choosing Y in the dialog as often as is allowed, and then trying to ruminate).

The Y/N dialog box seems to be created as part of you.assign_activity(consume_activity_actor(food)), which may cancel the consumption, but the furniture/terrain gets cleared either way by the code in avatar_action::eat_here.
One would probably need to hook into the "finish" method of this activity and clear the furniture/terrain there.
That might require a bigger change though since it seems to be built around consuming items, not furniture/terrain.