### PR TITLE
Tacoma blanket mission accepts quilts

### DIFF
--- a/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_foreman.json
@@ -262,6 +262,8 @@
         { "item": "fur_blanket", "amount": 25 },
         { "item": "down_blanket", "amount": 25 },
         { "item": "blanket_weighted", "amount": 25 },
+        { "item": "quilt", "amount": 25 },
+        { "item": "quilt_patchwork", "amount": 25 },
         { "item": "electric_blanket", "amount": 25 }
       ]
     },
@@ -327,6 +329,8 @@
             { "item": "blanket", "amount": 25 },
             { "item": "fur_blanket", "amount": 25 },
             { "item": "down_blanket", "amount": 25 },
+            { "item": "quilt", "amount": 25 },
+            { "item": "quilt_patchwork", "amount": 25 },
             { "item": "blanket_weighted", "amount": 25 },
             { "item": "electric_blanket", "amount": 25 }
           ]


### PR DESCRIPTION
#### Summary
Tacoma blanket mission accepts quilts

#### Purpose of change
There's a Tacoma mission where you need 25 blankets, but there are a bunch of blanket items and some weren't working.

#### Describe the solution
Add quilt and patchwork quilt to the accepted item list.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
