### PR TITLE
Backport bugfixes

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5244,7 +5244,7 @@ static bool can_place_monster( const monster &mon, map *here, const tripoint_bub
     if( creatures.creature_at<Character>( pos ) ) {
         return false;
     }
-    return mon.will_move_to( p ) && mon.know_danger_at( p );
+    return mon.will_move_to( here, p ) && mon.know_danger_at( here, p );
 }
 
 static bool can_place_npc( const tripoint_bub_ms &p )

--- a/src/game.h
+++ b/src/game.h
@@ -360,6 +360,8 @@ class game
         monster *place_critter_within( const mtype_id &id, const tripoint_range<tripoint_bub_ms> &range );
         monster *place_critter_within( const shared_ptr_fast<monster> &mon,
                                        const tripoint_range<tripoint_bub_ms> &range );
+        // Differs from the operations above in that it refers to a map that isn't necessarily the main one.
+        // Also, it places the critter at the center position if possible, and any available location with equal weight if not.
         monster *place_critter_at_or_within( const shared_ptr_fast<monster> &mon, map *here,
                                              const tripoint_bub_ms &center, const tripoint_range<tripoint_bub_ms> &range );
         /** @} */

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9280,35 +9280,9 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
                 tmp.ammo = tmp.type->starting_ammo;
             }
 
-            const auto valid_location = [&]( const tripoint_bub_ms & p ) {
-                // Checking for creatures via g is only meaningful if this is the main game map.
-                // If it's some local map instance, the coordinates will most likely not even match.
-                return ( !g || &get_map() != this || !creatures.creature_at( p ) ) && tmp.can_move_to( p );
-            };
-
-            const auto place_it = [&]( const tripoint_bub_ms & p ) {
-                monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ), p );
-                if( placed == nullptr ) {
-                    return;
-                }
-                if( !i.data.patrol_points_rel_ms.empty() ) {
-                    placed->set_patrol_route( i.data.patrol_points_rel_ms );
-                }
-                if( placed ) {
-                    placed->on_load();
-                }
-            };
-
-            // First check out defined spawn location for a valid placement, and if that doesn't work
-            // then fall back to picking a random point that is a valid location.
-            if( valid_location( center ) ) {
-                place_it( center );
-            } else {
-                const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location );
-                if( pos.has_value() ) {
-                    place_it( *pos );
-                }
-            }
+            // This can fail, but there isn't much we can do about it if it does. We could output some
+            // kind of info message, but, again, it's unlikely to result in anything that can be acted on.
+            g->place_critter_at_or_within( make_shared_fast<monster>( tmp ), this, center, points );
         }
     }
     current_submap->spawns.clear();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9231,8 +9231,6 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
     }
     const tripoint_bub_ms gp_ms = rebase_bub( coords::project_to<coords::ms>( gp ) );
 
-    creature_tracker &creatures = get_creature_tracker();
-
     // The list of spawns on the submap might be updated while we are iterating it.
     // For example, `monster::on_load` -> `monster::try_reproduce` calls `map::add_spawn`.
     // Therefore, this intentionally uses old-school indexed for-loop with re-check against `.size()` each step.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9288,6 +9288,9 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
 
             const auto place_it = [&]( const tripoint_bub_ms & p ) {
                 monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ), p );
+                if( placed == nullptr ) {
+                    return;
+                }
                 if( !i.data.patrol_points_rel_ms.empty() ) {
                     placed->set_patrol_route( i.data.patrol_points_rel_ms );
                 }
@@ -9300,8 +9303,11 @@ void map::spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight, b
             // then fall back to picking a random point that is a valid location.
             if( valid_location( center ) ) {
                 place_it( center );
-            } else if( const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location ) ) {
-                place_it( *pos );
+            } else {
+                const std::optional<tripoint_bub_ms> pos = random_point( points, valid_location );
+                if( pos.has_value() ) {
+                    place_it( *pos );
+                }
             }
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -144,54 +144,55 @@ static bool z_is_valid( int z )
     return z >= -OVERMAP_DEPTH && z <= OVERMAP_HEIGHT;
 }
 
-bool monster::will_move_to( const tripoint_bub_ms &p ) const
+bool monster::will_move_to( map *here, const tripoint_bub_ms &p ) const
 {
-    map &here = get_map();
-    if( here.impassable( p ) ) {
+    if( here->impassable( p ) ) {
         if( digging() ) {
-            if( !here.has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
+            if( !here->has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
                 return false;
             }
-        } else if( !( can_climb() && here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, p ) ) ) {
+        } else if( !( can_climb() && here->has_flag( ter_furn_flag::TFLAG_CLIMBABLE, p ) ) ) {
             return false;
         }
     }
 
-    if( !here.has_vehicle_floor( p ) ) {
-        if( !can_submerge() && !flies() && here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
+    if( !here->has_vehicle_floor( p ) ) {
+        if( !can_submerge() && !flies() && here->has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
             return false;
         }
     }
 
-    if( digs() && !here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
-        !here.has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
+    if( digs() && !here->has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
+        !here->has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
         return false;
     }
 
     if( has_flag( mon_flag_AQUATIC ) && (
-            !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ||
+            !here->has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) ||
             // AQUATIC (confined to water) monster avoid vehicles, unless they are already underneath one
-            ( here.veh_at( p ) && !here.veh_at( pos_bub() ) )
+            ( here->veh_at( p ) && !here->veh_at( pos_bub() ) )
         ) ) {
         return false;
     }
 
-    if( has_flag( mon_flag_SUNDEATH ) && g->is_in_sunlight( p ) ) {
+    if( has_flag( mon_flag_SUNDEATH ) && g->is_in_sunlight( here, p ) ) {
         return false;
     }
 
     if( get_size() > creature_size::medium &&
-        here.has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, p ) ) {
+        here->has_flag_ter( ter_furn_flag::TFLAG_SMALL_PASSAGE, p ) ) {
         return false; // if a large critter, can't move through tight passages
     }
 
     return true;
 }
-
-bool monster::know_danger_at( const tripoint_bub_ms &p ) const
+bool monster::will_move_to( const tripoint_bub_ms &p ) const
 {
     map &here = get_map();
-
+    return monster::will_move_to( &here, p );
+}
+bool monster::know_danger_at( map *here, const tripoint_bub_ms &p ) const
+{
     // Various avoiding behaviors.
 
     bool avoid_simple = has_flag( mon_flag_PATH_AVOID_DANGER );
@@ -207,8 +208,8 @@ bool monster::know_danger_at( const tripoint_bub_ms &p ) const
     // before hitting simple or complex but this is more explicit
     if( avoid_fire || avoid_fall || avoid_simple ||
         avoid_traps || avoid_dangerous_fields || avoid_sharp ) {
-        const ter_id &target = here.ter( p );
-        if( !here.has_vehicle_floor( p ) ) {
+        const ter_id &target = here->ter( p );
+        if( !here->has_vehicle_floor( p ) ) {
             // Don't enter lava if we have any concept of heat being bad
             if( avoid_fire && target == ter_t_lava ) {
                 return false;
@@ -216,11 +217,11 @@ bool monster::know_danger_at( const tripoint_bub_ms &p ) const
 
             if( avoid_fall ) {
                 // Don't throw ourselves off cliffs if we have a concept of falling
-                if( !here.has_floor_or_water( p ) && !flies() ) {
+                if( !here->has_floor_or_water( p ) && !flies() ) {
                     return false;
                 }
                 // Don't enter open pits unless tiny or flying, unless we're alread in one.
-                const trap trap_there = here.tr_at( p );
+                const trap trap_there = here->tr_at( p );
 
                 if( ( ( type->size != creature_size::tiny ) && !flies() && !has_effect( effect_in_pit ) ) &&
                     ( target == ter_t_pit || target == ter_t_pit_spiked || target == ter_t_pit_glass ||
@@ -233,7 +234,7 @@ bool monster::know_danger_at( const tripoint_bub_ms &p ) const
             if( get_player_character().pos_abs() != get_dest() ||
                 attitude( &get_player_character() ) != MATT_ATTACK ) {
                 // Sharp terrain is ignored while attacking
-                if( avoid_sharp && here.has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
+                if( avoid_sharp && here->has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
                     !( type->size == creature_size::tiny || flies() ||
                        get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) ) {
                     return false;
@@ -241,14 +242,14 @@ bool monster::know_danger_at( const tripoint_bub_ms &p ) const
             }
 
             // Don't step on any traps (if we can see)
-            const trap &target_trap = here.tr_at( p );
+            const trap &target_trap = here->tr_at( p );
             if( avoid_traps && has_flag( mon_flag_SEES ) &&
-                !target_trap.is_benign() && here.has_floor_or_water( p ) ) {
+                !target_trap.is_benign() && here->has_floor_or_water( p ) ) {
                 return false;
             }
         }
 
-        const field &target_field = here.field_at( p );
+        const field &target_field = here->field_at( p );
         // Higher awareness is needed for identifying these as threats.
         if( avoid_dangerous_fields && is_dangerous_fields( target_field ) ) {
             return false;
@@ -265,6 +266,11 @@ bool monster::know_danger_at( const tripoint_bub_ms &p ) const
     }
 
     return true;
+}
+
+bool monster::know_danger_at( const tripoint_bub_ms &p ) const
+{
+    return monster::know_danger_at( &get_map(), p );
 }
 
 bool monster::can_reach_to( const tripoint_bub_ms &p ) const

--- a/src/monster.h
+++ b/src/monster.h
@@ -217,7 +217,9 @@ class monster : public Creature
         bool can_move_to( const tripoint_bub_ms &p ) const;
         bool can_reach_to( const tripoint_bub_ms &p ) const;
         bool will_move_to( const tripoint_bub_ms &p ) const;
+        bool will_move_to( map *here, const tripoint_bub_ms &p ) const;
         bool know_danger_at( const tripoint_bub_ms &p ) const;
+        bool know_danger_at( map *here, const tripoint_bub_ms &p ) const;
 
         bool will_reach( const point_bub_ms &p ); // Do we have plans to get to (x, y)?
         int  turns_to_reach( const point_bub_ms &p ); // How long will it take?


### PR DESCRIPTION
#### Summary
Backport bugfixes

#### Purpose of change
Some infrastructural bugfixes.

#### Describe the solution
79053 - don't place null monsters or on null positions
79081 - reworked spawn_monsters_submap to handle non bub maps

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
