### PR TITLE
Backport 81774 - fix f_player_see erroring if talker is not visible

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1404,7 +1404,7 @@ conditional_t::func f_is_furniture( bool is_npc )
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [ is_npc ]( const_dialogue const & d ) {
+    return [is_npc]( const_dialogue const & d ) {
         if( d.has_actor( is_npc ) ) {
             const Creature *c = d.const_actor( is_npc )->get_const_creature();
             return get_player_view().sees( *c );


### PR DESCRIPTION
#### Summary
Backport 81774 - fix f_player_see erroring if talker is not visible

#### Purpose of change
It was possible for an invalid talker to be passed through an EoC if the player couldn't see them.

#### Describe the solution
Add a check.

#### Additional context
This one's dubious. It's a slightly different solution to the one DDA used because their sees() takes a map arg. I can't find exactly what segfaulted for the user who reported the bug that led to this backport, but we'll try it and see how it shakes out.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
