### PR TITLE
Faction board shows vitamins

### DIFF
--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -393,14 +393,14 @@ std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type 
     } );
     const double worst_intake = vitamins.at( 0 ).second;
     std::string vit_name = vitamins.at( 0 ).first.obj().name();
-    std::string msg = is_toxin ? _( "(SAFE)" ) : _( "(PLENTY)" );
+    std::string msg = is_toxin ? _( "(Safe)" ) : _( "(Plenty)" );
     if( worst_intake <= 0.3 ) {
-        msg = is_toxin ? _( "(WARNING)" ) : _( "(LACKING)" );
+        msg = is_toxin ? _( "(Warning)" ) : _( "(Lacking)" );
         return std::pair<nc_color, std::string>( c_yellow, string_format( _( "%1$s %2$s" ), vit_name,
                 msg ) );
     }
     if( worst_intake <= 1.0 ) {
-        msg = is_toxin ? _( "(DANGER)" ) : _( "(MEAGER)" );
+        msg = is_toxin ? _( "(Danger)" ) : _( "(Meager)" );
         return std::pair<nc_color, std::string>( c_red, string_format( _( "%1$s %2$s" ), vit_name,
                 msg ) );
     }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -338,9 +338,9 @@ std::string faction::food_supply_text()
         return pgettext( "Faction food", "Scraping By" );
     }
     if( val >= 3 ) {
-        return pgettext( "Faction food", "Malnourished" );
+        return pgettext( "Faction food", "Very Low" );
     }
-    return pgettext( "Faction food", "Starving" );
+    return pgettext( "Faction food", "Depleted" );
 }
 
 nc_color faction::food_supply_color()
@@ -373,7 +373,7 @@ std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type 
         }
     }
     if( stored_vits.empty() ) {
-        return std::pair<nc_color, std::string>( !is_toxin ? c_red : c_green, _( "None present (NONE)" ) );
+        return std::pair<nc_color, std::string>( !is_toxin ? c_red : c_green, _( "None present." ) );
     }
     std::vector<std::pair<vitamin_id, double>> vitamins;
     // Iterate the map's content into a sortable container...
@@ -389,19 +389,19 @@ std::pair<nc_color, std::string> faction::vitamin_stores( vitamin_type vit_type 
     }
     // Sort to find the worst-case scenario, lowest relative_intake is first
     std::sort( vitamins.begin(), vitamins.end(), []( const auto & x, const auto & y ) {
-        return x.second > y.second;
+        return x.second < y.second;
     } );
     const double worst_intake = vitamins.at( 0 ).second;
     std::string vit_name = vitamins.at( 0 ).first.obj().name();
-    std::string msg = is_toxin ? _( "(TRACE)" ) : _( "(PLENTY)" );
+    std::string msg = is_toxin ? _( "(SAFE)" ) : _( "(PLENTY)" );
     if( worst_intake <= 0.3 ) {
-        msg = is_toxin ? _( "(POISON)" ) : _( "(LACK)" );
-        return std::pair<nc_color, std::string>( c_red, string_format( _( "%1$s %2$s" ), vit_name,
+        msg = is_toxin ? _( "(WARNING)" ) : _( "(LACKING)" );
+        return std::pair<nc_color, std::string>( c_yellow, string_format( _( "%1$s %2$s" ), vit_name,
                 msg ) );
     }
     if( worst_intake <= 1.0 ) {
         msg = is_toxin ? _( "(DANGER)" ) : _( "(MEAGER)" );
-        return std::pair<nc_color, std::string>( c_yellow, string_format( _( "%1$s %2$s" ), vit_name,
+        return std::pair<nc_color, std::string>( c_red, string_format( _( "%1$s %2$s" ), vit_name,
                 msg ) );
     }
     return std::pair<nc_color, std::string>( c_green, string_format( _( "%1$s %2$s" ), vit_name,
@@ -576,14 +576,14 @@ void basecamp::faction_display( const catacurses::window &fac_w, const int width
     }
     mvwprintz( fac_w, point( width, ++y ), col, _( "Location: %s" ), camp_pos.to_string() );
     faction *yours = player_character.get_faction();
-    std::string food_text = string_format( _( "Food Supply: %s %d kilocalories" ),
+    std::string food_text = string_format( _( "Food Supply: %s (%d kcal)" ),
                                            yours->food_supply_text(), yours->food_supply.kcal() );
     nc_color food_col = yours->food_supply_color();
     mvwprintz( fac_w, point( width, ++y ), food_col, food_text );
     std::pair<nc_color, std::string> vitamins = yours->vitamin_stores( vitamin_type::VITAMIN );
-    mvwprintz( fac_w, point( width, ++y ), vitamins.first, _( "Worst vitamin:" ) + vitamins.second );
+    mvwprintz( fac_w, point( width, ++y ), vitamins.first, _( "Lowest vitamin: " ) + vitamins.second );
     std::pair<nc_color, std::string> toxins = yours->vitamin_stores( vitamin_type::TOXIN );
-    mvwprintz( fac_w, point( width, ++y ), toxins.first, _( "Worst toxin:" ) + toxins.second );
+    mvwprintz( fac_w, point( width, ++y ), toxins.first, _( "Toxin levels: " ) + toxins.second );
     std::string bldg = next_upgrade( base_camps::base_dir, 1 );
     std::string bldg_full = _( "Next Upgrade: " ) + bldg;
     mvwprintz( fac_w, point( width, ++y ), col, bldg_full );
@@ -750,10 +750,10 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
             can_see = _( "You do not have a radio" );
             see_color = c_light_red;
         } else if( !guy_has_radio && u_has_radio ) {
-            can_see = _( "Follower does not have a radio" );
+            can_see = _( "Your follower does not have a radio" );
             see_color = c_light_red;
         } else {
-            can_see = _( "Both you and follower need a radio" );
+            can_see = _( "Both you and your follower need a radio" );
             see_color = c_light_red;
         }
     } else {
@@ -763,7 +763,7 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     }
     // TODO: NPCS on mission contactable same as traveling
     if( has_companion_mission() ) {
-        can_see = _( "Press enter to recall from their mission." );
+        can_see = _( "Press enter to recall from their mission" );
         see_color = c_light_red;
     }
     mvwprintz( fac_w, point( width, ++y ), see_color, "%s", can_see );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1481,24 +1481,20 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
     if( !by_radio ) {
         {
             const mission_id miss_id = { Camp_Distribute_Food, "", {}, base_dir };
+            std::pair<nc_color, std::string> vitamins = fac()->vitamin_stores( vitamin_type::VITAMIN );
+
+            std::pair<nc_color, std::string> toxins = fac()->vitamin_stores( vitamin_type::TOXIN );
             entry = string_format( _( "Notes:\n"
-                                      "Distribute food to your follower and fill your larders.  "
-                                      "Place the food you wish to distribute in the camp food zone.  "
-                                      "You must have a camp food zone, and a camp storage zone, "
-                                      "or you will be prompted to create them using the zone manager.\n"
-                                      "Effects:\n"
-                                      "> Increases your faction's food supply value which in "
-                                      "turn is used to pay laborers for their time\n\n"
-                                      "Must have enjoyability >= -6\n"
-                                      "Perishable food liquidated at penalty depending on "
-                                      "upgrades and rot time:\n"
-                                      "> Rotten: 0%%\n"
-                                      "> Rots in < 2 days: 60%%\n"
-                                      "> Rots in < 5 days: 80%%\n\n"
-                                      "Total faction food stock: %d kcal\nor %d / %d / %d day's rations\n"
-                                      "where the days is measured for Extra / Moderate / No exercise levels" ),
-                                   fac()->food_supply.kcal(), camp_food_supply_days( EXTRA_EXERCISE ),
-                                   camp_food_supply_days( MODERATE_EXERCISE ), camp_food_supply_days( NO_EXERCISE ) );
+                                      "Distribute food from the Basecamp: Food zone to your faction.  "
+                                      "Distributed food will be banked and used to pay followers for "
+                                      "performing labor. Note that distributed food can't be recovered"
+                                      ", and distributed perishables will still go bad over time.\n\n"
+                                      "We have approximately %d kcal in storage, or enough for about "
+                                      "%d day(s) of moderate work for a healthy adult.\n"
+                                      "Lowest vitamin: %s\n"
+                                      "Toxin levels: %s" ),
+                                   fac()->food_supply.kcal(), camp_food_supply_days( MODERATE_EXERCISE ), vitamins.second,
+                                   toxins.second );
             mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                              entry );
         }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1490,10 +1490,10 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                                       "performing labor. Note that distributed food can't be recovered"
                                       ", and distributed perishables will still go bad over time.\n\n"
                                       "We have approximately %d kcal in storage, or enough for about "
-                                      "%d day(s) of moderate work for a healthy adult.\n"
+                                      "%d hour(s) of moderate work for a healthy adult.\n"
                                       "Lowest vitamin: %s\n"
                                       "Toxin levels: %s" ),
-                                   fac()->food_supply.kcal(), camp_food_supply_days( MODERATE_EXERCISE ), vitamins.second,
+                                   fac()->food_supply.kcal(), ( camp_food_supply_days( MODERATE_EXERCISE ) * 24 ), vitamins.second,
                                    toxins.second );
             mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                              entry );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1487,10 +1487,10 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
             entry = string_format( _( "Notes:\n"
                                       "Distribute food from the Basecamp: Food zone to your faction.  "
                                       "Distributed food will be banked and used to pay followers for "
-                                      "performing labor. Note that distributed food can't be recovered"
+                                      "performing labor.  Note that distributed food can't be recovered"
                                       ", and distributed perishables will still go bad over time.\n\n"
-                                      "We have approximately %d kcal in storage, or enough for about "
-                                      "%d hour(s) of moderate work for a healthy adult.\n"
+                                      "This faction has approximately %d kcal in storage, or enough "
+                                      "for about %d hour(s) of moderate work for a healthy adult.\n"
                                       "Lowest vitamin: %s\n"
                                       "Toxin levels: %s" ),
                                    fac()->food_supply.kcal(), ( camp_food_supply_days( MODERATE_EXERCISE ) * 24 ), vitamins.second,


### PR DESCRIPTION
#### Summary
Faction board shows vitamins

#### Purpose of change
The faction camp board has a lot of very old, outdated, confusing, and badly written information on it. Like most features involving NPCs, it generally does a horrible job explaining itself.

#### Describe the solution
- The faction camp board no longer has a bunch of math and nonsense on it in the "distribute food" job. Now it simply tells you how it works, how many kcal you have in storage, and what your faction's vitamin/toxin situation is. This information was already available on the faction menu, but it wasn't displaying properly due to some bad math.

#### Testing
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/3396a0bc-7910-4512-8053-0d5f5297bc2f" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/5791cea2-b6f1-474e-a9e2-77f44f959f6d" />

#### Additional context
For some reason, I can't currently distribute multivitamins despite their being an explicit option to do so. I'll have to figure that out, but this works fine for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
