### PR TITLE
Fix mansion eoc, make gradual mutation player only

### DIFF
--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -52,23 +52,28 @@
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [
       {
-        "u_location_variable": { "u_val": "mansion_centre" },
-        "target_params": { "om_terrain": "mansion_+4d", "search_range": 2, "z": -1 },
-        "min_radius": 0,
-        "max_radius": 0
+        "u_spawn_monster": "GROUP_MANSION_ARMORED",
+        "group": true,
+        "real_count": 1,
+        "min_radius": 30,
+        "max_radius": 45,
+        "indoor_only": true
       },
-      { "location_variable_adjust": { "u_val": "mansion_centre" }, "x_adjust": 11, "y_adjust": 11 },
-      { "run_eoc_with": "EOC_BANISH_MANSION_MONSTERS", "beta_loc": { "u_val": "mansion_centre" } },
-      { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS" },
-      { "location_variable_adjust": { "u_val": "mansion_centre" }, "z_adjust": 0, "z_override": true },
-      { "run_eoc_with": "EOC_BANISH_MANSION_MONSTERS", "beta_loc": { "u_val": "mansion_centre" } },
-      { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS" },
-      { "location_variable_adjust": { "u_val": "mansion_centre" }, "z_adjust": 1, "z_override": true },
-      { "run_eoc_with": "EOC_BANISH_MANSION_MONSTERS", "beta_loc": { "u_val": "mansion_centre" } },
-      { "run_eocs": "EOC_SPAWN_MANSION_MONSTERS" },
       {
-        "u_run_monster_eocs": [ { "id": "EOC_BANISH_MONSTERS_AROUND_PLAYER", "effect": { "run_eocs": "EOC_BANISH_SELF" } } ],
-        "monster_range": 6
+        "u_spawn_monster": "GROUP_MANSION_START",
+        "group": true,
+        "real_count": 2,
+        "min_radius": 20,
+        "max_radius": 35,
+        "indoor_only": true
+      },
+      {
+        "u_spawn_monster": "GROUP_MANSION_START",
+        "group": true,
+        "real_count": 2,
+        "min_radius": 25,
+        "max_radius": 40,
+        "indoor_only": true
       }
     ]
   },

--- a/data/json/mutations/mutation_gradual.json
+++ b/data/json/mutations/mutation_gradual.json
@@ -8,6 +8,7 @@
     "mixed_effect": true,
     "time": 3600,
     "processed_eocs": [ "EOC_AM_BECOME_MUTANT" ],
+    "random_at_chargen": false,
     "cancels": [
       "MUTATING_GRADUAL_BATRACHIAN",
       "MUTATING_GRADUAL_AVIAN",
@@ -189,6 +190,7 @@
     "description": "Something is happening to you, it's turning you into a monster.  You will be prompted to choose a mutation line and will thereafter gradually gain its traits over time.",
     "points": 5,
     "valid": false,
-    "starting_trait": true
+    "starting_trait": true,
+    "random_at_chargen": false
   }
 ]


### PR DESCRIPTION
#### Summary
Fix mansion eoc, make gradual mutation player only

#### Purpose of change
#1287 introduced an error to the mansion escape start. There was also an ongoing issue where NPCs could spawn with gradual mutation, which would run the eoc on the player due to the eoc selector.

#### Describe the solution
- Revert the change to the eoc and make gradual mutation player-only. Mutant NPCs ought to be very rare and not in the general pool for the most part.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
