### PR TITLE
Standardize trig_dist_z_adjust calls

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10891,7 +10891,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
                 }
             }
         }
-        bool in_range = ( is_adjacent( &critter, true ) ) || ( ( posz() == critter.posz() ) && ( std::round( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) <= range ) ) || ( std::ceil( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) <= range );
+        bool in_range = ( is_adjacent( &critter, true ) ) || ( ( posz() == critter.posz() ) && ( static_cast<int>(std::round( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) ) <= range ) ) || ( std::ceil( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) <= range );
         // TODO: get rid of fake npcs (pos() check)
         bool valid_target = this != &critter && pos_bub() != critter.pos_bub() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -490,7 +490,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
                 }
                 add_msg_debug( debugmode::DF_EXPLOSION, "Shrapnel hit %s at %d m/s at a distance of %d",
                                critter->disp_name(),
-                               frag.proj.speed, trig_dist_z_adjust( src.raw(), target.raw() ) );
+                               frag.proj.speed, static_cast<int>( std::round( trig_dist_z_adjust( src.raw(), target.raw() ) ) ) );
                 add_msg_debug( debugmode::DF_EXPLOSION, "Shrapnel dealt %d damage", frag.dealt_dam.total_damage() );
                 if( critter->is_dead_state() ) {
                     break;
@@ -606,7 +606,7 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune )
 {
     draw_explosion( p, 8, c_white );
     Character &player_character = get_player_character();
-    int dist = trig_dist_z_adjust( player_character.pos_bub(), p );
+    int dist = static_cast<int>( std::round( trig_dist_z_adjust( player_character.pos_bub(), p ) ) );
     map &here = get_map();
     if( dist <= 8 && !player_immune ) {
         if( !player_character.has_flag( STATIC( json_character_flag( "IMMUNE_HEARING_DAMAGE" ) ) ) ) {
@@ -635,7 +635,7 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune )
             continue;
         }
         // TODO: can the following code be called for all types of creatures
-        dist = trig_dist_z_adjust( critter.pos_bub(), p );
+        dist = static_cast<int>( std::round( trig_dist_z_adjust( critter.pos_bub(), p ) ) );
         if( dist <= 8 ) {
             if( dist <= 4 ) {
                 critter.add_effect( effect_stunned, time_duration::from_turns( 10 - dist ) );
@@ -664,7 +664,7 @@ void shockwave( const tripoint_bub_ms &p, int radius, int force, int stun, int d
         if( critter.posz() != p.z() ) {
             continue;
         }
-        if( trig_dist_z_adjust( critter.pos_bub(), p ) <= radius ) {
+        if( static_cast<int>( std::round( trig_dist_z_adjust( critter.pos_bub(), p ) <= radius ) ) ) {
             add_msg( _( "%s is caught in the shockwave!" ), critter.name() );
             g->knockback( p, critter.pos_bub(), force, stun, dam_mult );
         }
@@ -674,13 +674,13 @@ void shockwave( const tripoint_bub_ms &p, int radius, int force, int stun, int d
         if( guy.posz() != p.z() ) {
             continue;
         }
-        if( trig_dist_z_adjust( guy.pos_bub(), p ) <= radius ) {
+        if( static_cast<int>( std::round( trig_dist_z_adjust( guy.pos_bub(), p ) ) ) <= radius ) {
             add_msg( _( "%s is caught in the shockwave!" ), guy.get_name() );
             g->knockback( p, guy.pos_bub(), force, stun, dam_mult );
         }
     }
     Character &player_character = get_player_character();
-    if( trig_dist_z_adjust( player_character.pos_bub(), p ) <= radius && !ignore_player &&
+    if( static_cast<int>( std::round( trig_dist_z_adjust( player_character.pos_bub(), p ) ) ) <= radius && !ignore_player &&
         ( !player_character.has_trait( trait_LEG_TENT_BRACE ) ||
           !player_character.is_barefoot() ) ) {
         add_msg( m_bad, _( "You're caught in the shockwave!" ) );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8281,7 +8281,7 @@ std::vector<tripoint_bub_ms> map::find_clear_path( const tripoint_bub_ms &source
     const int max_start_offset = std::abs( ideal_start_offset ) * 2 + 1;
     for( int horizontal_offset = -1; horizontal_offset <= max_start_offset; ++horizontal_offset ) {
         int candidate_offset = horizontal_offset * ( start_sign == 0 ? 1 : start_sign );
-        if( sees( source, destination, trig_dist_z_adjust( source.raw(), destination.raw() ),
+        if( sees( source, destination, static_cast<int>( std::round( trig_dist_z_adjust( source, destination ) ) ),
                   candidate_offset, /*with_fields=*/true, /*allow_cached=*/false ) ) {
             return line_to( source, destination, candidate_offset, 0 );
         }
@@ -8415,12 +8415,10 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     if( std::abs( f.z() - t.z() ) > fov_3d_z_range ) {
         return false;
     }
-
     // Ugly `if` for now
     // TODO: Why is it even like this?
     if( f.z() == t.z() ) {
-        if( ( range >= 0 &&
-              range < static_cast<int>( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) ||
+        if( ( range < static_cast<int>(std::round( trig_dist_z_adjust( f, t ) ) ) ) ||
             !inbounds( t ) ) {
             return false; // Out of range!
         }
@@ -8464,14 +8462,13 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     }
 
     // 3D path check
-    if( ( range >= 0 && range < static_cast<int>( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) ||
+    if( ( range < static_cast<int>(std::round( trig_dist_z_adjust( f.raw(), t.raw() ) ) ) ) ||
         !inbounds( t ) ) {
         return false;
     }
 
     bool is_clear = true;
     tripoint_bub_ms last_point = f;
-
     bresenham( f, t, 0, 0,
     [this, &is_clear, cost_min, cost_max, t, &last_point]( const tripoint_bub_ms & new_point ) {
         if( new_point == t ) {
@@ -8523,11 +8520,9 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
                 return false;
             }
         }
-
         last_point = new_point;
         return true;
     } );
-
     return is_clear;
 }
 

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -299,7 +299,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
     spell_instance.set_message( spell_data.trigger_message );
 
     // Bail out if the target is out of range.
-    if( !spell_data.self && rl_dist( mon.pos_bub(), target ) > spell_instance.range( mon ) ) {
+    if( !spell_data.self && static_cast<int>( std::round( trig_dist_z_adjust( mon.pos_bub(), target ) > spell_instance.range( mon ) ) ) ) {
         return false;
     }
 
@@ -1171,7 +1171,7 @@ bool gun_actor::call( monster &z ) const
         }
     }
 
-    const int dist = rl_dist( z.pos_bub(), aim_at );
+    const int dist = static_cast<int>( std::round( trig_dist_z_adjust( z.pos_bub(), aim_at ) ) );
     if( target ) {
         add_msg_debug( debugmode::DF_MATTACK, "Target %s at range %d", target->disp_name(), dist );
     } else {

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -249,9 +249,14 @@ static bool within_visual_range( monster *z, int max_range )
 
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
+    if( z->is_adjacent( target, true ) ) {
+    add_msg ( _( "its true" ) );
+    } else {
+    add_msg ( _( "its false" ) );
+    }
     return target != nullptr &&
            ( z->is_adjacent( target, true ) ||
-             ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) <= range ) ) &&
+             static_cast<int>( ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) ) <= range ) ) &&
            z->sees( *target );
 }
 
@@ -1008,7 +1013,7 @@ bool mattack::pull_metal_aoe( monster *z )
         // FIXME: Hardcoded damage type
         proj.impact.add_damage( STATIC( damage_type_id( "bash" ) ), pr.first.weight() / 250_gram );
         // make the projectile stop one tile short to prevent hitting the user
-        proj.range = trig_dist_z_adjust( pr.second, z->pos_bub() ) - 1;
+        proj.range = static_cast<int>( std::round( trig_dist_z_adjust( pr.second, z->pos_bub() ) ) ) - 1;
         proj.proj_effects = {{ ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET }};
 
         dealt_projectile_attack dealt = projectile_attack(

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1429,7 +1429,7 @@ void monster::footsteps( const tripoint_bub_ms &p )
     if( volume == 0 ) {
         return;
     }
-    int dist = trig_dist_z_adjust( p, get_player_character().pos_bub() );
+    int dist = static_cast<int>( std::round( trig_dist_z_adjust( p, get_player_character().pos_bub() ) ) );
     sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
 }
 

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -197,7 +197,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
         if( source.sees( *critter ) ) {
             damage = attack_spell.dps( source, *critter );
         }
-        const int distance_to_me = trig_dist_z_adjust( source.pos_bub(), potential_target );
+        const int distance_to_me = static_cast<int>(std::round( trig_dist_z_adjust( source.pos_bub(), potential_target ) ) );
         const bool friendly_fire = att == Creature::Attitude::FRIENDLY &&
                                    !source.rules.has_flag( ally_rule::avoid_friendly_fire );
         int attitude_mult = 3;
@@ -243,8 +243,8 @@ void npc_attack_melee::use( npc &source, const tripoint_bub_ms &location ) const
         return;
     }
     // TODO: Move this to line.h
-    int target_distance = static_cast<int>( std::round( trig_dist_z_adjust( source.pos_bub(),
-                                            location ) ) );
+    int target_distance = static_cast<int>( static_cast<int>(std::round( trig_dist_z_adjust( source.pos_bub(),
+                                            location ) ) ) );
     if( source.posz() != location.z() ) {
         // Always round up so that the Z adjustment actually matters.
         target_distance = static_cast<int>( std::ceil( trig_dist_z_adjust( source.pos_bub(),
@@ -452,7 +452,7 @@ void npc_attack_gun::use( npc &source, const tripoint_bub_ms &location ) const
         return;
     }
 
-    const int dist = trig_dist_z_adjust( source.pos_bub(), location );
+    const int dist = static_cast<int>( std::round( trig_dist_z_adjust( source.pos_bub(), location ) ) );
 
     // Only aim if we aren't in risk of being hit
     // TODO: Get distance to closest enemy
@@ -568,7 +568,7 @@ npc_attack_rating npc_attack_gun::evaluate_tripoint(
     }
 
     const bool avoids_friendly_fire = source.rules.has_flag( ally_rule::avoid_friendly_fire );
-    const int distance_to_me = trig_dist_z_adjust( location, source.pos_bub() );
+    const int distance_to_me = static_cast<int>( std::round( trig_dist_z_adjust( location, source.pos_bub() ) ) );
 
     // Make attacks that involve moving to find clear LOS slightly less likely
     if( has_obstruction( source.pos_bub(), location, avoids_friendly_fire ) ) {
@@ -757,7 +757,7 @@ npc_attack_rating npc_attack_throw::evaluate(
         // Calculated for all targetable points, not just those with targets
         if( throw_now ) {
             // TODO: Take into account distance to allies too
-            const int distance_to_me = trig_dist_z_adjust( potential, source.pos_bub() );
+            const int distance_to_me = static_cast<int>( std::round( trig_dist_z_adjust( potential, source.pos_bub() ) ) );
             int result = npc_attack_constants::base_throw_now + distance_to_me;
             if( !has_obstruction( source.pos_bub(), potential, avoids_friendly_fire ) ) {
                 // More likely to pick a target tile that isn't obstructed
@@ -838,7 +838,7 @@ npc_attack_rating npc_attack_throw::evaluate_tripoint(
     const float throw_mult = throw_cost( source, single_item ) * source.speed_rating() / 100.0f;
     const int damage = source.thrown_item_total_damage_raw( single_item );
     float dps = damage / throw_mult;
-    const int distance_to_me = trig_dist_z_adjust( location, source.pos_bub() );
+    const int distance_to_me = static_cast<int>( std::round( trig_dist_z_adjust( location, source.pos_bub() ) ) );
     float suitable_item_mult = -0.15f;
     if( distance_to_me > 1 ) {
         if( thrown_item.has_flag( flag_NPC_THROWN ) ) {


### PR DESCRIPTION
#### Summary
Standardize trig_dist_z_adjust calls

#### Purpose of change
The function responsible for checking euclidian distance (diagonals > orthogonals) returns a float, but most range/distance functions use ints, since this is a tile based game. There were some inconsistencies in how this was being resolved, leading to oddities like cunning ferals being able to reach two tiles diagonally with their spears while the player could not.

#### Describe the solution
Nearly all trig_dist_z_adjust checks now use static_cast<int>( std::round() ), with the exception of those that need to use std::ceil.

#### Testing
Feral spear range is normal now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
