### PR TITLE
Move climb weight check to map

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13688,29 +13688,9 @@ int Character::climbing_cost( const tripoint_bub_ms &from, const tripoint_bub_ms
         return 0;
     }
 
-    const int diff = here.climb_difficulty( from );
+    const int diff = here.climb_difficulty( from, *this );
 
     if( diff > 5 ) {
-        return 0;
-    }
-
-    bool furn_supports_weight = true;
-    bool ter_supports_weight = true;
-    // Check both furn and ter. Only one needs to be climbable for us.
-    if( ( here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, from ) ||
-          here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) &&
-        get_weight() / 10000_gram > here.furn( from ).obj().bash->str_min ) {
-        add_msg_if_player( _( "The %s can't support your weight." ), here.furn( from ).obj().name() );
-        furn_supports_weight = false;
-    }
-    if( ( here.has_flag_ter( ter_furn_flag::TFLAG_LADDER, from ) ||
-          here.has_flag_ter( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) &&
-        get_weight() / 10000_gram > here.ter( from ).obj().bash->str_min ) {
-        add_msg_if_player( _( "The %s can't support your weight." ), here.ter( from ).obj().name() );
-        ter_supports_weight = false;
-    }
-
-    if( !furn_supports_weight || !ter_supports_weight ) {
         return 0;
     }
 

--- a/src/map.h
+++ b/src/map.h
@@ -1643,7 +1643,7 @@ class map
          * Checks 3x3 block centered on p for terrain to climb.
          * @return Difficulty of climbing check from point p.
          */
-        int climb_difficulty( const tripoint_bub_ms &p ) const;
+        int climb_difficulty( const tripoint_bub_ms &p, const Creature &you ) const;
 
         // Support (of weight, structures etc.)
     private:

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1605,7 +1605,7 @@ int monster::calc_climb_cost( const tripoint_bub_ms &f, const tripoint_bub_ms &t
 
     map &here = get_map();
     if( climbs() && !here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, t ) ) {
-        const int diff = here.climb_difficulty( f );
+        const int diff = here.climb_difficulty( f, *this );
         if( diff <= 10 ) {
             return 150;
         }


### PR DESCRIPTION
#### Summary
Move climb weight check to map

#### Purpose of change
The weight check for climbing was done in Character, but there was a separate check run inside of that function in map, which also checked adjacent tiles, making it possible to skip the weight check by being adjacent to something climbable. It makes more sense to just do the weight check in map, so let's do that.

#### Describe the solution
Move the check to map. Now it's a lot smarter and works for monsters too.

#### Describe alternatives you've considered

#### Testing
Climbed a tree, couldn't climb a downspout. Became spider. Could climb the wall next to a downspout. Still got a message about how the downspout can't support my weight, which is technically true - it's not being used to help me climb in that case.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
