### PR TITLE
Fix USE_TILES option in tiles build

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3314,11 +3314,13 @@ void Creature::draw( const catacurses::window &w, const point_bub_ms &origin, bo
 void Creature::draw( const catacurses::window &w, const tripoint_bub_ms &origin,
                      bool inverted ) const
 {
+    const tripoint_bub_ms pos = pos_bub();
+
     if( is_draw_tiles_mode() ) {
         return;
     }
 
-    point draw( point( getmaxx( w ) / 2 + posx(), getmaxy( w ) / 2 + posy() ) - origin.xy().raw() );
+    point draw( point( getmaxx( w ) / 2 + pos.x(), getmaxy( w ) / 2 + pos.y() ) - origin.xy().raw() );
     if( inverted ) {
         mvwputch_inv( w, draw, basic_symbol_color(), symbol() );
     } else if( is_symbol_highlighted() ) {
@@ -3326,8 +3328,6 @@ void Creature::draw( const catacurses::window &w, const tripoint_bub_ms &origin,
     } else {
         mvwputch( w, draw, symbol_color(), symbol() );
     }
-
-    Creature::draw( w, origin, inverted );
 }
 
 bool Creature::is_symbol_highlighted() const


### PR DESCRIPTION
#### Summary
Fix USE_TILES option in tiles build

#### Purpose of change
Some code got mangled during a backport and broke the option to not use tiles in tiles mode.

#### Describe the solution
Fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
