### PR TITLE
Attempt to make military base scenario only

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8749,6 +8749,16 @@
     "valid": false,
     "purifiable": false
   },
+    {
+    "type": "mutation",
+    "id": "MILITARY_BASE_SPAWN",
+    "name": { "str": "Active Duty" },
+    "points": 0,
+    "description": "Hidden trait for Overrun scenario that allows the military base to spawn.  You should not be able to see this.",
+    "player_display": false,
+    "valid": false,
+    "purifiable": false
+  },
   {
     "type": "mutation",
     "id": "NPC_RUM",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5952,7 +5952,10 @@
     "city_sizes": [ 4, -1 ],
     "priority": 1,
     "occurrences": [ 45, 100 ],
-    "//": "Inflated chance, in effect ~10%",
+    "eoc": {
+      "id": "EOC_MIL_BASE_GENERATE",
+      "condition": { "u_has_trait": "MILITARY_BASE_SPAWN" }
+    },
     "flags": [ "MILITARY", "GLOBALLY_UNIQUE", "MAN_MADE", "SAFE_AT_WORLDGEN" ]
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -828,6 +828,7 @@
     "id": "overrun",
     "name": "Challenge - Overrun",
     "points": 3,
+    "forced_traits": [ "MILITARY_BASE_SPAWN" ],
     "description": "Despite all the soldiers, guns, and minefields, the military base you were in was overrun by the dead.  Everyone was ordered to fall back to the armory, but during all the chaos you got lost and you are now stuck in the warehouse by yourself.  You are not sure if anyone made it to the armory, or if you are the last one alive.",
     "start_name": "Military Base Warehouse",
     "allowed_locs": [ "sloc_military_base_warehouse" ],

--- a/doc/JSON_LOADING_ORDER.md
+++ b/doc/JSON_LOADING_ORDER.md
@@ -1,1 +1,0 @@
-../data/json/LOADING_ORDER.md


### PR DESCRIPTION
#### Summary
Attempt to make military base scenario only

#### Purpose of change
The military base is a fantastic starting location if you're doing the overrun scenario, which aims to create a specific gameplay experience where you have everything you could ever want, but you cannot safely leave. It is a horrible location at all other times, as approaching from the outside with the usual survivor supplies is pretty easy, and once you get into the place, it has hundreds of guns, tens of thousands of rounds of ammo, rockets, grenades, armor, batteries, vehicle tools, and hundreds of MREs. It essentially ends your game immediately.

#### Describe the solution
Add an EoC to the overmap special which requires a hidden trait applied by the overrun scenario. If I understand correctly, this will prevent the place from spawning unless that condition is satisfied.

#### Describe alternatives you've considered
I really want to change the military base to make it a super difficult location where a powerful character can test their skills against dozens of armed feral soldiers, booby traps, robots, turrets, powerful zeds, etc.

#### Testing
- Tried the overrun scenario. Spawned correctly.
- Spawned a few characters on different scenarios and searched several overmap regions. I didn't see any military bases, but this location isn't exactly common. It's possible I didn't get it, but it looks like I didn't break anything, so I can just merge this and wait for player feedback.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
