### PR TITLE
Fix mac build and nausea rng

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1519,7 +1519,7 @@ void Character::modify_morale( item &food, const int nutr )
         }
     }
     if( nausea_chance > 0 && x_in_y( std::min( 100, nausea_chance ), 100 ) ) {
-        nausea_chance = static_cast<int>( nausea_chance * rng( 1.25, 0.5 ) );
+        nausea_chance = static_cast<int>( nausea_chance * rng_float( 1.25, 0.5 ) );
         // 15 minutes is the max duration, and the effect's intensity automatically scales with duration.
         add_effect( effect_nausea, ( 1 / ( std::min( 100, nausea_chance ) * .15 ) ) * 15_minutes );
         add_msg_player_or_npc( _( "You're not sure you're going to be able to keep that down." ),


### PR DESCRIPTION
#### Summary
Fix mac build and nausea rng

#### Purpose of change
I accidentally used rng instea of rng_float for the nausea calculation. This sort of flattened the nausea chances for eating bad food and also made the mac version not want to build.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
