### PR TITLE
Improve hardcoded effect text

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3912,7 +3912,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
     }
     if( source != nullptr ) {
         if( Character *attacker = source->as_character() ) {
-            type->families.practice_hit( *attacker );    
+            type->families.practice_hit( *attacker );
             enchantment_cache->cast_hit_me( *attacker, source );
         }
     }


### PR DESCRIPTION
#### Summary
Improve hardcoded effect text

#### Purpose of change
The text for anemia and mutant toxin were a bit weird and in some cases misleading.

#### Describe the solution
Improve the text and in some cases make the effects work a bit better.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
