### PR TITLE
Locked smartphone capacity and disassemble recipe fix

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -937,7 +937,7 @@
       }
     ],
     "pocket_data": [
-      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
+      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 120 } },
       {
         "forbidden": true,
         "//": "forbidden, so items still can spawn inside, but are not accessible by default.",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -1807,7 +1807,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "scrap_aluminum", 1 ] ],
-      [ [ "medium_battery_cell", 1 ] ],
+      [ [ "light_plus_battery_cell", 1 ] ],
       [ [ "small_lcd_screen", 1 ] ],
       [ [ "memory_card", 1 ] ],
       [ [ "processor", 1 ] ]


### PR DESCRIPTION
#### Summary
Locked smartphone capacity and disassemble recipe fix

#### Purpose of change
Locked smartphones had battery capacity way smaller than unlocked ones, and somehow carried heavy batteries inside

#### Describe the solution
Change all of it to their unlocked variant

#### Describe alternatives you've considered
Leave it as is and farm heavy batteries

#### Testing
Found locked smartphone in world, looks fine