### PR TITLE
Continue to backport

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -95,15 +95,6 @@
         "if": "u_has_weapon",
         "then": { "u_run_inv_eocs": "all", "search_data": [ { "wielded_only": true } ], "true_eocs": [ "item_talks_to_you" ] },
         "else": { "run_eocs": "minor_hallucinations" }
-      },
-      {
-        "run_eocs": {
-          "id": "determine_if_coversation",
-          "//": "85% chance for your weapon to make a conversation.  If not, try again some time later.",
-          "condition": { "x_in_y_chance": { "x": 85, "y": 100 } },
-          "effect": { "run_eocs": "weapon_talk_hallucination", "time_in_future": [ "10 seconds", "15 seconds" ] },
-          "false_effect": { "run_eocs": "weapon_talk_hallucination", "time_in_future": [ "4 hours", "6 hours" ] }
-        }
       }
     ],
     "false_effect": { "run_eocs": "minor_hallucinations" }

--- a/data/json/mapgen_palettes/house_general_abandoned.json
+++ b/data/json/mapgen_palettes/house_general_abandoned.json
@@ -49,6 +49,7 @@
         }
       }
     },
+    "palettes": [ "parametrized_walls_palette" ],
     "toilets": { "t": {  } },
     "furniture": {
       "a": "f_fireplace",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -626,9 +626,9 @@ std::optional<input_event> hotkey_for_action( const action_id action,
     }
 }
 
-bool can_butcher_at( const tripoint_bub_ms &p )
+bool can_butcher_at( map &here, const tripoint_bub_ms &p )
 {
-    map_stack items = get_map().i_at( p );
+    map_stack items = here.i_at( p );
     // Early exit when there's definitely nothing to butcher
     if( items.empty() ) {
         return false;
@@ -653,13 +653,12 @@ bool can_butcher_at( const tripoint_bub_ms &p )
     return has_corpse || has_item;
 }
 
-bool can_move_vertical_at( const tripoint_bub_ms &p, int movez )
+bool can_move_vertical_at( const map &here, const tripoint_bub_ms &p, int movez )
 {
     if( p.z() + movez < -OVERMAP_DEPTH || p.z() + movez > OVERMAP_HEIGHT ) {
         return false;
     }
     Character &player_character = get_player_character();
-    map &here = get_map();
     // TODO: unify this with game::move_vertical
     if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) &&
         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
@@ -678,9 +677,8 @@ bool can_move_vertical_at( const tripoint_bub_ms &p, int movez )
     }
 }
 
-bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup )
+bool can_examine_at( map &here, const tripoint_bub_ms &p, bool with_pickup )
 {
-    map &here = get_map();
     if( here.veh_at( p ) ) {
         return true;
     }
@@ -711,9 +709,8 @@ bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup )
     return here.can_see_trap_at( p, get_player_character() );
 }
 
-static bool can_pickup_at( const tripoint_bub_ms &p )
+static bool can_pickup_at( map &here, const tripoint_bub_ms &p )
 {
-    map &here = get_map();
     if( const std::optional<vpart_reference> ovp = here.veh_at( p ).cargo() ) {
         if( !ovp->items().empty() ) {
             return true;
@@ -724,9 +721,8 @@ static bool can_pickup_at( const tripoint_bub_ms &p )
            here.has_items( p );
 }
 
-bool can_interact_at( action_id action, const tripoint_bub_ms &p )
+bool can_interact_at( action_id action, map &here, const tripoint_bub_ms &p )
 {
-    map &here = get_map();
     if( here.impassable_field_at( p ) ) {
         return false;
     }
@@ -742,25 +738,25 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p )
                    here.close_door( p, !here.is_outside( player_pos ), true );
         }
         case ACTION_BUTCHER:
-            return can_butcher_at( p );
+            return can_butcher_at( here, p );
         case ACTION_MOVE_UP:
-            return can_move_vertical_at( p, 1 );
+            return can_move_vertical_at( here, p, 1 );
         case ACTION_MOVE_DOWN:
-            return can_move_vertical_at( p, -1 );
+            return can_move_vertical_at( here, p, -1 );
         case ACTION_EXAMINE:
-            return can_examine_at( p, false );
+            return can_examine_at( here, p, false );
         case ACTION_EXAMINE_AND_PICKUP:
-            return can_examine_at( p, true );
+            return can_examine_at( here, p, true );
         case ACTION_PICKUP:
-            return can_pickup_at( p );
+            return can_pickup_at( here, p );
         default:
             return false;
     }
 
-    return can_interact_at( action, p );
+    return can_interact_at( action, here, p );
 }
 
-action_id handle_action_menu()
+action_id handle_action_menu( map &here )
 {
     const input_context ctxt = get_default_mode_input_context();
     std::string catgname;
@@ -805,7 +801,6 @@ action_id handle_action_menu()
         action_weightings[ACTION_TOGGLE_PRONE] = 300;
     }
 
-    map &here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
     if( here.veh_at( player_character.pos_bub() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.
@@ -817,24 +812,24 @@ action_id handle_action_menu()
     for( const tripoint_bub_ms &pos : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
         if( pos != player_character.pos_bub() ) {
             // Check for actions that work on nearby tiles
-            if( can_interact_at( ACTION_OPEN, pos ) ) {
+            if( can_interact_at( ACTION_OPEN, here, pos ) ) {
                 action_weightings[ACTION_OPEN] = 200;
             }
-            if( can_interact_at( ACTION_CLOSE, pos ) ) {
+            if( can_interact_at( ACTION_CLOSE, here, pos ) ) {
                 action_weightings[ACTION_CLOSE] = 200;
             }
-            if( can_interact_at( ACTION_EXAMINE, pos ) ) {
+            if( can_interact_at( ACTION_EXAMINE, here, pos ) ) {
                 action_weightings[ACTION_EXAMINE] = 200;
             }
         } else {
             // Check for actions that work on own tile only
-            if( can_interact_at( ACTION_BUTCHER, pos ) ) {
+            if( can_interact_at( ACTION_BUTCHER, here, pos ) ) {
                 action_weightings[ACTION_BUTCHER] = 200;
             }
-            if( can_interact_at( ACTION_MOVE_UP, pos ) ) {
+            if( can_interact_at( ACTION_MOVE_UP, here, pos ) ) {
                 action_weightings[ACTION_MOVE_UP] = 200;
             }
-            if( can_interact_at( ACTION_MOVE_DOWN, pos ) ) {
+            if( can_interact_at( ACTION_MOVE_DOWN, here, pos ) ) {
                 action_weightings[ACTION_MOVE_DOWN] = 200;
             }
         }
@@ -1218,31 +1213,33 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
     }
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const action_id action,
         const bool allow_vertical, const bool allow_autoselect )
 {
-    const std::function<bool( const tripoint_bub_ms & )> f = [&action]( const tripoint_bub_ms & p ) {
-        return can_interact_at( action, p );
+    const std::function<bool( const tripoint_bub_ms & )> f = [&action,
+    &here]( const tripoint_bub_ms & p ) {
+        return can_interact_at( action, here, p );
     };
-    return choose_adjacent_highlight( message, failure_message, f, allow_vertical, allow_autoselect );
+    return choose_adjacent_highlight( here, message, failure_message, f, allow_vertical,
+                                      allow_autoselect );
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         const bool allow_vertical, const bool allow_autoselect )
 {
-    return choose_adjacent_highlight( get_avatar().pos_bub(), message, failure_message, allowed,
+    return choose_adjacent_highlight( here, get_avatar().pos_bub( here ), message, failure_message,
+                                      allowed,
                                       allow_vertical, allow_autoselect );
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const tripoint_bub_ms &pos,
         const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical, bool allow_autoselect )
 {
     std::vector<tripoint_bub_ms> valid;
-    map &here = get_map();
     if( allowed ) {
         for( const tripoint_bub_ms &pos : here.points_in_radius( pos, 1 ) ) {
             if( allowed( pos ) ) {

--- a/src/action.h
+++ b/src/action.h
@@ -12,6 +12,7 @@
 #include "coords_fwd.h"
 
 class input_context;
+class map;
 struct input_event;
 
 /**
@@ -523,7 +524,7 @@ std::optional<tripoint_rel_ms> choose_direction( const std::string &message,
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, action_id action,
         bool allow_vertical = false, bool allow_autoselect = true );
 
@@ -544,10 +545,10 @@ std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &mes
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const tripoint_bub_ms &pos,
         const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
@@ -597,7 +598,7 @@ point_rel_ms get_delta_from_movement_action( action_id act, iso_rotate rot );
  *
  * @returns action_id ID of action requested by user at menu.
  */
-action_id handle_action_menu();
+action_id handle_action_menu( map &here );
 
 /**
  * Show in-game main menu
@@ -622,7 +623,7 @@ action_id handle_main_menu();
  * @param p Point to perform test at
  * @returns true if movement is possible in the indicated direction
  */
-bool can_interact_at( action_id action, const tripoint_bub_ms &p );
+bool can_interact_at( action_id action, map &here, const tripoint_bub_ms &p );
 
 /**
  * Test whether it is possible to perform butcher action
@@ -636,7 +637,7 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p );
  * @param p Point to perform the test at
  * @returns true if there is a corpse or item that can be disassembled at a point, otherwise false
  */
-bool can_butcher_at( const tripoint_bub_ms &p );
+bool can_butcher_at( map &here, const tripoint_bub_ms &p );
 
 /**
  * Test whether vertical movement is possible
@@ -652,7 +653,7 @@ bool can_butcher_at( const tripoint_bub_ms &p );
  * @param movez Direction to move. -1 for down, all other values for up
  * @returns true if movement is possible in the indicated direction, otherwise false
  */
-bool can_move_vertical_at( const tripoint_bub_ms &p, int movez );
+bool can_move_vertical_at( const map &here, const tripoint_bub_ms &p, int movez );
 
 /**
  * Test whether examine is possible
@@ -666,6 +667,6 @@ bool can_move_vertical_at( const tripoint_bub_ms &p, int movez );
  * @param with_pickup True if the presence of items to pick up is sufficient eligibility
  * @returns true if the examine action is possible at this point, otherwise false
  */
-bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup = false );
+bool can_examine_at( map &here,  const tripoint_bub_ms &p, bool with_pickup = false );
 
 #endif // CATA_SRC_ACTION_H

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -460,7 +460,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     }
 
     gun_mode gun = weapon->gun_current_mode();
-    who.fire_gun( &here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
+    who.fire_gun( here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
     if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
         restore_view();
@@ -1984,13 +1984,15 @@ bool read_activity_actor::player_readma( avatar &you )
 
 bool read_activity_actor::npc_read( npc &learner )
 {
+    map &here = get_map();
+
     const cata::value_ptr<islot_book> &islotbook = book->type->book;
     const skill_id &skill = islotbook->skill;
 
     // NPCs don't need to identify the book or learn recipes yet.
     // NPCs don't read to other NPCs yet.
     const bool display_messages = learner.get_fac_id() == faction_your_followers &&
-                                  get_player_character().sees( learner );
+                                  get_player_character().sees( here, learner );
 
     const int book_fun = learner.book_fun_for( *book, learner );
     if( book_fun != 0 ) {
@@ -2733,6 +2735,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
 std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar &you )
 {
+    map &here = get_map();
+
     if( you.cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -2749,7 +2753,8 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
     };
 
     std::optional<tripoint_bub_ms> target = choose_adjacent_highlight(
-            _( "Use your lockpick where?" ), _( "There is nothing to lockpick nearby." ), is_pickable, false );
+            here, _( "Use your lockpick where?" ), _( "There is nothing to lockpick nearby." ), is_pickable,
+            false );
     if( !target ) {
         return std::nullopt;
     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -454,7 +454,7 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 {
     map &here = get_map();
 
-    return put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( &here ) );
+    put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( here ) );
 }
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
@@ -3118,8 +3118,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                     for( const tripoint_bub_ms &point_elem :
                          here.points_in_radius( src_loc, /*radius=*/PICKUP_RANGE - 1, /*radiusz=*/0 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
-                        if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
-                                                         point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
+                        if( !you.sees( here, point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
+                                                               point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
                             continue;
                         }
                         candidates.push_back( point_elem );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -102,7 +102,9 @@ class bullet_animation : public basic_animation
 
 bool is_point_visible( const tripoint_bub_ms &p, int margin = 0 )
 {
-    return g->is_in_viewport( p, margin ) && get_player_view().sees( p );
+    const map &here = get_map();
+
+    return g->is_in_viewport( p, margin ) && get_player_view().sees( here, p );
 }
 
 bool is_radius_visible( const tripoint_bub_ms &center, int radius )
@@ -655,9 +657,9 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
         const Creature *critter = creatures.creature_at( p, true );
 
         // NPCs and monsters get drawn with inverted colors
-        if( critter && player_character.sees( *critter ) ) {
+        if( critter && player_character.sees( here, *critter ) ) {
             critter->draw( g.w_terrain, center, true );
-        } else if( noreveal && !player_character.sees( p ) ) {
+        } else if( noreveal && !player_character.sees( here,  p ) ) {
             // Draw a meaningless symbol. Avoids revealing tile, but keeps feedback
             const char sym = '?';
             const nc_color col = c_dark_gray;
@@ -677,7 +679,9 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
+    const map &here = get_map();
+
+    if( !u.sees( here, p ) ) {
         return;
     }
 
@@ -693,7 +697,9 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
+    const map &here = get_map();
+
+    if( !u.sees( here, p ) ) {
         return;
     }
 
@@ -883,6 +889,8 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
                             const std::string &ncstr,
                             const nc_color &nccol )
 {
+    const map &here = get_map();
+
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
         return;
@@ -892,7 +900,7 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
         return;
     }
 
-    if( !u.sees( p ) ) {
+    if( !u.sees( here, p ) ) {
         return;
     }
 
@@ -907,7 +915,8 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
     g->invalidate_main_ui_adaptor();
 }
 #else
-void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &, const std::string &ncstr,
+void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &,
+                            const std::string &ncstr,
                             const nc_color &nccol )
 {
     if( !ncstr.empty() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -640,8 +640,8 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
             return;
         }
     }
-    tripoint_abs_ms old_abs_pos = m.get_abs( you.pos_bub() );
-    you.setpos( p );
+    tripoint_abs_ms old_abs_pos = you.pos_abs();
+    you.setpos( m, p );
     g->update_map( you );
 
     cata_event_dispatch::avatar_moves( old_abs_pos, you, m );
@@ -977,6 +977,8 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
 void avatar_action::plthrow( avatar &you, item_location loc,
                              const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {
+    map &here = get_map();
+
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
     if( in_shell ) {
@@ -1192,9 +1194,9 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     // Shift our position to our "peeking" position, so that the UI
     // for picking a throw point lets us target the location we couldn't
     // otherwise see.
-    const tripoint_bub_ms original_player_position = you.pos_bub();
+    const tripoint_abs_ms original_player_position = you.pos_abs();
     if( blind_throw_from_pos ) {
-        you.setpos( *blind_throw_from_pos, false );
+        you.setpos( here, *blind_throw_from_pos, false );
     }
 
     g->temp_exit_fullscreen();

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -615,8 +615,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 return false;
             }
             // search for creatures in radius 4 around impact site
-            if( rl_dist( z.pos_bub( here ), tp ) <= 4 &&
-                here->sees( z.pos_bub( here ), tp, -1 ) ) {
+            if( rl_dist( z.pos_bub( *here ), tp ) <= 4 &&
+                here->sees( z.pos_bub( *here ), tp, -1 ) ) {
                 // don't hit targets that have already been hit
                 for( auto it : attack.targets_hit ) {
                     if( &z == it.first ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1332,6 +1332,8 @@ ret_val<void> Character::can_deactivate_bionic( bionic &bio, bool eff_only ) con
 
 bool Character::deactivate_bionic( bionic &bio, bool eff_only )
 {
+    const map &here = get_map();
+
     const auto can_deactivate = can_deactivate_bionic( bio, eff_only );
     bio_flag_cache.clear();
     if( !can_deactivate.success() ) {
@@ -1374,7 +1376,7 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
         if( bio.get_uid() == get_weapon_bionic_uid() ) {
             bio.set_weapon( *get_wielded_item() );
             add_msg_if_player( _( "You withdraw your %s." ), weapon.tname() );
-            if( get_player_view().sees( pos_bub() ) ) {
+            if( get_player_view().sees( here, pos_bub( here ) ) ) {
                 if( male ) {
                     add_msg_if_npc( m_info, _( "<npcname> withdraws his %s." ), weapon.tname() );
                 } else {
@@ -1948,6 +1950,7 @@ void Character::bionics_uninstall_failure( int difficulty, int success, float ad
 void Character::bionics_uninstall_failure( monster &installer, Character &patient, int difficulty,
         int success, float adjusted_skill )
 {
+    const map &here = get_map();
 
     // "success" should be passed in as a negative integer representing how far off we
     // were for a successful removal.  We use this to determine consequences for failing.
@@ -1961,7 +1964,7 @@ void Character::bionics_uninstall_failure( monster &installer, Character &patien
                               adjusted_skill ) );
     const int fail_type = std::min( 5, failure_level );
 
-    bool u_see = sees( patient );
+    bool u_see = sees( here, patient );
 
     if( u_see || patient.is_avatar() ) {
         if( fail_type <= 0 ) {
@@ -2352,6 +2355,8 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
 bool Character::uninstall_bionic( const bionic &bio, monster &installer, Character &patient,
                                   float adjusted_skill )
 {
+    const map &here = get_map();
+
     viewer &player_view = get_player_view();
     if( installer.ammo[itype_anesthetic] <= 0 ) {
         add_msg_if_player_sees( installer, _( "The %s's anesthesia kit looks empty." ), installer.name() );
@@ -2396,7 +2401,7 @@ bool Character::uninstall_bionic( const bionic &bio, monster &installer, Charact
         if( patient.is_avatar() ) {
             add_msg( m_neutral, _( "Your parts are jiggled back into their familiar places." ) );
             add_msg( m_mixed, _( "Successfully removed %s." ), bio.info().name );
-        } else if( patient.is_npc() && player_view.sees( patient ) ) {
+        } else if( patient.is_npc() && player_view.sees( here, patient ) ) {
             add_msg( m_neutral, _( "%s's parts are jiggled back into their familiar places." ),
                      patient.disp_name() );
             add_msg( m_mixed, _( "Successfully removed %s." ), bio.info().name );

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -574,6 +574,9 @@ static nc_color get_bionic_text_color( const bionic &bio, const bool isHighlight
 
 void avatar::power_bionics()
 {
+    // Required because available power includes electricity via cables.
+    const map &here = get_map();
+
     sorted_bionics passive = filtered_bionics( *my_bionics, TAB_PASSIVE );
     sorted_bionics active = filtered_bionics( *my_bionics, TAB_ACTIVE );
     bionic *bio_last = nullptr;
@@ -990,7 +993,7 @@ void avatar::power_bionics()
                             } else {
                                 activate_bionic( bio, false, &close_ui );
                                 // Exit this ui if we are firing a complex bionic
-                                if( close_ui && tmp->get_weapon().shots_remaining( this ) > 0 ) {
+                                if( close_ui && tmp->get_weapon().shots_remaining( here, this ) > 0 ) {
                                     break;
                                 }
                             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1623,7 +1623,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
                         if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
                             g->displaying_visibility_creature && !invisible[0] ) {
-                            const bool visibility = g->displaying_visibility_creature->sees( pos );
+                            const bool visibility = g->displaying_visibility_creature->sees( here, pos );
 
                             // color overlay.
                             SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
@@ -4047,6 +4047,8 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
 bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_level, int &,
                                         const std::array<bool, 5> &invisible, const bool memorize_only )
 {
+    const map &here = get_map();
+
     if( memorize_only ) {
         return false;
     }
@@ -4055,7 +4057,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
     const auto low_override = draw_below_override.find( p );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
+            here.dont_draw_lower_floor( p ) ) ) {
         return false;
     }
 
@@ -4072,7 +4074,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
     // Check if the player can actually see the critter. We don't care if
     // it's via infrared or not, just whether or not they're seen. If not,
     // we can bail.
-    if( !you.sees( *critter ) && !you.sees_with_specials( *critter ) ) {
+    if( !you.sees( here, *critter ) && !you.sees_with_specials( *critter ) ) {
         return false;
     }
 
@@ -4084,6 +4086,8 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const std::array<bool, 5> &invisible, const bool memorize_only )
 {
+    const map &here = get_map();
+
     if( memorize_only ) {
         return false;
     }
@@ -4115,7 +4119,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         }
         const Creature &critter = *pcritter;
 
-        if( !you.sees( critter ) ) {
+        if( !you.sees( here, critter ) ) {
             const_dialogue d( get_const_talker_for( you ), get_const_talker_for( critter ) );
             enchant_cache::special_vision sees_with_special = you.enchantment_cache->get_vision( d );
             if( !sees_with_special.is_empty() ) {
@@ -4164,7 +4168,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
                                               subtile, rot_facing, ll, false, height_3d, 1.0f, 1.0f );
                 draw_entity_with_overlays( *m, p, ll, height_3d );
-                sees_player = m->sees( you );
+                sees_player = m->sees( here, you );
                 attitude = m->attitude_to( you );
             }
         }
@@ -4201,7 +4205,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             if( pl->is_avatar() ) {
                 is_player = true;
             } else {
-                sees_player = pl->sees( you );
+                sees_player = pl->sees( here, you );
                 attitude = pl->attitude_to( you );
             }
         }
@@ -4270,7 +4274,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
                              0, 0, ll, false, height_3d, 1.0f, 1.0f ) && scan_p.z() - 1 > you.pos_bub().z() &&
-        you.sees( critter ) ) {
+        you.sees( here, critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;
@@ -4279,7 +4283,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
         // Get critter status disposition if monster
         const monster *m = dynamic_cast<const monster *>( &critter );
         if( m != nullptr ) {
-            sees_player = m->sees( you );
+            sees_player = m->sees( here, you );
             attitude = m->attitude_to( you );
         }
 
@@ -4289,7 +4293,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
             if( pl->is_avatar() ) {
                 is_player = true;
             } else {
-                sees_player = pl->sees( you );
+                sees_player = pl->sees( here, you );
                 attitude = pl->attitude_to( you );
             }
         }
@@ -4910,11 +4914,13 @@ void cata_tiles::draw_hit_frame()
 }
 void cata_tiles::draw_line()
 {
+    map &here = get_map();
+
     if( line_trajectory.empty() ) {
         return;
     }
     static std::string line_overlay = "animation_line";
-    if( !is_target_line || get_player_view().sees( line_pos ) ) {
+    if( !is_target_line || get_player_view().sees( here, line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
             draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1814,6 +1814,8 @@ void Character::release_grapple()
 
 void Character::mount_creature( monster &z )
 {
+    map &here = get_map();
+
     tripoint_bub_ms pnt = z.pos_bub();
     shared_ptr_fast<monster> mons = g->shared_from( z );
     if( mons == nullptr ) {
@@ -1858,7 +1860,7 @@ void Character::mount_creature( monster &z )
         g->place_player( pnt );
     } else {
         npc &guy = dynamic_cast<npc &>( *this );
-        guy.setpos( pnt );
+        guy.setpos( here, pnt );
     }
     z.facing = facing;
     // some rideable mechs have night-vision
@@ -1873,6 +1875,8 @@ void Character::mount_creature( monster &z )
 
 bool Character::check_mount_will_move( const tripoint_bub_ms &dest_loc )
 {
+    const map &here = get_map();
+
     if( !is_mounted() || mounted_creature->has_flag( mon_flag_COMBAT_MOUNT ) ) {
         return true;
     }
@@ -1882,8 +1886,9 @@ bool Character::check_mount_will_move( const tripoint_bub_ms &dest_loc )
                 continue;
             }
             Attitude att = critter.attitude_to( *this );
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos_bub(), critter.pos_bub() ) <= 15 &&
-                rl_dist( dest_loc, critter.pos_bub() ) < rl_dist( pos_bub(), critter.pos_bub() ) ) {
+            if( att == Attitude::HOSTILE && sees( here, critter ) &&
+                rl_dist( pos_abs(), critter.pos_abs() ) <= 15 &&
+                rl_dist( dest_loc, critter.pos_bub( here ) ) < rl_dist( pos_abs(), critter.pos_abs() ) ) {
                 add_msg_if_player( _( "You fail to budge your %s!" ), mounted_creature->get_name() );
                 return false;
             }
@@ -1894,6 +1899,8 @@ bool Character::check_mount_will_move( const tripoint_bub_ms &dest_loc )
 
 bool Character::check_mount_is_spooked()
 {
+    const map &here = get_map();
+
     if( !is_mounted() ) {
         return false;
     }
@@ -1917,8 +1924,9 @@ bool Character::check_mount_is_spooked()
             double chance = 1.0;
             Attitude att = critter.attitude_to( *this );
             // actually too close now - horse might spook.
-            if( att == Attitude::HOSTILE && sees( critter ) && rl_dist( pos_bub(), critter.pos_bub() ) <= 10 ) {
-                chance += 10 - rl_dist( pos_bub(), critter.pos_bub() );
+            if( att == Attitude::HOSTILE && sees( here, critter ) &&
+                rl_dist( pos_abs(), critter.pos_abs() ) <= 10 ) {
+                chance += 10 - rl_dist( pos_abs(), critter.pos_abs() );
                 if( critter.get_size() >= mount_size ) {
                     chance *= 2;
                 }
@@ -1979,13 +1987,14 @@ void Character::forced_dismount()
         mon->mounted_player = nullptr;
     }
     std::vector<tripoint_bub_ms> valid;
-    for( const tripoint_bub_ms &jk : get_map().points_in_radius( pos_bub(), 1 ) ) {
+    valid.reserve( 8 );
+    for( const tripoint_bub_ms &jk : get_map().points_in_radius( pos_bub( here ), 1 ) ) {
         if( g->is_empty( jk ) ) {
             valid.push_back( jk );
         }
     }
     if( !valid.empty() ) {
-        setpos( random_entry( valid ) );
+        setpos( here, random_entry( valid ) );
         if( mech ) {
             add_msg_player_or_npc( m_bad, _( "You are ejected from your mech!" ),
                                    _( "<npcname> is ejected from their mech!" ) );
@@ -2068,6 +2077,8 @@ void Character::forced_dismount()
 
 void Character::dismount()
 {
+    map &here = get_map();
+
     if( !is_mounted() ) {
         add_msg_debug( debugmode::DF_CHARACTER, "dismount called when not riding" );
         return;
@@ -2095,7 +2106,7 @@ void Character::dismount()
         critter->add_effect( effect_controlled, 5_turns );
         mounted_creature = nullptr;
         critter->mounted_player = nullptr;
-        setpos( *pnt );
+        setpos( here, *pnt );
         mod_moves( -100 );
         set_movement_mode( move_mode_walk );
     }
@@ -2214,7 +2225,8 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
     martial_arts_data->ma_ondodge_effects( *this );
 
     // For adjacent attackers check for techniques usable upon successful dodge
-    if( source && square_dist( pos_bub(), source->pos_bub() ) == 1 ) {
+    map &here = get_map();
+    if( source && square_dist( pos_bub( here ), source->pos_bub( here ) ) == 1 ) {
         matec_id tec = std::get<0>( pick_technique( *source, used_weapon(), false, true, false ) );
 
         if( tec != tec_none && !is_dead_state() ) {
@@ -2234,8 +2246,10 @@ float Character::get_melee() const
 
 bool Character::uncanny_dodge()
 {
+    map &here = get_map();
+
     bool is_u = is_avatar();
-    bool seen = get_player_view().sees( *this );
+    bool seen = get_player_view().sees( here, *this );
 
     const units::energy trigger_cost = bio_uncanny_dodge->power_trigger;
 
@@ -2260,22 +2274,21 @@ bool Character::uncanny_dodge()
         burn_energy_legs( -300 );
     }
 
-    map &here = get_map();
-    const optional_vpart_position veh_part = here.veh_at( pos_bub() );
+    const optional_vpart_position veh_part = here.veh_at( pos_bub( here ) );
     if( in_vehicle && veh_part && veh_part.avail_part_with_feature( "SEATBELT" ) ) {
         return false;
     }
 
     //uncanny dodge triggered in car and wasn't secured by seatbelt
     if( in_vehicle && veh_part ) {
-        here.unboard_vehicle( pos_bub() );
+        here.unboard_vehicle( pos_bub( here ) );
     }
     if( adjacent.xy() != pos_bub().xy() ) {
-        set_pos_bub_only( adjacent );
+        set_pos_bub_only( here, adjacent );
 
         //landed in a vehicle tile
-        if( here.veh_at( pos_bub() ) ) {
-            here.board_vehicle( pos_bub(), this );
+        if( here.veh_at( pos_bub( here ) ) ) {
+            here.board_vehicle( pos_bub( here ), this );
         }
 
         if( is_u ) {
@@ -3420,7 +3433,7 @@ std::vector<item_location> Character::nearby( const
         return VisitResponse::NEXT;
     } );
 
-    for( const map_cursor &cur : map_selector( pos_bub( &here ), radius ) ) {
+    for( const map_cursor &cur : map_selector( pos_bub( here ), radius ) ) {
         cur.visit_items( [&]( const item * e, const item * parent ) {
             if( func( e, parent ) ) {
                 res.emplace_back( cur, const_cast<item *>( e ) );
@@ -3429,7 +3442,7 @@ std::vector<item_location> Character::nearby( const
         } );
     }
 
-    for( const vehicle_cursor &cur : vehicle_selector( here, pos_bub( &here ), radius ) ) {
+    for( const vehicle_cursor &cur : vehicle_selector( here, pos_bub( here ), radius ) ) {
         cur.visit_items( [&]( const item * e, const item * parent ) {
             if( func( e, parent ) ) {
                 res.emplace_back( cur, const_cast<item *>( e ) );
@@ -7297,11 +7310,11 @@ void Character::burn_move_stamina( int moves )
 
     ///\EFFECT_SWIMMING decreases stamina burn when swimming
     //Appropriate traits let you walk along the bottom without getting as tired
-    if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub( &here ) ) &&
+    if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub( here ) ) &&
         ( !has_flag( json_flag_WALK_UNDERWATER ) ||
-          here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, pos_bub( &here ) ) ) &&
-        !here.has_flag_furn( "BRIDGE", pos_bub( &here ) ) &&
-        !( in_vehicle && here.veh_at( pos_bub( &here ) )->vehicle().can_float( here ) ) ) {
+          here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, pos_bub( here ) ) ) &&
+        !here.has_flag_furn( "BRIDGE", pos_bub( here ) ) &&
+        !( in_vehicle && here.veh_at( pos_bub( here ) )->vehicle().can_float( here ) ) ) {
         burn_ratio += 100 / std::pow( 1.1, get_skill_level( skill_swimming ) );
     }
 
@@ -8456,7 +8469,7 @@ void Character::on_hit( map *here, Creature *source, bodypart_id bp_hit,
         as_npc()->on_attacked( *source );
     }
 
-    bool u_see = get_player_view().sees( *this );
+    bool u_see = get_player_view().sees( *here, *this );
     const units::energy trigger_cost_base = bio_ods->power_trigger;
     if( has_active_bionic( bio_ods ) && get_power_level() > ( 5 * trigger_cost_base ) ) {
         if( is_avatar() ) {
@@ -8662,14 +8675,14 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
         has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) {
         return dealt_damage_instance();
     }
-
+    const map &here = get_map();
     //damage applied here
     dealt_damage_instance dealt_dams = Creature::deal_damage( source, bp, d, attack );
     //block reduction should be by applied this point
     int dam = dealt_dams.total_damage();
 
     // TODO: Pre or post blit hit tile onto "this"'s location here
-    if( dam > 0 && get_player_view().sees( pos_bub() ) ) {
+    if( dam > 0 && get_player_view().sees( here, pos_bub( here ) ) ) {
         g->draw_hit_player( *this, dam );
 
         if( is_avatar() && source ) {
@@ -8682,7 +8695,7 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
     // And slimespawners too
     if( has_trait( trait_SLIMESPAWNER ) && ( dam >= 10 ) && one_in( 20 - dam ) ) {
-        if( monster *const slime = g->place_critter_around( mon_player_blob, pos_bub(), 1 ) ) {
+        if( monster *const slime = g->place_critter_around( mon_player_blob, pos_bub( here ), 1 ) ) {
             slime->friendly = -1;
             add_msg_if_player( m_warning, _( "A mass of slime is torn from you, and moves on its own!" ) );
         }
@@ -8690,12 +8703,12 @@ dealt_damage_instance Character::deal_damage( Creature *source, bodypart_id bp,
 
     Character &player_character = get_player_character();
     //Acid blood effects.
-    bool u_see = player_character.sees( *this );
+    bool u_see = player_character.sees( here, *this );
     // FIXME: Hardcoded damage type
     int cut_dam = dealt_dams.type_damage( damage_cut );
     if( source && has_flag( json_flag_ACIDBLOOD ) && !bp->has_flag( json_flag_BIONIC_LIMB ) &&
         !one_in( 3 ) &&
-        ( dam >= 4 || cut_dam > 0 ) && ( rl_dist( player_character.pos_bub(), source->pos_bub() ) <= 1 ) ) {
+        ( dam >= 4 || cut_dam > 0 ) && ( rl_dist( player_character.pos_abs(), source->pos_abs() ) <= 1 ) ) {
         if( is_avatar() ) {
             add_msg( m_good, _( "Your acidic blood splashes %s in mid-attack!" ),
                      source->disp_name() );
@@ -8865,6 +8878,8 @@ int Character::hitall( int dam, int vary, Creature *source )
 
 void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
 {
+    const map &here = get_map();
+
     if( has_trait( trait_ADRENALINE ) && !has_effect( effect_adrenaline ) &&
         ( get_part_hp_cur( body_part_head ) < 25 ||
           get_part_hp_cur( body_part_torso ) < 15 ) ) {
@@ -8877,7 +8892,7 @@ void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
         }
         if( uistate.distraction_attack && !is_npc() && !has_effect( effect_narcosis ) ) {
             if( source != nullptr ) {
-                if( sees( *source ) ) {
+                if( sees( here, *source ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::attacked,
                                                         string_format( _( "You were attacked by %s!" ), source->disp_name() ) );
                 } else {
@@ -10461,11 +10476,13 @@ float Character::adjust_for_focus( float amount ) const
 
 std::function<bool( const tripoint_bub_ms & )> Character::get_path_avoid() const
 {
+    const map &here = get_map();
+
     // TODO: Add known traps in a way that doesn't destroy performance
 
-    return [this]( const tripoint_bub_ms & p ) {
+    return [this, &here]( const tripoint_bub_ms & p ) {
         Creature *critter = get_creature_tracker().creature_at( p, true );
-        return critter && critter->is_npc() && this->sees( *critter );
+        return critter && critter->is_npc() && this->sees( here, *critter );
     };
 }
 
@@ -10822,7 +10839,7 @@ void Character::place_corpse( map *here )
         }
     }
 
-    here->add_item_or_charges( pos_bub( here ), body );
+    here->add_item_or_charges( pos_bub( *here ), body );
 }
 
 void Character::place_corpse( const tripoint_abs_omt &om_target )
@@ -10895,14 +10912,18 @@ bool Character::sees_with_infrared( const Creature &critter ) const
 
 bool Character::is_visible_in_range( const Creature &critter, const int range ) const
 {
-    return sees( critter ) && rl_dist( pos_bub(), critter.pos_bub() ) <= range;
+    const map &here = get_map();
+
+    return sees( here, critter ) && rl_dist( pos_abs(), critter.pos_abs() ) <= range;
 }
 
 std::vector<Creature *> Character::get_visible_creatures( const int range ) const
 {
-    return g->get_creatures_if( [this, range]( const Creature & critter ) -> bool {
-        return this != &critter && pos_bub() != critter.pos_bub() &&
-        rl_dist( pos_bub(), critter.pos_bub() ) <= range && sees( critter );
+    const map &here = get_map();
+
+    return g->get_creatures_if( [this, range, &here]( const Creature & critter ) -> bool {
+        return this != &critter && pos_abs() != critter.pos_abs() &&
+        rl_dist( pos_abs(), critter.pos_abs() ) <= range && sees( here, critter );
     } );
 }
 
@@ -10912,10 +10933,11 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
     return g->get_creatures_if( [this, range, melee, &here]( const Creature & critter ) -> bool {
         //the call to map.sees is to make sure that even if we can see it through walls
         //via a mutation or cbm we only attack targets with a line of sight
-        bool can_see = ( ( sees( critter ) || sees_with_specials( critter ) ) && here.sees( pos_bub(), critter.pos_bub(), 100 ) );
+        bool can_see = ( ( sees( here, critter ) || sees_with_specials( critter ) ) && here.sees( pos_bub( here ), critter.pos_bub( here ), 100 ) );
         if( can_see && melee )  //handles the case where we can see something with glass in the way for melee attacks
         {
-            std::vector<tripoint_bub_ms> path = here.find_clear_path( pos_bub(), critter.pos_bub() );
+            std::vector<tripoint_bub_ms> path = here.find_clear_path( pos_bub( here ),
+                    critter.pos_bub( here ) );
             for( const tripoint_bub_ms &point : path ) {
                 if( here.impassable( point ) && point != critter.pos_bub() &&
                     !( weapon.has_flag( flag_SPEAR ) && // Fences etc. Spears can stab through those
@@ -10953,12 +10975,14 @@ int Character::get_mutation_visibility_cap( const Character *observed ) const
 
 std::vector<Creature *> Character::get_hostile_creatures( int range ) const
 {
-    return g->get_creatures_if( [this, range]( const Creature & critter ) -> bool {
+    const map &here = get_map();
+
+    return g->get_creatures_if( [this, range, &here]( const Creature & critter ) -> bool {
         // Fixes circular distance range for ranged attacks
-        float dist_to_creature = std::round( rl_dist_exact( pos_bub(), critter.pos_bub() ) );
-        return this != &critter && pos_bub() != critter.pos_bub() &&
+        float dist_to_creature = std::round( rl_dist_exact( pos_abs(), critter.pos_abs() ) );
+        return this != &critter && pos_abs() != critter.pos_abs() &&
         dist_to_creature <= range && critter.attitude_to( *this ) == Creature::Attitude::HOSTILE
-        && sees( critter );
+        && sees( here, critter );
     } );
 }
 
@@ -11428,6 +11452,8 @@ void Character::process_one_effect( effect &it, bool is_new )
 
 void Character::process_effects()
 {
+    map &here = get_map();
+
     //Special Removals
     if( has_effect( effect_darkness ) && g->is_in_sunlight( pos_bub() ) ) {
         remove_effect( effect_darkness );
@@ -11513,7 +11539,7 @@ void Character::process_effects()
     // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
     bool cramped = has_effect( effect_cramped_space );
     // return is intentionally discarded, sets cramped if appropriate
-    can_move_to_vehicle_tile( get_map().get_abs( pos_bub() ), cramped );
+    can_move_to_vehicle_tile( get_map().get_abs( pos_bub( here ) ), cramped );
     if( cramped ) {
         if( is_npc() && !has_effect( effect_narcosis ) && !in_sleep_state() ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
@@ -11611,7 +11637,7 @@ void Character::gravity_check()
 
 void Character::gravity_check( map *here )
 {
-    const tripoint_bub_ms pos = pos_bub( here );
+    const tripoint_bub_ms pos = pos_bub( *here );
     if( here->is_open_air( pos ) && !in_vehicle && !has_effect_with_flag( json_flag_GLIDING ) &&
         here->try_fall( pos, this ) ) {
         here->update_visibility_cache( pos.z() );
@@ -11699,7 +11725,7 @@ void Character::stagger()
             add_msg_player_or_npc( m_bad,
                                    _( "You stumble!" ),
                                    _( "<npcname> stumbles!" ) );
-            setpos( dest );
+            setpos( here, dest );
             mod_moves( -100 );
             break;
         }
@@ -11875,11 +11901,11 @@ npc_attitude Character::get_attitude() const
     return NPCATT_NULL;
 }
 
-bool Character::sees( const tripoint_bub_ms &t, bool, int ) const
+bool Character::sees( const map &here, const tripoint_bub_ms &t, bool, int ) const
 {
-    const int wanted_range = rl_dist( pos_bub(), t );
+    const int wanted_range = rl_dist( pos_bub( here ), t );
     bool can_see = this->is_avatar() ? get_map().pl_sees( t, std::min( sight_max, wanted_range ) ) :
-                   Creature::sees( t );
+                   Creature::sees( here, t );
     // Clairvoyance is now pretty cheap, so we can check it early
     if( wanted_range < MAX_CLAIRVOYANCE && wanted_range < clairvoyance() ) {
         return true;
@@ -11888,10 +11914,10 @@ bool Character::sees( const tripoint_bub_ms &t, bool, int ) const
     return can_see;
 }
 
-bool Character::sees( const Creature &critter ) const
+bool Character::sees( const map &here, const Creature &critter ) const
 {
     // This handles only the player/npc specific stuff (monsters don't have traits or bionics).
-    const int dist = rl_dist( pos_bub(), critter.pos_bub() );
+    const int dist = rl_dist( pos_abs(), critter.pos_abs() );
     if( std::abs( posz() - critter.posz() ) > fov_3d_z_range ) {
         return false;
     }
@@ -11903,10 +11929,10 @@ bool Character::sees( const Creature &critter ) const
     }
     // Only players can spot creatures through clairvoyance fields
     if( is_avatar() && field_fd_clairvoyant.is_valid() &&
-        get_map().get_field( critter.pos_bub(), field_fd_clairvoyant ) ) {
+        here.get_field( critter.pos_bub( here ), field_fd_clairvoyant ) ) {
         return true;
     }
-    return Creature::sees( critter );
+    return Creature::sees( here, critter );
 }
 
 void Character::set_destination( const std::vector<tripoint_bub_ms> &route,
@@ -12616,6 +12642,8 @@ read_condition_result Character::check_read_condition( const item &book ) const
 const Character *Character::get_book_reader( const item &book,
         std::vector<std::string> &reasons ) const
 {
+    const map &here = get_map();
+
     const Character *reader = nullptr;
 
     if( !book.is_book() ) {
@@ -12698,7 +12726,7 @@ const Character *Character::get_book_reader( const item &book,
             reasons.push_back( string_format(
                                    _( "It's too dark for %s to read!" ),
                                    elem->disp_name() ) );
-        } else if( !elem->sees( *this ) ) {
+        } else if( !elem->sees( here, *this ) ) {
             reasons.push_back( string_format( _( "%s could read that to you, but they can't see you." ),
                                               elem->disp_name() ) );
         } else if( condition & read_condition_result::MORALE_LOW ) {
@@ -13352,7 +13380,7 @@ void Character::knock_back_to( const tripoint_bub_ms &to )
                                here.obstacle_name( to ) );
 
     } else { // It's no wall
-        setpos( tripoint_bub_ms( to ) );
+        setpos( here, to );
     }
 }
 
@@ -13409,8 +13437,8 @@ void Character::leak_items()
 
 void Character::process_items( map *here )
 {
-    if( weapon.process( *here, this, pos_bub( here ) ) ) {
-        weapon.spill_contents( here,  pos_bub( here ) );
+    if( weapon.process( *here, this, pos_bub( *here ) ) ) {
+        weapon.spill_contents( here,  pos_bub( *here ) );
         remove_weapon();
     }
 
@@ -13419,8 +13447,8 @@ void Character::process_items( map *here )
         if( !it ) {
             continue;
         }
-        if( it->process( *here, this, pos_bub( here ) ) ) {
-            it->spill_contents( here, pos_bub( here ) );
+        if( it->process( *here, this, pos_bub( *here ) ) ) {
+            it->spill_contents( here, pos_bub( *here ) );
             removed_items.push_back( it );
         }
     }
@@ -13483,7 +13511,7 @@ void Character::search_surroundings()
                                tr.name(), direction );
             add_known_trap( tp, tr );
         }
-        if( !sees( tp ) ) {
+        if( !sees( here, tp ) ) {
             continue;
         }
         if( tr.can_see( tp, *this ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11574,12 +11574,11 @@ void Character::process_effects()
         }
     }
 
-    map &here = get_map();
     if( has_effect( effect_slippery_terrain ) && !is_on_ground() &&
         here.has_flag( ter_furn_flag::TFLAG_FLAT, pos_bub() ) &&
         !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) ) {
         int rolls = -1;
-        bool u_see = get_player_view().sees( *this );
+        bool u_see = get_player_view().sees( here, *this );
         // ROAD tiles are hard, flat surfaces, so they are extra slippery.
         if( here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() ) ) {
             rolls += 2;

--- a/src/character.h
+++ b/src/character.h
@@ -3239,7 +3239,7 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+        int fire_gun( map &here, const tripoint_bub_ms &target, int shots, item &gun,
                       item_location ammo = item_location() );
         /** Execute a throw */
         dealt_projectile_attack throw_item( const tripoint_bub_ms &target, const item &to_throw,
@@ -3853,9 +3853,10 @@ class Character : public Creature, public visitable
         void add_known_trap( const tripoint_bub_ms &pos, const trap &t );
 
         // see Creature::sees
-        bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+                   int range_mod = 0 ) const override;
         // see Creature::sees
-        bool sees( const Creature &critter ) const override;
+        bool sees( const map &here, const Creature &critter ) const override;
         Attitude attitude_to( const Creature &other ) const override;
         virtual npc_attitude get_attitude() const;
 

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -282,7 +282,7 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
 bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_bodypart_id &bp,
                                        int roll )
 {
-
+    const map &here = get_map();
     for( item_pocket *const pocket : armor.get_all_ablative_pockets() ) {
         // if the pocket is ablative and not empty we should use its values
         if( !pocket->empty() ) {
@@ -349,7 +349,7 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                 if( damaged == item::armor_status::DESTROYED ) {
                     //the plate is damaged like normal armor but also ends up destroyed
                     describe_damage( du, ablative_armor );
-                    if( get_player_view().sees( *this ) ) {
+                    if( get_player_view().sees( here, *this ) ) {
                         SCT.add( point( posx(), posy() ), direction::NORTH, remove_color_tags( ablative_armor.tname() ),
                                  m_neutral, _( "destroyed" ), m_info );
                     }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2001,7 +2001,8 @@ void outfit::splash_attack( Character &guy, const spell &sp, Creature &caster, b
                         }
                     }
                     if( destroy ) {
-                        if( get_player_view().sees( guy ) ) {
+                        map &here = get_map();
+                        if( get_player_view().sees( here, guy ) ) {
                             SCT.add( point( guy.posx(), guy.posy() ), direction::NORTH, remove_color_tags( pre_damage_name ),
                                      m_neutral, _( "destroyed" ), m_info );
                         }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -38,6 +38,7 @@
 #include "line.h"
 #include "magic_enchantment.h"
 #include "make_static.h"
+#include "map.h"
 #include "melee.h"
 #include "messages.h"
 #include "morale.h"
@@ -338,6 +339,8 @@ Character::wear( item_location item_wear, bool interactive )
 std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, const item &to_wear,
         bool interactive, bool do_calc_encumbrance, bool do_sort_items, bool quiet )
 {
+    const map &here = get_map();
+
     const bool was_deaf = guy.is_deaf();
     const bool supertinymouse = guy.get_size() == creature_size::tiny;
     guy.last_item = to_wear.typeId();
@@ -386,7 +389,7 @@ std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, cons
                                    _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),
                                    to_wear.tname() );
         }
-    } else if( guy.is_npc() && get_player_view().sees( guy ) && !quiet ) {
+    } else if( guy.is_npc() && get_player_view().sees( here, guy ) && !quiet ) {
         guy.add_msg_if_npc( _( "<npcname> puts on their %s." ), to_wear.tname() );
     }
 
@@ -1800,6 +1803,8 @@ item &outfit::front()
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed )
 {
+    const map &here = get_map();
+
     sub_bodypart_id sbp;
     sub_bodypart_id secondary_sbp;
     // if this body part has sub part locations roll one
@@ -1857,7 +1862,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         }
 
         if( destroy ) {
-            if( get_player_view().sees( guy ) ) {
+            if( get_player_view().sees( here, guy ) ) {
                 SCT.add( point( guy.posx(), guy.posy() ), direction::NORTH, remove_color_tags( pre_damage_name ),
                          m_neutral, _( "destroyed" ), m_info );
             }

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -120,7 +120,7 @@ std::vector<item_location> Character::find_ammo( const item &obj, bool empty, in
         for( map_cursor &cursor : map_selector( pos_bub(), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
-        for( vehicle_cursor &cursor : vehicle_selector( here, pos_bub( &here ), radius ) ) {
+        for( vehicle_cursor &cursor : vehicle_selector( here, pos_bub( here ), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
     }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1415,23 +1415,27 @@ conditional_t::func f_is_furniture( bool is_npc )
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [is_npc]( const_dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( const_dialogue const & d ) {
         const Creature *c = d.const_actor( is_npc )->get_const_creature();
         if( c ) {
-            return get_player_view().sees( *c );
+            return get_player_view().sees( here, *c );
         } else {
-            return get_player_view().sees( d.const_actor( is_npc )->pos_bub() );
+            return get_player_view().sees( here,  d.const_actor( is_npc )->pos_bub() );
         }
     };
 }
 
 conditional_t::func f_see_opposite( bool is_npc )
 {
-    return [is_npc]( const_dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( const_dialogue const & d ) {
         if( d.const_actor( is_npc )->get_const_creature() &&
             d.const_actor( !is_npc )->get_const_creature() ) {
             return d.const_actor( is_npc )->get_const_creature()->sees(
-                       *d.const_actor( !is_npc )->get_const_creature() );
+                       here, *d.const_actor( !is_npc )->get_const_creature() );
         } else {
             return false;
         }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -507,7 +507,7 @@ bool Character::check_eligible_containers_for_crafting( const recipe &rec, int b
 
         // also check if we're currently in a vehicle that has the necessary storage
         if( charges_to_store > 0 ) {
-            if( optional_vpart_position vp = here.veh_at( pos_bub( &here ) ) ) {
+            if( optional_vpart_position vp = here.veh_at( pos_bub( here ) ) ) {
                 const itype_id &ftype = prod.typeId();
                 int fuel_cap = vp->vehicle().fuel_capacity( here, ftype );
                 int fuel_amnt = vp->vehicle().fuel_left( here, ftype );
@@ -648,7 +648,7 @@ const inventory &Character::crafting_inventory( map *here, const tripoint_bub_ms
 {
     tripoint_bub_ms inv_pos = src_pos;
     if( src_pos == tripoint_bub_ms::zero ) {
-        inv_pos = pos_bub( here );
+        inv_pos = pos_bub( *here );
     }
     if( crafting_cache.valid
         && moves == crafting_cache.moves

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2038,8 +2038,14 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "TOGGLE_RECIPE_UNREAD" && selection_ok( current, line, true ) ) {
             const recipe_id rcp = current[line]->ident();
             if( uistate.read_recipes.count( rcp ) ) {
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    uistate.read_recipes.erase( nested_rcp );
+                }
                 uistate.read_recipes.erase( rcp );
             } else {
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    uistate.read_recipes.insert( nested_rcp );
+                }
                 uistate.read_recipes.insert( rcp );
             }
             recalc_unread = highlight_unread_recipes;
@@ -2047,6 +2053,15 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "MARK_ALL_RECIPES_READ" ) {
             bool current_list_has_unread = false;
             for( const recipe *const rcp : current ) {
+                for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                    if( !uistate.read_recipes.count( nested_rcp->ident() ) ) {
+                        current_list_has_unread = true;
+                        break;
+                    }
+                    if( current_list_has_unread ) {
+                        break;
+                    }
+                }
                 if( !uistate.read_recipes.count( rcp->ident() ) ) {
                     current_list_has_unread = true;
                     break;
@@ -2069,10 +2084,16 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             if( query_yn( query_str ) ) {
                 if( current_list_has_unread ) {
                     for( const recipe *const rcp : current ) {
+                        for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                            uistate.read_recipes.insert( nested_rcp->ident() );
+                        }
                         uistate.read_recipes.insert( rcp->ident() );
                     }
                 } else {
                     for( const recipe *const rcp : available_recipes ) {
+                        for( const recipe_id nested_rcp : rcp->nested_category_data ) {
+                            uistate.read_recipes.insert( nested_rcp->ident() );
+                        }
                         uistate.read_recipes.insert( rcp->ident() );
                     }
                 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -206,24 +206,18 @@ tripoint_bub_ms Creature::pos_bub() const
     return get_map().get_bub( location );
 }
 
-tripoint_bub_ms Creature::pos_bub( map *here ) const
+tripoint_bub_ms Creature::pos_bub( const map &here ) const
 {
-    return here->get_bub( location );
+    return here.get_bub( location );
 }
 
-void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
-{
-    map &here = get_map();
-    setpos( &here, p, check_gravity );
-}
-
-void Creature::setpos( map *here, const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
+void Creature::setpos( map &here, const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     const tripoint_abs_ms old_loc = pos_abs();
-    set_pos_abs_only( here->get_abs( p ) );
+    set_pos_abs_only( here.get_abs( p ) );
     on_move( old_loc );
     if( check_gravity ) {
-        gravity_check( here );
+        gravity_check( &here );
     }
 }
 
@@ -267,7 +261,6 @@ int Creature::enum_size() const
 
 bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
 {
-    map &here = get_map();
     const optional_vpart_position vp_there = here.veh_at( loc );
     if( !vp_there ) {
         cramped = false;
@@ -351,9 +344,9 @@ void Creature::move_to( const tripoint_abs_ms &loc )
     on_move( old_loc );
 }
 
-void Creature::set_pos_bub_only( const tripoint_bub_ms &p )
+void Creature::set_pos_bub_only( const map &here, const tripoint_bub_ms &p )
 {
-    location = get_map().get_abs( p );
+    location = here.get_abs( p );
 }
 
 void Creature::set_pos_abs_only( const tripoint_abs_ms &loc )
@@ -387,9 +380,9 @@ void Creature::reset()
     reset_stats();
 }
 
-void Creature::bleed() const
+void Creature::bleed( map &here ) const
 {
-    get_map().add_splatter( bloodType(), pos_bub() );
+    here.add_splatter( bloodType(), pos_bub( here ) );
 }
 
 void Creature::reset_bonuses()
@@ -454,10 +447,11 @@ bool Creature::is_underwater() const
     return underwater;
 }
 
-bool Creature::is_likely_underwater() const
+bool Creature::is_likely_underwater( const map &here ) const
 {
     return is_underwater() ||
-           ( has_flag( mon_flag_AQUATIC ) && get_map().has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) );
+           ( has_flag( mon_flag_AQUATIC ) &&
+             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub( here ) ) );
 }
 
 // Detects whether a target is sapient or not (or barely sapient, since ferals count)
@@ -525,7 +519,7 @@ static bool majority_rule( const bool a_vote, const bool b_vote, const bool c_vo
     return ( a_vote + b_vote + c_vote ) > 1;
 }
 
-bool Creature::sees( const Creature &critter ) const
+bool Creature::sees( const map &here, const Creature &critter ) const
 {
     // Creatures always see themselves (simplifies drawing).
     if( &critter == this ) {
@@ -536,9 +530,7 @@ bool Creature::sees( const Creature &critter ) const
         return false;
     }
 
-    map &here = get_map();
-
-    const int target_range = rl_dist( pos_bub(), critter.pos_bub() );
+    const int target_range = rl_dist( pos_bub( here ), critter.pos_bub( here ) );
     if( target_range > MAX_VIEW_DISTANCE ) {
         return false;
     }
@@ -576,12 +568,12 @@ bool Creature::sees( const Creature &critter ) const
     // Can always see adjacent monsters on the same level.
     // We also bypass lighting for vertically adjacent monsters, but still check for floors.
     if( target_range <= 1 ) {
-        return ( posz() == critter.posz() || here.sees( pos_bub(), critter.pos_bub(), 1 ) ) &&
+        return ( posz() == critter.posz() || here.sees( pos_bub( here ), critter.pos_bub( here ), 1 ) ) &&
                visible( ch );
     }
 
     // If we cannot see without any of the penalties below, bail now.
-    if( !sees( critter.pos_bub(), critter.is_avatar() ) ) {
+    if( !sees( here, critter.pos_bub( here ), critter.is_avatar() ) ) {
         return false;
     }
 
@@ -609,7 +601,7 @@ bool Creature::sees( const Creature &critter ) const
 
     // Check if creature is digging and the tile is diggable
     if( target_range > 2 && critter.digging() &&
-        here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos_bub() ) ) {
+        here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos_bub( here ) ) ) {
         return false;
     }
 
@@ -620,15 +612,15 @@ bool Creature::sees( const Creature &critter ) const
 
     if( has_water_camouflage && target_range > this->get_eff_per() ) {
         if( is_underwater ||
-            here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub() ) ||
-            ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub() ) &&
+            here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ) ||
+            ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub( here ) ) &&
               critter.get_size() < creature_size::medium ) ) {
             return false;
         }
     }
 
     // Night Invisibility check
-    if( has_night_invisibility && here.light_at( critter.pos_bub() ) <= lit_level::LOW ) {
+    if( has_night_invisibility && here.light_at( critter.pos_bub( here ) ) <= lit_level::LOW ) {
         return false;
     }
 
@@ -638,28 +630,28 @@ bool Creature::sees( const Creature &critter ) const
     }
 
     // Underwater visibility check with majority rule
-    if( !is_likely_underwater() && is_underwater &&
+    if( !is_likely_underwater( here ) && is_underwater &&
         majority_rule( critter.has_flag( mon_flag_WATER_CAMOUFLAGE ),
-                       here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub() ),
+                       here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ),
                        different_levels ) ) {
         return false;
     }
 
-    if( ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub() ) ) &&
+    if( ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub( here ) ) ) &&
         critter.get_size() < creature_size::large ) {
         return false;
     }
 
-    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SMALL_HIDE, critter.pos_bub() ) &&
+    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SMALL_HIDE, critter.pos_bub( here ) ) &&
         critter.has_flag( mon_flag_SMALL_HIDER ) ) {
         return false;
     }
 
     int ledge_concealment = 0;
     if( different_levels ) {
-        ledge_concealment = ( here.ledge_concealment( pos_bub(), critter.pos_bub() ) );
+        ledge_concealment = ( here.ledge_concealment( pos_bub( here ), critter.pos_bub( here ) ) );
     }
-    const int concealment = std::max( here.obstacle_concealment( pos_bub(), critter.pos_bub() ),
+    const int concealment = std::max( here.obstacle_concealment( pos_bub( here ), critter.pos_bub( here ) ),
                                       ledge_concealment );
     if( ch != nullptr ) {
         if( concealment > eye_level() ) {
@@ -683,19 +675,19 @@ int Creature::eye_level() const
     }
 }
 
-bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) const
+bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+                     int range_mod ) const
 {
     if( std::abs( posz() - t.z() ) > fov_3d_z_range ) {
         return false;
     }
 
-    map &here = get_map();
     const int range_cur = sight_range( here.ambient_light_at( t ) );
     const int range_day = sight_range( default_daylight_level() );
     const int range_night = sight_range( 0 );
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );
-    const int wanted_range = rl_dist( pos_bub(), t );
+    const int wanted_range = rl_dist( pos_bub( here ), t );
     if( wanted_range <= range_min ||
         ( wanted_range <= range_max &&
           here.ambient_light_at( t ) > here.get_cache_ref( t.z() ).natural_light_level_cache ) ) {
@@ -718,7 +710,7 @@ bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) c
             return adj_range >= wanted_range &&
                    here.get_cache_ref( posz() ).seen_cache[posx()][posy()] > LIGHT_TRANSPARENCY_SOLID;
         } else {
-            return here.sees( pos_bub(), t, range );
+            return here.sees( pos_bub( here ), t, range );
         }
     } else {
         return false;
@@ -742,6 +734,8 @@ static bool overlaps_vehicle( const std::set<tripoint_abs_ms> &veh_area, const t
 
 Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area )
 {
+    map &here = get_map();
+
     Creature *target = nullptr;
     Character &player_character = get_player_character();
     tripoint_bub_ms player_pos = player_character.pos_bub();
@@ -754,10 +748,9 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     boo_hoo = 0;         // how many targets were passed due to IFF. Tragically.
     bool self_area_iff = false; // Need to check if the target is near the vehicle we're a part of
     bool area_iff = false;      // Need to check distance from target to player
-    bool angle_iff = sees( player_character ); // Need to check if player is in cone to target
-    int pldist = rl_dist( pos_bub(), player_pos );
-    map &here = get_map();
-    vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos_bub() ) ) : nullptr;
+    bool angle_iff = sees( here, player_character ); // Need to check if player is in cone to target
+    int pldist = rl_dist( pos_bub( here ), player_pos );
+    vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos_bub( here ) ) ) : nullptr;
     if( pldist < iff_dist && angle_iff ) {
         area_iff = area > 0;
         // Player inside vehicle won't be hit by shots from the roof,
@@ -769,7 +762,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             // granularity increases with proximity
             iff_hangle = ( pldist == 2 ? 30_degrees : 60_degrees );
         }
-        u_angle = coord_to_angle( pos_bub(), player_pos );
+        u_angle = coord_to_angle( pos_bub( here ), player_pos );
     }
 
     if( area > 0 && in_veh != nullptr ) {
@@ -789,15 +782,15 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         return false;
     } );
     for( Creature *&m : targets ) {
-        if( !sees( *m ) ) {
+        if( !sees( here, *m ) ) {
             // can't see nor sense it
             if( is_fake() && in_veh ) {
                 // If turret in the vehicle then
                 // Hack: trying yo avoid turret LOS blocking by frames bug by trying to see target from vehicle boundary
                 // Or turret wallhack for turret's car
                 // TODO: to visibility checking another way, probably using 3D FOV
-                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub(), m->pos_bub() );
-                path_to_target.insert( path_to_target.begin(), pos_bub() );
+                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub( here ), m->pos_bub( here ) );
+                path_to_target.insert( path_to_target.begin(), pos_bub( here ) );
 
                 // Getting point on vehicle boundaries and on line between target and turret
                 bool continueFlag = true;
@@ -811,10 +804,10 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                     }
                 } while( continueFlag );
 
-                tripoint_bub_ms oldPos = pos_bub();
-                setpos( path_to_target.back() ); //Temporary moving targeting npc on vehicle boundary position
-                bool seesFromVehBound = sees( *m ); // And look from there
-                setpos( tripoint_bub_ms( oldPos ) );
+                tripoint_bub_ms oldPos = pos_bub( here );
+                setpos( here, path_to_target.back() ); // Temporary moving targeting npc on vehicle boundary position
+                bool seesFromVehBound = sees( herem *m ); // And look from there
+                setpos( here, oldPos );
                 if( !seesFromVehBound ) {
                     continue;
                 }
@@ -822,7 +815,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                 continue;
             }
         }
-        int dist = rl_dist( pos_bub(), m->pos_bub() ) + 1; // rl_dist can be 0
+        int dist = rl_dist( pos_abs(), m->pos_abs() ) + 1; // rl_dist can be 0
         if( dist > range + 1 || dist < area ) {
             // Too near or too far
             continue;
@@ -835,11 +828,11 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             continue;
         }
 
-        if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( m->pos_bub() ) ) == in_veh ) {
+        if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( m->pos_bub( here ) ) ) == in_veh ) {
             // No shooting stuff on vehicle we're a part of
             continue;
         }
-        if( area_iff && rl_dist( player_pos, m->pos_bub() ) <= area ) {
+        if( area_iff && rl_dist( player_pos, m->pos_bub( here ) ) <= area ) {
             // Player in AoE
             boo_hoo++;
             continue;
@@ -848,7 +841,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         // only when the target is actually "hostile enough"
         bool maybe_boo = false;
         if( angle_iff ) {
-            units::angle tangle = coord_to_angle( pos_bub(), m->pos_bub() );
+            units::angle tangle = coord_to_angle( pos_abs(), m->pos_abs() );
             units::angle diff = units::fabs( u_angle - tangle );
             // Player is in the angle and not too far behind the target
             if( ( diff + iff_hangle > 360_degrees || diff < iff_hangle ) &&
@@ -1036,6 +1029,8 @@ double Creature::accuracy_projectile_attack( const int &speed, const double &mis
 void projectile::apply_effects_damage( Creature &target, Creature *source,
                                        const dealt_damage_instance &dealt_dam, bool critical ) const
 {
+    const map &here = get_map();
+
     int dam = dealt_dam.total_damage();
     // Apply ammo effects to target.
     if( proj_effects.count( ammo_effect_TANGLE ) ) {
@@ -1073,7 +1068,7 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
             }
             if( player_character.has_trait( trait_PYROMANIA ) &&
                 !player_character.has_morale( morale_pyromania_startfire ) &&
-                player_character.sees( target ) ) {
+                player_character.sees( here, target ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1089,7 +1084,7 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
             }
             if( player_character.has_trait( trait_PYROMANIA ) &&
                 !player_character.has_morale( morale_pyromania_startfire ) &&
-                player_character.sees( target ) ) {
+                player_character.sees( here, target ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1246,8 +1241,10 @@ projectile_attack_results Creature::select_body_part_projectile_attack(
 void Creature::messaging_projectile_attack( const Creature *source,
         const projectile_attack_results &hit_selection, const int total_damage ) const
 {
+    const map &here = get_map();
+
     const viewer &player_view = get_player_view();
-    const bool u_see_this = player_view.sees( *this );
+    const bool u_see_this = player_view.sees( here, *this );
 
     if( u_see_this ) {
         if( hit_selection.damage_mult == 0 ) {
@@ -1317,9 +1314,11 @@ void Creature::messaging_projectile_attack( const Creature *source,
 
 void Creature::print_proj_avoid_msg( Creature *source, viewer &player_view ) const
 {
+    const map &here = get_map();
+
     // "Avoid" rather than "dodge", because it includes removing self from the line of fire
     //  rather than just Matrix-style bullet dodging
-    if( source != nullptr && player_view.sees( *source ) ) {
+    if( source != nullptr && player_view.sees( here, *source ) ) {
         add_msg_player_or_npc(
             m_warning,
             _( "You avoid %s projectile!" ),
@@ -1501,6 +1500,8 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
 void Creature::deal_damage_handle_type( const effect_source &source, const damage_unit &du,
                                         bodypart_id bp, int &damage, int &pain )
 {
+    const map &here = get_map();
+
     // Handles ACIDPROOF, electric immunity etc.
     if( is_immune_damage( du.type ) ) {
         return;
@@ -1525,7 +1526,8 @@ void Creature::deal_damage_handle_type( const effect_source &source, const damag
 
             Character &player_character = get_player_character();
             if( player_character.has_trait( trait_PYROMANIA ) &&
-                !player_character.has_morale( morale_pyromania_startfire ) && player_character.sees( *this ) ) {
+                !player_character.has_morale( morale_pyromania_startfire ) &&
+                player_character.sees( here, *this ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), this->get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1569,16 +1571,18 @@ void Creature::heal_bp( bodypart_id /* bp */, int /* dam */ )
 
 void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 {
-    if( pos_bub() == p ) {
+    const map &here = get_map();
+
+    if( pos_bub( here ) == p ) {
         add_msg_if_player( _( "You try to pull yourself together." ) );
         return;
     }
 
-    std::vector<tripoint_bub_ms> path = line_to( pos_bub(), p, 0, 0 );
+    std::vector<tripoint_bub_ms> path = line_to( pos_bub( here ), p, 0, 0 );
     Creature *c = nullptr;
     for( const tripoint_bub_ms &path_p : path ) {
         c = get_creature_tracker().creature_at( path_p );
-        if( c == nullptr && get_map().impassable( path_p ) ) {
+        if( c == nullptr && here.impassable( path_p ) ) {
             add_msg_if_player( m_warning, _( "There's an obstacle in the way!" ) );
             return;
         }
@@ -1586,7 +1590,7 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
             break;
         }
     }
-    if( c == nullptr || !sees( *c ) ) {
+    if( c == nullptr || !sees( here, *c ) ) {
         // TODO: Latch onto objects?
         add_msg_if_player( m_warning, _( "There's nothing here to latch onto with your %s!" ),
                            name );
@@ -1607,7 +1611,7 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
         c->move_to( tripoint_abs_ms( line_to( pos_abs().raw(), c->pos_abs().raw(), 0,
                                               0 ).front() ) );
         c->add_effect( effect_stunned, 1_seconds );
-        sounds::sound( c->pos_bub(), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
+        sounds::sound( c->pos_bub( here ), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
     } else {
         add_msg_if_player( m_bad, _( "%s weight makes it difficult to pull towards you." ),
                            c->disp_name( true, true ) );
@@ -1640,6 +1644,8 @@ bool Creature::grapple_drag( Creature *c )
 
 bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
 {
+    map &here = get_map();
+
     // DEBUG insivibility can't be seen through
     if( player.has_trait( trait_DEBUG_CLOAK ) ) {
         return false;
@@ -1648,17 +1654,16 @@ bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
         return false;
     }
     if( stumblemsg ) {
-        const bool player_sees = player.sees( *this );
+        const bool player_sees = player.sees( here, *this );
         add_msg( m_bad, _( "%s stumbles into you!" ), player_sees ? this->disp_name( false,
                  true ) : _( "Something" ) );
     }
     add_effect( effect_stumbled_into_invisible, 6_seconds );
-    map &here = get_map();
     // Mark last known location, or extend duration if exists
-    if( here.has_field_at( player.pos_bub(), field_fd_last_known ) ) {
-        here.set_field_age( player.pos_bub(), field_fd_last_known, 0_seconds );
+    if( here.has_field_at( player.pos_bub( here ), field_fd_last_known ) ) {
+        here.set_field_age( player.pos_bub( here ), field_fd_last_known, 0_seconds );
     } else {
-        here.add_field( player.pos_bub(), field_fd_last_known );
+        here.add_field( player.pos_bub( here ), field_fd_last_known );
     }
     moves = 0;
     return true;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -261,6 +261,7 @@ int Creature::enum_size() const
 
 bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const
 {
+    map &here = get_map();
     const optional_vpart_position vp_there = here.veh_at( loc );
     if( !vp_there ) {
         cramped = false;
@@ -596,7 +597,7 @@ bool Creature::sees( const map &here, const Creature &critter ) const
         has_water_camouflage = critter.has_flag( mon_flag_WATER_CAMOUFLAGE );
         has_night_invisibility = critter.has_flag( mon_flag_NIGHT_INVISIBILITY );
     }
-    bool is_underwater = critter.is_likely_underwater();
+    bool is_underwater = critter.is_likely_underwater( here );
     bool is_invisible = critter.has_effect( effect_invisibility );
 
     // Check if creature is digging and the tile is diggable
@@ -651,7 +652,8 @@ bool Creature::sees( const map &here, const Creature &critter ) const
     if( different_levels ) {
         ledge_concealment = ( here.ledge_concealment( pos_bub( here ), critter.pos_bub( here ) ) );
     }
-    const int concealment = std::max( here.obstacle_concealment( pos_bub( here ), critter.pos_bub( here ) ),
+    const int concealment = std::max( here.obstacle_concealment( pos_bub( here ),
+                                      critter.pos_bub( here ) ),
                                       ledge_concealment );
     if( ch != nullptr ) {
         if( concealment > eye_level() ) {
@@ -805,8 +807,9 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                 } while( continueFlag );
 
                 tripoint_bub_ms oldPos = pos_bub( here );
-                setpos( here, path_to_target.back() ); // Temporary moving targeting npc on vehicle boundary position
-                bool seesFromVehBound = sees( herem *m ); // And look from there
+                setpos( here,
+                        path_to_target.back() ); // Temporary moving targeting npc on vehicle boundary position
+                bool seesFromVehBound = sees( here, *m ); // And look from there
                 setpos( here, oldPos );
                 if( !seesFromVehBound ) {
                     continue;

--- a/src/creature.h
+++ b/src/creature.h
@@ -308,7 +308,7 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         tripoint_bub_ms pos_bub() const;
-        tripoint_bub_ms pos_bub( map *here ) const;
+        tripoint_bub_ms pos_bub( const map &here ) const;
         inline int posx() const {
             return pos_bub().x();
         }
@@ -320,8 +320,7 @@ class Creature : public viewer
         }
         virtual void gravity_check();
         virtual void gravity_check( map *here );
-        void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
-        void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
+        void setpos( map &here, const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
         // Convert size to int. TODO: use this everywhere instead of enuming every time.
@@ -344,7 +343,7 @@ class Creature : public viewer
         /** Handles stat and bonus reset. */
         virtual void reset();
         /** Adds an appropriate blood splatter. */
-        virtual void bleed() const;
+        virtual void bleed( map &here ) const;
         /** Empty function. Should always be overwritten by the appropriate player/NPC/monster version. */
         virtual void die( map *here, Creature *killer ) = 0;
 
@@ -402,8 +401,9 @@ class Creature : public viewer
          * the other monster is visible.
          */
         /*@{*/
-        bool sees( const Creature &critter ) const override;
-        bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
+        bool sees( const map &here, const Creature &critter ) const override;
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+                   int range_mod = 0 ) const override;
         /*@}*/
 
         /**
@@ -554,7 +554,8 @@ class Creature : public viewer
         virtual bool is_on_ground() const = 0;
         bool cant_do_underwater( bool msg = true ) const;
         virtual bool is_underwater() const;
-        bool is_likely_underwater() const; // Should eventually be virtual, although not pure
+        bool is_likely_underwater( const map &here )
+        const; // Should eventually be virtual, although not pure
         virtual bool is_warm() const; // is this creature warm, for IR vision, heat drain, etc
         virtual bool in_species( const species_id & ) const;
 
@@ -806,7 +807,7 @@ class Creature : public viewer
         tripoint_abs_ms location;
     protected:
         // Sets the creature's position without any side-effects.
-        void set_pos_bub_only( const tripoint_bub_ms &p );
+        void set_pos_bub_only( const map &here, const tripoint_bub_ms &p );
         // Sets the creature's position without any side-effects.
         void set_pos_abs_only( const tripoint_abs_ms &loc );
         // Invoked when the creature's position changes.

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -797,7 +797,7 @@ static void monster_edit_menu()
         }
         case D_TELE: {
             if( tripoint_abs_ms newpos = player_picks_tile(); newpos != get_avatar().pos_abs() ) {
-                critter->setpos( get_map().get_bub( newpos ) );
+                critter->setpos( newpos );
             }
             break;
         }
@@ -2253,6 +2253,8 @@ static faction *select_faction()
 
 static void character_edit_menu()
 {
+    map &here = get_map();
+
     std::vector< tripoint_bub_ms > locations;
     uilist charmenu;
     int charnum = 0;
@@ -2563,10 +2565,10 @@ static void character_edit_menu()
             break;
         case D_TELE: {
             if( const std::optional<tripoint_bub_ms> newpos = g->look_around() ) {
-                you.setpos( *newpos );
+                you.setpos( here, *newpos );
                 if( you.is_avatar() ) {
                     if( you.is_mounted() ) {
-                        you.mounted_creature->setpos( *newpos );
+                        you.mounted_creature->setpos( here, *newpos );
                     }
                     g->update_map( player_character );
                 }
@@ -3121,12 +3123,14 @@ static void debug_menu_spawn_vehicle()
 
 static void display_talk_topic()
 {
+    const map &here = get_map();
+
     avatar &a = get_avatar();
     int menu_ind = 0;
     uilist npc_menu;
     npc_menu.text = _( "Choose NPC to hold topic:" );
     std::vector<npc *> visible_npcs = g->get_npcs_if( [&]( const npc & n ) {
-        return a.sees( n );
+        return a.sees( here, n );
     } );
     int npc_count = static_cast<int>( visible_npcs.size() );
     if( npc_count > 0 ) {

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -39,7 +39,8 @@ enum class description_target : int {
 static const Creature *seen_critter( const tripoint_bub_ms &p )
 {
     const Creature *critter = get_creature_tracker().creature_at( p, true );
-    if( critter != nullptr && get_player_view().sees( *critter ) ) {
+    map &here = get_map();
+    if( critter != nullptr && get_player_view().sees( here, *critter ) ) {
         return critter;
     }
 
@@ -100,6 +101,7 @@ void game::extended_description( const tripoint_bub_ms &p )
 
         std::string desc;
         // Allow looking at invisible tiles - player may want to examine hallucinations etc.
+        map &here = get_map();
         switch( cur_target ) {
             case description_target::creature: {
                 const Creature *critter = seen_critter( p );
@@ -111,7 +113,7 @@ void game::extended_description( const tripoint_bub_ms &p )
             }
             break;
             case description_target::furniture:
-                if( !u.sees( p ) || !m.has_furn( p ) ) {
+                if( !u.sees( here, p ) || !m.has_furn( p ) ) {
                     desc = _( "You do not see any furniture here." );
                 } else {
                     const furn_id fid = m.furn( p );
@@ -123,7 +125,7 @@ void game::extended_description( const tripoint_bub_ms &p )
                 }
                 break;
             case description_target::terrain:
-                if( !u.sees( p ) ) {
+                if( !u.sees( here, p ) ) {
                     desc = _( "You can't see the terrain here." );
                 } else {
                     const ter_id tid = m.ter( p );
@@ -136,7 +138,7 @@ void game::extended_description( const tripoint_bub_ms &p )
                 break;
             case description_target::vehicle:
                 const optional_vpart_position vp = m.veh_at( p );
-                if( !u.sees( p ) || !vp ) {
+                if( !u.sees( here, p ) || !vp ) {
                     desc = _( "You can't see vehicles or appliances here." );
                 } else {
                     desc = vp.extended_description();

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -282,9 +282,9 @@ void monmove()
                            critter.name(),
                            critter.posx(), critter.posy(), critter.posz(), m.tername( critter.pos_bub() ) );
             bool okay = false;
-            for( const tripoint_bub_ms &dest : m.points_in_radius( critter.pos_bub(), 3 ) ) {
+            for( const tripoint_bub_ms &dest : m.points_in_radius( critter.pos_bub( m ), 3 ) ) {
                 if( critter.can_move_to( dest ) && g->is_empty( dest ) ) {
-                    critter.setpos( dest );
+                    critter.setpos( m, dest );
                     okay = true;
                     break;
                 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -752,7 +752,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     const level_cache &map_cache = here.get_cache( target.z() );
 
     Character &player_character = get_player_character();
-    const std::string u_see_msg = player_character.sees( target ) ? _( "yes" ) : _( "no" );
+    const std::string u_see_msg = player_character.sees( here, target ) ? _( "yes" ) : _( "no" );
     mvwprintw( w_info, point( 1, off++ ), _( "dist: %d u_see: %s veh: %s scent: %d" ),
                rl_dist( player_character.pos_bub(), target ), u_see_msg, veh_msg, get_scent().get( target ) );
     mvwprintw( w_info, point( 1, off++ ), _( "sight_range: %d, noon_sight_range: %d," ),

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -692,9 +692,10 @@ void scrambler_blast( const tripoint_bub_ms &p )
 
 void emp_blast( const tripoint_bub_ms &p )
 {
-    Character &player_character = get_player_character();
-    const bool sight = player_character.sees( p );
     map &here = get_map();
+
+    Character &player_character = get_player_character();
+    const bool sight = player_character.sees( here, p );
     if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) {
         if( sight ) {
             add_msg( _( "The %s is rendered non-functional!" ), here.tername( p ) );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -30,7 +30,6 @@
 #include "line.h"
 #include "localized_comparator.h"
 #include "map.h"
-#include "map_scale_constants.h"
 #include "memory_fast.h"
 #include "mission_companion.h"
 #include "mtype.h"

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -29,6 +29,9 @@
 #include "json_error.h"
 #include "line.h"
 #include "localized_comparator.h"
+#include "map.h"
+#include "map_scale_constants.h"
+#include "memory_fast.h"
 #include "mission_companion.h"
 #include "mtype.h"
 #include "npc.h"
@@ -619,6 +622,8 @@ std::string npc::get_current_status() const
 
 int npc::faction_display( const catacurses::window &fac_w, const int width ) const
 {
+    const map &here = get_map();
+
     int retval = 0;
     int y = 2;
     const nc_color col = c_white;
@@ -685,8 +690,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     bool guy_has_radio = cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, pos_abs_omt() ) > 3 ||
-        ( rl_dist( player_character.pos_bub(), pos_bub() ) > SEEX * 2 ||
-          !player_character.sees( pos_bub() ) ) ) {
+        ( rl_dist( player_character.pos_abs(), pos_abs() ) > SEEX * 2 ||
+          !player_character.sees( here, pos_bub( here ) ) ) ) {
         if( u_has_radio && guy_has_radio ) {
             if( !( player_character.posz() >= 0 && posz() >= 0 ) &&
                 !( player_character.posz() == posz() ) ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1345,10 +1345,13 @@ void game::load_npcs( map *here )
 
 void game::on_witness_theft( const item &target )
 {
+    const map &here = get_map();
+
     Character &p = get_player_character();
     std::vector<npc *> witnesses;
     for( npc &elem : g->all_npcs() ) {
-        if( rl_dist( elem.pos_bub(), p.pos_bub() ) < MAX_VIEW_DISTANCE && elem.sees( p.pos_bub() ) &&
+        if( rl_dist( elem.pos_bub(), p.pos_bub() ) < MAX_VIEW_DISTANCE &&
+            elem.sees( here, p.pos_bub( here ) ) &&
             target.is_owned_by( elem ) ) {
             witnesses.push_back( &elem );
         }
@@ -1559,7 +1562,7 @@ void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character
     //spawn the corpse, rotten by a part of the duration
     m.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
                            catch_duration ) ) );
-    if( u.sees( pos ) ) {
+    if( u.sees( here, pos ) ) {
         u.add_msg_if_player( m_good, _( "You caught a %s." ), fish->type->nname() );
     }
     //quietly kill the caught
@@ -1919,7 +1922,7 @@ void game::validate_mounted_npcs()
                 continue;
             }
             mounted_pl->mounted_creature = shared_from( m );
-            mounted_pl->setpos( m.pos_bub() );
+            mounted_pl->setpos( m.pos_abs() );
             mounted_pl->add_effect( effect_riding, 1_turns, true );
             m.mounted_player = mounted_pl;
         }
@@ -2851,6 +2854,8 @@ bool game::try_get_left_click_action( action_id &act, const tripoint_bub_ms &mou
 
 bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mouse_target )
 {
+    const map &here = get_map();
+
     const bool cleared_destination = !destination_preview.empty();
     u.clear_destination();
     destination_preview.clear();
@@ -2865,7 +2870,7 @@ bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mo
     const bool is_adjacent = square_dist( mouse_target.xy(), u.pos_bub().xy() ) <= 1;
     const bool is_self = square_dist( mouse_target.xy(), u.pos_bub().xy() ) <= 0;
     if( const monster *const mon = get_creature_tracker().creature_at<monster>( mouse_target ) ) {
-        if( !u.sees( *mon ) ) {
+        if( !u.sees( here, *mon ) ) {
             add_msg( _( "Nothing relevant here." ) );
             return false;
         }
@@ -4298,6 +4303,8 @@ void game::draw_pixel_minimap( const catacurses::window &w )
 
 void game::draw_critter( const Creature &critter, const tripoint_bub_ms &center )
 {
+    const map &here = get_map();
+
     const int my = POSY + ( critter.posy() - center.y() );
     const int mx = POSX + ( critter.posx() - center.x() );
     if( !is_valid_in_w_terrain( { mx, my } ) ) {
@@ -4305,22 +4312,22 @@ void game::draw_critter( const Creature &critter, const tripoint_bub_ms &center 
     }
     if( critter.posz() != center.z() ) {
         if( critter.posz() == center.z() - 1 &&
-            ( debug_mode || u.sees( critter ) ) &&
-            m.valid_move( critter.pos_bub(), critter.pos_bub() + tripoint::above, false, true ) ) {
+            ( debug_mode || u.sees( here, critter ) ) &&
+            m.valid_move( critter.pos_bub( here ), critter.pos_bub( here ) + tripoint::above, false, true ) ) {
             // Monster is below
             // TODO: Make this show something more informative than just green 'v'
             // TODO: Allow looking at this mon with look command
             init_draw_blink_curses( { critter.pos_bub().xy(), center.z() }, "v", c_green_cyan );
         }
         if( critter.posz() == center.z() + 1 &&
-            ( debug_mode || u.sees( critter ) ) &&
+            ( debug_mode || u.sees( here, critter ) ) &&
             m.valid_move( critter.pos_bub(), critter.pos_bub() + tripoint::below, false, true ) ) {
             // Monster is above
             init_draw_blink_curses( { critter.pos_bub().xy(), center.z() }, "^", c_green_cyan );
         }
         return;
     }
-    if( u.sees( critter ) || &critter == &u ) {
+    if( u.sees( here, critter ) || &critter == &u ) {
         critter.draw( w_terrain, point_bub_ms( center.xy() ), false );
         return;
     }
@@ -4642,6 +4649,8 @@ std::vector<monster *> game::get_fishable_monsters( std::unordered_set<tripoint_
 
 void game::mon_info_update( )
 {
+    const map &here = get_map();
+
     int newseen = 0;
     const int safe_proxy_dist = get_option<int>( "SAFEMODEPROXIMITY" );
     const int iProxyDist = ( safe_proxy_dist <= 0 ) ? MAX_VIEW_DISTANCE :
@@ -4752,7 +4761,7 @@ void game::mon_info_update( )
                                    critter.get_dest() == u.pos_abs() );
             }
             if( need_processing ) {
-                if( index < 8 && critter.sees( get_player_character() ) ) {
+                if( index < 8 && critter.sees( here, get_player_character() ) ) {
                     dangerous[index] = true;
                 }
 
@@ -4791,7 +4800,7 @@ void game::mon_info_update( )
         } else if( p != nullptr ) {
             //Safe mode NPC check
 
-            const int npc_dist = rl_dist( u.pos_bub(), p->pos_bub() );
+            const int npc_dist = rl_dist( u.pos_abs(), p->pos_abs() );
             if( !safemode_empty ) {
                 need_processing = get_safemode().check_monster(
                                       get_safemode().npc_type_name(),
@@ -4938,7 +4947,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
             if( m.impassable( traj[i].xy() ) ) {
-                targ->setpos( traj[i - 1] );
+                targ->setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -4950,7 +4959,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                targ->setpos( traj[i - 1] );
+                targ->setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -4974,11 +4983,11 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 knockback( traj, stun, dam_mult );
                 break;
             }
-            targ->setpos( traj[i] );
+            targ->setpos( m, traj[i] );
             if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, targ->pos_bub() ) && !targ->can_drown() &&
                 !targ->is_dead() ) {
                 targ->die( &here, nullptr );
-                if( u.sees( *targ ) ) {
+                if( u.sees( here, *targ ) ) {
                     add_msg( _( "The %s drowns!" ), targ->name() );
                 }
             }
@@ -4986,7 +4995,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 targ->has_flag( mon_flag_AQUATIC ) &&
                 !targ->is_dead() ) {
                 targ->die( &here, nullptr );
-                if( u.sees( *targ ) ) {
+                if( u.sees( here, *targ ) ) {
                     add_msg( _( "The %s flops around and dies!" ), targ->name() );
                 }
             }
@@ -4998,7 +5007,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
             if( m.impassable( traj[i].xy() ) ) { // oops, we hit a wall!
-                targ->setpos( traj[i - 1] );
+                targ->setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -5024,7 +5033,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                targ->setpos( traj[i - 1] );
+                targ->setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     add_msg( _( "%s was stunned!" ), targ->get_name() );
@@ -5052,7 +5061,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 knockback( traj, stun, dam_mult );
                 break;
             }
-            targ->setpos( traj[i] );
+            targ->setpos( m, traj[i] );
         }
     } else if( u.pos_bub() == tp ) {
         if( stun > 0 ) {
@@ -5064,7 +5073,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
             if( m.impassable( traj[i] ) ) { // oops, we hit a wall!
-                u.setpos( traj[i - 1] );
+                u.setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     if( u.has_effect( effect_stunned ) ) {
@@ -5097,7 +5106,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 m.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                u.setpos( traj[i - 1] );
+                u.setpos( m, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     if( u.has_effect( effect_stunned ) ) {
@@ -5129,7 +5138,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, u.pos_bub() ) && force_remaining == 0 ) {
                 avatar_action::swim( m, u, u.pos_bub() );
             } else {
-                u.setpos( traj[i] );
+                u.setpos( m,  traj[i] );
             }
         }
     }
@@ -5611,13 +5620,13 @@ bool game::swap_critters( Creature &a, Creature &b )
         m.unboard_vehicle( other_npc->pos_bub() );
     }
 
-    tripoint_bub_ms temp = second.pos_bub();
-    second.setpos( first.pos_bub() );
+    tripoint_bub_ms temp = second.pos_bub( m );
+    second.setpos( m, first.pos_bub( m ) );
 
     if( first.is_avatar() ) {
         walk_move( temp );
     } else {
-        first.setpos( temp );
+        first.setpos( m, temp );
         if( m.veh_at( u_or_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
             m.board_vehicle( u_or_npc->pos_bub(), u_or_npc );
         }
@@ -6185,12 +6194,12 @@ void game::examine( bool with_pickup )
     std::optional<tripoint_bub_ms> examp;
     if( with_pickup ) {
         // Examine and/or pick up items
-        examp = choose_adjacent_highlight( _( "Examine terrain, furniture, or items where?" ),
+        examp = choose_adjacent_highlight( here, _( "Examine terrain, furniture, or items where?" ),
                                            _( "There is nothing that can be examined nearby." ),
                                            ACTION_EXAMINE_AND_PICKUP, false );
     } else {
         // Examine but do not pick up items
-        examp = choose_adjacent_highlight( _( "Examine terrain or furniture where?" ),
+        examp = choose_adjacent_highlight( here, _( "Examine terrain or furniture where?" ),
                                            _( "There is nothing that can be examined nearby." ),
                                            ACTION_EXAMINE, false );
     }
@@ -6450,9 +6459,11 @@ bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
 
 void game::pickup()
 {
+    map &here = get_map();
+
     // Prompt for which adjacent/current tile to pick up items from
     const std::optional<tripoint_bub_ms> where_ = choose_adjacent_highlight(
-                _( "Pick up items where?" ),
+                here, _( "Pick up items where?" ),
                 _( "There is nothing to pick up nearby." ),
                 ACTION_PICKUP, false );
     if( !where_ ) {
@@ -6514,7 +6525,7 @@ void game::peek( const tripoint_bub_ms &p )
 {
     u.mod_moves( -u.get_speed() * 2 );
     tripoint_bub_ms prev = u.pos_bub();
-    u.setpos( p, false );
+    u.setpos( m, p, false );
     const bool is_same_pos = u.pos_bub() == prev;
     const bool is_standup_peek = is_same_pos && u.is_crouching();
     tripoint_bub_ms center = p;
@@ -6529,7 +6540,7 @@ void game::peek( const tripoint_bub_ms &p )
         u.activate_crouch_mode();
     } else {                // Else is normal peek
         result = look_around( looka_params );
-        u.setpos( prev, false );
+        u.setpos( m, prev, false );
     }
 
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
@@ -6550,6 +6561,8 @@ std::optional<tripoint_bub_ms> game::look_debug()
 
 void game::draw_look_around_cursor( const tripoint_bub_ms &lp, const visibility_variables &cache )
 {
+    const map &here = get_map();
+
     if( !liveview.is_enabled() ) {
 #if defined( TILES )
         if( is_draw_tiles_mode() ) {
@@ -6565,7 +6578,7 @@ void game::draw_look_around_cursor( const tripoint_bub_ms &lp, const visibility_
         }
         if( visibility == visibility_type::CLEAR ) {
             const Creature *const creature = get_creature_tracker().creature_at( lp, true );
-            if( creature != nullptr && u.sees( *creature ) ) {
+            if( creature != nullptr && u.sees( here, *creature ) ) {
                 creature->draw( w_terrain, view_center, true );
             } else {
                 m.drawsq( w_terrain, lp, drawsq_params().highlight( true ).center( view_center ) );
@@ -6923,8 +6936,10 @@ void game::print_part_con_info( const tripoint_bub_ms &lp, const catacurses::win
 void game::print_creature_info( const Creature *creature, const catacurses::window &w_look,
                                 const int column, int &line, const int last_line )
 {
+    const map &here = get_map();
+
     int vLines = last_line - line;
-    if( creature != nullptr && ( u.sees( *creature ) || creature == &u ) ) {
+    if( creature != nullptr && ( u.sees( here,  *creature ) || creature == &u ) ) {
         line = creature->print_info( w_look, ++line, vLines, column );
     }
 }
@@ -7796,7 +7811,7 @@ std::optional<std::vector<tripoint_bub_ms>> game::safe_route_to( Character &who,
         const std::function<void( const std::string &msg )> &report ) const
 {
     map &here = get_map();
-    if( !who.sees( target ) ) {
+    if( !who.sees( here, target ) ) {
         report( _( "You can't see the destination." ) );
         return std::nullopt;
     }
@@ -7853,6 +7868,8 @@ look_around_result game::look_around(
     bool select_zone, bool peeking, bool is_moving_zone, const tripoint_bub_ms &end_point,
     bool change_lv )
 {
+    const map &here = get_map();
+
     bVMonsterLookFire = false;
 
     temp_exit_fullscreen();
@@ -7960,7 +7977,7 @@ look_around_result game::look_around(
 
             creature_tracker &creatures = get_creature_tracker();
             monster *const mon = creatures.creature_at<monster>( lp, true );
-            if( mon && u.sees( *mon ) ) {
+            if( mon && u.sees( here, *mon ) ) {
                 std::string mon_name_text = string_format( _( "%s - %s" ),
                                             ctxt.get_desc( "CHANGE_MONSTER_NAME" ),
                                             ctxt.get_action_name( "CHANGE_MONSTER_NAME" ) );
@@ -8080,7 +8097,7 @@ look_around_result game::look_around(
             center.z() = clamp( center.z() + dz, min_levz, max_levz );
 
             add_msg_debug( debugmode::DF_GAME, "levx: %d, levy: %d, levz: %d",
-                           get_map().get_abs_sub().x(), get_map().get_abs_sub().y(), center.z() );
+                           here.get_abs_sub().x(), here.get_abs_sub().y(), center.z() );
             u.view_offset.z() = center.z() - u.posz();
             m.invalidate_map_cache( center.z() );
             // Fix player character not visible from above
@@ -8232,6 +8249,8 @@ static void add_item_recursive( std::vector<std::string> &item_order,
 
 std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 {
+    const map &here = get_map();
+
     std::map<std::string, map_item_stack> temp_items;
     std::vector<map_item_stack> ret;
     std::vector<std::string> item_order;
@@ -8242,7 +8261,7 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 
     for( tripoint_bub_ms &points_p_it : closest_points_first( u.pos_bub(), iRadius ) ) {
         if( points_p_it.y() >= u.posy() - iRadius && points_p_it.y() <= u.posy() + iRadius &&
-            u.sees( points_p_it ) &&
+            u.sees( here, points_p_it ) &&
             m.sees_some_items( points_p_it, u ) ) {
 
             for( item &elem : m.i_at( points_p_it ) ) {
@@ -9080,6 +9099,8 @@ game::vmenu_ret game::list_items( const std::vector<map_item_stack> &item_list )
 
 game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list )
 {
+    const map &here = get_map();
+
     const int iInfoHeight = 15;
     const int width = 55;
     int offsetX = 0;
@@ -9225,7 +9246,7 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
                     Creature *critter = monster_list[iCurMon];
                     const bool selected = iCurMon == iActive;
                     ++iCurMon;
-                    if( critter->sees( u ) && player_knows ) {
+                    if( critter->sees( here, u ) && player_knows ) {
                         mvwprintz( w_monsters, point( 0, y ), c_yellow, "!" );
                     }
                     bool is_npc = false;
@@ -11302,10 +11323,10 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                             vp1 ) ) {
         u.stop_hauling();
     }
-    u.setpos( dest_loc );
+    u.setpos( m, dest_loc );
     if( u.is_mounted() ) {
         monster *mon = u.mounted_creature.get();
-        mon->setpos( dest_loc );
+        mon->setpos( m, dest_loc );
         mon->process_triggers();
         m.creature_in_field( *mon );
     }
@@ -11625,7 +11646,7 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         //tunneling costs 250 bionic power per impassable tile
         u.mod_power_level( -( tunneldist * trigger_cost ) );
         u.mod_moves( -to_moves<int>( 1_seconds ) ); //tunneling takes exactly one second
-        u.setpos( dest );
+        u.setpos( m, dest );
 
         if( m.veh_at( u.pos_bub() ).part_with_feature( "BOARDABLE", true ) ) {
             m.board_vehicle( u.pos_bub(), &u );
@@ -11683,7 +11704,7 @@ bool game::phasing_move_enchant( const tripoint_bub_ms &dest_loc, const int phas
             vertical_shift( dest.z() );
         }
 
-        u.setpos( dest );
+        u.setpos( m, dest );
 
         if( m.veh_at( u.pos_bub() ).part_with_feature( "BOARDABLE", true ) ) {
             m.board_vehicle( u.pos_bub(), &u );
@@ -12155,7 +12176,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         c->underwater = false;
         // TODO: Check whenever it is actually in the viewport
         // or maybe even just redraw the changed tiles
-        bool seen = is_u || u.sees( *c ); // To avoid redrawing when not seen
+        bool seen = is_u || u.sees( here, *c ); // To avoid redrawing when not seen
         tdir.advance();
         pt.x() = c->posx() + tdir.dx();
         pt.y() = c->posy() + tdir.dy();
@@ -12211,13 +12232,13 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                 if( is_u ) {
                     update_map( pt.x(), pt.y() );
                 } else {
-                    you->setpos( pt );
+                    you->setpos( m, pt );
                 }
             } else if( !creatures.creature_at( pt ) ) {
                 // Dying monster doesn't always leave an empty tile (blob spawning etc.)
                 // Just don't setpos if it happens - next iteration will do so
                 // or the monster will stop a tile before the unpassable one
-                c->setpos( pt );
+                c->setpos( m, pt );
             }
         } else {
             // Don't zero flvel - count this as slamming both the obstacle and the ground
@@ -12228,7 +12249,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
         if( range == 1 ) {
             c->remove_effect( effect_airborne );
         }
-        if( animate && ( seen || u.sees( *c ) ) ) {
+        if( animate && ( seen || u.sees( here, *c ) ) ) {
             invalidate_main_ui_adaptor();
             inp_mngr.pump_events();
             ui_manager::redraw_invalidated();
@@ -12598,7 +12619,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             Creature *target = critter.attack_target();
             if( ( target && target->is_avatar() ) || ( !critter.has_effect( effect_ridden ) &&
                     ( critter.is_pet_follow() || critter.has_effect( effect_led_by_leash ) ) &&
-                    !critter.has_effect( effect_tied ) && critter.sees( u ) ) ) {
+                    !critter.has_effect( effect_tied ) && critter.sees( here, u ) ) ) {
                 monsters_following.push_back( &critter );
             }
         }
@@ -12661,14 +12682,14 @@ void game::vertical_move( int movez, bool force, bool peeking )
         if( mon && !mon->mounted_player ) {
             crit_name = mon->get_name();
             if( mon->friendly == -1 ) {
-                mon->setpos( *displace );
+                mon->setpos( m, *displace );
                 add_msg( _( "Your %s moves out of the way for you." ), mon->get_name() );
             } else {
                 player_displace = true;
             }
         }
         if( player_displace ) {
-            u.setpos( *displace );
+            u.setpos( m, *displace );
             u.mod_moves( -to_moves<int>( 1_seconds ) * 0.2 );;
             add_msg( _( "You push past %s blocking the way." ), crit_name );
         }
@@ -12676,7 +12697,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
     // Now that we know the player's destination position, we can move their mount as well
     if( u.is_mounted() ) {
-        u.mounted_creature->setpos( u.pos_bub() );
+        u.mounted_creature->setpos( m, u.pos_bub( m ) );
     }
 
     // This ugly check is here because of stair teleport bullshit
@@ -13074,7 +13095,7 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
 
     if( shift == point_rel_sm::zero ) {
         // adjust player position
-        u.setpos( tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
+        u.setpos( m, tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
         if( z_level_changed ) {
             // Update what parts of the world map we can see
             // We may be able to see farther now that the z-level has changed.
@@ -13117,7 +13138,7 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
     // Also ensure the player is on current z-level
     // m.get_abs_sub().z should later be removed, when there is no longer such a thing
     // as "current z-level"
-    u.setpos( tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
+    u.setpos( m, tripoint_bub_ms( x, y, m.get_abs_sub().z() ) );
 
     // Only do the loading after all coordinates have been shifted.
 
@@ -14284,7 +14305,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
     float weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( EXPLOSIVE_EXERCISE );
 
     you.mod_moves( -to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult );
-    you.setpos( examp, false );
+    you.setpos( here, examp, false );
 
     // Pre-descent message.
     if( !aid.down.msg_before.empty() ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1660,9 +1660,11 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
 drop_locations game_menus::inv::edevice_select( Character &who, item_location &used_edevice,
         bool browse_equals, bool auto_include_used_edevice, bool unusable_only, efile_action action )
 {
+    const map &here = get_map();
+
     const inventory_filter_preset preset( [&]( const item_location & loc ) {
         //make sure this is an edevice before we make edevice calls
-        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( loc.pos_bub() ) ) {
+        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( here, loc.pos_bub() ) ) {
             efile_activity_actor::edevice_compatible compat =
                 efile_activity_actor::edevices_compatible( used_edevice, loc );
             bool is_tool_has_charge = !loc->is_tool() || loc->ammo_sufficient( &who );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -232,7 +232,7 @@ void gates::open_gate( const tripoint_bub_ms &pos )
         }
     }
 
-    if( get_player_view().sees( pos ) ) {
+    if( get_player_view().sees( here, pos ) ) {
         if( open ) {
             add_msg( gate.open_message );
         } else if( close ) {
@@ -385,7 +385,7 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
     const tripoint_bub_ms displace = pos.value();
     //knockback trajectory requires the line be flipped
     const tripoint_bub_ms kbp( -displace.x() + x * 2, -displace.y() + y * 2, displace.z() );
-    const bool can_see = u.sees( kbp );
+    const bool can_see = u.sees( m, kbp );
     creature_tracker &creatures = get_creature_tracker();
     Character *npc_or_player = creatures.creature_at<Character>( p, false );
     if( npc_or_player != nullptr ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -20,7 +20,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
     map &here = get_map();
 
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( &here ) + u.grab_point );
+    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( here ) + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -38,7 +38,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab( object_type::NONE );
         return false;
     }
-    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( &here ) ) );
+    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( here ) ) );
     if( grabbed_vehicle == veh_under_player ) {
         u.grab_point = - dp;
         return false;
@@ -185,8 +185,8 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         const tripoint_rel_ms actual_dir = tripoint_rel_ms( ( expected_pos - new_part_pos ).xy(), 0 );
 
         // Set player location to illegal value so it can't collide with vehicle.
-        const tripoint_bub_ms player_prev = u.pos_bub( &here );
-        u.setpos( tripoint_bub_ms::zero, false );
+        const tripoint_abs_ms player_prev = u.pos_abs( );
+        u.setpos( here, tripoint_bub_ms::zero, false );
         std::vector<veh_collision> colls;
         const bool failed = grabbed_vehicle->collision( here, colls, actual_dir, true );
         u.setpos( player_prev );

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -120,7 +120,8 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             str_req = std::min( str_req, max_str_req );
         }
         //finally, adjust by the off-road coefficient (always 1.0 on a road, as low as 0.1 off road.)
-        str_req /= grabbed_vehicle->k_traction( here, get_map().vehicle_wheel_traction( *grabbed_vehicle ) );
+        str_req /= grabbed_vehicle->k_traction( here,
+                                                get_map().vehicle_wheel_traction( *grabbed_vehicle ) );
         // If it would be easier not to use the wheels, don't use the wheels.
         str_req = std::min( str_req, max_str_req );
     } else {
@@ -181,7 +182,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         // and in roughly the same direction.
         const tripoint_bub_ms new_part_pos = grabbed_vehicle->pos_bub( here ) +
                                              grabbed_vehicle->part( grabbed_part ).precalc[ 1 ];
-        const tripoint_bub_ms expected_pos = u.pos_bub( &here ) + dp + from;
+        const tripoint_bub_ms expected_pos = u.pos_bub( here ) + dp + from;
         const tripoint_rel_ms actual_dir = tripoint_rel_ms( ( expected_pos - new_part_pos ).xy(), 0 );
 
         // Set player location to illegal value so it can't collide with vehicle.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -300,7 +300,7 @@ input_context game::get_player_input( std::string &action )
                     tripoint_bub_ms tmp( iter->getPosX() + i, iter->getPosY(), get_map().get_abs_sub().z() );
                     const Creature *critter = creatures.creature_at( tmp, true );
 
-                    if( critter != nullptr && u.sees( *critter ) ) {
+                    if( critter != nullptr && u.sees( here, *critter ) ) {
                         i = -1;
                         int iPos = iter->getStep() + iter->getStepOffset();
                         for( auto iter2 = iter; iter2 != SCT.vSCT.rend(); ++iter2 ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -243,6 +243,8 @@ class user_turn
 
 input_context game::get_player_input( std::string &action )
 {
+    const map &here = get_map();
+
     input_context ctxt;
     if( uquit == QUIT_WATCH ) {
         ctxt = input_context( "DEFAULTMODE", keyboard_mode::keycode );
@@ -495,8 +497,10 @@ static void pldrive( point_rel_ms d )
 
 static void open()
 {
+    map &here = get_map();
+
     avatar &player_character = get_avatar();
-    const std::optional<tripoint_bub_ms> openp_ = choose_adjacent_highlight( _( "Open where?" ),
+    const std::optional<tripoint_bub_ms> openp_ = choose_adjacent_highlight( here, _( "Open where?" ),
             pgettext( "no door, gate, curtain, etc.", "There is nothing that can be opened nearby." ),
             ACTION_OPEN, false );
 
@@ -504,7 +508,6 @@ static void open()
         return;
     }
     const tripoint_bub_ms openp = *openp_;
-    map &here = get_map();
 
     player_character.mod_moves( -to_moves<int>( 1_seconds ) );
 
@@ -581,8 +584,10 @@ static void open()
 
 static void close()
 {
+    map &here = get_map();
+
     if( const std::optional<tripoint_bub_ms> pnt = choose_adjacent_highlight(
-                _( "Close where?" ),
+                here, _( "Close where?" ),
                 pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
                 ACTION_CLOSE, false ) ) {
         doors::close_door( get_map(), get_player_character(), *pnt );
@@ -3118,6 +3123,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
 bool game::handle_action()
 {
+    map &here = get_map();
+
     std::string action;
     input_context ctxt;
     action_id act = ACTION_NULL;
@@ -3190,7 +3197,7 @@ bool game::handle_action()
             // No auto-move actions have or can be set at this point.
             player_character.clear_destination();
             destination_preview.clear();
-            act = handle_action_menu();
+            act = handle_action_menu( here );
             if( act == ACTION_NULL ) {
                 return false;
             }
@@ -3237,7 +3244,7 @@ bool game::handle_action()
             if( !mouse_pos ) {
                 return false;
             }
-            if( !player_character.sees( *mouse_pos ) ) {
+            if( !player_character.sees( here, *mouse_pos ) ) {
                 // Not clicked in visible terrain
                 return false;
             }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1345,7 +1345,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
                 if( !here.has_flag( ter_furn_flag::TFLAG_ELEVATOR, candidate ) &&
                     here.passable( candidate ) &&
                     creatures.creature_at( candidate ) == nullptr ) {
-                    critter.setpos( candidate );
+                    critter.setpos( here, candidate );
                     break;
                 }
             }
@@ -1371,7 +1371,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     for( Creature &critter : g->all_creatures() ) {
         auto const eit = std::find( this_elevator.cbegin(), this_elevator.cend(), critter.pos_bub() );
         if( eit != this_elevator.cend() ) {
-            critter.setpos( that_elevator[ std::distance( this_elevator.cbegin(), eit ) ] );
+            critter.setpos( here, that_elevator[ std::distance( this_elevator.cbegin(), eit ) ] );
         }
     }
 
@@ -1569,7 +1569,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
     if( you.in_vehicle ) {
         here.unboard_vehicle( you.pos_bub() );
     }
-    you.setpos( examp );
+    you.setpos( here, examp );
     if( examp.x() < HALF_MAPSIZE_X || examp.y() < HALF_MAPSIZE_Y ||
         examp.x() >= HALF_MAPSIZE_X + SEEX || examp.y() >= HALF_MAPSIZE_Y + SEEY ) {
         if( you.is_avatar() ) {
@@ -1602,7 +1602,7 @@ void iexamine::bars( Character &you, const tripoint_bub_ms &examp )
     }
     you.mod_moves( -to_moves<int>( 2_seconds ) );
     add_msg( _( "You slide right between the bars." ) );
-    you.setpos( examp );
+    you.setpos( here, examp );
 }
 
 void iexamine::deployed_furniture( Character &you, const tripoint_bub_ms &pos )
@@ -5502,7 +5502,7 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
                 you.remove_effect( effect_bouldering );
                 you.assign_activity( glide );
                 you.add_effect( effect_gliding, 1_turns, true );
-                you.setpos( examp );
+                you.setpos( here, examp );
             }
             break;
         }
@@ -5517,7 +5517,7 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
                 if( you.has_effect_with_flag( json_flag_LEVITATION ) ) {
                     you.add_effect( effect_slow_descent, 1_seconds, false );
                 }
-                you.setpos( examp );
+                you.setpos( here, examp );
                 you.gravity_check();
             } else {
                 // Just to highlight the trepidation

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6441,6 +6441,8 @@ void item::on_wield( Character &you )
 
 void item::handle_pickup_ownership( Character &c )
 {
+    const map &here = get_map();
+
     if( is_owned_by( c ) ) {
         return;
     }
@@ -6449,7 +6451,7 @@ void item::handle_pickup_ownership( Character &c )
         set_owner( c );
     } else {
         if( !is_owned_by( c ) && c.is_avatar() ) {
-            const auto sees_stealing = [&c, this]( const Creature & cr ) {
+            const auto sees_stealing = [&c, this, &here]( const Creature & cr ) {
                 const npc *const as_npc = cr.as_npc();
                 const monster *const as_monster = cr.as_monster();
                 bool owned_by = false;
@@ -6458,8 +6460,8 @@ void item::handle_pickup_ownership( Character &c )
                 } else if( as_monster ) {
                     owned_by = is_owned_by( *as_monster );
                 }
-                return &cr != &c && owned_by && rl_dist( cr.pos_bub(), c.pos_bub() ) < MAX_VIEW_DISTANCE &&
-                       cr.sees( c.pos_bub() );
+                return &cr != &c && owned_by && rl_dist( cr.pos_abs(), c.pos_abs() ) < MAX_VIEW_DISTANCE &&
+                       cr.sees( here, c.pos_bub( here ) );
             };
             const auto sort_criteria = []( const Creature * lhs, const Creature * rhs ) {
                 const npc *const lnpc = lhs->as_npc();
@@ -10954,10 +10956,8 @@ int item::gun_range( const Character *p ) const
     return std::max( 0, ret );
 }
 
-int item::shots_remaining( const Character *carrier ) const
+int item::shots_remaining( const map &here, const Character *carrier ) const
 {
-    map &here = get_map();
-
     int ret = 1000; // Arbitrary large number for things that do not require ammo.
     if( ammo_required() ) {
         ret = std::min( ammo_remaining_linked( here,  carrier ) / ammo_required(), ret );
@@ -11175,7 +11175,7 @@ bool item::ammo_sufficient( const Character *carrier, int qty ) const
         return true;
     }
 
-    return shots_remaining( carrier ) >= qty;
+    return shots_remaining( here, carrier ) >= qty;
 }
 
 bool item::ammo_sufficient( const Character *carrier, const std::string &method, int qty ) const

--- a/src/item.h
+++ b/src/item.h
@@ -2461,7 +2461,7 @@ class item : public visitable
          * Quantity of shots in the gun. Looks at both ammo and available energy.
          * @param carrier is used for UPS and bionic power
          */
-        int shots_remaining( const Character *carrier ) const;
+        int shots_remaining( const map &here, const Character *carrier ) const;
 
         /**
          * Energy available from battery/UPS/bionics

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -536,7 +536,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
             map &here = get_map();
             item *obj = target();
             int mv = ch.item_handling_cost( *obj, true, VEHICLE_HANDLING_PENALTY, qty );
-            mv += 100 * rl_dist( ch.pos_bub( &here ), cur.veh.bub_part_pos( here, cur.part ) );
+            mv += 100 * rl_dist( ch.pos_bub( here ), cur.veh.bub_part_pos( here, cur.part ) );
 
             // TODO: handle unpacking costs
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2504,6 +2504,7 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
         p->add_msg_if_player( m_info, _( "Purifying %i water using %i %s" ), charges_of_water, to_consume,
                               purifier->tname( to_consume ) );;
         // Pull from surrounding map first because it will update to_consume
+        map &here = get_map();
         get_map().use_amount( p->pos_bub( here ), PICKUP_RANGE, itype_pur_tablets, to_consume );
         // Then pull from inventory
         if( to_consume > 0 ) {
@@ -4996,7 +4997,8 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
             }
         }
         viewer &player_view = get_player_view();
-        if( player_view.sees( *critter ) ) {
+        map &here = get_map();
+        if( player_view.sees( here, *critter ) ) {
             if( blind ) {
                 p->add_msg_if_player( _( "%s is blinded by the spray." ), critter->disp_name() );
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -418,7 +418,7 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
 
     std::map<quality_id, int> unmet_reqs;
     inventory inv;
-    inv.form_from_map( p.pos_bub( here ), 1, &p, true, true );
+    inv.form_from_map( p.pos_bub( *here ), 1, &p, true, true );
     for( const auto &quality : qualities_needed ) {
         if( !p.has_quality( quality.first, quality.second ) &&
             !inv.has_quality( quality.first, quality.second ) ) {
@@ -566,7 +566,7 @@ std::optional<int> unpack_actor::use( Character *p, item &it, map *here,
             content.set_flag( flag_FILTHY );
         }
 
-        here->add_item_or_charges( p->pos_bub( here ), content );
+        here->add_item_or_charges( p->pos_bub( *here ), content );
     }
 
     p->i_rem( &it );
@@ -598,14 +598,14 @@ std::optional<int> message_iuse::use( Character *p, item &it,
 }
 
 std::optional<int> message_iuse::use( Character *p, item &it,
-                                      map * /*here*/, const tripoint_bub_ms &pos ) const
+                                      map *here, const tripoint_bub_ms &pos ) const
 {
     if( !p ) {
         return std::nullopt;
     }
 
     // TODO: Use map aware 'sees' when available.
-    if( p->sees( pos ) && !message.empty() ) {
+    if( p->sees( *here, pos ) && !message.empty() ) {
         p->add_msg_if_player( m_info, message.translated(), it.tname() );
     }
 
@@ -908,7 +908,7 @@ std::optional<int> consume_drug_iuse::use( Character *p, item &it, map *here,
         const field_type_id fid = field_type_id( field.first );
         for( int i = 0; i < 3; i++ ) {
             point_rel_ms offset( rng( -2, 2 ), rng( -2, 2 ) );
-            here->add_field( p->pos_bub( here ) + offset, fid, field.second );
+            here->add_field( p->pos_bub( *here ) + offset, fid, field.second );
         }
     }
 
@@ -1025,7 +1025,7 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it, map *here,
     newmon.init_from_item( it );
     if( place_randomly ) {
         // place_critter_around returns the same pointer as its parameter (or null)
-        if( !g->place_critter_around( newmon_ptr, p->pos_bub( here ), 1 ) ) {
+        if( !g->place_critter_around( newmon_ptr, p->pos_bub( *here ), 1 ) ) {
             p->add_msg_if_player( m_info, _( "There is no adjacent square to release the %s in!" ),
                                   newmon.name() );
             return std::nullopt;
@@ -1116,8 +1116,8 @@ std::optional<int> place_npc_iuse::use( Character *p, item &, map *here,
                                         const tripoint_bub_ms & ) const
 {
     const tripoint_range<tripoint_bub_ms> target_range = place_randomly ?
-            points_in_radius( p->pos_bub( here ), radius ) :
-            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub( here ) ), 0 );
+            points_in_radius( p->pos_bub( *here ), radius ) :
+            points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub( *here ) ), 0 );
 
     const std::optional<tripoint_bub_ms> target_pos =
     random_point( target_range, [here]( const tripoint_bub_ms & t ) {
@@ -1197,7 +1197,7 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
         return ret_val<tripoint_bub_ms>::make_failure( pos );
     }
     tripoint_bub_ms pnt( pos );
-    if( pos == p->pos_bub( here ) ) {
+    if( pos == p->pos_bub( *here ) ) {
         // TODO: Use map aware 'choose_adjacent' when available, or reject operation if not reality bubble map
         if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Deploy where?" ) ) ) {
             pnt = *pnt_;
@@ -1206,7 +1206,7 @@ static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
         }
     }
 
-    if( pnt == p->pos_bub( here ) ) {
+    if( pnt == p->pos_bub( *here ) ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos,
                 _( "You attempt to become one with the %s.  It doesn't work." ), it.tname() );
     }
@@ -1435,14 +1435,14 @@ bool firestarter_actor::prep_firestarter_use( const Character &p, map *here, tri
     }
 
     // checks for fuel are handled by use and the activity, not here
-    if( pos == p.pos_bub( here ) ) {
+    if( pos == p.pos_bub( *here ) ) {
         if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Light where?" ) ) ) {
             pos = *pnt_;
         } else {
             return false;
         }
     }
-    if( pos == p.pos_bub( here ) ) {
+    if( pos == p.pos_bub( *here ) ) {
         p.add_msg_if_player( m_info, _( "You would set yourself on fire." ) );
         p.add_msg_if_player( _( "But you're already smokin' hot." ) );
         return false;
@@ -1535,7 +1535,7 @@ ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
         return ret_val<void>::make_failure( _( "This tool doesn't have enough charges." ) );
     }
 
-    if( need_sunlight && light_mod( here, p.pos_bub( here ) ) <= 0.0f ) {
+    if( need_sunlight && light_mod( here, p.pos_bub( *here ) ) <= 0.0f ) {
         return ret_val<void>::make_failure( _( "You need direct sunlight to light a fire with this." ) );
     }
 
@@ -1593,7 +1593,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
 
     tripoint_bub_ms pos = spos;
 
-    float light = light_mod( here, p->pos_bub( here ) );
+    float light = light_mod( here, p->pos_bub( *here ) );
     if( !prep_firestarter_use( *p, here, pos ) ) {
         return std::nullopt;
     }
@@ -2201,7 +2201,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
     if( rng( 0, 10 ) - it.damage_level() > success_chance && !p->is_underwater() ) {
         if( noise > 0 ) {
             if( here == &get_map() ) { // or make 'sound' map aware
-                sounds::sound( p->pos_bub( here ), noise, sounds::sound_t::combat, success_message );
+                sounds::sound( p->pos_bub( *here ), noise, sounds::sound_t::combat, success_message );
             }
         } else {
             p->add_msg_if_player( "%s", success_message );
@@ -2322,7 +2322,7 @@ std::optional<int> manualnoise_actor::use( Character *p, item &, map *here,
     // Uses the moves specified by iuse_actor's definition
     p->mod_moves( -moves );
     if( noise > 0 ) {
-        sounds::sound( p->pos_bub( here ), noise, sounds::sound_t::activity,
+        sounds::sound( p->pos_bub( *here ), noise, sounds::sound_t::activity,
                        noise_message.empty() ? _( "Hsss" ) : noise_message.translated(), true, noise_id, noise_variant );
     }
     p->add_msg_if_player( "%s", use_message );
@@ -2535,15 +2535,16 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     if( morale_effect >= 0 ) {
-        sounds::sound( p->pos_bub( here ), volume, sounds::sound_t::music, desc, true, "musical_instrument",
+        sounds::sound( p->pos_bub( *here ), volume, sounds::sound_t::music, desc, true,
+                       "musical_instrument",
                        it.typeId().str() );
     } else {
-        sounds::sound( p->pos_bub( here ), volume, sounds::sound_t::music, desc, true,
+        sounds::sound( p->pos_bub( *here ), volume, sounds::sound_t::music, desc, true,
                        "musical_instrument_bad",
                        it.typeId().str() );
     }
 
-    if( !p->has_effect( effect_music ) && p->can_hear( p->pos_bub( here ), volume ) ) {
+    if( !p->has_effect( effect_music ) && p->can_hear( p->pos_bub( *here ), volume ) ) {
         // Sound code doesn't describe noises at the player position
         if( desc != "music" ) {
             p->add_msg_if_player( m_info, desc );
@@ -2551,7 +2552,7 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     // We already played the sounds, just handle applying effects now
-    iuse::play_music( p, p->pos_bub( here ), volume, morale_effect, /*play_sounds=*/false );
+    iuse::play_music( p, p->pos_bub( *here ), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;
 }
@@ -3662,7 +3663,7 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
 
 static Character &get_patient( Character &healer, map *here, const tripoint_bub_ms &pos )
 {
-    if( healer.pos_bub( here ) == pos ) {
+    if( healer.pos_bub( *here ) == pos ) {
         return healer;
     }
 
@@ -3793,6 +3794,8 @@ int heal_actor::get_stopbleed_level( const Character &healer ) const
 int heal_actor::finish_using( Character &healer, Character &patient, item &it,
                               bodypart_id healed ) const
 {
+    const map &here = get_map();
+
     float practice_amount = limb_power * 3.0f;
     const int dam = get_heal_value( healer, healed );
     const int cur_hp = patient.get_part_hp_cur( healed );
@@ -3805,7 +3808,7 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
 
     Character &player_character = get_player_character();
     const bool u_see = healer.is_avatar() || patient.is_avatar() ||
-                       player_character.sees( healer ) || player_character.sees( patient );
+                       player_character.sees( here, healer ) || player_character.sees( here,  patient );
     const bool player_healing_player = healer.is_avatar() && patient.is_avatar();
     // Need a helper here - messages are from healer's point of view
     // but it would be cool if NPCs could use this function too
@@ -5186,7 +5189,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
         }
 
         it.update_link_traits();
-        it.process( *here, p, p->pos_bub( here ) );
+        it.process( *here, p, p->pos_bub( *here ) );
         p->mod_moves( -move_cost );
         return 0;
 
@@ -5222,7 +5225,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
         it.link().source = link_state::ups;
         loc->set_var( "cable", "plugged_in" );
         it.update_link_traits();
-        it.process( *here, p, p->pos_bub( here ) );
+        it.process( *here, p, p->pos_bub( *here ) );
         p->mod_moves( -move_cost );
         return 0;
 
@@ -5258,7 +5261,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
         it.link().source = link_state::solarpack;
         loc->set_var( "cable", "plugged_in" );
         it.update_link_traits();
-        it.process( *here, p, p->pos_bub( here ) );
+        it.process( *here, p, p->pos_bub( *here ) );
         p->mod_moves( -move_cost );
         return 0;
     }
@@ -5276,7 +5279,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
         return ovp && ovp->vehicle().avail_linkable_part( ovp->mount_pos(), to_ports ) != -1;
     };
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Attach the cable where?" ),
+                here, _( "Attach the cable where?" ),
                 "", can_link, false, false );
     if( !pnt_ ) {
         p->add_msg_if_player( _( "Never mind." ) );
@@ -5379,7 +5382,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                to_towing ? _( "Attach cable to the vehicle that will do the towing." ) :
+                here, to_towing ? _( "Attach cable to the vehicle that will do the towing." ) :
                 _( "Attach cable to the vehicle that will be towed." ), "", can_link, false, false );
     if( !pnt_ ) {
         p->add_msg_if_player( _( "Never mind." ) );
@@ -5505,7 +5508,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         extended_ptr->link() = extension->link();
     }
     extended_ptr->update_link_traits();
-    extended_ptr->process( *here, p, p->pos_bub( here ) );
+    extended_ptr->process( *here, p, p->pos_bub( *here ) );
 
     if( extended_copy ) {
         // Check if there's another pocket on the same container that can hold the extended item, respecting pocket settings.
@@ -5629,7 +5632,7 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it, map *here,
     // We place the center of the structure (radius + 1)
     // spaces away from the player.
     // First check there's enough room.
-    const tripoint_bub_ms center = p->pos_bub( here ) + point_rel_ms( ( radius + 1 ) * direction.x(),
+    const tripoint_bub_ms center = p->pos_bub( *here ) + point_rel_ms( ( radius + 1 ) * direction.x(),
                                    ( radius + 1 ) * direction.y() );
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_bub_ms &dest : here->points_in_radius( center, radius ) ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -969,6 +969,8 @@ std::string spell::damage_string( const Character &caster ) const
 
 std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
 {
+    const map &here = get_map();
+
     tripoint_bub_ms target = source->pos_bub();
     bool target_is_valid = false;
     if( range( *source ) > 0 && !is_valid_target( spell_target::none ) &&
@@ -981,7 +983,7 @@ std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
                 if( !trajectory.empty() ) {
                     target = trajectory.back();
                     target_is_valid = is_valid_target( source_avatar, target );
-                    if( !( is_valid_target( spell_target::ground ) || source_avatar.sees( target ) ) ) {
+                    if( !( is_valid_target( spell_target::ground ) || source_avatar.sees( here, target ) ) ) {
                         target_is_valid = false;
                     }
                 } else {
@@ -1116,7 +1118,7 @@ std::vector<tripoint_bub_ms> spell::targetable_locations( const Character &sourc
         }
 
         if( !select_ground ) {
-            if( !source.sees( query ) ) {
+            if( !source.sees( here, query ) ) {
                 // can't target a critter you can't see
                 continue;
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -185,9 +185,11 @@ void spell_effect::short_range_teleport( const spell &sp, Creature &caster,
 
 static void swap_pos( Creature &caster, const tripoint_bub_ms &target )
 {
+    map &here = get_map();
+
     Creature *const critter = get_creature_tracker().creature_at<Creature>( target );
-    critter->setpos( caster.pos_bub() );
-    caster.setpos( target );
+    critter->setpos( caster.pos_abs() );
+    caster.setpos( here, target );
 
     //update map in case a monster swapped positions with the player
     Character &you = get_player_character();
@@ -1055,11 +1057,12 @@ static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint_bub_
         &fd_fatigue_field,
         Creature &caster )
 {
+    const map &here = get_map();
     for( const std::pair<const field_type_id, field_entry> &fd : std::get<0>( fd_fatigue_field ) ) {
         const int &intensity = fd.second.get_field_intensity();
         const translation &intensity_name = fd.second.get_intensity_level().name;
         const tripoint_bub_ms &field_position = std::get<1>( fd_fatigue_field );
-        const bool sees_field = caster.sees( field_position );
+        const bool sees_field = caster.sees( here, field_position );
 
         switch( intensity ) {
             case 1:
@@ -1084,7 +1087,7 @@ static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint_bub_
             case 3:
                 std::string message_prefix = "A nearby";
 
-                if( caster.sees( field_position ) ) {
+                if( caster.sees( here, field_position ) ) {
                     message_prefix = "The";
                 }
 
@@ -1159,8 +1162,10 @@ void spell_effect::area_push( const spell &sp, Creature &caster, const tripoint_
 static void character_push_effects( Creature *caster, Character &guy, tripoint_bub_ms &push_dest,
                                     const int push_distance, const std::vector<tripoint_bub_ms> &push_vec )
 {
+    map &here = get_map();
+
     int dist_left = std::abs( push_distance );
-    tripoint_bub_ms old_pushed_point = guy.pos_bub();
+    tripoint_bub_ms old_pushed_point = guy.pos_bub( here );
     for( const tripoint_bub_ms &pushed_point : push_vec ) {
         if( get_map().impassable( pushed_point ) ) {
             guy.hurtall( dist_left * 4, caster );
@@ -1174,7 +1179,7 @@ static void character_push_effects( Creature *caster, Character &guy, tripoint_b
             old_pushed_point = pushed_point;
         }
     }
-    guy.setpos( push_dest );
+    guy.setpos( here, push_dest );
 }
 
 void spell_effect::directed_push( const spell &sp, Creature &caster, const tripoint_bub_ms &target )
@@ -1251,7 +1256,7 @@ void spell_effect::directed_push( const spell &sp, Creature &caster, const tripo
                             old_pushed_push_point = pushed_push_point;
                         }
                     }
-                    mon->setpos( push_dest );
+                    mon->setpos( here, push_dest );
                 } else if( guy ) {
                     character_push_effects( &caster, *guy, push_dest, push_distance, push_vec );
                 }

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -234,7 +234,7 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
             m.add_field( location, field_potential->first, fld.second.get_field_intensity(),
                          fld.second.get_field_age(), true );
             m.remove_field( location, fld.first );
-            if( you.sees( location ) && !field_potential->second.first.empty() ) {
+            if( you.sees( m, location ) && !field_potential->second.first.empty() ) {
                 you.add_msg_if_player( field_potential->second.first.translated(),
                                        field_potential->second.second ? m_good : m_bad );
             }
@@ -279,21 +279,21 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 
     if( ter_potential ) {
         m.ter_set( location, ter_potential->first );
-        if( you.sees( location ) && !ter_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !ter_potential->second.first.empty() ) {
             you.add_msg_if_player( ter_potential->second.first.translated(),
                                    ter_potential->second.second ? m_good : m_bad );
         }
     }
     if( furn_potential ) {
         m.furn_set( location, furn_potential->first );
-        if( you.sees( location ) && !furn_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !furn_potential->second.first.empty() ) {
             you.add_msg_if_player( furn_potential->second.first.translated(),
                                    furn_potential->second.second ? m_good : m_bad );
         }
     }
     if( trap_potential ) {
         m.trap_set( location, trap_potential->first );
-        if( you.sees( location ) && !trap_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !trap_potential->second.first.empty() ) {
             you.add_msg_if_player( trap_potential->second.first.translated(),
                                    trap_potential->second.second ? m_good : m_bad );
         }

--- a/src/map.h
+++ b/src/map.h
@@ -594,7 +594,7 @@ class map
 
         bool is_open_air( const tripoint_bub_ms &p ) const;
 
-        bool try_fall( const tripoint_bub_ms &p, Creature *c ) const;
+        bool try_fall( const tripoint_bub_ms &p, Creature *c );
 
         /**
         * Similar behavior to `move_cost()`, but ignores vehicles.

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1476,7 +1476,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( you.pos_bub( this ) );
+    field &curfield = get_field( you.pos_bub( *this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)
@@ -1511,7 +1511,7 @@ void map::player_in_field( Character &you )
             // Sap does nothing to cars.
             if( !you.in_vehicle ) {
                 // Use up sap.
-                mod_field_intensity( you.pos_bub( this ), ft, -1 );
+                mod_field_intensity( you.pos_bub( *this ), ft, -1 );
             }
         }
         if( ft == fd_sludge ) {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -191,7 +191,7 @@ bool leap_actor::call( monster &z ) const
                            "Distance %d larger than previous best %d, candidate discarded", cur_dist, best );
             break;
         }
-        if( !z.sees( dest ) ) {
+        if( !z.sees( here, dest ) ) {
             add_msg_debug( debugmode::DF_MATTACK, "Can't see destination, candidate discarded" );
             continue;
         }
@@ -232,9 +232,9 @@ bool leap_actor::call( monster &z ) const
     z.mod_moves( -move_cost );
     viewer &player_view = get_player_view();
     const tripoint_bub_ms chosen = random_entry( options );
-    bool seen = player_view.sees( z ); // We can see them jump...
-    z.setpos( chosen );
-    seen |= player_view.sees( z ); // ... or we can see them land
+    bool seen = player_view.sees( here, z ); // We can see them jump...
+    z.setpos( here, chosen );
+    seen |= player_view.sees( here, z ); // ... or we can see them land
     if( seen && get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         add_msg( message, z.name() );
     }
@@ -447,6 +447,8 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
 
 Creature *melee_actor::find_target( monster &z ) const
 {
+    const map &here = get_map();
+
     if( !z.can_act() ) {
         return nullptr;
     }
@@ -458,8 +460,8 @@ Creature *melee_actor::find_target( monster &z ) const
     }
 
     if( range > 1 ) {
-        if( !z.sees( *target ) ||
-            !get_map().clear_path( z.pos_bub(), target->pos_bub(), range, 1, 200 ) ) {
+        if( !z.sees( here, *target ) ||
+            !here.clear_path( z.pos_bub( here ), target->pos_bub( here ), range, 1, 200 ) ) {
             return nullptr;
         }
 
@@ -472,16 +474,17 @@ Creature *melee_actor::find_target( monster &z ) const
 
 int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) const
 {
+    map &here = get_map();
+
     // Something went wrong
     if( !target ) {
         return -1;
     }
     // Handle some messaging in-grab
     game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
-    const std::string mon_name = get_player_character().sees( z.pos_bub() ) ?
+    const std::string mon_name = get_player_character().sees( here, z.pos_bub( here ) ) ?
                                  z.disp_name( false, true ) : _( "Something" );
     Character *foe = target->as_character();
-    map &here = get_map();
 
     int eff_grab_strength = grab_data.grab_strength == -1 ? z.get_grab_strength() :
                             grab_data.grab_strength;
@@ -558,7 +561,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
             }
 
             // Don't try to fall mid pull
-            target->setpos( pt, false );
+            target->setpos( here, pt, false );
             pull_range--;
             if( animate ) {
                 g->invalidate_main_ui_adaptor();
@@ -648,12 +651,12 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
                     if( foe->in_vehicle ) {
                         here.unboard_vehicle( foe->pos_bub() );
                     }
-                    foe->setpos( zpt );
+                    foe->setpos( here, zpt );
                     if( !foe->in_vehicle && here.veh_at( zpt ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
                         here.board_vehicle( zpt, foe );
                     }
                 } else {
-                    zz->setpos( zpt );
+                    zz->setpos( here, zpt );
                 }
                 target->add_msg_player_or_npc( m_bad, _( "You are dragged behind the %s!" ),
                                                _( "<npcname> gets dragged behind the %s!" ), z.name() );
@@ -703,7 +706,7 @@ bool melee_actor::call( monster &z ) const
 
     z.mod_moves( -move_cost );
 
-    const std::string mon_name = get_player_character().sees( z.pos_bub() ) ?
+    const std::string mon_name = get_player_character().sees( here, z.pos_bub( here ) ) ?
                                  z.disp_name( false, true ) : _( "Something" );
 
     // Add always-applied self effects
@@ -948,6 +951,8 @@ bool melee_actor::call( monster &z ) const
 
 void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance &dealt ) const
 {
+    const map &here = get_map();
+
     if( target.is_avatar() ) {
         sfx::play_variant_sound( "mon_bite", "bite_hit", sfx::get_heard_volume( z.pos_bub() ),
                                  sfx::get_heard_angle( z.pos_bub() ) );
@@ -957,7 +962,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
                                  Creature::Attitude::FRIENDLY ?
                                  m_bad : m_neutral;
     const bodypart_id &bp = dealt.bp_hit ;
-    const std::string mon_name = get_player_character().sees( z.pos_bub() ) ?
+    const std::string mon_name = get_player_character().sees( here, z.pos_bub( here ) ) ?
                                  z.disp_name( false, true ) : _( "Something" );
     target.add_msg_player_or_npc( msg_type, hit_dmg_u,
                                   get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? hit_dmg_npc : translation(),
@@ -1131,6 +1136,8 @@ int gun_actor::get_max_range()  const
 
 bool gun_actor::call( monster &z ) const
 {
+    map &here = get_map();
+
     Creature *target;
     tripoint_bub_ms aim_at;
     bool untargeted = false;
@@ -1158,16 +1165,16 @@ bool gun_actor::call( monster &z ) const
             }
             return false;
         }
-        aim_at = target->pos_bub();
+        aim_at = target->pos_bub( here );
     } else {
         target = z.attack_target();
-        aim_at = target ? target->pos_bub() : tripoint_bub_ms::zero;
-        if( !target || !z.sees( *target ) || ( !target->is_monster() && !z.aggro_character ) ) {
+        aim_at = target ? target->pos_bub( here ) : tripoint_bub_ms::zero;
+        if( !target || !z.sees( here, *target ) || ( !target->is_monster() && !z.aggro_character ) ) {
             if( !target_moving_vehicles ) {
                 return false;
             }
             untargeted = true; // no living targets, try to find moving car parts
-            const std::set<tripoint_bub_ms> moving_veh_parts = get_map()
+            const std::set<tripoint_bub_ms> moving_veh_parts = here
                     .get_moving_vehicle_targets( z, get_max_range() );
             if( moving_veh_parts.empty() ) {
                 return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -709,7 +709,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             } else {
                 add_msg( _( "You miss." ) );
             }
-        } else if( player_character.sees( *this ) ) {
+        } else if( player_character.sees( here, *this ) ) {
             if( miss_recovery.id != tec_none ) {
                 add_msg_if_npc( miss_recovery.npc_message.translated(), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
@@ -738,7 +738,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     } else {
         melee::melee_stats.hit_count += 1;
         // Remember if we see the monster at start - it may change
-        const bool seen = player_character.sees( t );
+        const bool seen = player_character.sees( here, t );
         // Start of attacks.
         float dodge_or_melee = std::max( ( t.dodge_roll() * 1.2f ), ( t.get_melee() * 5.f ) );
         const bool critical_hit = scored_crit( dodge_or_melee, cur_weap );
@@ -970,7 +970,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             }
 
             // Treat monster as seen if we see it before or after the attack
-            if( seen || player_character.sees( t ) ) {
+            if( seen || player_character.sees( here, t ) ) {
                 std::string message = melee_message( technique, *this, dealt_dam );
                 player_hit_message( this, message, t, dam, critical_hit, technique.id != tec_none,
                                     dealt_dam.wp_hit );
@@ -1882,6 +1882,8 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                                    damage_instance &di,
                                    int &move_cost, item_location &cur_weapon )
 {
+    map &here = get_map();
+
     add_msg_debug( debugmode::DF_MELEE, "Chose technique %s\ndmg before tec:", technique.name );
     print_damage_info( di );
     int rep = rng( technique.repeat_min, technique.repeat_max );
@@ -1986,10 +1988,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
 
         const tripoint_bub_ms &dest{ new_, b.z()};
         if( g->is_empty( dest ) ) {
-            t.setpos( dest );
+            t.setpos( here, dest );
         }
     }
-    map &here = get_map();
+
     if( technique.knockback_dist && !( t.has_flag( mon_flag_IMMOBILE ) ||
                                        t.has_effect_with_flag( json_flag_CANNOT_MOVE ) ) ) {
         const tripoint_bub_ms prev_pos = t.pos_bub(); // track target startpoint for knockback_follow

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -10,6 +10,7 @@
 #include "game.h"
 #include "input_context.h"
 #include "json.h"
+#include "map.h"
 #include "output.h"
 #include "panels.h"
 #include "point.h"
@@ -1003,14 +1004,18 @@ void add_msg( const game_message_params &params, std::string msg )
 
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
 }
 
 void add_msg_if_player_sees( const Creature &target, std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
 }
@@ -1018,7 +1023,9 @@ void add_msg_if_player_sees( const Creature &target, std::string msg )
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( params, std::move( msg ) );
     }
 }
@@ -1026,7 +1033,9 @@ void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_p
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,
                              std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( params, std::move( msg ) );
     }
 }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -549,7 +549,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
                 }
             };
             for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 5 ) ) {
-                if( player_character.sees( p ) ) {
+                if( player_character.sees( here, p ) ) {
                     if( here.has_items( p ) && here.accessible_items( p ) ) {
                         count_items( here.i_at( p ) );
                     }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2605,6 +2605,8 @@ std::vector<comp_rank> talk_function::companion_rank( const std::vector<npc_ptr>
 npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required_skills,
         bool silent_failure )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
     std::vector<npc_ptr> available;
     std::optional<basecamp *> bcp = overmap_buffer.find_camp(
@@ -2619,8 +2621,8 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
         // get non-assigned visible followers
         if( player_character.posz() == guy->posz() && !guy->has_companion_mission() &&
             !guy->is_travelling() &&
-            ( rl_dist( player_character.pos_bub(), guy->pos_bub() ) <= SEEX * 2 ) &&
-            player_character.sees( guy->pos_bub() ) ) {
+            ( rl_dist( player_character.pos_abs(), guy->pos_abs() ) <= SEEX * 2 ) &&
+            player_character.sees( here, guy->pos_bub( here ) ) ) {
             available.push_back( guy );
         } else if( bcp ) {
             basecamp *player_camp = *bcp;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -242,21 +242,27 @@ static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 // shared utility functions
 static bool within_visual_range( monster *z, int max_range )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
-    return !( rl_dist( z->pos_bub(), player_character.pos_bub() ) > max_range ||
-              !z->sees( player_character ) );
+    return !( rl_dist( z->pos_abs(), player_character.pos_abs() ) > max_range ||
+              !z->sees( here, player_character ) );
 }
 
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
+    const map &here = get_map();
+
     return target != nullptr &&
            ( z->is_adjacent( target, true ) ||
              static_cast<int>( ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) ) <= range ) ) &&
-           z->sees( *target );
+           z->sees( here, *target );
 }
 
 static Creature *sting_get_target( monster *z, float range = 5.0f )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
 
     if( target == nullptr ) {
@@ -264,12 +270,12 @@ static Creature *sting_get_target( monster *z, float range = 5.0f )
     }
 
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) ||
+    if( !z->sees( here,  *target ) ||
         !get_map().clear_path( z->pos_bub(), target->pos_bub(), range, 1, 100 ) ) {
         return nullptr;
     }
 
-    return rl_dist( z->pos_bub(), target->pos_bub() ) <= range ? target : nullptr;
+    return rl_dist( z->pos_abs(), target->pos_abs() ) <= range ? target : nullptr;
 }
 
 static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, float range )
@@ -630,10 +636,12 @@ bool mattack::browse( monster *z )
 
 bool mattack::shriek( monster *z )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ||
-        rl_dist( z->pos_bub(), target->pos_bub() ) > 4 ||
-        !z->sees( *target ) ) {
+        rl_dist( z->pos_abs(), target->pos_abs() ) > 4 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -646,6 +654,8 @@ bool mattack::shriek( monster *z )
 
 bool mattack::shriek_alert( monster *z )
 {
+    const map &here = get_map();
+
     if( !z->can_act() || z->has_effect( effect_shrieking ) ) {
         return false;
     }
@@ -653,7 +663,7 @@ bool mattack::shriek_alert( monster *z )
     Creature *target = z->attack_target();
 
     if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 15 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
     add_msg_if_player_sees( *z, _( "The %s begins shrieking!" ), z->name() );
@@ -667,6 +677,8 @@ bool mattack::shriek_alert( monster *z )
 
 bool mattack::shriek_stun( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() || !z->has_effect( effect_shrieking ) ) {
         return false;
     }
@@ -680,13 +692,12 @@ bool mattack::shriek_stun( monster *z )
     // Currently the cone is 2D, so don't use it for 3D attacks
     if( dist > 7 ||
         z->posz() != target->posz() ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
     units::angle target_angle = coord_to_angle( z->pos_bub(), target->pos_bub() );
     units::angle cone_angle = 20_degrees;
-    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_bub_ms &cone : here.points_in_radius( z->pos_bub(), 4 ) ) {
         units::angle tile_angle = coord_to_angle( z->pos_bub().raw(), cone.raw() );
@@ -748,12 +759,14 @@ bool mattack::howl( monster *z )
 
 bool mattack::rattle( monster *z )
 {
+    const map &here = get_map();
+
     // TODO: Let it rattle at non-player friendlies
     const int min_dist = z->friendly != 0 ? 1 : 4;
     Creature *target = &get_player_character();
     // Can't use attack_target - the snake has no target
-    if( rl_dist( z->pos_bub(), target->pos_bub() ) > min_dist ||
-        !z->sees( *target ) ) {
+    if( rl_dist( z->pos_abs(), target->pos_abs() ) > min_dist ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -778,7 +791,7 @@ bool mattack::acid( monster *z )
 
     map &here = get_map();
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) ||
+    if( !z->sees( here,  *target ) ||
         !here.clear_path( z->pos_bub(), target->pos_bub(), 10, 1, 100 ) ) {
         return false;
     }
@@ -888,6 +901,8 @@ bool mattack::acid_barf( monster *z )
 
 bool mattack::shockstorm( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -898,10 +913,9 @@ bool mattack::shockstorm( monster *z )
     }
 
     Character &player_character = get_player_character();
-    bool seen = player_character.sees( *z );
-    map &here = get_map();
+    bool seen = player_character.sees( here, *z );
 
-    bool can_attack = z->sees( *target ) && rl_dist( z->pos_bub(), target->pos_bub() ) <= 12;
+    bool can_attack = z->sees( here, *target ) && rl_dist( z->pos_abs(), target->pos_abs() ) <= 12;
     std::vector<tripoint_bub_ms> path = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     for( const tripoint_bub_ms &point : path ) {
         if( here.impassable( point ) &&
@@ -996,6 +1010,8 @@ bool mattack::pull_metal_aoe( monster *z )
 
 bool mattack::pull_metal_weapon( monster *z )
 {
+    map &here = get_map();
+
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Constants and Configuration
 
@@ -1014,7 +1030,7 @@ bool mattack::pull_metal_weapon( monster *z )
     }
 
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) || !get_map().clear_path( z->pos_bub(), target->pos_bub(),
+    if( !z->sees( here, *target ) || !here.clear_path( z->pos_bub( here ), target->pos_bub( here ),
             max_distance, 1, 100 ) ) {
         return false;
     }
@@ -1084,21 +1100,23 @@ bool mattack::pull_metal_weapon( monster *z )
 
 bool mattack::boomer( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
-    if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 3 || !z->sees( *target ) ) {
+    if( target == nullptr || rl_dist( z->pos_abs(), target->pos_abs() ) > 3 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    map &here = get_map();
     std::vector<tripoint_bub_ms> line = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     // It takes a while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 2.5 );
     Character &player_character = get_player_character();
-    bool u_see = player_character.sees( *z );
+    bool u_see = player_character.sees( here, *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -1125,21 +1143,23 @@ bool mattack::boomer( monster *z )
 
 bool mattack::boomer_glow( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
-    if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 3 || !z->sees( *target ) ) {
+    if( target == nullptr || rl_dist( z->pos_abs(), target->pos_abs() ) > 3 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    map &here = get_map();
     std::vector<tripoint_bub_ms> line = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     // It takes a while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 2.5 );
     Character &player_character = get_player_character();
-    bool u_see = player_character.sees( *z );
+    bool u_see = player_character.sees( here,  *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -1172,6 +1192,8 @@ bool mattack::boomer_glow( monster *z )
 
 bool mattack::resurrect( monster *z )
 {
+    map &here = get_map();
+
     // Chance to recover some of our missing speed (yes this will regain
     // loses from being revived ourselves as well).
     // Multiplying by (current base speed / max speed) means that the
@@ -1190,13 +1212,12 @@ bool mattack::resurrect( monster *z )
     }
 
     Character &player_character = get_player_character();
-    bool sees_necromancer = player_character.sees( *z );
+    bool sees_necromancer = player_character.sees( here, *z );
     std::vector<std::pair<tripoint_bub_ms, item *>> corpses;
     // Find all corpses that we can see within 10 tiles.
     int range = 10;
     bool found_eligible_corpse = false;
     int lowest_raise_score = INT_MAX;
-    map &here = get_map();
     // Cache map stats.
     std::unordered_map<tripoint_bub_ms, bool> sees_and_is_empty_cache;
     auto sees_and_is_empty = [&sees_and_is_empty_cache, &z, &here]( const tripoint_bub_ms & T ) {
@@ -1311,7 +1332,7 @@ bool mattack::resurrect( monster *z )
         }
 
         zed->make_ally( *z );
-        if( player_character.sees( *zed ) ) {
+        if( player_character.sees( here, *zed ) ) {
             add_msg( m_warning, _( "A nearby %s rises from the dead!" ), zed->name() );
         } else if( sees_necromancer ) {
             // We saw the necromancer but not the revival
@@ -1823,14 +1844,16 @@ bool mattack::vine( monster *z )
 
 bool mattack::spit_sap( monster *z )
 {
+    const map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
     if( target == nullptr ||
-        rl_dist( z->pos_bub(), target->pos_bub() ) > 12 ||
-        !z->sees( *target ) ) {
+        rl_dist( z->pos_abs(), target->pos_abs() ) > 12 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -1969,9 +1992,10 @@ bool mattack::fungus_haze( monster *z )
 
 bool mattack::fungus_big_blossom( monster *z )
 {
-    bool firealarm = false;
-    const bool u_see = get_player_view().sees( *z );
     map &here = get_map();
+
+    bool firealarm = false;
+    const bool u_see = get_player_view().sees( here, *z );
     // Fungal fire-suppressor! >:D
     for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 6 ) ) {
         if( here.get_field_intensity( dest, fd_fire ) != 0 ) {
@@ -2086,7 +2110,7 @@ bool mattack::fungus_bristle( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, true ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -2524,19 +2548,21 @@ bool mattack::callblobs( monster *z )
 
 bool mattack::dogthing( monster *z )
 {
+    map &here = get_map();
+
     if( z == nullptr ) {
         // TODO: replace pointers with references
         return false;
     }
 
-    if( !one_in( 3 ) || !get_player_view().sees( *z ) ) {
+    if( !one_in( 3 ) || !get_player_view().sees( here, *z ) ) {
         return false;
     }
 
     add_msg( _( "The %s's head explodes in a mass of roiling tentacles!" ),
              z->name() );
 
-    get_map().add_splash( z->bloodType(), z->pos_bub(), 2, 3 );
+    here.add_splash( z->bloodType(), z->pos_bub(), 2, 3 );
 
     z->friendly = 0;
     z->poly( mon_headless_dog_thing );
@@ -2582,7 +2608,7 @@ bool mattack::nurse_check_up( monster *z )
     map &here = get_map();
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0,
                              100 ) ) { // no need to scan players we can't reach
             if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
@@ -2621,8 +2647,9 @@ bool mattack::nurse_check_up( monster *z )
 }
 bool mattack::nurse_assist( monster *z )
 {
+    const map &here = get_map();
 
-    const bool u_see = get_player_view().sees( *z );
+    const bool u_see = get_player_view().sees( here, *z );
 
     if( u_see && one_in( 100 ) ) {
         add_msg( m_info, _( "The %s is scanning its surroundings." ), z->name() );
@@ -2630,14 +2657,13 @@ bool mattack::nurse_assist( monster *z )
 
     bool found_target = false;
     Character *target = nullptr;
-    map &here = get_map();
     tripoint_bub_ms tmp_pos( z->pos_bub() + point( 12, 12 ) );
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
         // No need to scan players we can't reach
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0, 100 ) ) {
-            if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
+            if( rl_dist( z->pos_abs(), tmp_player->pos_abs() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
                 tmp_pos = tmp_player->pos_bub();
                 target = tmp_player;
                 found_target = true;
@@ -2665,7 +2691,7 @@ bool mattack::nurse_operate( monster *z )
         return false;
     }
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( *z );
+    const bool u_see = player_character.sees( here, *z );
 
     if( u_see && one_in( 100 ) ) {
         add_msg( m_info, _( "The %s is scanning its surroundings." ), z->name() );
@@ -2686,15 +2712,14 @@ bool mattack::nurse_operate( monster *z )
 
     bool found_target = false;
     Character *target = nullptr;
-    map &here = get_map();
     tripoint_bub_ms tmp_pos( z->pos_bub() + point( 12, 12 ) );
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast< Character *>( critter );
         // No need to scan players we can't reach
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0, 100 ) ) {
             if( tmp_player->has_any_bionic() ) {
-                if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
+                if( rl_dist( z->pos_abs(), tmp_player->pos_abs() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
                     tmp_pos = tmp_player->pos_bub();
                     target = tmp_player;
                     found_target = true;
@@ -3168,6 +3193,7 @@ void mattack::tankgun( monster *z, Creature *target )
 
 bool mattack::searchlight( monster *z )
 {
+    map &here = get_map();
 
     int max_lamp_count = 3;
     if( z->get_hp() < z->get_hp_max() ) {
@@ -3179,7 +3205,6 @@ bool mattack::searchlight( monster *z )
 
     const point_bub_ms zpos( z->posx(), z->posy() );
 
-    map &here = get_map();
     //this searchlight is not initialized
     if( z->inv.empty() ) {
 
@@ -3276,7 +3301,7 @@ bool mattack::searchlight( monster *z )
 
         for( int i = 0; i < rng( 1, 2 ); i++ ) {
 
-            if( !z->sees( player_character ) ) {
+            if( !z->sees( here,  player_character ) ) {
                 shift = settings.get_var( "SL_DIR", shift );
 
                 switch( shift ) {
@@ -3345,7 +3370,7 @@ bool mattack::searchlight( monster *z )
         }
 
         tripoint_bub_ms t = tripoint_bub_ms( p, z->posz() );
-        if( z->sees( t, false, 0 ) ) {
+        if( z->sees( here, t, false, 0 ) ) {
             settings.set_var( "SL_SPOT_X", p.x() - zpos.x() );
             settings.set_var( "SL_SPOT_Y", p.y() - zpos.y() );
         } else {
@@ -3354,10 +3379,10 @@ bool mattack::searchlight( monster *z )
             // a window covered). If the searchlight cannot see the current location then
             // reset the searchlight to search from itself
             t = tripoint_bub_ms( preshift_p, z->posz() );
-            if( !z->sees( t, false, 0 ) ) {
+            if( !z->sees( here, t, false, 0 ) ) {
                 settings.set_var( "SL_SPOT_X", 0 );
                 settings.set_var( "SL_SPOT_Y", 0 );
-                t = z->pos_bub();
+                t = z->pos_bub( here );
             }
         }
 
@@ -3459,6 +3484,8 @@ void mattack::flame( monster *z, Creature *target )
 
 bool mattack::copbot( monster *z )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ) {
         return false;
@@ -3466,7 +3493,7 @@ bool mattack::copbot( monster *z )
 
     // TODO: Make it recognize zeds as human, but ignore animals
     Character *foe = dynamic_cast<Character *>( target );
-    bool sees_u = foe != nullptr && z->sees( *foe );
+    bool sees_u = foe != nullptr && z->sees( here, *foe );
     bool cuffed = foe != nullptr && foe->get_wielded_item() &&
                   foe->get_wielded_item()->typeId() == itype_e_handcuffs;
     // Taze first, then ask questions (simplifies later checks for non-humans)
@@ -3475,7 +3502,8 @@ bool mattack::copbot( monster *z )
         return true;
     }
 
-    if( rl_dist( z->pos_bub(), target->pos_bub() ) > 2 || foe == nullptr || !z->sees( *target ) ) {
+    if( rl_dist( z->pos_abs(), target->pos_abs() ) > 2 || foe == nullptr ||
+        !z->sees( here, *target ) ) {
         if( one_in( 3 ) ) {
             if( sees_u ) {
                 if( foe->unarmed_attack() ) {
@@ -3718,6 +3746,8 @@ bool mattack::generator( monster *z )
 
 bool mattack::upgrade( monster *z )
 {
+    const map &here = get_map();
+
     std::vector<monster *> targets;
     for( monster &zed : g->all_monsters() ) {
         // Check this first because it is a relatively cheap check
@@ -3745,11 +3775,11 @@ bool mattack::upgrade( monster *z )
 
     std::string old_name = target->name();
     viewer &player_view = get_player_view();
-    const bool could_see = player_view.sees( *target );
+    const bool could_see = player_view.sees( here, *target );
     target->hasten_upgrade();
     target->try_upgrade( false );
-    const bool can_see = player_view.sees( *target );
-    if( player_view.sees( *z ) ) {
+    const bool can_see = player_view.sees( here, *target );
+    if( player_view.sees( here, *z ) ) {
         if( could_see ) {
             add_msg( m_warning,
                      //~ %1$s is the name of the zombie upgrading the other, %2$s is the zombie being upgraded.
@@ -3787,9 +3817,9 @@ bool mattack::flesh_golem( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos_bub(), target->pos_bub() );
+    int dist = rl_dist( z->pos_abs(), target->pos_abs() );
     if( dist > 20 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -3797,7 +3827,8 @@ bool mattack::flesh_golem( monster *z )
         if( one_in( 12 ) ) {
             z->mod_moves( -to_moves<int>( 2_seconds ) );
             // It doesn't "nearly deafen you" when it roars from the other side of bubble
-            sounds::sound( z->pos_bub(), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false, "shout",
+            sounds::sound( z->pos_bub( here ), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false,
+                           "shout",
                            "roar" );
             return true;
         }
@@ -3878,7 +3909,7 @@ bool mattack::absorb_meat( monster *z )
                     z->heal( hp_to_heal, true );
                     here.use_amount( p, 0, current_item.type->get_id(), meat_absorbed );
                 }
-                if( player_character.sees( *z ) ) {
+                if( player_character.sees( here, *z ) ) {
                     add_msg( m_warning, _( "The %1$s absorbs the %2$s, growing larger." ), z->name(),
                              current_item.tname() );
                     add_msg_debug( debugmode::DF_MATTACK, "The %1$s now has %2$s out of %3$s hp", z->name(),
@@ -3905,17 +3936,17 @@ bool mattack::lunge( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos_bub(), target->pos_bub() );
+    int dist = rl_dist( z->pos_abs(), target->pos_abs() );
     if( dist > 20 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    bool seen = get_player_view().sees( *z );
+    bool seen = get_player_view().sees( here, *z );
     if( dist > 1 ) {
         if( one_in( 5 ) ) {
             // Out of range
-            if( dist > 4 || !z->sees( *target ) ) {
+            if( dist > 4 || !z->sees( here, *target ) ) {
                 return false;
             }
             z->mod_moves( z->get_speed() * 2.0 );
@@ -3971,16 +4002,18 @@ bool mattack::lunge( monster *z )
 
 bool mattack::blow_whistle( monster *z )
 {
+    const map &here = get_map();
+
     if( z->friendly ) {
         // TODO: handle friendly monsters
         return false;
     }
     // Only blow whistle if we can see you!
-    if( !z->sees( get_player_character() ) ) {
+    if( !z->sees( here, get_player_character() ) ) {
         return false;
     }
     add_msg_if_player_sees( *z, m_warning, _( "The %1$s loudly blows their whistle!" ), z->name() );
-    sounds::sound( z->pos_bub(), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc",
+    sounds::sound( z->pos_bub( here ), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc",
                    "whistle" );
 
     return true;
@@ -4012,18 +4045,21 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot]( Creature * creature ) {
+    const map &here = get_map();
+
+    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot,
+    &here]( Creature * creature ) {
         if( !creature->is_hallucination() && one_in( 20 ) ) {
             if( creature->is_avatar() || creature->is_npc() ) {
                 Character *character = creature->as_character();
                 return character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE &&
-                       parrot->sees( *character );
+                       parrot->sees( here, *character );
             } else {
                 monster *monster = creature->as_monster();
                 return ( monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
                          ( monster->anger > 0 &&
                            monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
-                       parrot->sees( *monster );
+                       parrot->sees( here, *monster );
             }
         }
         return false;
@@ -4039,21 +4075,23 @@ bool mattack::parrot_at_danger( monster *parrot )
 
 bool mattack::darkman( monster *z )
 {
+    const map &here = get_map();
+
     if( z->friendly ) {
         // TODO: handle friendly monsters
         return false;
     }
     Character &player_character = get_player_character();
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 40 ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) > 40 ) {
         return false;
     }
-    if( monster *const shadow = g->place_critter_around( mon_shadow, z->pos_bub(), 1 ) ) {
+    if( monster *const shadow = g->place_critter_around( mon_shadow, z->pos_bub( here ), 1 ) ) {
         z->mod_moves( -to_moves<int>( 1_seconds ) * 0.1 );
         shadow->make_ally( *z );
         add_msg_if_player_sees( *z, m_warning, _( "A shadow splits from the %s!" ), z->name() );
     }
     // Won't do the combat stuff unless it can see you
-    if( !z->sees( player_character ) ) {
+    if( !z->sees( here, player_character ) ) {
         return true;
     }
     // What do we say?
@@ -4087,8 +4125,10 @@ bool mattack::darkman( monster *z )
 
 bool mattack::slimespring( monster *z )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 30 ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) > 30 ) {
         return false;
     }
 
@@ -4102,7 +4142,8 @@ bool mattack::slimespring( monster *z )
         add_msg( m_good, "%s", SNIPPET.random_from_category( "slime_cheers" ).value_or( translation() ) );
         player_character.remove_effect( effect_social_dissatisfied );
     }
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) <= 3 && z->sees( player_character ) ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) <= 3 &&
+        z->sees( here, player_character ) ) {
         if( player_character.has_effect( effect_bleed ) ||
             player_character.has_effect( effect_bite ) ) {
             //~ Lowercase is intended: they're small voices.
@@ -4339,10 +4380,12 @@ bool mattack::riotbot( monster *z )
 
 bool mattack::evolve_kill_strike( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
     if( !z->can_act() ) {
@@ -4368,7 +4411,7 @@ bool mattack::evolve_kill_strike( monster *z )
                                        z->name() );
         return true;
     }
-    tripoint_bub_ms const target_pos = target->pos_bub();
+    tripoint_abs_ms const target_pos = target->pos_abs();
     const std::string target_name = target->disp_name();
 
     int damage_dealt = target->deal_damage( z, bodypart_id( "torso" ), damage ).total_damage();
@@ -4386,15 +4429,15 @@ bool mattack::evolve_kill_strike( monster *z )
         return true;
     }
     Character &player_character = get_player_character();
-    if( target->is_dead_state() && g->is_empty( target_pos ) &&
+    if( target->is_dead_state() && g->is_empty( &here, target_pos ) &&
         target->made_of_any( Creature::cmat_flesh ) ) {
         const std::string old_name = z->name();
-        const bool could_see_z = player_character.sees( *z );
+        const bool could_see_z = player_character.sees( here, *z );
         z->allow_upgrade();
         z->try_upgrade( false );
         z->setpos( target_pos );
         const std::string upgrade_name = z->name();
-        const bool can_see_z_upgrade = player_character.sees( *z );
+        const bool can_see_z_upgrade = player_character.sees( here, *z );
         if( could_see_z && can_see_z_upgrade ) {
             add_msg( m_warning, _( "The %1$s burrows within %2$s corpse and a %3$s emerges from the remains!" ),
                      old_name,
@@ -4410,13 +4453,15 @@ bool mattack::evolve_kill_strike( monster *z )
 
 bool mattack::tindalos_teleport( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ) {
         return false;
     }
     if( one_in( 7 ) ) {
         if( monster *const afterimage = g->place_critter_around( mon_hound_tindalos_afterimage,
-                                        z->pos_bub(),
+                                        z->pos_bub( here ),
                                         1 ) ) {
             z->mod_moves( -to_moves<int>( 1_seconds ) * 1.4 );
             afterimage->make_ally( *z );
@@ -4425,16 +4470,15 @@ bool mattack::tindalos_teleport( monster *z )
                                     _( "The hound's movements chaotically rewind as a living afterimage splits from it!" ) );
         }
     }
-    const int distance_to_target = rl_dist( z->pos_bub(), target->pos_bub() );
-    map &here = get_map();
+    const int distance_to_target = rl_dist( z->pos_abs(), target->pos_abs() );
     if( distance_to_target > 5 ) {
-        const tripoint_bub_ms oldpos = z->pos_bub();
-        for( const tripoint_bub_ms &dest : here.points_in_radius( target->pos_bub(), 4 ) ) {
+        const tripoint_bub_ms oldpos = z->pos_bub( here );
+        for( const tripoint_bub_ms &dest : here.points_in_radius( target->pos_bub( here ), 4 ) ) {
             if( here.is_cornerfloor( dest ) ) {
                 if( g->is_empty( dest ) ) {
-                    z->setpos( dest );
+                    z->setpos( here, dest );
                     // Not teleporting if it means losing sight of our current target
-                    if( z->sees( *target ) ) {
+                    if( z->sees( here, *target ) ) {
                         here.add_field( oldpos, fd_tindalos_rift, 2 );
                         here.add_field( dest, fd_tindalos_rift, 2 );
                         add_msg_if_player_sees( *z, m_bad,
@@ -4445,7 +4489,7 @@ bool mattack::tindalos_teleport( monster *z )
             }
         }
         // couldn't teleport without losing sight of target
-        z->setpos( oldpos );
+        z->setpos( here, oldpos );
         return true;
     }
     return true;
@@ -4453,9 +4497,11 @@ bool mattack::tindalos_teleport( monster *z )
 
 bool mattack::flesh_tendril( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
 
-    if( target == nullptr || !z->sees( *target ) ) {
+    if( target == nullptr || !z->sees( here, *target ) ) {
         if( one_in( 70 ) ) {
             add_msg( _( "The floor trembles underneath your feet." ) );
             z->mod_moves( -to_moves<int>( 2_seconds ) );
@@ -4465,7 +4511,7 @@ bool mattack::flesh_tendril( monster *z )
         return false;
     }
 
-    const int distance_to_target = rl_dist( z->pos_bub(), target->pos_bub() );
+    const int distance_to_target = rl_dist( z->pos_abs(), target->pos_abs() );
 
     // the monster summons stuff to fight you
     if( distance_to_target > 3 && one_in( 12 ) ) {
@@ -4476,7 +4522,7 @@ bool mattack::flesh_tendril( monster *z )
         if( monster *const summoned = g->place_critter_around( spawned, z->pos_bub(), 1 ) ) {
             z->mod_moves( -to_moves<int>( 1_seconds ) );
             summoned->make_ally( *z );
-            get_map().propagate_field( z->pos_bub(), fd_gibs_flesh, 75, 1 );
+            here.propagate_field( z->pos_bub( here ), fd_gibs_flesh, 75, 1 );
             add_msg_if_player_sees( *z, m_warning, _( "A %s struggles to pull itself free from the %s!" ),
                                     summoned->name(), z->name() );
         }
@@ -4507,6 +4553,8 @@ bool mattack::flesh_tendril( monster *z )
 
 bool mattack::bio_op_random_biojutsu( monster *z )
 {
+    const map &here = get_map();
+
     int choice = 0;
     bool redo = false;
 
@@ -4517,7 +4565,7 @@ bool mattack::bio_op_random_biojutsu( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -4561,11 +4609,11 @@ bool mattack::bio_op_takedown( monster *z )
     // TODO: Allow drop-takedown form above
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    bool seen = get_player_view().sees( *z );
+    bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
     if( seen ) {
         add_msg( _( "The %1$s mechanically grabs at %2$s!" ), z->name(),
@@ -4671,11 +4719,11 @@ bool mattack::bio_op_impale( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    const bool seen = get_player_view().sees( *z );
+    const bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
     if( seen ) {
         add_msg( _( "The %1$s mechanically lunges at %2$s!" ), z->name(),
@@ -4742,6 +4790,8 @@ bool mattack::bio_op_impale( monster *z )
 
 bool mattack::bio_op_disarm( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -4749,11 +4799,11 @@ bool mattack::bio_op_disarm( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    const bool seen = get_player_view().sees( *z );
+    const bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
 
     // disarm doesn't work on creatures or unarmed targets
@@ -4794,11 +4844,11 @@ bool mattack::bio_op_disarm( monster *z )
 
     if( my_roll >= their_roll && !it->has_flag( flag_NO_UNWIELD ) ) {
         target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
-        tripoint_bub_ms tp = foe->pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-        if( !get_map().can_put_items( tp ) ) {
-            tp = foe->pos_bub();
+        tripoint_bub_ms tp = foe->pos_bub( here ) + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        if( !here.can_put_items( tp ) ) {
+            tp = foe->pos_bub( here );
         }
-        get_map().add_item_or_charges( tp, foe->i_rem( &*it ) );
+        here.add_item_or_charges( tp, foe->i_rem( &*it ) );
     } else {
         target->add_msg_if_player( m_good, _( "but you break its grip!" ) );
     }
@@ -4969,6 +5019,8 @@ struct grenade_helper_struct {
 static int grenade_helper( monster *const z, Creature *const target, const int dist,
                            const int moves, std::map<itype_id, grenade_helper_struct> data )
 {
+    const map &here = get_map();
+
     // Can't do anything if we can't act
     if( !z->can_act() ) {
         return 0;
@@ -5008,7 +5060,7 @@ static int grenade_helper( monster *const z, Creature *const target, const int d
     z->ammo[att]--;
 
     // if the player can see it
-    if( get_player_view().sees( *z ) ) {
+    if( get_player_view().sees( here, *z ) ) {
         if( data[att].message.empty() ) {
             add_msg_debug( debugmode::DF_MATTACK, "Invalid ammo message in grenadier special." );
         } else {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -76,7 +76,7 @@ item_location mdeath::normal( map *here, monster &z )
         const float corpse_damage = 2.5 * overflow_damage / max_hp;
         const bool pulverized = corpse_damage > 5 && overflow_damage > z.get_hp_max();
 
-        z.bleed(); // leave some blood if we have to
+        z.bleed( *here ); // leave some blood if we have to
 
         if( pulverized ) {
             return splatter( here, z );
@@ -101,10 +101,10 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( z.pos_bub( here ) + point( rng( -distance, distance ),
+        tripoint_bub_ms tarp( z.pos_bub( *here ) + point( rng( -distance, distance ),
                               rng( -distance,
                                    distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( here ), tarp );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( *here ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -149,7 +149,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( *here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -208,7 +208,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( z.has_effect( effect_critter_underfed ) ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
     }
     return {};
 }
@@ -238,7 +238,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( *here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -261,14 +261,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( z.pos_bub( here ), mags );
+                            here->spawn_items( z.pos_bub( *here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( *here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -298,5 +298,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( z.has_effect( effect_critter_underfed ) ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
 }

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -77,7 +77,7 @@ void mdefense::zapback( monster &m, Creature *const source,
         return;
     }
 
-    if( get_player_view().sees( source->pos_bub() ) ) {
+    if( get_player_view().sees( here, source->pos_bub( here ) ) ) {
         const game_message_type msg_type = source->is_avatar() ? m_bad : m_info;
         add_msg( msg_type, _( "Striking the %1$s shocks %2$s!" ),
                  m.name(), source->disp_name() );
@@ -95,6 +95,8 @@ void mdefense::zapback( monster &m, Creature *const source,
 void mdefense::acidsplash( monster &m, Creature *const source,
                            dealt_projectile_attack const *const proj )
 {
+    const map &here = get_map();
+
     if( source == nullptr ) {
         return;
     }
@@ -127,7 +129,7 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     }
 
     // Don't splatter directly on the `m`, that doesn't work well
-    std::vector<tripoint_bub_ms> pts = closest_points_first( source->pos_bub(), 1 );
+    std::vector<tripoint_bub_ms> pts = closest_points_first( source->pos_bub( here ), 1 );
     pts.erase( std::remove( pts.begin(), pts.end(), m.pos_bub() ), pts.end() );
 
     projectile prj;
@@ -139,16 +141,18 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     dealt_projectile_attack atk;
     for( size_t i = 0; i < num_drops; i++ ) {
         const tripoint_bub_ms &target = random_entry( pts );
-        projectile_attack( atk, prj, m.pos_bub(), target, dispersion_sources{ 1200 }, &m );
+        projectile_attack( atk, prj, m.pos_bub( here ), target, dispersion_sources{ 1200 }, &m );
     }
 
-    if( get_player_view().sees( m.pos_bub() ) ) {
+    if( get_player_view().sees( here, m.pos_bub( here ) ) ) {
         add_msg( m_warning, _( "Acid sprays out of %s as it is hit!" ), m.disp_name() );
     }
 }
 
 void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile_attack *proj )
 {
+    const map &here = get_map();
+
     // No return fire for untargeted projectiles, i.e. from explosions.
     if( source == nullptr ) {
         return;
@@ -177,7 +181,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
     }
 
     // No return fire if attacker is seen
-    if( m.sees( *source ) ) {
+    if( m.sees( here, *source ) ) {
         return;
     }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1678,7 +1678,6 @@ bool monster::bash_at( const tripoint_bub_ms &p )
         return false;
     }
 
-    map &here = get_map();
     if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || too_cramped ) ) {
         // if the only thing here is road or flat, rarely bash it
         bool flat_ground = here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ||
@@ -1929,13 +1928,13 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         // Birds and other flying creatures flying over the deep water terrain
         Character &player_character = get_player_character();
-        if( was_water && flies() && sees( player_character ) &&
+        if( was_water && flies() && sees( here, player_character ) &&
             attitude_to( player_character ) == Attitude::HOSTILE ) {
             if( one_in( 4 ) ) {
                 add_msg_if_player_sees( *this, m_warning, _( "A %1$s flies over the %2$s!" ),
                                         name(), here.tername( pos_bub() ) );
             }
-        } else if( was_water && sees( player_character ) && !will_be_water &&
+        } else if( was_water && sees( here, player_character ) && !will_be_water &&
                    attitude_to( player_character ) == Attitude::HOSTILE ) {
             // Use more dramatic messages for swimming monsters
             add_msg_if_player_sees( *this, m_warning,
@@ -1944,7 +1943,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
                                     pgettext( "monster movement", "A %1$s %2$s from the %3$s!" ),
                                     name(), swims() ||
                                     has_flag( mon_flag_AQUATIC ) ? _( "leaps" ) : _( "emerges" ), here.tername( pos_bub() ) );
-        } else if( !was_water && sees( player_character ) && will_be_water &&
+        } else if( !was_water && sees( here, player_character ) && will_be_water &&
                    attitude_to( player_character ) == Attitude::HOSTILE ) {
             add_msg_if_player_sees( *this, m_warning, pgettext( "monster movement",
                                     //~ Message when a monster enters water

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -306,7 +306,9 @@ bool monster::can_move_to( const tripoint_bub_ms &p ) const
 
 float monster::rate_target( Creature &c, float best, bool smart ) const
 {
-    const FastDistanceApproximation d = rl_dist_fast( pos_bub(), c.pos_bub() );
+    const map &here = get_map();
+
+    const FastDistanceApproximation d = rl_dist_fast( pos_bub( here ), c.pos_bub( here ) );
     if( d <= 0 ) {
         return FLT_MAX;
     }
@@ -316,7 +318,7 @@ float monster::rate_target( Creature &c, float best, bool smart ) const
         return FLT_MAX;
     }
 
-    if( !sees( c ) ) {
+    if( !sees( here, c ) ) {
         return FLT_MAX;
     }
 
@@ -471,7 +473,7 @@ void monster::plan()
     Character &player_character = get_player_character();
     // If we can see the player, move toward them or flee.
     if( friendly == 0 && seen_levels.test( player_character.posz() + OVERMAP_DEPTH ) &&
-        sees( player_character ) ) {
+        sees( here, player_character ) ) {
         mon_plan.dist = rate_target( player_character, mon_plan.dist, mon_plan.smart_planning );
         mon_plan.fleeing = mon_plan.fleeing || is_fleeing( player_character );
         mon_plan.target = &player_character;
@@ -752,7 +754,7 @@ void monster::plan()
     } else if( friendly > 0 && one_in( 3 ) ) {
         // Grow restless with no targets
         friendly--;
-    } else if( is_pet_follow() && sees( player_character ) &&
+    } else if( is_pet_follow() && sees( here, player_character ) &&
                ( pos_abs().z() == player_character.pos_abs().z() ||
                  pos_abs().z() == get_dest().z() ) ) {
         // Simpleminded animals are too dumb to follow the player.
@@ -983,7 +985,7 @@ void monster::move()
     if( is_pet_follow() || ( friendly != 0 && has_effect( effect_led_by_leash ) ) ) {
         const int dist = rl_dist( pos_abs(), get_dest() );
         if( ( dist <= 1 || ( dist <= 2 && !has_effect( effect_led_by_leash ) &&
-                             sees( player_character ) ) ) &&
+                             sees( here, player_character ) ) ) &&
             ( get_dest() == player_character.pos_abs() &&
               pos_abs().z() == player_character.pos_abs().z() ) ) {
             moves = 0;
@@ -1648,6 +1650,8 @@ static std::vector<tripoint_bub_ms> get_bashing_zone( const tripoint_bub_ms &bas
 
 bool monster::bash_at( const tripoint_bub_ms &p )
 {
+    map &here = get_map();
+
     if( p.z() != posz() ) {
         // TODO: Remove this
         return false;
@@ -1751,6 +1755,8 @@ int monster::group_bash_skill( const tripoint_bub_ms &target )
 
 bool monster::attack_at( const tripoint_bub_ms &p )
 {
+    const map &here = get_map();
+
     if( has_flag( mon_flag_PACIFIST ) || has_flag( json_flag_CANNOT_ATTACK ) ) {
         return false;
     }
@@ -1759,7 +1765,7 @@ bool monster::attack_at( const tripoint_bub_ms &p )
         return false;
     }
     Character &player_character = get_player_character();
-    const bool sees_player = sees( player_character );
+    const bool sees_player = sees( here, player_character );
     // Targeting player location
     if( p == player_character.pos_bub() ) {
         if( sees_player ) {
@@ -1949,12 +1955,12 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
         }
     }
 
-    optional_vpart_position vp_orig = here.veh_at( pos_bub() );
+    optional_vpart_position vp_orig = here.veh_at( pos_abs() );
     if( vp_orig ) {
         vp_orig->vehicle().invalidate_mass();
     }
 
-    setpos( destination );
+    setpos( here, destination );
     footsteps( destination );
     underwater = will_be_water;
     optional_vpart_position vp_dest = here.veh_at( destination );
@@ -2191,7 +2197,7 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
                 critter_recur->die( &here, nullptr );
             }
         } else if( !critter->has_flag( mon_flag_IMMOBILE ) ) {
-            critter->setpos( tripoint_bub_ms( dest ) );
+            critter->setpos( here, dest );
             move_to( p );
             mod_moves( -movecost_attacker );
             critter->add_effect( effect_downed, time_duration::from_turns( movecost_from / 100 + 1 ) );
@@ -2278,7 +2284,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
 {
     map &here = get_map();
 
-    if( to == pos_bub() ) {
+    if( to == pos_bub( here ) ) {
         return; // No effect
     }
 
@@ -2287,7 +2293,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
         return;
     }
 
-    bool u_see = get_player_view().sees( to );
+    bool u_see = get_player_view().sees( here, to );
 
     creature_tracker &creatures = get_creature_tracker();
     // First, see if we hit another monster
@@ -2345,7 +2351,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
         }
 
     } else { // It's no wall
-        setpos( tripoint_bub_ms( to ) );
+        setpos( here, to );
     }
     check_dead_state( &here );
 }
@@ -2358,6 +2364,8 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
  */
 bool monster::will_reach( const point_bub_ms &p )
 {
+    const map &here = get_map();
+
     monster_attitude att = attitude( &get_player_character() );
     if( att != MATT_FOLLOW && att != MATT_ATTACK && att != MATT_FRIEND ) {
         return false;
@@ -2373,7 +2381,7 @@ bool monster::will_reach( const point_bub_ms &p )
         return false;
     }
 
-    const std::vector<tripoint_bub_ms> path = get_map().route( pos_bub(), tripoint_bub_ms( p,
+    const std::vector<tripoint_bub_ms> path = here.route( pos_bub(), tripoint_bub_ms( p,
             posz() ), get_pathfinding_settings() );
     if( path.empty() ) {
         return false;
@@ -2384,12 +2392,12 @@ bool monster::will_reach( const point_bub_ms &p )
         return true;
     }
 
-    if( can_hear() && wandf > 0 && rl_dist( get_map().get_bub( wander_pos ).xy(), p ) <= 2 &&
+    if( can_hear() && wandf > 0 && rl_dist( here.get_bub( wander_pos ).xy(), p ) <= 2 &&
         rl_dist( pos_abs().xy(), wander_pos.xy() ) <= wandf ) {
         return true;
     }
 
-    if( can_see() && sees( tripoint_bub_ms( p, posz() ) ) ) {
+    if( can_see() && sees( here, tripoint_bub_ms( p, posz() ) ) ) {
         return true;
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -326,7 +326,9 @@ monster::monster( const mtype_id &id ) : monster()
 
 monster::monster( const mtype_id &id, const tripoint_bub_ms &p ) : monster( id )
 {
-    set_pos_bub_only( p );
+    map &here = get_map();
+
+    set_pos_bub_only( here, p );
     unset_dest();
 }
 
@@ -712,7 +714,9 @@ void monster::try_biosignature()
 
 void monster::spawn( const tripoint_bub_ms &p )
 {
-    set_pos_bub_only( p );
+    map &here = get_map();
+
+    set_pos_bub_only( here, p );
     unset_dest();
     try_upgrade( false );
 }
@@ -873,6 +877,8 @@ std::string monster::speed_description( float mon_speed_rating,
 
 int monster::print_info( const catacurses::window &w, int vStart, int vLines, int column ) const
 {
+    const map &here = get_map();
+
     const int vEnd = vStart + vLines;
     const int max_width = getmaxx( w ) - column - 1;
     std::ostringstream oss;
@@ -900,7 +906,7 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
     vStart += fold_and_print( w, point( column, vStart ), max_width, c_white, oss.str() );
 
     Character &pc = get_player_character();
-    bool sees_player = sees( pc );
+    bool sees_player = sees( here, pc );
     const bool player_knows = !pc.has_trait( trait_INATTENTIVE );
 
     // Hostility indicator on the second line.
@@ -1478,13 +1484,16 @@ void monster::wander_to( const tripoint_abs_ms &p, int f )
 
 Creature *monster::attack_target()
 {
+    const map &here = get_map();
+
     if( !has_dest() ) {
         return nullptr;
     }
 
     Creature *target = get_creature_tracker().creature_at( get_dest() );
     if( target == nullptr || target == this ||
-        attitude_to( *target ) == Attitude::FRIENDLY || !sees( *target ) || target->is_hallucination() ) {
+        attitude_to( *target ) == Attitude::FRIENDLY || !sees( here,  *target ) ||
+        target->is_hallucination() ) {
         return nullptr;
     }
 
@@ -2000,7 +2009,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
     if( /*This happens sometimes*/ this == &target || !is_adjacent( &target, true ) ) {
         return false;
     }
-    if( !sees( target ) && !target.is_hallucination() ) {
+    if( !sees( here, target ) && !target.is_hallucination() ) {
         debugmsg( "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
         return false;
     }
@@ -2023,9 +2032,9 @@ bool monster::melee_attack( Creature &target, float accuracy )
         add_effect( effect_run, 4_turns );
     }
 
-    const bool u_see_me = player_character.sees( *this );
-    const bool u_see_my_spot = player_character.sees( this->pos_bub() );
-    const bool u_see_target = player_character.sees( target );
+    const bool u_see_me = player_character.sees( here, *this );
+    const bool u_see_my_spot = player_character.sees( here, this->pos_bub( here ) );
+    const bool u_see_target = player_character.sees( here, target );
 
     damage_instance damage = !is_hallucination() ? type->melee_damage : damage_instance();
     if( !is_hallucination() && type->melee_dice > 0 ) {
@@ -2311,7 +2320,7 @@ bool monster::move_effects( bool, tripoint_bub_ms dest_loc )
     }
 
     map &here = get_map();
-    bool u_see_me = get_player_view().sees( *this );
+    bool u_see_me = get_player_view().sees( here, *this );
     if( has_effect( effect_tied ) ) {
         // friendly pet, will stay tied down and obey.
         if( friendly == -1 ) {
@@ -2897,7 +2906,7 @@ void monster::process_turn()
                                "explosion",
                                "default" );
                 Character &player_character = get_player_character();
-                if( player_character.sees( pos_bub() ) ) {
+                if( player_character.sees( here, pos_bub( here ) ) ) {
                     add_msg( m_bad, _( "Lightning strikes the %s!" ), name() );
                     add_msg( m_bad, _( "Your vision goes white!" ) );
                     player_character.add_effect( effect_blind, rng( 1_minutes, 2_minutes ) );
@@ -2967,7 +2976,7 @@ void monster::die( map *here, Creature *nkiller )
     }
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         // Need to filter out which limb we were grabbing before death
-        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( here ), 1,
+        for( const tripoint_bub_ms &player_pos : here->points_in_radius( pos_bub( *here ), 1,
                 0 ) ) {
             Creature *you = creatures.creature_at( here->get_abs( player_pos ) );
             if( !you || !you->has_effect_with_flag( json_flag_GRAB ) ) {
@@ -3104,14 +3113,14 @@ void monster::die( map *here, Creature *nkiller )
             if( corpse ) {
                 corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
-                here->add_item_or_charges( pos_bub( here ), it );
+                here->add_item_or_charges( pos_bub( *here ), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
                 corpse->put_in( it, pocket_type::CORPSE );
             } else {
-                here->add_item( pos_bub( here ), it );
+                here->add_item( pos_bub( *here ), it );
             }
         }
     }
@@ -3233,7 +3242,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
     // for non corpses this is much simpler
     if( !corpse ) {
         for( item &it : new_items ) {
-            here->add_item_or_charges( pos_bub( here ), it );
+            here->add_item_or_charges( pos_bub( *here ), it );
         }
         return;
     }
@@ -3311,6 +3320,8 @@ void monster::spawn_dissectables_on_death( item *corpse ) const
 
 void monster::process_one_effect( effect &it, bool is_new )
 {
+    map &here = get_map();
+
     // Monsters don't get trait-based reduction, but they do get effect based reduction
     bool reduced = resists_effect( it );
     const auto get_effect = [&it, is_new]( const std::string & arg, bool reduced ) {
@@ -3360,7 +3371,7 @@ void monster::process_one_effect( effect &it, bool is_new )
                x_in_y( it.get_intensity(), it.get_max_intensity() ) ) {
         // this is for balance only
         it.mod_duration( -rng( 1_turns, it.get_int_dur_factor() / 2 ) );
-        bleed();
+        bleed( here );
         if( id == effect_bleed ) {
             // monsters are simplified so they just take damage from bleeding
             apply_damage( it.get_source().resolve_creature(), bodypart_id( "torso" ), 1 );
@@ -3416,6 +3427,8 @@ void monster::process_one_effect( effect &it, bool is_new )
 
 void monster::process_effects()
 {
+    map &here = get_map();
+
     // Monster only effects
     for( auto &elem : *effects ) {
         for( auto &_effect_it : elem.second ) {
@@ -3902,7 +3915,7 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
                 continue;
             }
 
-            if( here->sees( critter.pos_bub( here ), pos_bub( here ), light ) ) {
+            if( here->sees( critter.pos_bub( *here ), pos_bub( *here ), light ) ) {
                 // Anger trumps fear trumps ennui
                 if( critter.type->has_anger_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.anger += 15;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3427,8 +3427,6 @@ void monster::process_one_effect( effect &it, bool is_new )
 
 void monster::process_effects()
 {
-    map &here = get_map();
-
     // Monster only effects
     for( auto &elem : *effects ) {
         for( auto &_effect_it : elem.second ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1183,9 +1183,9 @@ void npc::place_on_map( map *here )
         return;
     }
 
-    for( const tripoint_abs_ms &p : closest_points_first( pos_abs( here ), SEEX + 1 ) ) {
+    for( const tripoint_abs_ms &p : closest_points_first( pos_abs(), SEEX + 1 ) ) {
         if( g->is_empty( here, p ) ) {
-            setpos( here, here->get_bub( p ) );
+            setpos( p );
             return;
         }
     }
@@ -3013,7 +3013,7 @@ void npc::die( map *here, Creature *nkiller )
     }
     if( !is_hallucination() ) {
         Character &you = get_player_character();
-        if( is_player_ally() && you.sees( *this ) ) {
+        if( is_player_ally() && you.sees( *here, pos_bub() ) ) {
             if( !you.has_flag( json_flag_PSYCHOPATH ) && !you.has_trait( trait_NUMB ) ) {
                 if( you.has_flag( json_flag_SPIRITUAL ) ) {
                     you.add_morale( morale_faction_member_died, -15, -15, 2_days, 18_hours );
@@ -3026,7 +3026,7 @@ void npc::die( map *here, Creature *nkiller )
             const character_id &cid = entry.first;
             Character *member = g->critter_by_id<Character>( cid );
             // TODO: Finding out after the fact.
-            if( member->sees( *this ) ) {
+            if( member->sees( *here, pos_bub() ) ) {
                 if( !member->has_flag( json_flag_PSYCHOPATH ) && !member->has_trait( trait_NUMB ) ) {
                     if( member->has_flag( json_flag_SPIRITUAL ) ) {
                         member->add_morale( morale_faction_member_died, -15, -15, 2_days, 18_hours );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -278,8 +278,10 @@ standard_npc::standard_npc( const std::string &name, const tripoint_bub_ms &pos,
                             const std::vector<std::string> &clothing,
                             int sk_lvl, int s_str, int s_dex, int s_int, int s_per )
 {
+    map &here = get_map();
+
     this->name = name;
-    set_pos_bub_only( pos );
+    set_pos_bub_only( here, pos );
     if( !getID().is_valid() ) {
         setID( g->assign_npc_id() );
     }
@@ -1181,7 +1183,7 @@ void npc::place_on_map( map *here )
         return;
     }
 
-    for( const tripoint_abs_ms &p : closest_points_first( pos_abs(), SEEX + 1 ) ) {
+    for( const tripoint_abs_ms &p : closest_points_first( pos_abs( here ), SEEX + 1 ) ) {
         if( g->is_empty( here, p ) ) {
             setpos( here, here->get_bub( p ) );
             return;
@@ -1482,6 +1484,8 @@ bool npc::wear_if_wanted( const item &it, std::string &reason )
 
 void npc::stow_item( item &it )
 {
+    map &here = get_map();
+
     bool stow_bionic_weapon = is_using_bionic_weapon()
                               && get_wielded_item().get_item() == &it;
     if( stow_bionic_weapon ) {
@@ -1489,7 +1493,7 @@ void npc::stow_item( item &it )
         return;
     }
 
-    bool avatar_sees = get_player_view().sees( pos_bub() );
+    bool avatar_sees = get_player_view().sees( here, pos_bub( here ) );
     if( wear_item( it, false ) ) {
         // Wearing the item was successful, remove weapon and post message.
         if( avatar_sees ) {
@@ -1509,12 +1513,14 @@ void npc::stow_item( item &it )
         if( avatar_sees ) {
             add_msg_if_npc( m_info, _( "<npcname> drops the %s." ), it.tname() );
         }
-        get_map().add_item_or_charges( pos_bub(), remove_item( it ) );
+        here.add_item_or_charges( pos_bub( here ), remove_item( it ) );
     }
 }
 
 bool npc::wield( item &it )
 {
+    const map &here = get_map();
+
     // sanity check: exit early if we're trying to wield the current weapon
     // needed for ranged_balance_test
     if( is_wielding( it ) ) {
@@ -1553,7 +1559,7 @@ bool npc::wield( item &it )
     cata::event e = cata::event::make<event_type::character_wields_item>( getID(), weapon->typeId() );
     get_event_bus().send_with_talker( this, &weapon, e );
 
-    if( get_player_view().sees( pos_bub() ) ) {
+    if( get_player_view().sees( here, pos_bub( here ) ) ) {
         add_msg_if_npc( m_info, _( "<npcname> wields a %s." ),  weapon->tname() );
     }
     invalidate_range_cache();
@@ -1750,10 +1756,12 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
 
 void npc::mutiny()
 {
+    const map &here = get_map();
+
     if( !my_fac || !is_player_ally() ) {
         return;
     }
-    const bool seen = get_player_view().sees( pos_bub() );
+    const bool seen = get_player_view().sees( here, pos_bub( here ) );
     if( seen ) {
         add_msg( m_bad, _( "%s is tired of your incompetent leadership and abuse!" ), disp_name() );
     }
@@ -1962,16 +1970,18 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
 
 int npc::indoor_voice() const
 {
+    const map &here = get_map();
+
     const int max_volume = get_shout_volume();
     const int min_volume = 1;
     // Actual hearing distance is incredibly dependent on ambient noise and our noise propagation model is... rather binary
     // But we'll assume people normally want to project their voice about 6 meters away.
     int wanted_volume = 6;
     Character &player = get_player_character();
-    const int distance_to_player = rl_dist( pos_bub(), player.pos_bub() );
+    const int distance_to_player = rl_dist( pos_abs(), player.pos_abs() );
     if( is_following() || is_ally( player ) ) {
         wanted_volume = distance_to_player;
-    } else if( is_enemy() && sees( player.pos_bub() ) ) {
+    } else if( is_enemy() && sees( here, player.pos_bub( here ) ) ) {
         // Battle cry! Bandits have no concept of indoor voice, even when not threatened.
         wanted_volume = max_volume;
     }
@@ -2647,6 +2657,8 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
 
 void npc::npc_dismount()
 {
+    map &here = get_map();
+
     if( !mounted_creature || !has_effect( effect_riding ) ) {
         add_msg_debug( debugmode::DF_NPC,
                        "NPC %s tried to dismount, but they have no mount, or they are not riding",
@@ -2654,7 +2666,7 @@ void npc::npc_dismount()
         return;
     }
     std::optional<tripoint_bub_ms> pnt;
-    for( const tripoint_bub_ms &elem : get_map().points_in_radius( pos_bub(), 1 ) ) {
+    for( const tripoint_bub_ms &elem : here.points_in_radius( pos_bub( here ), 1 ) ) {
         if( g->is_empty( elem ) ) {
             pnt = elem;
             break;
@@ -2672,7 +2684,7 @@ void npc::npc_dismount()
     mounted_creature->remove_effect( effect_ridden );
     mounted_creature->add_effect( effect_controlled, 5_turns );
     mounted_creature = nullptr;
-    setpos( *pnt );
+    setpos( here, *pnt );
     mod_moves( -get_speed() );
 }
 
@@ -2735,7 +2747,7 @@ int npc::follow_distance() const
         return 2;
     }
     // If NPC doesn't see player, change follow distance to 2
-    if( !sees( player_character ) ) {
+    if( !sees( here,  player_character ) ) {
         return 2;
     }
     return 4;
@@ -2759,6 +2771,8 @@ nc_color npc::basic_symbol_color() const
 
 int npc::print_info( const catacurses::window &w, int line, int vLines, int column ) const
 {
+    const map &here = get_map();
+
     const int last_line = line + vLines;
     const int iWidth = getmaxx( w ) - 1 - column;
     // First line of w is the border; the next 4 are terrain info, and after that
@@ -2784,10 +2798,10 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     wprintz( w, symbol_color(), " %s", npc_attitude_name( get_attitude() ) );
 
     // Awareness indicator on the third line.
-    std::string senses_str = sees( player_character ) ? _( "Aware of your presence" ) :
+    std::string senses_str = sees( here, player_character ) ? _( "Aware of your presence" ) :
                              _( "Unaware of you" );
     line += fold_and_print( w, point( column, line ), iWidth,
-                            sees( player_character ) ? c_yellow : c_green,
+                            sees( here, player_character ) ? c_yellow : c_green,
                             senses_str );
 
     // Print what item the NPC is holding if any on the fourth line.
@@ -3064,7 +3078,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( pos_bub( here ), true );
+        here->unboard_vehicle( pos_bub( *here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3267,7 +3281,9 @@ void npc::add_msg_player_or_npc( const game_message_params &params,
                                  const std::string &/*player_msg*/,
                                  const std::string &npc_msg ) const
 {
-    if( get_player_view().sees( *this ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, *this ) ) {
         add_msg( params, replace_with_npc_name( npc_msg ) );
     }
 }
@@ -3368,14 +3384,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
-        !here->has_vehicle_floor( pos_bub( here ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( *here ) ) &&
+        !here->has_vehicle_floor( pos_bub( *here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( pos_bub( here ), this );
+        here->board_vehicle( pos_bub( *here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {
@@ -3609,7 +3625,7 @@ std::string npc::extended_description() const
     } else if( attitude == NPCATT_FLEE || attitude == NPCATT_FLEE_TEMP ) {
         ss += _( "Is trying to flee from you." );
     } else if( is_player_ally() ) {
-        ss += _( "Is your friend." );
+        ss += _( "Is your ally." );
     } else if( is_following() ) {
         ss += _( "Is following you." );
     } else if( is_leader() ) {
@@ -3618,12 +3634,6 @@ std::string npc::extended_description() const
         ss += _( "Will try to kill you or flee from you if you reveal yourself." );
     } else {
         ss += _( "Is neutral." );
-    }
-
-    if( hit_by_player ) {
-        ss += "--\n";
-        ss += _( "Is still innocent and killing them will be considered murder." );
-        // TODO: "But you don't care because you're an edgy psycho"
     }
 
     return replace_colors( ss );
@@ -3778,6 +3788,8 @@ npc_attitude npc::get_attitude() const
 
 void npc::set_attitude( npc_attitude new_attitude )
 {
+    const map &here = get_map();
+
     if( new_attitude == attitude ) {
         return;
     }
@@ -3793,7 +3805,7 @@ void npc::set_attitude( npc_attitude new_attitude )
                    get_name(), npc_attitude_id( attitude ), npc_attitude_id( new_attitude ) );
     attitude_group new_group = get_attitude_group( new_attitude );
     attitude_group old_group = get_attitude_group( attitude );
-    if( new_group != old_group && !is_fake() && get_player_view().sees( *this ) ) {
+    if( new_group != old_group && !is_fake() && get_player_view().sees( here, *this ) ) {
         switch( new_group ) {
             case attitude_group::hostile:
                 add_msg_if_npc( m_bad, _( "<npcname> gets angry!" ) );

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -174,6 +174,8 @@ int npc_attack_spell::base_time_penalty( const npc &source ) const
 npc_attack_rating npc_attack_spell::evaluate_tripoint(
     const npc &source, const Creature *target, const tripoint_bub_ms &location ) const
 {
+    const map &here = get_map();
+
     const spell &attack_spell = source.magic->get_spell( attack_spell_id );
 
     double total_potential = 0;
@@ -195,7 +197,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
 
         const Creature::Attitude att = source.attitude_to( *critter );
         int damage = 0;
-        if( source.sees( *critter ) ) {
+        if( source.sees( here, *critter ) ) {
             damage = attack_spell.dps( source, *critter );
         }
         const int distance_to_me = static_cast<int>( std::round( trig_dist_z_adjust( source.pos_bub(),

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -966,6 +966,8 @@ static void tell_magic_veh_stop_following()
 
 void game::chat()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     int volume = player_character.get_shout_volume();
 
@@ -974,8 +976,8 @@ void game::chat()
         return ( guy.is_npc() || ( guy.is_monster() &&
                                    guy.as_monster()->has_flag( mon_flag_CONVERSATION ) &&
                                    !guy.as_monster()->type->chat_topics.empty() ) ) && u.posz() == guy.posz() &&
-               u.sees( guy.pos_bub() ) &&
-               rl_dist( u.pos_bub(), guy.pos_bub() ) <= SEEX * 2;
+               u.sees( here, guy.pos_bub( here ) ) &&
+               rl_dist( u.pos_abs(), guy.pos_abs() ) <= SEEX * 2;
     } );
     const int available_count = available.size();
     const std::vector<npc *> followers = get_npcs_if( [&]( const npc & guy ) {
@@ -999,7 +1001,7 @@ void game::chat()
     std::vector<vehicle *> following_vehicles;
     std::vector<vehicle *> magic_vehicles;
     std::vector<vehicle *> magic_following_vehicles;
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle &veh : here.get_vehicles() ) {
         vehicle *&v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) &&
             v->is_owned_by( player_character ) ) {
@@ -1227,7 +1229,6 @@ void game::chat()
                 return;
             }
 
-            map &here = get_map();
             std::optional<tripoint_bub_ms> p = look_around();
 
             if( !p ) {
@@ -1442,7 +1443,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
         say( chat_snippets().snip_acknowledged.translated() );
     }
 
-    if( sees( spos ) || is_hallucination() ) {
+    if( sees( here, spos ) || is_hallucination() ) {
         return;
     }
     // ignore low priority sounds if the NPC "knows" it came from a friend.
@@ -1460,7 +1461,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
     }
     // discount if sound source is player, or seen by player,
     // and listener is friendly and sound source is combat or alert only.
-    if( spriority < sounds::sound_t::alarm && player_character.sees( spos ) ) {
+    if( spriority < sounds::sound_t::alarm && player_character.sees( here, spos ) ) {
         if( is_player_ally() ) {
             add_msg_debug( debugmode::DF_NPC, "NPC %s ignored low priority noise that player can see",
                            get_name() );
@@ -5996,6 +5997,8 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
 talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                                         std::string_view member, const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::vector<str_or_var> unique_ids;
     for( JsonValue jv : jo.get_array( "unique_ids" ) ) {
@@ -6009,7 +6012,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
     }
     bool npc_must_see = jo.get_bool( "npc_must_see", false );
     if( local ) {
-        return [eocs, unique_ids, npc_must_see, npc_range, is_npc]( dialogue const & d ) {
+        return [eocs, unique_ids, npc_must_see, npc_range, is_npc, &here]( dialogue const & d ) {
             tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub();
             std::vector<std::string> ids;
             ids.reserve( unique_ids.size() );
@@ -6017,7 +6020,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                 ids.emplace_back( id.evaluate( d ) );
             }
             const std::vector<npc *> available = g->get_npcs_if( [npc_must_see, npc_range, actor_pos,
-                          ids]( const npc & guy ) {
+                          ids, &here]( const npc & guy ) {
                 bool id_valid = ids.empty();
                 for( const std::string &id : ids ) {
                     if( id == guy.get_unique_id() ) {
@@ -6026,7 +6029,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                     }
                 }
                 return id_valid && ( !npc_range.has_value() || actor_pos.z() == guy.posz() ) && ( !npc_must_see ||
-                        guy.sees( actor_pos ) ) &&
+                        guy.sees( here, actor_pos ) ) &&
                        ( !npc_range.has_value() || rl_dist( actor_pos, guy.pos_bub() ) <= npc_range.value() );
             } );
             for( npc *target : available ) {
@@ -6058,6 +6061,8 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
 talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         std::string_view member, const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::vector<str_or_var> mtype_ids;
     for( JsonValue jv : jo.get_array( "mtype_ids" ) ) {
@@ -6068,7 +6073,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         monster_range = jo.get_int( "monster_range" );
     }
     bool monster_must_see = jo.get_bool( "monster_must_see", false );
-    return [eocs, mtype_ids, monster_must_see, monster_range, is_npc]( dialogue const & d ) {
+    return [eocs, mtype_ids, monster_must_see, monster_range, is_npc, &here]( dialogue const & d ) {
         std::vector<mtype_id> ids;
         ids.reserve( mtype_ids.size() );
         for( const str_or_var &id : mtype_ids ) {
@@ -6076,7 +6081,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         }
         tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub();
         const std::vector<Creature *> available = g->get_creatures_if( [ ids, monster_must_see,
-             monster_range, actor_pos ]( const Creature & critter ) {
+             monster_range, actor_pos, &here ]( const Creature & critter ) {
             bool id_valid = ids.empty();
             bool creature_is_monster = critter.is_monster();
             if( creature_is_monster ) {
@@ -6090,7 +6095,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
             return creature_is_monster && id_valid && ( !monster_range.has_value() ||
                     actor_pos.z() == critter.posz() ) &&
                    ( !monster_must_see ||
-                     critter.sees( actor_pos ) ) &&
+                     critter.sees( here, actor_pos ) ) &&
                    ( !monster_range.has_value() || rl_dist( actor_pos, critter.pos_bub() ) <= monster_range.value() );
         } );
         for( Creature *target : available ) {
@@ -6655,6 +6660,8 @@ talk_effect_fun_t::func f_deal_damage( const JsonObject &jo, std::string_view me
 talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view member,
         const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     bool group = jo.get_bool( "group", false );
     bool single_target = jo.get_bool( "single_target", false );
     str_or_var monster_id = get_str_or_var( jo.get_member( member ), member );
@@ -6687,7 +6694,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
     return [monster_id, dov_target_range, dov_hallucination_count, dov_real_count, dov_min_radius,
                         dov_max_radius, outdoor_only, indoor_only, group, single_target, dov_lifespan, target_var,
                         spawn_message, spawn_message_plural, true_eocs, false_eocs, open_air_allowed, temporary_drop_items,
-                friendly, is_npc]( dialogue & d ) {
+                friendly, is_npc, &here]( dialogue & d ) {
         monster target_monster;
         std::vector<Creature *> target_monsters;
         mongroup_id target_mongroup;
@@ -6754,7 +6761,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
+            target_pos = here.get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6781,7 +6788,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                             critter->as_monster()->friendly = -1;
                         }
                         spawns++;
-                        if( get_avatar().sees( *critter ) ) {
+                        if( get_avatar().sees( here, *critter ) ) {
                             visible_spawns++;
                         }
                     }
@@ -6806,7 +6813,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                         spawned->friendly = -1;
                     }
                     spawns++;
-                    if( get_avatar().sees( *spawned ) ) {
+                    if( get_avatar().sees( here, *spawned ) ) {
                         visible_spawns++;
                     }
                     lifespan = dov_lifespan.evaluate( d );
@@ -6835,6 +6842,8 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
 talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view member,
                                      const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     str_or_var sov_npc_class = get_str_or_var( jo.get_member( member ), member );
     str_or_var unique_id;
     if( jo.has_member( "unique_id" ) ) {
@@ -6874,7 +6883,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
     return [sov_npc_class, unique_id, traits, dov_hallucination_count, dov_real_count,
                            dov_min_radius,
                            dov_max_radius, outdoor_only, indoor_only, dov_lifespan, target_var, spawn_message,
-                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc]( dialogue & d ) {
+                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc, &here]( dialogue & d ) {
         int min_radius = dov_min_radius.evaluate( d );
         int max_radius = dov_max_radius.evaluate( d );
         int real_count = dov_real_count.evaluate( d );
@@ -6889,7 +6898,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
+            target_pos = here.get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6905,7 +6914,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
                     Creature *guy = get_creature_tracker().creature_at( spawn_point );
                     if( guy ) {
                         spawns++;
-                        if( get_avatar().sees( *guy ) ) {
+                        if( get_avatar().sees( here, *guy ) ) {
                             visible_spawns++;
                         }
                     }
@@ -6926,7 +6935,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
                     Creature *guy = get_creature_tracker().creature_at( spawn_point );
                     if( guy ) {
                         spawns++;
-                        if( get_avatar().sees( *guy ) ) {
+                        if( get_avatar().sees( here, *guy ) ) {
                             visible_spawns++;
                         }
                     }
@@ -7090,13 +7099,15 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
 
 talk_effect_fun_t::func f_wants_to_talk( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( dialogue const & d ) {
         npc *p = d.actor( is_npc )->get_npc();
         if( p ) {
             if( p->get_attitude() == NPCATT_TALK ) {
                 return;
             }
-            if( p->sees( get_player_character() ) ) {
+            if( p->sees( here, get_player_character() ) ) {
                 add_msg( _( "%s wants to talk to you." ), p->get_name() );
             }
             p->set_attitude( NPCATT_TALK );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -820,9 +820,11 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
                         _( "Use whatever weapon you normally would" ) : _( "Don't use ranged weapons for a while" ) );
         nmenu.addentry( NPC_CHAT_PULP, true, 'p', guy->rules.has_override_enable( ally_rule::allow_pulp ) ?
                         _( "Pulp zombies if you like" ) : _( "Hold off on pulping zombies for a while" ) );
-        nmenu.addentry( NPC_CHAT_AVOID_DOORS, true, 'w', guy->rules.has_override_enable( ally_rule::avoid_doors ) ?
+        nmenu.addentry( NPC_CHAT_AVOID_DOORS, true, 'w',
+                        guy->rules.has_override_enable( ally_rule::avoid_doors ) ?
                         _( "Open doors to get where you're going" ) : _( "Don't walk through closed doors" ) );
-        nmenu.addentry( NPC_CHAT_CLOSE_DOORS, true, 'a', guy->rules.has_override_enable( ally_rule::close_doors ) ?
+        nmenu.addentry( NPC_CHAT_CLOSE_DOORS, true, 'a',
+                        guy->rules.has_override_enable( ally_rule::close_doors ) ?
                         _( "Close the doors" ) : _( "Leave doors open" ) );
         nmenu.addentry( NPC_CHAT_FOLLOW_CLOSE, true, 'c',
                         guy->rules.has_override_enable( ally_rule::follow_close ) &&

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -922,11 +922,13 @@ void talk_function::deny_personal_info( npc &p )
 
 void talk_function::hostile( npc &p )
 {
+    const map &here = get_map();
+
     if( p.get_attitude() == NPCATT_KILL ) {
         return;
     }
 
-    if( p.sees( get_player_character() ) ) {
+    if( p.sees( here, get_player_character() ) ) {
         add_msg( _( "%s turns hostile!" ), p.get_name() );
     }
 
@@ -1076,7 +1078,7 @@ void talk_function::player_weapon_drop( npc &/*p*/ )
     Character &player_character = get_player_character();
     item weap = player_character.remove_weapon();
     drop_on_map( player_character, item_drop_reason::deliberate, {weap}, &here,
-                 player_character.pos_bub( &here ) );
+                 player_character.pos_bub( here ) );
 }
 
 void talk_function::lead_to_safety( npc &p )
@@ -1247,11 +1249,13 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
 
 npc *pick_follower()
 {
+    const map &here = get_map();
+
     std::vector<npc *> followers;
     std::vector<tripoint_bub_ms> locations;
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_player_ally() && get_player_view().sees( guy ) ) {
+        if( guy.is_player_ally() && get_player_view().sees( here, guy ) ) {
             followers.push_back( &guy );
             locations.push_back( guy.pos_bub() );
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1599,7 +1599,7 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
         map &here = get_map();
-        const tripoint_bub_ms local = this_monster.pos_bub( &here );
+        const tripoint_bub_ms local = this_monster.pos_bub( here );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -545,7 +545,7 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
 
             Creature *critter = creatures.creature_at( p, true );
 
-            if( critter == nullptr || !get_player_view().sees( *critter ) ) {
+            if( critter == nullptr || !get_player_view().sees( m, *critter ) ) {
                 continue;
             }
 

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -306,6 +306,8 @@ static void eff_fun_rat( Character &u, effect &it )
 }
 static void eff_fun_bleed( Character &u, effect &it )
 {
+    map &here = get_map();
+
     if( u.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) {
         return;
     }
@@ -356,7 +358,7 @@ static void eff_fun_bleed( Character &u, effect &it )
                 }
                 suffer_string = iter->second;
             }
-            u.bleed();
+            u.bleed( here );
             bodypart_id bp = it.get_bp();
             // piece together the final displayed message here instead of inline, for readability's sake
             // format the chosen string with the relevant variables to make it human-readable, then translate everything we have so far
@@ -658,7 +660,7 @@ static void eff_fun_teleglow( Character &u, effect &it )
                 for( const MonsterGroupResult &mgr : spawn_details ) {
                     g->place_critter_at( mgr.name, dest );
                 }
-                if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
+                if( uistate.distraction_hostile_spotted && player_character.sees( here, dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                         _( "A monster appears nearby!" ) );
                     add_msg( m_warning, _( "A portal opens nearby, and a monster crawls through!" ) );
@@ -1270,7 +1272,7 @@ void Character::hardcoded_effects( effect &it )
                 for( const MonsterGroupResult &mgr : spawn_details ) {
                     g->place_critter_at( mgr.name, dest );
                 }
-                if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
+                if( uistate.distraction_hostile_spotted && player_character.sees( here, dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                         _( "A monster appears nearby!" ) );
                     add_msg_if_player( m_warning, _( "A portal opens nearby, and a monster crawls through!" ) );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -227,7 +227,9 @@ int max_aoe_size( const std::set<ammo_effect_str_id> &tags )
 void multi_projectile_hit_message( Creature *critter, int hit_count, int damage_taken,
                                    const std::string &projectile_name )
 {
-    if( hit_count > 0 && get_player_character().sees( *critter ) ) {
+    const map &here = get_map();
+
+    if( hit_count > 0 && get_player_character().sees( here, *critter ) ) {
         // Building a phrase to summarize the fragment effects.
         // Target, Number of impacts, total amount of damage, proportion of deflected fragments.
         std::map<int, std::string> impact_count_descriptions = {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -996,10 +996,10 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots )
         debugmsg( "%s doesn't have a gun to fire", get_name() );
         return 0;
     }
-    return fire_gun( &here, target, shots, *gun, item_location() );
+    return fire_gun( here, target, shots, *gun, item_location() );
 }
 
-int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, item &gun,
                          item_location ammo )
 {
     if( !gun.is_gun() ) {
@@ -1022,7 +1022,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
 
     // cap our maximum burst size by ammo and energy
     if( !gun.has_flag( flag_VEHICLE ) && !ammo ) {
-        shots = std::min( shots, gun.shots_remaining( this ) );
+        shots = std::min( shots, gun.shots_remaining( here, this ) );
     } else if( gun.ammo_required() ) {
         // This checks ammo only. Vehicle turret energy drain is handled elsewhere.
         const int ammo_left = ammo ? ammo.get_item()->count() : gun.ammo_remaining( );
@@ -1035,10 +1035,10 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
     }
 
     // usage of any attached bipod is dependent upon terrain or on being prone
-    bool bipod = here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
+    bool bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
                  is_prone();
     if( !bipod ) {
-        if( const optional_vpart_position vp = here->veh_at( pos_abs( ) ) ) {
+        if( const optional_vpart_position vp = here.veh_at( pos_abs( ) ) ) {
             bipod = vp->vehicle().has_part( pos_abs( ), "MOUNTABLE" );
         }
     }
@@ -1078,7 +1078,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         // If this is a vehicle mounted turret, which vehicle is it mounted on?
-        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here->veh_at(
+        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here.veh_at(
                                     pos_bub( here ) ) ) : nullptr;
 
         // Add gunshot noise
@@ -1101,7 +1101,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         dispersion.add_range( dispersion_variance() );
 
         dealt_projectile_attack shot;
-        projectile_attack( shot, proj, here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
+        projectile_attack( shot, proj, &here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
         if( !shot.targets_hit.empty() ) {
             hits++;
         }
@@ -1156,7 +1156,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
+        if( gun.ammo_consume( required, &here, pos_bub( here ), this ) != required ) {
             debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
             break;
         }
@@ -1164,7 +1164,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         // Vehicle turrets drain vehicle battery and do not care about this
         if( !gun.has_flag( flag_VEHICLE ) ) {
             const units::energy energ_req = gun.get_gun_energy_drain();
-            const units::energy drained = gun.energy_consume( energ_req, here, pos_bub( here ), this );
+            const units::energy drained = gun.energy_consume( energ_req, &here, pos_bub( here ), this );
             if( drained < energ_req ) {
                 debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
                           gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
@@ -1173,7 +1173,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         if( !current_ammo.is_null() ) {
-            cycle_action( gun, current_ammo, here, pos_bub( here ) );
+            cycle_action( gun, current_ammo, &here, pos_bub( here ) );
         }
 
         if( gun_skill == skill_launcher ) {
@@ -1276,6 +1276,8 @@ static double calculate_aim_cap_without_target( const Character &you,
 // Handle capping aim level when the player cannot see the target tile or there is nothing to aim at.
 double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
 {
+    const map &here = get_map();
+
     const Creature *victim = get_creature_tracker().creature_at( target, true );
     // nothing here, nothing to aim
     if( victim == nullptr ) {
@@ -1286,7 +1288,7 @@ double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
     enchant_cache::special_vision sees_with_special = you.enchantment_cache->get_vision( d );
 
     // you do not see it, but your sense it in other ways
-    if( !you.sees( *victim ) && !sees_with_special.is_empty() ) {
+    if( !you.sees( here,  *victim ) && !sees_with_special.is_empty() ) {
         if( sees_with_special.precise ) {
             // your senses are precise enough to aim it with no issues
             return 0.0;
@@ -1754,15 +1756,17 @@ static double target_size_in_moa( int range, double size )
 
 Target_attributes::Target_attributes( tripoint_bub_ms src, tripoint_bub_ms target )
 {
+    const map &here = get_map();
+
     Creature *target_critter = get_creature_tracker().creature_at( target );
     Creature *shooter = get_creature_tracker().creature_at( src );
     range = static_cast<int>( std::round( trig_dist_z_adjust( src, target ) ) );
     size = target_critter != nullptr ?
            target_critter->ranged_target_size() :
-           get_map().ranged_target_size( target );
+           here.ranged_target_size( target );
     size_in_moa = target_size_in_moa( range, size ) ;
-    light = get_map().ambient_light_at( target );
-    visible = shooter->sees( target );
+    light = here.ambient_light_at( target );
+    visible = shooter->sees( here, target );
 
 }
 Target_attributes::Target_attributes( int rng, double target_size, float light_target,
@@ -2137,8 +2141,10 @@ static int print_throwforce( const catacurses::window &w, int line_number, float
 // Whether player character knows creature's position and can roughly track it with the aim cursor
 static bool pl_sees( const Creature &cr )
 {
+    const map &here = get_map();
+
     Character &u = get_player_character();
-    return u.sees( cr ) || u.sees_with_specials( cr );
+    return u.sees( here,  cr ) || u.sees_with_specials( cr );
 }
 
 static int print_aim( const target_ui &ui, Character &you, const catacurses::window &w,
@@ -2174,8 +2180,10 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
                             int &text_y, input_context &ctxt, const item &weapon, const tripoint_bub_ms &target_pos,
                             bool is_blind_throw )
 {
+    const map &here = get_map();
+
     Creature *target = get_creature_tracker().creature_at( target_pos, true );
-    if( target != nullptr && !you.sees( *target ) ) {
+    if( target != nullptr && !you.sees( here, *target ) ) {
         target = nullptr;
     }
 
@@ -2202,8 +2210,8 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
             target_ui::TargetMode::ThrowBlind :
             target_ui::TargetMode::Throw;
     Target_attributes attributes( range, target_size,
-                                  get_map().ambient_light_at( target_pos ),
-                                  you.sees( target_pos ) );
+                                  here.ambient_light_at( target_pos ),
+                                  you.sees( here, target_pos ) );
 
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
             throwing_target_mode, ctxt, weapon, dispersion, confidence_config, attributes, target_pos,
@@ -3296,6 +3304,8 @@ void target_ui::update_target_list()
 
 tripoint_bub_ms target_ui::choose_initial_target()
 {
+    map &here = get_map();
+
     // Try previously targeted creature
     shared_ptr_fast<Creature> cr = you->last_target.lock();
     if( cr && pl_sees( *cr ) && dist_fn( cr->pos_bub() ) <= range ) {
@@ -3312,7 +3322,7 @@ tripoint_bub_ms target_ui::choose_initial_target()
     const std::vector<tripoint_bub_ms> nearby = closest_points_first( src, range );
     const auto target_spot = std::find_if( nearby.begin(), nearby.end(),
     [this, &here]( const tripoint_bub_ms & pt ) {
-        return here.tr_at( pt ).id == tr_practice_target && this->you->sees( pt );
+        return here.tr_at( pt ).id == tr_practice_target && this->you->sees( here, pt );
     } );
     if( target_spot != nearby.end() ) {
         return *target_spot;
@@ -3465,6 +3475,8 @@ bool target_ui::prompt_friendlies_in_lof()
 
 std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
 {
+    const map &here = get_map();
+
     std::vector<weak_ptr_fast<Creature>> ret;
     if( mode == TargetMode::Turrets || mode == TargetMode::Spell ) {
         debugmsg( "Not implemented" );
@@ -3474,7 +3486,7 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
     for( const tripoint_bub_ms &p : traj ) {
         if( p != dst && p != src ) {
             Creature *cr = creatures.creature_at( p, true );
-            if( cr && you->sees( *cr ) ) {
+            if( cr && you->sees( here, *cr ) ) {
                 Creature::Attitude a = cr->attitude_to( *this->you );
                 if(
                     ( cr->is_npc() && a != Creature::Attitude::HOSTILE ) ||
@@ -4272,9 +4284,11 @@ void target_ui::panel_spell_info( int &text_y )
 
 void target_ui::panel_target_info( int &text_y, bool fill_with_blank_if_no_target )
 {
+    const map &here = get_map();
+
     int max_lines = 6;
     if( dst_critter ) {
-        if( you->sees( *dst_critter ) ) {
+        if( you->sees( here, *dst_critter ) ) {
             // FIXME: print_info doesn't really care about line limit
             //        and can always occupy up to 4 of them (or even more?).
             //        To make things consistent, we ask it for 2 lines

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2225,7 +2225,8 @@ static void draw_throwcreature_aim( const target_ui &ui, const Character &you,
                                     int &text_y, input_context &ctxt, const tripoint_bub_ms &target_pos )
 {
     Creature *target = get_creature_tracker().creature_at( target_pos, true );
-    if( target != nullptr && !you.sees( *target ) ) {
+    map &here = get_map();
+    if( target != nullptr && !you.sees( here, *target ) ) {
         target = nullptr;
     }
     item weapon = null_item_reference();
@@ -2250,7 +2251,7 @@ static void draw_throwcreature_aim( const target_ui &ui, const Character &you,
     const target_ui::TargetMode throwing_target_mode = target_ui::TargetMode::ThrowCreature;
     Target_attributes attributes( range, target_size,
                                   get_map().ambient_light_at( tripoint_bub_ms( target_pos ) ),
-                                  you.sees( target_pos ) );
+                                  you.sees( here, target_pos ) );
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
             throwing_target_mode, ctxt, weapon, dispersion, throwforce_config_critter, attributes, target_pos,
             item_location() );
@@ -3318,7 +3319,6 @@ tripoint_bub_ms target_ui::choose_initial_target()
     }
 
     // Try closest practice target
-    map &here = get_map();
     const std::vector<tripoint_bub_ms> nearby = closest_points_first( src, range );
     const auto target_spot = std::find_if( nearby.begin(), nearby.end(),
     [this, &here]( const tripoint_bub_ms & pt ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -565,6 +565,8 @@ static bool describe_sound( sounds::sound_t category, bool from_player_position 
 
 void sounds::process_sound_markers( Character *you )
 {
+    const map &here = get_map();
+
     bool is_deaf = you->is_deaf();
     const float volume_multiplier = you->hearing_ability();
     const int weather_vol = get_weather().weather_id->sound_attn;
@@ -628,7 +630,7 @@ void sounds::process_sound_markers( Character *you )
 
         // Noises from vehicle player is in.
         if( you->controlling_vehicle ) {
-            vehicle *veh = veh_pointer_or_null( get_map().veh_at( you->pos_bub() ) );
+            vehicle *veh = veh_pointer_or_null( here.veh_at( you->pos_abs() ) );
             const int noise = veh ? static_cast<int>( veh->vehicle_noise ) : 0;
 
             you->volume = std::max( you->volume, noise );
@@ -665,7 +667,7 @@ void sounds::process_sound_markers( Character *you )
         }
 
         // don't print our own noise or things without descriptions
-        if( !sound.ambient && ( pos != you->pos_bub() ) && !get_map().pl_sees( pos, distance_to_sound ) ) {
+        if( !sound.ambient && ( pos != you->pos_bub() ) && !here.pl_sees( pos, distance_to_sound ) ) {
             if( uistate.distraction_noise &&
                 !you->activity.is_distraction_ignored( distraction_type::noise ) &&
                 !get_safemode().is_sound_safe( sound.description, distance_to_sound, you->controlling_vehicle ) ) {
@@ -684,9 +686,9 @@ void sounds::process_sound_markers( Character *you )
                 severity = m_warning;
             }
             // if we can see it, don't print a direction
-            if( pos == you->pos_bub() ) {
+            if( pos == you->pos_bub( here ) ) {
                 add_msg( severity, _( "From your position you hear %1$s" ), description );
-            } else if( you->sees( pos ) ) {
+            } else if( you->sees( here, pos ) ) {
                 add_msg( severity, _( "You hear %1$s" ), description );
             } else {
                 std::string direction = direction_name( direction_from( you->pos_bub(), pos ) );
@@ -725,7 +727,8 @@ void sounds::process_sound_markers( Character *you )
         }
 
         // Place footstep markers.
-        if( pos == you->pos_bub() || ( you->sees( pos ) && ( sound.category != sound_t::sensory ) ) ) {
+        if( pos == you->pos_bub() || ( you->sees( here, pos ) &&
+                                       ( sound.category != sound_t::sensory ) ) ) {
             // If we are or can see the source, don't draw a marker, except for sonar etc
             continue;
         }
@@ -763,8 +766,8 @@ void sounds::process_sound_markers( Character *you )
         // Unless the source is on a different z-level, then any point is fine
         // Also show sensory sounds like SONAR even if we can see the point.
         std::vector<tripoint_bub_ms> unseen_points;
-        for( const tripoint_bub_ms &newp : get_map().points_in_radius( pos, err_offset ) ) {
-            if( diff_z || sound.category == sound_t::sensory || !you->sees( newp ) ) {
+        for( const tripoint_bub_ms &newp : here.points_in_radius( pos, err_offset ) ) {
+            if( diff_z || sound.category == sound_t::sensory || !you->sees( here,  newp ) ) {
                 unseen_points.emplace_back( newp );
             }
         }
@@ -911,7 +914,7 @@ void sfx::do_vehicle_engine_sfx()
     } else if( player_character.in_sleep_state() && audio_muted ) {
         return;
     }
-    optional_vpart_position vpart_opt = here.veh_at( player_character.pos_bub( &here ) );
+    optional_vpart_position vpart_opt = here.veh_at( player_character.pos_bub( here ) );
     vehicle *veh;
     if( vpart_opt.has_value() ) {
         veh = &vpart_opt->vehicle();
@@ -1059,9 +1062,9 @@ void sfx::do_vehicle_exterior_engine_sfx()
     for( wrapped_vehicle vehicle : vehs ) {
         if( vehicle.v->vehicle_noise > 0 &&
             vehicle.v->vehicle_noise -
-            sound_distance( player_character.pos_bub( &here ), vehicle.v->pos_bub( here ) ) > noise_factor ) {
+            sound_distance( player_character.pos_bub( here ), vehicle.v->pos_bub( here ) ) > noise_factor ) {
 
-            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub( &here ),
+            noise_factor = vehicle.v->vehicle_noise - sound_distance( player_character.pos_bub( here ),
                            vehicle.v->pos_bub( here ) );
             veh = vehicle.v;
         }

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -515,7 +515,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
         }
     }
 
-    you.setpos( best_spot );
+    you.setpos( here, best_spot );
 
     if( !found_good_spot ) {
         debugmsg( "Could not find a good starting place for character" );

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -132,7 +132,9 @@ dealt_damage_instance talker_character_const::deal_damage( Creature *source, bod
 
 void talker_character::set_pos( tripoint_bub_ms new_pos )
 {
-    me_chr->setpos( new_pos );
+    map &here = get_map();
+
+    me_chr->setpos( here, new_pos );
 }
 
 void talker_character::set_str_max( int value )
@@ -876,7 +878,9 @@ bool talker_character_const::can_see() const
 
 bool talker_character_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
-    return me_chr_const->sees( pos );
+    const map &here = get_map();
+
+    return me_chr_const->sees( here, pos );
 }
 
 void talker_character::set_fatigue( int amount )

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -4,6 +4,8 @@
 #include "effect.h"
 #include "item.h"
 #include "magic.h"
+#include "map.h"
+#include "messages.h"
 #include "monster.h"
 #include "mtype.h"
 #include "point.h"
@@ -182,7 +184,9 @@ int talker_monster_const::get_grab_strength() const
 
 bool talker_monster_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
-    return me_mon_const->sees( pos );
+    const map &here = get_map();
+
+    return me_mon_const->sees( here, pos );
 }
 
 int talker_monster_const::get_volume() const

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -172,7 +172,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             if( tfrag_attempts-- < 1 ) {
                 if( p && display_message ) {
                     p->add_msg_player_or_npc( m_warning, _( "You flicker." ), _( "<npcname> flickers." ) );
-                } else if( get_player_view().sees( critter ) && display_message ) {
+                } else if( get_player_view().sees( here, critter ) && display_message ) {
                     add_msg( _( "%1$s flickers." ), critter.disp_name() );
                 }
                 return false;
@@ -207,7 +207,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                                                   poor_soul->disp_name() );
                     }
                 } else {
-                    if( get_player_view().sees( *poor_soul ) ) {
+                    if( get_player_view().sees( here, *poor_soul ) ) {
                         if( display_message ) {
                             add_msg( m_warning,
                                      _( "%1$s collides with %2$s mid teleport, and they are both knocked away by a violent explosion of energy!" ),

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -423,8 +423,8 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
                 }
             }
             if( !valid.empty() ) {
-                player_character.setpos( random_entry( valid ) );
-                z->setpos( player_character.pos_bub() );
+                player_character.setpos( here, random_entry( valid ) );
+                z->setpos( player_character.pos_abs() );
             }
             player_character.mod_moves( -z->get_speed() * 1.5 );
             g->update_map( player_character );
@@ -443,7 +443,7 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
             }
         }
         if( !valid.empty() ) {
-            you->setpos( random_entry( valid ) );
+            you->setpos( here, random_entry( valid ) );
         }
         you->mod_moves( -you->get_speed() * 1.5 );
         if( c->is_avatar() ) {
@@ -513,7 +513,7 @@ bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
                                             _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = get_player_view().sees( *z );
+            bool seen = get_player_view().sees( here, *z );
             int chance = 0;
             // adapted from shotgun code - chance of getting hit depends on size
             switch( z->type->size ) {
@@ -618,7 +618,7 @@ bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
                                             _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = get_player_view().sees( *z );
+            bool seen = get_player_view().sees( here,  *z );
             int chance = 0;
             switch( z->type->size ) {
                 case creature_size::tiny:
@@ -921,7 +921,7 @@ bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
         return false;
     }
     monster *z = dynamic_cast<monster *>( c );
-    bool player_sees = get_player_view().sees( p );
+    bool player_sees = get_player_view().sees( here, p );
     if( z != nullptr ) {
         if( z->type->in_species( species_ROBOT ) ) {
             //The monster is a robot. So the dissector should not try to dissect the monsters flesh.
@@ -1318,7 +1318,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
                                    _( "<npcname> steps on a sinkhole, but manages to pull themselves to safety." ) );
-        you.setpos( random_entry( safe ) );
+        you.setpos( here, random_entry( safe ) );
         if( you.is_avatar() ) {
             g->update_map( you );
         }

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -317,7 +317,7 @@ int turret_data::fire( Character &c, map *here, const tripoint_bub_ms &target )
     gun_mode mode = base()->gun_current_mode();
 
     prepare_fire( c );
-    shots = c.fire_gun( here, target, mode.qty, *mode );
+    shots = c.fire_gun( *here, target, mode.qty, *mode );
     post_fire( here, c, shots );
     return shots;
 }
@@ -576,7 +576,7 @@ npc &vehicle_part::get_targeting_npc( vehicle &veh )
         brain.name = string_format( _( "The %s turret" ), get_base().tname( 1 ) );
         brain.set_skill_level( get_base().gun_skill(), 8 );
     }
-    cpu.brain->setpos( veh.bub_part_pos( here, *this ) );
+    cpu.brain->setpos( here, veh.bub_part_pos( here, *this ) );
     cpu.brain->recalc_sight_limits();
     return *cpu.brain;
 }
@@ -606,7 +606,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( pos );
+    const bool u_see = player_character.sees( here, pos );
     const bool u_hear = !player_character.is_deaf();
     // The current target of the turret.
     auto &target = pt.target;

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -206,7 +206,7 @@ void orient_part( map &here, vehicle *veh, const vpart_info &vpinfo, int partnum
         point_rel_ms copied_placement = *part_placement;
         offset = offset + copied_placement;
     }
-    player_character.view_offset = offset - player_character.pos_bub( &here );
+    player_character.view_offset = offset - player_character.pos_bub( here );
 
     point_rel_ms delta;
     do {

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -35,7 +35,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
     const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
     [&]() {
         const avatar &you = get_avatar();
-        g->draw_cursor_unobscuring( you.pos_bub( &here ) + you.view_offset );
+        g->draw_cursor_unobscuring( you.pos_bub( here ) + you.view_offset );
     } );
     g->add_draw_callback( target_ui_cb );
     ui_adaptor ui;

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -140,7 +140,7 @@ bool repair_part( map &here, vehicle &veh, vehicle_part &pt, Character &who )
         const point_rel_ms mount = pt.mount;
         const units::angle direction = pt.direction;
         const std::string variant = pt.variant;
-        here.spawn_items( who.pos_bub( &here ), pt.pieces_for_broken_part() );
+        here.spawn_items( who.pos_bub( here ), pt.pieces_for_broken_part() );
         veh.remove_part( pt );
         const int partnum = veh.install_part( here, mount, vpid, std::move( base ) );
         if( partnum >= 0 ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -788,12 +788,12 @@ void vehicle::drive_to_local_target( map *here, const tripoint_abs_ms &target,
                                          player_character.current_movement_mode()->move_speed_mult();
     if( follow_protocol ) {
         if( ( ( turn_x > 0 || turn_x < 0 ) && velocity > safe_player_follow_speed ) ||
-            rl_dist( vehpos, here->get_abs( player_character.pos_bub( here ) ) ) < 7 + ( (
+            rl_dist( vehpos, here->get_abs( player_character.pos_bub( *here ) ) ) < 7 + ( (
                         mount_max.y() * 3 ) + 4 ) ) {
             accel_y = 1;
         }
         if( ( velocity < std::min( safe_velocity( *here ), safe_player_follow_speed ) && turn_x == 0 &&
-              rl_dist( vehpos, here->get_abs( player_character.pos_bub( here ) ) ) > 8 + ( (
+              rl_dist( vehpos, here->get_abs( player_character.pos_bub( *here ) ) ) > 8 + ( (
                           mount_max.y() * 3 ) + 4 ) ) ||
             velocity < 100 ) {
             accel_y = -1;
@@ -1900,7 +1900,7 @@ bool vehicle::merge_appliance_into_grid( map *here, vehicle &veh_target )
     }
     // Release grab if player is dragging either appliance
     if( get_avatar().get_grab_type() == object_type::VEHICLE ) {
-        const tripoint_bub_ms grab_point = get_avatar().pos_bub( here ) + get_avatar().grab_point;
+        const tripoint_bub_ms grab_point = get_avatar().pos_bub( *here ) + get_avatar().grab_point;
         const optional_vpart_position grabbed_veh = here->veh_at( grab_point );
         if( grabbed_veh && ( &grabbed_veh->vehicle() == this || &grabbed_veh->vehicle() == &veh_target ) ) {
             add_msg( _( "You release the %s." ), grabbed_veh->vehicle().name );
@@ -4815,6 +4815,8 @@ void vehicle::set_owner( const Character &c )
 
 bool vehicle::handle_potential_theft( Character const &you, bool check_only, bool prompt )
 {
+    const map &here = get_map();
+
     const bool is_owned_by_player =
         is_owned_by( you ) || ( you.is_npc() && is_owned_by( get_avatar() ) &&
                                 you.as_npc()->is_friendly( get_avatar() ) );
@@ -4822,10 +4824,12 @@ bool vehicle::handle_potential_theft( Character const &you, bool check_only, boo
     if( is_owned_by_player ) {
         return true;
     }
-    std::vector<Creature *> witnesses = g->get_creatures_if( [&you, this]( Creature const & cr ) {
+    std::vector<Creature *> witnesses = g->get_creatures_if( [&you, this,
+          &here]( Creature const & cr ) {
         Character const *const elem = cr.as_character();
         return elem != nullptr && you.getID() != elem->getID() && is_owned_by( *elem ) &&
-               rl_dist( elem->pos_bub(), you.pos_bub() ) < MAX_VIEW_DISTANCE && elem->sees( you.pos_bub() );
+               rl_dist( elem->pos_bub( here ), you.pos_bub( here ) ) < MAX_VIEW_DISTANCE &&
+               elem->sees( here, you.pos_bub( here ) );
     } );
     if( !has_owner() || ( witnesses.empty() && ( has_old_owner() || you.is_npc() ) ) ) {
         if( !has_owner() ||
@@ -5430,7 +5434,7 @@ void vehicle::power_parts( map &here )
                 for( int elem : reactors ) {
                     parts[ elem ].enabled = false;
                 }
-                if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( here ) ) ) {
+                if( player_is_driving_this_veh( &here ) || player_character.sees( here, pos_bub( here ) ) ) {
                     add_msg( _( "The %s's reactor dies!" ), name );
                 }
             }
@@ -5465,13 +5469,13 @@ void vehicle::power_parts( map &here )
 
         is_alarm_on = false;
         camera_on = false;
-        if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( here ) ) ) {
+        if( player_is_driving_this_veh( &here ) || player_character.sees( here, pos_bub( here ) ) ) {
             add_msg( _( "The %s's battery dies!" ), name );
         }
         if( engine_epower < 0_W ) {
             // Not enough epower to run gas engine ignition system
             engine_on = false;
-            if( player_is_driving_this_veh( &here ) || player_character.sees( pos_bub( here ) ) ) {
+            if( player_is_driving_this_veh( &here ) || player_character.sees( here, pos_bub( here ) ) ) {
                 add_msg( _( "The %s's engine dies!" ), name );
             }
         }
@@ -5831,7 +5835,7 @@ void vehicle::idle( map &here, bool on_map )
         engine_on = false;
     }
 
-    if( !warm_enough_to_plant( player_character.pos_bub( &here ) ) ) {
+    if( !warm_enough_to_plant( player_character.pos_bub( here ) ) ) {
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {
@@ -5896,7 +5900,7 @@ void vehicle::idle( map &here, bool on_map )
     for( vehicle_part *turret : turrets() ) {
         item_location base = turret_query( *turret ).base();
         // Notify player about status of a turret if they're on the same tile
-        if( player_at_controls || player_character.pos_bub( &here ) == base.pos_bub() ) {
+        if( player_at_controls || player_character.pos_bub( here ) == base.pos_bub() ) {
             base->process( here, &player_character, base.pos_bub() );
         } else {
             base->process( here, nullptr, base.pos_bub() );

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -728,7 +728,7 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
     // we reach them
     if( pt_omt == data.current_omt ) {
         // driver must see the tile or have seen it before in order to plan a route over it
-        if( !driver.sees( pt ) ) {
+        if( !driver.sees( here, pt ) ) {
             if( !driver.is_avatar() ) {
                 return false;
             }
@@ -750,7 +750,7 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
     // check for creatures
     // TODO: padding around monsters
     Creature *critter = get_creature_tracker().creature_at( pt, true );
-    if( critter && driver.sees( *critter ) ) {
+    if( critter && driver.sees( here, *critter ) ) {
         return false;
     }
 
@@ -1171,7 +1171,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( map 
     bool blind = true;
     for( const point_rel_ms &p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
         const tripoint_bub_ms next = data.adjust_z( here, veh_pos + forward_offset + p );
-        if( driver.sees( next ) ) {
+        if( driver.sees( here, next ) ) {
             blind = false;
         }
         // Known quirk: the player does not always see points above or below when driving
@@ -1217,7 +1217,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( map 
     }
     for( const point_rel_ms &p : collision_zone ) {
         const tripoint_bub_ms next = data.adjust_z( here, veh_pos + p );
-        if( !data.is_flying && !driver.sees( next ) ) {
+        if( !data.is_flying && !driver.sees( here, next ) ) {
             return collision_check_result::slow_down;
         }
         if( !check_drivable( here, next ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1182,7 +1182,7 @@ veh_collision vehicle::part_collision( map &here, int part, const tripoint_abs_m
             }
 
             if( vpi.has_flag( "SHARP" ) ) {
-                critter->bleed();
+                critter->bleed( here );
             } else {
                 sounds::sound( pos, 20, sounds::sound_t::combat, snd, false, "smash_success", "hit_vehicle" );
             }
@@ -1249,7 +1249,7 @@ void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp
 
     Character &player_character = get_player_character();
     const Character *driver = get_driver( *here );
-    const bool seen = player_character.sees( p );
+    const bool seen = player_character.sees( *here, p );
     const bool known = tr.can_see( p, player_character );
     const bool damage_done = vp_wheel.info().durability <= veh_data.damage;
     if( seen && damage_done ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1620,7 +1620,7 @@ void vehicle::use_harness( int part, map *here, const tripoint_bub_ms &pos )
 
     // TODO: Make 'choose_adjacent_highlight' map aware.
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
+                *here, _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
                 false );
     if( !pnt_ ) {
         add_msg( m_info, _( "Never mind." ) );

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -5,14 +5,15 @@
 #include "coords_fwd.h"
 
 class Creature;
+class map;
 
 // This is strictly an interface that provides access to a game entity's Field of View.
 class viewer
 {
     public:
-        virtual bool sees( const tripoint_bub_ms &target, bool is_avatar = false,
+        virtual bool sees( const map &here, const tripoint_bub_ms &target, bool is_avatar = false,
                            int range_mod = 0 ) const = 0;
-        virtual bool sees( const Creature &target ) const = 0;
+        virtual bool sees( const map &here, const Creature &target ) const = 0;
         virtual ~viewer() = default;
 };
 

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -116,7 +116,7 @@ static int running_steps( Character &they, const ter_str_id &terrain = ter_t_pav
         last_moves = they.get_moves();
     }
     // Reset to starting position
-    they.setpos( left );
+    they.setpos( here, left );
     return steps;
 }
 

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -74,19 +74,19 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
 
     clear_vehicles(); // extra safety
     here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
-    you.setpos( test_pos );
-    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( &here ) );
+    you.setpos( here, test_pos );
+    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( here ) );
     REQUIRE( vp_there );
     tripoint_abs_ms dest_loc = you.pos_abs();
 
     // Empty aisle
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Aisle with 10L rock, a tight fit but not impossible
     dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
@@ -97,24 +97,24 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     CHECK( 75_liter <= you.get_total_volume() );
     CHECK( you.get_total_volume() <= 100_liter );
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
     CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
-    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint::north;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
-    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // And finally, check that our HUGE body won't fit even into an empty aisle.
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
 }

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -49,6 +49,8 @@ static void check_not_near( const std::string &subject, float actual, const floa
 
 static float get_avg_melee_dmg( const std::string &clothing_id, bool infect_risk = false )
 {
+    map &here = get_map();
+
     monster zed( mon_manhack, mon_pos );
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     item cloth( clothing_id );
@@ -59,7 +61,7 @@ static float get_avg_melee_dmg( const std::string &clothing_id, bool infect_risk
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( dude, true );
-        dude.setpos( dude_pos );
+        dude.setpos( here, dude_pos );
         dude.wear_item( cloth, false );
         dude.add_effect( effect_sleep, 1_hours );
         if( zed.melee_attack( dude, 10000.0f ) ) {
@@ -85,6 +87,8 @@ static float get_avg_melee_dmg( const std::string &clothing_id, bool infect_risk
 
 static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 {
+    map &here = get_map();
+
     monster zed( mon_manhack, mon_pos );
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     if( infect_risk ) {
@@ -94,7 +98,7 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( dude, true );
-        dude.setpos( dude_pos );
+        dude.setpos( here, dude_pos );
         dude.wear_item( cloth, false );
         dude.add_effect( effect_sleep, 1_hours );
         if( zed.melee_attack( dude, 10000.0f ) ) {
@@ -120,6 +124,7 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 
 static float get_avg_bullet_dmg( const std::string &clothing_id )
 {
+    map &here = get_map();
     clear_map();
     std::unique_ptr<standard_npc> badguy = std::make_unique<standard_npc>( "TestBaddie",
                                            badguy_pos, std::vector<std::string>(), 0, 8, 8, 8, 8 );
@@ -137,13 +142,13 @@ static float get_avg_bullet_dmg( const std::string &clothing_id )
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( *dude, true );
-        dude->setpos( dude_pos );
+        dude->setpos( here, dude_pos );
         dude->wear_item( cloth, false );
         dude->add_effect( effect_sleep, 1_hours );
         dealt_projectile_attack atk;
         projectile_attack( atk, proj, badguy_pos, dude_pos, dispersion_sources(),
                            &*badguy );
-        dude->deal_projectile_attack( &get_map(),  & *badguy, atk, atk.missed_by, false );
+        dude->deal_projectile_attack( &here,  & *badguy, atk, atk.missed_by, false );
         if( atk.missed_by < 1.0 ) {
             num_hits++;
         }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -345,7 +345,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
         g->load_npcs();
 
         CHECK( !dummy.in_vehicle );
-        dummy.setpos( who.pos_bub() );
+        dummy.setpos( who.pos_abs() );
         const auto helpers( dummy.get_crafting_helpers() );
 
         REQUIRE( std::find( helpers.begin(), helpers.end(), &who ) != helpers.end() );
@@ -445,7 +445,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();
     player_character.toggle_trait( trait_DEBUG_CNF );
-    player_character.setpos( test_origin );
+    player_character.setpos( here, test_origin );
     const recipe &r = rid.obj();
     grant_skills_to_character( player_character, r, offset );
     if( grant_profs ) {
@@ -2317,7 +2317,7 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
     clear_vehicles();
     clear_avatar();
     avatar &player = get_avatar();
-    player.setpos( tripoint_bub_ms( 60, 58, 0 ) );
+    player.setpos( here, tripoint_bub_ms( 60, 58, 0 ) );
     const tripoint_bub_ms veh_pos( 60, 60, 0 );
     const tripoint_bub_ms furn1_pos( 60, 57, 0 );
     const tripoint_bub_ms furn2_pos( 60, 56, 0 );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -325,18 +325,19 @@ TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )
 
 TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 {
+    map &here = get_map();
     clear_avatar();
     clear_map();
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     overmap_buffer.insert_npc( guy );
     npc &npc = *guy;
     clear_character( npc );
-    std::optional<tripoint_bub_ms> const dest = random_point( get_map(), [](
+    std::optional<tripoint_bub_ms> const dest = random_point( here, [](
     tripoint_bub_ms const & p ) {
         return p.xy() != get_avatar().pos_bub().xy();
     } );
     REQUIRE( dest.has_value() );
-    npc.setpos( { dest.value().xy(), get_avatar().posz() } );
+    npc.setpos( here, { dest.value().xy(), get_avatar().posz() } );
 
     tripoint_abs_ms const start = get_avatar().pos_abs();
     tripoint_abs_ms const end = npc.pos_abs();
@@ -1234,7 +1235,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( &here, target_pos, 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( here, target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }
@@ -1254,7 +1255,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
         get_avatar().set_body();
         arm_shooter( get_avatar(), "shotgun_s" );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( &here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -410,13 +410,14 @@ TEST_CASE( "fungal_haze_test", "[field]" )
 
 TEST_CASE( "player_in_field_test", "[field][player]" )
 {
+    map &here = get_map();
     fields_test_setup();
     clear_avatar();
     const tripoint_bub_ms p{ 33, 33, 0 };
 
     Character &dummy = get_avatar();
-    const tripoint_bub_ms prev_char_pos = dummy.pos_bub();
-    dummy.setpos( p );
+    const tripoint_bub_ms prev_char_pos = dummy.pos_bub( here );
+    dummy.setpos( here, p );
 
     map &m = get_map();
 
@@ -443,7 +444,7 @@ TEST_CASE( "player_in_field_test", "[field][player]" )
     }
 
     clear_avatar();
-    dummy.setpos( prev_char_pos );
+    dummy.setpos( here, prev_char_pos );
     fields_test_cleanup();
 }
 
@@ -488,7 +489,7 @@ TEST_CASE( "player_double_effect_field_test", "[field][player]" )
     Character &dummy = get_avatar();
     map &m = get_map();
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -512,7 +513,7 @@ TEST_CASE( "player_single_effect_field_test_head", "[field][player]" )
     item head_armor( "test_hazmat_hat" );
     dummy.wear_item( head_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -536,7 +537,7 @@ TEST_CASE( "player_single_effect_field_test_torso", "[field][player]" )
     item torso_armor( "test_hazmat_shirt" );
     dummy.wear_item( torso_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -562,7 +563,7 @@ TEST_CASE( "player_single_effect_field_test_all", "[field][player]" )
     item head_armor( "test_hazmat_hat" );
     dummy.wear_item( head_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -749,12 +749,13 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
 
 TEST_CASE( "Inventory_letter_test", "[.invlet]" )
 {
+    map &here = get_map();
     avatar &dummy = get_avatar();
     const tripoint_bub_ms spot( 60, 60, 0 );
     clear_map();
-    dummy.setpos( spot );
-    get_map().ter_set( spot, ter_id( "t_dirt" ) );
-    get_map().furn_set( spot, furn_id( "f_null" ) );
+    dummy.setpos( here, spot );
+    here.ter_set( spot, ter_id( "t_dirt" ) );
+    here.furn_set( spot, furn_id( "f_null" ) );
 
     invlet_test_autoletter_off( "Picking up items from the ground", dummy, GROUND, INVENTORY );
     invlet_test_autoletter_off( "Wearing items from the ground", dummy, GROUND, WORN );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -728,11 +728,12 @@ static item_location give_water( avatar &dummy, int count, bool in_inventory )
 
 TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 {
+    map &here = get_map();
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
     const tripoint_bub_ms test_origin( 20, 20, 0 );
-    dummy.setpos( test_origin );
+    dummy.setpos( here, test_origin );
     // Give the player a backpack to hold the tablets
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
 
@@ -896,10 +897,10 @@ TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 
     SECTION( "6 tablets will purify a toilet tank" ) {
         item_location tablet = give_tablets( dummy, 6, true );
-        get_map().furn_set( dummy.pos_bub() + tripoint::north, furn_f_toilet );
+        here.furn_set( dummy.pos_bub( here ) + tripoint::north, furn_f_toilet );
         item water( itype_water );
         water.charges = 24;
-        get_map().add_item( dummy.pos_bub() + tripoint::north, water );
+        here.add_item( dummy.pos_bub( here ) + tripoint::north, water );
         item_location water_location( map_cursor( dummy.pos_bub() + tripoint::north ), &water );
 
         REQUIRE( water_location );
@@ -922,11 +923,12 @@ TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 
 TEST_CASE( "water_tablet_purification_test", "[iuse][pur_tablets]" )
 {
+    map &here = get_map();
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
     const tripoint_bub_ms test_origin( 20, 20, 0 );
-    dummy.setpos( test_origin );
+    dummy.setpos( here, test_origin );
 
     SECTION( "Test purifying time" ) {
         item_location tablet = give_tablets( dummy, 1, true );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -36,6 +36,7 @@ static std::set<tripoint_abs_ms> count_fields_near(
 
 TEST_CASE( "line_attack", "[magic]" )
 {
+    map &here = get_map();
     // manually construct a testable spell
     JsonObject obj = json_loader::from_string(
                          "  {\n"
@@ -60,7 +61,7 @@ TEST_CASE( "line_attack", "[magic]" )
     // set up Character to test with, only need position
     npc &c = spawn_npc( point_bub_ms::zero, "test_talker" );
     clear_character( c );
-    c.setpos( tripoint_bub_ms::zero );
+    c.setpos( here, tripoint_bub_ms::zero );
 
     // target point 5 tiles east of zero
     tripoint_bub_ms target = c.pos_bub() + tripoint_rel_ms::east * 5;
@@ -68,11 +69,11 @@ TEST_CASE( "line_attack", "[magic]" )
     // Ensure that AOE=0 spell covers the 5 tiles along vector towards target
     SECTION( "aoe=0" ) {
         const std::set<tripoint_bub_ms> reference( {
-            c.pos_bub() + tripoint_rel_ms::east * 1,
-            c.pos_bub() + tripoint_rel_ms::east * 2,
-            c.pos_bub() + tripoint_rel_ms::east * 3,
-            c.pos_bub() + tripoint_rel_ms::east * 4,
-            c.pos_bub() + tripoint_rel_ms::east * 5,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 1,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 2,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 3,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 4,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 5,
         } );
 
         std::set<tripoint_bub_ms> targets = calculate_spell_effect_area( sp, target, c );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -528,6 +528,7 @@ TEST_CASE( "spell_area_of_effect", "[magic][spell][aoe]" )
 TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack]" )
 {
     // World setup
+    map &here = get_map();
     clear_map();
 
     // Locations for avatar and monster
@@ -542,7 +543,7 @@ TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack
     // Avatar/spellcaster
     avatar &dummy = get_avatar();
     clear_character( dummy );
-    dummy.setpos( dummy_loc );
+    dummy.setpos( here, dummy_loc );
     REQUIRE( dummy.pos_bub() == dummy_loc );
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );
@@ -594,7 +595,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     avatar &dummy = get_avatar();
     creature_tracker &creatures = get_creature_tracker();
     clear_character( dummy );
-    dummy.setpos( dummy_loc );
+    dummy.setpos( here, dummy_loc );
     REQUIRE( dummy.pos_bub() == dummy_loc );
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -145,9 +145,10 @@ void clear_map( int zmin, int zmax )
 
 void clear_map_and_put_player_underground()
 {
+    map &here = get_map();
     clear_map();
     // Make sure the player doesn't block the path of the monster being tested.
-    get_player_character().setpos( tripoint_bub_ms{ 0, 0, -2 } );
+    get_player_character().setpos( here, tripoint_bub_ms{ 0, 0, -2 } );
 }
 
 monster &spawn_test_monster( const std::string &monster_type, const tripoint_bub_ms &start,

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -68,7 +68,7 @@ TEST_CASE( "destroy_grabbed_furniture" )
     GIVEN( "Furniture grabbed by the player" ) {
         const tripoint_bub_ms test_origin( 60, 60, 0 );
         map &here = get_map();
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         const tripoint_bub_ms grab_point = test_origin + tripoint::east;
         here.furn_set( grab_point, furn_id( "f_chair" ) );
         player_character.grab( object_type::FURNITURE, tripoint_rel_ms::east );
@@ -266,10 +266,10 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
 
 TEST_CASE( "active_monster_drops", "[active_item][map]" )
 {
-    clear_map();
-    get_avatar().setpos( tripoint_bub_ms::zero );
-    tripoint_bub_ms start_loc = get_avatar().pos_bub() + tripoint::east;
     map &here = get_map();
+    clear_map();
+    get_avatar().setpos( here, tripoint_bub_ms::zero );
+    tripoint_bub_ms start_loc = get_avatar().pos_bub( here ) + tripoint::east;
     restore_on_out_of_scope restore_temp(
         get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE( "mapgen_remove_npcs" )
         clear_map();
         clear_avatar();
         tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
-        get_avatar().setpos( start_loc );
+        get_avatar().setpos( here, start_loc );
         clear_npcs();
         set_time( calendar::turn_zero + 12_hours );
 
@@ -80,7 +80,7 @@ TEST_CASE( "mapgen_remove_npcs" )
         place_npc_and_check( here, loc2, update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
-        REQUIRE( get_avatar().sees( loc, true ) );
+        REQUIRE( get_avatar().sees( here, loc, true ) );
 
         WHEN( "removing NPC" ) {
             remove_npc_and_check( here, loc, update_mapgen_test_update_remove_npc,

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -90,7 +90,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     clear_avatar();
     // this position should prevent pointless mapgen
     tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
-    get_avatar().setpos( start_loc );
+    get_avatar().setpos( here, start_loc );
     clear_map();
     REQUIRE( here.get_vehicles().empty() );
 

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -71,6 +71,7 @@ static void reset_caches( int a_zlev, int t_zlev )
 static void test_monster_attack( const tripoint &target_offset, bool expect_attack,
                                  bool expect_vision, bool( *special_attack )( monster *x ) = nullptr )
 {
+    map &here = get_map();
     int day_hour = hour_of_day<int>( calendar::turn );
     CAPTURE( day_hour );
     REQUIRE( is_day( calendar::turn ) );
@@ -84,14 +85,14 @@ static void test_monster_attack( const tripoint &target_offset, bool expect_atta
     int t_zlev = target_location.z();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
     test_monster.set_dest( you.pos_abs() );
     reset_caches( a_zlev, t_zlev );
     // Trigger basic attack.
     CAPTURE( attacker_location );
     CAPTURE( target_location );
-    CHECK( test_monster.sees( target_location ) == expect_vision );
+    CHECK( test_monster.sees( here, target_location ) == expect_vision );
     if( special_attack == nullptr ) {
         CHECK( test_monster.attack_at( target_location ) == expect_attack );
     } else {
@@ -100,10 +101,10 @@ static void test_monster_attack( const tripoint &target_offset, bool expect_atta
     // Then test the reverse.
     clear_creatures();
     clear_avatar();
-    you.setpos( attacker_location );
+    you.setpos( here, attacker_location );
     monster &target_monster = spawn_test_monster( monster_type, target_location );
     reset_caches( a_zlev, t_zlev );
-    CHECK( you.sees( target_monster ) == expect_vision );
+    CHECK( you.sees( here, target_monster ) == expect_vision );
     if( special_attack == nullptr ) {
         CHECK( you.melee_attack( target_monster, false ) == expect_attack );
     }
@@ -217,7 +218,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     clear_avatar();
     you.set_dodges_left( 1 ) ;
     REQUIRE( Approx( you.get_dodge() ) == 4.0 );
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     const tripoint_abs_ms abs_target_location = you.pos_abs();
     reset_caches( target_location.z(), target_location.z() );
     REQUIRE( g->natural_light_level( 0 ) > 50.0 );
@@ -231,11 +232,11 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
         test_monster.set_dest( you.pos_abs() );
         const mtype_special_attack &attack = test_monster.type->special_attacks.at( "gun" );
         REQUIRE( test_monster.get_dest() == abs_target_location );
-        REQUIRE( test_monster.sees( target_location ) );
+        REQUIRE( test_monster.sees( here, target_location ) );
         Creature *target = test_monster.attack_target();
         REQUIRE( target );
-        REQUIRE( test_monster.sees( *target ) );
-        REQUIRE( rl_dist( test_monster.pos_bub(), target->pos_bub() ) <= 5 );
+        REQUIRE( test_monster.sees( here, *target ) );
+        REQUIRE( rl_dist( test_monster.pos_abs(), target->pos_abs() ) <= 5 );
         statistics<int> damage_dealt;
         statistics<bool> hits;
         epsilon_threshold threshold{ expected_damage, 2.5 };
@@ -268,12 +269,13 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
 
 TEST_CASE( "Mattack_dialog_condition_test", "[mattack]" )
 {
+    map &here = get_map();
     clear_map();
     clear_creatures();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     const std::string monster_type = "mon_test_mattack_dialog";
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
     test_monster.set_dest( you.pos_abs() );
@@ -320,7 +322,7 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     monster &test_monster_left = spawn_test_monster( grabber_left, attacker_location_e );
     monster &test_monster_right = spawn_test_monster( grabber_right, attacker_location );
@@ -351,6 +353,8 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
 
 TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 {
+    map &here = get_map();
+
     // Set up further from the target
     const tripoint_bub_ms target_location = attacker_location + tripoint{ 4, 0, 0 };
     clear_map();
@@ -360,14 +364,14 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     REQUIRE( units::to_gram<int>( you.get_weight() ) > 50000 );
 
     SECTION( "Weak puller" ) {
         const std::string monster_type = "mon_debug_puller_weak";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here,  you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         REQUIRE( units::to_gram<int>( test_monster.get_weight() ) == 100000 );
         // Fail to pull our too-chonky survivor
@@ -385,7 +389,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const std::string monster_type = "mon_debug_puller_strong";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here,  you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         REQUIRE( units::to_gram<int>( test_monster.get_weight() ) == 100000 );
         // Pull on the first try
@@ -396,7 +400,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const std::string monster_type = "mon_debug_puller_incompetent";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here, you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         // Can't pull, fail silently
         REQUIRE( !attack.call( test_monster ) );
@@ -411,7 +415,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const mattack_actor &grab = test_grabber.type->special_attacks.at( "grab" ).operator * ();
         test_monster.set_dest( you.pos_abs() );
         test_grabber.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here, you ) );
         REQUIRE( grab.call( test_grabber ) );
         int counter = 0;
         // Pull until the grabber lets go, it should eventually do so
@@ -425,12 +429,13 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 
 TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
 {
+    map &here = get_map();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     clear_map();
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     const std::string monster_type = "mon_debug_dragger";
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
@@ -438,7 +443,7 @@ TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
     const mattack_actor &attack_1 = test_monster.type->special_attacks.at( "grab_drag" ).operator * ();
     const mattack_actor &attack_2 = test_monster.type->special_attacks.at( "drag_followup" ).operator
                                     * ();
-    REQUIRE( test_monster.sees( you ) );
+    REQUIRE( test_monster.sees( here, you ) );
     // We're not too chonk
     REQUIRE( test_monster.get_weight() * 1.5f > you.get_weight() );
     // We fail to get dragged by the followup
@@ -457,6 +462,7 @@ TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
 
 TEST_CASE( "Unified_grab_break_test", "[mattack][grab]" )
 {
+    map &here = get_map();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     const tripoint_bub_ms attacker_location_2 = target_location + tripoint::north;
     const tripoint_bub_ms attacker_location_3 = target_location + tripoint::east;
@@ -472,7 +478,7 @@ TEST_CASE( "Unified_grab_break_test", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     SECTION( "Fresh character against 1 weak grab" ) {
         monster_type = "mon_debug_grabber";

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -93,6 +93,7 @@ static std::ostream &operator<<( std::ostream &os, const std::vector<track> &vec
  **/
 static int can_catch_player( const std::string &monster_type, const tripoint &direction_of_flight )
 {
+    map &here = get_map();
     clear_map();
     REQUIRE( g->num_creatures() == 1 ); // the player
     Character &test_player = get_player_character();
@@ -102,7 +103,7 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
     } );
 
     const tripoint_bub_ms center{ 65, 65, 0 };
-    test_player.setpos( center );
+    test_player.setpos( here, center );
     test_player.set_moves( 0 );
     // Give the player a head start.
     const tripoint_bub_ms monster_start = { -10 * direction_of_flight + test_player.pos_bub()
@@ -119,25 +120,25 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
     for( int turn = 0; turn < 1000; ++turn ) {
         test_player.mod_moves( target_speed );
         while( test_player.get_moves() >= 0 ) {
-            test_player.setpos( test_player.pos_bub() + direction_of_flight );
+            test_player.setpos( test_player.pos_abs() + direction_of_flight );
             if( test_player.posx() < SEEX * static_cast<int>( MAPSIZE / 2 ) ||
                 test_player.posy() < SEEY * static_cast<int>( MAPSIZE / 2 ) ||
                 test_player.posx() >= SEEX * ( 1 + static_cast<int>( MAPSIZE / 2 ) ) ||
                 test_player.posy() >= SEEY * ( 1 + static_cast<int>( MAPSIZE / 2 ) ) ) {
                 tripoint_rel_ms offset = center - test_player.pos_bub();
-                test_player.setpos( center );
-                test_monster.setpos( test_monster.pos_bub() + offset );
+                test_player.setpos( here, center );
+                test_monster.setpos( test_monster.pos_abs() + offset );
                 // Verify that only the player and one monster are present.
                 REQUIRE( g->num_creatures() == 2 );
             }
-            const int move_cost = get_map().combined_movecost(
+            const int move_cost = here.combined_movecost(
                                       test_player.pos_bub(), test_player.pos_bub() + direction_of_flight, nullptr, 0 );
             tracker.push_back( {'p', move_cost, rl_dist( test_monster.pos_bub(), test_player.pos_bub() ),
                                 test_player.pos_bub().raw()
                                } );
             test_player.mod_moves( -move_cost );
         }
-        get_map().clear_traps();
+        here.clear_traps();
         test_monster.set_dest( test_player.pos_abs() );
         test_monster.mod_moves( monster_speed );
         while( test_monster.get_moves() >= 0 ) {

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -24,6 +24,8 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 
 TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 {
+    const map &here = get_map();
+
     calendar::turn = midday;
     clear_map( -2, 1 );
     monster &upper = spawn_and_clear( { 5, 5, 0 }, true );
@@ -35,41 +37,41 @@ TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 
     // First check monsters whose vision should be blocked by floors.
     // One intervening floor between monsters.
-    CHECK( !upper.sees( lower ) );
-    CHECK( !lower.sees( upper ) );
+    CHECK( !upper.sees( here, lower ) );
+    CHECK( !lower.sees( here, upper ) );
     // Two intervening floors between monsters.
-    CHECK( !upper.sees( deep ) );
-    CHECK( !deep.sees( upper ) );
+    CHECK( !upper.sees( here, deep ) );
+    CHECK( !deep.sees( here,  upper ) );
     // One intervening floor and an open space between monsters.
-    CHECK( !sky.sees( lower ) );
-    CHECK( !lower.sees( sky ) );
+    CHECK( !sky.sees( here, lower ) );
+    CHECK( !lower.sees( here, sky ) );
     // One intervening floor between monsters, and offset one tile horizontally.
-    CHECK( !adjacent.sees( lower ) );
-    CHECK( !lower.sees( adjacent ) );
+    CHECK( !adjacent.sees( here, lower ) );
+    CHECK( !lower.sees( here,  adjacent ) );
     // One intervening floor between monsters, and offset two tiles horizontally.
-    CHECK( !distant.sees( lower ) );
-    CHECK( !lower.sees( distant ) );
+    CHECK( !distant.sees( here, lower ) );
+    CHECK( !lower.sees( here, distant ) );
     // Two intervening floors between monsters, and offset one tile horizontally.
-    CHECK( !adjacent.sees( deep ) );
-    CHECK( !deep.sees( adjacent ) );
+    CHECK( !adjacent.sees( here,  deep ) );
+    CHECK( !deep.sees( here, adjacent ) );
     // Two intervening floor between monsters, and offset two tiles horizontally.
-    CHECK( !distant.sees( deep ) );
-    CHECK( !deep.sees( distant ) );
+    CHECK( !distant.sees( here, deep ) );
+    CHECK( !deep.sees( here,  distant ) );
 
     // Then cases where they should be able to see each other.
     // No floor between monsters
-    CHECK( upper.sees( sky ) );
-    CHECK( sky.sees( upper ) );
+    CHECK( upper.sees( here, sky ) );
+    CHECK( sky.sees( here, upper ) );
     // Adjacent monsters.
-    CHECK( upper.sees( adjacent ) );
-    CHECK( adjacent.sees( upper ) );
+    CHECK( upper.sees( here, adjacent ) );
+    CHECK( adjacent.sees( here, upper ) );
     // distant monsters.
-    CHECK( upper.sees( distant ) );
-    CHECK( distant.sees( upper ) );
+    CHECK( upper.sees( here, distant ) );
+    CHECK( distant.sees( here, upper ) );
     // One intervening vertical tile and one intervening horizontal tile.
-    CHECK( sky.sees( adjacent ) );
-    CHECK( adjacent.sees( sky ) );
+    CHECK( sky.sees( here, adjacent ) );
+    CHECK( adjacent.sees( here, sky ) );
     // One intervening vertical tile and two intervening horizontal tiles.
-    CHECK( sky.sees( distant ) );
-    CHECK( distant.sees( sky ) );
+    CHECK( sky.sees( here, distant ) );
+    CHECK( distant.sees( here, sky ) );
 }

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -32,14 +32,15 @@ namespace npc_attack_setup
 {
 static npc &spawn_main_npc()
 {
+    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    get_player_character().setpos( { main_npc_start, -1 } );
+    get_player_character().setpos( here, { main_npc_start, -1 } );
     REQUIRE( creatures.creature_at<Creature>( main_npc_start_tripoint ) == nullptr );
-    const character_id model_id = get_map().place_npc( main_npc_start, npc_template_test_talker );
+    const character_id model_id = here.place_npc( main_npc_start, npc_template_test_talker );
 
     npc &model_npc = *g->find_npc( model_id );
     clear_character( model_npc );
-    model_npc.setpos( main_npc_start_tripoint );
+    model_npc.setpos( here, main_npc_start_tripoint );
 
     g->load_npcs();
 
@@ -65,7 +66,9 @@ static monster *spawn_zombie_at_range( const int range )
 
 TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
 {
-    get_player_character().setpos( main_npc_start_tripoint );
+    map &here = get_map();
+
+    get_player_character().setpos( here, main_npc_start_tripoint );
     clear_map_and_put_player_underground();
     clear_vehicles();
     scoped_weather_override sunny_weather( weather_sunny );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -125,6 +125,7 @@ static void change_om_type( const std::string &new_type )
 
 static npc &prep_test( dialogue &d, bool shopkeep = false )
 {
+    map &here = get_map();
     clear_avatar();
     clear_vehicles();
     clear_map();
@@ -134,7 +135,7 @@ static npc &prep_test( dialogue &d, bool shopkeep = false )
     REQUIRE_FALSE( player_character.in_vehicle );
 
     const tripoint_bub_ms test_origin( 15, 15, 0 );
-    player_character.setpos( test_origin );
+    player_character.setpos( here, test_origin );
 
     g->faction_manager_ptr->create_if_needed();
 
@@ -1077,6 +1078,8 @@ TEST_CASE( "npc_test_tags", "[npc_talk]" )
 
 TEST_CASE( "npc_compare_int", "[npc_talk]" )
 {
+    map &here = get_map();
+
     calendar::turn = calendar::turn_zero;
     calendar::start_of_cataclysm = calendar::turn_zero;
     calendar::start_of_game = calendar::turn_zero;
@@ -1158,7 +1161,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     get_weather().weather_precise->humidity = 16;
     get_weather().weather_precise->pressure = 17;
     get_weather().clear_temp_cache();
-    player_character.setpos( tripoint_bub_ms{ -1, -2, -3 } );
+    player_character.setpos( here, tripoint_bub_ms{ -1, -2, -3 } );
     player_character.set_pain( 21 );
     player_character.add_bionic( bio_power_storage );
     player_character.set_power_level( 22_mJ );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -327,6 +327,8 @@ static void check_npc_movement( const tripoint_bub_ms &origin )
 
 static npc *make_companion( const tripoint_bub_ms &npc_pos )
 {
+    map &here = get_map();
+
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     guy->normalize();
     guy->randomize();
@@ -336,7 +338,7 @@ static npc *make_companion( const tripoint_bub_ms &npc_pos )
     guy->companion_mission_role_id.clear();
     guy->guard_pos = std::nullopt;
     clear_character( *guy );
-    guy->setpos( npc_pos );
+    guy->setpos( here, npc_pos );
     talk_function::follow( *guy );
 
     return get_creature_tracker().creature_at<npc>( npc_pos );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -68,6 +68,8 @@ bool character_has_item_with_var_val( const Character &they, const std::string &
 
 void clear_character( Character &dummy, bool skip_nutrition )
 {
+    map &here = get_map();
+
     dummy.set_body();
     dummy.normalize(); // In particular this clears martial arts style
 
@@ -145,7 +147,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.cash = 0;
 
     const tripoint_bub_ms spot( 60, 60, 0 );
-    dummy.setpos( spot );
+    dummy.setpos( here, spot );
     dummy.clear_values();
     dummy.magic = pimpl<known_magic>();
     dummy.forget_all_recipes();

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
     creature_tracker &creatures = get_creature_tracker();
 
     // Move the player out of the way of the test area
-    get_player_character().setpos( tripoint_bub_ms{ 2, 2, 0 } );
+    get_player_character().setpos( here, tripoint_bub_ms{ 2, 2, 0 } );
 
     // Ensure that a projectile fired from a gun can pass through a chain link fence
     // First, set up a test area - three tiles in a row

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -460,7 +460,7 @@ static void shoot_monster( const std::string &gun_type, const std::vector<std::s
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( &here, monster_pos, 1, *shooter->get_wielded_item() );
+        shooter->fire_gun( here, monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( other_checks ) {
             other_check_success += other_checks( *shooter, mon );

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -514,29 +514,29 @@ TEST_CASE( "reading_a_book_with_an_ebook_reader", "[reading][book][ereader]" )
             test_ebook_is_reading( dummy, ereader, booklc );
         }
 
-            REQUIRE( ereader->ammo_remaining( ) == 100 );
+        REQUIRE( ereader->ammo_remaining( ) == 100 );
 
-    dummy.activity.start_or_resume( dummy, false );
-    REQUIRE( dummy.activity.id() == ACT_READ );
+        dummy.activity.start_or_resume( dummy, false );
+        REQUIRE( dummy.activity.id() == ACT_READ );
 
-            CHECK( ereader->ammo_remaining( ) == 99 );
+        CHECK( ereader->ammo_remaining( ) == 99 );
 
-    dummy.activity.do_turn( dummy );
+        dummy.activity.do_turn( dummy );
 
-    CHECK( dummy.activity.id() == ACT_READ );
+        CHECK( dummy.activity.id() == ACT_READ );
 
-            AND_THEN( "ereader has spent a charge while reading" ) {
-                CHECK( ereader->ammo_remaining( ) == 98 );
+        AND_THEN( "ereader has spent a charge while reading" ) {
+            CHECK( ereader->ammo_remaining( ) == 98 );
 
-                AND_THEN( "ereader runs out of battery" ) {
-                    ereader->ammo_consume( ereader->ammo_remaining( ), dummy.pos_bub(), &dummy );
-                    dummy.activity.do_turn( dummy );
+            AND_THEN( "ereader runs out of battery" ) {
+                ereader->ammo_consume( ereader->ammo_remaining( ), dummy.pos_bub(), &dummy );
+                dummy.activity.do_turn( dummy );
 
-            THEN( "reading stops" ) {
-                CHECK( dummy.activity.id() != ACT_READ );
+                THEN( "reading stops" ) {
+                    CHECK( dummy.activity.id() != ACT_READ );
+                }
             }
         }
     }
-}
 }
 }

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -25,7 +25,7 @@ static void check_reload_time( const std::string &weapon, const std::string &amm
     clear_map();
     avatar &shooter = get_avatar();
     g->place_critter_at( pseudo_debug_mon, spot );
-    shooter.setpos( test_origin );
+    shooter.setpos( here, test_origin );
     shooter.set_wielded_item( item( weapon, calendar::turn_zero, 0 ) );
     if( container.empty() ) {
         get_map().add_item( test_origin, item( ammo ) );
@@ -47,7 +47,7 @@ static void check_reload_time( const std::string &weapon, const std::string &amm
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( &here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( shooter.fire_gun( here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -23,6 +23,7 @@ static const efftype_id effect_blind( "blind" );
 
 static void clear_game_drag( const ter_id &terrain )
 {
+    map &here = get_map();
     // Set to turn 0 to prevent solars from producing power
     calendar::turn = calendar::turn_zero;
     clear_creatures();
@@ -31,7 +32,7 @@ static void clear_game_drag( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     CHECK( !player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
     // Make sure the ST is 8 so that muscle powered results are consistent
@@ -39,7 +40,6 @@ static void clear_game_drag( const ter_id &terrain )
 
     build_test_map( terrain );
 
-    map &here = get_map();
     // hard force a rebuild of caches
     here.shift( point_rel_sm::south );
     here.shift( point_rel_sm::north );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -40,6 +40,7 @@ static const itype_id itype_battery( "battery" );
 
 static void clear_game( const ter_id &terrain )
 {
+    map &here = get_map();
     // Set to turn 0 to prevent solars from producing power
     calendar::turn = calendar::turn_zero;
     clear_creatures();
@@ -49,7 +50,7 @@ static void clear_game( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -355,12 +355,12 @@ TEST_CASE( "fake_parts_are_opaque", "[vehicle][vehicle_fake]" )
     map &here = get_map();
     set_time_to_day();
 
-    REQUIRE( you.sees( you.pos_bub() + point( 10, 10 ) ) );
+    REQUIRE( you.sees( here, you.pos_bub( here ) + point( 10, 10 ) ) );
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100, 0 );
     REQUIRE( veh != nullptr );
     here.set_seen_cache_dirty( 0 );
     here.build_map_cache( 0 );
-    CHECK( !you.sees( you.pos_bub() + point( 10, 10 ) ) );
+    CHECK( !you.sees( here, you.pos_bub( here ) + point( 10, 10 ) ) );
 }
 
 TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
@@ -386,7 +386,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         if( vp.info().has_flag( "OPENABLE" ) && vp.part().is_fake ) {
             fakes_tested++;
             REQUIRE( !vp.part().open );
-            CHECK( can_interact_at( ACTION_OPEN, vp.pos_bub( here ) ) );
+            CHECK( can_interact_at( ACTION_OPEN, here, vp.pos_bub( here ) ) );
             int part_to_open = veh->next_part_to_open( vp.part_index() );
             // This should be the same part for this use case since there are no curtains etc.
             REQUIRE( part_to_open == static_cast<int>( vp.part_index() ) );
@@ -412,7 +412,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
             continue;
         }
         CAPTURE( prev_player_pos );
-        CAPTURE( you.pos_bub() );
+        CAPTURE( you.pos_bub( here ) );
         REQUIRE( veh->can_close( vp.part_index(), you ) );
         REQUIRE( veh->can_close( fake_door.part_index(), you ) );
         you.setpos( vp.pos_abs() );
@@ -423,7 +423,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         you.setpos( fake_door.pos_abs() );
         CHECK( !veh->can_close( vp.part_index(), you ) );
         CHECK( !veh->can_close( fake_door.part_index(), you ) );
-        you.setpos( prev_player_pos );
+        you.setpos( here, prev_player_pos );
     }
 
     // Then scan through all the openables including fakes and assert that we can close them.
@@ -432,7 +432,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         if( vp.info().has_flag( "OPENABLE" ) && vp.part().is_fake ) {
             fakes_tested++;
             CHECK( vp.part().open );
-            CHECK( can_interact_at( ACTION_CLOSE, vp.pos_bub( here ) ) );
+            CHECK( can_interact_at( ACTION_CLOSE, here, vp.pos_bub( here ) ) );
             int part_to_close = veh->next_part_to_close( vp.part_index() );
             // This should be the same part for this use case since there are no curtains etc.
             REQUIRE( part_to_close == static_cast<int>( vp.part_index() ) );

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -30,10 +30,12 @@ static const vproto_id vehicle_prototype_solar_panel_test( "solar_panel_test" );
 // TODO: Move this into player_helpers to avoid character include.
 static void reset_player()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE( !player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 }

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -109,15 +109,15 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
     Character &player_character = get_player_character();
-    player_character.setpos( map_starting_point );
+    player_character.setpos( here, map_starting_point );
 
-    REQUIRE( player_character.pos_bub() == map_starting_point );
-    if( player_character.pos_bub() != map_starting_point ) {
+    REQUIRE( player_character.pos_bub( here ) == map_starting_point );
+    if( player_character.pos_bub( here ) != map_starting_point ) {
         return;
     }
     get_map().board_vehicle( map_starting_point, &player_character );
-    REQUIRE( player_character.pos_bub() == map_starting_point );
-    if( player_character.pos_bub() != map_starting_point ) {
+    REQUIRE( player_character.pos_bub( here ) == map_starting_point );
+    if( player_character.pos_bub( here ) != map_starting_point ) {
         return;
     }
     const int transition_cycle = 3;
@@ -180,7 +180,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         const int z_change = map_starting_point.z() - player_character.posz();
         here.unboard_vehicle( *vp, &player_character, false );
         here.ter_set( map_starting_point, ter_id( "t_pavement" ) );
-        player_character.setpos( map_starting_point );
+        player_character.setpos( here, map_starting_point );
         if( z_change ) {
             g->vertical_move( z_change, true );
         }
@@ -245,7 +245,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     // Make sure the avatar is out of the way
     Character &player_character = get_player_character();
-    player_character.setpos( map_starting_point + point( 5, 5 ) );
+    player_character.setpos( here, map_starting_point + point( 5, 5 ) );
     vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180_degrees, 1, 0 );
 
     REQUIRE( veh_ptr != nullptr );

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
     for( units::angle dir = 0_degrees; dir < 360_degrees; dir += vehicles::steer_increment ) {
         CHECK( !player_character.in_vehicle );
         const tripoint_bub_ms test_origin( 15, 15, 0 );
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         tripoint_bub_ms vehicle_origin{ 10, 10, 0 };
         VehicleList vehs = here.get_vehicles();
         clear_vehicles();

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -58,7 +58,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
         map &here = get_map();
         const tripoint_bub_ms test_origin( 60, 60, 0 );
         avatar &player_character = get_avatar();
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         const tripoint_bub_ms vehicle_origin = test_origin + tripoint::south_east;
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, -90_degrees,
                                              0, 0 );
@@ -745,7 +745,7 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
     vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100, 0, false );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             REQUIRE( qry.query() == turret_data::status::ready );
             REQUIRE( qry.range() > 0 );
 
-            player_character.setpos( &here, veh->bub_part_pos( here, vp ) );
+            player_character.setpos( here, veh->bub_part_pos( here, vp ) );
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -557,6 +557,8 @@ TEST_CASE( "vision_single_tile_skylight", "[shadowcasting][vision]" )
 
 TEST_CASE( "vision_junction_reciprocity", "[vision][reciprocity]" )
 {
+    const map &here = get_map();
+
     bool player_in_junction = GENERATE( true, false );
     CAPTURE( player_in_junction );
 
@@ -604,16 +606,18 @@ TEST_CASE( "vision_junction_reciprocity", "[vision][reciprocity]" )
     t.test_all();
 
     if( player_in_junction ) {
-        REQUIRE( !get_avatar().sees( *zombie ) );
-        REQUIRE( !zombie->sees( get_avatar() ) );
+        REQUIRE( !get_avatar().sees( here, *zombie ) );
+        REQUIRE( !zombie->sees( here, get_avatar() ) );
     } else {
-        REQUIRE( get_avatar().sees( *zombie ) );
-        REQUIRE( zombie->sees( get_avatar() ) );
+        REQUIRE( get_avatar().sees( here, *zombie ) );
+        REQUIRE( zombie->sees( here, get_avatar() ) );
     }
 }
 
 TEST_CASE( "vision_blindfold_reciprocity", "[vision][reciprocity]" )
 {
+    const map &here = get_map();
+
     vision_test_case t {
         {
             "U  Z",
@@ -637,13 +641,15 @@ TEST_CASE( "vision_blindfold_reciprocity", "[vision][reciprocity]" )
         t.set_up_tiles;
     t.test_all();
 
-    REQUIRE( !get_avatar().sees( *zombie ) );
+    REQUIRE( !get_avatar().sees( here,  *zombie ) );
     // don't "optimize" lightcasting with player sight range
-    REQUIRE( zombie->sees( get_avatar() ) );
+    REQUIRE( zombie->sees( here, get_avatar() ) );
 }
 
 TEST_CASE( "vision_moncam_basic", "[shadowcasting][vision][moncam]" )
 {
+    const map &here = get_map();
+
     bool add_moncam = GENERATE( true, false );
     bool obstructed = GENERATE( true, false );
 
@@ -729,11 +735,11 @@ TEST_CASE( "vision_moncam_basic", "[shadowcasting][vision][moncam]" )
     t.test_all();
 
     avatar &u = get_avatar();
-    REQUIRE( zombie->sees( u ) == !obstructed );
+    REQUIRE( zombie->sees( here, u ) == !obstructed );
     if( add_moncam ) {
-        REQUIRE( u.sees( zombie->pos_bub(), true ) );
+        REQUIRE( u.sees( here,  zombie->pos_bub( here ), true ) );
     } else {
-        REQUIRE( !u.sees( zombie->pos_bub(), true ) );
+        REQUIRE( !u.sees( here, zombie->pos_bub( here ), true ) );
     }
 }
 
@@ -1168,11 +1174,13 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
 
 TEST_CASE( "pl_sees-oob-nocrash", "[vision]" )
 {
+    const map &here = get_map();
+
     // oob crash from game::place_player_overmap() or game::start_game(), simplified
     clear_avatar();
     get_map().load( project_to<coords::sm>( get_avatar().pos_abs() ) + point::south_east, false,
                     false );
-    get_avatar().sees( tripoint_bub_ms::zero ); // CRASH?
+    get_avatar().sees( here, tripoint_bub_ms::zero ); // CRASH?
 
     clear_avatar();
 }

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -81,11 +81,11 @@ TEST_CASE( "visitable_remove", "[visitable]" )
 
     // move player randomly until we find a suitable position
     constexpr int num_trials = 100;
-    for( int i = 0; i < num_trials && !suitable( p.pos_bub(), 1 ); ++i ) {
+    for( int i = 0; i < num_trials && !suitable( p.pos_bub( here ), 1 ); ++i ) {
         CHECK( !p.in_vehicle );
-        p.setpos( random_entry( closest_points_first( p.pos_bub(), 1 ) ) );
+        p.setpos( here, random_entry( closest_points_first( p.pos_bub( here ), 1 ) ) );
     }
-    REQUIRE( suitable( p.pos_bub(), 1 ) );
+    REQUIRE( suitable( p.pos_bub( here ), 1 ) );
 
     item temp_liquid( liquid_id );
     item obj = temp_liquid.in_container( temp_liquid.type->default_container.value_or( itype_null ) );
@@ -444,7 +444,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             v->add_item( here,  vp->part(), obj );
         }
 
-        vehicle_selector sel( here,  p.pos_bub( &here ), 1 );
+        vehicle_selector sel( here,  p.pos_bub( here ), 1 );
 
         REQUIRE( count_items( sel, container_id ) == count );
         REQUIRE( count_items( sel, liquid_id ) == count );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is above water at z0" ) {
         dummy.set_underwater( false );
-        dummy.setpos( test_origin );
+        dummy.setpos( here, test_origin );
         g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
@@ -66,7 +66,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z0" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin );
+        dummy.setpos( here, test_origin );
         g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
@@ -92,7 +92,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z-1" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin + tripoint::below );
+        dummy.setpos( here, test_origin + tripoint::below );
         g->vertical_shift( -1 );
 
         WHEN( "avatar dives down" ) {
@@ -118,7 +118,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z-2" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin + tripoint( 0, 0, -2 ) );
+        dummy.setpos( here, test_origin + tripoint( 0, 0, -2 ) );
         g->vertical_shift( -2 );
 
         WHEN( "avatar dives down" ) {
@@ -289,7 +289,7 @@ static int swimming_steps( avatar &swimmer )
         }
         last_moves = swimmer.get_moves();
     }
-    swimmer.setpos( left );
+    swimmer.setpos( here, left );
     return steps;
 }
 


### PR DESCRIPTION
#### Summary
Continue to backport

#### Purpose of change
79695 - fix weapon_talk_hallucination recursion
79697 - add walls to standard_domestic_abandoned_palette
79698 - also mark child recipes when marking parents as read
79699 - mapify character::sees()

#### Describe the solution
79699 is a big PR and affected a lot of things. While working on it I caught a couple of inconsequential bugs (improper guilt warning in extended description being one of them) and fixed them, but it may have broken other stuff.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
