### PR TITLE
Remove time penalty for reading ebooks in dim light

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -35,6 +35,7 @@
 #include "event_bus.h"
 #include "faction.h"
 #include "field_type.h"
+#include "flag.h"
 #include "flexbuffer_json-inl.h"
 #include "flexbuffer_json.h"
 #include "game.h"
@@ -668,7 +669,7 @@ bool avatar::read( item_location &book, item_location ereader )
         add_msg( m_info, _( "%s read with you for fun." ), them );
     }
 
-    if( std::min( fine_detail_vision_mod(), reader->fine_detail_vision_mod() ) > 1.0 ) {
+    if( !book->has_flag( flag_CAN_USE_IN_DARK ) && std::min( fine_detail_vision_mod(), reader->fine_detail_vision_mod() ) > 1.0 ) {
         add_msg( m_warning,
                  _( "It's difficult for %s to see fine details right now.  Reading will take longer than usual." ),
                  reader->disp_name() );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12725,7 +12725,9 @@ time_duration Character::time_to_read( const item &book, const Character &reader
     }
 
     time_duration retval = type->time * reading_speed / 100;
-    retval *= std::min( fine_detail_vision_mod(), reader.fine_detail_vision_mod() );
+    if( !book.has_flag( flag_CAN_USE_IN_DARK ) ) {
+        retval *= std::min( fine_detail_vision_mod(), reader.fine_detail_vision_mod() );
+    }
 
     const int effective_int = std::min( { get_int(), reader.get_int(), learner ? learner->get_int() : INT_MAX } );
     if( type->intel > effective_int && !reader.has_trait( trait_PROF_DICEMASTER ) ) {


### PR DESCRIPTION
#### Summary
Remove time penalty for reading ebooks in dim light

#### Purpose of change
Ebooks were readable in the dark, but it was still applying a penalty as if you were having trouble seeing.

#### Describe the solution
Remove the penalty for backlit devices.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
