### PR TITLE
Re-add mutant meat lifestyle malus

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -367,13 +367,25 @@ void Character::update_body( const time_point &from, const time_point &to )
                 vitamin_mod( v.first, qty );
             }
         }
-        if( calendar::once_every( 24_hours ) && v.first->type() == vitamin_type::VITAMIN ) {
-            const int &vit_quantity = get_daily_vitamin( v.first, true );
-            const int RDA = vitamin_RDA( v.first, vit_quantity );
-            // With three vitamins tracked, this essentially gives us three chances for a bonus.
-            // We average at about 2.6 points of lifestyle/day max.
-            if( ( RDA > 50 ) && ( rng( 1, 115 ) <= std::min( RDA, 100 ) ) ) {
-                mod_daily_health( 1, 200 );
+        if( calendar::once_every( 24_hours ) ) {
+            if( v.first->type() == vitamin_type::VITAMIN ) {
+                const int &vit_quantity = get_daily_vitamin( v.first, true );
+                const int RDA = vitamin_RDA( v.first, vit_quantity );
+                // With three vitamins tracked, this essentially gives us three chances for a bonus.
+                // We average at about 2.6 points of lifestyle/day max.
+                if( ( RDA > 50 ) && ( rng( 1, 115 ) <= std::min( RDA, 100 ) ) ) {
+                    mod_daily_health( 1, 200 );
+                }
+            }
+            if( v.first->type() == vitamin_type::TOXIN ) {
+                const int &toxin_quantity = get_daily_vitamin( v.first, true );
+                const int toxin_RDA = vitamin_RDA( v.first, toxin_quantity );
+                // No amount of toxins are safe, but they're not always harmful either. Find the
+                // "RDA" for our character and roll a chance to get a penalty tied to how much we ate.
+                if( ( toxin_RDA > 0 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
+                    int toxin_malus = static_cast<int>( std::ceil( toxin_RDA / 10.0 ) );
+                    mod_daily_health( std::max( -5, toxin_malus ), -200 );
+                }
             }
 
             // Once we've checked daily intake we should reset it.


### PR DESCRIPTION
#### Summary
Re-add mutant meat lifestyle malus

#### Purpose of change
The mutant meat lifestyle malus in #1259 broke somehow, I think it was refreshing the vitamins improperly or something. Anyway it works now.

#### Describe the solution
Eating any mutant meat at all creates a small chance that you will be penalized. The chance and the penalty both go up as you eat more mutant meat, relative to the amount your body is able to withstand. This should not really be an issue for mutants who are supposed to be eating the stuff, but it still isn't ideal for them and they should be preferentially seeking out good meat.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
