### PR TITLE
Fix pulp bug, adjust math

### DIFF
--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -54,7 +54,7 @@
     "id": "fire_ax",
     "type": "TOOL",
     "name": { "str": "fire axe" },
-    "description": "A hefty two-handed axe normally used by firefighters.  It makes a powerful melee weapon, but is a bit slow to recover between swings.  Thanks to its prying head, it can also be used to force locked door and windows open.",
+    "description": "A hefty two-handed axe normally used by firefighters.  It makes a powerful melee weapon, but is a bit slow to recover between swings.  Thanks to its prying head, it can also be used to force locked doors and windows open.",
     "weight": "3628 g",
     "volume": "2 L",
     "price": "200 USD",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8369,7 +8369,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             mess_radius = 2;
         }
     }
-    
+
     double total_power = std::max( 1, ( weap_bash + weap_cut + weap_stab ) );
 
     // If you have a weapon, bash specifically benefits from strength, which is counted again later regardless of damage type.
@@ -8383,8 +8383,8 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
 
     int adjusted_bash = static_cast<int>( std::round( weap_bash * ratio_bash ) );
     // Cut is OK at this, stab is very bad
-    int adjusted_cut  = static_cast<int>( std::round( (weap_cut * ratio_cut) / 1.25 ) );
-    int adjusted_stab = static_cast<int>( std::round( (weap_stab * ratio_stab) / 3.0 ) );
+    int adjusted_cut  = static_cast<int>( std::round( ( weap_cut * ratio_cut ) / 1.25 ) );
+    int adjusted_stab = static_cast<int>( std::round( ( weap_stab * ratio_stab ) / 3.0 ) );
 
     float pulp_power = sqrt( adjusted_bash + adjusted_cut + adjusted_stab + you.get_arm_str() );
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8369,24 +8369,27 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             mess_radius = 2;
         }
     }
+    
+    double total_power = std::max( 1, ( weap_bash + weap_cut + weap_stab ) );
 
     // If you have a weapon, bash specifically benefits from strength, which is counted again later regardless of damage type.
     if( weap_bash > 1 ) {
         weap_bash += you.get_arm_str();
     }
 
-    int total_power = std::min( 1, ( weap_bash + weap_cut + weap_stab ) );
+    double ratio_bash = static_cast<double>( weap_bash ) / total_power;
+    double ratio_cut  = static_cast<double>( weap_cut ) / total_power;
+    double ratio_stab = static_cast<double>( weap_stab ) / total_power;
 
-    int adjusted_bash = ( weap_bash ) / total_power;
-    // Cut is OK at this, stab is very bad.
-    int adjusted_cut = ( weap_cut / total_power ) / 2;
-    int adjusted_stab = ( weap_stab / total_power ) / 4;
+    int adjusted_bash = static_cast<int>( std::round( weap_bash * ratio_bash ) );
+    // Cut is OK at this, stab is very bad
+    int adjusted_cut  = static_cast<int>( std::round( (weap_cut * ratio_cut) / 1.25 ) );
+    int adjusted_stab = static_cast<int>( std::round( (weap_stab * ratio_stab) / 3.0 ) );
 
     float pulp_power = sqrt( adjusted_bash + adjusted_cut + adjusted_stab + you.get_arm_str() );
 
     // Multiplier to get the chance right + some bonus for survival skill.
-    pulp_power *= 20 + you.get_skill_level( skill_survival ) * 4;
-
+    pulp_power *= 20 + you.get_skill_level( skill_survival ) * 5;
     int moves = 0;
     for( auto pos_iter = placement.cbegin(); pos_iter != placement.end();/*left - out*/ ) {
         const tripoint_bub_ms &pos = here.get_bub( *pos_iter );
@@ -8408,14 +8411,13 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
 
             // Because of the square cube law, we need to sanity check pulp time vs size.
             // This is an incredibly lazy way to do it, but it works well enough.
-            units::volume divisor = 275_ml;
+            units::volume divisor = 175_ml;
             if( corpse.volume() <= 108000_ml ) {
                 divisor = 35_ml;
             } else if( corpse.volume() <= 483750_ml ) {
-                divisor = 150_ml;
+                divisor = 125_ml;
             }
             double corpse_volume_factor = corpse.volume() / divisor;
-
             while( corpse.damage() < corpse.max_damage() ) {
                 // Increase damage as we keep smashing ensuring we do eventually smash the target.
                 if( x_in_y( pulp_power, corpse_volume_factor ) ) {
@@ -8457,7 +8459,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
                 moves += ( ( you.attack_speed( weap ) * 2 ) / you.exertion_adjusted_move_multiplier(
                                act.exertion_level() ) );
                 if( moves >= you.get_moves() ) {
-                    // Enough for this turn;
+                    // Enough for this turn.
                     you.set_moves( you.get_moves() - moves );
                     return;
                 }


### PR DESCRIPTION
#### Summary
Fix pulp bug, adjust math

#### Purpose of change
- If the player was holding a 0 damage item while pulping corpses, it was possible to segfault.
- The math for multi-damage weapons and larger creatures needed tweaking.

#### Describe the solution
- Reduce the time discount for huge creatures. They were too easy to pulp.
- Increase the bonus for survival skill by 20%
- Make cut and stab weapons a bit less bad at pulping.
- Fix some integer division issues, and fix an issue with multiple damage types not getting their ratios properly checked.

#### Testing
Seems good. In rare cases it's possible to spend way too long pulping a corpse and to get super weary super fast. I need to devise a fix for that which doesn't break NPC behavior.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
