### PR TITLE
Backport DDA 79556 - fix insert segfault

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5116,7 +5116,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
         }
         ret = holster.parents_can_contain_recursive( &it );
         if( !ret.success() ) {
-            if( carrier->is_avatar() && query_yn(
+            if( carrier != nullptr && carrier->is_avatar() && query_yn(
                     _( "The parent container does not have enough space to fit more items.  Would you like to first wield %s to fit more?" ),
                     holster->tname() )
                 &&
@@ -5143,7 +5143,8 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     ret_val<int> max_parent_charges = holster.max_charges_by_parent_recursive( it );
     if( !max_parent_charges.success() ) {
         return ret_val<void>::make_failure( max_parent_charges.str() );
-    } else if( carrier->is_avatar() && max_parent_charges.value() < holstered_item.second ) {
+    } else if( carrier != nullptr && carrier->is_avatar() &&
+               max_parent_charges.value() < holstered_item.second ) {
         // if you cannot fit all items because parent container is too small
         if( query_yn(
                 _( "The parent container does not have enough space to fit more than %i %s.  Would you like to first wield %s to fit more?" ),


### PR DESCRIPTION
#### Summary
Backport DDA 79556 - fix insert segfault

#### Purpose of change
Inserting items with v was causing a segfault due to DDA 79518.

#### Describe the solution
Add a null guard.

#### Testing
Can insert, no crash.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
