### PR TITLE
Huge characters don't need gun mounts

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4417,7 +4417,8 @@ bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> 
                                      you.pos_bub() ).part_with_feature( "MOUNTABLE",
                                              true ) );
         bool t_mountable = m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, you.pos_bub() );
-        if( !t_mountable && !v_mountable ) {
+        bool no_mount_needed = ( you.enum_size() == 5 && you.str_cur >= 16 ) || ( you.enum_size() == 4 && you.str_cur >= 30 );
+        if( !t_mountable && !v_mountable && !no_mount_needed ) {
             messages.push_back( string_format(
                                     _( "You must stand near acceptable terrain or furniture to fire the %s.  A table, a mound of dirt, a broken window, etc." ),
                                     gmode->tname() ) );


### PR DESCRIPTION
#### Summary
Huge characters don't need gun mounts

#### Purpose of change
Some guns, such as the Browning M2HB, require you to mount them on a surface to fire. That makes sense for puny humans, but I'm a thirteen foot tall minotaur.

#### Describe the solution
If you are huge and have 16+ strength, or if you are large and have 30+ strength, you may operate these weapons by hand as if they were any other kind of gun.

I may nix the Large thing at some point, or make it weight-related, but if you have 30 strength I probably shouldn't be arguing with you about what kind of gun you are allowed to operate.

<img width="1600" height="1037" alt="image" src="https://github.com/user-attachments/assets/4b9e969e-4cd9-4bb7-83e7-7b07e7576fe2" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/a83dcf74-72a0-4a9e-b18e-380a7e2742a6" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
