### PR TITLE
NECC fixes

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -541,7 +541,8 @@
     "symbol": "[",
     "color": "white",
     "use_action": [ "MEDITATE" ],
-    "flags": [ "NO_WEAR_EFFECT" ]
+    "armor": [ { "encumbrance": 0, "coverage": 1, "covers": [ "torso" ], "specifically_covers": [ "torso_neck" ] } ],
+    "flags": [ "NO_WEAR_EFFECT", "BELTED", "UNRESTRICTED", "SOFT" ]
   },
   {
     "id": "wooden_hair_beads",

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -738,7 +738,7 @@
     "id": "MISSION_GODCO_CORRIE_MACHINE1",
     "type": "mission_definition",
     "name": { "str": "Renewable Energy" },
-    "description": "Find a solar panel for Corrie.",
+    "description": "Find a solar array or four solar panels for Corrie.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "u_has_items_sum": [
@@ -755,11 +755,11 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "I have a plan…",
-      "offer": "Okay, great.  We're gonna create a charger and a generator all in one.  Here's the battle plan.  Zack could create the framework, you'll get me a solar panel, the rest I can craft or repurpose from the bus.  Helena's promised us a reward if this thing lives up to her standards.",
+      "offer": "Okay, great.  We're gonna create a charger and a generator all in one.  Here's the battle plan.  Zack could create the framework, you'll get me a solar array or four solar panels.  The rest I can craft or repurpose from the bus.  Helena's promised us a reward if this thing lives up to her standards.",
       "accepted": "With my brains and your brawn we'll make an excellent team.  A regular solar panel will do just fine.",
       "rejected": "No electricity for us then.",
-      "advice": "All you need is a good wrench and a solar car.",
-      "inquire": "Do you have the solar panel?",
+      "advice": "The best place to look is probably on rooftops.  You'll need a wrench, and maybe a stepladder to get up and down safely.",
+      "inquire": "Do you have the solar panels?",
       "success": "The great work is now complete.  Are you good with words, by the way?  I was thinking, maybe you should be the one to negotiate with Helena.  But whatever you do, don't accept their icons.  Our work is worth a lot more than their valueless currency.",
       "success_lie": "Thanks for trying…  I guess.",
       "failure": "No electricity for us then."


### PR DESCRIPTION
#### Summary
NECC fixes

#### Purpose of change
- Corrie's quest was asking for "a solar panel" in the text, but you actually need 4 panels or an array.
- Relics weren't wearable.

#### Describe the solution
- Corrie now specifies what she means, and her advice now tells you to look on roofs rather than for a solar car, as those aren't very common.
- Relics are now wearable.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
