### PR TITLE
Remove fast healer from Reptilian

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -649,7 +649,7 @@
     "starting_trait": true,
     "types": [ "HEALING" ],
     "changes_to": [ "FASTHEALER2", "REGEN_LIZ" ],
-    "category": [ "MEDICAL", "PLANT", "BATRACHIAN", "LIZARD", "SLIME", "TROGLOBITE", "CRUSTACEAN" ],
+    "category": [ "MEDICAL", "PLANT", "BATRACHIAN", "SLIME", "TROGLOBITE", "CRUSTACEAN" ],
     "enchantments": [
       {
         "values": [


### PR DESCRIPTION
#### Summary
Remove fast healer from Reptilian

#### Purpose of change
Reptilian still had fast healer

#### Describe the solution
remove

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
