### PR TITLE
Fix the stupid corpse fallback sprite issue

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2811,7 +2811,7 @@ void options_manager::add_options_debug()
         to_translation( "Draw walls normal (Off), retracted/transparent (On), or automatically retracting/transparent near player (Auto)." ), {
             { 0, to_translation( "Off" ) }, { 1, to_translation( "On" ) },
             { 2, to_translation( "Auto" ) }
-        }, 2, 2
+        }, 0, 0
            );
 
         add( "PREVENT_OCCLUSION_TRANSP", page_id, to_translation( "Prevent occlusion via transparency" ),


### PR DESCRIPTION
#### Summary
Fix the stupid corpse fallback sprite issue

#### Purpose of change
Corpses were changing to a fallback sprite if you stood (usually) to the southwest of them. Do you know why? It's because a random anti-occlusion option designed to prevent tall sprites from obscuring the character in isometric mode was on by default. Isometric mode has never been anything but buggy (looks kinda nice sometimes, I'll admit) and is not even supported here.

#### Describe the solution
Disable the option by default. If some masochist wants to do iso they can re-enable it in the options menu.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
