### PR TITLE
Finally stop books spawning on steel mill rails

### DIFF
--- a/data/json/mapgen_palettes/steel_mill_slag_palette.json
+++ b/data/json/mapgen_palettes/steel_mill_slag_palette.json
@@ -89,7 +89,7 @@
       "!": { "item": "steel_mill_mill", "chance": 45 },
       "1": { "item": "steel_mill_foundry", "chance": 65 },
       "l": { "item": "clothing_work_set", "chance": 15 },
-      "H": { "item": "homebooks", "chance": 30 },
+      "S": { "item": "homebooks", "chance": 30 },
       "7": { "item": "office_paper", "chance": 30 }
     },
     "toilets": { "t": {  } },


### PR DESCRIPTION
#### Summary
Finally stop books spawning on steel mill rails

#### Purpose of change
Books were appearing on steel mill rails. This was due to an error in the slagged out steel mill's mapgen palette.

#### Describe the solution
H -> S

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
