### PR TITLE
Remove psychopath chat penalty

### DIFF
--- a/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
+++ b/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
@@ -134,16 +134,7 @@
         "topic": "TALK_DONE",
         "switch": true,
         "condition": { "u_has_trait": "PSYCHOPATH" },
-        "effect": [
-          {
-            "u_add_morale": "morale_chat_uncaring",
-            "bonus": -10,
-            "max_bonus": -20,
-            "duration": "120 minutes",
-            "decay_start": "60 minutes"
-          },
-          { "npc_add_effect": "asked_to_socialize", "duration": 7000 }
-        ]
+        "effect": [ { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ]
       }
     ]
   }


### PR DESCRIPTION
#### Summary
Remove psychopath chat penalty

#### Purpose of change
Psychopaths were being given a morale penalty for chitchatting with NPC pals. That's not appropriate. They don't hate you, they just don't feel the way you feel.

#### Describe the solution
Remove the morale penalty. They still get no bonus.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
