### PR TITLE
Remove the "stop targeting?" prompt from spellcasting

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -988,9 +988,7 @@ std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
                     target_is_valid = false;
                 }
                 if( !target_is_valid ) {
-                    if( query_yn( _( "Stop targeting?  Time spent will be lost." ) ) ) {
-                        return std::nullopt;
-                    }
+                    return std::nullopt;
                 }
             } while( !target_is_valid );
         } else if( source->is_npc() ) {


### PR DESCRIPTION
#### Summary
Remove the "stop targeting?" prompt from spellcasting

#### Purpose of change
There's a really annoying prompt that comes up every single time you cancel a spell once you've started targeting but before you've cast. This is meant to safeguard against a forced one second (ish) cost inherent to assigning an activity via activity_handlers, but a one second pause is not worth a prompt EVERY SINGLE TIME this happens.

#### Describe the solution
Just remove the prompt.

#### Describe alternatives you've considered
I would love to be rid of that forced time cost on cancel, but I think it's inherent to anything that uses activity_handlers. I'm not actually sure where the cost is being assessed, I'll keep trying to track that down.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
