### PR TITLE
Backport DDA 79477 - Convert some vehicle operations to be map aware

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10812,7 +10812,7 @@ void Character::place_corpse( map *here )
         }
     }
 
-    here->add_item_or_charges( here->get_bub( pos_abs() ), body );
+    here->add_item_or_charges( pos_bub( here ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -11601,7 +11601,7 @@ void Character::gravity_check()
 
 void Character::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    const tripoint_bub_ms pos = pos_bub( here );
     if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
         here->try_fall( pos, this ) ) {
         here->update_visibility_cache( pos.z() );
@@ -13393,8 +13393,8 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( *here, this, here->get_bub( pos_abs() ) ) ) {
-        weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
+    if( weapon.process( *here, this, pos_bub( here ) ) ) {
+        weapon.spill_contents( here,  pos_bub( here ) );
         remove_weapon();
     }
 
@@ -13403,8 +13403,8 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( *here, this, here->get_bub( pos_abs() ) ) ) {
-            it->spill_contents( here, here->get_bub( pos_abs() ) );
+        if( it->process( *here, this, pos_bub( here ) ) ) {
+            it->spill_contents( here, pos_bub( here ) );
             removed_items.push_back( it );
         }
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9708,7 +9708,7 @@ void map::build_obstacle_cache(
     }
     // Iterate over creatures and set them to block their squares relative to their size.
     for( Creature &critter : g->all_creatures() ) {
-        const tripoint_bub_ms loc = get_bub( critter.pos_abs() );
+        const tripoint_bub_ms loc = critter.pos_bub( this );
         if( loc.z() != start.z() || !inbounds( loc ) ) {
             continue;
         }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1476,7 +1476,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( get_bub( you.pos_abs() ) );
+    field &curfield = get_field( you.pos_bub( this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)
@@ -1511,7 +1511,7 @@ void map::player_in_field( Character &you )
             // Sap does nothing to cars.
             if( !you.in_vehicle ) {
                 // Use up sap.
-                mod_field_intensity( get_bub( you.pos_abs() ), ft, -1 );
+                mod_field_intensity( you.pos_bub( this ), ft, -1 );
             }
         }
         if( ft == fd_sludge ) {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -101,10 +101,10 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( here->get_bub( z.pos_abs() ) + point( rng( -distance, distance ),
+        tripoint_bub_ms tarp( z.pos_bub( here ) + point( rng( -distance, distance ),
                               rng( -distance,
                                    distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( here->get_bub( z.pos_abs() ), tarp );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( here ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -149,7 +149,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( here->get_bub( z.pos_abs() ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -208,7 +208,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( z.has_effect( effect_critter_underfed ) ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
     }
     return {};
 }
@@ -238,7 +238,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( here->get_bub( z.pos_abs() ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -261,14 +261,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( here->get_bub( z.pos_abs() ), mags );
+                            here->spawn_items( z.pos_bub( here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( here->get_bub( z.pos_abs() ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -298,5 +298,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( z.has_effect( effect_critter_underfed ) ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2967,7 +2967,7 @@ void monster::die( map *here, Creature *nkiller )
     }
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here->points_in_radius( here->get_bub( pos_abs() ), 1,
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( here ), 1,
                 0 ) ) {
             Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
@@ -3104,14 +3104,14 @@ void monster::die( map *here, Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+                here->add_item_or_charges( pos_bub( here ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                here->add_item( here->get_bub( pos_abs() ), it );
+                here->add_item( pos_bub( here ), it );
             }
         }
     }
@@ -3233,7 +3233,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+            here->add_item_or_charges( pos_bub( here ), it );
         }
         return;
     }
@@ -3892,7 +3892,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here->sees( here->get_bub( critter.pos_abs() ), here->get_bub( pos_abs() ), light ) ) {
+            if( here->sees( critter.pos_bub( here ), pos_bub( here ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3061,7 +3061,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( here->get_bub( pos_abs() ), true );
+        here->unboard_vehicle( pos_bub( here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3368,14 +3368,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, here->get_bub( pos_abs() ) ) &&
-        !here->has_vehicle_floor( here->get_bub( pos_abs() ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
+        !here->has_vehicle_floor( pos_bub( here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( here->get_bub( pos_abs() ), this );
+        here->board_vehicle( pos_bub( here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -1,0 +1,120 @@
+#include <memory>
+#include <utility>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "game.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mutation.h"
+#include "player_helpers.h"
+#include "vehicle.h"
+#include "veh_type.h"
+
+static const itype_id itype_backpack_giant( "backpack_giant" );
+static const itype_id itype_rock_volume_test( "rock_volume_test" );
+
+static const trait_id trait_HUGE( "HUGE" );
+static const trait_id trait_LARGE( "LARGE" );
+static const trait_id trait_SMALL( "SMALL" );
+static const trait_id trait_SMALL2( "SMALL2" );
+
+static const vproto_id vehicle_prototype_character_volume_test_car( "character_volume_test_car" );
+
+static units::volume your_volume_with_trait( trait_id new_trait )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.set_mutation( new_trait );
+    return you.get_base_volume();
+}
+
+static int your_height_with_trait( trait_id new_trait )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.set_mutation( new_trait );
+    return you.height();
+}
+
+TEST_CASE( "character_baseline_volumes", "[volume]" )
+{
+    clear_avatar();
+    Character &you = get_player_character();
+    you.set_stored_kcal( you.get_healthy_kcal() );
+    REQUIRE( you.get_mutations().empty() );
+    REQUIRE( you.height() == 175 );
+    REQUIRE( you.bodyweight() == 76562390_milligram );
+    CHECK( you.get_base_volume() == 73485_ml );
+
+    REQUIRE( your_height_with_trait( trait_SMALL2 ) == 70 );
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
+
+    REQUIRE( your_height_with_trait( trait_SMALL ) == 122 );
+    CHECK( your_volume_with_trait( trait_SMALL ) == 42476_ml );
+
+    REQUIRE( your_height_with_trait( trait_LARGE ) == 227 );
+    CHECK( your_volume_with_trait( trait_LARGE ) == 116034_ml );
+
+    REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
+}
+
+TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
+{
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    Character &you = get_player_character();
+    REQUIRE( you.get_mutations().empty() );
+
+    tripoint_bub_ms test_pos {10, 10, 0 };
+
+
+    clear_vehicles(); // extra safety
+    here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
+    you.setpos( test_pos );
+    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( &here ) );
+    REQUIRE( vp_there );
+    tripoint_abs_ms dest_loc = you.pos_abs();
+
+    // Empty aisle
+    dest_loc = dest_loc + tripoint::north_west;
+    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    dest_loc = you.pos_abs(); //reset
+
+    // Aisle with 10L rock, a tight fit but not impossible
+    dest_loc = dest_loc + tripoint::north;
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    dest_loc = you.pos_abs(); //reset
+
+    // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
+    item backpack( itype_backpack_giant );
+    auto worn_success = you.wear_item( backpack );
+    CHECK( worn_success );
+    you.i_add( item( itype_rock_volume_test ) );
+    CHECK( 75_liter <= you.get_total_volume() );
+    CHECK( you.get_total_volume() <= 100_liter );
+    dest_loc = dest_loc + tripoint::north_west;
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    dest_loc = you.pos_abs(); //reset
+
+    // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
+    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
+    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    dest_loc = dest_loc + tripoint::north;
+    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    dest_loc = you.pos_abs(); //reset
+
+    // Same aisle, but now we have HUGE GUTS. We will never fit.
+    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
+    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    dest_loc = dest_loc + tripoint::north;
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    dest_loc = you.pos_abs(); //reset
+
+    // And finally, check that our HUGE body won't fit even into an empty aisle.
+    dest_loc = dest_loc + tripoint::north_west;
+    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+}


### PR DESCRIPTION
#### Summary
Backport DDA 79477 - Convert some vehicle operations to be map aware

#### Purpose of change
Mapification project to allow stuff to happen offscreen.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
