### PR TITLE
Fix sleep/deprivation mutations

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1097,7 +1097,7 @@
     "types": [ "SLEEP" ],
     "starting_trait": true,
     "category": [ "ALPHA", "ELFA", "PLANT", "BATRACHIAN" ],
-    "enchantments": [ { "values": [ { "value": "FATIGUE", "multiply": -0.15 } ] } ]
+    "enchantments": [ { "values": [ { "value": "FATIGUE_REGEN", "multiply": 0.15 }, { "value": "FATIGUE", "multiply": -0.15 } ] } ]
   },
   {
     "type": "mutation",
@@ -1404,7 +1404,7 @@
     "starting_trait": true,
     "types": [ "SLEEP" ],
     "category": [ "BEAST", "CHIMERA", "MOUSE", "RABBIT", "FELINE", "RAT" ],
-    "enchantments": [ { "values": [ { "value": "FATIGUE", "multiply": 0.333 } ] } ]
+    "enchantments": [ { "values": [ { "value": "FATIGUE_REGEN", "multiply": -0.333 }, { "value": "FATIGUE", "multiply": 0.333 } ] } ]
   },
   {
     "type": "mutation",
@@ -5741,6 +5741,7 @@
         "values": [
           { "value": "MAX_HP", "add": -6 },
           { "value": "STRENGTH", "add": 4 },
+          { "value": "FATIGUE_REGEN", "multiply": -0.15 },
           { "value": "FATIGUE", "multiply": 0.15 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
           { "value": "CARRY_WEIGHT", "multiply": 0.1 }
@@ -6827,23 +6828,23 @@
     "id": "PERSISTENCE_HUNTER",
     "name": { "str": "Persistence Hunter" },
     "points": 2,
-    "description": "You can pursue prey for miles and miles at a variety of paces until they stop from exhaustion.",
+    "description": "You can pursue prey for quite a long time thanks to your increased stamina recovery and reduced need for sleep.",
     "types": [ "METABOLISM" ],
     "changes_to": [ "PERSISTENCE_HUNTER2" ],
     "category": [ "LUPINE" ],
-    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.1 }, { "value": "FATIGUE", "multiply": -0.1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.1 }, { "value": "FATIGUE_REGEN", "multiply": 0.1 }, { "value": "FATIGUE", "multiply": -0.1 } ] } ]
   },
   {
     "type": "mutation",
     "id": "PERSISTENCE_HUNTER2",
     "name": { "str": "Extreme Persistence Hunter" },
     "points": 10,
-    "description": "You can pursue prey for days until they literally die from exhaustion.  It's too bad zombies don't fatigue either.",
+    "description": "You can pursue prey for days if you have to.  Your stamina recovers quickly and you can go a bit longer without sleep.",
     "types": [ "METABOLISM" ],
     "prereqs": [ "PERSISTENCE_HUNTER" ],
     "threshreq": [ "THRESH_LUPINE" ],
     "category": [ "LUPINE" ],
-    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "FATIGUE", "multiply": -0.2 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "FATIGUE_REGEN", "multiply": 0.2 }, { "value": "FATIGUE", "multiply": -0.2 } ] } ]
   },
   {
     "type": "mutation",
@@ -6862,19 +6863,18 @@
     "id": "MET_RAT",
     "name": { "str": "Rapid Metabolism" },
     "points": 0,
-    "description": "You require more resources than most, but heal more rapidly as well.  Provides weak regeneration even when not asleep.",
-    "types": [ "HEALING", "SLEEP", "METABOLISM" ],
+    "description": "You require more food than most, but you recover stamina and heal from qounds more quickly.",
+    "types": [ "HEALING", "METABOLISM" ],
     "prereqs": [ "HUNGER" ],
     "prereqs2": [ "SLEEPY" ],
     "category": [ "RAT", "MOUSE", "RABBIT" ],
     "enchantments": [
       {
         "values": [
-          { "value": "FATIGUE_REGEN", "multiply": 0.333 },
-          { "value": "FATIGUE", "multiply": 0.5 },
-          { "value": "METABOLISM", "multiply": 0.333 },
+          { "value": "METABOLISM", "multiply": 0.66 },
           { "value": "REGEN_HP", "multiply": 0.5 },
-          { "value": "REGEN_HP_AWAKE", "multiply": 0.133 }
+          { "value": "REGEN_HP_AWAKE", "multiply": 0.133 },
+          { "value": "STAMINA_REGEN_MOD", "add": 0.15 }
         ]
       }
     ]
@@ -6883,13 +6883,14 @@
     "type": "mutation",
     "id": "HUNGER2",
     "name": { "str": "Very Fast Metabolism" },
-    "points": -2,
+    "points": 0,
+    "mixed_effect": true,
     "description": "You need about twice as much food as the average human to maintain your expanded cardiovascular and respiratory systems.  On the plus side, it doesn't take you much time to recover from any strenuous activity.",
     "prereqs": [ "HUNGER" ],
     "changes_to": [ "HUNGER3" ],
     "types": [ "METABOLISM" ],
     "category": [ "BEAST", "SLIME", "RAPTOR", "CHIMERA" ],
-    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.3 }, { "value": "METABOLISM", "multiply": 1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.18 }, { "value": "METABOLISM", "multiply": 1 } ] } ]
   },
   {
     "type": "mutation",
@@ -6969,7 +6970,7 @@
     "prereqs": [ "SLEEPY" ],
     "types": [ "SLEEP" ],
     "category": [ "FELINE" ],
-    "enchantments": [ { "values": [ { "value": "FATIGUE", "multiply": 1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "FATIGUE_REGEN", "multiply": -1 }, { "value": "FATIGUE", "multiply": 1 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/snippets/health_msgs.json
+++ b/data/json/snippets/health_msgs.json
@@ -54,13 +54,12 @@
       "You feel cruddy.  Maybe you should consider eating a bit healthier.",
       "You get up with a bit of a scratch in your throat.",
       "You stretch, but your muscles don't seem to be doing so good today.",
-      "Your stomach gurgles.  It's probably nothing, but maybe you should look into eating something healthy.",
-      "You struggle to awareness.  Being awake seems somewhat harder to reach today.",
-      "You wake up feeling a bit off, as if something is not quite right.",
+      "You wake up congested and bleary-eyed.",
+      "It's harder to get up today.",
+      "You wake up feeling grouchy and foggy-headed.",
       "Your body feels sluggish, making every movement an effort.",
-      "You get up feeling like you didn't get enough rest, even if you slept for hours.",
       "There's a nagging discomfort in your body, making it hard to focus on anything else.",
-      "You feel a general sense of malaise, as if something is draining your energy."
+      "You feel a general sense of malaise."
     ]
   },
   {
@@ -68,13 +67,13 @@
     "category": "health_very_bad",
     "text": [
       "Getting out of bed only comes with great difficulty, and your muscles resist the movement.",
-      "Getting up seems like it should be easy, but all you want to do is go back to bed.",
-      "Tired hands rub at your eyes, the little aches of yesterday protesting your stretches.",
+      "Getting up seems like it should be easy, but all you want to do is lie there.",
+      "You feel like crap today.",
       "Alertness seems flighty today, and your body argues when you move towards it.",
       "You're up, but your body seems like it would rather stay in bed.",
-      "You wake up feeling drained, as if you haven't slept at all.",
+      "You wake up feeling logy and your stomach is sour.",
       "Every movement feels like a chore, your muscles aching with every step.",
-      "You feel a pervasive sense of exhaustion, making it hard to even think clearly.",
+      "Your eyes are crusty and your mouth is dry.  Another day of this shit.",
       "Your body feels heavy and uncooperative, resisting every effort to get up.",
       "You wake up with a sense of dread, knowing today will be a struggle."
     ]
@@ -83,16 +82,16 @@
     "type": "snippet",
     "category": "health_horrible",
     "text": [
-      "You get up feeling horrible, as if something was messing with your body.",
+      "A part of you wishes you hadn't woken up.  Your aching body immediately protests.",
       "You feel awful, and every ache from yesterday is still there.",
-      "Your eyes struggle to open, and your muscles ache like you didn't sleep at all.",
+      "you feel stiff and sore all over.",
       "Bleary-eyed and half-asleep, you consider why you are doing this to yourself.",
       "Awareness seems to only come with a battle… and your body seems to be on its side.",
       "You wake up feeling like you've been hit by a truck, every part of your body protesting.",
-      "A deep, bone-weary exhaustion fills you, making it hard to even lift your head.",
+      "You're so congested it's a wonder you didn't choke to death in your sleep.",
+      "Your stomach feels sour, a sensation you can almost taste on the back of your tongue.",
       "You feel a persistent ache in your body, as if you were fighting off a severe illness.",
-      "Every joint and muscle screams in protest as you try to get up.",
-      "You wake up feeling completely depleted, with no energy to face the day."
+      "Every joint and muscle screams in protest as you try to get up."
     ]
   },
   {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4994,12 +4994,6 @@ void Character::mod_fatigue( int nfatigue )
 
 void Character::mod_sleep_deprivation( int nsleep_deprivation )
 {
-    // Slow the accrual of sleep deprivation if we biologically need less sleep.
-    // No need to bother if it's the other way around.
-    needs_rates rates = calc_needs_rates();
-    if( rates.fatigue < 1.f ) {
-        nsleep_deprivation *= rates.fatigue;
-    }
     set_sleep_deprivation( sleep_deprivation + nsleep_deprivation );
 }
 


### PR DESCRIPTION
#### Summary
Fix sleep/deprivation mutations

#### Purpose of change
All mutations which have a positive FATIGUE multiplier need to also have an equal but negative FATIGUE_REGEN multiplier and vice versa, otherwise sleep deprivation builds up either too fast or not fast enough. Sleep deprivation is not intended to punish frogs for not having to sleep as much as humans, it's there to punish people for abusing stimulants to stay awake.

#### Describe the solution
- Make sure each mutation gets a corresponding fatigue_regen bit added in.
- Clean up and improve the metabolism mutations, they had weird bonuses.
- Clean up a bunch of descriptions of these mutations.
- Clean up some health messages so that people don't confuse them with sleep deprivation.
- If you're injured or weary, your sleep needs will go up either 10 or 20 percent. This both reflects irl convalescence/recovery fatigue and helps make it so the less sleep mutants aren't left unable to properly heal.

#### Testing
Tried tireless, less sleep, very sleepy. All showed the appropriate amount of sleep dep and the appropriate amount of time before I got drowsy.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
