### PR TITLE
Add Bionic Power Cost to "Passive" Enhancement CBMS

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -591,7 +591,7 @@
     "name": { "str": "Wired Reflexes" },
     "description": "Your reaction time has been greatly enhanced with bionic nerve stimulators, giving you a +2 bonus to dexterity.",
     "occupied_bodyparts": [ [ "head", 3 ], [ "torso", 6 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 7 ], [ "leg_r", 7 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
     "enchantments": [
       {
         "condition": "ACTIVE",
@@ -599,7 +599,7 @@
       }
     ],
     "act_cost": "5 J",
-    "react_cost": "10 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {
@@ -675,7 +675,7 @@
     "occupied_bodyparts": [ [ "head", 2 ] ],
     "//": "BATEARS is better than this bionic, even if you combine the bionic with any existing hearing mutation.",
     "mutation_conflicts": [ "BATEARS" ],
-    "flags": [ "BIONIC_TOGGLED", "IMMUNE_HEARING_DAMAGE" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "IMMUNE_HEARING_DAMAGE" ],
     "active_flags": [ "SAFECRACK_NO_TOOL" ],
     "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "HEARING_MULT", "multiply": 2.5 } ] } ],
     "act_cost": "3 J",
@@ -1007,7 +1007,7 @@
     "description": "Your brain has been enhanced with bionic coprocessors, giving you a +2 bonus to intelligence.",
     "cant_remove_reason": "The bionic is now critical to the continued functionality of the user's brain.",
     "occupied_bodyparts": [ [ "head", 6 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
     "enchantments": [
       {
         "condition": "ACTIVE",
@@ -1015,7 +1015,7 @@
       }
     ],
     "act_cost": "5 J",
-    "react_cost": "20 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {
@@ -1406,7 +1406,7 @@
       [ "foot_l", 2 ],
       [ "foot_r", 2 ]
     ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
     "enchantments": [
       {
         "condition": "ACTIVE",
@@ -1414,7 +1414,7 @@
       }
     ],
     "act_cost": "10 J",
-    "react_cost": "50 J",
+    "react_cost": "10 J",
     "time": "1 s"
   },
   {
@@ -1440,7 +1440,7 @@
     "name": { "str": "Muscle Augmentation" },
     "description": "Your muscular system has been surgically enhanced with myomer fibers, giving you a +2 bonus to strength.",
     "occupied_bodyparts": [ [ "torso", 6 ], [ "arm_l", 4 ], [ "arm_r", 4 ], [ "leg_l", 8 ], [ "leg_r", 8 ] ],
-    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
     "enchantments": [
       {
         "condition": "ACTIVE",
@@ -1448,7 +1448,7 @@
       }
     ],
     "act_cost": "5 J",
-    "react_cost": "25 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {

--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -591,8 +591,16 @@
     "name": { "str": "Wired Reflexes" },
     "description": "Your reaction time has been greatly enhanced with bionic nerve stimulators, giving you a +2 bonus to dexterity.",
     "occupied_bodyparts": [ [ "head", 3 ], [ "torso", 6 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 7 ], [ "leg_r", 7 ] ],
-    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 2 } ] } ],
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "DEXTERITY", "add": 2 } ]
+      }
+    ],
+    "act_cost": "5 J",
+    "react_cost": "10 J",
+    "time": "1 s"
   },
   {
     "id": "bio_digestion",
@@ -670,6 +678,9 @@
     "flags": [ "BIONIC_TOGGLED", "IMMUNE_HEARING_DAMAGE" ],
     "active_flags": [ "SAFECRACK_NO_TOOL" ],
     "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "HEARING_MULT", "multiply": 2.5 } ] } ],
+    "act_cost": "3 J",
+    "react_cost": "3 J",
+    "time": "1 s",
     "auto_deactivates": [ "bio_earplugs" ],
     "included_bionics": [ "bio_earplugs" ],
     "activated_on_install": true
@@ -996,8 +1007,16 @@
     "description": "Your brain has been enhanced with bionic coprocessors, giving you a +2 bonus to intelligence.",
     "cant_remove_reason": "The bionic is now critical to the continued functionality of the user's brain.",
     "occupied_bodyparts": [ [ "head", 6 ] ],
-    "enchantments": [ { "values": [ { "value": "INTELLIGENCE", "add": 2 } ] } ],
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "INTELLIGENCE", "add": 2 } ]
+      }
+    ],
+    "act_cost": "5 J",
+    "react_cost": "20 J",
+    "time": "1 s"
   },
   {
     "id": "bio_itchy",
@@ -1387,8 +1406,16 @@
       [ "foot_l", 2 ],
       [ "foot_r", 2 ]
     ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": 0.1 } ] } ],
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "SPEED", "multiply": 0.1 } ]
+      }
+    ],
+    "act_cost": "10 J",
+    "react_cost": "50 J",
+    "time": "1 s"
   },
   {
     "id": "bio_stiff",
@@ -1413,8 +1440,16 @@
     "name": { "str": "Muscle Augmentation" },
     "description": "Your muscular system has been surgically enhanced with myomer fibers, giving you a +2 bonus to strength.",
     "occupied_bodyparts": [ [ "torso", 6 ], [ "arm_l", 4 ], [ "arm_r", 4 ], [ "leg_l", 8 ], [ "leg_r", 8 ] ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ],
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "STRENGTH", "add": 2 } ]
+      }
+    ],
+    "act_cost": "5 J",
+    "react_cost": "25 J",
+    "time": "1 s"
   },
   {
     "id": "bio_surgical_razor",
@@ -1756,8 +1791,11 @@
     "name": { "str": "Recoil Compensators" },
     "description": "Reactive shock absorbers installed in your wrists and elbows which greatly reduce felt recoil.",
     "occupied_bodyparts": [ [ "arm_l", 4 ], [ "arm_r", 4 ], [ "hand_l", 2 ], [ "hand_r", 2 ] ],
-    "flags": [ "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "RECOIL_MODIFIER", "multiply": -0.35 } ] } ]
+    "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE", "BIONIC_SHOCKPROOF" ],
+    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "RECOIL_MODIFIER", "multiply": -0.35 } ] } ],
+    "act_cost": "20 J",
+    "react_cost": "20 J",
+    "time": "1 s"
   },
   {
     "id": "bio_sleep_shutdown",


### PR DESCRIPTION
#### **Summary**
This change adds bionic power costs to many of the "passive" bionics that provide bonuses via electronic means. It also allows you to toggle them on/off. 

#### **Purpose of change**
Bionics that are described as functioning actively should not be able to function without power. This change adds a toggle & power drain to 

Wired Reflexes
Cerebral Booster
Muscle Augmentation
Recoil Compensators
Synaptic Accelerator

It also adds a power cost to enhanced hearing while active. 

#### **Describe the solution**
I've added a small placeholder power drain to the listed CBMs. Made them sleep friendly. Given them on/off toggles.

#### **Describe alternatives you've considered**
None

#### **Testing**
Works as intended & without error.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
