### PR TITLE
Improve descriptions for skins

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -1774,7 +1774,7 @@
     "spoils_in": "6 hours",
     "use_action": [ "POISON" ],
     "price_postapoc": "10 cent",
-    "description": "A carefully folded poisonous raw skin harvested from an unnatural creature.  You can cure it for storage and tanning.",
+    "description": "A ghastly skin marred by decay.  It sloughs apart like wet newspaper when handled, and the smell is intolerable.",
     "price": "0 cent"
   },
   {
@@ -1796,7 +1796,7 @@
     "id": "raw_hleather",
     "copy-from": "raw_leather",
     "name": { "str_sp": "raw human skin" },
-    "description": "A carefully folded raw skin harvested from a human.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
+    "description": "The flayed hide of a human being.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
     "material": [ "hflesh" ],
     "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
   },
@@ -1823,7 +1823,7 @@
     "symbol": ",",
     "quench": -20,
     "calories": 350,
-    "description": "A carefully folded raw skin harvested from a fur-bearing animal.  It still has the fur attached.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
+    "description": "A raw skin harvested from a fur-bearing animal.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
     "price": "3 USD 30 cent",
     "price_postapoc": "1 USD",
     "material": [ "fur", "flesh" ],
@@ -1838,7 +1838,7 @@
     "copy-from": "raw_fur",
     "spoils_in": "6 hours",
     "use_action": [ "POISON" ],
-    "description": "A carefully folded raw skin harvested from a fur-bearing unnatural creature.  It still has the fur attached and is poisonous.  You can cure it for storage and tanning.",
+    "description": "A rotting pelt from some long-dead furry creature.  It's already too far gone to be tanned, and rapidly getting worse.",
     "price": "0 cent"
   },
   {
@@ -1846,7 +1846,7 @@
     "id": "raw_hfur",
     "copy-from": "raw_fur",
     "name": { "str_sp": "raw human pelt" },
-    "description": "A carefully folded raw skin harvested from a fur-bearing mutant human.  It still has the fur attached.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
+    "description": "A raw skin harvested from a fur-bearing mutant human.  It still has the fur attached.  You can cure it for storage and tanning, or eat it if you're desperate enough.",
     "material": [ "fur", "hflesh" ],
     "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
   },
@@ -1875,12 +1875,12 @@
     "comestible_type": "FOOD",
     "id": "jabberwock_heart",
     "name": { "str": "putrid heart" },
-    "weight": "4535 g",
+    "weight": "1535 g",
     "color": "black_red",
     "symbol": "%",
     "healthy": -10,
     "calories": 347,
-    "description": "A thick, hulking mass of flesh that's easily the size of your head, superficially resembling a mammalian heart and covered in ribbed grooves.  It's still full of whatever passes for blood in jabberwocks, and is heavy in your hands.  After everything you've seen lately, you can't help but remember old sayings about eating the hearts of your enemies…",
+    "description": "A cartliginous knot of flesh the size of a small pumpkin, superficially resembling a mammalian heart and covered in ribbed grooves.  It's still full of whatever passes for blood in jabberwocks, and is heavy in your hands.  After everything you've seen lately, you can't help but remember old sayings about eating the hearts of your enemies…",
     "price": "65 USD",
     "price_postapoc": "5 USD",
     "material": [ "flesh" ],
@@ -1899,7 +1899,7 @@
     "symbol": "%",
     "healthy": -1,
     "calories": 217,
-    "description": "A huge strip of muscle - all that remains of a putrid heart that has been sliced open and drained of blood.  It could be eaten if you're hungry, but looks *disgusting*.",
+    "description": "A red-black strip of muscle - all that remains of a putrid heart that has been sliced open and drained of blood.  It could be eaten if you're hungry, but looks *disgusting*.",
     "price": "10 USD",
     "price_postapoc": "25 cent",
     "material": [ "flesh" ],

--- a/data/json/items/resources/tailoring.json
+++ b/data/json/items/resources/tailoring.json
@@ -270,7 +270,7 @@
     "symbol": ",",
     "color": "brown",
     "name": { "str": "tanned hide" },
-    "description": "A folded 12-inch by 24-inch sheet of leather made from carefully tanned animal hide.  Can be cut up or used as is.",
+    "description": "A sheet of leather made from carefully tanned animal hide.  Can be cut up or used as is.",
     "price": "50 USD",
     "price_postapoc": "5 USD",
     "material": [ "leather" ],
@@ -282,7 +282,7 @@
     "type": "GENERIC",
     "id": "sheet_leather",
     "name": { "str": "leather sheet" },
-    "description": "A 12-inch by 24-inch sheet of leather.  Can be cut up or used as is.",
+    "description": "A sheet of leather.  Can be cut up or used as is.",
     "category": "spare_parts",
     "material": [ "leather" ],
     "weight": "296 g",
@@ -296,7 +296,7 @@
     "type": "GENERIC",
     "id": "sheet_leather_patchwork",
     "name": { "str": "patchwork leather sheet" },
-    "description": "A folded 12-inch by 24-inch sheet of leather sewn together from patches.  Can be cut up or used as is.",
+    "description": "A sheet of leather sewn together from patches.  Can be cut up or used as is.",
     "copy-from": "sheet_leather"
   },
   {


### PR DESCRIPTION
#### Summary
Improve descriptions for skins

#### Purpose of change
A lot of descriptions for leather-related resources were odd.

#### Describe the solution
- Tainted hide and pelt no longer mention being curable. They aren't.
- Removed all reference to these items being "carefully folded". Who's folding them? Why would we assume every player character would be carefully folding things?
- The Jabberwock heart was 4.5 kg for some reason despite only being 1L. Now it's lighter.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
