### PR TITLE
Migrate golden krar and violin

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2597,5 +2597,15 @@
     "id": "workbench_with_recharger",
     "type": "MIGRATION",
     "replace": "workbench"
+  },
+  {
+    "id": "violin_golden",
+    "type": "MIGRATION",
+    "replace": "violin"
+  },
+  {
+    "id": "krar_golden",
+    "type": "MIGRATION",
+    "replace": "krar"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate golden krar and violin

#### Purpose of change
For some reason, there were solid gold violins and krars in mainline, in instrument shops, like it was normal. ??? these were removed, but needed to be migrated

#### Describe the solution
Migrate

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
