### PR TITLE
Fix bandit farm obsoletion

### DIFF
--- a/data/json/obsoletion_and_migration/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration/obsolete_overmap_special.json
@@ -14,7 +14,7 @@
     "id": "Cabin_Lapin",
     "new_id": "Cabin_8"
   },
-    {
+  {
     "type": "overmap_special_migration",
     "id": "bandit_work_camp",
     "new_id": "sand_pit"

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2547,29 +2547,6 @@
   },
   {
     "type": "overmap_special",
-    "id": "bandit_work_camp",
-    "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "bandit_farm_5_north" },
-      { "point": [ -1, 0, 0 ], "overmap": "bandit_farm_6_north" },
-      { "point": [ 1, 0, 0 ], "overmap": "bandit_farm_4_north" },
-      { "point": [ 0, -1, 0 ], "overmap": "bandit_farm_2_north" },
-      { "point": [ -1, -1, 0 ], "overmap": "bandit_farm_3_north" },
-      { "point": [ 1, -1, 0 ], "overmap": "bandit_farm_1_north" },
-      { "point": [ 0, 1, 0 ], "overmap": "bandit_farm_8_north" },
-      { "point": [ -1, 1, 0 ], "overmap": "bandit_farm_9_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "bandit_farm_7_north" },
-      { "point": [ 0, -1, 1 ], "overmap": "bandit_farm_2_roof_north" },
-      { "point": [ -1, -1, 1 ], "overmap": "bandit_farm_3_roof_north" }
-    ],
-    "locations": [ "field" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 4, -1 ],
-    "occurrences": [ 10, 100 ],
-    "priority": 1,
-    "flags": [ "CLASSIC", "WILDERNESS", "OVERMAP_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
-  },
-  {
-    "type": "overmap_special",
     "id": "sai",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "sai_north" }, { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],


### PR DESCRIPTION
#### Summary
Fix bandit farm obsoletion

#### Purpose of change
#1405 removed the bandit farm, but I forgot to remove one of the overmap definitions, so the obsoletion didn't work.

#### Describe the solution
Remove it!

#### Testing
No more warnings or crashes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
