### PR TITLE
Fix contagion

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3366,25 +3366,35 @@ void monster::process_one_effect( effect &it, bool is_new )
             apply_damage( it.get_source().resolve_creature(), bodypart_id( "torso" ), 1 );
         }
     } else if( id == effect_fake_common_cold ) {
-        if( calendar::once_every( time_duration::from_seconds( rng( 30, 3000 ) ) ) && one_in( 4 ) ) {
-            sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
-                           "cough" );
-        }
-
-        avatar &you = get_avatar(); // No NPCs for now.
-        if( rl_dist( pos_bub(), you.pos_bub() ) <= 1 ) {
-            you.get_sick( false );
+        if( one_in( 400 ) ) {
+            if( one_in( 20 ) ) {
+                sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
+                            "cough" );
+            }
+            map &here = get_map();
+            creature_tracker &creatures = get_creature_tracker();
+            for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 4 ) ) {
+                Character *guy = creatures.creature_at<Character>( p );
+                if( guy && here.clear_path( pos_bub(), guy->pos_bub(), 4, 1, 100 ) ) {
+                    guy->get_sick( false );
+                }
+            }
         }
     } else if( id == effect_fake_flu ) {
-        // Need to define the two separately because it's theoretically (and realistically) possible to have both flu and cold at once, both for players and monsters.
-        if( calendar::once_every( time_duration::from_seconds( rng( 30, 3000 ) ) ) && one_in( 4 ) ) {
-            sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
-                           "cough" );
-        }
-
-        avatar &you = get_avatar(); // No NPCs for now.
-        if( rl_dist( pos_bub(), you.pos_bub() ) <= 1 ) {
-            you.get_sick( true );
+        // Need to define the two separately because it's possible to have both flu and cold at once, both for players and monsters.
+        if( one_in( 300 ) ) {
+            if( one_in( 20 ) ) {
+                sounds::sound( pos_bub(), 4, sounds::sound_t::speech, _( "a hacking cough." ), false, "misc",
+                            "cough" );
+            }
+            map &here = get_map();
+            creature_tracker &creatures = get_creature_tracker();
+            for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 5 ) ) {
+                Character *guy = creatures.creature_at<Character>( p );
+                if( guy && here.clear_path( pos_bub(), guy->pos_bub(), 5, 1, 100 ) ) {
+                    guy->get_sick( true );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix contagion

#### Purpose of change
- There was a longstanding bug inherited from DDA in how cold/flu contagion worked. Instead of checking every X seconds, it checked every second. Given that the base chance to get sick is 33%, you were rolling those dice every single second you were in melee with a sick feral. That's a really bad bug, and meant that you'd basically always get sick if you encountered one.
- Only the player was able to get sick.
- It was only possible to get sick in melee range.

#### Describe the solution
The check now rolls one_in( 400 ) for cold and 300 for flu each second. When it procs, it checks clear_path to all characters within 4 tiles (cold) and 5 tiles (flu). That's every 6.66 and 5 minutes respectively, though note that's an average and not an absolute.

#### Describe alternatives you've considered
There needs to be a version of clear_path that ignores creatures, and characters need to be able to spread disease to each other.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
