### PR TITLE
Remove bash exploit from grappling hook

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1747,7 +1747,7 @@
       "str_max": 20,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "scrap", "charges": [ 1, 5 ] }, { "item": "rope_30", "count": 1 } ]
+      "items": [ { "item": "scrap", "count": [ 1, 4 ] }, { "item": "rope_30", "count": 1 } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Remove bash exploit from grappling hook

#### Purpose of change
I made it so you can't undeploy grappling hooks from the ground, but it was still easy to bash them loose. Now all that's liable to do is break your hook.

#### Describe the solution
Remove BASH_UNDEPLOY and change the bash results to scrap.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
