### PR TITLE
Fix some compile errors

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13829,8 +13829,10 @@ void Character::pause()
                                    _( "<npcname> drops and rolls on the ground!" ) );
         } else if( total_removed > 0_turns ) {
             if( on_ground ) {
-                _( "You roll on the ground, trying to smother the fire!" ),
-                _( "<npcname> rolls on the ground!" );
+                add_msg_player_or_npc( m_warning,
+                    _( "You roll on the ground, trying to smother the fire!" ),
+                    _( "<npcname> rolls on the ground!" )
+                );
             } else {
                 add_msg_player_or_npc( m_warning,
                                        _( "You attempt to put out the fire on you!" ),

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -295,14 +295,15 @@ struct OM_point { // NOLINT(cata-xy)
 std::istream &operator>>( std::istream &is, fake_tripoint &pos )
 {
     char c = 0;
-    is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y &&is.get( c ) &&c == '.' &&is >> pos.z;
+    static_cast<void>( is >> pos.x && is.get( c ) && c == '.' && is >> pos.y && is.get( c ) &&
+                       c == '.' && is >> pos.z );
     return is;
 }
 
 std::istream &operator>>( std::istream &is, OM_point &pos )
 {
     char c = 0;
-    is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y;
+    static_cast<void>( is >> pos.x && is.get( c ) && c == '.' && is >> pos.y );
     return is;
 }
 
@@ -529,9 +530,7 @@ static void monster_ammo_edit( monster &mon )
         const itype *display_type = item::find_type( new_ammo );
         if( query_int( value, _( "Set %s to how much ammo?  Currently: %d" ), display_type->nname( 1 ),
                        mon.ammo[new_ammo] ) )  {
-            if( value < 0 ) {
-                value = 0;
-            }
+            value = std::max( value, 0 );
             mon.ammo[new_ammo] = value;
         }
     }

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -104,16 +104,18 @@ std::ostream &operator<<( std::ostream &os, const tripoint &pos )
 std::istream &operator>>( std::istream &is, point &pos )
 {
     char c;
-    is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&
-                                is.get( c ) &&c == ')';
+    static_cast<void>( is.get( c ) && c == '(' && is >> pos.x && is.get( c ) && c == ',' &&
+                       is >> pos.y &&
+                       is.get( c ) && c == ')' );
     return is;
 }
 
 std::istream &operator>>( std::istream &is, tripoint &pos )
 {
     char c;
-    is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&
-                                is.get( c ) &&c == ',' &&is >> pos.z &&is.get( c ) &&c == ')';
+    static_cast<void>( is.get( c ) && c == '(' && is >> pos.x && is.get( c ) && c == ',' &&
+                       is >> pos.y &&
+                       is.get( c ) && c == ',' && is >> pos.z && is.get( c ) && c == ')' );
     return is;
 }
 


### PR DESCRIPTION
#### Summary
Build "Fix compile errors"

#### Purpose of change
Some compilation errors were thrown when compiling with `make CCACHE=1 TILES=1 SOUND=1 LOCALIZE=0 BACKTRACE=0 ASTYLE=0 LINTJSON=0 TESTS=0 RUNTESTS=0 CLANG=1 RELEASE=0`.

The errors were:

```
src/character.cpp:13832:20: error: left operand of comma operator has no effect [-Werror,-Wunused-value]                                                                                                                                                                       
 13832 |                 _( "You roll on the ground, trying to smother the fire!" ),                                                                                                                                                                                           
       |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/debug_menu.cpp:298:81: error: expression result unused [-Werror,-Wunused-value]                                                                                                                                                                                            
  298 |     is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y &&is.get( c ) &&c == '.' &&is >> pos.z;                                                                                                                                                                         
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~                                                                                                                                                                          
src/debug_menu.cpp:305:42: error: expression result unused [-Werror,-Wunused-value]                                                                                                                                                                                            
  305 |     is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y;                                                                                                                                                                                                                
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~

src/point.cpp:108:45: error: expression result unused [-Werror,-Wunused-value]                                                                                                                                                                                                 
  107 |     is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&                                                                                                                                                                                     
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                     
  108 |                                 is.get( c ) &&c == ')';                                                                                                                                                                                                                
      |                                 ~~~~~~~~~~~ ^ ~~~~~~~~                                                                                                                                                                                                                 
src/point.cpp:116:84: error: expression result unused [-Werror,-Wunused-value]                                                                                                                                                                                                 
  115 |     is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&                                                                                                                                                                                     
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                                                                     
  116 |                                 is.get( c ) &&c == ',' &&is >> pos.z &&is.get( c ) &&c == ')';                                                                                                                                                                         
      |                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~                                                                                                                                                                          

```

#### Describe the solution
Saw errors, fixed errors.

#### Describe alternatives you've considered
To let Nurgle take me.

#### Testing
Compiles, launches, plays.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
