### PR TITLE
Remove ALLOWS_REMOTE_USE from generators for now

### DIFF
--- a/data/json/items/appliances/appliances_generators.json
+++ b/data/json/items/appliances/appliances_generators.json
@@ -30,7 +30,7 @@
     "symbol": "O",
     "color": "green_white",
     "//2": "Prevent loading items into the generator while it's not in appliance form.",
-    "flags": [ "NO_RELOAD", "ALLOWS_REMOTE_USE" ],
+    "flags": [ "NO_RELOAD" ],
     "melee_damage": { "bash": 5 }
   },
   {


### PR DESCRIPTION
#### Summary
Remove ALLOWS_REMOTE_USE from generators for now

#### Purpose of change
This flag was causing a bug where the generator would get duplicated when deployed. DDA 81280 has a fix for this, but there are a bunch of prereqs we don't have as that PR is from like June 2025.

#### Describe the solution
Remove the flag for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
