### PR TITLE
Disable (for now) riot damage in subways

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -144,7 +144,7 @@
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2,
-    "flags": [ "KNOWN_DOWN", "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_DOWN", "SIDEWALK" ]
   },
   {
     "type": "overmap_terrain",
@@ -167,7 +167,7 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE" ]
   },
   {
     "type": "overmap_terrain",
@@ -178,7 +178,7 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_UP", "NO_ROTATE" ]
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
#### Summary
Disable (for now) riot damage in subways

#### Purpose of change
We're not using riot damage for now, so this shouldn't be enabled.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
