### PR TITLE
Adjust denim overalls and cloak thickness

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1925,7 +1925,7 @@
       }
     ],
     "warmth": 25,
-    "material_thickness": 1.1
+    "material_thickness": 0.75
   },
   {
     "id": "cape_costume",

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -116,7 +116,7 @@
     "id": "denim_overalls",
     "type": "ARMOR",
     "name": { "str": "pair of denim overalls", "str_pl": "pairs of denim overalls" },
-    "description": "A pair of denim pants with a front apron and shoulder straps across the back.  It's tough and has plenty of storage space.",
+    "description": "A pair of denim pants with a front apron and shoulder straps across the back.  They're tough and have plenty of storage space.",
     "//": "16.5 oz heavy denim overalls, modeled after the work overalls despite the description.",
     "weight": "1200 g",
     "volume": "3300 ml",
@@ -182,7 +182,7 @@
       }
     ],
     "warmth": 18,
-    "material_thickness": 1.1,
+    "material_thickness": 0.75,
     "flags": [ "VARSIZE", "POCKETS", "STURDY" ]
   },
   {


### PR DESCRIPTION
#### Summary
Adjust denim overalls and cloak thickness

#### Purpose of change
The denim overalls and cloak were a bit too thick, providing more protection than intended.

#### Describe the solution
Make them less thick.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
