### PR TITLE
Partially revert mutant meat RDA penalty

### DIFF
--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -473,7 +473,7 @@ class cata_tiles
         find_tile_looks_like( const std::string &id, TILE_CATEGORY category, const std::string &variant,
                               int looks_like_jumps_limit = 10 ) const;
 
-        // this templated method is used only from it's own cpp file, so it's ok to declare it here
+        // This templated method is used only from its own cpp file, so it's ok to declare it here
         template<typename T>
         std::optional<tile_lookup_res>
         find_tile_looks_like_by_string_id( std::string_view id, TILE_CATEGORY category,

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -375,26 +375,10 @@ void Character::update_body( const time_point &from, const time_point &to )
             if( ( RDA > 50 ) && ( rng( 1, 115 ) <= std::min( RDA, 100 ) ) ) {
                 mod_daily_health( 1, 200 );
             }
+
+            // Once we've checked daily intake we should reset it.
+            reset_daily_vitamin( v.first );
         }
-        // Hey so it turns out no amount of poison is healthy to ingest.
-        if( calendar::once_every( 24_hours ) && v.first->type() == vitamin_type::TOXIN ) {
-            const int &toxin_quantity = get_daily_vitamin( v.first, true );
-            const int toxin_RDA = vitamin_RDA( v.first, toxin_quantity );
-            // Three chances to lose lifestyle. Once if we had any...
-            if( ( toxin_RDA >= 1 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
-                mod_daily_health( -1, -100 );
-            }
-            // Once if we've had half of our limit... 
-            if( ( toxin_RDA >= 50 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
-                mod_daily_health( -2, -200 );
-            }
-            // And once if we've gotten near the point of actual symptoms.
-            if( ( toxin_RDA >= 90 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
-                mod_daily_health( -2, -200 );
-            }
-        }
-        // Once we've checked daily intake we should reset it.
-        reset_daily_vitamin( v.first );
     }
 
     const int thirty_mins = ticks_between( from, to, 30_minutes );

--- a/src/item.h
+++ b/src/item.h
@@ -1697,7 +1697,7 @@ class item : public visitable
          * @param it the item being put in
          * @param nested whether or not the current call is nested (used recursively).
          * @param ignore_pkt_settings whether to ignore pocket autoinsert settings
-         * @param remaining_parent_volume the ammount of space in the parent pocket,
+         * @param remaining_parent_volume the amount of space in the parent pocket,
          * @param allow_nested whether nested pockets should be checked
          * needed to make sure we dont try to nest items which can't fit in the nested pockets
          */

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1276,7 +1276,7 @@ int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel
                                              static_cast<float>( pocket.front().fuel_energy().value() ) * fuel_efficiency ) );
 
                 const int res = pocket.ammo_consume( charges_used );
-                //calculate the ammount of energy generated
+                //calculate the amount of energy generated
                 int energy_generated = res * units::to_kilojoule( pocket.front().fuel_energy() );
                 consumed += energy_generated;
                 qty -= energy_generated;


### PR DESCRIPTION
#### Summary
Partially revert mutant meat RDA penalty

#### Purpose of change
Something about #1259 broke the ability to get vitamins at all. Let's revert it until we can figure that out.

#### Describe the solution
Revert that bit of the code in character_body

#### Additional context
For some reason, vitamins seem to be giving about double what they say they ought to give. I think that's a pre-existing issue. Either way this fix is better than nothing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
