### PR TITLE
Fix stray reference to mutagen_spider

### DIFF
--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -724,7 +724,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the aranean mutagen.",
-      "vitamins": [ [ "mutagen_spider", 120, 220 ], [ "mutagen", 90 ] ]
+      "vitamins": [ [ "mutagen_aranean", 120, 220 ], [ "mutagen", 90 ] ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Fix stray reference to mutagen_spider

#### Purpose of change
One of the mutagens still contained mutagen_spider, when it's supposed to be mutagen_aranean. oops.

#### Describe the solution
fix

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
