### PR TITLE
Dandelion nerf

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -784,7 +784,7 @@
     "spoils_in": "1 day 6 hours",
     "comestible_type": "FOOD",
     "symbol": "%",
-    "calories": 41,
+    "calories": 31,
     "description": "A handful of freshly-picked yellow dandelions.  In their current raw state they are quite bitter.",
     "price": "15 cent",
     "price_postapoc": "12 cent",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -2117,7 +2117,7 @@
       { "proficiency": "prof_frying" },
       { "proficiency": "prof_frying_bread" }
     ],
-    "components": [ [ [ "any_butter_or_oil", 1, "LIST" ] ], [ [ "raw_dandelion", 2 ] ], [ [ "batter", 1, "LIST" ] ] ]
+    "components": [ [ [ "any_butter_or_oil", 1, "LIST" ] ], [ [ "raw_dandelion", 4 ] ], [ [ "batter", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -2243,7 +2243,7 @@
       { "proficiency": "prof_frying_bread" }
     ],
     "components": [
-      [ [ "raw_dandelion", 1 ] ],
+      [ [ "raw_dandelion", 2 ] ],
       [ [ "raw_burdock", 1 ] ],
       [ [ "any_butter_or_oil", 1, "LIST" ] ],
       [ [ "batter", 1, "LIST" ] ]


### PR DESCRIPTION
#### Summary
Dandelion nerf

#### Purpose of change
Dandelions had 10 more kcal than their volume really warranted.

#### Describe the solution
Reduce it! Increase the amount of dandelions in the fried recipes. The others all inherit kcal so they're fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
