### PR TITLE
Add npc door behaviour overrides

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -589,6 +589,8 @@ enum npc_chat_menu {
     NPC_CHAT_ORDERS,
     NPC_CHAT_NO_GUNS,
     NPC_CHAT_PULP,
+    NPC_CHAT_AVOID_DOORS,
+    NPC_CHAT_CLOSE_DOORS,
     NPC_CHAT_FOLLOW_CLOSE,
     NPC_CHAT_MOVE_FREELY,
     NPC_CHAT_SLEEP,
@@ -818,6 +820,10 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
                         _( "Use whatever weapon you normally would" ) : _( "Don't use ranged weapons for a while" ) );
         nmenu.addentry( NPC_CHAT_PULP, true, 'p', guy->rules.has_override_enable( ally_rule::allow_pulp ) ?
                         _( "Pulp zombies if you like" ) : _( "Hold off on pulping zombies for a while" ) );
+        nmenu.addentry( NPC_CHAT_AVOID_DOORS, true, 'w', guy->rules.has_override_enable( ally_rule::avoid_doors ) ?
+                        _( "Open doors to get where you're going" ) : _( "Don't walk through closed doors" ) );
+        nmenu.addentry( NPC_CHAT_CLOSE_DOORS, true, 'a', guy->rules.has_override_enable( ally_rule::close_doors ) ?
+                        _( "Close the doors" ) : _( "Leave doors open" ) );
         nmenu.addentry( NPC_CHAT_FOLLOW_CLOSE, true, 'c',
                         guy->rules.has_override_enable( ally_rule::follow_close ) &&
                         guy->rules.has_override( ally_rule::follow_close ) ?
@@ -841,6 +847,12 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
                 break;
             case NPC_CHAT_PULP:
                 npc_batch_override_toggle( npc_list, ally_rule::allow_pulp, false );
+                break;
+            case NPC_CHAT_AVOID_DOORS:
+                npc_batch_override_toggle( npc_list, ally_rule::avoid_doors, true );
+                break;
+            case NPC_CHAT_CLOSE_DOORS:
+                npc_batch_override_toggle( npc_list, ally_rule::close_doors, false );
                 break;
             case NPC_CHAT_FOLLOW_CLOSE:
                 npc_batch_override_toggle( npc_list, ally_rule::follow_close, true );


### PR DESCRIPTION
#### Summary
Add npc door behaviour overrides: don't walk through closed doors and leave doors open

#### Purpose of change
To ease micromanaging npcs behaviour. Currently, these two options are only toggleable through chatting directly with npcs. If you have multiple npcs following you, this change will make it easier to control them.

#### Describe the solution
Added override options on the Chat with NPC menu -> (o) Tell everyone on your team to temporarily...
Those two options are bound to the `w` and `a` keys.

#### Describe alternatives you've considered
The `c` and `d` keys were already occupied on this menu, so I figured it is better to not change them, to avoid player misinput from muscle memory.

#### Testing
Got a follower npc, set their miscellaneous behaviour to default, used Chat with npc menu to override them. Video below.

#### Additional context
I would like feedback on whether the `w` and `a` keys are good for this. Feel free to change them.
Also, I used the same string for these options as the one on dialogue, but to my surprise they are not automatically translated. Screenshot below the video.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
https://github.com/user-attachments/assets/4d610f8b-f6ad-4aba-8ec4-88a8064f49c6

<img width="301" height="220" alt="image" src="https://github.com/user-attachments/assets/b60fa6d3-9627-4616-a4df-2d580d8691cd" />

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
