### PR TITLE
Melee weapon balance adjustments

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -221,7 +221,7 @@
     "id": "battleaxe",
     "type": "TOOL",
     "name": { "str": "battle axe" },
-    "description": "A huge axe designed for warfare.  Though intended for use as a weapon, it can also be pressed into service as a rather clumsy woodcutting tool.",
+    "description": "An axe designed for medieval warfare, the head secured to the haft with langets.  Though formidable, it's lighter than the sort you'd use for felling trees, and would make an inferior tool for that purpose.",
     "weight": "2002 g",
     "volume": "2500 ml",
     "longest_side": "100 cm",

--- a/data/json/items/tool/entry_tools.json
+++ b/data/json/items/tool/entry_tools.json
@@ -3,10 +3,10 @@
     "id": "crowbar",
     "type": "TOOL",
     "name": { "str": "crowbar" },
-    "description": "A hefty prying tool.  Use it to open locked doors without destroying them, or to lift manhole covers.  You could also wield it to bash some heads in.",
-    "weight": "3120 g",
-    "volume": "1040 ml",
-    "longest_side": "120 cm",
+    "description": "A long prying tool with a slender wedge at either end.  Use it to open locked doors without destroying them, or to lift manhole covers.",
+    "weight": "1884 g",
+    "volume": "240 ml",
+    "longest_side": "76 cm",
     "price": "26 USD",
     "price_postapoc": "5 USD",
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },
@@ -18,7 +18,7 @@
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "BELT_CLIP", "DURABLE_MELEE" ],
     "weapon_category": [ "BLUDGEONS", "HOOKING_WEAPONRY" ],
-    "melee_damage": { "bash": 24, "cut": 2 }
+    "melee_damage": { "bash": 21, "cut": 2 }
   },
   {
     "id": "emergency_lockpick",

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -20,7 +20,7 @@
     "weapon_category": [ "HAND_AXES" ],
     "use_action": [ "CROWBAR" ],
     "qualities": [ [ "AXE", 2 ], [ "CUT", 1 ], [ "PRY", 2 ], [ "BUTCHER", 16 ] ],
-    "melee_damage": { "bash": 10, "cut": 20 }
+    "melee_damage": { "bash": 12, "cut": 18 }
   },
   {
     "id": "extinguisher",
@@ -54,8 +54,8 @@
     "id": "fire_ax",
     "type": "TOOL",
     "name": { "str": "fire axe" },
-    "description": "A large, two-handed pickhead axe normally used by firefighters.  It makes a powerful melee weapon, but is a bit slow to recover between swings.",
-    "weight": "3448 g",
+    "description": "A hefty two-handed axe normally used by firefighters.  It makes a powerful melee weapon, but is a bit slow to recover between swings.  Thanks to its prying head, it can also be used to force locked door and windows open.",
+    "weight": "3628 g",
     "volume": "2 L",
     "price": "200 USD",
     "longest_side": "90 cm",
@@ -79,14 +79,14 @@
         "holster": true
       }
     ],
-    "melee_damage": { "bash": 18, "cut": 37 }
+    "melee_damage": { "bash": 23, "cut": 27 }
   },
   {
     "id": "halligan",
     "type": "TOOL",
     "name": { "str": "Halligan bar" },
-    "description": "A heavy, multiple-use tool commonly carried by firefighters, law enforcement, and military rescue units.  Use it to open locked doors without destroying them or to lift manhole covers.  You could also wield it to bash some heads in.",
-    "weight": "4772 g",
+    "description": "A heavy, multiple-use tool commonly carried by firefighters, law enforcement, and military rescue units.  Use it to open locked doors or to lift manhole covers, or just bash enemies with the nasty-looking spike on one end.",
+    "weight": "4080 g",
     "volume": "550 ml",
     "longest_side": "76 cm",
     "price": "75 USD",
@@ -99,7 +99,9 @@
     "use_action": [ "CROWBAR" ],
     "weapon_category": [ "BLUDGEONS" ],
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "SHEATH_AXE" ],
-    "melee_damage": { "bash": 42, "stab": 5 }
+    "//": "It's a blunt instrument all over, but we're trying to hit with the spike. surface: line is a compromise between any and point.",
+    "to_hit": { "grip": "solid", "length": "short", "surface": "line", "balance": "neutral" },
+    "melee_damage": { "bash": 38, "stab": 7 }
   },
   {
     "id": "sm_extinguisher",

--- a/data/json/items/tool/knives.json
+++ b/data/json/items/tool/knives.json
@@ -16,7 +16,7 @@
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 11 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "KNIVES" ],
-    "melee_damage": { "bash": 2, "stab": 11 }
+    "melee_damage": { "stab": 9 }
   },
   {
     "id": "bronze_knife",
@@ -77,7 +77,7 @@
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 3 ] ],
     "flags": [ "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
-    "melee_damage": { "bash": 1, "stab": 8 }
+    "melee_damage": { "stab": 8 }
   },
   {
     "id": "pockknife",

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -17,7 +17,7 @@
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "NO_SALVAGE" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "GREAT_AXES" ],
-    "melee_damage": { "bash": 14, "cut": 28 }
+    "melee_damage": { "bash": 18, "cut": 22 }
   },
   {
     "id": "bow_saw",
@@ -300,7 +300,7 @@
     "type": "TOOL",
     "name": { "str": "copper hatchet" },
     "description": "A primitive axe made from a small wedge of copper affixed to a short haft.",
-    "weight": "379 g",
+    "weight": "459 g",
     "volume": "1000 ml",
     "longest_side": "35 cm",
     "price": "5 USD",
@@ -312,7 +312,7 @@
     "qualities": [ [ "CUT", 1 ], [ "AXE", 1 ], [ "BUTCHER", -44 ] ],
     "flags": [ "BELT_CLIP", "NONCONDUCTIVE", "SHEATH_AXE" ],
     "weapon_category": [ "HAND_AXES" ],
-    "melee_damage": { "bash": 7, "cut": 14 }
+    "melee_damage": { "bash": 8, "cut": 12 }
   },
   {
     "id": "bronze_axe",
@@ -333,7 +333,7 @@
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],
     "flags": [ "NONCONDUCTIVE", "SHEATH_AXE" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "GREAT_AXES" ],
-    "melee_damage": { "bash": 12, "cut": 24 }
+    "melee_damage": { "bash": 14, "cut": 18 }
   },
   {
     "type": "GENERIC",
@@ -354,7 +354,7 @@
     "weapon_category": [ "HAND_AXES" ],
     "category": "weapons",
     "qualities": [ [ "AXE", 2 ], [ "CUT", 1 ], [ "HAMMER", 2 ], [ "HAMMER_FINE", 1 ], [ "BUTCHER", 16 ] ],
-    "melee_damage": { "bash": 10, "cut": 20 }
+    "melee_damage": { "bash": 14, "cut": 16 }
   },
   {
     "id": "luthier_toolset",
@@ -568,7 +568,7 @@
     "description": "A chunk of steel with one edge hammered down to something resembling a cutting edge.  It works passably well, but really can't compare to a proper axe.",
     "material": [ "steel" ],
     "flags": [ "SHEATH_AXE" ],
-    "melee_damage": { "bash": 8, "cut": 12 }
+    "melee_damage": { "bash": 6, "cut": 10 }
   },
   {
     "id": "primitive_adze",


### PR DESCRIPTION
#### Summary
Melee weapon balance adjustments

#### Purpose of change
- The crowbar was way too big. It was equal to the biggest type of crowbar that exists! This is excessive as we already have the halligan bar to fill that role.
- The fire axe was slightly too light.
- Tool axes were doing too much cut and not enough bash damage.
- The halligan bar was too heavy, and its damage and to-hit were too high.
- The copper knife never had its impact damage reduced and was too damaging in general. It's not meant to be a serious weapon.

#### Describe the solution
- Crowbar 3kg -> 1.8kg. Damage reduced very slightly.
- Fire axe gets heavier, loses some cut, gains some bash.
- Halligan bar is almost 1kg lighter, loses some bash but gains a little sab.
- Halligan bar loses some accuracy.
- Copper knife and honey scraper lose bash damage.
- Copper knife loses some stab.
- Rebalanced tool axes in general, adding more bash to two-handed axes. They're not super great at cutting, they just smash through stuff with a sharp wedge. Hatchets etc lean a bit more toward cut.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
