### PR TITLE
Clean up MA technique helptext

### DIFF
--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -2103,14 +2103,6 @@ std::string ma_technique::get_description() const
 
     dump += string_format( _( condition_desc ) ) + "\n";
 
-    if( weighting > 1 ) {
-        dump += string_format( _( "* <info>Greater chance</info> to activate: <stat>+%s%%</stat>" ),
-                               ( 100 * ( weighting - 1 ) ) ) + "\n";
-    } else if( weighting < -1 ) {
-        dump += string_format( _( "* <info>Lower chance</info> to activate: <stat>1/%s</stat>" ),
-                               std::abs( weighting ) ) + "\n";
-    }
-
     if( crit_ok ) {
         dump += _( "* Can activate on a <info>normal</info> or a <info>crit</info> hit" ) +
                 std::string( "\n" );
@@ -2143,7 +2135,7 @@ std::string ma_technique::get_description() const
     }
 
     if( miss_recovery ) {
-        dump += _( "* Reduces the time of a <info>miss</info> by <info>half</info>" ) +
+        dump += _( "* Makes a <info>miss</info> take only <info>half</info> the time" ) +
                 std::string( "\n" );
     }
 


### PR DESCRIPTION
#### Summary
Clean up MA technique helptext

#### Purpose of change
- Techniques had some nearly nonsensical text related to their weighting.
- Miss recovery was weirdly worded.

#### Describe the solution
Remove the former, fix the latter.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
