### PR TITLE
aw mom, just one more backport before bed?

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3335,7 +3335,8 @@ Examples:
 
 #### The following optional fields are specific to ROTORs.
 ```c++
-"rotor_diameter": 15,         // Rotor diameter in meters.  Larger rotors provide more lift.
+"rotor_diameter": 15,         // Rotor diameter in meters.  Larger rotors provide more lift. This also determines the size of the rotor during collisions.
+"bonus": 5,                   // Adds additional rotor diameter during lift calculations. This does not affect rotor collision. This is useful for things like ducted fans or vtol engines that have good lift but smaller danger zones.
 ```
 
 #### The following optional fields are specific to WORKBENCHes.

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -1002,6 +1002,7 @@ by the frequency assigned to the city building within the `region_settings`. Con
 | `locations` | As in `overmap_special`.                                                         |
 | `flags`     | As in `overmap_special`.                                                         |
 | `rotate`    | As in `overmap_special`.                                                         |
+| `city_sizes`| As in `overmap_special`.                                                         |
 
 ### Example
 

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1826,17 +1826,14 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
 {
     avatar &u = get_avatar();
     item_location loc;
+    item it = *sitem->items.front();
+
     if( spane.get_area() == AIM_CONTAINER && spane.container->can_unload() ) {
         loc = spane.container;
-    } else if( sitem && sitem->items.front()->can_unload() ) {
-        if( sitem -> contents_count > 0 ) {
-            loc = sitem->items.front();
-        } else {
-            popup_getkey( _( "%1$s is already empty." ), sitem->items.front()->display_name() );
-        }
-
+    } else if( sitem && it.can_unload() && !it.empty() ) {
+        loc = sitem->items.front();
     } else {
-        popup_getkey( _( "%1$s can't be unloaded." ), sitem->items.front()->display_name() );
+        popup_getkey( _( "%1$s can't be unloaded." ), it.display_name() );
         return false;
     }
 

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1838,7 +1838,7 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
     do_return_entry();
     // always exit to proc do_return_entry even when no activity was assigned
     exit = true;
-    return u.unload( loc );;
+    return u.unload( loc );
 }
 
 void advanced_inventory::display()

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1826,22 +1826,19 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
 {
     avatar &u = get_avatar();
     item_location loc;
-    item it = *sitem->items.front();
 
-    if( spane.get_area() == AIM_CONTAINER && spane.container->can_unload() ) {
+    if( spane.get_area() == AIM_CONTAINER ) {
         loc = spane.container;
-    } else if( sitem && it.can_unload() && !it.empty() ) {
+    } else if( sitem ) {
         loc = sitem->items.front();
     } else {
-        popup_getkey( _( "%1$s can't be unloaded." ), it.display_name() );
         return false;
     }
 
-    if( loc != item_location::nowhere && !loc->is_container_empty() ) {
-        do_return_entry();
-        return u.unload( loc );;
-    }
-    return false;
+    do_return_entry();
+    // always exit to proc do_return_entry even when no activity was assigned
+    exit = true;
+    return u.unload( loc );;
 }
 
 void advanced_inventory::display()
@@ -2054,8 +2051,7 @@ void advanced_inventory::display()
                 action_examine( sitem, spane );
             }
         } else if( action == "UNLOAD_CONTAINER" ) {
-            recalc = exit = action_unload( sitem, spane );
-
+            recalc = action_unload( sitem, spane );
         } else if( action == "QUIT" ) {
             exit = true;
         } else if( action == "PAGE_DOWN" ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3707,7 +3707,7 @@ bool Character::can_pickVolume( const item &it, bool, const item *avoid,
 }
 
 bool Character::can_pickVolume_partial( const item &it, bool, const item *avoid,
-                                        const bool ignore_pkt_settings, const bool is_pick_up_inv ) const
+                                        const bool ignore_pkt_settings, const bool ignore_non_container_pocket ) const
 {
     item copy = it;
     if( it.count_by_charges() ) {
@@ -3715,11 +3715,12 @@ bool Character::can_pickVolume_partial( const item &it, bool, const item *avoid,
     }
 
     if( ( avoid == nullptr || &weapon != avoid ) &&
-        weapon.can_contain( copy, false, false, ignore_pkt_settings, is_pick_up_inv ).success() ) {
+        weapon.can_contain( copy, false, false, ignore_pkt_settings, ignore_non_container_pocket
+                          ).success() ) {
         return true;
     }
 
-    return worn.can_pickVolume( copy, ignore_pkt_settings, is_pick_up_inv );
+    return worn.can_pickVolume( copy, ignore_pkt_settings, ignore_non_container_pocket );
 }
 
 bool Character::can_pickWeight( const item &it, bool safe ) const

--- a/src/character.h
+++ b/src/character.h
@@ -2367,7 +2367,7 @@ class Character : public Creature, public visitable
         bool can_pickVolume( const item &it, bool safe = false, const item *avoid = nullptr,
                              bool ignore_pkt_settings = true ) const;
         bool can_pickVolume_partial( const item &it, bool safe = false, const item *avoid = nullptr,
-                                     bool ignore_pkt_settings = true, bool is_pick_up_inv = false ) const;
+                                     bool ignore_pkt_settings = true, bool ignore_non_container_pocket = false ) const;
         bool can_pickWeight( const item &it, bool safe = true ) const;
         bool can_pickWeight_partial( const item &it, bool safe = true ) const;
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1738,10 +1738,11 @@ void outfit::add_dependent_item( std::list<item *> &dependent )
 }
 
 bool outfit::can_pickVolume( const item &it, const bool ignore_pkt_settings,
-                             const bool is_pick_up_inv ) const
+                             const bool ignore_non_container_pocket ) const
 {
     for( const item &w : worn ) {
-        if( w.can_contain( it, false, false, ignore_pkt_settings, is_pick_up_inv ).success() ) {
+        if( w.can_contain( it, false, false, ignore_pkt_settings, ignore_non_container_pocket
+                         ).success() ) {
             return true;
         }
     }

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -104,7 +104,7 @@ class outfit
         // will someone get shocked by zapback
         bool hands_conductive() const;
         bool can_pickVolume( const item &it, bool ignore_pkt_settings = true,
-                             bool is_pick_up_inv = false ) const;
+                             bool ignore_non_container_pocket = false ) const;
         side is_wearing_shoes( const bodypart_id &bp ) const;
         bool is_barefoot() const;
         item item_worn_with_flag( const flag_id &f, const bodypart_id &bp ) const;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10303,19 +10303,19 @@ ret_val<void> item::can_contain_directly( const item &it ) const
 }
 
 ret_val<void> item::can_contain( const item &it, const bool nested, const bool ignore_rigidity,
-                                 const bool ignore_pkt_settings, const bool is_pick_up_inv,
+                                 const bool ignore_pkt_settings, const bool ignore_non_container_pocket,
                                  const item_location &parent_it,
                                  units::volume remaining_parent_volume, const bool allow_nested ) const
 {
     int copies = 1;
     return can_contain( it, copies, nested, ignore_rigidity,
-                        ignore_pkt_settings, is_pick_up_inv, parent_it,
+                        ignore_pkt_settings, ignore_non_container_pocket, parent_it,
                         remaining_parent_volume, allow_nested );
 }
 
 ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bool nested,
                                  const bool ignore_rigidity, const bool ignore_pkt_settings,
-                                 const bool is_pick_up_inv, const item_location &parent_it,
+                                 const bool ignore_non_container_pocket, const item_location &parent_it,
                                  units::volume remaining_parent_volume,
                                  const bool allow_nested ) const
 {
@@ -10361,7 +10361,7 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
                     continue;
                 }
                 auto ret = internal_it->can_contain( it, copies_remaining, true, ignore_nested_rigidity,
-                                                     ignore_pkt_settings, is_pick_up_inv, parent_it,
+                                                     ignore_pkt_settings, ignore_non_container_pocket, parent_it,
                                                      pkt->remaining_volume() );
                 if( copies_remaining <= 0 ) {
                     return ret;
@@ -10370,10 +10370,11 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
         }
     }
 
-    return nested && !ignore_rigidity ?
-           contents.can_contain_rigid( it, copies_remaining, ignore_pkt_settings, is_pick_up_inv ) :
-           contents.can_contain( it, copies_remaining, ignore_pkt_settings, is_pick_up_inv,
-                                 remaining_parent_volume );
+    return nested && !ignore_rigidity
+           ? contents.can_contain_rigid( it, copies_remaining, ignore_pkt_settings,
+                                         ignore_non_container_pocket )
+           : contents.can_contain( it, copies_remaining, ignore_pkt_settings, ignore_non_container_pocket,
+                                   remaining_parent_volume );
 }
 
 ret_val<void> item::can_contain( const itype &tp ) const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12940,7 +12940,7 @@ void item::mark_as_used_by_player( const Character &p )
     used_by_ids += string_format( "%d;", p.getID().get_value() );
 }
 
-bool item::can_holster( const item &obj, bool ) const
+bool item::can_holster( const item &obj ) const
 {
     if( !type->can_use( "holster" ) ) {
         return false; // item is not a holster

--- a/src/item.h
+++ b/src/item.h
@@ -1848,11 +1848,11 @@ class item : public visitable
         // spill items that don't fit in the container
         void overflow( const tripoint_bub_ms &pos, const item_location &loc = item_location::nowhere );
 
-        /** Checks if item is a holster and currently capable of storing obj
-         *  @param obj object that we want to holster
-         *  @param ignore only check item is compatible and ignore any existing contents
+        /**
+         * Check if item is a holster and currently capable of storing obj.
+         * @param obj object that we want to holster.
          */
-        bool can_holster( const item &obj, bool ignore = false ) const;
+        bool can_holster( const item &obj ) const;
 
         /**
          * Callback when a character starts wearing the item. The item is already in the worn

--- a/src/item.h
+++ b/src/item.h
@@ -1723,7 +1723,8 @@ class item : public visitable
          * @param it the item being put in
          * @param nested whether or not the current call is nested (used recursively).
          * @param ignore_pkt_settings whether to ignore pocket autoinsert settings
-         * @param remaining_parent_volume the amount of space in the parent pocket,
+         * @param ignore_non_container_pocket ignore magazine pockets, such as weapon magazines
+         * @param remaining_parent_volume the ammount of space in the parent pocket,
          * @param allow_nested whether nested pockets should be checked
          * needed to make sure we dont try to nest items which can't fit in the nested pockets
          */
@@ -1731,14 +1732,14 @@ class item : public visitable
         ret_val<void> can_contain( const item &it, bool nested = false,
                                    bool ignore_rigidity = false,
                                    bool ignore_pkt_settings = true,
-                                   bool is_pick_up_inv = false,
+                                   bool ignore_non_container_pocket = false,
                                    const item_location &parent_it = item_location(),
                                    units::volume remaining_parent_volume = 10000000_ml,
                                    bool allow_nested = true ) const;
         ret_val<void> can_contain( const item &it, int &copies_remaining, bool nested = false,
                                    bool ignore_rigidity = false,
                                    bool ignore_pkt_settings = true,
-                                   bool is_pick_up_inv = false,
+                                   bool ignore_non_container_pocket = false,
                                    const item_location &parent_it = item_location(),
                                    units::volume remaining_parent_volume = 10000000_ml,
                                    bool allow_nested = true ) const;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1052,22 +1052,20 @@ ret_val<void> item_contents::is_compatible( const item &it ) const
 }
 
 ret_val<void> item_contents::can_contain_rigid( const item &it,
-        const bool ignore_pkt_settings, const bool is_pick_up_inv ) const
+        const bool ignore_pkt_settings, const bool ignore_non_container_pocket ) const
 {
     int copies = 1;
-    return can_contain_rigid( it, copies, ignore_pkt_settings, is_pick_up_inv );
+    return can_contain_rigid( it, copies, ignore_pkt_settings, ignore_non_container_pocket );
 }
 
 ret_val<void> item_contents::can_contain_rigid( const item &it, int &copies_remaining,
-        const bool ignore_pkt_settings, const bool is_pick_up_inv ) const
+        const bool ignore_pkt_settings, const bool ignore_non_container_pocket ) const
 {
     ret_val<void> ret = ret_val<void>::make_failure( _( "is not a container" ) );
     for( const item_pocket &pocket : contents ) {
         // Only count container in pickup_inventory_preset.
-        if( is_pick_up_inv ) {
-            if( !pocket.is_type( pocket_type::CONTAINER ) ) {
-                continue;
-            }
+        if( ignore_non_container_pocket && !pocket.is_type( pocket_type::CONTAINER ) ) {
+            continue;
         }
         if( pocket.is_type( pocket_type::MOD ) ||
             pocket.is_type( pocket_type::CORPSE ) ||
@@ -1093,14 +1091,15 @@ ret_val<void> item_contents::can_contain_rigid( const item &it, int &copies_rema
 }
 
 ret_val<void> item_contents::can_contain( const item &it, const bool ignore_pkt_settings,
-        const bool is_pick_up_inv, units::volume remaining_parent_volume ) const
+        const bool ignore_non_container_pocket, units::volume remaining_parent_volume ) const
 {
     int copies = 1;
-    return can_contain( it, copies, ignore_pkt_settings, is_pick_up_inv, remaining_parent_volume );
+    return can_contain( it, copies, ignore_pkt_settings, ignore_non_container_pocket,
+                        remaining_parent_volume );
 }
 
 ret_val<void> item_contents::can_contain( const item &it, int &copies_remaining,
-        const bool ignore_pkt_settings, const bool is_pick_up_inv,
+        const bool ignore_pkt_settings, const bool ignore_non_container_pocket,
         units::volume remaining_parent_volume ) const
 {
     ret_val<void> ret = ret_val<void>::make_failure( _( "is not a container" ) );
@@ -1114,10 +1113,8 @@ ret_val<void> item_contents::can_contain( const item &it, int &copies_remaining,
             continue;
         }
         // Only count container in pickup_inventory_preset.
-        if( is_pick_up_inv ) {
-            if( !pocket.is_type( pocket_type::CONTAINER ) ) {
-                continue;
-            }
+        if( ignore_non_container_pocket && !pocket.is_type( pocket_type::CONTAINER ) ) {
+            continue;
         }
         // mod, migration, corpse, and software aren't regular pockets.
         if( !pocket.is_standard_type() ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -64,20 +64,21 @@ class item_contents
          * physical pockets.
          * @param it the item being put in
          * @param ignore_pkt_settings whether to ignore pocket autoinsert settings
+         * @param ignore_non_container_pocket ignore magazine pockets, such as weapon magazines
          * @param remaining_parent_volume if we are nesting things without concern for rigidity we need to be careful about overfilling pockets
          * this tracks the remaining volume of any parent pockets
          */
         ret_val<void> can_contain( const item &it, bool ignore_pkt_settings = true,
-                                   bool is_pick_up_inv = false,
+                                   bool ignore_non_container_pocket = false,
                                    units::volume remaining_parent_volume = 10000000_ml ) const;
         ret_val<void> can_contain( const item &it, int &copies_remaining, bool ignore_pkt_settings = true,
-                                   bool is_pick_up_inv = false,
+                                   bool ignore_non_container_pocket = false,
                                    units::volume remaining_parent_volume = 10000000_ml ) const;
         ret_val<void> can_contain_rigid( const item &it, bool ignore_pkt_settings = true,
-                                         bool is_pick_up_inv = false ) const;
+                                         bool ignore_non_container_pocket = false ) const;
         ret_val<void> can_contain_rigid( const item &it, int &copies_remaining,
                                          bool ignore_pkt_settings = true,
-                                         bool is_pick_up_inv = false ) const;
+                                         bool ignore_non_container_pocket = false ) const;
         bool can_contain_liquid( bool held_or_ground ) const;
 
         bool contains_no_solids() const;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3559,6 +3559,9 @@ std::function<bool( const tripoint_bub_ms & )> npc::get_path_avoid() const
             doors::can_unlock_door( here, *this, p ) ) {
             return true;
         }
+        if( here.is_open_air( p ) ) {
+            return true;
+        }
         if( rules.has_flag( ally_rule::hold_the_line ) &&
             ( here.close_door( p, true, true ) ||
               here.move_cost( p ) > 2 ) ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1329,11 +1329,20 @@ static bool create_note( const tripoint_abs_omt &curs, std::optional<std::string
 // if false, search yielded no results
 static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripoint_abs_omt &orig )
 {
+    input_context ctxt( "STRING_INPUT" );
+    std::vector<std::string> act_descs;
+    const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
+        act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
+    };
+    add_action_desc( "HISTORY_UP", pgettext( "string input", "History" ) );
+    add_action_desc( "TEXT.CLEAR", pgettext( "string input", "Clear text" ) );
+    add_action_desc( "TEXT.QUIT", pgettext( "string input", "Abort" ) );
+    add_action_desc( "TEXT.CONFIRM", pgettext( "string input", "Save" ) );
     std::string term = string_input_popup()
                        .title( _( "Search term:" ) )
                        .description( string_format( "%s\n%s",
                                      _( "Multiple entries separated with comma (,). Excludes starting with hyphen (-)." ),
-                                     colorize( _( "UP: history, CTRL-U: clear line, ESC: abort, ENTER: save" ), c_green ) ) )
+                                     colorize( enumerate_as_string( act_descs, enumeration_conjunction::none ), c_green ) ) )
                        .desc_color( c_white )
                        .identifier( "overmap_search" )
                        .query_string();
@@ -1394,7 +1403,6 @@ static bool search( const ui_adaptor &om_ui, tripoint_abs_omt &curs, const tripo
     } );
     ui.mark_resize();
 
-    input_context ctxt( "OVERMAP_SEARCH" );
     ctxt.register_action( "NEXT_TAB", to_translation( "Next result" ) );
     ctxt.register_action( "PREV_TAB", to_translation( "Previous result" ) );
     ctxt.register_action( "CONFIRM" );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4548,7 +4548,8 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
 {
     int rotor_area_in_feet = 0;
     for( const int rotor : rotors ) {
-        double rotor_diameter_in_feet = parts[rotor].info().rotor_info->rotor_diameter * 3.28084;
+        double rotor_diameter_in_feet = ( parts[rotor].info().rotor_info->rotor_diameter +
+                                          parts[rotor].info().bonus ) * 3.28084;
         rotor_area_in_feet += ( M_PI / 4 ) * std::pow( rotor_diameter_in_feet, 2 );
     }
     // take off 15 % due to the imaginary tail rotor power.


### PR DESCRIPTION
#### Summary
aw mom, just one more backport before bed?

#### Purpose of change
These are mostly bugfixes and infrastructure. I need that rotor thrust update to fix helicopters, and the NPC thing should be an immediate help.

#### Describe the solution
79305 - refactor pocket code
79314 - prevent NPCs from walking off cliffs
79309 - overmap documentation to include missing field
79316 - misc fixes for unloading via AIM
79325 - unhardcode overmap filter popup text
79328 - add part bonus for rotor thrust

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
