### PR TITLE
Missile silo is globally unique

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -976,7 +976,7 @@
     "city_distance": [ 30, -1 ],
     "city_sizes": [ -1, 4 ],
     "occurrences": [ 10, 100 ],
-    "flags": [ "MILITARY", "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "flags": [ "MILITARY", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
Missile silo is globally unique

#### Purpose of change
The missile silo, a story setpiece with huge amounts of loot, was set to overmap_unique, so they were spawning all over the place.

#### Describe the solution
Globally_unique.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
