### PR TITLE
Remove an invalid sky island dialog option

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -53,7 +53,7 @@
   {
     "type": "talk_topic",
     "id": "SKYISLAND_EXPLAIN5",
-    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, dispel an ongoing portal storm, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
+    "dynamic_line": "This statue offers a variety of services.  You can be instantly healed, check your current statistics and progress, and tweak your expedition difficulty settings.\n\nHealing is free until you have survived 10 expeditions.  After this point, healing costs 4 warp shards per treatment.\n\nExpedition difficulty is set to default when you start a new game, but here you can change many finer details to suit your own playstyle.",
     "responses": [ { "text": "Interesting…", "topic": "SKYISLAND_QUESTIONS" } ]
   },
   {
@@ -96,14 +96,6 @@
         "text": "Heal me.  (Costs 4 Warp Shards)",
         "condition": { "math": [ "islandrank != 0" ] },
         "effect": [ { "run_eocs": [ "EOC_HEAL_NEWBIE" ] } ],
-        "topic": "SKYISLAND_SERVICES"
-      },
-      {
-        "text": "End an active portal storm.",
-        "effect": [
-          { "run_eocs": [ "EOC_CANCEL_PORTAL_STORM" ] },
-          { "u_message": "The air crackles with static electricity, then stabilizes.", "popup": true }
-        ],
         "topic": "SKYISLAND_SERVICES"
       },
       {


### PR DESCRIPTION
#### Summary
Remove an invalid sky island dialog option

#### Purpose of change
There was a leftover portal storm thing.

#### Describe the solution
It's gone.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
