### PR TITLE
Fix a typo in one of the quiver descriptions.

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -484,7 +484,7 @@
     "id": "quiver_large",
     "type": "ARMOR",
     "name": { "str": "large quiver" },
-    "description": "A large leather quiver trimmed with metal, worn on the back, that can hold a large amount of arrows or crossbow bolts.  It's even lomg enough for atlatl or fishing spears.",
+    "description": "A large leather quiver trimmed with metal, worn on the back, that can hold a large amount of arrows or crossbow bolts.  It's even long enough for atlatl or fishing spears.",
     "weight": "920 g",
     "volume": "1500 ml",
     "price": "88 USD",


### PR DESCRIPTION
#### Summary
Fix a typo in one of the quiver descriptions.

#### Purpose of change
typo

#### Describe the solution
lomg->long

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
