### PR TITLE
Remove golden violin, change krar from gold to wood.json

### DIFF
--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -258,51 +258,19 @@
     "melee_damage": { "bash": 12 }
   },
   {
-    "id": "violin_golden",
+    "id": "krar",
     "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
-    "name": { "str": "golden fiddle" },
-    "description": "A shiny golden fiddle, with a strange aura around it.  You feel like it once belonged to the best there's ever been.",
-    "weight": "13000 g",
-    "volume": "2500 ml",
-    "longest_side": "60 cm",
-    "price": "10000 USD",
-    "price_postapoc": "10 USD",
-    "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "clumsy" },
-    "material": [ "gold" ],
-    "symbol": "}",
-    "color": "yellow",
-    "use_action": [ { "type": "play_instrument" } ],
-    "tick_action": {
-      "type": "musical_instrument",
-      "volume": 25,
-      "fun": 1,
-      "fun_bonus": 4,
-      "speed_penalty": 25,
-      "description_frequency": 10,
-      "player_descriptions": [
-        "You play a quick, folksy tune on your fiddle.",
-        "As you pull the bow across its strings, it makes an evil hiss.",
-        "You play a tune so fierce, it feels like hell's broke loose."
-      ]
-    },
-    "melee_damage": { "bash": 9 }
-  },
-  {
-    "id": "krar_golden",
-    "looks_like": "acoustic_guitar",
-    "type": "TOOL",
-    "category": "tools",
-    "name": { "str": "golden krar" },
-    "description": "A shiny golden krar, similar to a harp.",
-    "weight": "13000 g",
+    "name": { "str": "krar" },
+    "description": "A wooden krar, similar to a harp.",
+    "weight": "6800 g",
     "volume": "12 L",
     "longest_side": "100 cm",
-    "price": "10000 USD",
-    "price_postapoc": "10 USD",
+    "price": "75 USD",
+    "price_postapoc": "6 USD",
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "clumsy" },
-    "material": [ "gold" ],
+    "material": [ "wood" ],
     "symbol": "}",
     "color": "yellow",
     "use_action": [ { "type": "play_instrument" } ],
@@ -316,16 +284,6 @@
       "player_descriptions": [ "You play a relaxed, folksy tune on your krar." ]
     },
     "melee_damage": { "bash": 9 }
-  },
-  {
-    "id": "krar",
-    "looks_like": "krar_golden",
-    "type": "TOOL",
-    "name": { "str": "krar" },
-    "description": "A wooden krar, similar to a harp.",
-    "copy-from": "krar_golden",
-    "material": "wood",
-    "weight": "2500 g"
   },
   {
     "id": "drum_percussion",


### PR DESCRIPTION
Deletion of the golden violin item. Edited the krar from gold to wood.

#### Summary
Category "Brief description"
Deletion of the golden violin item, changes to the krar to account for it being wood instead of gold. 

#### Purpose of change
Cleaning up some legacy musical instruments and updating the krar (harp)

#### Describe the solution
Deletion of the golden violin item, changes to the krar to account for it being wood instead of gold. I also changed the weight of the krar to be in line with harps, roughly 15 lbs on the low end.

#### Describe alternatives you've considered
None.

#### Testing
Ran fine with no errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
