### PR TITLE
Remove workbench with recharger

### DIFF
--- a/data/json/items/vehicle/tables.json
+++ b/data/json/items/vehicle/tables.json
@@ -38,16 +38,5 @@
     "price": "120 USD",
     "copy-from": "v_table",
     "melee_damage": { "bash": 8 }
-  },
-  {
-    "type": "GENERIC",
-    "id": "workbench_with_recharger",
-    "name": { "str": "workbench with battery recharger", "str_pl": "workbenches with battery rechargers" },
-    "description": "A sturdy metal workbench, perfect for crafting large and heavy things.  It also has a built-in battery charger for your phone.",
-    "weight": "20370 g",
-    "flags": [ "TRADER_AVOID" ],
-    "price": "400 USD",
-    "price_postapoc": "1 USD",
-    "copy-from": "workbench"
   }
 ]

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2592,5 +2592,10 @@
     "id": "active_backup_generator",
     "type": "MIGRATION",
     "replace": "diesel_generator"
+  },
+  {
+    "id": "workbench_with_recharger",
+    "type": "MIGRATION",
+    "replace": "workbench"
   }
 ]

--- a/data/json/obsoletion_and_migration/migration_terrain.json
+++ b/data/json/obsoletion_and_migration/migration_terrain.json
@@ -23,5 +23,15 @@
     "type": "vehicle_part_migration",
     "from": "stowed_big_portable_freezer",
     "to": "stowed_chest_minifreezer"
+  },
+  {
+    "type": "vehicle_part_migration",
+    "from": "ap_workbench_with_recharger",
+    "to": "ap_veh_tools_kitchen"
+  },
+  {
+    "type": "vehicle_part_migration",
+    "from": "workbench_with_recharger",
+    "to": "workbench"
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -652,22 +652,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "workbench_with_recharger",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_PARTS",
-    "skill_used": "fabrication",
-    "difficulty": 2,
-    "time": "15 m",
-    "reversible": true,
-    "decomp_learn": 1,
-    "autolearn": true,
-    "using": [ [ "welding_standard", 5 ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
-    "components": [ [ [ "workbench", 1 ] ], [ [ "battery_charger", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "rolling_paper",
     "category": "CC_OTHER",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1018,37 +1018,6 @@
   },
   {
     "type": "vehicle_part",
-    "id": "workbench_with_recharger",
-    "name": { "str": "workbench with battery recharger" },
-    "copy-from": "workbench",
-    "durability": 295,
-    "bonus": 15,
-    "epower": "-50 W",
-    "item": "workbench_with_recharger",
-    "//": "20 cm weld per quadrant of damage",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "15 m", "using": [ [ "repair_welding_standard", 2 ] ] }
-    },
-    "flags": [ "CARGO", "MOUNTABLE", "FLAT_SURF", "WORKBENCH", "ENABLED_DRAINS_EPOWER", "RECHARGE" ],
-    "breaks_into": [
-      { "item": "pipe", "prob": 25 },
-      { "item": "sheet_metal", "prob": 5 },
-      { "item": "sheet_metal_small", "count": [ 5, 14 ] },
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 7, 12 ] },
-      { "item": "scrap", "count": [ 15, 30 ] },
-      { "item": "plastic_chunk", "prob": 50 },
-      { "item": "cable", "charges": [ 1, 4 ] },
-      { "item": "e_scrap", "count": [ 0, 2 ] }
-    ],
-    "size": "29500 ml",
-    "workbench": { "volume": "29 L" },
-    "damage_reduction": { "all": 29 }
-  },
-  {
-    "type": "vehicle_part",
     "id": "boat_board",
     "name": { "str": "wooden boat hull" },
     "description": "A wooden board that keeps the water out of your boat.",


### PR DESCRIPTION
#### Summary
Remove workbench with recharger

#### Purpose of change
The workbench with recharger was a very old and very badly designed item that never quite worked the way it was meant to. It was also never properly updated to use the appliance system, and there's really just no reason it should exist given the functionality of modern chargers.

#### Describe the solution
remove 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
