### PR TITLE
Backport some NPC fixes

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1035,6 +1035,8 @@ construction_id construction_menu( const bool blueprint )
                     if( constructs[select] != construction_group_deconstruct_simple_furniture &&
                         !player_can_see_to_build( player_character, constructs[select] ) ) {
                         add_msg( m_info, _( "It is too dark to construct right now." ) );
+                    } else if( !g->warn_player_maybe_anger_local_faction( true ) ) {
+                        continue; // player declined to mess with faction's stuff
                     } else {
                         draw_preview.reset();
                         restore_view.reset();

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -139,11 +139,14 @@ static time_duration next_recurrence( const effect_on_condition_id &eoc, dialogu
 void effect_on_conditions::load_new_character( Character &you )
 {
     bool is_avatar = you.is_avatar();
-    for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
-        effect_on_condition eoc = eoc_id.obj();
-        if( eoc.type == eoc_type::SCENARIO_SPECIFIC && ( is_avatar || eoc.run_for_npcs ) ) {
-            queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
-            you.queued_effect_on_conditions.push( new_eoc );
+    // NPCs do not have scenarios, so check for that.
+    if( get_scenario() ) {
+        for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
+            effect_on_condition eoc = eoc_id.obj();
+            if( is_avatar || eoc.run_for_npcs ) {
+                queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
+                you.queued_effect_on_conditions.push( new_eoc );
+            }
         }
     }
     for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2747,9 +2747,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( player_character.in_vehicle ) {
                 add_msg( m_info, _( "You can't construct while in a vehicle." ) );
             } else {
-                if( !g->warn_player_maybe_anger_local_faction( true ) ) {
-                    break; // player declined to mess with faction's stuff
-                }
                 construction_menu( false );
             }
             break;


### PR DESCRIPTION
#### Summary
Backport some NPC fixes

#### Describe the solution
80301 - delay faction npc anger until you confirm construction on their turf
82332 - don't try to assign scenario EoCs to NPCs (should prevent some crashes)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
