### PR TITLE
Fix small lighthouse map

### DIFF
--- a/data/json/mapgen/lake_buildings/lighthouse_small.json
+++ b/data/json/mapgen/lake_buildings/lighthouse_small.json
@@ -32,7 +32,7 @@
         ],
         "prob": 90
       },
-      { "item": "con_milk", "count": [ 0, 10 ], "prob": 25 },
+      { "item": "con_milk", "count": [ 0, 2 ], "prob": 25 },
       { "item": "instant_coffee", "count": [ 0, 5 ], "prob": 50 }
     ]
   },
@@ -79,7 +79,6 @@
       "t": "f_table",
       "P": "f_cupboard",
       "f": "f_rack_coat",
-      "u": "f_stool",
       "W": "f_woodstove",
       "l": "f_locker",
       "m": "f_machinery_old",


### PR DESCRIPTION
#### Summary
Fix small lighthouse map

#### Purpose of change
A backport left a stool floating in a window. There was also way too much powdered milk.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
