### PR TITLE
Fix murder and nomad morale

### DIFF
--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -71,16 +71,16 @@ void Character::apply_persistent_morale()
         float max_time;
         if( has_trait( trait_NOMAD ) ) {
             max_unhappiness = 20;
-            min_time = to_moves<float>( 12_hours );
-            max_time = to_moves<float>( 1_days );
+            min_time = to_moves<float>( 5_days );
+            max_time = to_moves<float>( 10_days );
         } else if( has_trait( trait_NOMAD2 ) ) {
             max_unhappiness = 40;
-            min_time = to_moves<float>( 4_hours );
-            max_time = to_moves<float>( 8_hours );
+            min_time = to_moves<float>( 60_hours );
+            max_time = to_moves<float>( 5_days );
         } else { // traid_NOMAD3
             max_unhappiness = 60;
-            min_time = to_moves<float>( 1_hours );
-            max_time = to_moves<float>( 2_hours );
+            min_time = to_moves<float>( 1_days );
+            max_time = to_moves<float>( 2_days );
         }
         // The penalty starts at 1 at min_time and scales up to max_unhappiness at max_time.
         const float t = ( total_time - min_time ) / ( max_time - min_time );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1844,7 +1844,7 @@ void npc::on_attacked( const Creature &attacker )
     if( is_hallucination() ) {
         die( &here, nullptr );
     }
-    if( attacker.is_avatar() && !is_enemy() && !is_dead() && !guaranteed_hostile() ) {
+    if( attacker.is_avatar() && !is_dead() ) {
         make_angry();
         hit_by_player = true;
     }
@@ -3069,6 +3069,11 @@ void npc::die( map *here, Creature *nkiller )
         critter->mounted_player = nullptr;
         critter->mounted_player_id = character_id();
     }
+    // Let's attempt to figure out if this was justifiable or not.
+    bool murder = false;
+    if( !is_enemy() && !guaranteed_hostile() ) {
+        murder = true;
+    }
     // if this NPC was the only member of a micro-faction, clean it up.
     if( my_fac ) {
         if( !is_fake() && !is_hallucination() ) {
@@ -3092,53 +3097,45 @@ void npc::die( map *here, Creature *nkiller )
 
     add_msg_if_player_sees( *this, _( "%s dies!" ), get_name() );
 
-    if( Character *ch = dynamic_cast<Character *>( killer ) ) {
-        get_event_bus().send<event_type::character_kills_character>( ch->getID(), getID(), get_name() );
-    }
-    Character &player_character = get_player_character();
-    if( killer == &player_character ) {
-        if( player_character.has_trait( trait_PACIFIST ) ) {
-            add_msg( _( "A cold shock of guilt washes over you." ) );
-            player_character.add_morale( morale_killer_has_killed, -15, 0, 1_days, 1_hours );
+    if( killer && !killer->is_monster() ) {
+        Character &player_character = get_player_character();
+        Character &killer_character = *killer->as_character();
+        get_event_bus().send<event_type::character_kills_character>( killer_character.getID(), getID(),
+                get_name() );
+        // Pacifists are never truly OK with killing, even when it's totally justified.
+        if( killer_character.has_trait( trait_PACIFIST ) ) {
+            killer_character.add_msg_if_player( _( "A cold shock of guilt washes over you." ) );
+            killer_character.add_morale( morale_killer_has_killed, -15, 0, 1_days, 1_hours );
         }
-        if( hit_by_player ) {
+        if( murder ) {
             int morale_effect = -90;
-            // Just because you like eating people doesn't mean you love killing innocents
-            if( player_character.has_flag( json_flag_CANNIBAL ) && morale_effect < 0 ) {
+            // Just because you like eating people doesn't mean you love killing innocents.
+            if( killer_character.has_flag( json_flag_CANNIBAL ) && morale_effect < 0 ) {
                 morale_effect = std::min( 0, morale_effect + 50 );
-            } // Pacifists double dip on penalties if they kill an innocent
-            if( player_character.has_trait( trait_PACIFIST ) ) {
+            } // Pacifists double dip on penalties if they kill an innocent.
+            if( killer_character.has_trait( trait_PACIFIST ) ) {
                 morale_effect -= 15;
             }
-            if( player_character.has_flag( json_flag_PSYCHOPATH ) ||
-                player_character.has_flag( json_flag_SAPIOVORE ) ) {
+            if( killer_character.has_flag( json_flag_PSYCHOPATH ) ||
+                killer_character.has_flag( json_flag_SAPIOVORE ) ) {
                 morale_effect = 0;
             }
-            if( player_character.has_flag( json_flag_SPIRITUAL ) &&
-                ( !player_character.has_flag( json_flag_PSYCHOPATH ) ||
-                  player_character.has_flag( json_flag_PSYCHOPATH ) ) &&
-                !player_character.has_flag( json_flag_SAPIOVORE ) ) {
+            if( killer_character.has_flag( json_flag_SPIRITUAL ) &&
+                ( !killer_character.has_flag( json_flag_PSYCHOPATH ) ) ) {
                 if( morale_effect < 0 ) {
                     add_msg( _( "You feel ashamed of your actions." ) );
                     morale_effect -= 10;
-                } // skulls for the skull throne
-                if( morale_effect > 0 ) {
-                    add_msg( _( "You feel a sense of righteous purpose." ) );
-                    morale_effect += 5;
                 }
             }
             if( morale_effect == 0 ) {
                 // No morale effect
             } else if( morale_effect <= -50 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 14_days, 7_days );
-            } else if( morale_effect > -50 && morale_effect < 0 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 10_days, 7_days );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 12_days, 6_days, true );
             } else {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 7_days, 4_days );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 7_days, 4_days, true );
             }
         }
     }
-
     place_corpse( here );
 }
 


### PR DESCRIPTION
#### Summary
Fix murder and nomad morale

#### Purpose of change
The check for assigning a morale penalty when murdering an innocent was all sorts of stupid, primarily because it was tied up with the check for whether the player would be blamed (by the target) for attacking them. There were checks in place to try to make sure this didn't cause issues, but they famously broke all the time and were just really annoying to deal with, and what's worse is that all of this was only being applied to the player character.

As for the nomad traits (do we really need 3 of them?), these had such ridiculously short timers that they essentially made the game unplayable, with NOMAD3 capping its penalty at just 2 hours.

#### Describe the solution
- Move the murder check out of on_hit() and explicitly define it in npc::die().
- Simplify some of the trait interactions.
- Reduce the max duration of the guilt from 14 days to 12 days.
- Increase the NOMAD1 timer from 1 day to 10 days.
- Increase the NOMAD2 timer from 8 hours to 5 days.
- Increase the NOMAD3 timer from 2 hours to 2 days.

#### Testing
- Spawned in, spawned IR vision. Killed a bandit which I didn't see with regular vision. No morale penalty.
- Killed a bandit which I did see with regular vision. No morale penalty.
- Killed a refugee center NPC. Morale penalty.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
