### PR TITLE
Add a null guard to vehicles and remove debug msg

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2899,8 +2899,13 @@ bool map::has_vehicle_floor( const tripoint &p ) const
     const tripoint_bub_ms p_bub( p );
     return has_vehicle_floor( p_bub );
 }
+
 bool map::has_vehicle_floor( const tripoint_bub_ms &p ) const
 {
+    const optional_vpart_position vp = veh_at( p );
+    if( !vp ) {
+        return false;
+    }
     return veh_at( p ).part_with_feature( "BOARDABLE", false ) ||
            veh_at( p ).part_with_feature( "OBSTACLE", false );
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -249,11 +249,6 @@ static bool within_visual_range( monster *z, int max_range )
 
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
-    if( z->is_adjacent( target, true ) ) {
-        add_msg( _( "its true" ) );
-    } else {
-        add_msg( _( "its false" ) );
-    }
     return target != nullptr &&
            ( z->is_adjacent( target, true ) ||
              static_cast<int>( ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) ) <= range ) ) &&


### PR DESCRIPTION
#### Summary
Add a null guard to vehicles and remove debug msg

#### Describe the solution
- Attempts to patch a persistent vehicle-related segfault by adding a null guard to has_vehicle_floor()
- Gets rid of a leftover debug message.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
