### PR TITLE
Fix chainmail vest adjustment

### DIFF
--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -914,7 +914,7 @@
     "looks_like": "vest_leather",
     "color": "light_red",
     "warmth": 0,
-    "flags": [ "STURDY" ],
+    "flags": [ "STURDY", "NORMAL" ],
     "use_action": {
       "type": "transform",
       "msg": "You adjust your mail for a looser fit.",
@@ -977,6 +977,7 @@
       "target": "chainmail_vest",
       "menu_text": "Loosen"
     },
+    "delete": { "flags": [ "NORMAL" ] },
     "extend": { "flags": [ "OUTER" ] }
   },
   {


### PR DESCRIPTION
#### Summary
Fix chainmail vest adjustment

#### Purpose of change
- The chainmail vest wasn't properly adjusting to OUTER when activated. This is because it didn't explicitly have the NORMAL flag set.  Now it does.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
