### PR TITLE
Release grabs before capturing animals

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8160,6 +8160,10 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
             // If the monster is friendly, then put it in the item
             // without checking if it rolled a success.
             if( f.friendly != 0 || one_in( chance ) ) {
+                if( p->grab_1.victim != nullptr && p->grab_1.victim.get()->is_monster() &&
+                    p->grab_1.victim.get()->as_monster() == &f ) {
+                    p->release_grapple();
+                }
                 p->add_msg_if_player( _( "You capture the %1$s in your %2$s." ),
                                       f.type->nname(), it->tname() );
                 p->invalidate_weight_carried_cache();


### PR DESCRIPTION
#### Summary
Release grabs before capturing monsters

#### Purpose of change
If you had a grappled monster and tried to put it in an animal carrier or pet carrier, it would segfault.

#### Describe the solution
When putting a monster in a carrier, check if the character is grappling, check if the grapple target is the monster in question, and release it if so, then put it in the carrier.

#### Testing
Grabbed a little dog and shoved it in a pet carrier. Success.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
