### PR TITLE
Fix hauling error

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4047,7 +4047,9 @@ void inventory_haul_selector::apply_selection( std::vector<item_location> &items
     std::unordered_map<inventory_entry *, int> counts;
     for( item_location &item : items ) {
         inventory_entry *entry = find_entry_by_location( item );
-        if( counts.count( entry ) ) {
+        if( !entry ) {
+            continue;
+        } else if( counts.count( entry ) ) {
             counts.at( entry ) += 1;
         } else {
             counts.emplace( entry, 1 );


### PR DESCRIPTION
#### Summary
Fix hauling error

#### Purpose of change
While hauling, it was possible to run into an error if you went through a window. Checking for this issue on DDA, I found https://github.com/CleverRaven/Cataclysm-DDA/issues/82632 where @Procyonae recommended a fix in the comments.

#### Describe the solution
Pasted the code from the comment verbatim and the issue appears to be gone.

#### Testing
- Hauled 100 dog food up to a window and went inside. The dog food was left behind, my game did not throw an error or crash.
- Hauled the dog food around and spawned a bunch of razorclaws and screechers. They immediately started screaming, playing havoc with movecost as I hauled my items, but there was no error or crash.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
