### PR TITLE
Fix MA weapon category display

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -94,8 +94,7 @@
       "tec_aikido_blockdisarm",
       "tec_aikido_dodgethrow",
       "tec_aikido_blockthrow"
-    ],
-    "weapon_category": [ "CLAWS" ]
+    ]
   },
   {
     "type": "martial_art",
@@ -498,7 +497,7 @@
       }
     ],
     "techniques": [ "tec_dragon_claw", "tec_dragon_tail", "tec_dragon_strike", "tec_kung_fu_rapid", "tec_kung_fu_feint" ],
-    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "KUNG_FU_WEAPONS" ]
+    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "CLAWS", "KUNG_FU_WEAPONS" ]
   },
   {
     "type": "martial_art",
@@ -543,7 +542,7 @@
       "tec_eskrima_low",
       "tec_eskrima_combination"
     ],
-    "weapon_category": [ "KNIVES", "BATONS", "SHORT_SWORDS", "CLAWS", "SHIVS" ]
+    "weapon_category": [ "KNIVES", "BATONS", "SHORT_SWORDS", "SHIVS" ]
   },
   {
     "type": "martial_art",
@@ -706,8 +705,7 @@
         ]
       }
     ],
-    "techniques": [ "tec_judo_backthrow", "tec_judo_disarm", "tec_judo_break", "tec_judo_throw" ],
-    "weapon_category": [ "CLAWS" ]
+    "techniques": [ "tec_judo_backthrow", "tec_judo_disarm", "tec_judo_break", "tec_judo_throw" ]
   },
   {
     "type": "martial_art",
@@ -863,7 +861,7 @@
       "tec_kung_fu_rapid",
       "tec_kung_fu_feint"
     ],
-    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "KUNG_FU_WEAPONS" ]
+    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "CLAWS", "KUNG_FU_WEAPONS" ]
   },
   {
     "type": "martial_art",
@@ -1467,7 +1465,7 @@
       "tec_kung_fu_rapid",
       "tec_kung_fu_feint"
     ],
-    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "KUNG_FU_WEAPONS" ]
+    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "CLAWS", "KUNG_FU_WEAPONS" ]
   },
   {
     "type": "martial_art",
@@ -1578,7 +1576,7 @@
       "tec_kung_fu_rapid",
       "tec_kung_fu_feint"
     ],
-    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "KUNG_FU_WEAPONS" ]
+    "weapon_category": [ "SHORT_SWORDS", "KNIVES", "POLEARMS", "QUARTERSTAVES", "BATONS", "CLAWS", "KUNG_FU_WEAPONS" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION
#### Summary
Fix MA weapon category display

#### Purpose of change
Aikido and Judo were showing that they used claws in the _ menu. They do not. MAs which do interact with claws were not showing them. Now they do.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
