### PR TITLE
Inglorious Backperts

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -2297,6 +2297,11 @@
     "//": "Any item that can be an electronic file"
   },
   {
+    "id": "E_STORABLE_EXCLUSIVE",
+    "type": "json_flag",
+    "//": "Any item that can ONLY be an electronic file"
+  },
+  {
     "id": "E_COPIABLE",
     "type": "json_flag",
     "//": "Any item that can be electronically copied and scanned"

--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -51,6 +51,11 @@
     "info": "This item can be activated or reloaded from an adjacent tile without picking it up."
   },
   {
+    "id": "CAN_USE_IN_DARK",
+    "type": "json_flag",
+    "info": "This item can use all of its features in darkness."
+  },
+  {
     "id": "ALWAYS_AIMED",
     "type": "json_flag",
     "info": "This gun is <good>always fully aimed</good>."

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -56,6 +56,7 @@
     "use_action": [ "CAMERA", "PORTABLE_GAME", "EBOOKSAVE", "E_FILE_DEVICE" ],
     "etransfer_rate": "140 MB",
     "e_port": "phone",
+    "variables": { "browsed": "true" },
     "pocket_data": [
       {
         "pocket_type": "E_FILE_STORAGE",

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -156,7 +156,8 @@
     "name": "map cache",
     "description": "Information about nearby locations stored from previous use.",
     "ememory_size": "32 MB",
-    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_CHECK_MAP_CACHE" ] }
+    "use_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_CHECK_MAP_CACHE" ] },
+    "extend": { "flags": [ "PRESERVE_SPAWN_OMT" ] }
   },
   {
     "abstract": "abstract_efile_recipes",

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "abstract_software",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "GENERIC",
     "category": "software",
     "name": { "str_sp": "abstract software" },
@@ -110,6 +110,17 @@
     "variables": { "browsed": "false" }
   },
   {
+    "abstract": "abstract_efile_exclusive",
+    "copy-from": "abstract_efile",
+    "type": "ITEM",
+    "symbol": "o",
+    "name": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
+    "description": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
+    "ememory_size": "1 KB",
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_STORABLE_EXCLUSIVE" ] }
+  },
+  {
     "abstract": "abstract_efile_copiable",
     "copy-from": "abstract_efile",
     "type": "GENERIC",
@@ -118,6 +129,17 @@
     "description": "abstract copiable electronic file",
     "ememory_size": "1 KB",
     "extend": { "flags": [ "E_COPIABLE" ] }
+  },
+  {
+    "abstract": "abstract_efile_exclusive_copiable",
+    "copy-from": "abstract_efile",
+    "type": "ITEM",
+    "symbol": "o",
+    "name": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
+    "description": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
+    "ememory_size": "1 KB",
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_COPIABLE", "E_STORABLE_EXCLUSIVE" ] }
   },
   {
     "abstract": "abstract_efile_read",
@@ -130,7 +152,7 @@
   },
   {
     "id": "efile_junk",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "GENERIC",
     "symbol": "o",
     "name": "junk file",
@@ -140,7 +162,7 @@
   },
   {
     "id": "efile_lore",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "GENERIC",
     "symbol": "o",
     "name": "questionable media file",
@@ -150,7 +172,7 @@
   },
   {
     "id": "efile_map",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "GENERIC",
     "symbol": "o",
     "name": "map cache",
@@ -161,13 +183,14 @@
   },
   {
     "abstract": "abstract_efile_recipes",
-    "copy-from": "abstract_efile_copiable",
+    "copy-from": "abstract_efile_exclusive_copiable",
     "type": "GENERIC",
     "symbol": "o",
     "name": "abstract recipe catalog",
     "description": "for any collection of recipes",
     "ememory_size": "4 MB",
-    "extend": { "flags": [ "E_FILE_COLLECTION" ] },
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_FILE_COLLECTION", "E_STORABLE_EXCLUSIVE" ] },
     "variables": { "browsed": "false" }
   },
   {
@@ -221,7 +244,7 @@
   },
   {
     "id": "efile_photos",
-    "copy-from": "abstract_efile_copiable",
+    "copy-from": "abstract_efile_exclusive_copiable",
     "type": "GENERIC",
     "symbol": "o",
     "name": { "str": "photo gallery", "str_pl": "photo galleries" },

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -112,7 +112,7 @@
   {
     "abstract": "abstract_efile_exclusive",
     "copy-from": "abstract_efile",
-    "type": "ITEM",
+    "type": "GENERIC",
     "symbol": "o",
     "name": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
     "description": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
@@ -133,7 +133,7 @@
   {
     "abstract": "abstract_efile_exclusive_copiable",
     "copy-from": "abstract_efile",
-    "type": "ITEM",
+    "type": "GENERIC",
     "symbol": "o",
     "name": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
     "description": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -20,7 +20,7 @@
     "charges_per_use": 1,
     "etransfer_rate": "30 MB",
     "e_port": "laptop",
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "CAN_USE_IN_DARK" ],
     "melee_damage": { "bash": 6 }
   },
   {
@@ -32,6 +32,17 @@
     "charges_per_use": 1,
     "etransfer_rate": "30 MB",
     "e_port": "phone",
+    "flags": [
+      "WATCH",
+      "WATER_BREAK",
+      "ELECTRONIC",
+      "ALARMCLOCK",
+      "CALORIES_INTAKE",
+      "CAN_USE_IN_DARK",
+      "USE_UPS",
+      "NO_UNLOAD",
+      "NO_RELOAD"
+    ],
     "e_ports_banned": [ "USB-A" ]
   },
   {
@@ -845,7 +856,6 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
-    "flags": [ "WATCH", "ALARMCLOCK", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 120 } },
       {
@@ -924,7 +934,6 @@
         "effect_on_conditions": [ "EOC_SMARTPHONE_RECOVERY" ]
       }
     ],
-    "flags": [ "WATCH", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
       {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1145,7 +1145,8 @@
         "rigid": true,
         "max_contains_volume": "1 ml",
         "max_contains_weight": "1 g",
-        "weight_multiplier": 0
+        "weight_multiplier": 0,
+        "ememory_max": "1 TB"
       }
     ],
     "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "eyes" ] } ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1162,7 +1162,8 @@
       "THERMOMETER",
       "WATER_BREAK",
       "PADDED",
-      "ELECTRONIC"
+      "ELECTRONIC",
+      "CAN_USE_IN_DARK"
     ]
   },
   {

--- a/data/json/mapgen/crater.json
+++ b/data/json/mapgen/crater.json
@@ -84,7 +84,7 @@
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 8, 11 ] },
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 12, 15 ] }
       ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -135,7 +135,7 @@
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 8, 11 ] },
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 12, 15 ] }
       ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -208,7 +208,7 @@
           "neighbors": { "north_west": "crater_core_large" }
         }
       ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -245,7 +245,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -282,7 +282,7 @@
         "             ..........."
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -319,7 +319,7 @@
         "........................"
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -356,7 +356,7 @@
         "...........             "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -393,7 +393,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -430,7 +430,7 @@
         "             ..........."
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -467,7 +467,7 @@
         "...........             "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -504,7 +504,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -541,7 +541,7 @@
         "       ??????????       "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -578,7 +578,7 @@
         "  ???????????           "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -615,7 +615,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -652,7 +652,7 @@
         "           ???????????  "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -689,7 +689,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -726,7 +726,7 @@
         "  ???????????           "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -763,7 +763,7 @@
         "           ???????????  "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -800,7 +800,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -837,7 +837,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -874,7 +874,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -911,7 +911,7 @@
         " ?????????????????????? "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -948,7 +948,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
     }
   }
 ]

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -970,7 +970,8 @@
         "max_contains_weight": "1 g",
         "weight_multiplier": 0.0
       }
-    ]
+    ],
+    "extend": { "flags": [ "CAN_USE_IN_DARK" ] }
   },
   {
     "id": "test_battery_disposable",

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -783,7 +783,8 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```DURABLE_MELEE``` Item is made to hit stuff and it does it well, so it's considered to be a lot tougher than other weapons made of the same materials.
 - ```E_COPIABLE``` This item can be scanned onto an electronic device and can be electronically copied.
 - ```E_FILE_COLLECTION``` This item represents a combinable collection of files. Does not imply E_COPIABLE.
-- ```E_STORABLE``` This item can be stored on an electronic device.
+- ```E_STORABLE``` This item can be stored on an in-game electronic device.
+- ```E_STORABLE_EXCLUSIVE``` This item can ONLY be stored on an in-game electronic device; it may only be handled electronically.
 - ```ELECTRONIC``` This item contain sensitive electronics which can be fried by nearby EMP blast.
 - ```FAKE_MILL``` Item is a fake item, to denote a partially milled product by @ref Item::process_fake_mill, where conditions for its removal are set.
 - ```FAKE_SMOKE``` Item is a fake item generating smoke, recognizable by @ref item::process_fake_smoke, where conditions for its removal are set.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2959,18 +2959,31 @@ std::string enum_to_string<efile_combo>( efile_combo data )
 }
 } // namespace io
 
+bool efile_activity_actor::processed_edevices_remain() const
+{
+    return target_edevices.empty();
+}
+
+bool  efile_activity_actor::processed_efiles_remain() const
+{
+    return currently_processed_efiles.empty();
+}
+
 item_location &efile_activity_actor::get_currently_processed_edevice()
 {
-    return *next_edevice;
+    return target_edevices.back();
 }
 
 item_location &efile_activity_actor::get_currently_processed_efile()
 {
-    return *next_efile;
+    return currently_processed_efiles.back();
 }
 void efile_activity_actor::start( player_activity &act, Character &who )
 {
-    //handle combo move
+    if( combo_type == COMBO_MOVE_ONTO_BROWSE ) {
+        target_edevices_copy = target_edevices;
+    }
+    //handle combo move e-device (browsing may have included used e-device)
     if( action_type == EF_MOVE_ONTO_THIS ) {
         auto i = target_edevices.begin();
         while( i != target_edevices.end() ) {
@@ -2992,15 +3005,15 @@ void efile_activity_actor::start( player_activity &act, Character &who )
     }
     //only skip if loaded through deserialization
     if( !started_processing ) {
-        next_edevice = target_edevices.begin();
         started_processing = true;
         computer_low_skill = who.get_skill_level( skill_computer ) < 1;
     }
 
-    if( next_edevice != target_edevices.end() ) {
+    if( !processed_edevices_remain() ) {
         const time_duration total_time = total_processing_time( used_edevice, target_edevices,
                                          selected_efiles, action_type, who, computer_low_skill );
         act.moves_total = to_moves<int>( total_time );
+        target_edevices_count = target_edevices.size();
         add_msg_debug( debugmode::DF_ACT_EBOOK, "total processing moves: %d",
                        act.moves_total );
     } else {
@@ -3036,8 +3049,11 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
                 do {
                     failed_processing_current_edevice();
                 } while( !done_processing );
-            } else if( !*next_edevice || !edevice_reduce_charge( get_currently_processed_edevice() ) ) {
-                failed_processing_current_edevice();
+            } else {
+                item_location next_edevice = get_currently_processed_edevice();
+                if( !next_edevice || !edevice_reduce_charge( next_edevice ) ) {
+                    failed_processing_current_edevice();
+                }
             }
         }
     }
@@ -3066,7 +3082,7 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
     }
     if( next_edevice_booted ) { //should not be an "else" because files start processing in same turn
         //current file exists check
-        if( !*next_efile ) {
+        if( !get_currently_processed_efile() ) {
             failed_processing_current_efile( act, who );
         } else if( turns_left_on_current_efile > 0 ) {
             turns_left_on_current_efile--;
@@ -3090,14 +3106,13 @@ void efile_activity_actor::start_processing_next_edevice()
         currently_processed_efiles = ignore_filter ? selected_efiles :
                                      filter_edevice_efiles( edevice_filter, selected_efiles );
     }
-    next_efile = currently_processed_efiles.begin();
     add_msg_debug( debugmode::DF_ACT_EBOOK, string_format( "started processing edevice %s",
                    current_edevice->display_name() ) );
 }
 
 void efile_activity_actor::start_processing_next_efile( player_activity &/*act*/, Character &who )
 {
-    if( next_efile != currently_processed_efiles.end() ) {
+    if( !processed_efiles_remain() ) {
         //separate for easy debugging
         item_location &current_efile = get_currently_processed_efile();
         item_location &current_edevice = get_currently_processed_edevice();
@@ -3123,8 +3138,8 @@ void efile_activity_actor::completed_processing_current_edevice()
 
     next_edevice_booted = false;
     turns_left_on_current_edevice.reset();
-    next_edevice++;
-    if( next_edevice == target_edevices.end() ) {
+    target_edevices.pop_back();
+    if( processed_edevices_remain() ) {
         done_processing = true;
     }
 }
@@ -3215,7 +3230,7 @@ void efile_activity_actor::completed_processing_current_efile( player_activity &
             break;
     }
     processed_efiles++;
-    next_efile++;
+    currently_processed_efiles.pop_back();
 }
 
 void efile_activity_actor::failed_processing_current_edevice()
@@ -3224,8 +3239,8 @@ void efile_activity_actor::failed_processing_current_edevice()
 
     turns_left_on_current_edevice.reset();
     next_edevice_booted = false;
-    next_edevice++;
-    if( next_edevice == target_edevices.end() ) {
+    target_edevices.pop_back();
+    if( processed_edevices_remain() ) {
         done_processing = true;
     }
 }
@@ -3241,7 +3256,7 @@ void efile_activity_actor::finish( player_activity &act, Character &who )
 {
     act.set_to_null();
     std::string action_name = efile_action_name( action_type, true, true );
-    int total_edevices = target_edevices.size();
+    int total_edevices = target_edevices_count;
     if( total_edevices == 0 && processed_edevices == 0 ) {
         add_msg_if_player_sees( who, m_info, _( "No devices needed to be processed." ) );
     } else if( processed_edevices == 0 ) {
@@ -3249,22 +3264,22 @@ void efile_activity_actor::finish( player_activity &act, Character &who )
                                 efile_action_name( action_type, false, true ), total_edevices );
     } else {
         add_msg_if_player_sees( who, m_good, _( "You successfully %s %d/%d device(s)." ),
-                                action_name, processed_edevices, target_edevices.size() );
+                                action_name, processed_edevices, total_edevices );
     }
     combo_next_activity( who );
 }
 
 std::vector<item_location> efile_activity_actor::filter_edevice_efiles(
-    const item_location &edevice,
-    const std::vector<item_location> &filter_files )
+    const item_location &edevice, std::vector<item_location> &filter_files )
 {
     std::vector<item_location> filtered_efiles;
-    if( !filter_files.empty() ) {
-        //filter e-files
-        for( const item_location &i : filter_files ) {
-            if( i.parent_item() == edevice ) {
-                filtered_efiles.emplace_back( i );
-            }
+    std::vector<item_location>::iterator it = filter_files.begin();
+    while( it != filter_files.end() ) {
+        if( it->parent_item() == edevice ) {
+            filtered_efiles.emplace_back( *it );
+            it = filter_files.erase( it );
+        } else {
+            it++;
         }
     }
     return filtered_efiles;
@@ -3338,18 +3353,17 @@ void efile_activity_actor::combo_next_activity( Character &who )
 {
     efile_combo new_combo = COMBO_NONE;
     efile_action new_action = EF_INVALID;
-
-    //filter out invalidated e-files removed during prior operation
-    std::vector<item_location> valid_efiles;
-    for( const item_location &efile : selected_efiles ) {
-        if( efile ) {
-            valid_efiles.emplace_back( efile );
-        }
-    }
+    std::vector<item_location> all_updated_files;
 
     if( combo_type == COMBO_MOVE_ONTO_BROWSE ) {
+        for( item_location &edevice : target_edevices_copy ) {
+            for( item *efile : edevice->efiles() ) {
+                all_updated_files.emplace_back( edevice, efile );
+            }
+        }
+
         units::ememory total_ememory;
-        for( item_location &edevice : target_edevices ) {
+        for( item_location &edevice : target_edevices_copy ) {
             if( edevice->is_browsed() ) {
                 for( item *efile : edevice->efiles() ) {
                     total_ememory += efile->ememory_size();
@@ -3363,10 +3377,9 @@ void efile_activity_actor::combo_next_activity( Character &who )
                                     _( "File size exceeds available memory; canceling file move." ) );
         }
     }
-
     if( new_action != EF_INVALID ) {
-        const efile_activity_actor new_activity( used_edevice, target_edevices,
-                valid_efiles, new_action, new_combo );
+        const efile_activity_actor new_activity( used_edevice, target_edevices_copy,
+                all_updated_files, new_action, new_combo );
         who.assign_activity( player_activity( new_activity ) );
     }
 }
@@ -3395,12 +3408,12 @@ void efile_activity_actor::serialize( JsonOut &jsout ) const
     jsout.start_object();
     jsout.member( "used_edevice", used_edevice );
     jsout.member( "target_edevices", target_edevices );
+    jsout.member( "target_edevices_copy", target_edevices_copy );
     jsout.member( "action_type", action_type );
     jsout.member( "combo_type", combo_type );
     jsout.member( "selected_efiles", selected_efiles );
     jsout.member( "currently_processed_efiles", currently_processed_efiles );
-    jsout.member( "next_edevice", next_edevice - target_edevices.begin() );
-    jsout.member( "next_efile", next_efile - currently_processed_efiles.begin() );
+    jsout.member( "target_edevices_count", target_edevices_count );
     jsout.member( "processed_edevices", processed_edevices );
     jsout.member( "failed_edevices", failed_edevices );
     jsout.member( "processed_efiles", processed_efiles );
@@ -3410,10 +3423,7 @@ void efile_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "next_edevice_booted", next_edevice_booted );
     jsout.member( "computer_low_skill", computer_low_skill );
     jsout.member( "turns_left_on_current_edevice", turns_left_on_current_edevice );
-    jsout.member( "processed_edevices", processed_edevices );
     jsout.member( "turns_left_on_current_efile", turns_left_on_current_efile );
-
-
     jsout.end_object();
 }
 
@@ -3424,19 +3434,14 @@ std::unique_ptr<activity_actor> efile_activity_actor::deserialize( JsonValue &js
     JsonObject data = jsin.get_object();
     data.read( "used_edevice", actor.used_edevice );
     data.read( "target_edevices", actor.target_edevices );
+    data.read( "target_edevices_copy", actor.target_edevices_copy );
     data.read( "turns_left_on_current_edevice", actor.turns_left_on_current_edevice );
     data.read( "action_type", actor.action_type );
     data.read( "combo_type", actor.combo_type );
+    data.read( "target_edevices_count", actor.target_edevices_count );
     data.read( "processed_edevices", actor.processed_edevices );
     data.read( "selected_efiles", actor.selected_efiles );
     data.read( "currently_processed_efiles", actor.currently_processed_efiles );
-    if( data.has_member( "next_edevice" ) ) {
-        actor.next_edevice = actor.target_edevices.begin() + data.get_int( "next_edevice" );
-    }
-    if( data.has_member( "next_efile" ) ) {
-        actor.next_efile = actor.currently_processed_efiles.begin() + data.get_int( "next_efile" );
-    }
-    data.read( "processed_edevices", actor.processed_edevices );
     data.read( "failed_edevices", actor.failed_edevices );
     data.read( "processed_efiles", actor.processed_efiles );
     data.read( "failed_efiles", actor.failed_efiles );
@@ -3444,8 +3449,6 @@ std::unique_ptr<activity_actor> efile_activity_actor::deserialize( JsonValue &js
     data.read( "done_processing", actor.done_processing );
     data.read( "next_edevice_booted", actor.next_edevice_booted );
     data.read( "computer_low_skill", actor.computer_low_skill );
-    data.read( "turns_left_on_current_edevice", actor.turns_left_on_current_edevice );
-    data.read( "processed_edevices", actor.processed_edevices );
     data.read( "turns_left_on_current_efile", actor.turns_left_on_current_efile );
     return actor.clone();
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1694,7 +1694,7 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
                  book_type::martial_art : book_type::normal;
     }
 
-    if( who.fine_detail_vision_mod() > 4 ) {
+    if( who.fine_detail_vision_mod() > 4 && !book->has_flag( flag_CAN_USE_IN_DARK ) ) {
         // It got too dark during the process of reading, bail out.
         act.set_to_null();
         who.add_msg_if_player( m_bad, _( "It's too dark to read!" ) );
@@ -2866,9 +2866,12 @@ void ebooksave_activity_actor::completed_scanning_current_book( player_activity 
         Character &who )
 {
     item_location scanned_book = books.back();
+
     books.pop_back();
     if( scanned_book ) {
+
         ereader->put_in( *scanned_book, pocket_type::E_FILE_STORAGE );
+
         if( who.is_avatar() ) {
             if( !who.has_identified( scanned_book->typeId() ) ) {
                 who.identify( *scanned_book );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -835,10 +835,11 @@ class efile_activity_actor : public activity_actor
         /** Returns the effective electronic transfer rate with `external_transfer_rate` factored in */
         static units::ememory current_etransfer_rate( Character &who, const efile_transfer &transfer,
                 const item_location &efile );
-        /** Returns all e-files on this device that are in the filter_files list
-        @param filter_files list of e-files to use, usually selected_files */
+        /** Returns all e-files on this device that are in the filter_files list,
+        * and removes matching efiles from filter_files list
+        * @param filter_files list of e-files to use, usually selected_files */
         static std::vector<item_location> filter_edevice_efiles( const item_location &edevice,
-                const std::vector<item_location> &filter_files );
+                std::vector<item_location> &filter_files );
         /** Returns the most optimal estorage (if needed) for improving transfer speed given the two edevices provided */
         static item_location find_external_transfer_estorage( Character &p,
                 const item_location &efile, const item_location &ed1, const item_location &ed2 );
@@ -855,15 +856,16 @@ class efile_activity_actor : public activity_actor
     private:
         item_location used_edevice;
         std::vector<item_location> target_edevices;
+        /** Held for combo activity */
+        std::vector<item_location> target_edevices_copy;
+        /** e-files that have yet to be processed, across all devices */
         std::vector<item_location> selected_efiles;
         efile_action action_type = EF_INVALID;
         efile_combo combo_type = COMBO_NONE;
-        /** contents copy of currently processed e-device */
+        /** e-files currently processed on current e-device */
         std::vector<item_location> currently_processed_efiles;
-        /** iterator pointing to next e-file to process */
-        std::vector<item_location>::iterator next_efile;
-        /** iterator pointing to next e-device to process */
-        std::vector<item_location>::iterator next_edevice;
+        /** How many e-devices this activity started with. */
+        int target_edevices_count = 0;
         /** How many e-devices this activity has successfully processed so far. */
         int processed_edevices = 0;
         /** How many e-devices this activity has failed to process so far. */
@@ -896,6 +898,9 @@ class efile_activity_actor : public activity_actor
 
         item_location &get_currently_processed_edevice();
         item_location &get_currently_processed_efile();
+        bool processed_edevices_remain() const;
+        bool processed_efiles_remain() const;
+
         /** Segway to the next player activity for a combo type */
         void combo_next_activity( Character &who );
         time_duration charge_time( efile_action action_type );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12582,7 +12582,7 @@ read_condition_result Character::check_read_condition( const item &book ) const
             !has_flag( STATIC( json_character_flag( "ENHANCED_VISION" ) ) ) ) {
             result |= read_condition_result::NEED_GLASSES;
         }
-        if( fine_detail_vision_mod() > 4 ) {
+        if( fine_detail_vision_mod() > 4 && !book.has_flag( flag_CAN_USE_IN_DARK ) ) {
             result |= read_condition_result::TOO_DARK;
         }
         if( is_blind() ) {
@@ -12630,15 +12630,15 @@ const Character *Character::get_book_reader( const item &book,
         return nullptr;
     }
 
-    // Check for conditions that disqualify us only if no other Characters can read to us
+    // Check for conditions that disqualify us only if no other Characters can read to us.
     if( condition & read_condition_result::ILLITERATE ) {
         reasons.emplace_back( is_avatar() ? _( "You're illiterate!" ) : string_format(
                                   _( "%s is illiterate!" ), disp_name() ) );
     } else if( condition & read_condition_result::NEED_GLASSES ) {
         reasons.emplace_back( is_avatar() ? _( "Your eyes won't focus without reading glasses." ) :
                               string_format( _( "%s's eyes won't focus without reading glasses." ), disp_name() ) );
-    } else if( condition & read_condition_result::TOO_DARK ) {
-        // Too dark to read only applies if the player can read to himself
+    } else if( condition & read_condition_result::TOO_DARK && !book.has_flag( flag_CAN_USE_IN_DARK ) ) {
+        // Too dark to read only applies if the player can read to themself.
         reasons.emplace_back( _( "It's too dark to read!" ) );
         return nullptr;
     } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13646,7 +13646,7 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
     } else if( used.is_book() ) {
         // TODO: Handle this with dynamic dispatch.
         if( avatar *u = as_avatar() ) {
-            if( item::is_efile( loc ) ) {
+            if( loc.is_efile() ) {
                 u->read( loc, loc.parent_item() );
             } else {
                 u->read( loc );

--- a/src/character.h
+++ b/src/character.h
@@ -1972,7 +1972,7 @@ class Character : public Creature, public visitable
             bool operator()( const item &it ) const {
                 return it.mission_id == mission_id || it.has_any_with( [&]( const item & it ) {
                     return it.mission_id == mission_id;
-                }, pocket_type::SOFTWARE );
+                }, pocket_type::E_FILE_STORAGE );
             }
         };
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -382,21 +382,42 @@ str_translation_or_var get_str_translation_or_var(
     return ret_val;
 }
 
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
-                                       bool is_npc )
+template<typename T>
+T convert_tripoint_from_var( std::optional<var_info> &var, const_dialogue const &d,
+                             bool is_npc )
 {
     if( var.has_value() ) {
         std::string value = read_var_value( var.value(), d );
         if( !value.empty() ) {
-            return tripoint_abs_ms( tripoint::from_string( value ) );
+            return T( tripoint::from_string( value ) );
         }
     }
     if( !d.has_actor( is_npc ) ) {
         debugmsg( "Tried to access location of invalid %s talker.  %s", is_npc ? "beta" : "alpha",
                   d.get_callstack() );
-        return tripoint_abs_ms::invalid;
+        return T::invalid;
     }
-    return get_map().get_abs( d.const_actor( is_npc )->pos_bub() );
+    return T::invalid;
+}
+
+tripoint_abs_ms get_tripoint_ms_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc )
+{
+    tripoint_abs_ms pt = convert_tripoint_from_var<tripoint_abs_ms>( var, d, is_npc );
+    if( pt.is_invalid() ) {
+        return get_map().get_abs( d.const_actor( is_npc )->pos_bub() );
+    }
+    return pt;
+}
+
+tripoint_abs_omt get_tripoint_omt_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc )
+{
+    tripoint_abs_omt pt = convert_tripoint_from_var<tripoint_abs_omt>( var, d, is_npc );
+    if( pt.is_invalid() ) {
+        return coords::project_to<coords::omt>( get_map().get_abs( d.const_actor( is_npc )->pos_bub() ) );
+    }
+    return pt;
 }
 
 template<class T>
@@ -1723,8 +1744,8 @@ conditional_t::func f_line_of_sight( const JsonObject &jo, std::string_view memb
         with_fields = jo.get_bool( "with_fields" );
     }
     return [range, loc_var_1, loc_var_2, with_fields]( const_dialogue const & d ) {
-        tripoint_bub_ms loc_1 = get_map().get_bub( get_tripoint_from_var( loc_var_1, d, false ) );
-        tripoint_bub_ms loc_2 = get_map().get_bub( get_tripoint_from_var( loc_var_2, d, false ) );
+        tripoint_bub_ms loc_1 = get_map().get_bub( get_tripoint_ms_from_var( loc_var_1, d, false ) );
+        tripoint_bub_ms loc_2 = get_map().get_bub( get_tripoint_ms_from_var( loc_var_2, d, false ) );
 
         return get_map().sees( loc_1, loc_2, range.evaluate( d ), with_fields );
     };
@@ -1836,7 +1857,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
         terrain = false;
     }
     return [terrain, furn_type, loc_var]( const_dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_ms_from_var( loc_var, d, false ) );
         if( terrain ) {
             return get_map().ter( loc )->has_flag( furn_type.evaluate( d ) );
         } else {
@@ -1851,7 +1872,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
     var_info loc_var = read_var_info( jo.get_object( "loc" ) );
 
     return [member, furn_type, loc_var]( const_dialogue const & d ) {
-        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_from_var( loc_var, d, false ) );
+        tripoint_bub_ms loc = get_map().get_bub( get_tripoint_ms_from_var( loc_var, d, false ) );
         if( member == "map_terrain_id" ) {
             return get_map().ter( loc ) == ter_id( furn_type.evaluate( d ) );
         } else if( member == "map_furniture_id" ) {

--- a/src/condition.h
+++ b/src/condition.h
@@ -59,8 +59,13 @@ duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_vie
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv, const std::string_view &member,
         bool required = true,
         time_duration default_val = 0_seconds );
-tripoint_abs_ms get_tripoint_from_var( std::optional<var_info> var, const_dialogue const &d,
-                                       bool is_npc );
+template<typename T>
+T convert_tripoint_from_var( std::optional<var_info> &var, const_dialogue const &d,
+                             bool is_npc );
+tripoint_abs_ms get_tripoint_ms_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc );
+tripoint_abs_omt get_tripoint_omt_from_var( std::optional<var_info> var, const_dialogue const &d,
+        bool is_npc );
 var_info read_var_info( const JsonObject &jo );
 translation_var_info read_translation_var_info( const JsonObject &jo );
 void write_var_value( var_type type, const std::string &name, dialogue *d,

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -61,6 +61,7 @@ const flag_id flag_CAMERA_PRO( "CAMERA_PRO" );
 const flag_id flag_CANNIBAL( "CANNIBAL" );
 const flag_id flag_CANT_HEAL_EVERYONE( "CANT_HEAL_EVERYONE" );
 const flag_id flag_CANT_WEAR( "CANT_WEAR" );
+const flag_id flag_CAN_USE_IN_DARK( "CAN_USE_IN_DARK" );
 const flag_id flag_CARNIVORE_OK( "CARNIVORE_OK" );
 const flag_id flag_CASING( "CASING" );
 const flag_id flag_CATTLE( "CATTLE" );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -123,6 +123,7 @@ const flag_id flag_EXO_UNDERLAYER( "EXO_UNDERLAYER" );
 const flag_id flag_E_COPIABLE( "E_COPIABLE" );
 const flag_id flag_E_FILE_COLLECTION( "E_FILE_COLLECTION" );
 const flag_id flag_E_STORABLE( "E_STORABLE" );
+const flag_id flag_E_STORABLE_EXCLUSIVE( "E_STORABLE_EXCLUSIVE" );
 const flag_id flag_FAKE_MILL( "FAKE_MILL" );
 const flag_id flag_FAKE_SMOKE( "FAKE_SMOKE" );
 const flag_id flag_FANCY( "FANCY" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -117,6 +117,7 @@ extern const flag_id flag_ELECTRIC_IMMUNE;
 extern const flag_id flag_ELECTRONIC;
 extern const flag_id flag_ENERGY_SHIELD;
 extern const flag_id flag_E_STORABLE;
+extern const flag_id flag_E_STORABLE_EXCLUSIVE;
 extern const flag_id flag_ETHEREAL_ITEM;
 extern const flag_id flag_EXO_ARM_PLATE;
 extern const flag_id flag_EXO_BOOT_PLATE;

--- a/src/flag.h
+++ b/src/flag.h
@@ -69,6 +69,7 @@ extern const flag_id flag_CAMERA_PRO;
 extern const flag_id flag_CANNIBAL;
 extern const flag_id flag_CANT_HEAL_EVERYONE;
 extern const flag_id flag_CANT_WEAR;
+extern const flag_id flag_CAN_USE_IN_DARK;
 extern const flag_id flag_CARNIVORE_OK;
 extern const flag_id flag_CASING;
 extern const flag_id flag_CATTLE;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1466,10 +1466,8 @@ class read_inventory_preset: public pickup_inventory_preset
                   !denials.empty() &&
                   !loc->type->can_use( "learn_spell" ) ) ) {
                 return denials.front();
-            } else if( loc.is_efile() ) {
-                return std::string();
             }
-            return pickup_inventory_preset::get_denial( loc );
+            return pickup_inventory_preset::get_denial( loc.is_efile() ? loc.parent_item() : loc );
         }
 
         std::function<bool( const inventory_entry & )> get_filter( const std::string &filter ) const

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1462,9 +1462,12 @@ class read_inventory_preset: public pickup_inventory_preset
 
         std::string get_denial( const item_location &loc ) const override {
             std::vector<std::string> denials;
-            if( you.get_book_reader( *loc, denials ) == nullptr && !denials.empty() &&
-                !loc->type->can_use( "learn_spell" ) ) {
+            if( ( you.get_book_reader( *loc, denials ) == nullptr &&
+                  !denials.empty() &&
+                  !loc->type->can_use( "learn_spell" ) ) ) {
                 return denials.front();
+            } else if( loc.is_efile() ) {
+                return std::string();
             }
             return pickup_inventory_preset::get_denial( loc );
         }
@@ -1751,7 +1754,7 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
     bool wiping = action == EF_WIPE;
 
     const inventory_filter_preset preset( [&copying]( const item_location & loc ) {
-        return item::is_efile( loc ) && ( !copying || loc->is_ecopiable() );
+        return loc.is_efile() && ( !copying || loc->is_ecopiable() );
     } );
 
     const int available_charges = to_edevice->ammo_remaining();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1720,7 +1720,9 @@ static void read()
                 the_book.get_use( "learn_spell" )->call( &player_character, the_book, player_character.pos_bub() );
             } else {
                 loc = loc.obtain( player_character );
-                player_character.read( loc );
+                item_location parent_loc = loc.parent_item();
+                loc.is_efile() ?
+                player_character.read( loc, parent_loc ) : player_character.read( loc );
             }
         }
     } else {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8513,7 +8513,12 @@ bool item::is_estorage() const
 
 bool item::is_estorable() const
 {
-    return has_flag( flag_E_STORABLE ) || is_book();
+    return has_flag( flag_E_STORABLE ) || has_flag( flag_E_STORABLE_EXCLUSIVE ) || is_book();
+}
+
+bool item::is_estorable_exclusive() const
+{
+    return has_flag( flag_E_STORABLE_EXCLUSIVE );
 }
 
 bool item::is_browsed() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15468,6 +15468,17 @@ std::list<const item *> item::all_items_ptr() const
     return all_items_internal;
 }
 
+std::list<item *> item::all_items_ptr()
+{
+    std::list<item *> all_items_internal;
+    for( int i = static_cast<int>( pocket_type::CONTAINER );
+         i < static_cast<int>( pocket_type::LAST ); i++ ) {
+        std::list<item *> inserted{ all_items_top_recursive( static_cast<pocket_type>( i ) ) };
+        all_items_internal.insert( all_items_internal.end(), inserted.begin(), inserted.end() );
+    }
+    return all_items_internal;
+}
+
 std::list<const item *> item::all_items_ptr( pocket_type pk_type ) const
 {
     return all_items_top_recursive( pk_type );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6546,6 +6546,14 @@ void item::update_inherited_flags()
             }
         }
     }
+
+    // ensure efiles in device can be used in darkness if edevice can be used in darkness
+    if( has_flag( flag_CAN_USE_IN_DARK ) ) {
+        for( item *file : efiles() ) {
+            file->set_flag( flag_CAN_USE_IN_DARK );
+        }
+    }
+
     update_prefix_suffix_flags();
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1284,7 +1284,7 @@ item item::in_container( const itype_id &cont, int qty, bool sealed,
     if( !variant.empty() ) {
         container.set_itype_variant( variant );
     }
-    if( container.is_container() ) {
+    if( container.is_container() || container.is_estorage() ) {
         container.fill_with( *this, qty );
         container.invlet = invlet;
         if( sealed ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8591,11 +8591,6 @@ units::ememory item::remaining_ememory() const
     return total_ememory() - occupied_ememory();
 }
 
-bool item::is_efile( const item_location &loc )
-{
-    return loc.parent_item() && loc.parent_item()->is_estorage();
-}
-
 item *item::get_recipe_catalog()
 {
     const std::function<bool( const item &i )> filter = []( const item & i ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15343,6 +15343,16 @@ std::list<item *> item::all_items_top()
     return contents.all_items_top();
 }
 
+std::list<const item *> item::all_items_container_top() const
+{
+    return contents.all_items_container_top();
+}
+
+std::list<item *> item::all_items_container_top()
+{
+    return contents.all_items_container_top();
+}
+
 std::list<const item *> item::all_items_top( pocket_type pk_type ) const
 {
     return contents.all_items_top( pk_type );

--- a/src/item.h
+++ b/src/item.h
@@ -378,8 +378,6 @@ class item : public visitable
         units::ememory occupied_ememory() const;
         /** @return remaining electronic memory on this e-device */
         units::ememory remaining_ememory() const;
-        /** Returns whether the given item location is inside an e-device) */
-        static bool is_efile( const item_location &loc );
         /** Returns the recipe catalog for this item if it exists, otherwise returns nullptr */
         item *get_recipe_catalog();
         const item *get_recipe_catalog() const;

--- a/src/item.h
+++ b/src/item.h
@@ -364,6 +364,7 @@ class item : public visitable
 
         bool is_estorage() const;
         bool is_estorable() const;
+        bool is_estorable_exclusive() const;
         bool is_browsed() const;
         void set_browsed( bool browsed );
         /** @return if item can be copied as an e-file */

--- a/src/item.h
+++ b/src/item.h
@@ -2959,14 +2959,19 @@ class item : public visitable
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
 
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<const item *> all_items_top() const;
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<item *> all_items_top();
-        /** returns a list of pointers to all top-level items */
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<const item *> all_items_container_top() const;
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<item *> all_items_container_top();
+        /** returns a list of pointers to all top-level items in pk_type pockets only */
         std::list<const item *> all_items_top( pocket_type pk_type ) const;
-        /** returns a list of pointers to all top-level items
-         *  if unloading is true it ignores items in pockets that are flagged to not unload
+        /**
+         * Return a list of pointers to all top-level items in pk_type pockets only
+         * If unloading is true ignore items in pockets flagged not to be unloaded.
          */
         std::list<item *> all_items_top( pocket_type pk_type, bool unloading = false );
 

--- a/src/item.h
+++ b/src/item.h
@@ -2995,16 +2995,18 @@ class item : public visitable
         aggregate_t aggregated_contents( int depth = 0, int maxdepth = 2 ) const;
 
         /**
-         * returns a list of pointers to all items inside recursively
+         * returns a list of pointers to *all items in all pockets* inside recursively
          * includes mods.  used for item_location::unpack()
          */
         std::list<const item *> all_items_ptr() const;
+        std::list<item *> all_items_ptr();
         /** returns a list of pointers to all items inside recursively */
         std::list<const item *> all_items_ptr( pocket_type pk_type ) const;
         /** returns a list of pointers to all items inside recursively */
         std::list<item *> all_items_ptr( pocket_type pk_type );
 
-        /** returns a list of pointers to all visible or remembered top-level items */
+        /** returns a list of pointers to all visible or remembered
+        * top-level items in standard pockets */
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1735,6 +1735,20 @@ std::list<const item *> item_contents::all_items_top() const
     } );
 }
 
+std::list<const item *> item_contents::all_items_container_top() const
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_container_like_type();
+    } );
+}
+
+std::list<item *> item_contents::all_items_container_top()
+{
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_container_like_type();
+    } );
+}
+
 std::list<item *> item_contents::all_known_contents()
 {
     return all_items_top( []( const item_pocket & pocket ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -897,7 +897,7 @@ std::pair<item_location, item_pocket *> item_contents::best_pocket( const item &
             continue;
         }
         if( !pocket.is_type( pocket_type::CONTAINER ) &&
-            !( pocket.is_type( pocket_type::E_FILE_STORAGE ) && it.is_estorable() ) ) {
+            !( pocket.is_type( pocket_type::E_FILE_STORAGE ) && it.is_estorable_exclusive() ) ) {
             // best pocket is for picking stuff up.
             // containers are the only pockets that are available for such...
             // unless it's an e-device spawning with contents; we can do this here because

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -896,9 +896,12 @@ std::pair<item_location, item_pocket *> item_contents::best_pocket( const item &
         if( pocket.is_forbidden() ) {
             continue;
         }
-        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) &&
+            !( pocket.is_type( pocket_type::E_FILE_STORAGE ) && it.is_estorable() ) ) {
             // best pocket is for picking stuff up.
-            // containers are the only pockets that are available for such
+            // containers are the only pockets that are available for such...
+            // unless it's an e-device spawning with contents; we can do this here because
+            // software items should never spawn outside a container
             continue;
         }
         if( !allow_sealed && pocket.sealed() ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -114,10 +114,14 @@ class item_contents
         /** returns a list of pointers to all top-level items */
         std::list<const item *> all_items_top( pocket_type pk_type ) const;
 
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<item *> all_items_top();
-        /** returns a list of pointers to all top-level items that are not mods */
+        /** returns a list of pointers to all top-level items in standard pockets */
         std::list<const item *> all_items_top() const;
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<item *> all_items_container_top();
+        /** returns a list of pointers to all top-level items in container-like pockets */
+        std::list<const item *> all_items_container_top() const;
 
         /** returns a list of pointers to all visible or remembered content items that are not mods */
         std::list<item *> all_known_contents();

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -587,7 +587,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 return -1;
             }
             int idx = 0;
-            for( const item *it : container->all_items_top() ) {
+            for( const item *it : container->all_items_container_top() ) {
                 if( target() == it ) {
                     return idx;
                 }
@@ -857,7 +857,7 @@ void item_location::deserialize( const JsonObject &obj )
             ptr.reset( new impl::item_on_map( map_cursor( parent.pos_bub() ), idx ) ); // drop on ground
             return;
         }
-        const std::list<item *> parent_contents = parent->all_items_top();
+        const std::list<item *> parent_contents = parent->all_items_container_top();
         if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
             auto iter = parent_contents.begin();
             std::advance( iter, idx );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -893,6 +893,11 @@ bool item_location::has_parent() const
     return false;
 }
 
+bool item_location::is_efile() const
+{
+    return parent_item() && parent_item()->is_estorage();
+}
+
 ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
 {
     item_pocket *parent_pocket;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -124,6 +124,11 @@ class item_location
         bool has_parent() const;
 
         /**
+        * Returns whether the item location is inside an e-device)
+        */
+        bool is_efile() const;
+
+        /**
         * Returns available volume capacity where this item is located.
         */
         units::volume volume_capacity() const;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2220,6 +2220,11 @@ bool item_pocket::is_standard_type() const
            data->type == pocket_type::MAGAZINE_WELL;
 }
 
+bool item_pocket::is_container_like_type() const
+{
+    return is_standard_type() || data->type == pocket_type::E_FILE_STORAGE;
+}
+
 bool item_pocket::is_forbidden() const
 {
     return data->forbidden;

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -154,8 +154,10 @@ class item_pocket
         bool allows_speedloader( const itype_id &speedloader_id ) const;
 
         // is this pocket one of the standard types?
-        // exceptions are MOD, CORPSE, SOFTWARE, MIGRATION, etc.
+        // exceptions are MOD, CORPSE, MIGRATION, etc.
         bool is_standard_type() const;
+        // is this pocket a type that acts like a container in its underlying implementation?
+        bool is_container_like_type() const;
 
         bool is_forbidden() const;
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1300,7 +1300,7 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     if( it.already_used_by_player( *p ) ) {
         p->add_msg_if_player( _( "There isn't anything new on the %s." ), it.tname() );
         return std::nullopt;
-    } else if( p->fine_detail_vision_mod() > 4 ) {
+    } else if( p->fine_detail_vision_mod() > 4 && !it.has_flag( flag_CAN_USE_IN_DARK ) ) {
         p->add_msg_if_player( _( "It's too dark to read." ) );
         return std::nullopt;
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5852,16 +5852,14 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
                           coords::project_to<coords::omt>( get_abs( p ) ) );
     }
 
-    if( new_item.has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
-        !new_item.has_var( "spawn_location_omt" ) ) {
-        new_item.set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
-    }
-    for( item *const it : new_item.all_items_top( pocket_type::CONTAINER ) ) {
+    std::list<item *> all_items = new_item.all_items_ptr();
+    all_items.emplace_back( &new_item );
+    for( item *it : all_items ) {
         if( it->has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
             !it->has_var( "spawn_location_omt" ) ) {
             it->set_var( "spawn_location_omt", coords::project_to<coords::omt>( get_abs( p ) ) );
         }
-    }
+    };
 
     if( new_item.has_flag( flag_ACTIVATE_ON_PLACE ) ) {
         new_item.activate();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3086,7 +3086,7 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                 int max_recurse = 10; // insurance against infinite looping
                 std::string initial_furn = dat.m.furn( p ) != furn_str_id::NULL_ID() ? dat.m.furn(
                                                p ).id().str() : "";
-                while( dat.m.has_furn( p ) && max_recurse-- > 0 ) {
+                while( dat.m.has_furn( p ) && --max_recurse > 0 ) {
                     const furn_t &f = dat.m.furn( p ).obj();
                     if( f.deconstruct ) {
                         if( f.deconstruct->furn_set.str().empty() ) {
@@ -3104,10 +3104,12 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                                 dat.m.furn_set( p, furn_bash->furn_set );
                             }
                             dat.m.spawn_items( p, item_group::items_from( furn_bash->drop_group, calendar::turn ) );
+                        } else {
+                            break;
                         }
                     }
                 }
-                if( !max_recurse ) {
+                if( max_recurse <= 0 ) {
                     dat.m.furn_clear( p );
                     debugmsg( "In %s on %s, the mapgen failed to arrive at an empty tile after "
                               "dismantling preexisting furniture %s at %s 10 times in succession.",
@@ -4799,32 +4801,32 @@ static bool check_furn( const furn_id &id, const std::string &context )
 
 void mapgen_function_json_base::check_common() const
 {
-    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_other_data ) ) +
-        flags_.test( jmapgen_flags::dismantle_all_before_placing_terrain ) +
-        flags_.test( jmapgen_flags::erase_all_before_placing_terrain ) > 1 ) {
+    if( static_cast<int>( flags_.test( jmapgen_flags::allow_terrain_under_other_data ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::dismantle_all_before_placing_terrain ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::erase_all_before_placing_terrain ) ) > 1 ) {
         debugmsg( "In %s, the mutually exclusive flags ERASE_ALL_BEFORE_PLACING_TERRAIN, "
                   "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN and ALLOW_TERRAIN_UNDER_OTHER_DATA "
-                  "cannot be used together", context_ );
+                  "cannot be used together.", context_ );
     }
-    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_furniture ) ) +
-        flags_.test( jmapgen_flags::dismantle_furniture_before_placing_terrain ) +
-        flags_.test( jmapgen_flags::erase_furniture_before_placing_terrain ) > 1 ) {
+    if( static_cast<int>( flags_.test( jmapgen_flags::allow_terrain_under_furniture ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::dismantle_furniture_before_placing_terrain ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::erase_furniture_before_placing_terrain ) ) > 1 ) {
         debugmsg( "In %s, the mutually exclusive flags ALLOW_TERRAIN_UNDER_FURNITURE, "
                   "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN and ERASE_FURNITURE_BEFORE_PLACING_TERRAIN "
-                  "cannot be used together", context_ );
+                  "cannot be used together.", context_ );
     }
-    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_trap ) ) +
-        flags_.test( jmapgen_flags::dismantle_trap_before_placing_terrain ) +
-        flags_.test( jmapgen_flags::erase_trap_before_placing_terrain ) > 1 ) {
+    if( static_cast<int>( flags_.test( jmapgen_flags::allow_terrain_under_trap ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::dismantle_trap_before_placing_terrain ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::erase_trap_before_placing_terrain ) ) > 1 ) {
         debugmsg( "In %s, the mutually exclusive flags ALLOW_TERRAIN_UNDER_TRAP, "
                   "DISMANTLE_TRAP_BEFORE_PLACING_TERRAIN and ERASE_TRAP_BEFORE_PLACING_TERRAIN "
-                  "cannot be used together", context_ );
+                  "cannot be used together.", context_ );
     }
-    if( static_cast <int>( flags_.test( jmapgen_flags::allow_terrain_under_items ) ) +
-        flags_.test( jmapgen_flags::erase_items_before_placing_terrain ) > 1 ) {
+    if( static_cast<int>( flags_.test( jmapgen_flags::allow_terrain_under_items ) ) +
+        static_cast<int>( flags_.test( jmapgen_flags::erase_items_before_placing_terrain ) ) > 1 ) {
         debugmsg( "In %s, the mutually exclusive flags "
                   "ALLOW_TERRAIN_UNDER_ITEMS and ERASE_ITEMS_BEFORE_PLACING_TERRAIN "
-                  "cannot be used together", context_ );
+                  "cannot be used together.", context_ );
     }
     for( const jmapgen_setmap &setmap : setmap_points ) {
         if( setmap.op != JMAPGEN_SETMAP_FURN &&

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -381,7 +381,7 @@ diag_eval_dbl_f field_strength_eval( char scope, std::vector<diag_value> const &
         map &here = get_map();
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->global_pos();
         }
@@ -769,7 +769,7 @@ diag_eval_dbl_f _characters_nearby_eval( char scope, std::vector<diag_value> con
          allow_hallucinations_val ]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->global_pos();
         }
@@ -884,7 +884,7 @@ diag_eval_dbl_f _monsters_nearby_eval( char scope, std::vector<diag_value> const
          f]( const_dialogue const & d ) {
         tripoint_abs_ms loc;
         if( loc_var.has_value() ) {
-            loc = get_tripoint_from_var( loc_var, d, beta );
+            loc = get_tripoint_ms_from_var( loc_var, d, beta );
         } else {
             loc = d.const_actor( beta )->global_pos();
         }

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -180,7 +180,7 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     tripoint_abs_omt target_pos = tripoint_abs_omt::invalid;
 
     if( params.target_var.has_value() ) {
-        return project_to<coords::omt>( get_tripoint_from_var( params.target_var.value(), d, false ) );
+        return project_to<coords::omt>( get_tripoint_ms_from_var( params.target_var.value(), d, false ) );
     }
 
     omt_find_params find_params;

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -5,6 +5,7 @@
 #include "creature_tracker.h"
 #include "dialogue.h"
 #include "flag.h"
+#include "inventory.h"
 #include "item.h"
 #include "itype.h"
 #include "line.h"
@@ -492,14 +493,7 @@ int npc_attack_gun::base_time_penalty( const npc &source ) const
     if( !weapon.ammo_sufficient( &source ) ) {
         time_penalty += npc_attack_constants::base_time_penalty;
     }
-    int recoil_penalty = 0;
-    if( source.is_wielding( weapon ) ) {
-        recoil_penalty = source.recoil;
-    } else {
-        recoil_penalty = MAX_RECOIL;
-    }
-    recoil_penalty /= 100;
-    return time_penalty + recoil_penalty;
+    return time_penalty;
 }
 
 tripoint_range<tripoint_bub_ms> npc_attack_gun::targetable_points( const npc &source ) const

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -130,7 +130,6 @@ static const efftype_id effect_npc_fire_bad( "npc_fire_bad" );
 static const efftype_id effect_npc_flee_player( "npc_flee_player" );
 static const efftype_id effect_npc_player_still_looking( "npc_player_still_looking" );
 static const efftype_id effect_npc_run_away( "npc_run_away" );
-static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
 static const efftype_id effect_stumbled_into_invisible( "stumbled_into_invisible" );
 static const efftype_id effect_stunned( "stunned" );
@@ -1988,27 +1987,31 @@ void npc::evaluate_best_attack( const Creature *target )
     std::shared_ptr<npc_attack> best_attack;
     npc_attack_rating best_evaluated_attack;
     const auto compare = [&best_attack, &best_evaluated_attack, this, &target]
-    ( const std::shared_ptr<npc_attack> &potential_attack ) {
+    ( const std::shared_ptr<npc_attack> &potential_attack, const std::string & disp ) {
         const npc_attack_rating evaluated = potential_attack->evaluate( *this, target );
-        if( evaluated > best_evaluated_attack ) {
-            best_attack = potential_attack;
-            best_evaluated_attack = evaluated;
+        if( evaluated.value() ) {
+            add_msg_debug( debugmode::DF_NPC_ITEMAI, "%s: Item %s has effectiveness %d",
+                           this->get_name(), disp, *evaluated.value() );
+            if( evaluated > best_evaluated_attack ) {
+                best_attack = potential_attack;
+                best_evaluated_attack = evaluated;
+            }
         }
     };
 
     // punching things is always available
-    compare( std::make_shared<npc_attack_melee>( null_item_reference() ) );
+    compare( std::make_shared<npc_attack_melee>( null_item_reference() ), "barehanded" );
     visit_items( [&compare, this]( item * it, item * ) {
         // you can theoretically melee with anything.
         if( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) {
-            compare( std::make_shared<npc_attack_melee>( *it ) );
+            compare( std::make_shared<npc_attack_melee>( *it ), "(as MELEE) " + it->display_name() );
         }
         if( ( !is_wielding( *it ) || !it->has_flag( flag_NO_UNWIELD ) ) &&
             ( !it->has_flag( flag_INTEGRATED ) && !is_worn( *it ) ) ) {
-            compare( std::make_shared<npc_attack_throw>( *it ) );
+            compare( std::make_shared<npc_attack_throw>( *it ), "(as THROWN) " );
         }
         if( !it->type->use_methods.empty() ) {
-            compare( std::make_shared<npc_attack_activate_item>( *it ) );
+            compare( std::make_shared<npc_attack_activate_item>( *it ), "(as ACTIVATED) " + it->display_name() );
         }
         if( rules.has_flag( ally_rule::use_guns ) ) {
             for( const std::pair<const gun_mode_id, gun_mode> &mode : it->gun_all_modes() ) {
@@ -2017,9 +2020,9 @@ void npc::evaluate_best_attack( const Creature *target )
                        ( rules.has_flag( ally_rule::use_silent ) && is_player_ally() &&
                          !mode.second->is_silent() ) ) ) {
                     if( it->shots_remaining( this ) > 0 || can_reload_current() ) {
-                        compare( std::make_shared<npc_attack_gun>( *it, mode.second ) );
+                        compare( std::make_shared<npc_attack_gun>( *it, mode.second ), "(as FIRED) " + it->display_name() );
                     } else {
-                        compare( std::make_shared<npc_attack_melee>( *it ) );
+                        compare( std::make_shared<npc_attack_melee>( *it ), "(as THROWN) " + it->display_name() );
                     }
                 }
             }
@@ -2032,7 +2035,7 @@ void npc::evaluate_best_attack( const Creature *target )
         magic->evaluate_opens_spellbook_data();
     }
     for( const spell_id &sp : magic->spells() ) {
-        compare( std::make_shared<npc_attack_spell>( sp ) );
+        compare( std::make_shared<npc_attack_spell>( sp ), sp.c_str() );
     }
 
     ai_cache.current_attack = best_attack;
@@ -2702,8 +2705,8 @@ int npc::confident_gun_mode_range( const gun_mode &gun, int at_recoil ) const
                             expected_dispersion_variance();
     double even_chance_range = range_with_even_chance_of_good_hit( max_dispersion );
     double confident_range = even_chance_range * confidence_mult();
-    add_msg_debug( debugmode::DF_NPC, "confident_gun (%s<=%.2f) at %.1f", gun.tname(), confident_range,
-                   max_dispersion );
+    add_msg_debug( debugmode::DF_NPC, "%s: Even Chance Dist / Max Dispersion: %.1f / %.1f",
+                   gun.tname(), even_chance_range, max_dispersion );
     return std::max<int>( confident_range, 1 );
 }
 
@@ -2739,7 +2742,7 @@ bool npc::wont_hit_friend( const tripoint_bub_ms &tar, const item &it, bool thro
 
     for( const auto &fr : ai_cache.friends ) {
         const shared_ptr_fast<Creature> ally_p = fr.lock();
-        if( !ally_p ) {
+        if( !ally_p || !sees( *ally_p ) ) {
             continue;
         }
         const Creature &ally = *ally_p;
@@ -2808,12 +2811,17 @@ void npc::aim( const Target_attributes &target_attributes )
     const item_location weapon = get_wielded_item();
     double aim_amount = weapon ? aim_per_move( *weapon, recoil ) : 0.0;
     const aim_mods_cache aim_cache = gen_aim_mods_cache( *weapon );
+    int hold_moves = moves;
+    double hold_recoil = recoil;
     while( aim_amount > 0 && recoil > 0 && moves > 0 ) {
         moves--;
         recoil -= aim_amount;
         recoil = std::max( 0.0, recoil );
         aim_amount = aim_per_move( *weapon, recoil, target_attributes, { std::ref( aim_cache ) } );
     }
+    add_msg_debug( debugmode::debug_filter::DF_NPC_COMBATAI,
+                   "%s reduced recoil from %f to %f in %d moves",
+                   this->get_name(), hold_recoil, recoil, hold_moves );
 }
 
 bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool force )
@@ -3399,20 +3407,7 @@ void npc::move_pause()
             return;
         }
     }
-    // NPCs currently always aim when using a gun, even with no target
-    // This simulates them aiming at stuff just at the edge of their range
-    if( !get_wielded_item() || !get_wielded_item()->is_gun() ) {
-        pause();
-        return;
-    }
-
-    // Stop, drop, and roll
-    if( has_effect( effect_onfire ) ) {
-        pause();
-    } else {
-        aim( Target_attributes() );
-        moves = std::min( moves, 0 );
-    }
+    pause();
 }
 
 static std::optional<tripoint_bub_ms> nearest_passable( const tripoint_bub_ms &p,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3646,7 +3646,7 @@ talk_effect_fun_t f_spawn_item( const JsonObject &jo, std::string_view member,
     talk_effect_fun_t ret( [item_name, count, container_name, use_item_group, suppress_message,
                add_talker, loc_var, force_equip, flags]( dialogue & d ) {
         itype_id iname = itype_id( item_name.evaluate( d ) );
-        const tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, false );
+        const tripoint_abs_ms target_location = get_tripoint_ms_from_var( loc_var, d, false );
         std::vector<std::string> flags_str;
         flags_str.reserve( flags.size() );
         for( const str_or_var &flat_sov : flags ) {
@@ -4224,7 +4224,7 @@ talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
     }
     return [input_var, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override,
                output_var, overmap_tile ]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( input_var, d, false );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( input_var, d, false );
 
         if( overmap_tile ) {
             target_pos = target_pos + tripoint( dov_x_adjust.evaluate( d ) * coords::map_squares_per(
@@ -4267,7 +4267,7 @@ talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_vi
     return [dov, transform, target_var, dov_time_in_future, key, is_npc]( dialogue & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var( target_var, d, is_npc );
+            target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
 
         int radius = dov.evaluate( d );
@@ -4329,7 +4329,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
                 is_npc]( dialogue const & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
-            tripoint_abs_ms abs_ms = get_tripoint_from_var( target_var, d, is_npc );
+            tripoint_abs_ms abs_ms = get_tripoint_ms_from_var( target_var, d, is_npc );
             target_pos = get_map().get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub();
@@ -4376,7 +4376,7 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
 
             tripoint_abs_omt target_pos = d.actor( is_npc )->global_omt_location();
             if( target_var.has_value() ) {
-                tripoint_abs_ms abs_ms = get_tripoint_from_var( target_var, d, is_npc );
+                tripoint_abs_ms abs_ms = get_tripoint_ms_from_var( target_var, d, is_npc );
                 target_pos = project_to<coords::omt>( abs_ms );
             }
 
@@ -4404,8 +4404,8 @@ talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view
     var_info second = read_var_info( jo.get_object( "second" ) );
 
     return [transform, first, second]( dialogue const & d ) {
-        tripoint_abs_ms const t_first = get_tripoint_from_var( first, d, false );
-        tripoint_abs_ms const t_second = get_tripoint_from_var( second, d, false );
+        tripoint_abs_ms const t_first = get_tripoint_ms_from_var( first, d, false );
+        tripoint_abs_ms const t_second = get_tripoint_ms_from_var( second, d, false );
         tripoint_abs_ms const orig = coord_min( t_first, t_second );
         map tm;
         tm.load( project_to<coords::sm>( orig ), false );
@@ -4459,7 +4459,7 @@ talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view 
     return [target_params, update_ids, target_var, dov_time_in_future, key]( dialogue & d ) {
         tripoint_abs_omt omt_pos;
         if( target_var.has_value() ) {
-            const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d, false ) );
+            const tripoint_abs_ms abs_ms( get_tripoint_ms_from_var( target_var, d, false ) );
             omt_pos = project_to<coords::omt>( abs_ms );
         } else {
             mission_target_params update_params = target_params;
@@ -4511,7 +4511,7 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
     }
     std::optional<var_info> target_var = read_var_info( jo.get_object( member ) );
     return [target_var, dov_time_in_future, key]( dialogue & d ) {
-        const tripoint_abs_ms abs_ms( get_tripoint_from_var( target_var, d, false ) );
+        const tripoint_abs_ms abs_ms( get_tripoint_ms_from_var( target_var, d, false ) );
         tripoint_abs_omt omt_pos = project_to<coords::omt>( abs_ms );
         time_point tif = calendar::turn + dov_time_in_future.evaluate( d ) + 1_seconds;
         // Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
@@ -4582,7 +4582,7 @@ talk_effect_fun_t::func f_guard_pos( const JsonObject &jo, std::string_view memb
             if( unique_id ) {
                 cur_var.name.insert( 0, guy->get_unique_id() );
             }
-            tripoint_abs_ms target_location = get_tripoint_from_var( cur_var, d, is_npc );
+            tripoint_abs_ms target_location = get_tripoint_ms_from_var( cur_var, d, is_npc );
             guy->set_guard_pos( target_location );
         }
     };
@@ -5168,7 +5168,7 @@ talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view mem
                 }
             } else {
                 const tripoint_bub_ms target_pos = loc_var ?
-                                                   get_map().get_bub( get_tripoint_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
+                                                   get_map().get_bub( get_tripoint_ms_from_var( loc_var, d, is_npc ) ) : caster->pos_bub();
                 sp.cast_all_effects( *caster, target_pos );
                 caster->add_msg_player_or_npc( fake.trigger_message, fake.npc_trigger_message );
             }
@@ -5483,7 +5483,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                     return;
                 }
                 if( target_var.has_value() ) {
-                    tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+                    tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
                     if( get_map().inbounds( target_pos ) ) {
                         guy->invoke_item( it->get_item(), method_str, get_map().get_bub( target_pos ) );
                         return;
@@ -5579,7 +5579,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
     }
     return [is_npc, snip_id, message, volume, ambient, type, target_var, snippet,
             same_snippet]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         std::string translated_message;
         if( snippet ) {
             if( same_snippet ) {
@@ -6124,7 +6124,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
 
     return [is_npc, option, true_eocs, false_eocs, data, loc_var, dov_min_radius, dov_max_radius,
             title]( dialogue & d ) {
-        tripoint_abs_ms target_location = get_tripoint_from_var( loc_var, d, is_npc );
+        tripoint_abs_ms target_location = get_tripoint_ms_from_var( loc_var, d, is_npc );
         std::vector<item_location> items;
         map &here = get_map();
         tripoint_bub_ms center = here.get_bub( target_location );
@@ -6203,7 +6203,7 @@ talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view m
 
         tripoint_abs_ms pos;
         if( target_var.has_value() ) {
-            pos = get_tripoint_from_var( target_var, d, is_npc );
+            pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         } else {
             pos = d.actor( is_npc )->global_pos();
         }
@@ -6718,7 +6718,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6853,7 +6853,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_from_var( target_var, d, is_npc ) );
+            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6933,7 +6933,7 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->global_pos();
         if( target_var.has_value() ) {
-            target_pos = get_tripoint_from_var( target_var, d, is_npc );
+            target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
         for( const tripoint_bub_ms &dest : get_map().points_in_radius( get_map().get_bub( target_pos ),
                 radius ) ) {
@@ -6954,9 +6954,7 @@ talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view mem
     dbl_or_var radius = get_dbl_or_var( jo, "radius", false, 0 );
 
     return [ radius, target_var ]( dialogue & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, false );
-        tripoint_abs_omt omt = project_to<coords::omt>( target_pos );
-
+        tripoint_abs_omt omt = get_tripoint_omt_from_var( target_var, d, false );
         overmap_buffer.reveal( omt, radius.evaluate( d ) );
     };
 }
@@ -6970,9 +6968,9 @@ talk_effect_fun_t::func f_reveal_route( const JsonObject &jo, std::string_view m
     bool road_only = jo.get_bool( "road_only", false );
 
     return [ radius, from, to, road_only ]( dialogue & d ) {
-        tripoint_abs_ms from_pos = get_tripoint_from_var( from, d, false );
+        tripoint_abs_ms from_pos = get_tripoint_ms_from_var( from, d, false );
         tripoint_abs_omt omt_from = project_to<coords::omt>( from_pos );
-        tripoint_abs_ms to_pos = get_tripoint_from_var( to, d, false );
+        tripoint_abs_ms to_pos = get_tripoint_ms_from_var( to, d, false );
         tripoint_abs_omt omt_to = project_to<coords::omt>( to_pos );
 
         overmap_buffer.reveal_route( omt_from, omt_to, radius.evaluate( d ), road_only );
@@ -6988,7 +6986,7 @@ talk_effect_fun_t::func f_closest_city( const JsonObject &jo, std::string_view m
     bool known = jo.get_bool( "known", true );
 
     return [var, type, var_name, known]( dialogue & d ) {
-        tripoint_abs_ms loc_ms = get_tripoint_from_var( var, d, false );
+        tripoint_abs_ms loc_ms = get_tripoint_ms_from_var( var, d, false );
         tripoint_abs_sm loc_sm = project_to<coords::sm>( loc_ms );
 
         if( known ) {
@@ -7035,7 +7033,7 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
     bool force_safe = jo.get_bool( "force_safe", false );
     return [is_npc, target_var, fail_message, success_message, force,
             force_safe]( dialogue const & d ) {
-        tripoint_abs_ms target_pos = get_tripoint_from_var( target_var, d, is_npc );
+        tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         Creature *teleporter = d.actor( is_npc )->get_creature();
         if( teleporter ) {
             if( teleport::teleport_to_point( *teleporter, get_map().get_bub( target_pos ), true, false,

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3794,10 +3794,13 @@ bool target_ui::action_aim()
     set_last_target();
     apply_aim_turning_penalty();
     const double min_recoil = calculate_aim_cap( *you, dst );
+    double hold_recoil = you->recoil;
     for( int i = 0; i < 10; ++i ) {
         do_aim( *you, *relevant, min_recoil );
     }
-
+    add_msg_debug( debugmode::debug_filter::DF_BALLISTIC,
+                   "you reduced recoil from %f to %f in 10 moves",
+                   hold_recoil, you->recoil );
     // We've changed pc.recoil, update penalty
     recalc_aim_turning_penalty();
 

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -1,5 +1,5 @@
-#include <iosfwd>
-#include <list>
+#include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -9,6 +9,9 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "character_attire.h"
+#include "coordinates.h"
+#include "flag.h"
 #include "item.h"
 #include "itype.h"
 #include "map_helpers.h"
@@ -482,28 +485,42 @@ TEST_CASE( "reading_a_book_with_an_ebook_reader", "[reading][book][ereader]" )
     avatar &dummy = get_avatar();
     clear_avatar();
 
-    WHEN( "reading a book" ) {
+    WHEN( "having a book in the inventory" ) {
 
-        dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
-        dummy.i_add( item( "atomic_lamp" ) );
-        REQUIRE( dummy.fine_detail_vision_mod() == 1 );
-
-        item_location ereader = dummy.i_add( item( "test_ebook_reader" ) );
+        dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+        item_location ereader = dummy.i_add( item( itype_test_ebook_reader ) );
 
         item book( itype_test_textbook_fabrication );
         ereader->put_in( book, pocket_type::E_FILE_STORAGE );
+        REQUIRE( ereader->has_flag( flag_CAN_USE_IN_DARK ) );
+
+        item *ebook = ereader->get_item_with( [&]( const item & it ) {
+            return it.typeId() == book.typeId();
+        } );
+        REQUIRE_FALSE( ebook->is_null() );
+
+        // CAN_USE_IN_DARK should get inherited from the ereader.
+        REQUIRE( ebook->has_flag( flag_CAN_USE_IN_DARK ) );
 
         item battery( "test_battery_disposable" );
         battery.ammo_set( battery.ammo_default(), 100 );
         ereader->put_in( battery, pocket_type::MAGAZINE_WELL );
+        item_location booklc{dummy, ebook};
+        REQUIRE( booklc );
 
-        THEN( "player can read the book" ) {
+        WHEN( "it is bright outside" ) {
+            dummy.i_add( item( itype_atomic_lamp ) );
+            REQUIRE( dummy.fine_detail_vision_mod() == 1 );
+            test_ebook_is_reading( dummy, ereader, booklc );
+        }
 
-            item_location booklc{dummy, &book};
-            read_activity_actor actor( dummy.time_to_read( *booklc, dummy ), booklc, ereader, true );
-            dummy.activity = player_activity( actor );
-
-            REQUIRE( ereader->ammo_remaining() == 100 );
+        WHEN( "it is dark outside" ) {
+            time_point midnight = calendar::turn - time_past_midnight( calendar::turn ) + 1_days;
+            set_time( midnight );
+            REQUIRE( dummy.fine_detail_vision_mod() > 4 );
+            test_ebook_is_reading( dummy, ereader, booklc );
+        }
+    }
 
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_READ );


### PR DESCRIPTION
#### Summary
Inglorious Backperts

#### Purpose of change
Fix a bunch of e-reader stuff and some random bugs

#### Describe the solution
79307 - fix map cache eoc/item
79522 - fix e-storage segfault
79863 - fix ar glasses
79307 - fix map cache functions
79639 - fix mission_get_software not finding software
80498 - fix not being able to read e-device with full inv
81123 - fix software crafting
81829 - add E_STORABLE_EXCLUSIVE flag
81157 - allow you to read most e-readers in the dark
80900 - fix crater errors
80463 - remove unconditional passive aiming for NPCs

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
