### PR TITLE
Stronger furniture, better smashing

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -341,7 +341,7 @@
     "close": "f_gunsafe_c",
     "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM", "MOUNTABLE" ],
     "bash": {
-      "str_min": 40,
+      "str_min": 50,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -368,7 +368,7 @@
     "open": "f_gunsafe_o",
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE" ],
     "bash": {
-      "str_min": 40,
+      "str_min": 50,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -397,7 +397,7 @@
     "examine_action": "locked_object_pickable",
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "bash": {
-      "str_min": 40,
+      "str_min": 50,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -424,7 +424,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "PLACE_ITEM", "MOUNTABLE" ],
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "bash": {
-      "str_min": 40,
+      "str_min": 50,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -452,7 +452,7 @@
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "examine_action": "gunsafe_el",
     "bash": {
-      "str_min": 40,
+      "str_min": 50,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -732,7 +732,7 @@
     "open": "f_safe_o",
     "examine_action": "open_safe",
     "bash": {
-      "str_min": 40,
+      "str_min": 60,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -760,7 +760,7 @@
     "oxytorch": { "result": "f_safe_o", "duration": "14 seconds" },
     "examine_action": "safe",
     "bash": {
-      "str_min": 40,
+      "str_min": 60,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -787,7 +787,7 @@
     "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM", "MOUNTABLE" ],
     "close": "f_safe_c",
     "bash": {
-      "str_min": 40,
+      "str_min": 60,
       "str_max": 200,
       "sound": "screeching metal!",
       "sound_fail": "whump!",
@@ -1314,8 +1314,8 @@
     "examine_action": "keg",
     "keg_capacity": "300 L",
     "bash": {
-      "str_min": 10,
-      "str_max": 20,
+      "str_min": 25,
+      "str_max": 100,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [ { "item": "scrap", "count": [ 8, 32 ] }, { "item": "water_faucet", "prob": 50 } ]
@@ -1338,8 +1338,8 @@
     "examine_action": "keg",
     "keg_capacity": "1500 L",
     "bash": {
-      "str_min": 16,
-      "str_max": 32,
+      "str_min": 30,
+      "str_max": 120,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [ { "item": "scrap", "count": [ 40, 160 ] }, { "item": "water_faucet", "prob": 50 } ]
@@ -1467,8 +1467,8 @@
       ]
     },
     "bash": {
-      "str_min": 8,
-      "str_max": 45,
+      "str_min": 40,
+      "str_max": 100,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
@@ -1498,8 +1498,8 @@
     "keg_capacity": "11250 ml",
     "deconstruct": { "items": [ { "item": "churn", "count": 1 } ] },
     "bash": {
-      "str_min": 12,
-      "str_max": 50,
+      "str_min": 30,
+      "str_max": 75,
       "sound": "smash!",
       "sound_fail": "whump.",
       "items": [
@@ -1527,7 +1527,7 @@
     "max_volume": "1000 L",
     "flags": [ "CONTAINER", "SEALED", "BLOCKSDOOR", "MOUNTABLE" ],
     "bash": {
-      "str_min": 30,
+      "str_min": 60,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -1561,7 +1561,7 @@
       "prying_data": { "difficulty": 4, "prying_level": 1, "noisy": true, "failure": "The lid is sealed more tightly than you thought." }
     },
     "bash": {
-      "str_min": 30,
+      "str_min": 60,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -1588,7 +1588,7 @@
     "max_volume": "1000 L",
     "flags": [ "CONTAINER", "PLACE_ITEM", "NO_SIGHT", "HIDE_PLACE", "BLOCKSDOOR", "MOUNTABLE", "SMALL_HIDE" ],
     "bash": {
-      "str_min": 30,
+      "str_min": 60,
       "str_max": 150,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -1617,8 +1617,8 @@
       "items": [ { "item": "wood_panel", "count": 5 }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": [ 6, 10 ] } ]
     },
     "bash": {
-      "str_min": 12,
-      "str_max": 40,
+      "str_min": 20,
+      "str_max": 60,
       "sound": "smash!",
       "sound_fail": "wham!",
       "items": [ { "item": "2x4", "count": [ 1, 5 ] }, { "item": "hinge", "count": 2 }, { "item": "nail", "charges": [ 2, 10 ] } ]
@@ -1642,8 +1642,8 @@
     "max_volume": "68208 ml",
     "deconstruct": { "items": [ { "item": "foot_locker", "count": 1 } ] },
     "bash": {
-      "str_min": 12,
-      "str_max": 40,
+      "str_min": 20,
+      "str_max": 60,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "items": [
@@ -1673,7 +1673,7 @@
     "max_volume": "67669 ml",
     "deconstruct": { "items": [ { "item": "foot_locker_aluminum", "count": 1 } ] },
     "bash": {
-      "str_min": 12,
+      "str_min": 16,
       "str_max": 40,
       "sound": "metal screeching!",
       "sound_fail": "clang!",

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -926,10 +926,13 @@ static bool is_smashable_corpse( const item &maybe_corpse )
 
 static void smash()
 {
-    const bool allow_floor_bash = debug_mode; // Should later become "true"
+    static tripoint_bub_ms last_smash;
+    static int repeat_count = 0;
+    const bool allow_floor_bash = debug_mode;
     const std::optional<tripoint_bub_ms> smashp_ = choose_adjacent( _( "Smash where?" ),
             allow_floor_bash );
     if( !smashp_ ) {
+        repeat_count = 0;
         return;
     }
     tripoint_bub_ms smashp = *smashp_;
@@ -945,12 +948,25 @@ static void smash()
     }
 
     if( !smashable_corpse_at_target && !g->warn_player_maybe_anger_local_faction( true ) ) {
-        return; // player declined to smash faction's stuff
+        repeat_count = 0;
+        return; // Player declined to smash faction's stuff.
     }
 
     avatar &player_character = get_avatar();
     avatar::smash_result res = player_character.smash( smashp );
-    if( res.did_smash && !res.success &&
+
+    // Prompt to keep smashing only if the player targets the same spot 3 times.
+    if( res.did_smash ) {
+        if( smashp == last_smash ) {
+            repeat_count = std::min( 4, repeat_count + 1);
+        } else {
+            repeat_count = 1;
+            last_smash = smashp;
+        }
+    } else {
+        repeat_count = 0;
+    }
+    if( repeat_count == 3 && res.did_smash && !res.success &&
         res.resistance > 0 && res.skill >= res.resistance &&
         query_yn( _( "Keep smashing until destroyed?" ) ) ) {
         player_character.assign_activity( bash_activity_actor( smashp ) );


### PR DESCRIPTION
#### Summary
Stronger furniture, better smashing

#### Purpose of change
- Constant "keep smashing" prompt was annoying, no way to disable.
- Some furniture (mostly safes) was too easy to bash.

#### Describe the solution
- Raise bash strength of safes to 50, adjust some other random things most people will never notice.
- To get the "keep smashing" prompt, smash the same spot 3 times in a row. If you say no, you won't see it again until you smash someplace else, pause, or move.

#### Describe alternatives you've considered
- Probably some random other actions ought to reset the counter too.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
