### PR TITLE
Backport 82176 - Update NECC to use faction relationship setting

### DIFF
--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -133,7 +133,7 @@
     "id": "TALK_GODCO_Julian_Join",
     "dynamic_line": "Aight, here are the rules: don't commit sins, don't litter, and try not to die.  Have some mutual respect, capiche?",
     "responses": [
-      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee" },
+      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee", "effect": { "u_set_fac_relation": "share public goods" } },
       { "text": "Actually, I had better go.", "topic": "TALK_DONE" }
     ]
   },


### PR DESCRIPTION
#### Summary
Backport 82176 - Update NECC to use faction relationship setting

#### Purpose of change
NECC was saying you could sleep in their base but wouldn't actually let you do so.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
