### PR TITLE
Make jittery and chemical imbalance slightly less annoying

### DIFF
--- a/data/json/mapgen/private_resort.json
+++ b/data/json/mapgen/private_resort.json
@@ -194,10 +194,7 @@
         "                             xx__________xx                             "
       ],
       "palettes": [ "p_resort_palette_main_floor" ],
-      "place_vendingmachines": [
-        { "item_group": "vending_food", "x": 60, "y": 1  },
-        { "item_group": "vending_drink", "x": 60, "y": 2  }
-      ],
+      "place_vendingmachines": [ { "item_group": "vending_food", "x": 60, "y": 1 }, { "item_group": "vending_drink", "x": 60, "y": 2 } ],
       "items": {
         "L": [
           {

--- a/data/json/mapgen/regional_airport.json
+++ b/data/json/mapgen/regional_airport.json
@@ -356,7 +356,7 @@
         { "item": "mechanics", "chance": 20, "repeat": [ 1, 2 ] }
       ]
     },
-    "vendingmachines": { "8": { "item_group": "vending_drink"  }, "9": { "item_group": "vending_food"  } },
+    "vendingmachines": { "8": { "item_group": "vending_drink" }, "9": { "item_group": "vending_food" } },
     "vehicles": {
       "Á": { "vehicle": "parkinglotbasic", "chance": 33, "rotation": 270 },
       "É": { "vehicle": "parkinglotbasic", "chance": 33, "rotation": 90 }

--- a/data/json/mapgen/reststop.json
+++ b/data/json/mapgen/reststop.json
@@ -97,7 +97,7 @@
         "R": "f_bike_rack"
       },
       "toilets": { "B": {  } },
-      "vendingmachines": { "%": { "item_group": "vending_drink"  }, "F": { "item_group": "vending_food"  } },
+      "vendingmachines": { "%": { "item_group": "vending_drink" }, "F": { "item_group": "vending_food" } },
       "items": {
         "B": { "item": "SUS_toilet", "chance": 30 },
         "Y": { "item": "trash", "chance": 20, "repeat": [ 2, 4 ] },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1744,7 +1744,7 @@
     "id": "JITTERY",
     "name": { "str": "Jittery" },
     "points": -3,
-    "description": "When very hungry or under the effects of stimulants, you may find your hands shaking uncontrollably, severely reducing your Dexterity.",
+    "description": "You tend to get a bad case of the shakes when you're hungry or under the effects of stimulants.",
     "starting_trait": true,
     "category": [ "MEDICAL", "MOUSE", "RABBIT" ]
   },

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -512,11 +512,13 @@ void suffer::while_awake( Character &you, const int current_stim )
 
     if( you.has_trait( trait_JITTERY ) && !you.has_effect( effect_shakes ) ) {
         if( current_stim > 50 && one_in( to_turns<int>( 30_minutes ) - ( current_stim * 6 ) ) ) {
-            you.add_effect( effect_shakes, 30_minutes + 1_turns * current_stim );
+            time_duration dur = 1_minutes * rng( 1, 30 );
+            you.add_effect( effect_shakes, dur + 1_turns * current_stim );
         } else if( ( you.get_hunger() > 80 || ( you.get_kcal_percent() < 0.9f &&
                                                 you.get_hunger() > ( 80 - ( 100 - you.get_kcal_percent() * 100 ) ) ) )  &&
                    one_in( to_turns<int>( 50_minutes ) - ( you.get_hunger() * 6 ) ) ) {
-            you.add_effect( effect_shakes, 40_minutes );
+            time_duration dur = 1_minutes * rng( 1, 30 );
+            you.add_effect( effect_shakes, dur );
         }
     }
 
@@ -557,11 +559,11 @@ void suffer::while_awake( Character &you, const int current_stim )
 
 void suffer::from_chemimbalance( Character &you )
 {
-    if( one_turn_in( 6_hours ) && !you.has_flag( json_flag_PAIN_IMMUNE ) ) {
+    if( one_turn_in( 6_hours ) && !you.has_flag( json_flag_PAIN_IMMUNE ) && rng( 0, 1) == 1 ) {
         you.add_msg_if_player( m_bad, _( "You suddenly feel sharp pain for no reason." ) );
         you.mod_pain( 3 * rng( 1, 3 ) );
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours ) && rng( 0, 1) == 1 ) {
         int pkilladd = 5 * rng( -1, 2 );
         if( pkilladd > 0 ) {
             you.add_msg_if_player( m_bad, _( "You suddenly feel numb." ) );
@@ -570,11 +572,11 @@ void suffer::from_chemimbalance( Character &you )
         }
         you.mod_painkiller( pkilladd );
     }
-    if( one_turn_in( 6_hours ) && !you.has_effect( effect_sleep ) ) {
+    if( one_turn_in( 6_hours ) && !you.has_effect( effect_sleep ) && rng( 0, 1) == 1 ) {
         you.add_msg_if_player( m_bad, _( "You feel dizzy for a moment." ) );
         you.mod_moves( -to_moves<int>( 1_seconds ) * rng_float( 0.1, 0.3 ) );
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours )  && rng( 0, 1) == 1 ) {
         int hungadd = 5 * rng( -1, 3 );
         if( hungadd > 0 ) {
             you.add_msg_if_player( m_bad, _( "You suddenly feel hungry." ) );
@@ -583,22 +585,22 @@ void suffer::from_chemimbalance( Character &you )
         }
         you.mod_hunger( hungadd );
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours )  && rng( 0, 1) == 1 ) {
         you.add_msg_if_player( m_bad, _( "You suddenly feel thirsty." ) );
         you.mod_thirst( 5 * rng( 1, 3 ) );
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours ) && rng( 0, 1) == 1 ) {
         you.add_msg_if_player( m_good, _( "You feel fatigued all of a sudden." ) );
         you.mod_fatigue( 10 * rng( 2, 4 ) );
     }
-    if( one_turn_in( 8_hours ) ) {
+    if( one_turn_in( 8_hours ) && rng( 0, 1) == 1 ) {
         if( one_in( 3 ) ) {
             you.add_morale( morale_feeling_good, 20, 100 );
         } else {
             you.add_morale( morale_feeling_bad, -20, -100 );
         }
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours ) && rng( 0, 1) == 1 ) {
         if( one_in( 3 ) ) {
             you.add_msg_if_player( m_bad, _( "You suddenly feel very cold." ) );
             you.set_all_parts_temp_cur( BODYTEMP_VERY_COLD );
@@ -607,7 +609,7 @@ void suffer::from_chemimbalance( Character &you )
             you.set_all_parts_temp_cur( BODYTEMP_COLD );
         }
     }
-    if( one_turn_in( 6_hours ) ) {
+    if( one_turn_in( 6_hours ) && rng( 0, 1) == 1 ) {
         if( one_in( 3 ) ) {
             you.add_msg_if_player( m_bad, _( "You suddenly feel very hot." ) );
             you.set_all_parts_temp_cur( BODYTEMP_VERY_HOT );


### PR DESCRIPTION
#### Summary
Make jittery and chemical imbalance slightly less annoying

#### Purpose of change
- Make chemical imbalance 50% less likely to trigger at all times.
- Improve the description of jittery.
- Randomize the effect timers for jittery.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
