### PR TITLE
Fix bashed fences leaving holes

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -17,7 +17,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     }
   },
@@ -38,7 +38,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     }
   },
@@ -61,7 +61,7 @@
       "str_max_blocked": 240,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "steel_chunk", "count": [ 1, 4 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
     }
   },
@@ -104,7 +104,7 @@
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "wire", "count": [ 8, 20 ] }, { "item": "scrap", "count": [ 0, 12 ] } ]
     }
   },
@@ -140,7 +140,7 @@
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "wire", "count": [ 6, 15 ] },
         { "item": "pipe", "count": [ 6, 15 ] },
@@ -177,7 +177,7 @@
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "wire", "count": [ 6, 15 ] },
         { "item": "pipe", "count": [ 6, 15 ] },
@@ -218,7 +218,7 @@
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "wire", "count": [ 8, 20 ] },
         { "item": "chain", "count": [ 1, 2 ] },
@@ -258,7 +258,7 @@
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "wire", "count": [ 6, 15 ] },
         { "item": "chain", "count": [ 1, 2 ] },
@@ -283,7 +283,7 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "wire", "count": [ 6, 15 ] },
         { "item": "pipe", "count": [ 6, 15 ] },
@@ -321,7 +321,7 @@
       "str_max_blocked": 30,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 2, 8 ] },
@@ -357,7 +357,7 @@
       "str_max": 60,
       "sound": "crash!",
       "sound_fail": "wham!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 2, 8 ] },
@@ -475,7 +475,7 @@
       "str_max_blocked": 15,
       "sound": "rattle!",
       "sound_fail": "thump!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "wire", "count": [ 4, 6 ] }, { "item": "2x4", "count": [ 2, 4 ] }, { "item": "hinge", "count": [ 1, 2 ] } ]
     }
   },
@@ -507,7 +507,7 @@
       "str_max": 12,
       "sound": "rattle!",
       "sound_fail": "thump!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "wire", "count": [ 4, 6 ] }, { "item": "2x4", "count": [ 2, 4 ] }, { "item": "hinge", "count": [ 1, 2 ] } ]
     }
   },
@@ -540,7 +540,7 @@
       "str_max": 20,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "nail", "charges": [ 2, 6 ] }, { "item": "splinter", "count": 1 } ]
     },
     "prying": {
@@ -584,7 +584,7 @@
       "str_max": 20,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": [ 0, 2 ] }, { "item": "splinter", "count": [ 5, 15 ] } ]
     }
   },
@@ -604,7 +604,7 @@
       "str_max": 20,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "stick", "count": [ 1, 4 ] } ]
     }
   },
@@ -669,7 +669,7 @@
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "pipe", "count": [ 1, 4 ] },
         { "item": "pipe_fittings", "count": [ 0, 2 ] },
@@ -750,7 +750,7 @@
       "str_max": 10,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "2x4", "count": [ 0, 2 ] } ]
     }
   },
@@ -770,7 +770,7 @@
       "str_max": 20,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": [ 0, 2 ] } ]
     }
   },
@@ -796,7 +796,7 @@
       "str_max": 15,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": [ 0, 2 ] }, { "item": "wire", "count": [ 0, 2 ] } ]
     }
   },
@@ -822,7 +822,7 @@
       "str_max": 15,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [ { "item": "pointy_stick", "count": [ 0, 2 ] }, { "item": "wire_barbed", "count": [ 0, 2 ] } ]
     }
   },
@@ -842,7 +842,7 @@
       "str_max": 15,
       "sound": "crack.",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "pointy_stick", "count": [ 0, 2 ] },
         { "item": "rope_6", "prob": 50 },
@@ -905,7 +905,7 @@
       "str_max_blocked": 16,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 2, 8 ] },
@@ -944,7 +944,7 @@
       "str_max_blocked": 16,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 1, 4 ] },
         { "item": "nail", "charges": [ 2, 8 ] },
@@ -1125,7 +1125,7 @@
       "str_max_blocked": 16,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 4, 8 ] },
         { "item": "nail", "charges": [ 10, 20 ] },
@@ -1164,7 +1164,7 @@
       "str_max_blocked": 16,
       "sound": "crack.",
       "sound_fail": "wham.",
-      "ter_set": "t_null",
+      "ter_set": "t_dirt",
       "items": [
         { "item": "2x4", "count": [ 4, 8 ] },
         { "item": "nail", "charges": [ 10, 20 ] },

--- a/data/json/mapgen/riverside/whaleys_boat_rental.json
+++ b/data/json/mapgen/riverside/whaleys_boat_rental.json
@@ -61,7 +61,7 @@
         { "chance": 45, "item": "swimmer_gloves", "repeat": [ 1, 4 ] }
       ]
     },
-    "vendingmachines": { "D": { "item_group": "vending_drink"  }, "F": { "item_group": "vending_food"  } },
+    "vendingmachines": { "D": { "item_group": "vending_drink" }, "F": { "item_group": "vending_food" } },
     "toilets": { "t": {  } }
   },
   {


### PR DESCRIPTION
#### Summary
Fix bashed fences leaving holes

#### Purpose of change
It's been an ongoing issue that destroying a fence or fence post was sometimes making holes in the ground. I have backported at least two DDA PRs that aimed to fix this, but it's actually not fixed in either game, because the whole thing relies on there being terrain beneath the fence that had SUPPORTS_ROOF. A lot of stuff that's going to be underground, particularly sewers, does not have SUPPORTS_ROOF and probably shouldn't, especially as it'd mean smashing a fence post stuck in the dirt would suddenly turn the ground there into a concrete floor or something, since that's what the roofs are made of.

#### Describe the solution
This was happening because fences had t_null defined as the terrain they'd turn into when bashed. There's really no reason not to make it t_dirt.

#### Describe alternatives you've considered
There are rare cases like labs and other facilities where fences would be set into pavement or concrete, but in those cases that needs to be a different kind of terrain, or perhaps fences ought to be furniture instead. This doesn't address that, so you might see some dirt appearing in old labs if you smash their chainlink fences. Ah well.

#### Testing
Made a fence post above a sewer. Smashed it. It turned into dirt instead of a pit leading down into the sewer.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
