### PR TITLE
Revolvers drop casings on reload

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "activity_handlers.h"
 #include "ammo.h"
 #include "ascii_art.h"
 #include "avatar.h"
@@ -11996,9 +11997,16 @@ bool item::reload( Character &u, item_location ammo, int qty )
 
     qty = std::min( qty, limit );
 
-    casings_handle( [&u]( item & e ) {
-        return u.i_add_or_drop( e );
-    } );
+    if( has_flag( flag_RELOAD_EJECT ) ) {
+        casings_handle( [&u]( item & e ) {
+            put_into_vehicle_or_drop( u, item_drop_reason::tumbling, { e } );
+            return true;
+        } );
+    } else {
+        casings_handle( [&u]( item & e ) {
+            return u.i_add_or_drop( e );
+        } );
+    }
 
     if( is_magazine() ) {
         qty = std::min( qty, ammo->charges );


### PR DESCRIPTION
#### Summary
Revolvers drop casings on reload

#### Purpose of change
Revolvers and some other guns were sticking the spent casings into random pockets in your inventory whenever you reloaded them. This is not how all other guns handle casings. While some people might want to keep casings, most don't, and anyway this wasn't assessing a movecost for pocketing the items.

#### Describe the solution
Items with RELOAD_EJECT now dump all their spent casings on the floor when you reload them. If you are in the minority who wishes to keep them, you can simply pick them up or enable autopickup.

#### Testing
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/774b529f-4aa1-4db0-a74b-036c5d79c321" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
