### PR TITLE
Remove zombie master from prison island start

### DIFF
--- a/data/json/mapgen/prison/prison_island.json
+++ b/data/json/mapgen/prison/prison_island.json
@@ -116,7 +116,7 @@
       ],
       "place_monster": [
         { "monster": "mon_zombie_brute_shocker", "x": 65, "y": 36, "name": "The Foreman" },
-        { "monster": "mon_zombie_master", "x": 40, "y": 63, "name": "The Warden" },
+        { "monster": "mon_feral_warden_prison_island", "x": 40, "y": 63, "name": "The Warden" },
         { "monster": "mon_zombie_kevlar_2", "x": 77, "y": 48, "name": "The Chief" },
         { "monster": "mon_zombie_scientist", "x": 81, "y": 58, "name": "The Doctor" },
         { "monster": "mon_zombie_necro", "x": 75, "y": 28, "name": "The Priest" },

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -517,6 +517,41 @@
     "armor": { "bash": 4, "cut": 4, "acid": 7, "bullet": 4 }
   },
   {
+    "id": "mon_feral_warden_prison_island",
+    "type": "MONSTER",
+    "name": { "str": "feral warden" },
+    "description": "The warden of this prison is somehow still alive, but that doesn't mean they haven't turned.  They still regard these surroundings with cold authority, even wielding a rifle to back it up, but their staring bloodshot eyes and eerie silence mark them as one of the billions whose minds shattered under the unbearable weight of the Cataclysm.",
+    "copy-from": "mon_feral_militia",
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_militia_gun",
+        "ammo_type": "223",
+        "fake_skills": [ [ "gun", 2 ], [ "rifle", 2 ] ],
+        "fake_dex": 8,
+        "fake_per": 10,
+        "ranges": [ [ 2, 35, "DEFAULT" ] ],
+        "condition": {
+          "and": [
+            { "not": { "u_has_effect": "maimed_arm" } },
+            { "not": { "u_has_flag": "grab" } },
+            { "not": { "u_has_flag": "grab_filter" } }
+          ]
+        },
+        "require_targeting_player": false,
+        "target_moving_vehicles": true,
+        "description": "The feral warden fires their rifle!"
+      },
+      { "id": "feral_weapon_feral_militia_gun" },
+      { "id": "feral_unarmed" },
+      { "id": "feral_bite" },
+      [ "BROWSE", 100 ],
+      [ "EAT_FOOD", 100 ]
+    ]
+  },
+  {
     "id": "mon_feral_survivalist",
     "type": "MONSTER",
     "name": { "str": "feral survivor" },


### PR DESCRIPTION
#### Summary
Remove zombie master from prison island start

#### Purpose of change
One of the island prison starts had a guaranteed zombie master in the warden's office. That was cute, but while you spent hours trying to solve the escape room puzzle, he'd be upgrading every single zombie that walked by his window, which generally wound up making the scenario unwinnable.

#### Describe the solution
Replace him with a unique feral that has a rifle.

#### Testing
He shot me through the window.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
