### PR TITLE
Move stack for rocks and arrows

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1466,7 +1466,7 @@ void advanced_inventory::start_activity(
     const bool from_vehicle, const bool to_vehicle ) const
 {
 
-    const bool by_charges = sitem->items.front()->count_by_charges();
+    const bool by_charges = sitem->items.front()->count_by_charges() && sitem->items.front()->type->stack_max != 1;
 
     Character &player_character = get_player_character();
 
@@ -2177,7 +2177,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // valid item is obviously required
     cata_assert( !sitem.items.empty() );
     const item &it = *sitem.items.front();
-    const bool by_charges = it.count_by_charges();
+    const bool by_charges = it.count_by_charges() && it.type->stack_max != 1;
     // default to move all, unless if being equipped
     const int input_amount = by_charges ? it.charges : action == "MOVE_SINGLE_ITEM" ? 1 : sitem.stacks;
     // there has to be something to begin with


### PR DESCRIPTION
#### Summary
Move stack for rocks and arrows

#### Purpose of change
Every couple of days, someone shows up complaining about a bug with a feature in Advanced Inventory Management that I have never even heard of. This time it was the Move Stack button, which wasn't working on stack_max = 1 items like rocks and arrows.

#### Describe the solution
Add a couple checks to AIM to not count stack_max = 1 items as charges.

#### Testing
werks

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
