### PR TITLE
Add a minor lifestyle penalty for wearing filthy clothes

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -306,7 +306,7 @@ void Character::update_body( const time_point &from, const time_point &to )
 
     activity_history.new_turn( in_sleep_state() );
 
-    // Cardio related health stuff
+    // Lifestyle and cardio stuff.
     if( calendar::once_every( 1_days ) ) {
         // not getting below half stamina even once in a whole day is not healthy
         if( get_value( "got_to_half_stam" ).empty() ) {
@@ -343,6 +343,10 @@ void Character::update_body( const time_point &from, const time_point &to )
             mod_daily_health( -2, -200 );
         } else {
             remove_value( "got_to_very_low_morale" );
+        }
+
+        if( worn_with_flag( flag_FILTHY ) ) {
+            mod_daily_health( -1, -200 );
         }
     }
 


### PR DESCRIPTION
#### Summary
Add a minor lifestyle penalty for wearing filthy clothes

#### Purpose of change
We needed more lifestyle penalties. Wearing clothing caked in putrescence is a good one.

#### Describe the solution
Once per day, a check runs. If you're wearing any filthy clothing at that time, you get a -1 lifestyle penalty. Doesn't matter how much you're wearing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
