### PR TITLE
Raise toxins in honeydew

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -110,7 +110,7 @@
     "fun": 2,
     "comestible_type": "FOOD",
     "flags": [ "NUTRIENT_OVERRIDE" ],
-    "vitamins": [ [ "mutant_toxin", 6 ] ],
+    "vitamins": [ [ "mutant_toxin", 24 ] ],
     "//": "It takes about 30 portions of honeydew to feed an adult (~2000 kkal). 2000 kkal is about 10 raw chunks of mutant meat, which is 250% toxins. Honeydew probably isn't as toxic as meat, so 30 portions of it would give you 180% of toxins.",
     "volume": "16 ml"
   },


### PR DESCRIPTION
#### Summary
Raise toxins in honeydew

#### Purpose of change
Honeydew had really low toxins so you could eat a ton of bug shit with no downsides.

#### Describe the solution
Give it toxins.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
