### PR TITLE
Adjust first aid amounts, add recipe

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -150,28 +150,28 @@
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": 12 } ]
+    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": 18 } ]
   },
   {
     "id": "tampon_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": [ 1, 12 ] } ]
+    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": [ 1, 18 ] } ]
   },
   {
     "id": "menstrual_pad_box_full",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "menstrual_pad", "prob": 100, "count": 12 } ]
+    "items": [ { "item": "menstrual_pad", "prob": 100, "count": 18 } ]
   },
   {
     "id": "menstrual_pad_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "menstrual_pad", "prob": 100, "count": [ 1, 12 ] } ]
+    "items": [ { "item": "menstrual_pad", "prob": 100, "count": [ 1, 18 ] } ]
   },
   {
     "id": "drugs_analgesic",

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -108,28 +108,28 @@
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "adhesive_bandages", "prob": 100, "count": 20 } ]
+    "items": [ { "item": "adhesive_bandages", "prob": 100, "count": 10 } ]
   },
   {
     "id": "adhesive_bandages_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "adhesive_bandages", "prob": 100, "count": [ 1, 20 ] } ]
+    "items": [ { "item": "adhesive_bandages", "prob": 100, "count": [ 1, 10 ] } ]
   },
   {
     "id": "alcohol_wipes_box_full",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "alcohol_wipes", "prob": 100, "count": 40 } ]
+    "items": [ { "item": "alcohol_wipes", "prob": 100, "count": 10 } ]
   },
   {
     "id": "alcohol_wipes_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "alcohol_wipes", "prob": 100, "count": [ 1, 40 ] } ]
+    "items": [ { "item": "alcohol_wipes", "prob": 100, "count": [ 1, 10 ] } ]
   },
   {
     "id": "cotton_ball_bag_full",
@@ -150,28 +150,28 @@
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": 24 } ]
+    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": 12 } ]
   },
   {
     "id": "tampon_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": [ 1, 24 ] } ]
+    "items": [ { "item": "tampon", "prob": 100, "container-item": "null", "count": [ 1, 12 ] } ]
   },
   {
     "id": "menstrual_pad_box_full",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "menstrual_pad", "prob": 100, "count": 24 } ]
+    "items": [ { "item": "menstrual_pad", "prob": 100, "count": 12 } ]
   },
   {
     "id": "menstrual_pad_box_used",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "box_small",
-    "items": [ { "item": "menstrual_pad", "prob": 100, "count": [ 1, 24 ] } ]
+    "items": [ { "item": "menstrual_pad", "prob": 100, "count": [ 1, 12 ] } ]
   },
   {
     "id": "drugs_analgesic",

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -4,7 +4,7 @@
     "type": "GENERIC",
     "category": "drugs",
     "name": { "str": "adhesive bandage" },
-    "description": "A tiny bandage made of a piece of sterile cloth and sticky tape, usually used for quickly covering superficial wounds.",
+    "description": "A tiny square of gauze stuck to a strip of sticky tape, usually used for quickly covering superficial wounds.",
     "weight": "2 g",
     "volume": "2 ml",
     "price": "5 cent",
@@ -144,7 +144,7 @@
     "id": "medical_gauze",
     "type": "GENERIC",
     "category": "drugs",
-    "name": { "str": "adhesive gauze bandage" },
+    "name": { "str": "adhesive gauze patch" },
     "description": "A palm-sized square of sterile fabric with adhesive tape along the edges, designed for easy application.",
     "weight": "760 mg",
     "volume": "4 ml",
@@ -160,7 +160,7 @@
     "id": "medical_gauze_makeshift",
     "type": "GENERIC",
     "category": "drugs",
-    "name": { "str": "makeshift adhesive bandage" },
+    "name": { "str": "makeshift gauze patch" },
     "description": "A palm-sized square of absorbent material with adhesive tape along the edges, designed for easy application.  It's neither professional nor sterile, but maybe this isn't the time to be choosy.",
     "weight": "760 mg",
     "volume": "4 ml",
@@ -170,7 +170,7 @@
     "symbol": ",",
     "color": "white",
     "flags": [ "SINGLE_USE", "TINDER" ],
-    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 10, "move_cost": 550 }
+    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 8, "move_cost": 550 }
   },
   {
     "id": "liq_bandage_spray",

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -154,7 +154,23 @@
     "symbol": ",",
     "color": "white",
     "flags": [ "SINGLE_USE", "TINDER" ],
-    "use_action": { "type": "heal", "bandages_power": 3, "bleed": 12, "move_cost": 850 }
+    "use_action": { "type": "heal", "bandages_power": 3, "bleed": 12, "move_cost": 550 }
+  },
+    {
+    "id": "medical_gauze_makeshift",
+    "type": "GENERIC",
+    "category": "drugs",
+    "name": { "str": "makeshift adhesive bandage" },
+    "description": "A palm-sized square of absorbent material with adhesive tape along the edges, designed for easy application.  It's neither professional nor sterile, but maybe this isn't the time to be choosy.",
+    "weight": "760 mg",
+    "volume": "4 ml",
+    "price": "3 USD 50 cent",
+    "price_postapoc": "2 USD",
+    "material": [ "cotton" ],
+    "symbol": ",",
+    "color": "white",
+    "flags": [ "SINGLE_USE", "TINDER" ],
+    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 10, "move_cost": 550 }
   },
   {
     "id": "liq_bandage_spray",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -1001,7 +1001,9 @@
       "bandages_makeshift_with_tool",
       "bandages_makeshift_bleached",
       "bandages_makeshift_boiled",
-      "adhesive_bandages"
+      "adhesive_bandages",
+      "medical_gauze",
+      "medical_gauze_makeshift"
     ],
     "difficulty": 1
   },

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -1,6 +1,6 @@
 [
   {
-    "result": "bandages",
+    "result": "medical_gauze",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_*",
@@ -9,10 +9,10 @@
     "difficulty": 1,
     "time": "30 s",
     "autolearn": true,
-    "result_mult": 3,
+    "result_mult": 1,
     "components": [
-      [ [ "cotton_patchwork", 3 ], [ "medical_gauze", 1 ] ],
-      [ [ "duct_tape", 20 ], [ "medical_tape", 5 ] ],
+      [ [ "cotton_patchwork", 1 ] ],
+      [ [ "duct_tape", 25 ], [ "medical_tape", 2 ] ],
       [
         [ "disinfectant", 5 ],
         [ "thyme_oil", 1 ],
@@ -22,7 +22,29 @@
       ]
     ]
   },
-  {
+    {
+    "result": "bandages",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "firstaid",
+    "difficulty": 1,
+    "time": "30 s",
+    "autolearn": true,
+    "result_mult": 2,
+    "components": [
+      [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ], [ "bandages_makeshift", 2 ], [ "bandages_makeshift_boiled", 2 ], [ "bandages_makeshift_bleached", 2 ] ],
+      [
+        [ "disinfectant", 5 ],
+        [ "thyme_oil", 1 ],
+        [ "chem_ethanol", 250 ],
+        [ "denat_alcohol", 250 ],
+        [ "methed_alcohol", 250 ]
+      ]
+    ]
+  },
+    {
     "result": "bandages_makeshift",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
@@ -35,6 +57,19 @@
     "//2": "Too simple to learn any tailoring or healthcare.",
     "result_mult": 2,
     "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ] ] ]
+  },
+  {
+    "result": "medical_gauze_makeshift",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "time": "10 s",
+    "autolearn": true,
+    "flags": [ "BLIND_EASY", "NO_MORALE_OK" ],
+    "//2": "Too simple to learn any tailoring or healthcare.",
+    "components": [ [ [ "cotton_patchwork", 1 ], [ "denim_patch", 1 ], [ "toilet_paper", 1 ] ],
+      [ [ "duct_tape", 25 ], [ "medical_tape", 2 ] ] ]
   },
   {
     "result": "bandages_makeshift",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -445,15 +445,15 @@
     "//": "Materials for fletching arrows.",
     "components": [
       [
-        [ "feather", 10 ],
-        [ "duct_tape", 40 ],
-        [ "cardboard", 10 ],
+        [ "feather", 2 ],
+        [ "duct_tape", 10 ],
+        [ "cardboard", 1 ],
         [ "bag_plastic", 1 ],
-        [ "bag_plastic_small", 4 ],
+        [ "bag_plastic_small", 1 ],
         [ "bottle_plastic_small", 1 ],
         [ "plastic_chunk", 1 ],
-        [ "aluminum_foil", 40 ],
-        [ "cash_card", 2 ]
+        [ "aluminum_foil", 10 ],
+        [ "cash_card", 1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Adjust first aid amounts, add recipe

#### Purpose of change
- Too many band-aids, tampons, and alcohol wipes per box.
- There was no way to make an improvised bandage out of cloth or tissue and tape.
- Bandage recipe was wrong.
- While we're here, remember to fix the fletching requirements.

#### Describe the solution
- Adhesive bandages and alcohol wipes now come in boxes of up to 10.
- Tampons and pads are now up to 18 instead of up to 24. Bigger boxes exist irl, but 18 is a common size, and keeps our numbers that much saner.
- Renames adhesive gauze bandage to adhesive gauze patch, hopefully making it clear it's a larger bandage.
- Adds a new item, makeshift gauze patch. This is just duct tape and toilet paper or some such. Surprisingly effective and quick to apply, but nowhere near as good as the real thing.
- Adjusts bandage recipe. The old one now makes adhesive gauze patches. The new one uses cotton sheets or makeshift bandages of any kind and no tape.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
