### PR TITLE
Refactor weapon pulp power and stamina cost

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8454,7 +8454,8 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
                 }
 
                 item weap = you.get_wielded_item() ? *you.get_wielded_item() : null_item_reference();
-                moves += ( ( you.attack_speed( weap) * 2 ) / you.exertion_adjusted_move_multiplier( act.exertion_level() ) );
+                moves += ( ( you.attack_speed( weap ) * 2 ) / you.exertion_adjusted_move_multiplier(
+                               act.exertion_level() ) );
                 if( moves >= you.get_moves() ) {
                     // Enough for this turn;
                     you.set_moves( you.get_moves() - moves );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -746,7 +746,8 @@ static void set_mapgen_defer( const JsonObject &jsi, const std::string &member,
  * load a single mapgen json structure; this can be inside an overmap_terrain, or on it's own.
  */
 std::shared_ptr<mapgen_function>
-load_mapgen_function( const JsonObject &jio, const std::string &id_base, const point_rel_omt &offset,
+load_mapgen_function( const JsonObject &jio, const std::string &id_base,
+                      const point_rel_omt &offset,
                       const point_rel_omt &total )
 {
     dbl_or_var weight = get_dbl_or_var( jio, "weight", false,  1000 );
@@ -858,7 +859,8 @@ void load_mapgen( const JsonObject &jo )
             }
             if( !mapgenid_list.empty() ) {
                 const std::string mapgenid = mapgenid_list[0];
-                const auto mgfunc = load_mapgen_function( jo, mapgenid, point_rel_omt::zero, point_rel_omt( 1, 1 ) );
+                const auto mgfunc = load_mapgen_function( jo, mapgenid, point_rel_omt::zero, point_rel_omt( 1,
+                                    1 ) );
                 if( mgfunc ) {
                     for( auto &i : mapgenid_list ) {
                         oter_mapgen.add( i, mgfunc );
@@ -867,7 +869,8 @@ void load_mapgen( const JsonObject &jo )
             }
         }
     } else if( jo.has_string( "om_terrain" ) ) {
-        load_and_add_mapgen_function( jo, jo.get_string( "om_terrain" ), point_rel_omt::zero, point_rel_omt( 1, 1 ) );
+        load_and_add_mapgen_function( jo, jo.get_string( "om_terrain" ), point_rel_omt::zero,
+                                      point_rel_omt( 1, 1 ) );
     } else if( jo.has_string( "nested_mapgen_id" ) ) {
         load_nested_mapgen( jo, nested_mapgen_id( jo.get_string( "nested_mapgen_id" ) ) );
     } else if( jo.has_string( "update_mapgen_id" ) ) {
@@ -5590,7 +5593,8 @@ void map::draw_lab( mapgendata &dat )
             ter_set( point_bub_ms( SEEX - 1, SEEY * 2 - 3 ), ter_t_stairs_down );
             ter_set( point_bub_ms( SEEX, SEEY * 2 - 3 ), ter_t_stairs_down );
             science_room( this, point_bub_ms( 2, 2 ), point_bub_ms( SEEX - 3, SEEY * 2 - 3 ), dat.zlevel(), 1 );
-            science_room( this, point_bub_ms( SEEX + 2, 2 ), point_bub_ms( SEEX * 2 - 3, SEEY * 2 - 3 ), dat.zlevel(), 3 );
+            science_room( this, point_bub_ms( SEEX + 2, 2 ), point_bub_ms( SEEX * 2 - 3, SEEY * 2 - 3 ),
+                          dat.zlevel(), 3 );
             science_room( this, point_bub_ms( SEEX + 2, 2 ), point_bub_ms( SEEX * 2 - 3, SEEY * 2 - 3 ),
                           dat.zlevel(), 3 );
 
@@ -6291,11 +6295,14 @@ void map::draw_lab( mapgendata &dat )
                         mtrap_set( this, tripoint_bub_ms( SEEX + 2, SEEY - 3, dat.zlevel() ), tr_dissector );
                         mtrap_set( this, tripoint_bub_ms( SEEX - 3, SEEY + 2, dat.zlevel() ), tr_dissector );
                         mtrap_set( this, tripoint_bub_ms( SEEX + 2, SEEY + 2, dat.zlevel() ), tr_dissector );
-                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX + 1, SEEY + 1 ), point_bub_ms( SEEX - 2, SEEY + 1 ),
+                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX + 1, SEEY + 1 ), point_bub_ms( SEEX - 2,
+                                SEEY + 1 ),
                               dat.zlevel() );
-                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX - 2, SEEY ), point_bub_ms( SEEX - 2, SEEY - 2 ),
+                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX - 2, SEEY ), point_bub_ms( SEEX - 2,
+                                SEEY - 2 ),
                               dat.zlevel() );
-                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX - 1, SEEY - 2 ), point_bub_ms( SEEX + 1, SEEY - 2 ),
+                        line( this, ter_t_reinforced_glass, point_bub_ms( SEEX - 1, SEEY - 2 ), point_bub_ms( SEEX + 1,
+                                SEEY - 2 ),
                               dat.zlevel() );
                         ter_set( point_bub_ms( SEEX + 1, SEEY - 1 ), ter_t_reinforced_glass );
                         ter_set( point_bub_ms( SEEX + 1, SEEY ), ter_t_reinforced_door_glass_c );
@@ -6620,7 +6627,8 @@ character_id map::place_npc( const point_bub_ms &p, const string_id<npc_template
     return temp->getID();
 }
 
-void map::apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2, const faction_id &id )
+void map::apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2,
+                                   const faction_id &id )
 {
     for( const tripoint_bub_ms &p : points_in_rectangle( tripoint_bub_ms( p1.x(), p1.y(), abs_sub.z() ),
             tripoint_bub_ms( p2.x(), p2.y(),

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -598,7 +598,8 @@ class update_mapgen
 std::shared_ptr<mapgen_function> load_mapgen_function( const JsonObject &jio,
         const std::string &id_base, const point_rel_omt &offset, const point_rel_omt &total );
 void load_and_add_mapgen_function(
-    const JsonObject &jio, const std::string &id_base, const point_rel_omt &offset, const point_rel_omt &total );
+    const JsonObject &jio, const std::string &id_base, const point_rel_omt &offset,
+    const point_rel_omt &total );
 /*
  * Load the above directly from a file via init, as opposed to riders attached to overmap_terrain. Added check
  * for oter_mapgen / oter_mapgen_weights key, multiple possible ( i.e., [ "house_w_1", "duplex" ] )

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -910,7 +910,8 @@ bool mattack::acid_accurate( monster *z )
     proj.impact.add_damage( damage_acid, rng( 3, 5 ) );
     // Make it arbitrarily less accurate at close ranges
     dealt_projectile_attack dealt;
-    projectile_attack( dealt, proj, z->pos_bub(), target->pos_bub(), dispersion_sources{ 8000.0 * range }, z );
+    projectile_attack( dealt, proj, z->pos_bub(), target->pos_bub(), dispersion_sources{ 8000.0 * range },
+                       z );
 
     return true;
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -229,7 +229,8 @@ static void deserialize( weak_ptr_fast<monster> &obj, const JsonObject &data )
 static tripoint_bub_ms read_legacy_creature_pos( const JsonObject &data )
 {
     tripoint_bub_ms pos;
-    if( !data.read( "posx", pos.x() ) || !data.read( "posy", pos.y() ) || !data.read( "posz", pos.z() ) ) {
+    if( !data.read( "posx", pos.x() ) || !data.read( "posy", pos.y() ) ||
+        !data.read( "posz", pos.z() ) ) {
         debugmsg( R"(Bad Creature JSON: neither "location" nor "posx", "posy", "posz" found)" );
     }
     return pos;


### PR DESCRIPTION
#### Summary
Refactor weapon pulp power and stamina cost

#### Purpose of change
Pulp power and stamina costs were really bizarrely implemented. Cut was better at pulping than bash, and weapons with multiple damage types had a huge advantage. These weapons tend to have inflated damage values because there's an expectation that armor is going to be doubly effective against them. Since that's not a factor for corpses, that's a problem.

Pulp_effort, which was the stamina cost for smashing, was equal to your strength plus your weapon's bash damage. I cannot even get my head around that decision, especially when the function is aware of what weapon we're using and what its stamina costs would be.

It was also taking a really long time to smash huge enemies, but not enough time to smash medium enemies. This is because we're using x_in_y( pulp_power, corpse.volume() ). yes, they should be harder to pulp, but it shouldn't be a totally linear thing like this.

Lastly, pulp times were not properly accounting for weariness and were actually getting FASTER as you got more tired. AUGH

#### Describe the solution
- All three damage types are checked for and divided by their percentage of the whole.
- Bash damage has your effective strength score added to it.
- Cut damage has its contribution cut by half.
- Stab damage has its contribution quartered.
- If you are unarmed, you are treated as having a weapon with bash damage of 1. Bare hands are not the ideal tool for this job.
- The three types, their proportional values adjusted as listed above, are added together with your effective strength score. This is multiplied by 25 + ( 4 * your survival skill ) to give your pulp_power.
- Pulp_effort is gone. Smashing now uses the standard stamina cost for making a melee attack with whatever you're using.
- It's now slightly tougher to pulp stuff that isn't huge, and slightly easier to pulp stuff that is.
 
#### Describe alternatives you've considered
- Integrated weapons should count.
- Creature volume 

#### Testing
Barehanded with low skill takes up to ~10m for a hulk. Can take a few minutes for a regular zomboid. Faster (down to under a minute) with a decent weapon. Survival skill helps.

At extreme weariness, it took almost 30m to smash a hulk.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
