### PR TITLE
You can't just eat lard

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -1486,6 +1486,8 @@
     "price_postapoc": "2 USD",
     "//": "*May* have been commercially traded.",
     "material": [ "flesh" ],
+    "use_action": [ "BLECH" ],
+    "flags": [ "NO_AUTO_CONSUME" ],
     "volume": "62 ml",
     "vitamins": [ [ "meat_allergen", 1 ] ],
     "fun": -18

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -133,6 +133,7 @@
     "material": [ "milk" ],
     "volume": "15 ml",
     "flags": [ "NO_AUTO_CONSUME" ],
+    "use_action": [ "BLECH" ],
     "fun": -1,
     "vitamins": [ [ "milk_allergen", 1 ] ]
   },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1095,13 +1095,13 @@ std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & )
 {
-    // TODO: Add more effects?
+    // TODO: Move this to consumption.cpp
     if( it->made_of( phase_id::LIQUID ) ) {
-        if( !p->query_yn( _( "This looks unhealthy, sure you want to drink it?" ) ) ) {
+        if( !p->query_yn( _( "This seems like a bad idea, are you sure you want to drink it?" ) ) ) {
             return std::nullopt;
         }
-    } else { //Assume that if a blech consumable isn't a drink, it will be eaten.
-        if( !p->query_yn( _( "This looks unhealthy, sure you want to eat it?" ) ) ) {
+    } else { // Assume that if a blech consumable isn't a drink, it will be eaten.
+        if( !p->query_yn( _( "This seems like a bad idea, are you sure you want to eat it?" ) ) ) {
             return std::nullopt;
         }
     }
@@ -1109,11 +1109,11 @@ std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & 
     if( it->has_flag( flag_ACID ) && ( p->has_trait( trait_ACIDPROOF ) ||
                                        p->has_trait( trait_ACIDBLOOD ) ) ) {
         p->add_msg_if_player( m_bad, _( "Blech, that tastes gross!" ) );
-        //reverse the harmful values of drinking this acid.
+        // Reverse the harmful values of drinking this acid.
         double multiplier = -1;
         p->stomach.mod_nutr( -p->nutrition_for( *it ) * multiplier );
         p->mod_thirst( -it->get_comestible()->quench * multiplier );
-        p->stomach.mod_quench( 20 ); //acidproof people can drink acids like diluted water.
+        p->stomach.mod_quench( 20 ); // Acidproof people can drink acids like diluted water.
         p->mod_daily_health( it->get_comestible()->healthy * multiplier,
                              it->get_comestible()->healthy * multiplier );
         p->add_morale( morale_food_bad, it->get_comestible_fun() * multiplier, 60, 1_hours, 30_minutes,
@@ -1126,7 +1126,7 @@ std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & 
         p->vomit();
     } else {
         p->add_msg_if_player( m_bad, _( "Blech, you don't feel you can stomach much of that." ) );
-        p->add_effect( effect_nausea, 3_minutes );
+        p->add_effect( effect_nausea, 2_minutes * rng( 1, 6 ) );
     }
     return 1;
 }


### PR DESCRIPTION
#### Summary
You can't just eat lard

#### Purpose of change
- Lard, butter, tallow, and cooking oil should not be edible in large quantities without getting sick.

#### Describe the solution
- Add the BLECH use_action to lard, tallow, and butter.
- Adjust the duration of BLECH nausea (randomizing it a bit) and adjust the messaging to be more generally applicable.

#### Describe alternatives you've considered
- BLECH and other food-related iuse actions should be moved to consumption.

#### Testing
- Ate tallow, kept it down, tried again and got sick.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
