### PR TITLE
Make sword bayonet use knife sheath

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -673,9 +673,9 @@
     "techniques": [ "WBLOCK_1", "RAPID" ],
     "qualities": [ [ "CUT", 1 ], [ "COOK", 1 ], [ "BUTCHER", 7 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
-    "flags": [ "DURABLE_MELEE", "PUMP_RAIL_COMPATIBLE", "SHEATH_SWORD" ],
+    "flags": [ "DURABLE_MELEE", "PUMP_RAIL_COMPATIBLE", "SHEATH_KNIFE" ],
     "weapon_category": [ "SHORT_SWORDS" ],
-    "melee_damage": { "bash": 4, "stab": 16 }
+    "melee_damage": { "bash": 4, "stab": 13 }
   },
   {
     "id": "tanto",


### PR DESCRIPTION
#### Summary
Make sword bayonet use knife sheath

#### Purpose of change
- The sword bayonet was using sword sheaths, even though it's knife-sized. This was letting rifles fit in scabbards if they had sword bayonets attached. That's a separate bug that needs to be addressed, but for now we can do a quick fix.
- The thing did too much damage relative to similar and more purpose-built weapons.

#### Describe the solution
- Balance it relative to the tanto, which is a pretty similar blade. We'll give the bayonet better bash and worse stab.
- Switch it to use knife sheaths.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
