### PR TITLE
Add defensive coding to EoCs, update Theresa's conditions

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -47,11 +47,11 @@
     "global": true,
     "condition": {
       "and": [
-        { "u_has_var": "general_completed_theresa_going_away", "value": "yes" },
+        { "compare_string": [ "yes", { "u_val": "general_completed_theresa_going_away" } ] },
         { "u_near_om_location": "godco_3", "range": 12 }
       ]
     },
-    "deactivate_condition": { "u_has_var": "general_completed_theresa_gone", "value": "yes" },
+    "deactivate_condition": { "compare_string": [ "yes", { "u_val": "general_completed_theresa_gone" } ] },
     "effect": [
       { "mapgen_update": "theresa_remove", "om_terrain": "godco_3" },
       { "u_lose_var": "general_completed_theresa_going_away" },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1404,12 +1404,13 @@ conditional_t::func f_is_furniture( bool is_npc )
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [ is_npc ]( const_dialogue const & d ) {
-        if( d.has_actor( is_npc ) ) {
-            const Creature *c = d.const_actor( is_npc )->get_const_creature();
+    return [is_npc]( const_dialogue const & d ) {
+        const Creature *c = d.const_actor( is_npc )->get_const_creature();
+        if( c ) {
             return get_player_view().sees( *c );
+        } else {
+            return get_player_view().sees( d.const_actor( is_npc )->pos_bub() );
         }
-        return false;
     };
 }
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1404,7 +1404,7 @@ conditional_t::func f_is_furniture( bool is_npc )
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [is_npc]( const_dialogue const & d ) {
+    return [ is_npc ]( const_dialogue const & d ) {
         if( d.has_actor( is_npc ) ) {
             const Creature *c = d.const_actor( is_npc )->get_const_creature();
             return get_player_view().sees( *c );

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -214,17 +214,28 @@ void effect_on_conditions::load_existing_character( Character &you )
     }
 }
 
-void effect_on_conditions::queue_effect_on_condition( time_duration duration,
-        effect_on_condition_id eoc, Character &you,
+void effect_on_conditions::queue_effect_on_condition(
+        time_duration duration,
+        effect_on_condition_id eoc,
+        Character &you,
         const std::unordered_map<std::string, std::string> &context )
 {
-    queued_eoc new_eoc = queued_eoc{ eoc, calendar::turn + duration, context };
+    // Validate the EOC before dereferencing
+    if( !eoc.is_valid() ) {
+        debugmsg( "queue_effect_on_condition called with invalid/dangling EOC: %s", eoc.str().c_str() );
+        return;
+    }
+
+    // Create the queued EOC
+    queued_eoc new_eoc{ eoc, calendar::turn + duration, context };
+
+    // Decide where to queue it
     if( eoc->global ) {
         g->queued_global_effect_on_conditions.push( new_eoc );
     } else if( eoc->type == eoc_type::ACTIVATION || eoc->type == eoc_type::RECURRING ) {
         you.queued_effect_on_conditions.push( new_eoc );
     } else {
-        debugmsg( "Invalid effect_on_condition and/or target.  EOC: %s", eoc->id.c_str() );
+        debugmsg( "Invalid effect_on_condition type for queuing: %s", eoc->id.c_str() );
     }
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5501,6 +5501,11 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
 void process_eoc( const effect_on_condition_id &eoc, dialogue &d,
                   time_duration time_in_future )
 {
+    if( !eoc.is_valid() ) {
+        debugmsg( "process_eoc called with invalid EOC: %s", eoc.str().c_str() );
+        return;
+    }
+
     if( eoc->type == eoc_type::ACTIVATION ) {
         Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
         if( alpha ) {
@@ -5520,10 +5525,13 @@ void run_eoc_once( const std::vector<eoc_entry> &eocs, dialogue &d, dialogue new
                    const duration_or_var &dov_time, bool random_time )
 {
     time_duration time_in_future = dov_time.evaluate( d );
-
     for( const eoc_entry &entry : eocs ) {
         effect_on_condition_id eoc_id =
             entry.var ? effect_on_condition_id( entry.var->evaluate( d ) ) : entry.id;
+        if( !eoc_id.is_valid() ) {
+            debugmsg( "run_eoc_once found invalid EOC ID: %s", eoc_id.str().c_str() );
+            continue;
+        }
         if( time_in_future == 0_seconds ) {
             eoc_id->activate( newDialog );
         } else {
@@ -5535,6 +5543,7 @@ void run_eoc_once( const std::vector<eoc_entry> &eocs, dialogue &d, dialogue new
         }
     };
 }
+
 
 dialogue generate_new_dialogue( dialogue &d, bool has_alpha_var, bool has_beta_var,
                                 const str_or_var &alpha_var, const str_or_var &beta_var, bool is_alpha_loc, bool is_beta_loc,


### PR DESCRIPTION
#### Summary
Add defensive coding to EoCs, update Theresa's conditions

#### Purpose of change
Backports messed up some stuff with EoCs. A lot of it got fixed, but not all.

#### Describe the solution
- Revert #1285 (false alarm!)
- Modernize Theresa's EoC.
- Add some defensive coding to several places in the EoC chain of functions. These should prevent bad data from being run as EoCs (and the associated crashes) and hopefully tell us more about what is causing them.

#### Testing
Seems OK.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
