### PR TITLE
Fix backport of 76105

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5735,19 +5735,26 @@ bool basecamp::distribute_food( bool player_command )
     }
 
     if( nutrients_to_add.kcal() <= 0 && nutrients_to_add.vitamins().empty() ) {
-        popup( _( "No suitable items are located at the drop points…" ) );
+        if( player_command ) {
+            popup( _( "No suitable items are located at the drop points…" ) );
+        }
         return false;
     }
 
     std::string popup_msg;
     if( nutrients_to_add.kcal() > 0 ) {
-        popup_msg = string_format( _( "You distribute %d kcal worth of food to your companions." ),
-                                   nutrients_to_add.kcal() );
+        if( player_command ) {
+            popup_msg = string_format( _( "You distribute %d kcal worth of food to your companions." ),
+                                       nutrients_to_add.kcal() );
+        }
     } else {
-        popup_msg = _( "You distribute vitamins and medicine to your companions." );
+        if( player_command ) {
+            popup_msg = _( "You distribute vitamins and medicine to your companions." );
+        }
     }
-
-    popup( popup_msg );
+    if( player_command ) {
+        popup( popup_msg );
+    }
     camp_food_supply( nutrients_to_add );
     return true;
 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -958,7 +958,7 @@ static void smash()
     // Prompt to keep smashing only if the player targets the same spot 3 times.
     if( res.did_smash ) {
         if( smashp == last_smash ) {
-            repeat_count = std::min( 4, repeat_count + 1);
+            repeat_count = std::min( 4, repeat_count + 1 );
         } else {
             repeat_count = 1;
             last_smash = smashp;


### PR DESCRIPTION
#### Summary
Fix backport of 76105

#### Purpose of change
Either due to a regression or an issue with the backport script (seems likelier since I tried to run it again with the same result), the check for whether the player was the one distributing food was getting skipped, so NPC factions distributing food, like when you give food to the refugee center, were causing popup messages that shouldn't have been there.

#### Describe the solution
Manually backport the solution in DDA 76015

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
