### PR TITLE
Bleeds require damage

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1931,6 +1931,9 @@ void monster::make_bleed( const effect_source &source, time_duration duration, i
     }
 
     duration = ( duration * type->bleed_rate ) / 100;
+    if( duration < 1_seconds ) {
+       return;
+    }
     if( type->in_species( species_ROBOT ) ) {
         add_effect( source, effect_dripping_mechanical_fluid, duration, bodypart_str_id::NULL_ID() );
     } else {
@@ -2220,7 +2223,7 @@ void monster::deal_damage_handle_type( const effect_source &source, const damage
             return;
         }
     }
-    if( du.type == damage_bullet || du.type->edged ) {
+    if( ( du.type == damage_bullet || du.type->edged ) && adjusted_damage >= 1 ) {
         make_bleed( source, 1_minutes * rng( 0, adjusted_damage ) );
     }
 


### PR DESCRIPTION
#### Summary
Bleeds require damage

#### Purpose of change
Due to some backports, it was possible to inflict bleeds on enemies with 0 damage attacks. These ended instantly.

#### Describe the solution
You need to do at least 1 damage. Add a similar check in the make_bleed() code to be sure that bleed_rate isn't screwing it up either.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
