### PR TITLE
Roofs under deep water

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1611,15 +1611,16 @@ void iexamine::deployed_furniture( Character &you, const tripoint_bub_ms &pos )
                                name );
     } else {
         if( here.has_flag_furn( ter_furn_flag::TFLAG_DEPLOYED_FURNITURE_ABOVE, pos ) ) {
-            you.add_msg_if_player( m_info, _( "The %s is anchored firmly above, you can't take it down from here." ),
-                                name );
+            you.add_msg_if_player( m_info,
+                                   _( "The %s is anchored firmly above, you can't take it down from here." ),
+                                   name );
             return;
         } else {
             if( !you.query_yn( _( "Take down the %s?" ), name ) ) {
                 return;
             }
             you.add_msg_if_player( m_info, _( "You take down the %s." ),
-                                name );
+                                   name );
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10286,8 +10286,10 @@ bool map::build_floor_cache( const int zlev )
                         terrain.has_flag( ter_furn_flag::TFLAG_NO_FLOOR_WATER ) ||
                         terrain.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ||
                         terrain.has_flag( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR ) ) {
+                        // If below SUPPORTS_ROOF then there is indeed a floor.
                         if( below_submap &&
-                            below_submap->get_furn( sp ).obj().has_flag( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE ) ) {
+                            ( below_submap->get_furn( sp ).obj().has_flag( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE ) ||
+                              below_submap->get_ter( sp ).obj().has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ) ) {
                             continue;
                         }
                         const point p( sx + smx * SEEX, sy + smy * SEEY );


### PR DESCRIPTION
#### Summary
Roofs under deep water

#### Purpose of change
Due to a backport, deep water was opening holes into lower Z levels if they existed.

#### Describe the solution
Add a check that looks for SUPPORTS_ROOF below the deep water and gives that deep water tile a floor if one exists.

#### Testing
- Spawned deep water over a sewer. Could not see, swim, or fall down through it.
- Went to a sewage treatment plant that has a lot of deep water over sewers beneath. Worked as intended.
- Went to a lake and swam up and down multiple z levels to ensure that no floors were being incorrectly added where none should exist.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
