### PR TITLE
Update solars and turbines

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -647,7 +647,7 @@
     "type": "vehicle_part",
     "id": "ap_ground_solar_panel",
     "flags": [ "SOLAR_PANEL", "OBSTACLE", "APPLIANCE" ],
-    "description": "A solar panel, mounted on a frame and ready to power other appliances.",
+    "description": "Four solar panels arrayed together to provide energy when exposed to direct sunlight.",
     "item": "ground_solar_panel",
     "copy-from": "solar_panel",
     "//": "4 times the panels, 1.2x matching the above appliance",
@@ -661,10 +661,11 @@
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 32 ] },
-      { "item": "steel_chunk", "count": [ 8, 32 ] },
-      { "item": "scrap", "count": [ 8, 32 ] },
-      { "item": "solar_cell", "count": [ 4, 16 ] }
+      { "item": "steel_chunk", "count": [ 2, 16 ] },
+      { "item": "scrap", "count": [ 2, 16 ] },
+      { "item": "solar_cell", "count": [ 1, 16 ] }
+      { "item": "tempered_glass_shard", "charges": [ 4, 36 ] },
+      { "item": "plastic_chunk", "count": [ 1, 6 ] }
     ],
     "variants": [ { "symbols": "#", "symbols_broken": "x" } ]
   },
@@ -684,7 +685,7 @@
     "id": "ap_solar_panel_v2",
     "name": { "str": "small advanced solar panel" },
     "flags": [ "SOLAR_PANEL", "OBSTACLE", "APPLIANCE" ],
-    "description": "A  small, high-performance solar panel, mounted on a frame and ready to power other appliances.",
+    "description": "A small, high-performance solar panel, mounted on a frame and ready to power other appliances.",
     "copy-from": "solar_panel_v2",
     "proportional": { "epower": 1.2 },
     "requirements": { "removal": { "time": "3 m", "using": [ [ "vehicle_wrench_2", 1 ] ] } },
@@ -696,6 +697,7 @@
     "copy-from": "solar_panel_v2",
     "flags": [ "SOLAR_PANEL", "OBSTACLE", "APPLIANCE" ],
     "item": "ground_solar_panel_v2",
+    "description": "Four high-performance solar panels arrayed together to provide energy when exposed to direct sunlight.",
     "//": "4 times from 4 more panels, 1.2 times as is done above",
     "proportional": { "epower": 4.8 },
     "requirements": {
@@ -707,10 +709,11 @@
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 8, 16 ] },
-      { "item": "steel_chunk", "count": [ 8, 16 ] },
-      { "item": "scrap", "count": [ 8, 16 ] },
-      { "item": "solar_cell_v2", "count": [ 4, 24 ] }
+      { "item": "steel_chunk", "count": [ 2, 16 ] },
+      { "item": "scrap", "count": [ 2, 16 ] },
+      { "item": "solar_cell_v2", "count": [ 4, 24 ] },
+      { "item": "tempered_glass_shard", "charges": [ 4, 36 ] },
+      { "item": "plastic_chunk", "count": [ 1, 6 ] }
     ]
   },
   {
@@ -727,42 +730,139 @@
   {
     "type": "vehicle_part",
     "id": "ap_wind_turbine",
-    "location": "structure",
+    "name": { "str": "wind turbine" },
+    "categories": [ "energy" ],
     "flags": [ "WIND_TURBINE", "OBSTACLE", "APPLIANCE" ],
-    "description": "A mounted wind turbine, ready to power other appliances.",
-    "copy-from": "wind_turbine",
-    "requirements": { "removal": { "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] } },
+    "color": "yellow",
+    "broken_color": "yellow",
+    "damage_modifier": 10,
+    "durability": 15,
+    "description": "A structure supporting a set of sails rotating around a central axle which may be moved by wind to generate electricity.",
+    "epower": "1 W",
+    "item": "wind_turbine",
+    "location": "structure",
+    "//": "20 cm weld per quadrant of damage",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "repair": {
+        "skills": [ [ "mechanics", 1 ] ],
+        "time": "15 m",
+        "using": [ [ "repair_welding_standard", 2 ], [ "soldering_standard", 4 ] ]
+      }
+    },
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "count": [ 2, 6 ] },
+      { "item": "e_scrap", "count": [ 2, 4 ] },
+      { "item": "splinter", "count": [ 2, 8 ] },
+      { "item": "cable", "charges": [ 80, 115 ] },
+      { "item": "nail", "charges": [ 2, 6 ] }
+    ],
+    "damage_reduction": { "all": 8 },
     "variants": [ { "symbols": "T", "symbols_broken": "X" } ]
   },
-  {
+   {
     "type": "vehicle_part",
     "id": "ap_xl_wind_turbine",
+    "name": { "str": "large wind turbine" },
+    "looks_like": "wind_turbine",
+    "categories": [ "energy" ],
+    "color": "yellow",
+    "broken_color": "yellow",
+    "damage_modifier": 10,
+    "durability": 70,
+    "description": "A sturdy structure supporting a large set of sails rotating around a central axle which may be moved by wind to generate electricity.",
+    "epower": "3 W",
+    "item": "xl_wind_turbine",
     "location": "structure",
+    "power": "-3000 W",
+    "//": "30 cm weld per quadrant of damage",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "repair": {
+        "skills": [ [ "mechanics", 3 ] ],
+        "time": "20 m",
+        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 10 ] ]
+      }
+    },
     "flags": [ "WIND_TURBINE", "OBSTACLE", "APPLIANCE" ],
-    "description": "A large mounted wind turbine, ready to power other appliances.",
-    "copy-from": "xl_wind_turbine",
-    "requirements": { "removal": { "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] } },
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 1, 2 ] },
+      { "item": "steel_chunk", "count": [ 3, 6 ] },
+      { "item": "scrap", "count": [ 10, 20 ] },
+      { "item": "e_scrap", "count": [ 8, 16 ] },
+      { "item": "splinter", "count": [ 25, 50 ] },
+      { "item": "cable", "charges": [ 300, 500 ] },
+      { "item": "nail", "charges": [ 8, 15 ] },
+      { "item": "nuts_bolts", "charges": [ 4, 7 ] }
+    ],
+    "damage_reduction": { "all": 9 },
     "variants": [ { "symbols": "Y", "symbols_broken": "X" } ]
   },
-  {
+    {
     "type": "vehicle_part",
     "id": "ap_water_wheel",
+    "name": { "str": "water wheel" },
+    "categories": [ "energy" ],
+    "color": "yellow",
+    "broken_color": "yellow",
+    "damage_modifier": 10,
+    "durability": 50,
+    "description": "A set of paddles which can be moved by flowing water to turn an axle and generate power.",
+    "epower": "80 W",
+    "item": "water_wheel",
     "location": "structure",
     "flags": [ "WATER_WHEEL", "OBSTACLE", "APPLIANCE" ],
-    "description": "A mounted water wheel, ready to power other appliances.",
-    "copy-from": "water_wheel",
-    "requirements": { "removal": { "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] } },
-    "variants": [ { "symbols": "x", "symbols_broken": "x" } ]
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "10 m", "using": [ [ "rope_natural_short", 1 ] ] }
+    },
+    "breaks_into": [
+      { "item": "splinter", "count": [ 40, 60 ] },
+      { "item": "steel_chunk", "count": [ 1, 3 ] },
+      { "item": "scrap", "count": [ 6, 15 ] },
+      { "item": "cable", "charges": [ 90, 180 ] },
+      { "item": "nail", "charges": [ 21, 35 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] }
+    ],
+    "damage_reduction": { "all": 15, "stab": 6, "cut": 8 },
+    "variants": [ { "symbols": "*", "symbols_broken": "x" } ]
   },
   {
     "type": "vehicle_part",
     "id": "ap_xl_water_wheel",
+    "name": { "str": "large water wheel" },
+    "looks_like": "water_wheel",
+    "categories": [ "energy" ],
+    "color": "yellow",
+    "broken_color": "yellow",
+    "damage_modifier": 10,
+    "durability": 80,
+    "description": "A large set of paddles which can be moved by flowing water to turn an axle and generate power.",
+    "epower": "180 W",
+    "item": "xl_water_wheel",
     "location": "structure",
     "flags": [ "WATER_WHEEL", "OBSTACLE", "APPLIANCE" ],
-    "description": "A mounted large water wheel, ready to power other appliances.",
-    "copy-from": "xl_water_wheel",
-    "requirements": { "removal": { "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] } },
-    "variants": [ { "symbols": "x", "symbols_broken": "x" } ]
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
+      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "15 m", "using": [ [ "rope_natural_short", 2 ] ] }
+    },
+    "breaks_into": [
+      { "item": "splinter", "count": [ 60, 100 ] },
+      { "item": "steel_lump", "count": [ 1, 3 ] },
+      { "item": "steel_chunk", "count": [ 4, 9 ] },
+      { "item": "scrap", "count": [ 20, 35 ] },
+      { "item": "cable", "charges": [ 225, 400 ] },
+      { "item": "nail", "charges": [ 80, 130 ] },
+      { "item": "nuts_bolts", "charges": [ 5, 12 ] }
+    ],
+    "damage_reduction": { "all": 16, "stab": 6, "cut": 8 },
+    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
     "type": "vehicle_part",

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2623,22 +2623,44 @@
     "type": "MIGRATION",
     "replace": "egg_grasshopper"
   },
-    {
+  {
     "id": "surv_rocket_launcher",
     "type": "MIGRATION",
     "replace": "pipe"
   },
-    {
+  {
     "id": "spiked_rocket",
     "type": "MIGRATION",
     "replace": "pipe"
-  },    {
+  },
+  {
     "id": "incendiary_hm_rocket",
     "type": "MIGRATION",
     "replace": "pipe"
-  },    {
+  },
+  {
     "id": "explosive_hm_rocket",
     "type": "MIGRATION",
     "replace": "pipe"
+  },
+  {
+    "type": "vehicle_part_migration",
+    "from": "water_wheel",
+    "to": "solar_panel"
+  },
+    {
+    "type": "vehicle_part_migration",
+    "from": "xl_water_wheel",
+    "to": "solar_panel"
+  },
+  {
+    "type": "vehicle_part_migration",
+    "from": "wind_turbine",
+    "to": "solar_panel"
+  },
+  {
+    "type": "vehicle_part_migration",
+    "from": "xl_wind_turbine",
+    "to": "solar_panel"
   }
 ]

--- a/data/json/recipes/other/power_supplies.json
+++ b/data/json/recipes/other/power_supplies.json
@@ -19,7 +19,7 @@
       { "proficiency": "prof_welding" }
     ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "solar_panel", 1 ] ], [ [ "reinforced_glass_pane", 1 ] ], [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "solar_panel", 1 ] ], [ [ "wire", 10 ] ], [ [ "scrap", 4 ] ] ]
   },
   {
     "type": "recipe",
@@ -41,7 +41,7 @@
       { "proficiency": "prof_welding" }
     ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "solar_panel_v2", 1 ] ], [ [ "reinforced_glass_pane", 1 ] ], [ [ "scrap", 1 ] ] ]
+    "components": [ [ [ "solar_panel_v2", 1 ] ], [ [ "wire", 10 ] ], [ [ "scrap", 4 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1671,75 +1671,13 @@
   },
   {
     "type": "vehicle_part",
-    "id": "water_wheel",
-    "name": { "str": "water wheel" },
-    "categories": [ "energy" ],
-    "color": "yellow",
-    "broken_color": "yellow",
-    "damage_modifier": 10,
-    "durability": 50,
-    "description": "A water wheel.",
-    "epower": "80 W",
-    "item": "water_wheel",
-    "location": "center",
-    "flags": [ "WATER_WHEEL", "OBSTACLE" ],
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "250 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "250 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "20 s", "using": [ [ "rope_natural_short", 1 ] ] }
-    },
-    "breaks_into": [
-      { "item": "splinter", "count": [ 40, 60 ] },
-      { "item": "steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 6, 15 ] },
-      { "item": "cable", "charges": [ 90, 180 ] },
-      { "item": "nail", "charges": [ 21, 35 ] },
-      { "item": "nuts_bolts", "charges": [ 3, 6 ] }
-    ],
-    "damage_reduction": { "all": 15, "stab": 6, "cut": 8 },
-    "variants": [ { "symbols": "*", "symbols_broken": "x" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "xl_water_wheel",
-    "name": { "str": "large water wheel" },
-    "looks_like": "water_wheel",
-    "categories": [ "energy" ],
-    "color": "yellow",
-    "broken_color": "yellow",
-    "damage_modifier": 10,
-    "durability": 80,
-    "description": "A large water wheel with wooden supports.",
-    "epower": "180 W",
-    "item": "xl_water_wheel",
-    "location": "center",
-    "flags": [ "WATER_WHEEL", "OBSTACLE", "EXTRA_DRAG" ],
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 4 ] ], "time": "750 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 4 ] ], "time": "750 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "60 s", "using": [ [ "rope_natural_short", 2 ] ] }
-    },
-    "breaks_into": [
-      { "item": "splinter", "count": [ 60, 100 ] },
-      { "item": "steel_lump", "count": [ 1, 3 ] },
-      { "item": "steel_chunk", "count": [ 4, 9 ] },
-      { "item": "scrap", "count": [ 20, 35 ] },
-      { "item": "cable", "charges": [ 225, 400 ] },
-      { "item": "nail", "charges": [ 80, 130 ] },
-      { "item": "nuts_bolts", "charges": [ 5, 12 ] }
-    ],
-    "damage_reduction": { "all": 16, "stab": 6, "cut": 8 },
-    "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
-  },
-  {
-    "type": "vehicle_part",
     "id": "solar_panel",
     "name": { "str": "solar panel" },
     "categories": [ "energy" ],
     "color": "yellow",
     "broken_color": "yellow",
-    "damage_modifier": 10,
-    "durability": 20,
+    "damage_modifier": 15,
+    "durability": 25,
     "description": "A solar panel.",
     "epower": "50 W",
     "item": "solar_panel",
@@ -1755,87 +1693,13 @@
     },
     "flags": [ "SOLAR_PANEL" ],
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
       { "item": "scrap", "count": [ 2, 4 ] },
-      { "item": "solar_cell", "count": [ 1, 4 ] }
+      { "item": "solar_cell", "count": [ 1, 4 ] },
+      { "item": "tempered_glass_shard", "charges": [ 4, 18 ] },
+      { "item": "plastic_chunk", "count": [ 1, 3 ] }
     ],
     "variants": [ { "symbols": "#", "symbols_broken": "x" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "wind_turbine",
-    "name": { "str": "wind turbine" },
-    "categories": [ "energy" ],
-    "color": "yellow",
-    "broken_color": "yellow",
-    "damage_modifier": 10,
-    "durability": 15,
-    "description": "A small wind turbine.",
-    "epower": "1 W",
-    "item": "wind_turbine",
-    "location": "on_roof",
-    "//": "20 cm weld per quadrant of damage",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "150 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": {
-        "skills": [ [ "mechanics", 1 ] ],
-        "time": "15 m",
-        "using": [ [ "repair_welding_standard", 2 ], [ "soldering_standard", 4 ] ]
-      }
-    },
-    "flags": [ "WIND_TURBINE" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 2, 4 ] },
-      { "item": "scrap", "count": [ 2, 6 ] },
-      { "item": "e_scrap", "count": [ 2, 4 ] },
-      { "item": "splinter", "count": [ 2, 8 ] },
-      { "item": "cable", "charges": [ 80, 115 ] },
-      { "item": "nail", "charges": [ 2, 6 ] }
-    ],
-    "damage_reduction": { "all": 8 },
-    "variants": [ { "symbols": "T", "symbols_broken": "X" } ]
-  },
-  {
-    "type": "vehicle_part",
-    "id": "xl_wind_turbine",
-    "name": { "str": "large wind turbine" },
-    "looks_like": "wind_turbine",
-    "categories": [ "energy" ],
-    "color": "yellow",
-    "broken_color": "yellow",
-    "damage_modifier": 10,
-    "durability": 70,
-    "description": "A large wind turbine with stabilizing legs.  Will cause extra drag on the vehicle.",
-    "epower": "3 W",
-    "item": "xl_wind_turbine",
-    "location": "on_roof",
-    "power": "-3000 W",
-    "//": "30 cm weld per quadrant of damage",
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "450 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ], "time": "450 s", "qualities": [ { "id": "WRENCH", "level": 1 } ] },
-      "repair": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "20 m",
-        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 10 ] ]
-      }
-    },
-    "flags": [ "WIND_TURBINE", "EXTRA_DRAG" ],
-    "breaks_into": [
-      { "item": "steel_lump", "count": [ 1, 2 ] },
-      { "item": "steel_chunk", "count": [ 3, 6 ] },
-      { "item": "scrap", "count": [ 10, 20 ] },
-      { "item": "e_scrap", "count": [ 8, 16 ] },
-      { "item": "splinter", "count": [ 25, 50 ] },
-      { "item": "cable", "charges": [ 300, 500 ] },
-      { "item": "nail", "charges": [ 8, 15 ] },
-      { "item": "nuts_bolts", "charges": [ 4, 7 ] }
-    ],
-    "damage_reduction": { "all": 9 },
-    "variants": [ { "symbols": "Y", "symbols_broken": "X" } ]
   },
   {
     "type": "vehicle_part",
@@ -1844,10 +1708,10 @@
     "name": { "str": "reinforced solar panel" },
     "color": "light_blue",
     "broken_color": "light_gray",
-    "proportional": { "epower": 0.9 },
-    "damage_modifier": 80,
-    "durability": 300,
-    "description": "A solar panel.  Reinforced with armored glass to make it more resistant to damage.",
+    "proportional": { "epower": 0.8 },
+    "damage_modifier": 60,
+    "durability": 100,
+    "description": "A solar panel with sturdy brackets and wire shielding across its face, trading efficiency for durability.",
     "item": "reinforced_solar_panel",
     "requirements": {
       "repair": {
@@ -1857,10 +1721,12 @@
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] },
-      { "item": "solar_cell", "count": [ 1, 4 ] }
+      { "item": "wire", "count": [ 2, 4 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "count": [ 2, 4 ] },
+      { "item": "solar_cell", "count": [ 1, 4 ] },
+      { "item": "tempered_glass_shard", "charges": [ 4, 18 ] },
+      { "item": "plastic_chunk", "count": [ 1, 3 ] }
     ],
     "damage_reduction": { "all": 12 }
   },
@@ -1869,9 +1735,11 @@
     "id": "solar_panel_v2",
     "copy-from": "solar_panel",
     "name": { "str": "advanced solar panel" },
-    "description": "A high-performance solar panel.",
+    "description": "A high-performance solar panel.  Its delicate components are a bit more fragile than the standard variety.",
     "item": "solar_panel_v2",
     "proportional": { "epower": 2.0 },
+    "damage_modifier": 10,
+    "durability": 20,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 6 ] ] },
       "removal": { "skills": [ [ "mechanics", 4 ] ] },
@@ -1882,7 +1750,6 @@
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 2, 4 ] },
       { "item": "steel_chunk", "count": [ 2, 4 ] },
       { "item": "scrap", "count": [ 2, 4 ] },
       { "item": "solar_cell_v2", "count": [ 1, 6 ] }
@@ -1896,10 +1763,10 @@
     "name": { "str": "advanced reinforced solar panel" },
     "color": "light_blue",
     "broken_color": "light_gray",
-    "proportional": { "epower": 0.9 },
-    "damage_modifier": 80,
-    "durability": 300,
-    "description": "A high-performance solar panel.  Reinforced with armored glass to make it more resistant to damage.",
+    "proportional": { "epower": 0.8 },
+    "damage_modifier": 40,
+    "durability": 80,
+    "description": "A high-performance solar panel with sturdy brackets and wire guards across its face, trading efficiency for durability.",
     "item": "reinforced_solar_panel_v2",
     "requirements": {
       "repair": {
@@ -1909,10 +1776,10 @@
       }
     },
     "breaks_into": [
-      { "item": "steel_lump", "count": [ 4, 7 ] },
-      { "item": "steel_chunk", "count": [ 4, 7 ] },
-      { "item": "scrap", "count": [ 4, 7 ] },
-      { "item": "solar_cell", "count": [ 1, 6 ] }
+      { "item": "wire", "count": [ 2, 4 ] },
+      { "item": "steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "count": [ 2, 4 ] },
+      { "item": "solar_cell_v2", "count": [ 1, 6 ] }
     ],
     "damage_reduction": { "all": 10 }
   },


### PR DESCRIPTION
#### Summary
Update solars and turbines

#### Purpose of change
- For legacy reasons, it was possible to build functional wind turbines and water wheels on cars and boats. I should not have to explain why this is preposterous.
- "Reinforced glass" is not what DDA thinks it is, and would be of no benefit to solar panels, which are already made of stronger stuff.

#### Describe the solution
- Remove the vehicle versions of wind turbine, large wind turbine, water wheel, and large water wheel. These items are only available as appliances.
- Update the descriptions, recipes, and stats for reinforced solar panels. These items are now described and statted as being bound up and secured with wire, providing a modicum of protection but impeding power generation.
- Updated the bash results for all kinds of solar panels.

#### Testing
- Built all the stuff and it worked, no errors.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
