### PR TITLE
Reduce welding store loot a bit

### DIFF
--- a/data/json/mapgen_palettes/welding_store.json
+++ b/data/json/mapgen_palettes/welding_store.json
@@ -53,15 +53,15 @@
       "S": "f_rack"
     },
     "item": {
-      "f": { "item": "weldtank", "chance": 65, "repeat": [ 0, 3 ] },
-      "F": { "item": "weldtank", "chance": 50, "repeat": [ 0, 3 ] }
+      "f": { "item": "weldtank", "chance": 45, "repeat": [ 0, 2 ] },
+      "F": { "item": "weldtank", "chance": 40, "repeat": [ 0, 2 ] }
     },
     "items": {
       "H": { "item": "cash_register_random" },
-      "s": { "item": "SUS_welding_gear", "chance": 45, "repeat": [ 0, 4 ] },
-      "C": { "item": "SUS_welding_gear", "chance": 40, "repeat": [ 0, 4 ] },
-      "r": { "item": "SUS_welding_gear", "chance": 40, "repeat": [ 0, 4 ] },
-      "S": { "item": "tools_common_small", "chance": 45, "repeat": [ 0, 4 ] },
+      "s": { "item": "SUS_welding_gear", "chance": 40, "repeat": [ 0, 2 ] },
+      "C": { "item": "SUS_welding_gear", "chance": 35, "repeat": [ 0, 2 ] },
+      "r": { "item": "SUS_welding_gear", "chance": 35, "repeat": [ 0, 2 ] },
+      "S": { "item": "tools_common_small", "chance": 45, "repeat": [ 0, 2 ] },
       "l": { "item": "clothing_work_set", "chance": 45, "repeat": [ 0, 1 ] }
     },
     "vehicles": {


### PR DESCRIPTION
#### Summary
Reduce welding store loot a bit

#### Purpose of change
Welding stores are meant to be really nice finds for welding, but they were too loaded up, providing more than you could ever really use in some cases.

#### Describe the solution
Reduce the loot a bit.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
