### PR TITLE
Skip iuse syringe check while crafting

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -813,6 +813,9 @@ void consume_drug_iuse::info( const item &, std::vector<iteminfo> &dump ) const
 
 std::optional<int> consume_drug_iuse::use( Character *p, item &it, const tripoint_bub_ms & ) const
 {
+    if( it.is_craft() ) {
+        return 0;
+    }
     auto need_these = tools_needed;
 
     // Check prerequisites first.


### PR DESCRIPTION
#### Summary
Skip iuse syringe check while crafting

#### Purpose of change
fixes #764 

#### Describe the solution
Adds a check for whether this is the actual item or an in-progress craft, return zero if the latter is true.

#### Testing
- Crafted infusion. Paused. Resumed crafting by activating the infusion in my hands. No issues.
- Finished crafting it, could not consume without syringe.
- Got a syringe, could consume.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
