### PR TITLE
Make cigarette smoke vanish faster indoors

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1288,7 +1288,7 @@
     "outdoor_age_speedup": "6 minutes",
     "dirty_transparency_cache": true,
     "priority": 8,
-    "half_life": "35 minutes",
+    "half_life": "525 turns",
     "phase": "gas",
     "accelerated_decay": true,
     "display_field": true,


### PR DESCRIPTION
#### Summary
Make cigarette smoke vanish faster indoors

#### Purpose of change
For some reason, cigarette smoke had a half-life of 35 minutes. This meant it took forever to go away indoors.

#### Describe the solution
Shorten it to an amount comparable to other smokables.

#### Testing
Smoked a cigarette. A puff of smoke appeared and vanished quickly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
