### PR TITLE
Un-revert temporary reversion

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -438,6 +438,8 @@ void aim_activity_actor::do_turn( player_activity &act, Character &who )
 
 void aim_activity_actor::finish( player_activity &act, Character &who )
 {
+    map &here = get_map();
+
     act.set_to_null();
     item_location weapon = get_weapon();
     if( !weapon ) {
@@ -456,7 +458,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     }
 
     gun_mode gun = weapon->gun_current_mode();
-    who.fire_gun( fin_trajectory.back(), gun.qty, *gun, reload_loc );
+    who.fire_gun( &here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
     if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
         restore_view();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -595,8 +595,8 @@ static bool vehicle_activity( Character &you, const tripoint_bub_ms &src_loc, in
     // so , NPCs can remove the last part on a position, then there is no vehicle there anymore,
     // for someone else who stored that position at the start of their activity.
     // so we may need to go looking a bit further afield to find it , at activities end.
-    for( const tripoint_bub_ms &pt : veh->get_points( true ) ) {
-        you.activity.coord_set.insert( here.get_abs( pt ) );
+    for( const tripoint_abs_ms &pt : veh->get_points( true ) ) {
+        you.activity.coord_set.insert( pt );
     }
     // values[0]
     you.activity.values.push_back( here.get_abs( src_loc ).x() );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -705,11 +705,11 @@ void avatar::grab( object_type grab_type_new, const tripoint_rel_ms &grab_point_
         map &m = get_map();
         if( gtype == object_type::VEHICLE ) {
             if( const optional_vpart_position ovp = m.veh_at( pos_bub() + gpoint ) ) {
-                for( const tripoint_bub_ms &target : ovp->vehicle().get_points() ) {
+                for( const tripoint_abs_ms &target : ovp->vehicle().get_points() ) {
                     if( erase ) {
-                        memorize_clear_decoration( m.get_abs( target ), /* prefix = */ "vp_" );
+                        memorize_clear_decoration( target, /* prefix = */ "vp_" );
                     }
-                    m.memory_cache_dec_set_dirty( target, true );
+                    m.memory_cache_dec_set_dirty( m.get_bub( target ), true );
                 }
             }
         } else if( gtype != object_type::NONE ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -830,7 +830,7 @@ bool avatar_action::fire_turret_manual( avatar &you, map &m, turret_data &turret
     target_handler::trajectory trajectory = target_handler::mode_turret_manual( you, turret );
 
     if( !trajectory.empty() ) {
-        turret.fire( you, trajectory.back() );
+        turret.fire( you, &m, trajectory.back() );
     }
     g->reenter_fullscreen();
     return true;

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -544,7 +544,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                     multishot = true;
                     proj.multishot = true;
                 }
-                here.shoot( tp, source, proj, !no_item_damage && tp == target, aim.dispersion );
+                here->shoot( tp, source, proj, !no_item_damage && tp == target, aim.dispersion );
                 has_momentum = multishot ?
                                proj.shot_impact.total_damage() >= 1.0f :
                                proj.impact.total_damage() >= 1.0f;
@@ -556,7 +556,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             }
 
             // Gases, liquids, and tiny projectiles can go through bars, but not walls.
-            if( here.impassable( tp ) && ( !has_momentum || !is_bullet ) ) {
+            if( here->impassable( tp ) && ( !has_momentum || !is_bullet ) ) {
                 traj_len = i;
                 break;
             }

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -61,7 +61,7 @@ static const itype_id itype_glass_shard( "glass_shard" );
 
 static const json_character_flag json_flag_HARDTOHIT( "HARDTOHIT" );
 
-static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
+static void drop_or_embed_projectile( map *here, const dealt_projectile_attack &attack )
 {
     const projectile &proj = attack.proj;
     const item &drop_item = proj.get_drop();
@@ -77,12 +77,15 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
         add_msg_if_player_sees( pt, _( "The %s shatters!" ), drop_item.tname() );
 
         // copies the drop item to spill the contents
-        item( drop_item ).spill_contents( pt );
+        item( drop_item ).spill_contents( here, pt );
 
         // TODO: Non-glass breaking
         // TODO: Wine glass breaking vs. entire sheet of glass breaking
-        sounds::sound( pt, 16, sounds::sound_t::combat, _( "glass breaking!" ), false, "bullet_hit",
-                       "hit_glass" );
+        // TODO: Refine logic to allow for overlapping maps.
+        if( here == &get_map() ) {
+            sounds::sound( pt, 16, sounds::sound_t::combat, _( "glass breaking!" ), false, "bullet_hit",
+                           "hit_glass" );
+        }
 
         const units::mass shard_mass = itype_glass_shard->weight;
         const int max_nb_of_shards = floor( to_gram( drop_item.type->weight ) / to_gram( shard_mass ) );
@@ -95,7 +98,7 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
         for( int i = 0; i < nb_of_dropped_shard; ++i ) {
             item shard( "glass_shard" );
             //actual dropping of shards
-            get_map().add_item_or_charges( pt, shard );
+            here->add_item_or_charges( pt, shard );
         }
 
         return;
@@ -103,10 +106,11 @@ static void drop_or_embed_projectile( const dealt_projectile_attack &attack )
 
     if( effects.count( ammo_effect_BURST ) ) {
         // Drop the contents, not the thrown item
-        add_msg_if_player_sees( pt, _( "The %s bursts!" ), drop_item.tname() );
+        add_msg_if_player_sees( get_map().get_bub( here->get_abs( pt ) ), _( "The %s bursts!" ),
+                                drop_item.tname() );
 
         // copies the drop item to spill the contents
-        item( drop_item ).spill_contents( pt );
+        item( drop_item ).spill_contents( here, pt );
 
         // TODO: Sound
         return;
@@ -223,14 +227,23 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         const dispersion_sources &dispersion, Creature *origin, const vehicle *in_veh,
                         const weakpoint_attack &wp_attack )
 {
+    projectile_attack( attack, proj_arg, &get_map(), source, target_arg, dispersion, origin, in_veh,
+                       wp_attack );
+}
+
+void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
+                        map *here, const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+                        const dispersion_sources &dispersion, Creature *origin, const vehicle *in_veh,
+                        const weakpoint_attack &wp_attack )
+{
     const bool do_animation = get_option<bool>( "ANIMATION_PROJECTILES" );
 
     double range = rl_dist( source, target_arg );
 
     creature_tracker &creatures = get_creature_tracker();
     Creature *target_critter = creatures.creature_at( target_arg );
-    map &here = get_map();
     double target_size;
+
     if( target_critter != nullptr ) {
         const monster *mon = target_critter->as_monster();
         if( mon && proj_arg.proj_effects.count( ammo_effect_WIDE ) ) {
@@ -240,7 +253,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             target_size = target_critter->ranged_target_size();
         }
     } else {
-        target_size = here.ranged_target_size( target_arg );
+        target_size = here->ranged_target_size( target_arg );
     }
     projectile_attack_aim aim = projectile_attack_roll( dispersion, range, target_size );
 
@@ -286,7 +299,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
     // If we were targeting a tile rather than a monster, don't overshoot
     // Unless the target was a wall, then we are aiming high enough to overshoot
     const bool no_overshoot = proj_effects.count( ammo_effect_NO_OVERSHOOT ) ||
-                              ( creatures.creature_at( target_arg ) == nullptr && here.passable( target_arg ) );
+                              ( creatures.creature_at( here->get_abs( target_arg ) ) == nullptr && here->passable( target_arg ) );
 
     double extend_to_range = no_overshoot ? range : proj_arg.range;
 
@@ -322,13 +335,16 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         range = rl_dist( source, target );
         extend_to_range = range;
 
-        sfx::play_variant_sound( "bullet_hit", "hit_wall", sfx::get_heard_volume( target ),
-                                 sfx::get_heard_angle( target ) );
+        if( get_map().inbounds( here->get_abs( target ) ) ) {
+            const tripoint_bub_ms bub_target = get_map().get_bub( here->get_abs( target ) );
+            sfx::play_variant_sound( "bullet_hit", "hit_wall", sfx::get_heard_volume( bub_target ),
+                                     sfx::get_heard_angle( bub_target ) );
+        }
         // TODO: Z dispersion
     }
 
     //Use find clear path to draw the trajectory with optimal initial tile offsets.
-    trajectory = here.find_clear_path( source, target );
+    trajectory = here->find_clear_path( source, target );
 
     add_msg_debug( debugmode::DF_BALLISTIC,
                    "missed_by_tiles: %.2f; missed_by: %.2f; target (orig/hit): %s/%s",
@@ -343,7 +359,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
 
     static emit_id muzzle_smoke( "emit_smaller_smoke_plume" );
     if( proj_effects.count( ammo_effect_MUZZLE_SMOKE ) ) {
-        here.emit_field( trajectory.front(), muzzle_smoke );
+        here->emit_field( trajectory.front(), muzzle_smoke );
     }
 
     if( !no_overshoot && range < extend_to_range ) {
@@ -385,7 +401,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                     target_c.x() = source.x() + sgn( dx );
                     target_c.y() = source.y() + sgn( dy );
                 }
-                t_copy = here.find_clear_path( first_p, target_c );
+                t_copy = here->find_clear_path( first_p, target_c );
                 // point-blank tile should be the same
                 t_copy.insert( t_copy.begin(), first_p );
                 t_copy.insert( t_copy.begin(), source );
@@ -428,7 +444,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 }
                 // We only stop the bullet if there are two floors in a row
                 // this allow the shooter to shoot adjacent enemies from rooftops.
-                if( here.has_floor_or_water( floor1 ) && here.has_floor_or_water( floor2 ) ) {
+                if( here->has_floor_or_water( floor1 ) && here->has_floor_or_water( floor2 ) ) {
                     // Currently strictly no shooting through floor
                     // TODO: Bash the floor
                     tp = prev_point;
@@ -442,7 +458,10 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             if( first && do_animation && !do_draw_line ) {
                 // TODO: Make this draw thrown item/launched grenade/arrow
                 if( projectile_skip_current_frame >= projectile_skip_calculation ) {
-                    g->draw_bullet( tp, static_cast<int>( i ), trajectory, bullet );
+                    // TODO: Refine so overlapping maps are handled.
+                    if( here == &get_map() ) {
+                        g->draw_bullet( tp, static_cast<int>( i ), trajectory, bullet );
+                    }
                     projectile_skip_current_frame = 0;
                     // If we missed recalculate the skip factor so they spread out.
                     projectile_skip_calculation =
@@ -453,7 +472,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             }
 
             if( in_veh != nullptr ) {
-                const optional_vpart_position other = here.veh_at( tp );
+                const optional_vpart_position other = here->veh_at( tp );
                 if( in_veh == veh_pointer_or_null( other ) && other->is_inside() ) {
                     // Turret is on the roof and can't hit anything inside
                     continue;
@@ -494,7 +513,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             }
 
             if( critter != nullptr && cur_missed_by < 1.0 ) {
-                if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( tp ) ) == in_veh &&
+                if( in_veh != nullptr && veh_pointer_or_null( here->veh_at( tp ) ) == in_veh &&
                     critter->is_avatar() ) {
                     // Turret either was aimed by the player (who is now ducking) and shoots from above
                     // Or was just IFFing, giving lots of warnings and time to get out of the line of fire
@@ -512,7 +531,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                     attack.proj.multishot = true;
                     print_messages = false;
                 }
-                critter->deal_projectile_attack( &here, null_source ? nullptr : origin, attack, cur_missed_by,
+                critter->deal_projectile_attack( here, null_source ? nullptr : origin, attack, cur_missed_by,
                                                  print_messages, wp_attack );
 
                 if( critter->is_npc() ) {
@@ -527,17 +546,20 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         const size_t bt_len = blood_trail_len( attack.dealt_dam.total_damage() );
                         if( bt_len >= 1 ) {
                             const tripoint_bub_ms &dest = move_along_line( tp, t_copy, bt_len );
-                            here.add_splatter_trail( blood_type, tp, dest );
+                            here->add_splatter_trail( blood_type, tp, dest );
                         }
                     }
-                    sfx::do_projectile_hit( *attack.last_hit_critter );
+                    // TODO: Refine to account for overlapping maps
+                    if( here == &get_map() ) {
+                        sfx::do_projectile_hit( *attack.last_hit_critter );
+                    }
                     has_momentum = false;
                     // on-hit effects for inflicted damage types
                     for( const std::pair<const damage_type_id, int> &dt : attack.dealt_dam.dealt_dams ) {
                         dt.first->onhit_effects( origin, attack.last_hit_critter );
                     }
                 }
-            } else if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( tp ) ) == in_veh ) {
+            } else if( in_veh != nullptr && veh_pointer_or_null( here->veh_at( tp ) ) == in_veh ) {
                 // Don't do anything, especially don't call map::shoot as this would damage the vehicle
             } else {
                 if( proj.count > 1 && distance > 1 ) {
@@ -570,17 +592,17 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             g->draw_bullet( tp, static_cast<int>( traj_len-- ), t_copy, bullet );
         }
 
-        if( here.impassable( tp ) ) {
+        if( here->impassable( tp ) ) {
             tp = prev_point;
         }
 
-        drop_or_embed_projectile( attack );
+        drop_or_embed_projectile( here, attack );
 
         int dealt_damage = attack.dealt_dam.total_damage();
         apply_ammo_effects( null_source ? nullptr : origin, tp, proj.proj_effects, dealt_damage );
         const explosion_data &expl = proj.get_custom_explosion();
         if( expl.power > 0.0f ) {
-            explosion_handler::explosion( null_source ? nullptr : origin, tp,
+            explosion_handler::explosion( null_source ? nullptr : origin, here, tp,
                                           proj.get_custom_explosion() );
         }
         first = false;
@@ -593,8 +615,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 return false;
             }
             // search for creatures in radius 4 around impact site
-            if( rl_dist( z.pos_bub(), tp ) <= 4 &&
-                here.sees( z.pos_bub(), tp, -1 ) ) {
+            if( rl_dist( z.pos_bub( here ), tp ) <= 4 &&
+                here->sees( z.pos_bub( here ), tp, -1 ) ) {
                 // don't hit targets that have already been hit
                 for( auto it : attack.targets_hit ) {
                     if( &z == it.first ) {
@@ -608,9 +630,12 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         if( mon_ptr ) {
             Creature &z = *mon_ptr;
             add_msg( _( "The attack bounced to %s!" ), z.get_name() );
-            projectile_attack( attack, proj, tp, z.pos_bub(), dispersion, origin, in_veh );
-            sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
-                                     sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
+            projectile_attack( attack, proj, here, tp, z.pos_bub(), dispersion, origin, in_veh );
+            // TODO: Refine to handle overlapping maps
+            if( here == &get_map() ) {
+                sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
+                                         sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
+            }
         }
     }
 }

--- a/src/ballistics.h
+++ b/src/ballistics.h
@@ -45,6 +45,11 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
                         const weakpoint_attack &wp_attack = weakpoint_attack() );
 
+void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_arg,
+                        map *here, const tripoint_bub_ms &source, const tripoint_bub_ms &target_arg,
+                        const dispersion_sources &dispersion, Creature *origin = nullptr, const vehicle *in_veh = nullptr,
+                        const weakpoint_attack &wp_attack = weakpoint_attack() );
+
 /* Used for selecting which part to target in a projectile attack
  * Primarily a template for ease of testing, but can be reused!
  * To use:

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3975,7 +3975,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( you )
                 && !( you.get_grab_type() == object_type::VEHICLE
-                      && veh.get_points().count( ( you.pos_bub() + you.grab_point ) ) )
+                      && veh.get_points().count( ( you.pos_abs() + you.grab_point ) ) )
                 && here.memory_cache_dec_is_dirty( p ) ) {
                 you.memorize_decoration( here.get_abs( p ), vd.get_tileset_id(), subtile, rotation );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10818,7 +10818,7 @@ void Character::place_corpse( map *here )
         }
     }
 
-    here->add_item_or_charges( here->get_bub( pos_abs() ), body );
+    here->add_item_or_charges( pos_bub( here ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -11607,7 +11607,7 @@ void Character::gravity_check()
 
 void Character::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = here->get_bub( pos_abs() );
+    const tripoint_bub_ms pos = pos_bub( here );
     if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
         here->try_fall( pos, this ) ) {
         here->update_visibility_cache( pos.z() );
@@ -13401,8 +13401,8 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( *here, this, here->get_bub( pos_abs() ) ) ) {
-        weapon.spill_contents( here,  here->get_bub( pos_abs() ) );
+    if( weapon.process( *here, this, pos_bub( here ) ) ) {
+        weapon.spill_contents( here,  pos_bub( here ) );
         remove_weapon();
     }
 
@@ -13411,8 +13411,8 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( *here, this, here->get_bub( pos_abs() ) ) ) {
-            it->spill_contents( here, here->get_bub( pos_abs() ) );
+        if( it->process( *here, this, pos_bub( here ) ) ) {
+            it->spill_contents( here, pos_bub( here ) );
             removed_items.push_back( it );
         }
     }

--- a/src/character.h
+++ b/src/character.h
@@ -3237,7 +3237,7 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( const tripoint_bub_ms &target, int shots, item &gun,
+        int fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
                       item_location ammo = item_location() );
         /** Execute a throw */
         dealt_projectile_attack throw_item( const tripoint_bub_ms &target, const item &to_throw,
@@ -3565,6 +3565,9 @@ class Character : public Creature, public visitable
         * @returns Craftable inventory items found.
         * */
         const inventory &crafting_inventory( const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
+                                             int radius = PICKUP_RANGE, bool clear_path = true ) const;
+        const inventory &crafting_inventory( map *here,
+                                             const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
                                              int radius = PICKUP_RANGE, bool clear_path = true ) const;
         void invalidate_crafting_inventory();
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -639,9 +639,16 @@ const inventory &Character::crafting_inventory( bool clear_path ) const
 const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, int radius,
         bool clear_path ) const
 {
+    return Character::crafting_inventory( &get_map(), src_pos, radius, clear_path );
+}
+
+const inventory &Character::crafting_inventory( map *here, const tripoint_bub_ms &src_pos,
+        int radius,
+        bool clear_path ) const
+{
     tripoint_bub_ms inv_pos = src_pos;
     if( src_pos == tripoint_bub_ms::zero ) {
-        inv_pos = pos_bub();
+        inv_pos = pos_bub( here );
     }
     if( crafting_cache.valid
         && moves == crafting_cache.moves
@@ -653,7 +660,7 @@ const inventory &Character::crafting_inventory( const tripoint_bub_ms &src_pos, 
     }
     crafting_cache.crafting_inventory->clear();
     if( radius >= 0 ) {
-        crafting_cache.crafting_inventory->form_from_map( inv_pos, radius, this, false, clear_path );
+        crafting_cache.crafting_inventory->form_from_map( here, inv_pos, radius, this, false, clear_path );
     }
 
     std::map<itype_id, int> tmp_liq_list;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -206,6 +206,11 @@ tripoint_bub_ms Creature::pos_bub() const
     return get_map().get_bub( location );
 }
 
+tripoint_bub_ms Creature::pos_bub( map *here ) const
+{
+    return here->get_bub( location );
+}
+
 void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     map &here = get_map();

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -722,10 +722,10 @@ bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) c
 
 // Helper function to check if potential area of effect of a weapon overlaps vehicle
 // Maybe TODO: If this is too slow, precalculate a bounding box and clip the tested area to it
-static bool overlaps_vehicle( const std::set<tripoint_bub_ms> &veh_area, const tripoint_bub_ms &pos,
+static bool overlaps_vehicle( const std::set<tripoint_abs_ms> &veh_area, const tripoint_abs_ms &pos,
                               const int area )
 {
-    for( const tripoint_bub_ms &tmp : tripoint_range<tripoint_bub_ms>( pos - tripoint( area, area, 0 ),
+    for( const tripoint_abs_ms &tmp : tripoint_range<tripoint_abs_ms>( pos - tripoint( area, area, 0 ),
             pos + tripoint( area - 1, area - 1, 0 ) ) ) {
         if( veh_area.count( tmp ) > 0 ) {
             return true;
@@ -867,7 +867,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             continue; // Handle this late so that boo_hoo++ can happen
         }
         // Expensive check for proximity to vehicle
-        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), m->pos_bub(), area ) ) {
+        if( self_area_iff && overlaps_vehicle( in_veh->get_points(), m->pos_abs(), area ) ) {
             continue;
         }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -308,6 +308,7 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( map *here ) const;
         inline int posx() const {
             return pos_bub().x();
         }

--- a/src/creature.h
+++ b/src/creature.h
@@ -321,6 +321,7 @@ class Creature : public viewer
         virtual void gravity_check( map *here );
         void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
+        void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
         // Convert size to int. TODO: use this everywhere instead of enuming every time.
         int enum_size() const;

--- a/src/creature.h
+++ b/src/creature.h
@@ -321,7 +321,6 @@ class Creature : public viewer
         virtual void gravity_check( map *here );
         void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
-        void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
         // Convert size to int. TODO: use this everywhere instead of enuming every time.
         int enum_size() const;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -527,6 +527,12 @@ void explosion( const Creature *source, const tripoint_bub_ms &p, const explosio
     _explosions.emplace_back( source, get_map().get_abs( p ), ex );
 }
 
+void explosion( const Creature *source, map *here, const tripoint_bub_ms &p,
+                const explosion_data &ex )
+{
+    _explosions.emplace_back( source, here->get_abs( p ), ex );
+}
+
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex )
 {

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -84,6 +84,8 @@ void explosion(
 // until triggered normally.
 bool explosion_processing_active();
 void explosion( const Creature *source, const tripoint_bub_ms &p, const explosion_data &ex );
+void explosion( const Creature *source, map *here, const tripoint_bub_ms &p,
+                const explosion_data &ex );
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5984,9 +5984,9 @@ void game::control_vehicle()
     if( veh ) {
         // If we reached here, we gained control of a vehicle.
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
-        for( const tripoint_bub_ms &target : veh->get_points() ) {
-            u.memorize_clear_decoration( m.get_abs( target ), "vp_" );
-            m.memory_cache_dec_set_dirty( target, true );
+        for( const tripoint_abs_ms &target : veh->get_points() ) {
+            u.memorize_clear_decoration( target, "vp_" );
+            m.memory_cache_dec_set_dirty( m.get_bub( target ), true );
         }
         veh->is_following = false;
         veh->is_patrolling = false;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -773,7 +773,6 @@ static void grab()
         //solid vehicles can't be grabbed while boarded
         const optional_vpart_position vp_boarded = here.veh_at( you.pos_bub() );
         if( vp_boarded ) {
-            const std::set<tripoint_bub_ms> grabbed_veh_points = vp->vehicle().get_points();
             if( &vp_boarded->vehicle() == &vp->vehicle() &&
                 !empty( vp->vehicle().get_avail_parts( VPFLAG_OBSTACLE ) ) ) {
                 add_msg( m_info, _( "You can't move the %s while you're boarding it." ), veh_name );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -484,21 +484,28 @@ void inventory::form_from_map( const tripoint_bub_ms &origin, int range, const C
                                bool assign_invlet,
                                bool clear_path )
 {
-    map &m = get_map();
+    inventory::form_from_map( &get_map(), origin, range, pl, assign_invlet, clear_path );
+}
+
+void inventory::form_from_map( map *here, const tripoint_bub_ms &origin, int range,
+                               const Character *pl,
+                               bool assign_invlet,
+                               bool clear_path )
+{
     // Populate a grid of spots that can be reached
     // If we need a clear path we care about the reachability of points
     if( clear_path ) {
-        const std::vector<tripoint_bub_ms> &reachable_pts = m.reachable_flood_steps( origin, range, 1,
+        const std::vector<tripoint_bub_ms> &reachable_pts = here->reachable_flood_steps( origin, range, 1,
                 100 );
-        form_from_map( m, reachable_pts, pl, assign_invlet );
+        form_from_map( *here, reachable_pts, pl, assign_invlet );
     } else {
         std::vector<tripoint_bub_ms> reachable_pts;
-        // Fill reachable points with points_in_radius
-        tripoint_range<tripoint_bub_ms> in_radius = m.points_in_radius( origin, range );
+        // Fill reachable points with points_in_radius.
+        tripoint_range<tripoint_bub_ms> in_radius = here->points_in_radius( origin, range );
         for( const tripoint_bub_ms &p : in_radius ) {
             reachable_pts.emplace_back( p );
         }
-        form_from_map( m, reachable_pts, pl, assign_invlet );
+        form_from_map( *here, reachable_pts, pl, assign_invlet );
     }
 }
 

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -158,6 +158,10 @@ class inventory : public visitable
         void form_from_map( const tripoint_bub_ms &origin, int range, const Character *pl = nullptr,
                             bool assign_invlet = true,
                             bool clear_path = true );
+        void form_from_map( map *here, const tripoint_bub_ms &origin, int range,
+                            const Character *pl = nullptr,
+                            bool assign_invlet = true,
+                            bool clear_path = true );
         void form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const Character *pl,
                             bool assign_invlet = true );
         /**

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11172,6 +11172,11 @@ bool item::ammo_sufficient( const Character *carrier, const std::string &method,
 
 int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier )
 {
+    return item::ammo_consume( qty, &get_map(), pos, carrier );
+}
+
+int item::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, Character *carrier )
+{
     if( qty < 0 ) {
         debugmsg( "Cannot consume negative quantity of ammo for %s", tname() );
         return 0;
@@ -11182,7 +11187,7 @@ int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier 
     if( is_tool_with_carrier && has_flag( flag_USES_NEARBY_AMMO ) ) {
         const ammotype ammo = ammo_type();
         if( !ammo.is_null() ) {
-            const inventory &carrier_inventory = carrier->crafting_inventory();
+            const inventory &carrier_inventory = carrier->crafting_inventory( here );
             itype_id ammo_type = ammo->default_ammotype();
             const int charges_avalable = carrier_inventory.charges_of( ammo_type, INT_MAX );
 
@@ -11200,7 +11205,7 @@ int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier 
         if( link().t_veh && link().efficiency >= MIN_LINK_EFFICIENCY ) {
             qty = link().t_veh->discharge_battery( qty, true );
         } else {
-            const optional_vpart_position vp = get_map().veh_at( link().t_abs_pos );
+            const optional_vpart_position vp = here->veh_at( link().t_abs_pos );
             if( vp ) {
                 qty = vp->vehicle().discharge_battery( qty, true );
             }
@@ -11209,7 +11214,7 @@ int item::ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier 
 
     // Consume charges loaded in the item or its magazines
     if( is_magazine() || uses_magazine() ) {
-        qty -= contents.ammo_consume( qty, pos );
+        qty -= contents.ammo_consume( qty, here, pos );
         if( ammo_capacity( ammo_battery ) == 0 && carrier != nullptr ) {
             carrier->invalidate_weight_carried_cache();
         }
@@ -11257,6 +11262,13 @@ units::energy item::energy_consume( units::energy qty, const tripoint_bub_ms &po
                                     Character *carrier,
                                     float fuel_efficiency )
 {
+    return item::energy_consume( qty, &get_map(), pos, carrier, fuel_efficiency );
+}
+
+units::energy item::energy_consume( units::energy qty, map *here, const tripoint_bub_ms &pos,
+                                    Character *carrier,
+                                    float fuel_efficiency )
+{
     if( qty < 0_kJ ) {
         debugmsg( "Cannot consume negative quantity of energy for %s", tname() );
         return 0_kJ;
@@ -11266,7 +11278,7 @@ units::energy item::energy_consume( units::energy qty, const tripoint_bub_ms &po
 
     // Consume battery(ammo) and other fuel (if allowed)
     if( is_battery() || fuel_efficiency >= 0 ) {
-        int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
+        int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), here, pos, fuel_efficiency );
         qty -= units::from_kilojoule( static_cast<std::int64_t>( consumed_kj ) );
         // fix negative quantity
         if( qty < 0_J ) {
@@ -11276,7 +11288,7 @@ units::energy item::energy_consume( units::energy qty, const tripoint_bub_ms &po
 
     // Consume energy from contained magazine
     if( magazine_current() ) {
-        qty -= magazine_current()->energy_consume( qty, pos, carrier );
+        qty -= magazine_current()->energy_consume( qty, here, pos, carrier );
     }
 
     // Consume UPS energy from various sources

--- a/src/item.h
+++ b/src/item.h
@@ -2535,6 +2535,7 @@ class item : public visitable
          * @return amount of ammo consumed which will be between 0 and qty
          */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, Character *carrier );
 
         /**
          * Consume energy (if available) and return the amount of energy that was consumed
@@ -2546,6 +2547,9 @@ class item : public visitable
          * @return amount of energy consumed which will be between 0 kJ and qty+1 kJ
          */
         units::energy energy_consume( units::energy qty, const tripoint_bub_ms &pos, Character *carrier,
+                                      float fuel_efficiency = -1.0 );
+        units::energy energy_consume( units::energy qty, map *here, const tripoint_bub_ms &pos,
+                                      Character *carrier,
                                       float fuel_efficiency = -1.0 );
 
         /**

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1254,6 +1254,12 @@ void item_contents::heat_up()
 
 int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency )
 {
+    return item_contents::ammo_consume( qty, &get_map(), pos, fuel_efficiency );
+}
+
+int item_contents::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos,
+                                 float fuel_efficiency )
+{
     int consumed = 0;
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
@@ -1263,12 +1269,12 @@ int item_contents::ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel
             }
             // assuming only one mag
             item &mag = pocket.front();
-            const int res = mag.ammo_consume( qty, pos, nullptr );
+            const int res = mag.ammo_consume( qty, here, pos, nullptr );
             if( res && mag.ammo_remaining() == 0 ) {
                 if( mag.has_flag( STATIC( flag_id( "MAG_DESTROY" ) ) ) ) {
                     pocket.remove_item( mag );
                 } else if( mag.has_flag( STATIC( flag_id( "MAG_EJECT" ) ) ) ) {
-                    get_map().add_item( pos, mag );
+                    here->add_item( pos, mag );
                     pocket.remove_item( mag );
                 }
             }

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -314,6 +314,7 @@ class item_contents
         void heat_up();
         // returns amount of ammo consumed
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
         std::set<ammotype> ammo_types() const;
         int ammo_capacity( const ammotype &ammo ) const;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9784,7 +9784,7 @@ void map::build_obstacle_cache(
     }
     // Iterate over creatures and set them to block their squares relative to their size.
     for( Creature &critter : g->all_creatures() ) {
-        const tripoint_bub_ms loc = get_bub( critter.pos_abs() );
+        const tripoint_bub_ms loc = critter.pos_bub( this );
         if( loc.z() != start.z() || !inbounds( loc ) ) {
             continue;
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -393,12 +393,12 @@ void map::memory_cache_ter_set_dirty( const tripoint_bub_ms &p, bool value ) con
 void map::memory_clear_vehicle_points( const vehicle &veh ) const
 {
     avatar &player_character = get_avatar();
-    for( const tripoint_bub_ms &p : veh.get_points() ) {
+    for( const tripoint_abs_ms &p : veh.get_points() ) {
         if( !inbounds( p ) ) {
             continue;
         }
-        memory_cache_dec_set_dirty( p, true );
-        player_character.memorize_clear_decoration( get_abs( p ), "vp_" );
+        memory_cache_dec_set_dirty( get_bub( p ), true );
+        player_character.memorize_clear_decoration( p, "vp_" );
     }
 }
 
@@ -618,11 +618,11 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
     level_cache &ch = get_cache( z );
     for( size_t i = 0; i < current_submap->vehicles.size(); i++ ) {
         if( current_submap->vehicles[i].get() == veh ) {
-            for( const tripoint_bub_ms &pt : veh->get_points() ) {
+            for( const tripoint_abs_ms &pt : veh->get_points() ) {
                 if( inbounds( pt ) ) {
-                    memory_cache_dec_set_dirty( pt, true );
+                    memory_cache_dec_set_dirty( get_bub( pt ), true );
                 }
-                get_avatar().memorize_clear_decoration( get_abs( pt ), "vp_" );
+                get_avatar().memorize_clear_decoration( pt, "vp_" );
             }
             ch.vehicle_list.erase( veh );
             ch.zone_vehicles.erase( veh );
@@ -760,11 +760,12 @@ bool map::vehproceed( VehicleList &vehicle_list )
     return true;
 }
 
+// TODO: Make reality bubble independent.
 static bool sees_veh( const Creature &c, vehicle &veh, bool force_recalc )
 {
-    const auto &veh_points = veh.get_points( force_recalc );
-    return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint_bub_ms & pt ) {
-        return c.sees( pt );
+    const std::set<tripoint_abs_ms> &veh_points = veh.get_points( force_recalc );
+    return std::any_of( veh_points.begin(), veh_points.end(), [&c]( const tripoint_abs_ms & pt ) {
+        return c.sees( get_map().get_bub( pt ) );
     } );
 }
 
@@ -902,10 +903,11 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     if( !vertical && !veh.valid_wheel_config() && !( veh.is_watercraft() && veh.can_float() ) &&
         !veh.is_flying_in_air() && dp.z() == 0 ) {
         veh.velocity -= std::clamp( veh.velocity, -2000, 2000 ); // extra drag
-        for( const tripoint_bub_ms &p : veh.get_points() ) {
-            const ter_id &pter = ter( p );
+        for( const tripoint_abs_ms &p : veh.get_points() ) {
+            const tripoint_bub_ms pos = get_bub( p );
+            const ter_id &pter = ter( pos );
             if( pter == ter_t_dirt || pter == ter_t_grass ) {
-                ter_set( p, ter_t_dirtmound );
+                ter_set( pos, ter_t_dirtmound );
             }
         }
     }
@@ -7415,7 +7417,7 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
 
         if( !veh->forward_velocity() && !veh->player_in_control( player_character )
             && !( player_character.get_grab_type() == object_type::VEHICLE
-                  && veh->get_points().count( ( player_character.pos_bub() +
+                  && veh->get_points().count( ( player_character.pos_abs() +
                                                 player_character.grab_point ) ) ) ) {
             memory_sym = sym;
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1505,7 +1505,10 @@ static bool mx_burned_ground( map &m, const tripoint_abs_sm &abs_sub )
     std::vector<tripoint_bub_ms> points;
     for( wrapped_vehicle vehicle : vehs ) {
         vehicles.push_back( vehicle.v );
-        std::set<tripoint_bub_ms> occupied = vehicle.v->get_points();
+        std::set<tripoint_bub_ms> occupied;
+        for( const tripoint_abs_ms &pt : vehicle.v->get_points() ) {
+            occupied.insert( m.get_bub( pt ) );
+        }
         for( const tripoint_bub_ms &t : occupied ) {
             points.push_back( t );
         }

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1476,7 +1476,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( get_bub( you.pos_abs() ) );
+    field &curfield = get_field( you.pos_bub( this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)
@@ -1511,7 +1511,7 @@ void map::player_in_field( Character &you )
             // Sap does nothing to cars.
             if( !you.in_vehicle ) {
                 // Use up sap.
-                mod_field_intensity( get_bub( you.pos_abs() ), ft, -1 );
+                mod_field_intensity( you.pos_bub( this ), ft, -1 );
             }
         }
         if( ft == fd_sludge ) {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6927,13 +6927,14 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
              */
             std::unique_ptr<RemovePartHandler> handler_ptr;
             bool did_merge = false;
-            for( const tripoint_bub_ms &map_pos : first_veh->get_points( true ) ) {
-                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_pos, "",
+            for( const tripoint_abs_ms &map_pos : first_veh->get_points( true ) ) {
+                const tripoint_bub_ms map_bub_pos = get_bub( map_pos ); // TODO: Make usages use this map.
+                std::vector<vehicle_part *> parts_to_move = veh_to_add->get_parts_at( map_bub_pos, "",
                         part_status_flag::any );
                 if( !parts_to_move.empty() ) {
                     // Store target_point by value because first_veh->parts may reallocate
                     // to a different address after install_part()
-                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_pos, "",
+                    std::vector<vehicle_part *> first_veh_parts = first_veh->get_parts_at( map_bub_pos, "",
                             part_status_flag:: any );
                     // This happens if this location is occupied by a fake part.
                     if( first_veh_parts.empty() || first_veh_parts.front()->is_fake ) {
@@ -6949,7 +6950,7 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
                                   veh_to_add->name, veh_to_add->type.str(),
                                   veh_to_add->pos_abs().to_string(),
                                   to_degrees( veh_to_add->turn_dir ),
-                                  map_pos.to_string() );
+                                  map_bub_pos.to_string() );
                     }
                     did_merge = true;
                     const point_rel_ms target_point = first_veh_parts.front()->mount;

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -101,10 +101,10 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( here->get_bub( z.pos_abs() ) + point( rng( -distance, distance ),
+        tripoint_bub_ms tarp( z.pos_bub( here ) + point( rng( -distance, distance ),
                               rng( -distance,
                                    distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( here->get_bub( z.pos_abs() ), tarp );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( here ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -149,7 +149,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( here->get_bub( z.pos_abs() ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -208,7 +208,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( z.has_effect( effect_critter_underfed ) ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
     }
     return {};
 }
@@ -238,7 +238,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( here->get_bub( z.pos_abs() ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -261,14 +261,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( here->get_bub( z.pos_abs() ), mags );
+                            here->spawn_items( z.pos_bub( here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( here->get_bub( z.pos_abs() ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -298,5 +298,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( z.has_effect( effect_critter_underfed ) ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( here->get_bub( z.pos_abs() ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2967,7 +2967,7 @@ void monster::die( map *here, Creature *nkiller )
     }
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here->points_in_radius( here->get_bub( pos_abs() ), 1,
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( here ), 1,
                 0 ) ) {
             Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
@@ -3104,14 +3104,14 @@ void monster::die( map *here, Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+                here->add_item_or_charges( pos_bub( here ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                here->add_item( here->get_bub( pos_abs() ), it );
+                here->add_item( pos_bub( here ), it );
             }
         }
     }
@@ -3233,7 +3233,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            here->add_item_or_charges( here->get_bub( pos_abs() ), it );
+            here->add_item_or_charges( pos_bub( here ), it );
         }
         return;
     }
@@ -3902,7 +3902,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here->sees( here->get_bub( critter.pos_abs() ), here->get_bub( pos_abs() ), light ) ) {
+            if( here->sees( critter.pos_bub( here ), pos_bub( here ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3061,7 +3061,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( here->get_bub( pos_abs() ), true );
+        here->unboard_vehicle( pos_bub( here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3365,14 +3365,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, here->get_bub( pos_abs() ) ) &&
-        !here->has_vehicle_floor( here->get_bub( pos_abs() ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
+        !here->has_vehicle_floor( pos_bub( here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( here->get_bub( pos_abs() ), this );
+        here->board_vehicle( pos_bub( here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1730,7 +1730,7 @@ void npc::execute_action( npc_action action )
             if( is_hallucination() ) {
                 pretend_fire( this, mode.qty, *mode );
             } else {
-                fire_gun( tar, mode.qty, *mode );
+                fire_gun( &here, tar, mode.qty, *mode );
                 // "discard" the fake bio weapon after shooting it
                 if( is_using_bionic_weapon() ) {
                     discharge_cbm_weapon();

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1598,8 +1598,8 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     std::for_each( monster_bucket.first, monster_bucket.second,
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
-        const map &here = get_map();
-        const tripoint_bub_ms local = here.get_bub( this_monster.pos_abs() );
+        map &here = get_map();
+        const tripoint_bub_ms local = this_monster.pos_bub( &here );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -195,7 +195,7 @@ static int RAS_time( const Character &p, const item_location &loc );
 * @param ammo   Ammo used.
 * @param pos    Character position.
 */
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos );
+static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos );
 static void make_gun_sound_effect( const Character &p, bool burst, item *weapon );
 
 class target_ui
@@ -988,15 +988,18 @@ void npc::pretend_fire( npc *source, int shots, item &gun )
 
 int Character::fire_gun( const tripoint_bub_ms &target, int shots )
 {
+    map &here = get_map();
+
     item_location gun = get_wielded_item();
     if( !gun ) {
         debugmsg( "%s doesn't have a gun to fire", get_name() );
         return 0;
     }
-    return fire_gun( target, shots, *gun, item_location() );
+    return fire_gun( &here, target, shots, *gun, item_location() );
 }
 
-int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, item_location ammo )
+int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+                         item_location ammo )
 {
     if( !gun.is_gun() ) {
         debugmsg( "%s tried to fire non-gun (%s).", get_name(), gun.tname() );
@@ -1030,12 +1033,12 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         return 0;
     }
 
-    map &here = get_map();
     // usage of any attached bipod is dependent upon terrain or on being prone
-    bool bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub() ) || is_prone();
+    bool bipod = here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
+                 is_prone();
     if( !bipod ) {
-        if( const optional_vpart_position vp = here.veh_at( pos_bub() ) ) {
-            bipod = vp->vehicle().has_part( pos_bub(), "MOUNTABLE" );
+        if( const optional_vpart_position vp = here->veh_at( pos_bub( here ) ) ) {
+            bipod = vp->vehicle().has_part( pos_bub( here ), "MOUNTABLE" );
         }
     }
 
@@ -1074,8 +1077,8 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         // If this is a vehicle mounted turret, which vehicle is it mounted on?
-        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here.veh_at(
-                                    pos_bub() ) ) : nullptr;
+        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here->veh_at(
+                                    pos_bub( here ) ) ) : nullptr;
 
         // Add gunshot noise
         make_gun_sound_effect( *this, shots > 1, &gun );
@@ -1097,7 +1100,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         dispersion.add_range( dispersion_variance() );
 
         dealt_projectile_attack shot;
-        projectile_attack( shot, proj, pos_bub(), aim, dispersion, this, in_veh, wp_attack );
+        projectile_attack( shot, proj, here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
         if( !shot.targets_hit.empty() ) {
             hits++;
         }
@@ -1152,7 +1155,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, pos_bub(), this ) != required ) {
+        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
             debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
             break;
         }
@@ -1160,7 +1163,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         // Vehicle turrets drain vehicle battery and do not care about this
         if( !gun.has_flag( flag_VEHICLE ) ) {
             const units::energy energ_req = gun.get_gun_energy_drain();
-            const units::energy drained = gun.energy_consume( energ_req, pos_bub(), this );
+            const units::energy drained = gun.energy_consume( energ_req, here, pos_bub( here ), this );
             if( drained < energ_req ) {
                 debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
                           gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
@@ -1169,7 +1172,7 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots, item &gun, it
         }
 
         if( !current_ammo.is_null() ) {
-            cycle_action( gun, current_ammo, pos_bub() );
+            cycle_action( gun, current_ammo, here, pos_bub( here ) );
         }
 
         if( gun_skill == skill_launcher ) {
@@ -2357,20 +2360,19 @@ int RAS_time( const Character &p, const item_location &loc )
     return time;
 }
 
-static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_ms &pos )
+static void cycle_action( item &weap, const itype_id &ammo, map *here, const tripoint_bub_ms &pos )
 {
-    map &here = get_map();
     // eject casings and linkages in random direction avoiding walls using player position as fallback
     std::vector<tripoint_bub_ms> tiles = closest_points_first( pos, 1 );
     tiles.erase( tiles.begin() );
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&]( const tripoint_bub_ms & e ) {
-        return !here.passable( e );
+        return !here->passable( e );
     } ), tiles.end() );
     tripoint_bub_ms eject{ tiles.empty() ? pos : random_entry( tiles ) };
 
     // for turrets try and drop casings or linkages directly to any CARGO part on the same tile
     const std::optional<vpart_reference> ovp_cargo = weap.has_flag( flag_VEHICLE )
-            ? here.veh_at( pos ).cargo()
+            ? here->veh_at( pos ).cargo()
             : std::nullopt;
 
     item *brass_catcher = weap.gunmod_find_by_flag( flag_BRASS_CATCHER );
@@ -2390,11 +2392,14 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_m
             } else if( ovp_cargo ) {
                 ovp_cargo->vehicle().add_item( ovp_cargo->part(), casing );
             } else {
-                here.add_item_or_charges( eject, casing );
+                here->add_item_or_charges( eject, casing );
             }
 
-            sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
-                                     sfx::get_heard_angle( eject ) );
+            // TODO: Refine critera to handle overlapping maps.
+            if( here == &get_map() ) {
+                sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
+                                         sfx::get_heard_angle( eject ) );
+            }
         }
     }
 
@@ -2407,7 +2412,7 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint_bub_m
             if( ovp_cargo ) {
                 ovp_cargo->items().insert( linkage );
             } else {
-                here.add_item_or_charges( eject, linkage );
+                here->add_item_or_charges( eject, linkage );
             }
         }
     }
@@ -3536,10 +3541,12 @@ void target_ui::set_view_offset( const tripoint_rel_ms &new_offset ) const
 
 void target_ui::update_turrets_in_range()
 {
+    map &here = get_map();
+
     turrets_in_range.clear();
     for( vehicle_part *t : *vturrets ) {
         turret_data td = veh->turret_query( *t );
-        if( td.in_range( dst ) ) {
+        if( td.in_range( here.get_abs( dst ) ) ) {
             tripoint_bub_ms src = veh->bub_part_pos( *t );
             turrets_in_range.push_back( {t, line_to( src, dst )} );
         }

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -199,13 +199,13 @@ int turret_data::range() const
     return res;
 }
 
-bool turret_data::in_range( const tripoint_bub_ms &target ) const
+bool turret_data::in_range( const tripoint_abs_ms &target ) const
 {
     if( !veh || !part ) {
         return false;
     }
     int range = veh->turret_query( *part ).range();
-    int dist = rl_dist( veh->bub_part_pos( *part ), target );
+    int dist = rl_dist( veh->abs_part_pos( *part ), target );
     return range >= dist;
 }
 
@@ -277,7 +277,7 @@ void turret_data::prepare_fire( Character &you )
     }
 }
 
-void turret_data::post_fire( Character &you, int shots )
+void turret_data::post_fire( map *here, Character &you, int shots )
 {
     // remove any temporary recoil adjustments
     you.remove_effect( effect_on_roof );
@@ -299,16 +299,16 @@ void turret_data::post_fire( Character &you, int shots )
 
     // handle draining of vehicle tanks or batteries, if applicable
     if( uses_vehicle_tanks_or_batteries() ) {
-        veh->drain( ammo_current(), mode->ammo_required() * shots );
+        veh->drain( here, ammo_current(), mode->ammo_required() * shots );
         mode->ammo_unset();
 
         clear_mag_wells( *base() );
     }
 
-    veh->drain( fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
+    veh->drain( here, fuel_type_battery, units::to_kilojoule( mode->get_gun_energy_drain() * shots ) );
 }
 
-int turret_data::fire( Character &c, const tripoint_bub_ms &target )
+int turret_data::fire( Character &c, map *here, const tripoint_bub_ms &target )
 {
     if( !veh || !part ) {
         return 0;
@@ -317,8 +317,8 @@ int turret_data::fire( Character &c, const tripoint_bub_ms &target )
     gun_mode mode = base()->gun_current_mode();
 
     prepare_fire( c );
-    shots = c.fire_gun( target, mode.qty, *mode );
-    post_fire( c, shots );
+    shots = c.fire_gun( here, target, mode.qty, *mode );
+    post_fire( here, c, shots );
     return shots;
 }
 
@@ -383,6 +383,8 @@ void vehicle::turrets_override_automatic_aim()
 
 int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
 {
+    map &here = get_map();
+
     int shots = 0;
     if( turrets_aim( turrets ) ) {
         for( vehicle_part *t : turrets ) {
@@ -390,8 +392,8 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
             if( has_target ) {
                 turret_data turret = turret_query( *t );
                 npc &cpu = t->get_targeting_npc( *this );
-                shots += turret.fire( cpu, get_map().get_bub( t->target.second ) );
-                t->reset_target( bub_part_pos( *t ) );
+                shots += turret.fire( cpu, &here, here.get_bub( t->target.second ) );
+                t->reset_target( abs_part_pos( *t ) );
             }
         }
     }
@@ -400,13 +402,15 @@ int vehicle::turrets_aim_and_fire( std::vector<vehicle_part *> &turrets )
 
 bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
 {
+    map &here = get_map();
+
     // Clear existing targets
     for( vehicle_part *t : turrets ) {
         if( !turret_query( *t ) ) {
             debugmsg( "Expected a valid vehicle turret" );
             return false;
         }
-        t->reset_target( bub_part_pos( *t ) );
+        t->reset_target( abs_part_pos( *t ) );
     }
 
     avatar &player_character = get_avatar();
@@ -424,9 +428,11 @@ bool vehicle::turrets_aim( std::vector<vehicle_part *> &turrets )
     if( got_target ) {
         tripoint_bub_ms target = trajectory.back();
         // Set target for any turret in range
+        const tripoint_abs_ms abs_target = here.get_abs( target );
+
         for( vehicle_part *t : turrets ) {
-            if( turret_query( *t ).in_range( target ) ) {
-                t->target.second = get_map().get_abs( target );
+            if( turret_query( *t ).in_range( abs_target ) ) {
+                t->target.second = abs_target;
             }
         }
 
@@ -452,6 +458,8 @@ std::vector<vehicle_part *> vehicle::find_all_ready_turrets( bool manual, bool a
 
 void vehicle::turrets_set_targeting()
 {
+    map &here = get_map();
+
     std::vector<vehicle_part *> turrets;
     std::vector<tripoint_bub_ms> locations;
 
@@ -502,7 +510,7 @@ void vehicle::turrets_set_targeting()
 
         // clear the turret's current targets to prevent unwanted auto-firing
         tripoint_bub_ms pos = locations[ sel ];
-        turrets[ sel ]->reset_target( pos );
+        turrets[ sel ]->reset_target( here.get_abs( pos ) );
     }
 }
 
@@ -572,6 +580,8 @@ npc &vehicle_part::get_targeting_npc( vehicle &veh )
 
 int vehicle::automatic_fire_turret( vehicle_part &pt )
 {
+    map &here = get_map();
+
     turret_data gun = turret_query( pt );
 
     int shots = 0;
@@ -601,7 +611,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
         // Manual target not set, find one automatically.
         // BEWARE: Calling turret_data.fire on tripoint min coordinates starts a crash
         //      triggered at `trajectory.insert( trajectory.begin(), source )` at ranged.cpp:236
-        pt.reset_target( pos );
+        pt.reset_target( here.get_abs( pos ) );
         int boo_hoo;
 
         // TODO: calculate chance to hit and cap range based upon this
@@ -632,7 +642,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
 
     } else {
         // Target is already set, make sure we didn't move after aiming (it's a bug if we did).
-        if( pos != get_map().get_bub( target.first ) ) {
+        if( pos != here.get_bub( target.first ) ) {
             target.second = target.first;
             debugmsg( "%s moved after aiming but before it could fire.", cpu.get_name() );
             return shots;
@@ -640,10 +650,10 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     // Get the turret's target and reset it
-    tripoint_bub_ms targ( get_map().get_bub( target.second ) );
-    pt.reset_target( pos );
+    tripoint_bub_ms targ( here.get_bub( target.second ) );
+    pt.reset_target( here.get_abs( pos ) );
 
-    shots = gun.fire( cpu, targ );
+    shots = gun.fire( cpu, &here, targ );
 
     if( shots && u_see ) {
         add_msg_if_player_sees( targ, _( "The %1$s fires its %2$s!" ), name, pt.name() );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -411,12 +411,11 @@ void veh_app_interact::refill()
         act.targets.push_back( target );
         act.str_values.push_back( pt->info().id.str() );
         const point_rel_ms q = veh->coord_translate( pt->mount );
-        map &here = get_map();
-        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.get_abs( p ) );
+        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+            act.coord_set.insert( p );
         }
-        act.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );
-        act.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );
+        act.values.push_back( veh->pos_abs().x() + q.x() );
+        act.values.push_back( veh->pos_abs().y() + q.y() );
         act.values.push_back( a_point.x() );
         act.values.push_back( a_point.y() );
         act.values.push_back( -a_point.x() );
@@ -501,8 +500,8 @@ void veh_app_interact::remove()
     } else if( query_yn( _( "Are you sure you want to take down the %s?" ), veh->name ) ) {
         act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
         act.str_values.push_back( vpinfo.id.str() );
-        for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( here.get_abs( p ) );
+        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+            act.coord_set.insert( p );
         }
         const tripoint_abs_ms a_point_abs( here.get_abs( a_point_bub ) );
         act.values.push_back( a_point_abs.x() );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -176,12 +176,11 @@ player_activity veh_interact::serialize_activity()
     // otherwise (e.g. installing a new frame), just use part 0
     const point_rel_ms q = veh->coord_translate( pt ? pt->mount : veh->part( 0 ).mount );
     const vehicle_part *vpt = pt ? pt : &veh->part( 0 );
-    map &here = get_map();
-    for( const tripoint_bub_ms &p : veh->get_points( true ) ) {
-        res.coord_set.insert( here.get_abs( p ) );
+    for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
+        res.coord_set.insert( p );
     }
-    res.values.push_back( here.get_abs( veh->pos_bub() ).x() + q.x() );   // values[0]
-    res.values.push_back( here.get_abs( veh->pos_bub() ).y() + q.y() );   // values[1]
+    res.values.push_back( veh->pos_abs().x() + q.x() );   // values[0]
+    res.values.push_back( veh->pos_abs().y() + q.y() );   // values[1]
     res.values.push_back( dd.x() );   // values[2]
     res.values.push_back( dd.y() );   // values[3]
     res.values.push_back( -dd.x() );   // values[4]

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3704,6 +3704,13 @@ int vehicle::drain( const itype_id &ftype, int amount,
                     const std::function<bool( vehicle_part & )> &filter,
                     bool apply_loss )
 {
+    return vehicle::drain( &get_map(), ftype, amount, filter, apply_loss );
+}
+
+int vehicle::drain( map *here, const itype_id &ftype, int amount,
+                    const std::function<bool( vehicle_part & )> &filter,
+                    bool apply_loss )
+{
     if( ftype == fuel_type_battery ) {
         // Batteries get special handling to take advantage of jumper
         // cables -- discharge_battery knows how to recurse properly
@@ -3725,7 +3732,7 @@ int vehicle::drain( const itype_id &ftype, int amount,
             break;
         }
         if( p.ammo_current() == ftype ) {
-            int qty = p.ammo_consume( amount, bub_part_pos( p ) );
+            int qty = p.ammo_consume( amount, here, here->get_bub( abs_part_pos( p ) ) );
             drained += qty;
             amount -= qty;
         }
@@ -3737,6 +3744,8 @@ int vehicle::drain( const itype_id &ftype, int amount,
 
 int vehicle::drain( const int index, int amount, bool apply_loss )
 {
+    map &here = get_map();
+
     if( index < 0 || index >= static_cast<int>( parts.size() ) ) {
         debugmsg( "Tried to drain an invalid part index: %d", index );
         return 0;
@@ -3755,7 +3764,7 @@ int vehicle::drain( const int index, int amount, bool apply_loss )
         return 0;
     }
 
-    const int drained = pt.ammo_consume( amount, bub_part_pos( pt ) );
+    const int drained = pt.ammo_consume( amount, &here, bub_part_pos( pt ) );
     invalidate_mass();
     return drained;
 }
@@ -5343,6 +5352,8 @@ void vehicle::update_alternator_load()
 
 void vehicle::power_parts()
 {
+    map &here = get_map();
+
     update_alternator_load();
     // Things that drain energy: engines and accessories.
     units::power engine_epower = total_engine_epower();
@@ -5390,7 +5401,7 @@ void vehicle::power_parts()
                     int fuel_consumed = reactors_output_bat / efficiency;
                     // Remainder has a chance of resulting in more fuel consumption
                     fuel_consumed += x_in_y( reactors_output_bat % efficiency, efficiency ) ? 1 : 0;
-                    vp.ammo_consume( fuel_consumed, bub_part_pos( vp ) );
+                    vp.ammo_consume( fuel_consumed, &here, bub_part_pos( vp ) );
                     reactor_working = true;
                     delta_energy_bat += reactors_output_bat;
                 }
@@ -5924,17 +5935,17 @@ void vehicle::slow_leak()
         if( fuel != fuel_type_battery && fuel != fuel_type_plutonium_cell ) {
             item leak( fuel, calendar::turn, qty );
             here.add_item_or_charges( dest, leak );
-            p.ammo_consume( qty, bub_part_pos( p ) );
+            p.ammo_consume( qty, &here, bub_part_pos( p ) );
         } else if( fuel == fuel_type_plutonium_cell ) {
             if( p.ammo_remaining() >= PLUTONIUM_CHARGES / 10 ) {
                 item leak( "plut_slurry_dense", calendar::turn, qty );
                 here.add_item_or_charges( dest, leak );
-                p.ammo_consume( qty * PLUTONIUM_CHARGES / 10, bub_part_pos( p ) );
+                p.ammo_consume( qty * PLUTONIUM_CHARGES / 10, &here, bub_part_pos( p ) );
             } else {
-                p.ammo_consume( p.ammo_remaining(), bub_part_pos( p ) );
+                p.ammo_consume( p.ammo_remaining(), &here, bub_part_pos( p ) );
             }
         } else {
-            p.ammo_consume( qty, bub_part_pos( p ) );
+            p.ammo_consume( qty, &here, bub_part_pos( p ) );
         }
     }
 }
@@ -7730,7 +7741,7 @@ void vehicle::leak_fuel( vehicle_part &pt ) const
     const itype *fuel = item::find_type( pt.ammo_current() );
     while( !tiles.empty() && pt.ammo_remaining() ) {
         int qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining() / 3, 1 ) ),
-                                   bub_part_pos( pt ) );
+                                   &here, bub_part_pos( pt ) );
         if( qty > 0 ) {
             here.add_item_or_charges( random_entry( tiles ), item( fuel, calendar::turn, qty ) );
         }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3529,6 +3529,16 @@ tripoint_bub_ms vehicle::bub_part_pos( const vehicle_part &pt ) const
     return pos_bub() + pt.precalc[ 0 ];
 }
 
+tripoint_abs_ms vehicle::abs_part_pos( const int index ) const
+{
+    return abs_part_pos( parts[index] );
+}
+
+tripoint_abs_ms vehicle::abs_part_pos( const vehicle_part &pt ) const
+{
+    return pos_abs() + pt.precalc[0];
+}
+
 void vehicle::set_submap_moved( const tripoint_bub_sm &p )
 {
     const point_abs_ms old_msp = pos_abs().xy();
@@ -6619,7 +6629,7 @@ void vehicle::refresh( const bool remove_fakes )
     zones_dirty = true;
     coeff_air_dirty = true;
     invalidate_mass();
-    occupied_cache_pos = { -1, -1, -1 };
+    occupied_cache_pos = tripoint_abs_ms::invalid;
     refresh_active_item_cache();
 }
 
@@ -7882,19 +7892,19 @@ bool vehicle::restore_folded_parts( const item &it )
     return true;
 }
 
-const std::set<tripoint_bub_ms> &vehicle::get_points( const bool force_refresh,
+const std::set<tripoint_abs_ms> &vehicle::get_points( const bool force_refresh,
         const bool no_fake ) const
 {
-    if( force_refresh || occupied_cache_pos != pos_bub() ||
+    if( force_refresh || occupied_cache_pos != pos_abs() ||
         occupied_cache_direction != face.dir() ) {
-        occupied_cache_pos = pos_bub();
+        occupied_cache_pos = pos_abs();
         occupied_cache_direction = face.dir();
         occupied_points.clear();
         for( const std::pair<const point_rel_ms, std::vector<int>> &part_location : relative_parts ) {
             if( no_fake && part( part_location.second.front() ).is_fake ) {
                 continue;
             }
-            occupied_points.insert( bub_part_pos( part_location.second.front() ) );
+            occupied_points.insert( abs_part_pos( part_location.second.front() ) );
         }
     }
 
@@ -7915,13 +7925,13 @@ void vehicle::part_project_points( const tripoint_rel_ms &dp )
         }
         // Coordinates of where part will go due to movement (dx/dy/dz)
         //  and turning (precalc[1])
-        vp.next_pos = pos_bub() + dp + vp.precalc[1];
+        vp.next_pos = pos_abs() + dp + vp.precalc[1];
     }
 }
 
-std::set<tripoint_bub_ms> vehicle::get_projected_part_points() const
+std::set<tripoint_abs_ms> vehicle::get_projected_part_points() const
 {
-    std::set<tripoint_bub_ms> projected_points;
+    std::set<tripoint_abs_ms> projected_points;
 
     for( int p = 0; p < part_count(); p++ ) {
         const vehicle_part &vp = parts.at( p );
@@ -8247,18 +8257,17 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
 
     precalc_mounts( 0, turn_dir, point_rel_ms::zero );
 
-    for( const tripoint_bub_ms &p : get_points( true, no_fake ) ) {
+    for( const tripoint_abs_ms &p : get_points( true, no_fake ) ) {
         point_rel_ms pt;
         if( use_precalc ) {
             const int i_use = 0;
-            // TODO: Check if this is correct. part_at takes a vehicle relative position, not a bub one...
-            int part_idx = part_at( rebase_rel( p.xy() ) );
+            int part_idx = part_at( ( p - pos_abs() ).xy() );
             if( part_idx < 0 ) {
                 continue;
             }
             pt = parts[part_idx].precalc[i_use].xy();
         } else {
-            pt = rebase_rel( p.xy() );
+            pt = ( p - pos_abs() ).xy();
         }
         if( pt.x() < min_x ) {
             min_x = pt.x();
@@ -8396,7 +8405,7 @@ std::set<int> vehicle::advance_precalc_mounts( const point_sm_ms &new_pos,
         }
         pos = new_pos;
     }
-    occupied_cache_pos = { -1, -1, -1 };
+    occupied_cache_pos = tripoint_abs_ms::invalid;
     return smzs;
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -337,7 +337,7 @@ struct vehicle_part {
          * @param pos current reality bubble location of part from which ammo is being consumed
          * @return amount consumed which will be between 0 and specified qty
          */
-        int ammo_consume( int qty, const tripoint_bub_ms &pos );
+        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos );
 
         /**
          * Consume fuel by energy content.
@@ -394,7 +394,7 @@ struct vehicle_part {
         void unset_crew();
 
         /** Reset the target for this part. */
-        void reset_target( const tripoint_bub_ms &pos );
+        void reset_target( const tripoint_abs_ms &pos );
 
         /**
          * @name Part capabilities
@@ -638,7 +638,7 @@ class turret_data
          * Check if target is in range of this turret (considers current ammo)
          * Assumes this turret's status is 'ready'
          */
-        bool in_range( const tripoint_bub_ms &target ) const;
+        bool in_range( const tripoint_abs_ms &target ) const;
 
         /**
          * Prepare the turret for firing, called by firing function.
@@ -653,7 +653,7 @@ class turret_data
          * @param p the player that just fired (or attempted to fire) the turret.
          * @param shots the number of shots fired by the most recent call to turret::fire.
          */
-        void post_fire( Character &you, int shots );
+        void post_fire( map *here, Character &you, int shots );
 
         /**
          * Fire the turret's gun at a given target.
@@ -661,7 +661,7 @@ class turret_data
          * @param target coordinates that will be fired on.
          * @return the number of shots actually fired (may be zero).
          */
-        int fire( Character &c, const tripoint_bub_ms &target );
+        int fire( Character &c, map *here, const tripoint_bub_ms &target );
 
         bool can_reload() const;
         bool can_unload() const;
@@ -1462,6 +1462,9 @@ class vehicle
         // drains a fuel type (e.g. for the kitchen unit)
         // returns amount actually drained, does not engage reactor
         int drain( const itype_id &ftype, int amount,
+                   const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
+                   bool apply_loss = true );
+        int drain( map *here, const itype_id &ftype, int amount,
                    const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
                    bool apply_loss = true );
         int drain( int index, int amount, bool apply_loss = true );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -452,7 +452,7 @@ struct vehicle_part {
         std::array<tripoint_rel_ms, 2> precalc = { { tripoint_rel_ms( -1, -1, 0 ), tripoint_rel_ms( -1, -1, 0 ) } };
 
         /** temporarily held projected position */
-        tripoint_bub_ms next_pos = tripoint_bub_ms( -1, -1, 0 ); // NOLINT(cata-serialize)
+        tripoint_abs_ms next_pos = tripoint_abs_ms( -1, -1, 0 ); // NOLINT(cata-serialize)
 
         /** current part health with range [0,durability] */
         int hp() const;
@@ -1436,6 +1436,8 @@ class vehicle
          */
         tripoint_bub_ms bub_part_pos( int index ) const;
         tripoint_bub_ms bub_part_pos( const vehicle_part &pt ) const;
+        tripoint_abs_ms abs_part_pos( int index ) const;
+        tripoint_abs_ms abs_part_pos( const vehicle_part &pt ) const;
         /**
          * All the fuels that are in all the tanks in the vehicle, nicely summed up.
          * Note that empty tanks don't count at all. The value is the amount as it would be
@@ -1791,7 +1793,7 @@ class vehicle
 
         // Handle given part collision with vehicle, monster/NPC/player or terrain obstacle
         // Returns collision, which has type, impulse, part, & target.
-        veh_collision part_collision( int part, const tripoint_bub_ms &p,
+        veh_collision part_collision( int part, const tripoint_abs_ms &p,
                                       bool just_detect, bool bash_floor );
 
         // Process the trap beneath
@@ -1991,14 +1993,14 @@ class vehicle
         bool assign_seat( vehicle_part &pt, const npc &who );
 
         // Update the set of occupied points and return a reference to it
-        const std::set<tripoint_bub_ms> &get_points( bool force_refresh = false,
+        const std::set<tripoint_abs_ms> &get_points( bool force_refresh = false,
                 bool no_fake = false ) const;
 
         // calculate the new projected points for all vehicle parts to move to
         void part_project_points( const tripoint_rel_ms &dp );
 
         // get all vehicle parts' projected points
-        std::set<tripoint_bub_ms> get_projected_part_points() const;
+        std::set<tripoint_abs_ms> get_projected_part_points() const;
 
         /**
         * Consumes specified charges (or fewer) from the vehicle part
@@ -2161,12 +2163,12 @@ class vehicle
         mutable double draft_m = 1; // NOLINT(cata-serialize)
         mutable double hull_height = 0.3; // NOLINT(cata-serialize)
 
-        // Bubble location when cache was last refreshed.
-        mutable tripoint_bub_ms occupied_cache_pos = { -1, -1, -1 }; // NOLINT(cata-serialize)
+        // Absolute location when cache was last refreshed.
+        mutable tripoint_abs_ms occupied_cache_pos = tripoint_abs_ms::invalid; // NOLINT(cata-serialize)
         // Vehicle facing when cache was last refreshed.
         mutable units::angle occupied_cache_direction = 0_degrees; // NOLINT(cata-serialize)
         // Cached points occupied by the vehicle
-        mutable std::set<tripoint_bub_ms> occupied_points; // NOLINT(cata-serialize)
+        mutable std::set<tripoint_abs_ms> occupied_points; // NOLINT(cata-serialize)
 
         // Master list of parts installed in the vehicle.
         std::vector<vehicle_part> parts; // NOLINT(cata-serialize)

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -361,7 +361,7 @@ void vehicle_part::ammo_unset()
     }
 }
 
-int vehicle_part::ammo_consume( int qty, const tripoint_bub_ms &pos )
+int vehicle_part::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos )
 {
     if( is_tank() && !base.empty() ) {
         const int res = std::min( ammo_remaining(), qty );
@@ -372,7 +372,7 @@ int vehicle_part::ammo_consume( int qty, const tripoint_bub_ms &pos )
         }
         return res;
     }
-    return base.ammo_consume( qty, pos, nullptr );
+    return base.ammo_consume( qty, here, pos, nullptr );
 }
 
 units::energy vehicle_part::consume_energy( const itype_id &ftype, units::energy wanted_energy )
@@ -553,11 +553,10 @@ void vehicle_part::unset_crew()
     crew_id = character_id();
 }
 
-void vehicle_part::reset_target( const tripoint_bub_ms &pos )
+void vehicle_part::reset_target( const tripoint_abs_ms &pos )
 {
-    const tripoint_abs_ms tgt = get_map().get_abs( pos );
-    target.first = tgt;
-    target.second = tgt;
+    target.first = pos;
+    target.second = pos;
 }
 
 bool vehicle_part::is_engine() const

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1234,7 +1234,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( &here, target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }
@@ -1254,7 +1254,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( &here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -460,7 +460,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( monster_pos, 1, *shooter->get_wielded_item() );
+        shooter->fire_gun( &here, monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( other_checks ) {
             other_check_success += other_checks( *shooter, mon );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -18,6 +18,8 @@ static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
 static void check_reload_time( const std::string &weapon, const std::string &ammo,
                                const std::string &container, int expected_moves )
 {
+    map &here = get_map();
+
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms spot( 61, 60, 0 );
     clear_map();
@@ -45,7 +47,7 @@ static void check_reload_time( const std::string &weapon, const std::string &amm
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( shooter.fire_gun( &here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -231,8 +231,8 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
         veh.idle( true );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint_bub_ms &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+        for( const tripoint_abs_ms &pos : veh.get_points() ) {
+            REQUIRE( here.ter( here.get_bub( pos ) ) );
         }
         // How much it moved
         tiles_travelled += square_dist( starting_point, veh.pos_bub() );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -188,7 +188,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
     // Remove all items from cargo to normalize weight.
     for( const vpart_reference &vp : veh.get_all_parts() ) {
         veh_ptr->get_items( vp.part() ).clear();
-        vp.part().ammo_consume( vp.part().ammo_remaining(), vp.pos_bub() );
+        vp.part().ammo_consume( vp.part().ammo_remaining(), &here, vp.pos_bub() );
     }
     for( const vpart_reference &vp : veh.get_avail_parts( "OPENABLE" ) ) {
         veh.close( vp.part_index() );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -132,13 +132,13 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     int cycles = 0;
     const int target_z = use_ramp ? ( up ? 1 : -1 ) : 0;
 
-    std::set<tripoint_bub_ms> vpts = veh.get_points();
+    std::set<tripoint_abs_ms> vpts = veh.get_points();
     while( veh.engine_on && veh.safe_velocity() > 0 && cycles < 10 ) {
         clear_creatures();
         CAPTURE( cycles );
-        for( const tripoint_bub_ms &checkpt : vpts ) {
+        for( const tripoint_abs_ms &checkpt : vpts ) {
             int partnum = 0;
-            vehicle *check_veh = here.veh_at_internal( checkpt, partnum );
+            vehicle *check_veh = here.veh_at_internal( here.get_bub( checkpt ), partnum );
             CAPTURE( veh_ptr->pos_bub() );
             CAPTURE( veh_ptr->face.dir() );
             CAPTURE( checkpt );
@@ -149,8 +149,8 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         CHECK( veh.velocity == target_velocity );
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
-        for( const tripoint_bub_ms &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+        for( const tripoint_abs_ms &pos : veh.get_points() ) {
+            REQUIRE( here.ter( here.get_bub( pos ) ) );
         }
         for( const vpart_reference &vp : veh.get_all_parts() ) {
             if( vp.info().location != "structure" ) {
@@ -266,8 +266,8 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
     CHECK( veh.safe_velocity() > 0 );
 
     std::vector<vehicle_part *> all_parts;
-    for( const tripoint_bub_ms &pos : veh.get_points() ) {
-        for( vehicle_part *prt : veh.get_parts_at( pos, "", part_status_flag::any ) ) {
+    for( const tripoint_abs_ms &pos : veh.get_points() ) {
+        for( vehicle_part *prt : veh.get_parts_at( here.get_bub( pos ), "", part_status_flag::any ) ) {
             all_parts.push_back( prt );
             if( drop_pos && prt->mount.x() < 0 ) {
                 prt->precalc[0].z() = -1;

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -29,7 +29,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_cross_split_test,
                                              vehicle_origin, dir, 0, 0 );
         REQUIRE( veh_ptr != nullptr );
-        std::set<tripoint_bub_ms> original_points = veh_ptr->get_points( true );
+        std::set<tripoint_abs_ms> original_points = veh_ptr->get_points( true );
 
         here.destroy( vehicle_origin );
         veh_ptr->part_removal_cleanup();
@@ -43,21 +43,21 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
             CHECK( vehs[1].v->part_count() == 12 );
             CHECK( vehs[2].v->part_count() == 2 );
             CHECK( vehs[3].v->part_count() == 3 );
-            std::vector<std::set<tripoint_bub_ms>> all_points;
+            std::vector<std::set<tripoint_abs_ms>> all_points;
             for( int i = 0; i < 4; i++ ) {
-                const std::set<tripoint_bub_ms> &veh_points = vehs[i].v->get_points( true );
+                const std::set<tripoint_abs_ms> &veh_points = vehs[i].v->get_points( true );
                 all_points.push_back( veh_points );
             }
             for( int i = 0; i < 4; i++ ) {
-                std::set<tripoint_bub_ms> &veh_points = all_points[i];
+                std::set<tripoint_abs_ms> &veh_points = all_points[i];
                 // every point in the new vehicle was in the old vehicle
-                for( const tripoint_bub_ms &vpos : veh_points ) {
+                for( const tripoint_abs_ms &vpos : veh_points ) {
                     CHECK( original_points.find( vpos ) != original_points.end() );
                 }
                 // no point in any new vehicle is in any other new vehicle
                 for( int j = i + 1; j < 4; j++ ) {
-                    std::set<tripoint_bub_ms> &other_points = all_points[j];
-                    for( const tripoint_bub_ms &vpos : veh_points ) {
+                    std::set<tripoint_abs_ms> &other_points = all_points[j];
+                    for( const tripoint_abs_ms &vpos : veh_points ) {
                         CHECK( other_points.find( vpos ) == other_points.end() );
                     }
                 }

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -100,7 +100,8 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {
-                shots_fired += qry.fire( player_character, player_character.pos_bub() + point( qry.range(), 0 ) );
+                shots_fired += qry.fire( player_character, &here, player_character.pos_bub() + point( qry.range(),
+                                         0 ) );
             }
             CHECK( shots_fired > 0 );
 


### PR DESCRIPTION
#### Summary
Un-revert temporary reversion

#### Purpose of change
Re-adds the code temporarily reverted to make #1432 work

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
