### PR TITLE
Backport 79336 - Don't do map processing for creatures off map

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -409,7 +409,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {
-                critter.die( &you );
+                critter.die( &m, &you );
             }
             g->draw_hit_mon( dest_loc, critter, critter.is_dead() );
             return false;

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -512,7 +512,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                     attack.proj.multishot = true;
                     print_messages = false;
                 }
-                critter->deal_projectile_attack( null_source ? nullptr : origin, attack, cur_missed_by,
+                critter->deal_projectile_attack( &here, null_source ? nullptr : origin, attack, cur_missed_by,
                                                  print_messages, wp_attack );
 
                 if( critter->is_npc() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1962,6 +1962,8 @@ bool Character::is_mounted() const
 
 void Character::forced_dismount()
 {
+    map &here = get_map();
+
     remove_effect( effect_riding );
     remove_effect( effect_mech_recon_vision );
     bool mech = false;
@@ -2038,7 +2040,7 @@ void Character::forced_dismount()
                     pgettext( "memorial_male", "Fell off a mount." ),
                     pgettext( "memorial_female", "Fell off a mount." ) );
             }
-            check_dead_state();
+            check_dead_state( &here );
         }
         add_effect( effect_downed, 5_turns, true );
     } else {
@@ -2553,6 +2555,7 @@ void Character::expose_to_disease( const diseasetype_id &dis_type )
 
 void Character::process_turn()
 {
+    map &here = get_map();
     // Has to happen before reset_stats
     clear_miss_reasons();
     migrate_items_to_storage( false );
@@ -2597,7 +2600,7 @@ void Character::process_turn()
     if( leak_level_dirty ) {
         calculate_leak_level();
     }
-    process_items();
+    process_items( &here );
     leak_items();
     // Didn't just pick something up
     last_item = itype_null;
@@ -4036,7 +4039,7 @@ void Character::normalize()
 }
 
 // Actual player death is mostly handled in game::is_game_over
-void Character::die( Creature *nkiller )
+void Character::die( map *here, Creature *nkiller )
 {
     g->set_critter_died();
     set_all_parts_hp_cur( 0 );
@@ -8427,10 +8430,10 @@ std::string Character::weapname_ammo() const
     }
 }
 
-void Character::on_hit( Creature *source, bodypart_id bp_hit,
+void Character::on_hit( map *here, Creature *source, bodypart_id bp_hit,
                         float /*difficulty*/, dealt_projectile_attack const *const proj )
 {
-    check_dead_state();
+    check_dead_state( here );
     if( source == nullptr || proj != nullptr ) {
         return;
     }
@@ -8515,8 +8518,7 @@ void Character::on_hit( Creature *source, bodypart_id bp_hit,
         }
     }
 
-    map &here = get_map();
-    const optional_vpart_position veh_part = here.veh_at( pos_bub() );
+    const optional_vpart_position veh_part = here->veh_at( pos_abs() );
     bool in_skater_vehicle = in_vehicle && veh_part.part_with_feature( "SEAT_REQUIRES_BALANCE", false );
 
     if( ( worn_with_flag( flag_REQUIRES_BALANCE ) || in_skater_vehicle ) && !is_on_ground() &&
@@ -10784,7 +10786,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     return effects;
 }
 
-void Character::place_corpse()
+void Character::place_corpse( map *here )
 {
     //If the character/NPC is on a distant mission, don't drop their their gear when they die since they still have a local pos
     if( !death_drops ) {
@@ -10793,7 +10795,6 @@ void Character::place_corpse()
     std::vector<item *> tmp = inv_dump();
     item body = item::make_corpse( mtype_id::NULL_ID(), calendar::turn, get_name() );
     body.set_item_temperature( units::from_celsius( 37 ) );
-    map &here = get_map();
     for( item *itm : tmp ) {
         body.force_insert_item( *itm, pocket_type::CONTAINER );
     }
@@ -10811,7 +10812,7 @@ void Character::place_corpse()
         }
     }
 
-    here.add_item_or_charges( pos_bub(), body );
+    here->add_item_or_charges( here->get_bub( pos_abs() ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -11594,9 +11595,15 @@ void Character::process_effects()
 void Character::gravity_check()
 {
     map &here = get_map();
-    if( here.is_open_air( pos_bub() ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) ) {
-        here.try_fall( pos_bub(), this );
-        here.update_visibility_cache( pos_bub().z() );
+    gravity_check( here );
+}
+
+void Character::gravity_check( map *here )
+{
+    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
+        here->try_fall( pos, this ) ) {
+        here->update_visibility_cache( pos.z() );
     }
 }
 
@@ -13273,6 +13280,7 @@ bool Character::can_fly()
 // FIXME: Relies on hardcoded bash damage type
 void Character::knock_back_to( const tripoint_bub_ms &to )
 {
+    map &here = get_map();
     if( to == pos_bub() ) {
         return;
     }
@@ -13292,7 +13300,7 @@ void Character::knock_back_to( const tripoint_bub_ms &to )
             critter->apply_damage( this, bodypart_id( "torso" ), ( str_max - 6 ) / 4 );
             critter->add_effect( effect_stunned, 1_turns );
         }
-        critter->check_dead_state();
+        critter->check_dead_state( &here );
 
         add_msg_player_or_npc( _( "You bounce off a %s!" ), _( "<npcname> bounces off a %s!" ),
                                critter->name() );
@@ -13306,11 +13314,10 @@ void Character::knock_back_to( const tripoint_bub_ms &to )
         np->deal_damage( this, bodypart_id( "torso" ), damage_instance( damage_bash, 3 ) );
         add_msg_player_or_npc( _( "You bounce off %s!" ), _( "<npcname> bounces off %s!" ),
                                np->get_name() );
-        np->check_dead_state();
+        np->check_dead_state( &here );
         return;
     }
 
-    map &here = get_map();
     // If we're still in the function at this point, we're actually moving a tile!
     if( here.has_flag( ter_furn_flag::TFLAG_LIQUID, to ) &&
         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, to ) ) {
@@ -13383,10 +13390,10 @@ void Character::leak_items()
     }
 }
 
-void Character::process_items()
+void Character::process_items( map *here )
 {
-    if( weapon.process( get_map(), this, pos_bub() ) ) {
-        weapon.spill_contents( pos_bub() );
+    if( weapon.process( here[0], this, here->get_bub( pos_abs() ) ) ) {
+        weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
         remove_weapon();
     }
 
@@ -13395,8 +13402,8 @@ void Character::process_items()
         if( !it ) {
             continue;
         }
-        if( it->process( get_map(), this, pos_bub() ) ) {
-            it->spill_contents( pos_bub() );
+        if( it->process( here[0], this, here->get_bub( pos_abs() ) ) ) {
+            it->spill_contents( here, here->get_bub( pos_abs() ) );
             removed_items.push_back( it );
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4039,7 +4039,7 @@ void Character::normalize()
 }
 
 // Actual player death is mostly handled in game::is_game_over
-void Character::die( map *here, Creature *nkiller )
+void Character::die( map *, Creature *nkiller )
 {
     g->set_critter_died();
     set_all_parts_hp_cur( 0 );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13392,7 +13392,7 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( here[0], this, here->get_bub( pos_abs() ) ) ) {
+    if( weapon.process( *here, this, here->get_bub( pos_abs() ) ) ) {
         weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
         remove_weapon();
     }
@@ -13402,7 +13402,7 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( here[0], this, here->get_bub( pos_abs() ) ) ) {
+        if( it->process( *here, this, here->get_bub( pos_abs() ) ) ) {
             it->spill_contents( here, here->get_bub( pos_abs() ) );
             removed_items.push_back( it );
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2580,7 +2580,6 @@ void Character::process_turn()
     }
 
     // TODO: Maybe a unified function for terrain effects?
-    map &here = get_map();
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
         !here.has_vehicle_floor( pos_bub() ) && !has_effect( effect_bouldering ) ) {
         add_effect( effect_bouldering, 1_turns, true );
@@ -11595,7 +11594,7 @@ void Character::process_effects()
 void Character::gravity_check()
 {
     map &here = get_map();
-    gravity_check( here );
+    gravity_check( &here );
 }
 
 void Character::gravity_check( map *here )

--- a/src/character.h
+++ b/src/character.h
@@ -760,6 +760,7 @@ class Character : public Creature, public visitable
 
         // Wile E Coyote looking down.
         void gravity_check() override;
+        void gravity_check( map *here ) override;
         // For events which might cause a stagger, such as missing an attack on unstable ground.
         void stagger_check();
         // Called by stagger_check(), or directly by things like being drunk.
@@ -1315,7 +1316,7 @@ class Character : public Creature, public visitable
 
         // any side effects that might happen when the Character is hit
         /** Handles special defenses from melee attack that hit us (source can be null) */
-        void on_hit( Creature *source, bodypart_id bp_hit,
+        void on_hit( map *here, Creature *source, bodypart_id bp_hit,
                      float difficulty = INT_MIN, dealt_projectile_attack const *proj = nullptr ) override;
         // any side effects that might happen when the Character hits a Creature
         void did_hit( Creature &target );
@@ -1938,7 +1939,7 @@ class Character : public Creature, public visitable
         virtual item::reload_option select_ammo( const item_location &base, bool prompt = false,
                 bool empty = true ) = 0;
 
-        void process_items();
+        void process_items( map *here );
         void leak_items();
         /** Search surrounding squares for traps (and maybe other things in the future). */
         void search_surroundings();
@@ -2619,7 +2620,7 @@ class Character : public Creature, public visitable
          *  Should only be called through player::normalize(), not on it's own!
          */
         void normalize() override;
-        void die( Creature *nkiller ) override;
+        void die( map *here, Creature *nkiller ) override;
         virtual void prevent_death();
 
         std::string get_name() const override;
@@ -3338,7 +3339,7 @@ class Character : public Creature, public visitable
         */
         bool sees_with_infrared( const Creature &critter ) const;
         // Put corpse+inventory on map at the place where this is.
-        void place_corpse();
+        void place_corpse( map *here );
         // Put corpse+inventory on defined om tile
         void place_corpse( const tripoint_abs_omt &om_target );
 

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -589,7 +589,7 @@ void computer_session::action_terminate()
               t_south == ter_t_concrete_wall ) ||
             ( t_south == ter_t_reinforced_glass &&
               t_north == ter_t_concrete_wall ) ) {
-            mon->die( &player_character );
+            mon->die( &here, &player_character );
         }
     }
     query_any( _( "Subjects terminated.  Press any key…" ) );

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -358,7 +358,7 @@ void Creature::gravity_check()
 {
 }
 
-void Creature::gravity_check( map *here )
+void Creature::gravity_check( map * )
 {
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -209,7 +209,7 @@ tripoint_bub_ms Creature::pos_bub() const
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     map &here = get_map();
-    setpos( here, p, check_gravity );
+    setpos( &here, p, check_gravity );
 }
 
 void Creature::setpos( map *here, const tripoint_bub_ms &p, bool check_gravity/* = true*/ )

--- a/src/creature.h
+++ b/src/creature.h
@@ -46,6 +46,7 @@ class effects_map;
 class field;
 class field_entry;
 class item;
+class map;
 class monster;
 class nc_color;
 class npc;
@@ -317,7 +318,9 @@ class Creature : public viewer
             return pos_abs().z();
         }
         virtual void gravity_check();
+        virtual void gravity_check( map *here );
         void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
+        void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
 
         // Convert size to int. TODO: use this everywhere instead of enuming every time.
         int enum_size() const;
@@ -341,7 +344,7 @@ class Creature : public viewer
         /** Adds an appropriate blood splatter. */
         virtual void bleed() const;
         /** Empty function. Should always be overwritten by the appropriate player/NPC/monster version. */
-        virtual void die( Creature *killer ) = 0;
+        virtual void die( map *here, Creature *killer ) = 0;
 
         /** Should always be overwritten by the appropriate player/NPC/monster version. */
         virtual float hit_roll() const = 0;
@@ -472,7 +475,7 @@ class Creature : public viewer
 
         // Makes a ranged projectile attack against the creature
         // Sets relevant values in `attack`.
-        virtual void deal_projectile_attack( Creature *source, dealt_projectile_attack &attack,
+        virtual void deal_projectile_attack( map *here, Creature *source, dealt_projectile_attack &attack,
                                              const double &missed_by = 0,
                                              bool print_messages = true, const weakpoint_attack &wp_attack = weakpoint_attack() );
 
@@ -539,7 +542,7 @@ class Creature : public viewer
          * This creature just got hit by an attack - possibly special/ranged attack - from source.
          * Players should train dodge, possibly counter-attack somehow.
          */
-        virtual void on_hit( Creature *source, bodypart_id bp_hit,
+        virtual void on_hit( map *here, Creature *source, bodypart_id bp_hit,
                              float difficulty = INT_MIN, dealt_projectile_attack const *proj = nullptr ) = 0;
 
         /** Returns true if this monster has a gun-type attack or the RANGED_ATTACKER flag*/
@@ -611,7 +614,7 @@ class Creature : public viewer
          * much damage has been dealt, how the attack was performed, what has been blocked...), do
          * it *before* calling this function.
          */
-        void check_dead_state();
+        void check_dead_state( map *here );
 
         /** Processes move stopping effects. Returns false if movement is stopped. */
         virtual bool move_effects( bool attacking, tripoint_bub_ms dest_loc ) = 0;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3326,7 +3326,7 @@ static void damage_self()
     if( query_int( dbg_damage, _( "Damage self for how much?  HP: %s" ), part.id().c_str() ) ) {
         player_character.apply_damage( nullptr, part, dbg_damage );
         if( player_character.is_dead_state() ) {
-            player_character.die( nullptr );
+            player_character.die( &get_map(), nullptr );
         }
     }
 }
@@ -3421,6 +3421,7 @@ static void import_folower()
 
 static void kill_area()
 {
+    map &here = get_map();
     static_popup popup;
     popup.on_top( true );
     popup.message( "%s", _( "Select first point." ) );
@@ -3450,7 +3451,7 @@ static void kill_area()
     } );
 
     for( Creature *critter : creatures ) {
-        critter->die( nullptr );
+        critter->die( &here, nullptr );
     }
 
     g->cleanup_dead();
@@ -3952,7 +3953,7 @@ void debug()
                 // Use the normal death functions, useful for testing death
                 // and for getting a corpse.
                 if( critter.type->id != mon_generator ) {
-                    critter.die( nullptr );
+                    critter.die( &here, nullptr );
                 }
             }
             g->cleanup_dead();

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -267,6 +267,9 @@ void monmove()
     avatar &u = get_avatar();
 
     for( monster &critter : g->all_monsters() ) {
+        if( !m.inbounds( critter.pos_abs() ) ) {
+            continue;
+        }
         // Critters in impassable tiles get pushed away, unless it's not impassable for them
         if( !critter.is_dead() && ( m.impassable( critter.pos_bub() ) &&
                                     !m.get_impassable_field_at( critter.pos_bub() ).has_value() ) &&

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -291,7 +291,7 @@ void monmove()
             }
             if( !okay ) {
                 // die of "natural" cause (overpopulation is natural)
-                critter.die( nullptr );
+                critter.die( &m, nullptr );
             }
         }
 

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -350,7 +350,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
             const int actual_dmg = std::max( 0.0, rng_float( ( -dmg * 0.5 ) / critter->ranged_target_size(),
                                              dmg * 3 ) );
             critter->apply_damage( mutable_source, bodypart_id( "torso" ), actual_dmg );
-            critter->check_dead_state();
+            critter->check_dead_state( m );
             add_msg_debug( debugmode::DF_EXPLOSION, "Blast hits %s for %d damage", critter->disp_name(),
                            actual_dmg );
             continue;
@@ -470,7 +470,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
             frag.proj.impact = damage_instance( damage_bullet, damage );
             for( int i = 0; i < hits; ++i ) {
                 frag.missed_by = rng_float( 0.05, 1.0 / critter->ranged_target_size() );
-                critter->deal_projectile_attack( mutable_source, frag, frag.missed_by, false );
+                critter->deal_projectile_attack( m, mutable_source, frag, frag.missed_by, false );
                 add_msg_debug( debugmode::DF_EXPLOSION, "Shrapnel hit %s at %d m/s at a distance of %d",
                                critter->disp_name(),
                                frag.proj.speed, static_cast<int>( std::round( trig_dist_z_adjust( src.raw(), target.raw() ) ) ) );
@@ -757,7 +757,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 }
                 int dam = dice( 10, 10 );
                 critter.apply_damage( nullptr, bodypart_id( "torso" ), dam );
-                critter.check_dead_state();
+                critter.check_dead_state( &here );
                 if( !critter.is_dead() && one_in( 6 ) ) {
                     critter.make_friendly();
                 }
@@ -777,7 +777,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 }
                 critter.add_effect( effect_emp, 1_minutes );
                 critter.apply_damage( nullptr, bodypart_id( "torso" ), dam );
-                critter.check_dead_state();
+                critter.check_dead_state( &here );
             }
         } else if( sight ) {
             add_msg( _( "The %s is unaffected by the EMP blast." ), critter.name() );
@@ -965,6 +965,7 @@ void process_explosions()
             process_explosions_in_progress = true;
             m.load( origo, false, false );
             m.spawn_monsters( true, true );
+            g->load_npcs( &m );
             process_explosions_in_progress = false;
             _make_explosion( &m, ex.source, m.get_bub( ex.pos ), ex.data );
         } else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1230,8 +1230,9 @@ vehicle *game::place_vehicle_nearby(
 //Make any nearby overmap npcs active, and put them in the right location.
 void game::load_npcs()
 {
+    map &here = get_map();
     const int radius = HALF_MAPSIZE - 1;
-    const tripoint_abs_sm abs_sub( get_map().get_abs_sub() );
+    const tripoint_abs_sm abs_sub( here.get_abs_sub() );
     const half_open_rectangle<point_abs_sm> map_bounds( abs_sub.xy(), abs_sub.xy() + point( MAPSIZE,
             MAPSIZE ) );
     // uses submap coordinates
@@ -1262,14 +1263,14 @@ void game::load_npcs()
 
         add_msg_debug( debugmode::DF_NPC, "game::load_npcs: Spawning static NPC, %s %s",
                        abs_sub.to_string_writable(), sm_loc.to_string_writable() );
-        temp->place_on_map();
+        temp->place_on_map( &here );
         if( !m.inbounds( temp->pos_bub() ) ) {
             continue;
         }
         // In the rare case the npc was marked for death while
         // it was on the overmap. Kill it.
         if( temp->marked_for_death ) {
-            temp->die( nullptr );
+            temp->die( &here, nullptr );
         } else {
             critter_tracker->active_npc.push_back( temp );
             just_added.push_back( temp );
@@ -1277,7 +1278,64 @@ void game::load_npcs()
     }
 
     for( const auto &npc : just_added ) {
-        npc->on_load();
+        npc->on_load( &here );
+    }
+
+    npcs_dirty = false;
+}
+
+void game::load_npcs( map *here )
+{
+    const int mapsize = here->getmapsize();
+    const int radius = mapsize / 2 - 1;
+    const tripoint_abs_sm abs_sub( here->get_abs_sub() );
+    const tripoint_abs_sm center = abs_sub + point_rel_sm{radius, radius};
+    const half_open_rectangle<point_abs_sm> map_bounds( abs_sub.xy(), abs_sub.xy() + point( mapsize,
+            mapsize ) );
+    // uses submap coordinates
+    std::vector<shared_ptr_fast<npc>> just_added;
+    for( const auto &temp : overmap_buffer.get_npcs_near( center, radius ) ) {
+        const character_id &id = temp->getID();
+        const auto found = std::find_if( critter_tracker->active_npc.begin(),
+                                         critter_tracker->active_npc.end(),
+        [id]( const shared_ptr_fast<npc> &n ) {
+            return n->getID() == id;
+        } );
+        if( found != critter_tracker->active_npc.end() ) {
+            continue;
+        }
+        if( temp->is_active() ) {
+            continue;
+        }
+        if( temp->has_companion_mission() ) {
+            continue;
+        }
+
+        const tripoint_abs_sm sm_loc = temp->pos_abs_sm();
+        // NPCs who are out of bounds before placement would be pushed into bounds
+        // This can cause NPCs to teleport around, so we don't want that
+        if( !map_bounds.contains( sm_loc.xy() ) ) {
+            continue;
+        }
+
+        add_msg_debug( debugmode::DF_NPC, "game::load_npcs: Spawning static NPC, %s %s",
+                       abs_sub.to_string_writable(), sm_loc.to_string_writable() );
+        temp->place_on_map( here );
+        if( !here->inbounds( temp->pos_abs() ) ) {
+            continue;
+        }
+        // In the rare case the npc was marked for death while
+        // it was on the overmap. Kill it.
+        if( temp->marked_for_death ) {
+            temp->die( here, nullptr );
+        } else {
+            critter_tracker->active_npc.push_back( temp );
+            just_added.push_back( temp );
+        }
+    }
+
+    for( const auto &npc : just_added ) {
+        npc->on_load( here );
     }
 
     npcs_dirty = false;
@@ -1492,6 +1550,8 @@ void game::set_driving_view_offset( const point_rel_ms &p )
 void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character *p,
                             const time_duration &catch_duration ) // catching function
 {
+    map &here = get_map();
+
     //spawn the corpse, rotten by a part of the duration
     m.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
                            catch_duration ) ) );
@@ -1500,7 +1560,7 @@ void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character
     }
     //quietly kill the caught
     fish->no_corpse_quiet = true;
-    fish->die( p );
+    fish->die( &here, p );
 }
 
 static bool cancel_auto_move( Character &you, const std::string &text )
@@ -2828,6 +2888,8 @@ bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mo
 
 bool game::is_game_over()
 {
+    map &here = get_map();
+
     if( uquit == QUIT_DIED || uquit == QUIT_WATCH ) {
         Creature *player_killer = u.get_killer();
         if( player_killer && player_killer->as_character() ) {
@@ -2850,7 +2912,7 @@ bool game::is_game_over()
         if( u.in_vehicle ) {
             m.unboard_vehicle( u.pos_bub() );
         }
-        u.place_corpse();
+        u.place_corpse( &here );
         return true;
     }
     if( uquit == QUIT_SUICIDE ) {
@@ -4791,6 +4853,8 @@ void game::mon_info_update( )
 
 void game::cleanup_dead()
 {
+    map &here = get_map();
+
     // Dead monsters need to stay in the tracker until everything else that needs to die does so
     // This is because dying monsters can still interact with other dying monsters (@ref Creature::killer)
     bool monster_is_dead = critter_tracker->kill_marked_for_death();
@@ -4799,7 +4863,7 @@ void game::cleanup_dead()
     // can't use all_npcs as that does not include dead ones
     for( const auto &n : critter_tracker->active_npc ) {
         if( n->is_dead() ) {
-            n->die( nullptr ); // make sure this has been called to create corpses etc.
+            n->die( &here, nullptr ); // make sure this has been called to create corpses etc.
             npc_is_dead = true;
         }
     }
@@ -4852,6 +4916,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
     // the header file says higher force causes more damage.
     // perhaps that is what it should do?
     tripoint_bub_ms tp = traj.front();
+    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     if( !creatures.creature_at( tp ) ) {
         debugmsg( _( "Nothing at (%d,%d,%d) to knockback!" ), tp.x(), tp.y(), tp.z() );
@@ -4872,7 +4937,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                     add_msg( _( "%s was stunned!" ), targ->name() );
                     add_msg( _( "%s slammed into an obstacle!" ), targ->name() );
                     targ->apply_damage( nullptr, bodypart_id( "torso" ), dam_mult * force_remaining );
-                    targ->check_dead_state();
+                    targ->check_dead_state( &here );
                 }
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
@@ -4904,7 +4969,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             targ->setpos( traj[i] );
             if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, targ->pos_bub() ) && !targ->can_drown() &&
                 !targ->is_dead() ) {
-                targ->die( nullptr );
+                targ->die( &here, nullptr );
                 if( u.sees( *targ ) ) {
                     add_msg( _( "The %s drowns!" ), targ->name() );
                 }
@@ -4912,7 +4977,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             if( !m.has_flag( ter_furn_flag::TFLAG_LIQUID, targ->pos_bub() ) &&
                 targ->has_flag( mon_flag_AQUATIC ) &&
                 !targ->is_dead() ) {
-                targ->die( nullptr );
+                targ->die( &here, nullptr );
                 if( u.sees( *targ ) ) {
                     add_msg( _( "The %s flops around and dies!" ), targ->name() );
                 }
@@ -4946,7 +5011,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                             targ->deal_damage( nullptr, bp, damage_instance( damage_bash, force_remaining * dam_mult ) );
                         }
                     }
-                    targ->check_dead_state();
+                    targ->check_dead_state( &here );
                 }
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
@@ -5019,7 +5084,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                             u.deal_damage( nullptr, bp, damage_instance( damage_bash, force_remaining * dam_mult ) );
                         }
                     }
-                    u.check_dead_state();
+                    u.check_dead_state( &here );
                 }
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
@@ -5561,6 +5626,13 @@ bool game::is_empty( const tripoint_bub_ms &p )
     map &here = get_map();
 
     return ( here.passable( p ) || here.has_flag( ter_furn_flag::TFLAG_LIQUID, p ) ) &&
+           get_creature_tracker().creature_at( p ) == nullptr;
+}
+
+bool game::is_empty( map *here, const tripoint_abs_ms &p )
+{
+    const tripoint_bub_ms pos = here->get_bub( p );
+    return ( here->passable( pos ) || here->has_flag( ter_furn_flag::TFLAG_LIQUID, pos ) ) &&
            get_creature_tracker().creature_at( p ) == nullptr;
 }
 
@@ -11964,6 +12036,7 @@ void game::water_affect_items( Character &ch ) const
 bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bool controlled,
                            bool intentional )
 {
+    map &here = get_map();
     if( c == nullptr ) {
         debugmsg( "game::fling_creature invoked on null target" );
         return false;
@@ -12046,7 +12119,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                                              ( damage - critter.get_armor_type( damage_bash, bodypart_id( "torso" ) ) ) * 6 );
             // TODO: Pass the "flinger" here - it's not the flung critter that deals damage
             critter.apply_damage( c, bodypart_id( "torso" ), zed_damage );
-            critter.check_dead_state();
+            critter.check_dead_state( &here );
             if( !critter.is_dead() ) {
                 thru = false;
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5636,13 +5636,6 @@ bool game::is_empty( map *here, const tripoint_abs_ms &p )
            get_creature_tracker().creature_at( p ) == nullptr;
 }
 
-bool game::is_empty( map *here, const tripoint_abs_ms &p )
-{
-    const tripoint_bub_ms pos = here->get_bub( p );
-    return ( here->passable( pos ) || here->has_flag( ter_furn_flag::TFLAG_LIQUID, pos ) ) &&
-           get_creature_tracker().creature_at( p ) == nullptr;
-}
-
 bool game::is_in_sunlight( const tripoint_bub_ms &p )
 {
     return !is_sheltered( p ) &&

--- a/src/game.h
+++ b/src/game.h
@@ -545,6 +545,7 @@ class game
         npc *find_npc_by_unique_id( const std::string &unique_id );
         /** Makes any nearby NPCs on the overmap active. */
         void load_npcs();
+        void load_npcs( map *here );
 
         /** NPCs who saw player interacting with their stuff (disassembling, cutting etc)
         * will notify the player that thievery was witnessed and make angry at the player. */

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -421,7 +421,7 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
             critter.die_in_explosion( nullptr );
         } else {
             critter.apply_damage( nullptr, bodypart_id( "torso" ), bash_dmg );
-            critter.check_dead_state();
+            critter.check_dead_state( &m );
         }
         if( !critter.is_dead() && critter.get_size() >= creature_size::huge ) {
             // big critters simply prevent the gate from closing

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1114,7 +1114,7 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
                                      rng( 0, static_cast<int>( vol * .5 ) ) ) );
                     }
                     remove_weapon();
-                    check_dead_state();
+                    check_dead_state( &here );
                 }
             }
         }
@@ -2259,6 +2259,8 @@ static std::map<action_id, std::string> get_actions_disabled_mounted()
 bool game::do_regular_action( action_id &act, avatar &player_character,
                               const std::optional<tripoint_bub_ms> &mouse_target )
 {
+    map &here = get_map();
+
     item_location weapon = player_character.get_wielded_item();
     const bool in_shell = player_character.has_active_mutation( trait_SHELL2 )
                           || player_character.has_active_mutation( trait_SHELL3 );
@@ -2832,7 +2834,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( query_yn( _( "Abandon this character?" ) ) ) {
                 if( query_yn( _( "This will kill your character.  Continue?" ) ) ) {
                     player_character.set_moves( 0 );
-                    player_character.place_corpse();
+                    player_character.place_corpse( &here );
                     uquit = QUIT_SUICIDE;
                 }
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10433,6 +10433,15 @@ bool item::spill_contents( const tripoint_bub_ms &pos )
     return contents.spill_contents( pos );
 }
 
+bool item::spill_contents( map *here, const tripoint_bub_ms &pos )
+{
+    if( ( !is_container() && !is_magazine() && !uses_magazine() ) ||
+        is_container_empty() ) {
+        return true;
+    }
+    return contents.spill_contents( here, pos );
+}
+
 bool item::spill_open_pockets( Character &guy, const item *avoid )
 {
     return contents.spill_open_pockets( guy, avoid );

--- a/src/item.h
+++ b/src/item.h
@@ -1842,6 +1842,7 @@ class item : public visitable
          * @return If the item is now empty.
          */
         bool spill_contents( const tripoint_bub_ms &pos );
+        bool spill_contents( map *here, const tripoint_bub_ms &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         // spill items that don't fit in the container
         void overflow( const tripoint_bub_ms &pos, const item_location &loc = item_location::nowhere );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1227,6 +1227,17 @@ bool item_contents::spill_contents( const tripoint_bub_ms &pos )
     return spilled;
 }
 
+bool item_contents::spill_contents( map *here, const tripoint_bub_ms &pos )
+{
+    bool spilled = false;
+    for( item_pocket &pocket : contents ) {
+        if( !pocket.get_pocket_data()->_no_unload ) {
+            spilled = pocket.spill_contents( here, pos ) || spilled;
+        }
+    }
+    return spilled;
+}
+
 void item_contents::overflow( const tripoint_bub_ms &pos, const item_location &loc )
 {
     for( item_pocket &pocket : contents ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -25,6 +25,7 @@ class JsonOut;
 class item;
 class item_location;
 class iteminfo_query;
+class map;
 struct iteminfo;
 struct tripoint;
 
@@ -290,7 +291,8 @@ class item_contents
         item_pocket *contained_where( const item &contained );
         void on_pickup( Character &guy, item *avoid = nullptr );
         bool spill_contents( const tripoint_bub_ms &pos );
-        // spill items that don't fit in the container
+        bool spill_contents( map *here, const tripoint_bub_ms &pos );
+        /** Spill items that don't fit in the container. */
         void overflow( const tripoint_bub_ms &pos, const item_location &loc );
         void clear_items();
         // clears all items from magazine type pockets

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2062,14 +2062,18 @@ void item_pocket::on_contents_changed()
 
 bool item_pocket::spill_contents( const tripoint_bub_ms &pos )
 {
+    return item_pocket::spill_contents( &get_map(), pos );
+}
+
+bool item_pocket::spill_contents( map *here, const tripoint_bub_ms &pos )
+{
     if( is_type( pocket_type::E_FILE_STORAGE ) ||
         is_type( pocket_type::CORPSE ) || is_type( pocket_type::CABLE ) ) {
         return false;
     }
 
-    map &here = get_map();
     for( item &it : contents ) {
-        here.add_item_or_charges( pos, it );
+        here->add_item_or_charges( pos, it );
     }
 
     contents.clear();

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -28,6 +28,7 @@ class JsonObject;
 class JsonOut;
 class item;
 class item_location;
+class map;
 class pocket_data;
 struct iteminfo;
 struct itype;
@@ -293,6 +294,7 @@ class item_pocket
         // spills any contents that can't fit into the pocket, largest items first
         void overflow( const tripoint_bub_ms &pos, const item_location &loc );
         bool spill_contents( const tripoint_bub_ms &pos );
+        bool spill_contents( map *here, const tripoint_bub_ms &pos );
         void on_pickup( Character &guy, item *avoid = nullptr );
         void on_contents_changed();
         void handle_liquid_or_spill( Character &guy, const item *avoid = nullptr );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -749,7 +749,7 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms 
                                                 critter.name() );
                     }
                     if( !critter.make_fungus() ) {
-                        critter.die( p ); // counts as kill by player
+                        critter.die( &here, p ); // counts as kill by player
                     }
                 } else {
                     g->place_critter_at( mon_spore, dest );
@@ -1571,6 +1571,8 @@ std::optional<int> iuse::mycus( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     if( !it->is_comestible() ) {
         p->add_msg_if_player( _( "You doubt someone would want to eat %1$s." ), it->tname() );
         return std::nullopt;
@@ -1626,7 +1628,7 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms 
         if( halluc && one_in( 4 ) ) {
             p->add_msg_if_player( _( "You try to feed the %1$s some %2$s, but it vanishes!" ),
                                   mon->type->nname(), it->tname() );
-            mon->die( nullptr );
+            mon->die( &here, nullptr );
             return std::nullopt;
         }
 
@@ -4064,6 +4066,8 @@ std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     if( !p ) {
         debugmsg( "%s called action solarpack_off that requires character but no character is present",
                   it->typeId().str() );
@@ -4080,7 +4084,7 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_b
     // 3 = "_on"
     it->convert( itype_id( it->typeId().str().substr( 0,
                            it->typeId().str().size() - 3 ) ), p ).active = false;
-    p->process_items(); // Process carried items to disconnect any connected cables
+    p->process_items( &here ); // Process carried items to disconnect any connected cables
     return 0;
 }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -693,7 +693,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                         val.amount = roll_remainder( val.amount / multishot );
                     }
                     for( int i = 0; i < multishot; ++i ) {
-                        cr->deal_projectile_attack( cr, atk, atk.missed_by, true );
+                        cr->deal_projectile_attack( &here, cr, atk, atk.missed_by, true );
                     }
                 } else if( sp.has_flag( spell_flag::SPLIT_DAMAGE ) ) {
                     int amount_of_bp = target_bdpts.size();
@@ -711,7 +711,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                         }
                     }
                 } else {
-                    cr->deal_projectile_attack( &caster, atk, atk.missed_by, true );
+                    cr->deal_projectile_attack( &here, &caster, atk, atk.missed_by, true );
                 }
             }
             // If the target is a monster:
@@ -721,7 +721,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                         val.amount = cr->get_hp() * sp.damage( caster ) / 100.0;
                     }
                 }
-                cr->deal_projectile_attack( &caster, atk, atk.missed_by, true );
+                cr->deal_projectile_attack( &here, &caster, atk, atk.missed_by, true );
             }
         } else if( sp.damage( caster ) < 0 ) {
             sp.heal( target, caster );
@@ -1934,6 +1934,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
 
 void spell_effect::banishment( const spell &sp, Creature &caster, const tripoint_bub_ms &target )
 {
+    auto &here = get_map(); // "map" is overridden by a spell_effect operation...
     int total_dam = sp.damage( caster );
     if( total_dam <= 0 ) {
         debugmsg( "ERROR: Banishment has negative or 0 damage value" );
@@ -2001,7 +2002,7 @@ void spell_effect::banishment( const spell &sp, Creature &caster, const tripoint
         caster.add_msg_if_player( m_good, string_format( _( "%s banished." ), mon->name() ) );
         // banished monsters take their stuff with them
         mon->death_drops = false;
-        mon->die( &caster );
+        mon->die( &here, &caster );
     }
 }
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1934,7 +1934,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
 
 void spell_effect::banishment( const spell &sp, Creature &caster, const tripoint_bub_ms &target )
 {
-    auto &here = get_map(); // "map" is overridden by a spell_effect operation...
+    class map &here = get_map(); // "map" is overridden by a spell_effect operation...
     int total_dam = sp.damage( caster );
     if( total_dam <= 0 ) {
         debugmsg( "ERROR: Banishment has negative or 0 damage value" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9693,8 +9693,8 @@ void map::build_obstacle_cache(
     }
     // Iterate over creatures and set them to block their squares relative to their size.
     for( Creature &critter : g->all_creatures() ) {
-        const tripoint_bub_ms loc = critter.pos_bub();
-        if( loc.z() != start.z() ) {
+        const tripoint_bub_ms loc = get_bub( critter.pos_abs() );
+        if( loc.z() != start.z() || !inbounds( loc ) ) {
             continue;
         }
         // TODO: scale this with expected creature "thickness".

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3020,18 +3020,18 @@ void map::drop_fields( const tripoint_bub_ms &p )
     }
 }
 
-void map::drop_creature( const tripoint_bub_ms &p ) const
+void map::drop_creature( const tripoint_bub_ms &p )
 {
     monster *mon_at_p = get_creature_tracker().creature_at<monster>( p );
     if( mon_at_p ) {
-        mon_at_p->gravity_check();
+        mon_at_p->gravity_check( this );
         // Handle character potentially standing on monster ("zed walking")
         drop_creature( p + tripoint::above );
         return;
     }
     Character *char_at_p = get_creature_tracker().creature_at<Character>( p );
     if( char_at_p ) {
-        char_at_p->gravity_check();
+        char_at_p->gravity_check( this );
     }
 }
 
@@ -3978,16 +3978,20 @@ void map::smash_items( const tripoint_bub_ms &p, const int power, const std::str
 
     // Let the player know that the item was damaged if they can see it.
     if( items_destroyed > 1 ) {
-        add_msg_if_player_sees( p, m_bad, _( "The %s destroys several items!" ), cause_message );
+        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+                                _( "The %s destroys several items!" ), cause_message );
     } else if( items_destroyed == 1 && items_damaged == 1 ) {
         //~ %1$s: the cause of destruction, %2$s: destroyed item name
-        add_msg_if_player_sees( p, m_bad, _( "The %1$s destroys the %2$s!" ), cause_message,
+        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+                                _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {
-        add_msg_if_player_sees( p, m_bad, _( "The %s damages several items." ), cause_message );
+        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+                                _( "The %s damages several items." ), cause_message );
     } else if( items_damaged == 1 ) {
         //~ %1$s: the cause of damage, %2$s: damaged item name
-        add_msg_if_player_sees( p, m_bad, _( "The %1$s damages the %2$s." ), cause_message,
+        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad, _( "The %1$s damages the %2$s." ),
+                                cause_message,
                                 damaged_item_name );
     }
 
@@ -4525,7 +4529,7 @@ void map::crush( const tripoint_bub_ms &p )
 
             // Pin whoever got hit
             crushed_player->add_effect( effect_crushed, 1_turns, true );
-            crushed_player->check_dead_state();
+            crushed_player->check_dead_state( this );
         }
     }
 
@@ -4536,7 +4540,7 @@ void map::crush( const tripoint_bub_ms &p )
 
         // Pin whoever got hit
         monhit->add_effect( effect_crushed, 1_turns, true );
-        monhit->check_dead_state();
+        monhit->check_dead_state( this );
     }
 
     if( const optional_vpart_position vp = veh_at( p ) ) {
@@ -5267,7 +5271,7 @@ item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool 
     std::pair<item *, tripoint_bub_ms> ret = _add_item_or_charges( pos, std::move( obj ), copies,
             overflow );
     if( ret.first != nullptr && !ret.first->is_null() ) {
-        return item_location{ map_cursor{ tripoint_bub_ms( ret.second ) }, ret.first };
+        return item_location{ map_cursor{ get_abs( ret.second ) }, ret.first };
     }
 
     return {};

--- a/src/map.h
+++ b/src/map.h
@@ -1672,7 +1672,7 @@ class map
         void drop_items( const tripoint_bub_ms &p );
         void drop_vehicle( const tripoint_bub_ms &p );
         void drop_fields( const tripoint_bub_ms &p );
-        void drop_creature( const tripoint_bub_ms &p ) const;
+        void drop_creature( const tripoint_bub_ms &p );
         /*@}*/
     public:
         /**

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5013,7 +5013,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                 Creature *tmp_critter = get_creature_tracker().creature_at( m.get_abs(
                                             target_pos ), true );
                 if( tmp_critter && !tmp_critter->is_avatar() ) {
-                    tmp_critter->die( nullptr );
+                    tmp_critter->die( &m, nullptr );
                 }
             }
             break;
@@ -5079,7 +5079,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                                                 tripoint_bub_ms( i.x(), i.y(),
                                                         z_level ) ) ), true );
                     if( tmp_critter && !tmp_critter->is_avatar() ) {
-                        tmp_critter->die( nullptr );
+                        tmp_critter->die( &m, nullptr );
                     }
                 }
             }
@@ -5162,7 +5162,7 @@ bool jmapgen_setmap::apply( const mapgendata &dat, const tripoint_rel_ms &offset
                                                     tripoint_bub_ms( tx,
                                                             ty, z_level ) ) ), true );
                         if( tmp_critter && !tmp_critter->is_avatar() ) {
-                            tmp_critter->die( nullptr );
+                            tmp_critter->die( &m, nullptr );
                         }
                     }
                 }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -686,6 +686,8 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
 
 bool melee_actor::call( monster &z ) const
 {
+    map &here = get_map();
+
     Creature *target = find_target( z );
     if( target == nullptr ) {
         return false;
@@ -865,7 +867,7 @@ bool melee_actor::call( monster &z ) const
     dealt_damage.bp_hit = bp_id;
 
     // On hit effects
-    target->on_hit( &z, bp_id );
+    target->on_hit( &here, &z, bp_id );
 
     // Apply onhit self effects
     for( const mon_effect_data &eff : self_effects_onhit ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -587,6 +587,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                                        const matec_id &force_technique,
                                        bool allow_unarmed, int forced_movecost )
 {
+    map &here = get_map();
+
     if( !enough_working_legs() ) {
         if( !movement_mode_is( move_mode_prone ) ) {
             add_msg_if_player( m_bad, _( "Your broken legs cannot hold you and you fall down." ) );
@@ -988,7 +990,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
         }
 
-        t.check_dead_state();
+        t.check_dead_state( &here );
 
         if( t.is_dead_state() ) {
             // trigger martial arts on-kill effects
@@ -1032,11 +1034,11 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     // trigger martial arts on-attack effects
     martial_arts_data->ma_onattack_effects( *this );
     // some things (shattering weapons) can harm the attacking creature.
-    check_dead_state();
+    check_dead_state( &here );
     did_hit( t );
     if( t.as_character() ) {
         dealt_projectile_attack dp = dealt_projectile_attack();
-        t.as_character()->on_hit( this, bodypart_str_id::NULL_ID().id(), 0.0f, &dp );
+        t.as_character()->on_hit( &here, this, bodypart_str_id::NULL_ID().id(), 0.0f, &dp );
     }
     if( drop_weapon && !cur_weap.is_null() && !cur_weap.has_flag( flag_INTEGRATED ) ) {
         map &here = get_map();

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2854,7 +2854,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
         //Kill zombies!  Only works against pre-spawned enemies at the moment...
         Creature *critter = creatures.creature_at( rebase_bub( p ) );
         if( critter != nullptr ) {
-            critter->die( nullptr );
+            critter->die( bay.cast_to_map(), nullptr );
         }
         //Hoover up tasty items!
         map_stack items = bay.i_at( p );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -822,6 +822,8 @@ bool mattack::acid( monster *z )
 
 bool mattack::acid_barf( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -879,7 +881,7 @@ bool mattack::acid_barf( monster *z )
             body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
 
     return true;
 }
@@ -1824,7 +1826,7 @@ bool mattack::vine( monster *z )
             d.add_damage( damage_cut, 8 );
             d.add_damage( damage_bash, 8 );
             critter->deal_damage( z, bphit, d );
-            critter->check_dead_state();
+            critter->check_dead_state( &here );
             z->mod_moves( -to_moves<int>( 1_seconds ) );
             return true;
         }
@@ -2041,6 +2043,7 @@ bool mattack::fungus_big_blossom( monster *z )
 
 bool mattack::fungus_inject( monster *z )
 {
+    map &here = get_map();
     // For faster copy+paste
     Creature *target = &get_player_character();
     Character &player_character = get_player_character();
@@ -2097,14 +2100,16 @@ bool mattack::fungus_inject( monster *z )
                  body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( z, hit,  z->type->melee_skill );
-    player_character.check_dead_state();
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    player_character.check_dead_state( &here );
 
     return true;
 }
 
 bool mattack::fungus_bristle( monster *z )
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     if( player_character.has_trait( trait_THRESH_MARLOSS ) ||
         player_character.has_trait( trait_THRESH_MYCUS ) ) {
@@ -2153,7 +2158,7 @@ bool mattack::fungus_bristle( monster *z )
                                    z->name(), body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
 
     return true;
 }
@@ -2271,7 +2276,7 @@ bool mattack::fungus_fortify( monster *z )
             add_msg( m_bad, _( "A fungal tendril bursts forth from the earth and pierces your %s!" ),
                      body_part_name_accusative( hit ) );
             player_character.deal_damage( z,  hit, damage_instance( damage_cut, rng( 5, 11 ) ) );
-            player_character.check_dead_state();
+            player_character.check_dead_state( &here );
             // Probably doesn't have spores available *just* yet.  Let's be nice.
         } else if( monster *const tendril = g->place_critter_at( mon_fungal_tendril, hit_pos ) ) {
             add_msg( m_bad, _( "A fungal tendril bursts forth from the earth!" ) );
@@ -2311,8 +2316,8 @@ bool mattack::fungus_fortify( monster *z )
                  body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( z, hit,  z->type->melee_skill );
-    player_character.check_dead_state();
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    player_character.check_dead_state( &here );
     return true;
 }
 
@@ -2352,7 +2357,7 @@ bool mattack::depart( monster *z )
     }
     z->no_corpse_quiet = true;
     z->no_extra_death_drops = true;
-    z->die( nullptr );
+    z->die( &here, nullptr );
     return true;
 }
 
@@ -2838,6 +2843,8 @@ bool mattack::check_money_left( monster *z )
 }
 bool mattack::photograph( monster *z )
 {
+    map &here = get_map();
+
     if( !within_visual_range( z, 6 ) ) {
         return false;
     }
@@ -2855,7 +2862,7 @@ bool mattack::photograph( monster *z )
                          z->name() );
                 z->no_corpse_quiet = true;
                 z->no_extra_death_drops = true;
-                z->die( nullptr );
+                z->die( &here, nullptr );
                 return false;
             } else {
                 add_msg( m_info,
@@ -2875,7 +2882,7 @@ bool mattack::photograph( monster *z )
                          z->name() );
                 z->no_corpse_quiet = true;
                 z->no_extra_death_drops = true;
-                z->die( nullptr );
+                z->die( &here, nullptr );
                 return false;
             } else {
                 add_msg( m_info,
@@ -2893,7 +2900,7 @@ bool mattack::photograph( monster *z )
                          z->name() );
                 z->no_corpse_quiet = true;
                 z->no_extra_death_drops = true;
-                z->die( nullptr );
+                z->die( &here, nullptr );
                 return false;
             } else {
                 add_msg( m_info, _( "The %s acknowledges you as SWAT onsite, but hangs around to watch." ),
@@ -2910,7 +2917,7 @@ bool mattack::photograph( monster *z )
             add_msg( m_info, _( "The %s flashes a LED and departs.  The Feds got this." ), z->name() );
             z->no_corpse_quiet = true;
             z->no_extra_death_drops = true;
-            z->die( nullptr );
+            z->die( &here, nullptr );
             return false;
         }
     }
@@ -2978,6 +2985,8 @@ bool mattack::tazer( monster *z )
 
 void mattack::taze( monster *z, Creature *target )
 {
+    map &here = get_map();
+
     // It takes a while
     z->mod_moves( -to_moves<int>( 2_seconds ) );
     if( target == nullptr ) {
@@ -3018,7 +3027,7 @@ void mattack::taze( monster *z, Creature *target )
                                    _( "The %s shocks you!" ),
                                    _( "The %s shocks <npcname>!" ),
                                    z->name() );
-    target->check_dead_state();
+    target->check_dead_state( &here );
 }
 
 void mattack::rifle( monster *z, Creature *target )
@@ -3799,6 +3808,8 @@ bool mattack::upgrade( monster *z )
 
 bool mattack::flesh_golem( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -3853,7 +3864,7 @@ bool mattack::flesh_golem( monster *z )
     //~ 1$s is bodypart name, 2$d is damage value.
     target->add_msg_if_player( m_bad, _( "Your %1$s is battered for %2$d damage!" ),
                                body_part_name( hit ), dam );
-    target->on_hit( z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
 
     return true;
 }
@@ -3915,6 +3926,8 @@ bool mattack::absorb_meat( monster *z )
 
 bool mattack::lunge( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -3983,8 +3996,8 @@ bool mattack::lunge( monster *z )
     if( one_in( 6 ) ) {
         target->add_effect( effect_downed, 3_turns );
     }
-    target->on_hit( z, hit,  z->type->melee_skill );
-    target->check_dead_state();
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->check_dead_state( &here );
     return true;
 }
 
@@ -4570,6 +4583,8 @@ bool mattack::bio_op_random_biojutsu( monster *z )
 
 bool mattack::bio_op_takedown( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -4609,7 +4624,7 @@ bool mattack::bio_op_takedown( monster *z )
         if( seen ) {
             add_msg( _( "%1$s slams %2$s to the ground!" ), z->name(), target->disp_name() );
         }
-        target->check_dead_state();
+        target->check_dead_state( &here );
         return true;
     }
     // Yes, it has the CQC bionic.
@@ -4671,14 +4686,16 @@ bool mattack::bio_op_takedown( monster *z )
         target->add_msg_if_player( m_bad, _( "and slams you for %d damage!" ), dam );
         foe->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_bash, dam ) );
     }
-    target->on_hit( z, hit,  z->type->melee_skill );
-    foe->check_dead_state();
+    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    foe->check_dead_state( &here );
 
     return true;
 }
 
 bool mattack::bio_op_impale( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -4726,7 +4743,7 @@ bool mattack::bio_op_impale( monster *z )
         if( seen ) {
             add_msg( _( "The %1$s impales %2$s!" ), z->name(), target->disp_name() );
         }
-        target->check_dead_state();
+        target->check_dead_state( &here );
         return true;
     }
 
@@ -4749,8 +4766,8 @@ bool mattack::bio_op_impale( monster *z )
                                        _( "but fails to penetrate <npcname>'s armor!" ) );
     }
 
-    target->on_hit( z, hit, z->type->melee_skill );
-    foe->check_dead_state();
+    target->on_hit( &here, z, hit, z->type->melee_skill );
+    foe->check_dead_state( &here );
 
     return true;
 }
@@ -4823,17 +4840,21 @@ bool mattack::bio_op_disarm( monster *z )
 
 bool mattack::suicide( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
     if( !within_target_range( z, target, 2 ) ) {
         return false;
     }
-    z->die( z );
+    z->die( &here, z );
 
     return false;
 }
 
 bool mattack::kamikaze( monster *z )
 {
+    map &here = get_map();
+
     if( z->ammo.empty() ) {
         // We somehow lost our ammo! Toggle this special off so we stop processing
         debugmsg( "Missing ammo in kamikaze special for %s.", z->name() );
@@ -4874,7 +4895,7 @@ bool mattack::kamikaze( monster *z )
     // HACK: HORRIBLE HACK ALERT! Remove the following code completely once we have working monster inventory processing
     if( z->has_effect( effect_countdown ) ) {
         if( z->get_effect( effect_countdown ).get_duration() == 1_turns ) {
-            z->die( nullptr );
+            z->die( &here, nullptr );
             // Timer is out, detonate
             item i_explodes( act_bomb_type, calendar::turn );
             i_explodes.active = true;
@@ -5194,9 +5215,11 @@ bool mattack::stretch_attack( monster *z )
 
 bool mattack::zombie_fuse( monster *z )
 {
+    map &here = get_map();
+
     monster *critter = nullptr;
     creature_tracker &creatures = get_creature_tracker();
-    for( const tripoint_bub_ms &p : get_map().points_in_radius( z->pos_bub(), 1 ) ) {
+    for( const tripoint_bub_ms &p : here.points_in_radius( z->pos_bub(), 1 ) ) {
         critter = creatures.creature_at<monster>( p );
         if( critter != nullptr && critter->faction == z->faction
             && critter != z && critter->get_size() <= z->get_size() ) {
@@ -5230,7 +5253,7 @@ bool mattack::zombie_fuse( monster *z )
     }
     critter->death_drops = false;
     critter->quiet_death = true;
-    critter->die( z );
+    critter->die( &here, z );
     return true;
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -881,7 +881,7 @@ bool mattack::acid_barf( monster *z )
             body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
 
     return true;
 }
@@ -2100,7 +2100,7 @@ bool mattack::fungus_inject( monster *z )
                  body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
     player_character.check_dead_state( &here );
 
     return true;
@@ -2158,7 +2158,7 @@ bool mattack::fungus_bristle( monster *z )
                                    z->name(), body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
 
     return true;
 }
@@ -2316,7 +2316,7 @@ bool mattack::fungus_fortify( monster *z )
                  body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
     player_character.check_dead_state( &here );
     return true;
 }
@@ -3864,7 +3864,7 @@ bool mattack::flesh_golem( monster *z )
     //~ 1$s is bodypart name, 2$d is damage value.
     target->add_msg_if_player( m_bad, _( "Your %1$s is battered for %2$d damage!" ),
                                body_part_name( hit ), dam );
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
 
     return true;
 }
@@ -3996,7 +3996,7 @@ bool mattack::lunge( monster *z )
     if( one_in( 6 ) ) {
         target->add_effect( effect_downed, 3_turns );
     }
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
     target->check_dead_state( &here );
     return true;
 }
@@ -4686,7 +4686,7 @@ bool mattack::bio_op_takedown( monster *z )
         target->add_msg_if_player( m_bad, _( "and slams you for %d damage!" ), dam );
         foe->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_bash, dam ) );
     }
-    target->on_hit( &here, z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
     foe->check_dead_state( &here );
 
     return true;
@@ -5200,7 +5200,7 @@ bool mattack::stretch_attack( monster *z )
                                        z->name(),
                                        body_part_name_accusative( hit ) );
 
-        target->check_dead_state();
+        target->check_dead_state( &here );
     } else {
         target->add_msg_player_or_npc( _( "The %1$s arm hits your %2$s, but glances off your armor!" ),
                                        _( "The %1$s hits <npcname>'s %2$s, but glances off armor!" ),
@@ -5208,7 +5208,7 @@ bool mattack::stretch_attack( monster *z )
                                        body_part_name_accusative( hit ) );
     }
 
-    target->on_hit( z, hit,  z->type->melee_skill );
+    target->on_hit( &here, z, hit, z->type->melee_skill );
 
     return true;
 }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -55,14 +55,14 @@ static const harvest_drop_type_id harvest_drop_flesh( "flesh" );
 
 static const species_id species_ZOMBIE( "ZOMBIE" );
 
-item_location mdeath::normal( monster &z )
+item_location mdeath::normal( map *here, monster &z )
 {
     if( z.no_corpse_quiet ) {
         return {};
     }
 
     if( !z.quiet_death && !z.has_flag( mon_flag_QUIETDEATH ) ) {
-        if( z.type->in_species( species_ZOMBIE ) ) {
+        if( z.type->in_species( species_ZOMBIE ) && get_map().inbounds( z.pos_abs() ) ) {
             sfx::play_variant_sound( "mon_death", "zombie_death", sfx::get_heard_volume( z.pos_bub() ) );
         }
 
@@ -79,16 +79,17 @@ item_location mdeath::normal( monster &z )
         z.bleed(); // leave some blood if we have to
 
         if( pulverized ) {
-            return splatter( z );
+            return splatter( here, z );
         } else {
             const float damage = std::floor( corpse_damage * itype::damage_scale );
-            return make_mon_corpse( z, static_cast<int>( damage ) );
+            return make_mon_corpse( here,  z, static_cast<int>( damage ) );
         }
     }
     return {};
 }
 
-static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &z, int distance,
+static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt, monster &z,
+                            int distance,
                             int pile_size = 1 )
 {
     // can't have less than one item in a pile or it would cause an infinite loop
@@ -97,24 +98,24 @@ static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &
     pile_size = std::min( chunk_amt, pile_size );
     distance = std::abs( distance );
     const item chunk( chunk_name, calendar::turn );
-    map &here = get_map();
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( z.pos_bub() + point( rng( -distance, distance ), rng( -distance,
-                              distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub(), tarp );
+        tripoint_bub_ms tarp( here->get_bub( z.pos_abs() ) + point( rng( -distance, distance ),
+                              rng( -distance,
+                                   distance ) ) );
+        const std::vector<tripoint_bub_ms> traj = line_to( here->get_bub( z.pos_abs() ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
             if( one_in( 2 ) && z.bloodType().id() ) {
-                here.add_splatter( z.bloodType(), tarp );
+                here->add_splatter( z.bloodType(), tarp );
             } else {
-                here.add_splatter( z.gibType(), tarp, rng( 1, j + 1 ) );
+                here->add_splatter( z.gibType(), tarp, rng( 1, j + 1 ) );
             }
-            if( here.impassable( tarp ) ) {
-                here.bash( tarp, distance );
-                if( here.impassable( tarp ) ) {
+            if( here->impassable( tarp ) ) {
+                here->bash( tarp, distance );
+                if( here->impassable( tarp ) ) {
                     // Target is obstacle, not destroyed by bashing,
                     // stop trajectory in front of it, if this is the first
                     // point (e.g. wall adjacent to monster), don't drop anything on it
@@ -129,14 +130,14 @@ static void scatter_chunks( const itype_id &chunk_name, int chunk_amt, monster &
         }
         if( drop_chunks ) {
             for( int i = placed_chunks; i < chunk_amt && i < placed_chunks + pile_size; i++ ) {
-                here.add_item_or_charges( tarp, chunk );
+                here->add_item_or_charges( tarp, chunk );
             }
         }
         placed_chunks += pile_size;
     }
 }
 
-item_location mdeath::splatter( monster &z )
+item_location mdeath::splatter( map *here, monster &z )
 {
     const bool gibbable = !z.type->has_flag( mon_flag_NOGIB );
 
@@ -147,19 +148,21 @@ item_location mdeath::splatter( monster &z )
     const field_type_id type_blood = z.bloodType();
     const field_type_id type_gib = z.gibType();
 
-    map &here = get_map();
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here.points_in_radius( z.pos_bub(), 1 );
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( here->get_bub( z.pos_abs() ),
+                1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
         if( z.type->size >= creature_size::medium ) {
             number_of_gibs += rng( 1, 6 );
-            sfx::play_variant_sound( "mon_death", "zombie_gibbed", sfx::get_heard_volume( z.pos_bub() ) );
+            if( get_map().inbounds( z.pos_abs() ) ) {
+                sfx::play_variant_sound( "mon_death", "zombie_gibbed", sfx::get_heard_volume( z.pos_bub() ) );
+            }
         }
 
         for( int i = 0; i < number_of_gibs; ++i ) {
-            here.add_splatter( type_gib, random_entry( area ), rng( 1, i + 1 ) );
-            here.add_splatter( type_blood, random_entry( area ) );
+            here->add_splatter( type_gib, random_entry( area ), rng( 1, i + 1 ) );
+            here->add_splatter( type_blood, random_entry( area ) );
         }
     }
     // 1% of the weight of the monster is the base, with overflow damage as a multiplier
@@ -179,7 +182,7 @@ item_location mdeath::splatter( monster &z )
                 const int chunk_amt =
                     entry.mass_ratio / overflow_ratio / 10 *
                     z.get_weight() / item::find_type( itype_id( entry.drop ) )->weight;
-                scatter_chunks( itype_id( entry.drop ), chunk_amt, z, gib_distance,
+                scatter_chunks( here, itype_id( entry.drop ), chunk_amt, z, gib_distance,
                                 chunk_amt / ( gib_distance - 1 ) );
                 gibbed_weight -= entry.mass_ratio / overflow_ratio / 20 * to_gram( z.get_weight() );
             }
@@ -188,7 +191,7 @@ item_location mdeath::splatter( monster &z )
             const itype_id &leftover_id = z.type->id->harvest->leftovers;
             const int chunk_amount =
                 gibbed_weight / to_gram( item::find_type( leftover_id )->weight );
-            scatter_chunks( leftover_id, chunk_amount, z, gib_distance,
+            scatter_chunks( here, leftover_id, chunk_amount, z, gib_distance,
                             chunk_amount / ( gib_distance + 1 ) );
         }
         // add corpse with gib flag
@@ -205,7 +208,7 @@ item_location mdeath::splatter( monster &z )
         if( z.has_effect( effect_critter_underfed ) ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here.add_item_ret_loc( z.pos_bub(), corpse );
+        return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
     }
     return {};
 }
@@ -217,7 +220,7 @@ void mdeath::disappear( monster &z )
     }
 }
 
-void mdeath::broken( monster &z )
+void mdeath::broken( map *here, monster &z )
 {
     // Bail out if flagged (simulates eyebot flying away)
     if( z.no_corpse_quiet ) {
@@ -235,8 +238,7 @@ void mdeath::broken( monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    map &here = get_map();
-    here.add_item_or_charges( z.pos_bub(), broken_mon );
+    here->add_item_or_charges( here->get_bub( z.pos_abs() ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -259,15 +261,15 @@ void mdeath::broken( monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here.spawn_items( z.pos_bub(), mags );
+                            here->spawn_items( here->get_bub( z.pos_abs() ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here.spawn_item( z.pos_bub(), ammo_entry.first, ammo_entry.second, 1,
-                                     calendar::turn );
+                    here->spawn_item( here->get_bub( z.pos_abs() ), ammo_entry.first, ammo_entry.second, 1,
+                                      calendar::turn );
                 }
             }
         }
@@ -281,7 +283,7 @@ void mdeath::broken( monster &z )
     }
 }
 
-item_location make_mon_corpse( monster &z, int damageLvl )
+item_location make_mon_corpse( map *here, monster &z, int damageLvl )
 {
     item corpse = item::make_corpse( z.type->id, calendar::turn, z.unique_name, z.get_upgrade_time() );
     // All corpses are at 37 C at time of death
@@ -296,5 +298,5 @@ item_location make_mon_corpse( monster &z, int damageLvl )
     if( z.has_effect( effect_critter_underfed ) ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return get_map().add_item_ret_loc( z.pos_bub(), corpse );
+    return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
 }

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -4,20 +4,21 @@
 
 #include "item.h"
 
+class map;
 class monster;
 
 namespace mdeath
 {
 // Drop a body
-item_location normal( monster &z );
+item_location normal( map *here, monster &z );
 // Overkill splatter (also part of normal under conditions)
-item_location splatter( monster &z );
+item_location splatter( map *here, monster &z );
 // Hallucination disappears
 void disappear( monster &z );
 // Broken robot drop
-void broken( monster &z );
+void broken( map *here, monster &z );
 } //namespace mdeath
 
-item_location make_mon_corpse( monster &z, int damageLvl );
+item_location make_mon_corpse( map *here, monster &z, int damageLvl );
 
 #endif // CATA_SRC_MONDEATH_H

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -47,6 +47,8 @@ void mdefense::none( monster &, Creature *, const dealt_projectile_attack * )
 void mdefense::zapback( monster &m, Creature *const source,
                         dealt_projectile_attack const *proj )
 {
+    map &here = get_map();
+
     if( source == nullptr ) {
         return;
     }
@@ -87,7 +89,7 @@ void mdefense::zapback( monster &m, Creature *const source,
     source->deal_damage( &m, bodypart_id( "arm_l" ), shock );
     source->deal_damage( &m, bodypart_id( "arm_r" ), shock );
 
-    source->check_dead_state();
+    source->check_dead_state( &here );
 }
 
 void mdefense::acidsplash( monster &m, Creature *const source,

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -789,9 +789,11 @@ bool monster::is_aquatic_danger( const tripoint_bub_ms &at_pos ) const
 
 bool monster::die_if_drowning( const tripoint_bub_ms &at_pos, const int chance )
 {
+    map &here = get_map();
+
     if( is_aquatic_danger( at_pos ) && one_in( chance ) ) {
-        add_msg_if_player_sees( pos_bub(), _( "The %s drowns!" ), name() );
-        die( nullptr );
+        add_msg_if_player_sees( at_pos, _( "The %s drowns!" ), name() );
+        die( &here, nullptr );
         return true;
     }
     return false;
@@ -805,6 +807,8 @@ bool monster::die_if_drowning( const tripoint_bub_ms &at_pos, const int chance )
 // 4) Sound-based tracking
 void monster::move()
 {
+    map &here = get_map();
+
     add_msg_debug( debugmode::DF_MONMOVE, "Monster %s starting monmove::move, remaining moves %d",
                    name(), moves );
     // We decrement wandf no matter what.  We'll save our wander_to plans until
@@ -815,10 +819,9 @@ void monster::move()
 
     //Hallucinations have a chance of disappearing each turn
     if( is_hallucination() && one_in( 25 ) ) {
-        die( nullptr );
+        die( &here, nullptr );
         return;
     }
-    map &here = get_map();
     Character &player_character = get_player_character();
 
     behavior::monster_oracle_t oracle( this );
@@ -2079,6 +2082,8 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
 
 bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t depth )
 {
+    map &here = get_map();
+
     if( is_hallucination() ) {
         // Don't let hallucinations push, not even other hallucinations
         return false;
@@ -2103,7 +2108,7 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
 
     if( critter->is_hallucination() ) {
         // Kill the hallu, but return false so that the regular move_to is uses instead
-        critter->die( nullptr );
+        critter->die( &here, nullptr );
         return false;
     }
 
@@ -2115,7 +2120,6 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
         return false;
     }
 
-    map &here = get_map();
     const int movecost_from = 50 * here.move_cost( p );
     const int movecost_attacker = std::max( movecost_from, 200 - 10 * ( attack - defend ) );
     const tripoint_rel_ms dir = p - pos_bub();
@@ -2178,7 +2182,7 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
         critter_recur = creatures.creature_at( dest );
         if( critter_recur != nullptr ) {
             if( critter_recur->is_hallucination() ) {
-                critter_recur->die( nullptr );
+                critter_recur->die( &here, nullptr );
             }
         } else if( !critter->has_flag( mon_flag_IMMOBILE ) ) {
             critter->setpos( tripoint_bub_ms( dest ) );
@@ -2266,12 +2270,14 @@ void monster::stumble()
 
 void monster::knock_back_to( const tripoint_bub_ms &to )
 {
+    map &here = get_map();
+
     if( to == pos_bub() ) {
         return; // No effect
     }
 
     if( is_hallucination() ) {
-        die( nullptr );
+        die( &here, nullptr );
         return;
     }
 
@@ -2290,7 +2296,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
             z->apply_damage( this, bodypart_id( "torso" ), static_cast<float>( type->size ) );
             z->add_effect( effect_stunned, 1_turns );
         }
-        z->check_dead_state();
+        z->check_dead_state( &here );
 
         if( u_see ) {
             add_msg( _( "The %1$s bounces off a %2$s!" ), name(), z->name() );
@@ -2308,7 +2314,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
             add_msg( _( "The %1$s bounces off %2$s!" ), name(), p->get_name() );
         }
 
-        p->check_dead_state();
+        p->check_dead_state( &here );
         return;
     }
 
@@ -2316,13 +2322,12 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
     // die_if_drowning will kill the monster if necessary, but if the deep water
     // tile is on a vehicle, we should check for swimmers out of water
     if( !die_if_drowning( to ) && has_flag( mon_flag_AQUATIC ) ) {
-        die( nullptr );
+        die( &here, nullptr );
         if( u_see ) {
             add_msg( _( "The %s flops around and dies!" ), name() );
         }
     }
 
-    map &here = get_map();
     // It's some kind of wall.
     if( here.impassable( to ) ) {
         const int dam = static_cast<int>( type->size );
@@ -2336,7 +2341,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
     } else { // It's no wall
         setpos( tripoint_bub_ms( to ) );
     }
-    check_dead_state();
+    check_dead_state( &here );
 }
 
 /* will_reach() is used for determining whether we'll get to stairs (and

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3116,7 +3116,7 @@ void monster::die( map *here, Creature *nkiller )
         }
     }
     if( corpse ) {
-        corpse->process( here[0], nullptr, corpse.pos_bub() );
+        corpse->process( *here, nullptr, corpse.pos_bub() );
         if( get_map().inbounds( pos_abs() ) ) {
             corpse.make_active();
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -392,7 +392,7 @@ void monster::gravity_check()
 void monster::gravity_check( map *here )
 {
     const tripoint_bub_ms pos = here->get_bub( pos_abs() );
-    if( here->is_open_air( pos ) && !flies() && !here.has_vehicle_floor( pos_bub() ) ) {
+    if( here->is_open_air( pos ) && !flies() && !here->has_vehicle_floor( pos_bub() ) ) {
         here->try_fall( pos, this );
     }
 }
@@ -2475,7 +2475,7 @@ bool monster::move_effects( bool, tripoint_bub_ms dest_loc )
                 continue;
             }
             if( friendly == 0 ) {
-                on_hit( grabber, bodypart_id( "torso" ), INT_MIN );
+                on_hit( &here, grabber, bodypart_id( "torso" ), INT_MIN );
                 if( type->has_anger_trigger( mon_trigger::HURT ) ) {
                     anger += 5;
                     if( grabber != nullptr && !grabber->is_monster() && !grabber->is_fake() ) {
@@ -2942,7 +2942,7 @@ void monster::die( map *here, Creature *nkiller )
 
     if( has_effect_with_flag( json_flag_GRAB ) ) {
         // The monster on monster stuff is pretty hacky, but has worked out so far.
-        const tripoint_range<tripoint_bub_ms> &surrounding = here.points_in_radius( pos_bub(), 1, 0 );
+        const tripoint_range<tripoint_bub_ms> &surrounding = here->points_in_radius( pos_bub(), 1, 0 );
         Creature *grabber = nullptr;
         for( const effect &grab : get_effects_with_flag( json_flag_GRAB ) ) {
             // Is our grabber around?

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -386,9 +386,14 @@ bool monster::can_upgrade() const
 
 void monster::gravity_check()
 {
-    map &here = get_map();
-    if( here.is_open_air( pos_bub() ) && !flies() && !here.has_vehicle_floor( pos_bub() ) ) {
-        here.try_fall( pos_bub(), this );
+    monster::gravity_check( &get_map() );
+}
+
+void monster::gravity_check( map *here )
+{
+    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    if( here->is_open_air( pos ) && !flies() && !here.has_vehicle_floor( pos_bub() ) ) {
+        here->try_fall( pos, this );
     }
 }
 
@@ -441,6 +446,8 @@ int monster::next_upgrade_time()
 
 void monster::try_upgrade( bool pin_time )
 {
+    map &here = get_map();
+
     if( !can_upgrade() ) {
         return;
     }
@@ -514,7 +521,7 @@ void monster::try_upgrade( bool pin_time )
                     if( type->upgrade_null_despawn ) {
                         g->remove_zombie( *this );
                     } else {
-                        die( nullptr );
+                        die( &here, nullptr );
                     }
                     return;
                 }
@@ -1986,6 +1993,7 @@ bool monster::melee_attack( Creature &target )
 
 bool monster::melee_attack( Creature &target, float accuracy )
 {
+    map &here = get_map();
     // Note: currently this method must consume move even if attack hasn't actually happen
     // otherwise infinite loop will happen
     mod_moves( -type->attack_cost );
@@ -2136,11 +2144,11 @@ bool monster::melee_attack( Creature &target, float accuracy )
         }
     }
 
-    target.check_dead_state();
+    target.check_dead_state( &here );
 
     if( is_hallucination() ) {
         if( one_in( 7 ) ) {
-            die( nullptr );
+            die( &here, nullptr );
         }
         return true;
     }
@@ -2180,7 +2188,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
     return true;
 }
 
-void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack &attack,
+void monster::deal_projectile_attack( map *here, Creature *source, dealt_projectile_attack &attack,
                                       const double &missed_by, bool print_messages,
                                       const weakpoint_attack &wp_attack )
 {
@@ -2197,11 +2205,11 @@ void monster::deal_projectile_attack( Creature *source, dealt_projectile_attack 
         return;
     }
 
-    Creature::deal_projectile_attack( source, attack, missed_by, print_messages, wp_attack );
+    Creature::deal_projectile_attack( here, source, attack, missed_by, print_messages, wp_attack );
 
     if( !is_hallucination() && attack.last_hit_critter == this ) {
         // Maybe TODO: Get difficulty from projectile speed/size/missed_by
-        on_hit( source, bodypart_id( "torso" ), INT_MIN, &attack );
+        on_hit( here, source, bodypart_id( "torso" ), INT_MIN, &attack );
     }
 }
 
@@ -2277,8 +2285,10 @@ void monster::apply_damage( Creature *source, bodypart_id /*bp*/, int dam,
 
 void monster::die_in_explosion( Creature *source )
 {
+    map &here = get_map();
+
     hp = -9999; // huge to trigger explosion and prevent corpse item
-    die( source );
+    die( &here, source );
 }
 
 void monster::heal_bp( bodypart_id, int dam )
@@ -2903,7 +2913,7 @@ void monster::process_turn()
     Creature::process_turn();
 }
 
-void monster::die( Creature *nkiller )
+void monster::die( map *here, Creature *nkiller )
 {
     if( dead ) {
         // We are already dead, don't die again, note that monster::dead is
@@ -2928,7 +2938,6 @@ void monster::die( Creature *nkiller )
             get_event_bus().send_with_talker( ch, this, e );
         }
     }
-    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
 
     if( has_effect_with_flag( json_flag_GRAB ) ) {
@@ -2958,15 +2967,16 @@ void monster::die( Creature *nkiller )
     }
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here.points_in_radius( pos_bub(), 1, 0 ) ) {
-            Creature *you = creatures.creature_at( player_pos );
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( here->get_bub( pos_abs() ), 1,
+                0 ) ) {
+            Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
                 continue;
             }
             // ...but if there are no grabbers around we can just skip to the end
             bool grabbed = false;
-            for( const tripoint_bub_ms &mon_pos : here.points_in_radius( player_pos, 1, 0 ) ) {
-                const monster *const mon = creatures.creature_at<monster>( mon_pos );
+            for( const tripoint_bub_ms &mon_pos : here->points_in_radius( player_pos, 1, 0 ) ) {
+                const monster *const mon = creatures.creature_at<monster>( here->get_abs( mon_pos ) );
                 // No persisting our grabs from beyond the grave, but we also don't get to remove the effect early
                 if( mon && mon->has_effect_with_flag( json_flag_GRAB_FILTER ) && mon != this ) {
                     grabbed = true;
@@ -2996,7 +3006,7 @@ void monster::die( Creature *nkiller )
     if( !is_hallucination() && has_flag( mon_flag_QUEEN ) ) {
         // The submap coordinates of this monster, monster groups coordinates are
         // submap coordinates.
-        const tripoint_abs_sm abssub = coords::project_to<coords::sm>( here.get_abs( pos_bub() ) );
+        const tripoint_abs_sm abssub = coords::project_to<coords::sm>( pos_abs() );
         // Do it for overmap above/below too
         for( const tripoint_abs_sm &p : points_in_radius( abssub, HALF_MAPSIZE, 1 ) ) {
             for( mongroup *&mgp : overmap_buffer.groups_at( p ) ) {
@@ -3020,10 +3030,13 @@ void monster::die( Creature *nkiller )
         //Not a hallucination, go process the death effects.
         spell death_spell = type->mdeath_effect.sp.get_spell( *this );
         if( killer != nullptr && !type->mdeath_effect.sp.self &&
-            death_spell.is_target_in_range( *this, killer->pos_bub() ) ) {
-            death_spell.cast_all_effects( *this, killer->pos_bub() );
+            // TODO: Get the death_spell stuff to work on any map.
+            death_spell.is_target_in_range( *this,
+                                            killer->pos_bub() ) ) { // The operation called uses reality bubble internally
+            death_spell.cast_all_effects( *this,
+                                          killer->pos_bub() );      // ditto, so we should feed them pos_bub().
         } else if( type->mdeath_effect.sp.self ) {
-            death_spell.cast_all_effects( *this, pos_bub() );
+            death_spell.cast_all_effects( *this, pos_bub() );              // ditto.
         }
     }
 
@@ -3049,13 +3062,13 @@ void monster::die( Creature *nkiller )
     // drop a corpse, or not - this needs to happen after the spell, for e.g. revivification effects
     switch( type->mdeath_effect.corpse_type ) {
         case mdeath_type::NORMAL:
-            corpse =  mdeath::normal( *this );
+            corpse =  mdeath::normal( here, *this );
             break;
         case mdeath_type::BROKEN:
-            mdeath::broken( *this );
+            mdeath::broken( here, *this );
             break;
         case mdeath_type::SPLATTER:
-            corpse = mdeath::splatter( *this );
+            corpse = mdeath::splatter( here, *this );
             break;
         default:
             break;
@@ -3080,7 +3093,7 @@ void monster::die( Creature *nkiller )
     }
 
     if( death_drops && !no_extra_death_drops ) {
-        drop_items_on_death( corpse.get_item() );
+        drop_items_on_death( here, corpse.get_item() );
         spawn_dissectables_on_death( corpse.get_item() );
     }
     if( death_drops && !is_hallucination() ) {
@@ -3091,20 +3104,22 @@ void monster::die( Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                get_map().add_item_or_charges( pos_bub(), it );
+                here->add_item_or_charges( here->get_bub( pos_abs() ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                get_map().add_item( pos_bub(), it );
+                here->add_item( here->get_bub( pos_abs() ), it );
             }
         }
     }
     if( corpse ) {
-        corpse->process( get_map(), nullptr, corpse.pos_bub() );
-        corpse.make_active();
+        corpse->process( here[0], nullptr, corpse.pos_bub() );
+        if( get_map().inbounds( pos_abs() ) ) {
+            corpse.make_active();
+        }
     }
 
     // Adjust anger/morale of nearby monsters, if they have the appropriate trigger and are friendly
@@ -3198,7 +3213,7 @@ void monster::generate_inventory( bool disableDrops )
     no_extra_death_drops = disableDrops;
 }
 
-void monster::drop_items_on_death( item *corpse )
+void monster::drop_items_on_death( map *here, item *corpse )
 {
     if( is_hallucination() ) {
         return;
@@ -3218,7 +3233,7 @@ void monster::drop_items_on_death( item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            get_map().add_item_or_charges( pos_bub(), it );
+            here->add_item_or_charges( here->get_bub( pos_abs() ), it );
         }
         return;
     }
@@ -3852,7 +3867,7 @@ void monster::on_dodge( Creature *, float, float )
     }
 }
 
-void monster::on_hit( Creature *source, bodypart_id,
+void monster::on_hit( map *here, Creature *source, bodypart_id,
                       float, dealt_projectile_attack const *const proj )
 {
     if( is_hallucination() ) {
@@ -3871,14 +3886,13 @@ void monster::on_hit( Creature *source, bodypart_id,
 
     if( trigger ) {
         int light = g->light_level( posz() );
-        map &here = get_map();
         for( monster &critter : g->all_monsters() ) {
             // Do we actually care about this faction?
             if( critter.faction->attitude( faction ) != MFA_FRIENDLY ) {
                 continue;
             }
 
-            if( here.sees( critter.pos_bub(), pos_bub(), light ) ) {
+            if( here->sees( here->get_bub( critter.pos_abs() ), here->get_bub( pos_abs() ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;
@@ -3898,11 +3912,12 @@ void monster::on_hit( Creature *source, bodypart_id,
     }
     if( source != nullptr ) {
         if( Character *attacker = source->as_character() ) {
-            type->families.practice_hit( *attacker );
+            type->families.practice_hit( *attacker );    
+            enchantment_cache->cast_hit_me( *attacker, source );
         }
     }
 
-    check_dead_state();
+    check_dead_state( here );
     // TODO: Faction relations
 }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -33,6 +33,7 @@ class JsonOut;
 class effect;
 class effect_source;
 class item;
+class map;
 struct monster_plan;
 namespace catacurses
 {
@@ -109,6 +110,7 @@ class monster : public Creature
             return faction.id();
         }
         void gravity_check() override;
+        void gravity_check( map *here ) override;
         void poly( const mtype_id &id );
         bool can_upgrade() const;
         void hasten_upgrade();
@@ -362,7 +364,7 @@ class monster : public Creature
         bool melee_attack( Creature &target );
         bool melee_attack( Creature &target, float accuracy );
         void melee_attack( Creature &p, bool ) = delete;
-        void deal_projectile_attack( Creature *source, dealt_projectile_attack &attack,
+        void deal_projectile_attack( map *here, Creature *source, dealt_projectile_attack &attack,
                                      const double &missed_by = 0, bool print_messages = true,
                                      const weakpoint_attack &wp_attack = weakpoint_attack() ) override;
         void deal_damage_handle_type( const effect_source &source, const damage_unit &du, bodypart_id bp,
@@ -436,7 +438,7 @@ class monster : public Creature
         void on_dodge( Creature *source, float difficulty, float training_level = 0.0 ) override;
         void on_try_dodge() override {}
         // Something hit us (possibly null source)
-        void on_hit( Creature *source, bodypart_id bp_hit,
+        void on_hit( map *here, Creature *source, bodypart_id bp_hit,
                      float difficulty = INT_MIN, dealt_projectile_attack const *proj = nullptr ) override;
 
         /** Resets a given special to its monster type cooldown value */
@@ -458,8 +460,8 @@ class monster : public Creature
         /** Resets stats, and applies effects in an idempotent manner */
         void reset_stats() override;
 
-        void die( Creature *killer ) override; //this is the die from Creature, it calls kill_mo
-        void drop_items_on_death( item *corpse );
+        void die( map *here, Creature *killer ) override; //this is the die from Creature, it calls kill_mo
+        void drop_items_on_death( map *here, item *corpse );
         void spawn_dissectables_on_death( item *corpse ) const; //spawn dissectable CBMs into CORPSE pocket
         //spawn monster's inventory without killing it
         void generate_inventory( bool disableDrops = true );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1174,15 +1174,15 @@ void npc::spawn_at_precise( const tripoint_abs_ms &p )
     set_pos_abs_only( p );
 }
 
-void npc::place_on_map()
+void npc::place_on_map( map *here )
 {
-    if( g->is_empty( pos_bub() ) || is_mounted() ) {
+    if( g->is_empty( here, pos_abs() ) || is_mounted() ) {
         return;
     }
 
-    for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), SEEX + 1 ) ) {
-        if( g->is_empty( p ) ) {
-            setpos( p );
+    for( const tripoint_abs_ms &p : closest_points_first( pos_abs(), SEEX + 1 ) ) {
+        if( g->is_empty( here, p ) ) {
+            setpos( here, here->get_bub( p ) );
             return;
         }
     }
@@ -1839,8 +1839,10 @@ void npc::make_angry()
 
 void npc::on_attacked( const Creature &attacker )
 {
+    map &here = get_map();
+
     if( is_hallucination() ) {
-        die( nullptr );
+        die( &here, nullptr );
     }
     if( attacker.is_avatar() && !is_enemy() && !is_dead() && !guaranteed_hostile() ) {
         make_angry();
@@ -2968,7 +2970,7 @@ void npc::reboot()
     add_effect( effect_npc_suspend, 24_hours, true, 1 );
 }
 
-void npc::die( Creature *nkiller )
+void npc::die( map *here, Creature *nkiller )
 {
     if( dead ) {
         // We are already dead, don't die again, note that npc::dead is
@@ -3059,7 +3061,7 @@ void npc::die( Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        get_map().unboard_vehicle( pos_bub(), true );
+        here->unboard_vehicle( here->get_bub( pos_abs() ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3081,7 +3083,7 @@ void npc::die( Creature *nkiller )
         }
     }
     dead = true;
-    Character::die( nkiller );
+    Character::die( here, nkiller );
 
     if( is_hallucination() || lifespan_end ) {
         add_msg_if_player_sees( *this, _( "%s disappears." ), get_name().c_str() );
@@ -3137,7 +3139,7 @@ void npc::die( Creature *nkiller )
         }
     }
 
-    place_corpse();
+    place_corpse( here );
 }
 
 void npc::prevent_death()
@@ -3300,7 +3302,7 @@ void npc::npc_update_body()
     }
 }
 
-void npc::on_load()
+void npc::on_load( map *here )
 {
     const auto advance_effects = [&]( const time_duration & elapsed_dur ) {
         for( auto &elem : *effects ) {
@@ -3354,7 +3356,7 @@ void npc::on_load()
     if( dt > 0_turns ) {
         // This ensures food is properly rotten at load
         // Otherwise NPCs try to eat rotten food and fail
-        process_items();
+        process_items( here );
         // give NPCs that are doing activities a pile of moves
         if( has_destination() || activity ) {
             mod_moves( to_moves<int>( dt ) );
@@ -3364,20 +3366,19 @@ void npc::on_load()
     // Not necessarily true, but it's not a bad idea to set this
     has_new_items = true;
 
-    map &here = get_map();
     // for spawned npcs
-    gravity_check();
-    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
-        !here.has_vehicle_floor( pos_bub() ) ) {
+    gravity_check( here );
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, here->get_bub( pos_abs() ) ) &&
+        !here->has_vehicle_floor( here->get_bub( pos_abs() ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
-    if( here.veh_at( pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here.board_vehicle( pos_bub(), this );
+    if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
+        here->board_vehicle( here->get_bub( pos_abs() ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
-        if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_bub() ) ) {
+        if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {
             mounted_creature = g->shared_from( *mon );
         } else {
             add_msg_debug( debugmode::DF_NPC,

--- a/src/npc.h
+++ b/src/npc.h
@@ -51,6 +51,7 @@
 class JsonObject;
 class JsonOut;
 class JsonValue;
+class map;
 class mission;
 class monfaction;
 class monster;
@@ -815,7 +816,7 @@ class npc : public Character
          * If the square on the map where the NPC would go is not empty
          * a spiral search for an empty square around it is performed.
          */
-        void place_on_map();
+        void place_on_map( map *here );
         /**
          * See @ref dialogue_chatbin::add_new_mission
          */
@@ -1012,7 +1013,7 @@ class npc : public Character
         int indoor_voice() const;
         void decide_needs();
         void reboot();
-        void die( Creature *killer ) override;
+        void die( map *here, Creature *killer ) override;
         bool is_dead() const;
         void prevent_death() override;
         // How well we smash terrain (not corpses!)
@@ -1404,7 +1405,7 @@ class npc : public Character
         /**
          * Retroactively update npc.
          */
-        void on_load();
+        void on_load( map *here );
         /**
          * Update body, but throttled.
          */

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2428,6 +2428,8 @@ healing_options npc::patient_assessment( const Character &c )
 
 npc_action npc::address_needs( float danger )
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     // rng because NPCs are not meant to be hypervigilant hawks that notice everything
     // and swing into action with alarming alacrity.
@@ -2507,7 +2509,7 @@ npc_action npc::address_needs( float danger )
     }
     //Hallucinations have a chance of disappearing each turn
     if( is_hallucination() && one_in( 25 ) ) {
-        die( nullptr );
+        die( &here, nullptr );
     }
 
     if( danger > NPC_DANGER_VERY_LOW ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5203,7 +5203,8 @@ talk_effect_fun_t::func f_attack( const JsonObject &jo, std::string_view member,
 talk_effect_fun_t::func f_die( bool is_npc )
 {
     return [is_npc]( dialogue const & d ) {
-        d.actor( is_npc )->die();
+        map &here = get_map();
+        d.actor( is_npc )->die( &here );
     };
 }
 

--- a/src/talker.h
+++ b/src/talker.h
@@ -780,7 +780,7 @@ class talker: virtual public const_talker
         virtual void set_npc_anger( int ) {}
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
-        virtual void die( map *here ) {}
+        virtual void die( map * ) {}
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_lifestyle( int ) {}

--- a/src/talker.h
+++ b/src/talker.h
@@ -14,6 +14,7 @@
 class computer;
 class faction;
 class item_location;
+class map;
 class mission;
 class monster;
 class npc;
@@ -778,7 +779,8 @@ class talker: virtual public const_talker
         virtual void set_npc_value( int ) {}
         virtual void set_npc_anger( int ) {}
         virtual void set_all_parts_hp_cur( int ) {}
-        virtual void die() {}
+        virtual void set_degradation( int ) {}
+        virtual void die( map *here ) {}
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_lifestyle( int ) {}

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -1320,9 +1320,9 @@ bool talker_character_const::is_warm() const
     return me_chr_const->is_warm();
 }
 
-void talker_character::die()
+void talker_character::die( map *here )
 {
-    me_chr->die( nullptr );
+    me_chr->die( here, nullptr );
 }
 
 matec_id talker_character_const::get_random_technique( Creature const &t, bool crit,

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -16,6 +16,7 @@
 class character_id;
 class faction;
 class item;
+class map;
 
 class time_duration;
 class vehicle;
@@ -322,7 +323,7 @@ class talker_character: virtual public talker
         void remove_bionic( const bionic_id &old_bionic ) override;
         void set_all_parts_hp_cur( int ) override;
         void set_part_hp_cur( const bodypart_id &id, int set ) override;
-        void die() override;
+        void die( map *here ) override;
         void attack_target( Creature &t, bool allow_special, const matec_id &force_technique,
                             bool allow_unarmed, int forced_movecost ) override;
         void learn_martial_art( const matype_id &id ) override;

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -147,7 +147,12 @@ void talker_item::set_all_parts_hp_cur( int set )
     me_it->get_item()->set_damage( me_it->get_item()->max_damage() - set );
 }
 
-void talker_item::die()
+void talker_item::set_degradation( int set )
+{
+    me_it->get_item()->set_degradation( set );
+}
+
+void talker_item::die( map *here )
 {
     me_it->remove_item();
 }

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -152,7 +152,7 @@ void talker_item::set_degradation( int set )
     me_it->get_item()->set_degradation( set );
 }
 
-void talker_item::die( map *here )
+void talker_item::die( map * )
 {
     me_it->remove_item();
 }

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -9,6 +9,7 @@
 #include "type_id.h"
 
 class item;
+class map;
 
 struct tripoint;
 
@@ -84,7 +85,8 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
 
         void set_power_cur( units::energy value ) override;
         void set_all_parts_hp_cur( int ) override;
-        void die() override;
+        void set_degradation( int ) override;
+        void die( map *here ) override;
 
     private:
         item_location *me_it{};

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -215,9 +215,9 @@ bool talker_monster::get_is_alive() const
     return !me_mon->is_dead();
 }
 
-void talker_monster::die()
+void talker_monster::die( map *here )
 {
-    me_mon->die( nullptr );
+    me_mon->die( here, nullptr );
 }
 
 void talker_monster::set_all_parts_hp_cur( int set )

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -14,6 +14,7 @@
 
 class faction;
 class item;
+class map;
 class mission;
 class npc;
 class time_duration;
@@ -121,7 +122,7 @@ class talker_monster: public talker_monster_const, public talker_cloner<talker_m
         void set_morale( int ) override;
         void set_friendly( int ) override;
         bool get_is_alive() const override;
-        void die() override;
+        void die( map *here ) override;
 
         void set_all_parts_hp_cur( int ) override;
         dealt_damage_instance deal_damage( Creature *source, bodypart_id bp,

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -850,9 +850,9 @@ bool talker_npc_const::is_safe() const
     return me_npc->is_safe();
 }
 
-void talker_npc::die()
+void talker_npc::die( map *here )
 {
-    me_npc->die( nullptr );
+    me_npc->die( here, nullptr );
     const shared_ptr_fast<npc> guy = overmap_buffer.find_npc( me_npc->getID() );
     if( guy && !guy->is_dead() ) {
         guy->marked_for_death = true;

--- a/src/talker_npc.h
+++ b/src/talker_npc.h
@@ -12,6 +12,7 @@
 class Character;
 class item;
 class mission;
+class map;
 class talker;
 
 /*
@@ -119,7 +120,7 @@ class talker_npc : virtual public talker_npc_const,
         void add_opinion( const npc_opinion &op ) override;
         bool enslave_mind() override;
         void set_first_topic( const std::string &chat_topic ) override;
-        void die() override;
+        void die( map *here ) override;
         void set_npc_trust( int trust ) override;
         void set_npc_fear( int fear ) override;
         void set_npc_value( int value ) override;

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -124,7 +124,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                     add_msg( m_bad, _( "Your body is torn apart as it is teleported into a solid obstacle." ) );
                 }
             }
-            critter.check_dead_state();
+            critter.check_dead_state( &here );
         }
     }
     //update pos
@@ -187,7 +187,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             if( force ) {
                 //this should only happen through debug menu, so this won't affect the player.
                 poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
-                poor_soul->check_dead_state();
+                poor_soul->check_dead_state( &here );
             } else if( safe ) {
                 if( c_is_u && display_message ) {
                     add_msg( m_bad, _( "You cannot teleport safely." ) );
@@ -233,7 +233,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                             static_cast<float>( poor_soul->get_part_hp_max( bp_id ) ) / static_cast<float>( rng( 6, 12 ) );
                         poor_soul->apply_damage( nullptr, bp_id, damage_to_deal );
                     }
-                    poor_soul->check_dead_state();
+                    poor_soul->check_dead_state( &here );
                 }
             }
         }
@@ -251,7 +251,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 static_cast<float>( critter.get_part_hp_max( bp_id ) ) / static_cast<float>( rng( 6, 12 ) );
             critter.apply_damage( nullptr, bp_id, damage_to_deal );
         }
-        critter.check_dead_state();
+        critter.check_dead_state( &here );
     }
     // Player and npc exclusive teleporting effects
     if( p && add_teleglow ) {

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -142,6 +142,8 @@ bool trapfunc::bubble( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -160,7 +162,7 @@ bool trapfunc::glass( const tripoint_bub_ms &p, Creature *c, item * )
     }
     sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap", "glass" );
     get_map().remove_trap( p );
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -218,7 +220,7 @@ bool trapfunc::beartrap( const tripoint_bub_ms &p, Creature *c, item * )
                 you->add_effect( effect_tetanus, 1_turns, true );
             }
         }
-        c->check_dead_state();
+        c->check_dead_state( &here );
     }
     return true;
 }
@@ -283,7 +285,7 @@ bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
                                random_entry( c->get_ground_contact_bodyparts() ),
                                damage_instance( damage_cut, rng( 3, 5 ) ) );
     try_apply_tetanus( c->as_character(), dd.type_damage( damage_cut ) );
-    c->check_dead_state();
+    c->check_dead_state( &here );
     // Weight of 100kg+ is guaranteed to break the trap, linear chance as weight increases
     if( x_in_y( c->get_weight() / 1_kilogram, 100 ) ) {
         // destroy trap
@@ -339,7 +341,7 @@ bool trapfunc::caltrops( const tripoint_bub_ms &p, Creature *c, item * )
         // 20% chance disarm trap
         here.tr_at( p ).on_disarmed( here, p );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -364,7 +366,7 @@ bool trapfunc::caltrops_glass( const tripoint_bub_ms &p, Creature *c, item * )
     }
     c->deal_damage( nullptr, random_entry( c->get_ground_contact_bodyparts() ),
                     damage_instance( damage_cut, rng( 3, 10 ) ) );
-    c->check_dead_state();
+    c->check_dead_state( &here );
     add_msg_if_player_sees( p, _( "The shards shatter!" ) );
     sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap",
                    "glass_caltrops" );
@@ -454,12 +456,13 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
             }
         }
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
 bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
     bool add_bolt = true;
     if( c != nullptr ) {
         if( c->has_effect( effect_ridden ) ) {
@@ -544,9 +547,8 @@ bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
                 add_msg( m_neutral, _( "A bolt shoots out, but misses the %s." ), z->name() );
             }
         }
-        c->check_dead_state();
+        c->check_dead_state( &here );
     }
-    map &here = get_map();
     here.remove_trap( p );
     here.spawn_item( p, "crossbow" );
     here.spawn_item( p, "string_36" );
@@ -649,7 +651,7 @@ bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
                             rng( 40 * shots,
                                  60 * shots ) ) );
         }
-        c->check_dead_state();
+        c->check_dead_state( &here );
     }
 
     here.spawn_item( p, here.tr_at( p ) == tr_shotgun_1 ? "shotgun_s" : "shotgun_d" );
@@ -660,6 +662,7 @@ bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::blade( const tripoint_bub_ms &, Creature *c, item * )
 {
+    map &here = get_map();
     if( c == nullptr ) {
         return false;
     }
@@ -672,7 +675,7 @@ bool trapfunc::blade( const tripoint_bub_ms &, Creature *c, item * )
     d.add_damage( damage_bash, 12 );
     d.add_damage( damage_cut, 30 );
     c->deal_damage( nullptr, bodypart_id( "torso" ), d );
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -706,8 +709,9 @@ bool trapfunc::snare_light( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::snare_heavy( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
     sounds::sound( p, 4, sounds::sound_t::combat, _( "Snap!" ), false, "trap", "snare" );
-    get_map().remove_trap( p );
+    here.remove_trap( p );
     if( c == nullptr ) {
         return false;
     }
@@ -748,7 +752,7 @@ bool trapfunc::snare_heavy( const tripoint_bub_ms &p, Creature *c, item * )
         }
         z->deal_damage( nullptr, hit, damage_instance( damage_bash, damage ) );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -807,7 +811,7 @@ bool trapfunc::snare_species( const tripoint_bub_ms &p, Creature *critter, item 
         }
         // Actual effects
         critter->add_effect( effect_immobilization, 10_turns, hit );
-        critter->check_dead_state();
+        critter->check_dead_state( &here );
     }
 
     here.remove_trap( p );
@@ -862,7 +866,8 @@ bool trapfunc::telepad( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::goo( const tripoint_bub_ms &p, Creature *c, item * )
 {
-    get_map().remove_trap( p );
+    map &here = get_map();
+    here.remove_trap( p );
     if( c == nullptr ) {
         return false;
     }
@@ -884,7 +889,7 @@ bool trapfunc::goo( const tripoint_bub_ms &p, Creature *c, item * )
                                                 you->string_for_ground_contact_bodyparts( bps ) ),
                                         string_format( _( "The acidic goo eats away at <npcname>'s %s!" ),
                                                 you->string_for_ground_contact_bodyparts( bps ) ) );
-            you->check_dead_state();
+            you->check_dead_state( &here );
         }
         return true;
     } else if( z != nullptr ) {
@@ -910,6 +915,8 @@ bool trapfunc::goo( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -942,7 +949,7 @@ bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
                 ch->add_msg_player_or_npc( m_bad, _( "Electrical beams emit from the floor and slice your flesh!" ),
                                            _( "Electrical beams emit from the floor and slice <npcname>s flesh!" ) );
             }
-            ch->check_dead_state();
+            ch->check_dead_state( &here );
         }
     }
 
@@ -962,12 +969,14 @@ bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
     c->deal_damage( nullptr, bodypart_id( "foot_l" ), damage_instance( damage_cut, 10 ) );
     c->deal_damage( nullptr, bodypart_id( "foot_r" ), damage_instance( damage_cut, 10 ) );
 
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
 bool trapfunc::pit( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -1018,12 +1027,14 @@ bool trapfunc::pit( const tripoint_bub_ms &p, Creature *c, item * )
         z->deal_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( damage_bash, eff * rng( 10,
                         20 ) ) );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
 bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -1098,7 +1109,7 @@ bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
         }
         z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_cut, rng( 20, 50 ) ) );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     if( one_in( 4 ) ) {
         add_msg_if_player_sees( p, _( "The spears break!" ) );
         map &here = get_map();
@@ -1115,6 +1126,8 @@ bool trapfunc::pit_spikes( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -1194,7 +1207,7 @@ bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
         z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_cut, rng( 20,
                         50 ) ) );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     if( one_in( 5 ) ) {
         add_msg_if_player_sees( p, _( "The shards shatter!" ) );
         map &here = get_map();
@@ -1211,6 +1224,8 @@ bool trapfunc::pit_glass( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::lava( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -1248,7 +1263,7 @@ bool trapfunc::lava( const tripoint_bub_ms &p, Creature *c, item * )
         }
         z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_heat, dam ) );
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -1360,6 +1375,8 @@ bool trapfunc::sinkhole( const tripoint_bub_ms &p, Creature *c, item *i )
 
 bool trapfunc::glow( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c == nullptr ) {
         return false;
     }
@@ -1394,7 +1411,7 @@ bool trapfunc::glow( const tripoint_bub_ms &p, Creature *c, item * )
             c->add_msg_if_player( _( "Small flashes surround you." ) );
         }
     }
-    c->check_dead_state();
+    c->check_dead_state( &here );
     return true;
 }
 
@@ -1477,6 +1494,8 @@ bool trapfunc::map_regen( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::drain( const tripoint_bub_ms &, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c != nullptr ) {
         c->add_msg_if_player( m_bad, _( "You feel your life force sapping away." ) );
         monster *z = dynamic_cast<monster *>( c );
@@ -1486,7 +1505,7 @@ bool trapfunc::drain( const tripoint_bub_ms &, Creature *c, item * )
         } else if( z != nullptr ) {
             z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_pure, 1 ) );
         }
-        c->check_dead_state();
+        c->check_dead_state( &here );
         return true;
     }
     return false;

--- a/tests/active_item_test.cpp
+++ b/tests/active_item_test.cpp
@@ -35,7 +35,7 @@ TEST_CASE( "active_items_processed_regularly", "[active_item]" )
 
     // Call item processing entry points.
     here.process_items();
-    player_character.process_items();
+    player_character.process_items( &here );
 
     // Each chainsaw was processed and turned off from lack of fuel
     CHECK( inventory_item->typeId().str() == "chainsaw_off" );

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -61,7 +61,7 @@ static void test_projectile_attack( const std::string &target_type, bool killabl
         monster target{ mtype_id( target_type ), tripoint_bub_ms::zero };
         //the missed_by field is modified by deal_projectile_attack() and must be reset
         attack.missed_by = headshot ? accuracy_headshot * 0.75 : accuracy_critical;
-        target.deal_projectile_attack( nullptr, attack, attack.missed_by, false );
+        target.deal_projectile_attack( &get_map(), nullptr, attack, attack.missed_by, false );
         CAPTURE( target_type );
         CAPTURE( target.get_hp() );
         CAPTURE( target.get_hp_max() );

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -143,7 +143,7 @@ static float get_avg_bullet_dmg( const std::string &clothing_id )
         dealt_projectile_attack atk;
         projectile_attack( atk, proj, badguy_pos, dude_pos, dispersion_sources(),
                            &*badguy );
-        dude->deal_projectile_attack( &*badguy, atk, atk.missed_by, false );
+        dude->deal_projectile_attack( &get_map(),  & *badguy, atk, atk.missed_by, false );
         if( atk.missed_by < 1.0 ) {
             num_hits++;
         }

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -66,7 +66,7 @@ static void test_generic_ench( avatar &p, enchant_test enc_test )
     clear_map();
     monster &zombie = spawn_test_monster( "mon_zombie", spot );
 
-    p.on_hit( &zombie, bodypart_id( "torso" ), 0.0, nullptr );
+    p.on_hit( &get_map(),  & zombie, bodypart_id( "torso" ), 0.0, nullptr );
 
     CHECK( zombie.has_effect( effect_blind ) );
 }

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1191,6 +1191,8 @@ TEST_CASE( "EOC_event_test", "[eoc]" )
 
 TEST_CASE( "EOC_combat_event_test", "[eoc]" )
 {
+    map &here = get_map();
+
     size_t loop;
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
@@ -1268,7 +1270,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     // character_kills_monster
     clear_map();
     monster &victim = spawn_test_monster( "mon_zombie", target_pos );
-    victim.die( &get_avatar() );
+    victim.die( &here, &get_avatar() );
 
     CHECK( get_avatar().get_value( "test_event_last_event" ) == "character_kills_monster" );
     CHECK( globvars.get_global_value( "victim_type" ) == "mon_zombie" );

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -57,7 +57,7 @@ static float get_damage_vs_target( const std::string &target_id )
         //REQUIRE( target_monster.type->armor_bullet == 0 );
         // This mirrors code in explosion::shrapnel() that scales hit rate with size and avoids crits.
         frag.missed_by = rng_float( 0.05, 1.0 / target_monster.ranged_target_size() );
-        target_monster.deal_projectile_attack( nullptr, frag, frag.missed_by, false );
+        target_monster.deal_projectile_attack( &get_map(), nullptr, frag, frag.missed_by, false );
         if( frag.dealt_dam.total_damage() > 0 ) {
             damaging_hits++;
             damage_taken += frag.dealt_dam.total_damage();

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -38,7 +38,7 @@ static void butcher_mon( const mtype_id &monid, const activity_id &actid, int *c
         u.wield( scalpel );
         monster cow( monid, mon_pos );
         const tripoint_bub_ms cow_loc = cow.pos_bub();
-        cow.die( nullptr );
+        cow.die( &here, nullptr );
         u.move_to( cow.pos_abs() );
         player_activity act( actid, 0, true );
         act.targets.emplace_back( map_cursor( u.pos_abs() ), &*here.i_at( cow_loc ).begin() );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -583,6 +583,8 @@ TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack
 // spell_effect::spawn_summoned_monster
 TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
 {
+    map &here = get_map();
+
     clear_map();
 
     // Avatar/spellcaster and summoned mummy locations
@@ -607,7 +609,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     CHECK( g->num_creatures() == 2 );
 
     //kill the ghost
-    creatures.creature_at( mummy_loc )->die( nullptr );
+    creatures.creature_at( mummy_loc )->die( &here, nullptr );
     g->cleanup_dead();
 
     //a corpse was not created
@@ -625,7 +627,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     CHECK( g->num_creatures() == 2 );
 
     //kill the mummy
-    creatures.creature_at( mummy_loc )->die( nullptr );
+    creatures.creature_at( mummy_loc )->die( &here, nullptr );
     g->cleanup_dead();
 
     //a corpse was created

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -80,10 +80,11 @@ void clear_creatures()
 
 void clear_npcs()
 {
+    map &here = get_map();
     // Reload to ensure that all active NPCs are in the overmap_buffer.
     g->reload_npcs();
     for( npc &n : g->all_npcs() ) {
-        n.die( nullptr );
+        n.die( & here, nullptr );
     }
     g->cleanup_dead();
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -290,7 +290,7 @@ TEST_CASE( "active_monster_drops", "[active_item][map]" )
     zombo.no_extra_death_drops = true;
     zombo.inv.emplace_back( bag_plastic );
     calendar::turn += time_duration::from_seconds( cookie.processing_speed() + 1 );
-    zombo.die( nullptr );
+    zombo.die( &here, nullptr );
     REQUIRE( here.i_at( start_loc ).size() == 1 );
     item &dropped_bag = here.i_at( start_loc ).begin()->only_item();
 

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -309,6 +309,7 @@ TEST_CASE( "Mattack_dialog_condition_test", "[mattack]" )
 
 TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
 {
+    map &here = get_map();
 
     const std::string grabber_left = "mon_debug_grabber_left";
     const std::string grabber_right = "mon_debug_grabber_right";
@@ -341,7 +342,7 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
     REQUIRE( test_monster_left.is_grabbing( body_part_arm_l ) );
 
     // Kill the left grabber
-    test_monster_left.die( nullptr );
+    test_monster_left.die( &here, nullptr );
 
     // Now we only have the one
     REQUIRE( you.has_effect( effect_grabbed, body_part_arm_r ) );

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -52,7 +52,7 @@ static npc &respawn_main_npc()
 {
     npc *guy = get_creature_tracker().creature_at<npc>( main_npc_start_tripoint );
     if( guy ) {
-        guy->die( nullptr );
+        guy->die( &get_map(), nullptr );
     }
     return spawn_main_npc();
 }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1158,7 +1158,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     get_weather().weather_precise->humidity = 16;
     get_weather().weather_precise->pressure = 17;
     get_weather().clear_temp_cache();
-    player_character.setpos( { -1, -2, -3 } );
+    player_character.setpos( tripoint_bub_ms{ -1, -2, -3 } );
     player_character.set_pain( 21 );
     player_character.add_bionic( bio_power_storage );
     player_character.set_power_level( 22_mJ );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -52,7 +52,7 @@ static void on_load_test( npc &who, const time_duration &from, const time_durati
     calendar::turn = calendar::turn_zero + from;
     who.on_unload();
     calendar::turn = calendar::turn_zero + to;
-    who.on_load();
+    who.on_load( &get_map() );
 }
 
 static void test_needs( const npc &who, const numeric_interval<int> &hunger,

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -426,6 +426,8 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
     SECTION( "shearing losing tool" ) {
         GIVEN( "an electric tool with shearing quality three" ) {
+            map &here = get_map();
+
             clear_avatar();
             clear_map();
             monster &mon = test_monster( true );
@@ -455,7 +457,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
             WHEN( "tool runs out of charges mid activity" ) {
                 for( int i = 0; i < 10000; ++i ) {
-                    dummy.process_items();
+                    dummy.process_items( &here );
                 }
 
                 CHECK( dummy.get_wielded_item()->ammo_remaining() == 0 );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -445,6 +445,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
                            const std::function<bool ( const standard_npc &, const monster & )> &other_checks = nullptr,
                            const Approx &expected_other_checks = Approx( 0 ) )
 {
+    map &here = get_map();
     clear_map();
     statistics<int> damage;
     constexpr tripoint_bub_ms shooter_pos{ 60, 60, 0 };
@@ -467,10 +468,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         if( damage.margin_of_error() < 0.05 && damage.n() > 500 ) {
             break;
         }
-        if( other_checks ) {
-            other_check_success += other_checks( *shooter, mon );
-        }
-        mon.die( nullptr );
+        mon.die( &here, nullptr );
     } while( damage.n() < 1000 ); // In fact, stable results can only be obtained when n reaches 10000
     const double avg = damage.avg();
     CAPTURE( gun_type );


### PR DESCRIPTION
#### Summary
Backport 79336 - Don't do map processing for creatures off map

#### Purpose of change
Begin doing map-aware stuff. Shouldn't be player-visible, unless this causes some bugs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
