### PR TITLE
Remove tommy gun and golden violin from music store item groups.json

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1006,11 +1006,6 @@
           { "item": "fog_machine", "prob": 1, "charges": [ 0, 500 ] },
           { "item": "violin", "prob": 90 },
           { "item": "guitar_electric", "prob": 90 },
-          {
-            "collection": [ { "item": "case_violin" }, { "item": "tommygun" }, { "item": "grip" }, { "item": "thompson_drum" } ],
-            "prob": 15
-          },
-          { "collection": [ { "item": "case_violin" }, { "item": "violin_golden" } ], "prob": 50 },
           { "collection": [ { "item": "spoon" }, { "item": "washboard" } ], "prob": 15 }
         ]
       }


### PR DESCRIPTION
Removed tommygun and golden violin from music stores.

#### Summary
Category "Brief description"
This removes Tommyguns and golden violins from music stores.

#### Purpose of change
While funny, this is silly and a immersion breaking. 

#### Describe the solution
Removal of tommyguns and golden violins from music stores. 

#### Describe alternatives you've considered
None

#### Testing
Ran without errors. Generated 30 music stores and did not see either the tommy gun or golden violin.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
