### PR TITLE
Backport 79722 - Added ground protection from bashing

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -204,7 +204,11 @@ static const ter_str_id ter_t_grass( "t_grass" );
 static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_reb_cage( "t_reb_cage" );
 static const ter_str_id ter_t_rock( "t_rock" );
+static const ter_str_id ter_t_rock_blue( "t_rock_blue" );
 static const ter_str_id ter_t_rock_floor( "t_rock_floor" );
+static const ter_str_id ter_t_rock_floor_no_roof( "t_rock_floor_no_roof" );
+static const ter_str_id ter_t_rock_green( "t_rock_green" );
+static const ter_str_id ter_t_rock_red( "t_rock_red" );
 static const ter_str_id ter_t_rootcellar( "t_rootcellar" );
 static const ter_str_id ter_t_soil( "t_soil" );
 static const ter_str_id ter_t_stump( "t_stump" );
@@ -4627,7 +4631,16 @@ void map::bash_ter_furn( const tripoint_bub_ms &p, bash_params &params )
 
         set_to_air = roof_of_below_tile; //do not add the roof for the tile below if it was already removed
         furn_set( p, furn_str_id::NULL_ID() );
-        ter_set( p, ter_t_open_air );
+        if( ter_below.id == ter_t_soil ) {
+            ter_set( p, ter_t_dirt );
+        } else if( ter_below.id == ter_t_rock ||
+                   ter_below.id == ter_t_rock_blue ||
+                   ter_below.id == ter_t_rock_green ||
+                   ter_below.id == ter_t_rock_red ) {
+            ter_set( p, ter_t_rock_floor_no_roof );
+        } else {
+            ter_set( p, ter_t_open_air );
+        }
     }
 
     if( !tent ) {
@@ -9486,6 +9499,7 @@ void map::add_tree_tops( const tripoint_rel_sm &grid )
     for( int x = 0; x < SEEX; x++ ) {
         for( int y = 0; y < SEEY; y++ ) {
             const ter_id &ter_here = sub_here->get_ter( { x, y } );
+
             if( !ter_here.id()->has_flag( "EMPTY_SPACE" ) ) {
                 continue;
             }
@@ -9499,7 +9513,19 @@ void map::add_tree_tops( const tripoint_rel_sm &grid )
             const ter_t &ter_below = sub_below->get_ter( { x, y } ).obj();
             if( ter_below.has_flag( "TREE" ) && ter_below.roof ) {
                 sub_here->set_ter( { x, y }, ter_below.roof.id() );
-            }
+            } else
+                // This code is needed to handle bashing during mapgen, because the Z level below
+                // hasn't yet been generated when the bashing occurs.
+                if( ter_here.id() == ter_t_open_air ) {
+                    if( ter_below.id == ter_t_soil ) {
+                        sub_here->set_ter( {x, y}, ter_t_dirt );
+                    } else if( ter_below.id == ter_t_rock ||
+                               ter_below.id == ter_t_rock_blue ||
+                               ter_below.id == ter_t_rock_green ||
+                               ter_below.id == ter_t_rock_red ) {
+                        sub_here->set_ter( {x, y}, ter_t_rock_floor_no_roof );
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
#### Summary
Backport 79722 - Added ground protection from bashing

#### Purpose of change
The changes to bashing caused a reversion in fence-smashing, once again opening holes to the level below.

#### Describe the solution
The backport adds a new roof fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
