### PR TITLE
fix crafting amount of bodkin arrows

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -192,7 +192,6 @@
     "skills_required": [ [ "archery", 4 ], [ "survival", 1 ] ],
     "using": [ [ "forging_standard", 1 ] ],
     "difficulty": 5,
-    "charges": 10,
     "time": "40 m",
     "batch_time_factors": [ 80, 2 ],
     "autolearn": true,


### PR DESCRIPTION
#### Summary
Fix wooden bodkin arrow recipe resulting amount

#### Purpose of change
Make wooden bodkin arrows recipe produce only 1 arrow

#### Describe the solution
Removed the amount of charges on its recipe result json

#### Describe alternatives you've considered
None

#### Testing
Before:
<img width="1269" height="847" alt="image" src="https://github.com/user-attachments/assets/2f5228fb-eb44-4640-8888-74506b4d5e58" />

After:
<img width="1262" height="639" alt="image" src="https://github.com/user-attachments/assets/2a82dd6e-87a9-4954-9a7f-9ddc5b4b40db" />

#### Additional context
None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
