### PR TITLE
A few more weapon adjustments

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1256,7 +1256,7 @@
     "symbol": "/",
     "color": "light_gray",
     "name": { "str": "butterfly sword" },
-    "description": "A Shaolin butterfly sword, about the same size as a machete but with hand guards and wider blades.  Traditionally used in pairs, but just one is more than enough.",
+    "description": "A Shaolin butterfly sword, short, with a handguard and an unusually wide blade.  These are traditionally used in pairs, but just one is more than enough.",
     "price": "500 USD",
     "price_postapoc": "60 USD",
     "material": [ "steel" ],
@@ -1269,7 +1269,7 @@
     "to_hit": { "grip": "weapon", "length": "short", "surface": "line", "balance": "good" },
     "category": "weapons",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "melee_damage": { "bash": 6, "cut": 30 }
+    "melee_damage": { "bash": 3, "cut": 20 }
   },
   {
     "id": "cutlass",
@@ -1292,7 +1292,7 @@
     "to_hit": { "grip": "weapon", "length": "short", "surface": "line", "balance": "good" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
     "weapon_category": [ "MEDIUM_SWORDS" ],
-    "melee_damage": { "bash": 5, "cut": 23 }
+    "melee_damage": { "bash": 5, "cut": 24 }
   },
   {
     "id": "cutlass_inferior",
@@ -1569,11 +1569,11 @@
     "material": [ "steel" ],
     "volume": "51 ml",
     "longest_side": "17 cm",
-    "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "good" },
+    "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "neutral" },
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE", "ALLOWS_BODY_BLOCK" ],
     "weapon_category": [ "SHIVS" ],
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 14 ] ],
-    "melee_damage": { "stab": 14 }
+    "melee_damage": { "bash": 2, "stab": 12 }
   },
   {
     "type": "GENERIC",


### PR DESCRIPTION
#### Summary
A few more weapon adjustments

#### Purpose of change
The butterfly sword and punch dagger were doing too much damage, the cutlass too little.

#### Describe the solution
The punch dagger's stab has been reduced, but owing to its design, it gets two points of bash, which no other knife has. This isn't a huge advantage, but it's something a very strong character might do well with.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
