### PR TITLE
Changes judo info text to note where a grab is required.

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1538,7 +1538,7 @@
         { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
       ]
     },
-    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight",
+    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight that you are <info>grabbing</info>",
     "down_dur": 1,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.25 } ],
     "attack_vectors": [ "vector_grasp" ]
@@ -1574,7 +1574,7 @@
         { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
       ]
     },
-    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight",
+    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight that you are <info>grabbing</info>",
     "down_dur": 1,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.25 } ],
     "attack_vectors": [ "vector_grasp" ]
@@ -1602,7 +1602,7 @@
         { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
       ]
     },
-    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight",
+    "condition_desc": "* Only works on a <info>non-downed</info> target of <info>identical</info> size incapable of flight that you are <info>grabbing</info>",
     "down_dur": 1,
     "stun_dur": 1,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.5 } ],


### PR DESCRIPTION
#### Summary
Changes judo info screen to now state if a technique requires the player to be grabbing the target.

#### Purpose of change
To change judo text to be more inline with other MA techniques, like pankration
#### Describe the solution
Added text to judo technique line in techniques.json
#### Describe alternatives you've considered
None
#### Testing
<img width="620" height="932" alt="image" src="https://github.com/user-attachments/assets/9f2ad23d-78bf-436e-89e3-060b4f6a66a4" />

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
