### PR TITLE
Fix exercise equipment components

### DIFF
--- a/data/json/construction/furniture_recreation.json
+++ b/data/json/construction/furniture_recreation.json
@@ -28,16 +28,16 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "240 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ], [ { "id": "WRENCH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SCREW", "level": 1 } ], [ { "id": "WRENCH", "level": 1 } ] ],
     "components": [
       [ [ "foot_crank", 1 ] ],
       [ [ "plastic_chunk", 10 ] ],
       [ [ "scrap", 4 ] ],
-      [ [ "chain", 1 ] ],
       [ [ "pipe", 5 ] ],
       [ [ "saddle", 1 ] ],
+      [ [ "wire", 8 ] ],
       [ [ "wheel_small", 1 ] ],
-      [ [ "nails", 8, "LIST" ] ]
+      [ [ "nuts_bolts", 8 ] ]
     ],
     "pre_special": "check_empty",
     "post_terrain": "f_ergometer_mechanical"
@@ -133,7 +133,7 @@
     "components": [
       [ [ "heavy_punching_bag_sack", 1 ] ],
       [ [ "nuts_bolts", 4 ] ],
-      [ [ "chain", 4 ] ],
+      [ [ "chain", 1 ] ],
       [ [ "blanket", 6 ] ],
       [ [ "material_sand", 4000 ] ],
       [ [ "duct_tape", 20 ] ]

--- a/data/json/furniture_and_terrain/furniture-recreation.json
+++ b/data/json/furniture_and_terrain/furniture-recreation.json
@@ -243,14 +243,14 @@
         { "item": "foot_crank", "count": 1 },
         { "item": "plastic_chunk", "count": [ 8, 10 ] },
         { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "chain", "count": 1 },
         { "item": "pipe", "count": [ 4, 5 ] },
         { "item": "saddle", "count": 1 },
+        { "item": "wire", "count": 8 },
         { "item": "wheel_small", "count": 1 },
         { "item": "small_lcd_screen", "count": 1 },
         { "item": "processor", "count": 1 },
         { "item": "RAM", "count": 1 },
-        { "item": "nail", "charges": [ 6, 8 ] }
+        { "item": "nuts_bolts", "charges": [ 6, 8 ] }
       ]
     },
     "bash": {
@@ -262,7 +262,6 @@
         { "item": "foot_crank", "prob": 50 },
         { "item": "plastic_chunk", "count": [ 4, 6 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
-        { "item": "chain", "prob": 50 },
         { "item": "pipe", "count": [ 0, 4 ] },
         { "item": "saddle", "prob": 50 },
         { "item": "wheel_small", "prob": 50 },
@@ -291,11 +290,11 @@
         { "item": "foot_crank", "count": 1 },
         { "item": "plastic_chunk", "count": [ 8, 10 ] },
         { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "chain", "count": 1 },
         { "item": "pipe", "count": [ 4, 5 ] },
+        { "item": "wire", "count": 8 },
         { "item": "saddle", "count": 1 },
         { "item": "wheel_small", "count": 1 },
-        { "item": "nail", "charges": [ 6, 8 ] }
+        { "item": "nuts_bolts", "charges": [ 6, 8 ] }
       ]
     },
     "examine_action": "workout",
@@ -308,11 +307,11 @@
         { "item": "foot_crank", "prob": 50 },
         { "item": "plastic_chunk", "count": [ 4, 6 ] },
         { "item": "scrap", "count": [ 0, 2 ] },
-        { "item": "chain", "prob": 50 },
+        { "item": "wire", "count": 8 },
         { "item": "pipe", "count": [ 0, 4 ] },
         { "item": "saddle", "prob": 50 },
         { "item": "wheel_small", "prob": 50 },
-        { "item": "nail", "charges": [ 2, 6 ] }
+        { "item": "nuts_bolts", "charges": [ 2, 6 ] }
       ]
     }
   },
@@ -407,7 +406,7 @@
       "items": [
         { "item": "heavy_punching_bag_sack", "count": 1 },
         { "item": "nuts_bolts", "charges": 4 },
-        { "item": "chain", "count": 4 },
+        { "item": "chain", "count": 1 },
         { "item": "blanket", "count": 6 },
         { "item": "material_sand", "charges": 4000 }
       ]
@@ -418,7 +417,7 @@
       "sound": "whack!",
       "sound_fail": "whud.",
       "items": [
-        { "item": "chain", "count": [ 1, 3 ] },
+        { "item": "chain", "count": [ 0, 1 ] },
         { "item": "leather", "count": [ 16, 32 ] },
         { "item": "tanned_hide", "count": [ 0, 4 ] },
         { "item": "material_sand", "charges": 4000 },


### PR DESCRIPTION
#### Summary
Fix exercise equipment components

#### Purpose of change
- Ergometers included heavy steel chains and nails(???)
- Punching bags included like 28 feet of chain for some reason.

#### Describe the solution
- Ergometers now use wire instead of chain and bolts instead of nails. The wire is meant to represent the braided steel wire you'd be pulling along the wheels, we don't currently differentiate between that and the galvanized wire of a chain link fence. It's not terribly important but it's not perfect either.
- Heavy punching bags only need one chain instead of four.

#### Testing
- Loads, runs, can build the things.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
