### PR TITLE
Crafting improvements

### DIFF
--- a/data/json/mapgen/s_gun.json
+++ b/data/json/mapgen/s_gun.json
@@ -234,7 +234,7 @@
         ",,,,,,,,,,,,,,,,,,,,,,,,"
       ],
       "palettes": [ "gun_store_palette" ],
-      "vendingmachines": { "V": { "item_group": "vending_ammo"  } },
+      "vendingmachines": { "V": { "item_group": "vending_ammo" } },
       "terrain": { ";": "t_sidewalk" },
       "place_loot": [
         { "group": "cash_register_random", "x": [ 4, 6 ], "y": 5 },
@@ -374,7 +374,7 @@
       ],
       "palettes": [ "gun_store_palette" ],
       "terrain": { ";": "t_sidewalk" },
-      "vendingmachines": { "V": { "item_group": "vending_ammo"  } },
+      "vendingmachines": { "V": { "item_group": "vending_ammo" } },
       "nested": {
         "#": { "chunks": [ [ "general_graffiti", 15 ], [ "null", 75 ] ] },
         "m": { "chunks": [ [ "destroyed_furniture", 40 ], [ "null", 80 ] ] },

--- a/data/json/mapgen/s_hardware.json
+++ b/data/json/mapgen/s_hardware.json
@@ -325,7 +325,7 @@
         "u": "f_trashcan",
         "v": "f_counter"
       },
-      "place_vendingmachines": [ { "x": 8, "y": 2  }, { "x": 8, "y": 3  } ],
+      "place_vendingmachines": [ { "x": 8, "y": 2 }, { "x": 8, "y": 3 } ],
       "toilets": { "t": {  } },
       "place_items": [
         { "item": "hardware_bulk", "x": 2, "y": [ 2, 7 ], "chance": 90, "repeat": [ 1, 6 ] },

--- a/src/character.h
+++ b/src/character.h
@@ -3697,7 +3697,12 @@ class Character : public Creature, public visitable
         float get_recipe_weighted_skill_average( const recipe &making ) const;
         float recipe_success_chance( const recipe &making ) const;
         float item_destruction_chance( const recipe &making ) const;
-        craft_roll_data recipe_success_roll_data( const recipe &making ) const;
+        /**
+         * If final == true, then this function will print a message about NPCs helping with the task.
+         * This prevents us from spamming the message window when the player is simply browsing recipes,
+         * as this function is called multiple times.
+         */
+        craft_roll_data recipe_success_roll_data( const recipe &making, bool final = false ) const;
         craft_roll_data recipe_failure_roll_data( const recipe &making ) const;
         void complete_craft( item &craft, const std::optional<tripoint_bub_ms> &loc );
         /**

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -68,7 +68,7 @@ constexpr int MM_REG_SIZE = 8;
  * Items on the map with at most this distance to the player are considered available for crafting,
  * see inventory::form_from_map
 */
-constexpr int PICKUP_RANGE = 7;
+constexpr int PICKUP_RANGE = 8;
 
 // Number of z-levels below 0 (not including 0).
 constexpr int OVERMAP_DEPTH = 10;

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -68,7 +68,7 @@ constexpr int MM_REG_SIZE = 8;
  * Items on the map with at most this distance to the player are considered available for crafting,
  * see inventory::form_from_map
 */
-constexpr int PICKUP_RANGE = 6;
+constexpr int PICKUP_RANGE = 7;
 
 // Number of z-levels below 0 (not including 0).
 constexpr int OVERMAP_DEPTH = 10;

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -500,7 +500,7 @@ void inventory::form_from_map( map *here, const tripoint_bub_ms &origin, int ran
         form_from_map( *here, reachable_pts, pl, assign_invlet );
     } else {
         std::vector<tripoint_bub_ms> reachable_pts;
-        // Fill reachable points with points_in_radius
+        // Fill reachable points with points_in_radius.
         tripoint_range<tripoint_bub_ms> in_radius = here->points_in_radius( origin, range );
         for( const tripoint_bub_ms &p : in_radius ) {
             reachable_pts.emplace_back( p );


### PR DESCRIPTION
#### Summary
Crafting improvements

#### Purpose of change
- Crafting helpers were spamming "X helps you craft..." when browsing the crafting menu because that code was called every time the game tried to predict a success chance.
- Pickup range for crafting was not respecting trigonometric distances or working across Z levels.
- Farsightedness was not penalizing the devices skill during crafting despite that being like the number one thing it should penalize.
- Some messaging wasn't clear.

#### Describe the solution
- Upped the pickup range to 8 tiles to help compensate for the change to Euclidian distances. Z levels have been added, but the Z range is only 4 tiles.
- Crafting now uses Euclidian distances to determine which items and tools are in easy reach for crafting. This means that diagonals are counted as 1.41 tiles, giving you a circular area rather than a square one. This should make intuitive sense as everything else in the game works this way and it's also how Fire Emblem ranged attacks work 😛 
- This also affects use_amount, use_ups, use_charges, use_charges_from_furn - basically any of the functions that work similarly to crafting reach. I think this might improve appliance functionality, or maybe it will break everything. Let me know.
- This distance calculation now works across Z levels provided there is a walkable path (a ramp, a ladder, stairs) within the radius. This does not count dangerous climbables (ie trees) or take special movement modes like spider climb into account.
- This function tries to draw a walkable path following the above rules. It will not walk through dangerous fields or known traps.
- Fixed the spammy messaging for NPCs helping you craft. You now only see it once, when you actually craft something.
- Updated the messaging for crafting something "from reference" to clarify whether it is an NPC showing you how to make the recipe rather than a book you have on hand. This should make it a bit more clear that your buddies are helping you out.

#### Describe alternatives you've considered
- I don't want larger pickup ranges as this could lead to exploits, lag, and players inadvertantly getting access to things they don't even know exist.

#### Testing
All of this seems OK so far. I can craft on a roof using components from down below as long as the ladder's there.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
