### PR TITLE
(Mod Support) Blind read/craft flags

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -2662,5 +2662,20 @@
     "id": "NATURAL_UNDERGROUND",
     "type": "json_flag",
     "//": "Wall tiles with this flag occur naturally underground and are not manmade."
+  },
+  {
+    "id": "BLIND_READ_SLOW",
+    "type": "json_flag",
+    "//": "This character can always read as though visiblity is at least poor."
+  },
+  {
+    "id": "BLIND_READ_FAST",
+    "type": "json_flag",
+    "//": "This character can read as though visibility is perfect."
+  },
+  {
+    "id": "BLIND_CRAFT",
+    "type": "json_flag",
+    "//": "This character can perform most manual labor as though visibility is perfect."
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -234,6 +234,8 @@ static const itype_id itype_stick_long( "stick_long" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
 
+static const json_character_flag json_flag_BLIND_READ_FAST( "BLIND_READ_FAST" );
+static const json_character_flag json_flag_BLIND_READ_SLOW( "BLIND_READ_SLOW" );
 static const json_character_flag json_flag_SAFECRACK_NO_TOOL( "SAFECRACK_NO_TOOL" );
 
 static const morale_type morale_book( "morale_book" );
@@ -979,7 +981,7 @@ void bookbinder_copy_activity_actor::start( player_activity &act, Character & )
 
 void bookbinder_copy_activity_actor::do_turn( player_activity &, Character &p )
 {
-    if( p.fine_detail_vision_mod() > 4.0f ) {
+    if( p.fine_detail_vision_mod() > 4.0f && !p.has_flag( json_flag_BLIND_READ_SLOW ) && !p.has_flag( json_flag_BLIND_READ_FAST ) ) {
         p.cancel_activity();
         p.add_msg_if_player( m_info, _( "It's too dark to write!" ) );
         return;
@@ -1708,7 +1710,7 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
                  book_type::martial_art : book_type::normal;
     }
 
-    if( who.fine_detail_vision_mod() > 4 && !book->has_flag( flag_CAN_USE_IN_DARK ) ) {
+    if( who.fine_detail_vision_mod() > 4 && !book->has_flag( flag_CAN_USE_IN_DARK ) && !who.has_flag( json_flag_BLIND_READ_SLOW ) && !who.has_flag( json_flag_BLIND_READ_FAST ) ) {
         // It got too dark during the process of reading, bail out.
         act.set_to_null();
         who.add_msg_if_player( m_bad, _( "It's too dark to read!" ) );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -108,6 +108,8 @@ static const itype_id itype_stick( "stick" );
 static const itype_id itype_string_36( "string_36" );
 static const itype_id itype_wall_wiring( "wall_wiring" );
 
+static const json_character_flag json_flag_BLIND_CRAFT( "BLIND_CRAFT" );
+
 static const morale_type morale_funeral( "morale_funeral" );
 static const morale_type morale_gravedigger( "morale_gravedigger" );
 
@@ -1117,7 +1119,7 @@ bool player_can_build( Character &you, const read_only_visitable &inv, const con
 
 bool player_can_see_to_build( Character &you, const construction_group_str_id &group )
 {
-    if( you.fine_detail_vision_mod() < 4 || you.has_trait( trait_DEBUG_HS ) ) {
+    if( you.fine_detail_vision_mod() < 4 || you.has_trait( trait_DEBUG_HS ) || you.has_flag( json_flag_BLIND_CRAFT ) ) {
         return true;
     }
     std::vector<construction *> cons = constructions_by_group( group );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -98,6 +98,7 @@ static const furn_str_id furn_f_ground_crafting_spot( "f_ground_crafting_spot" )
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_plut_cell( "plut_cell" );
 
+static const json_character_flag json_flag_BLIND_CRAFT( "BLIND_CRAFT" );
 static const json_character_flag json_flag_HYPEROPIC( "HYPEROPIC" );
 
 static const limb_score_id limb_score_manip( "manip" );
@@ -171,6 +172,10 @@ float Character::lighting_craft_speed_multiplier( const recipe &rec,
 {
     // negative is bright, 0 is just bright enough, positive is dark, +7.0f is pitch black
     float darkness = fine_detail_vision_mod( p ) - 4.0f;
+    // BLIND_CRAFT flags are for things like ESP where the reader is not using their eyes to see.
+    if( has_flag( json_flag_BLIND_CRAFT ) ) {
+        darkness = std::min( darkness, 0.0f );
+    }
     if( darkness <= 0.0f ) {
         return 1.0f; // it's bright, go for it
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -298,6 +298,9 @@ static const itype_id itype_swim_fins( "swim_fins" );
 static const itype_id itype_towel( "towel" );
 static const itype_id itype_towel_wet( "towel_wet" );
 
+static const json_character_flag json_flag_BLIND_CRAFT( "BLIND_CRAFT" );
+static const json_character_flag json_flag_BLIND_READ_FAST( "BLIND_READ_FAST" );
+static const json_character_flag json_flag_BLIND_READ_SLOW( "BLIND_READ_SLOW" );
 static const json_character_flag json_flag_CLIMB_NO_LADDER( "CLIMB_NO_LADDER" );
 static const json_character_flag json_flag_GRAB( "GRAB" );
 static const json_character_flag json_flag_GRAB_FILTER( "GRAB_FILTER" );
@@ -5178,16 +5181,18 @@ void game::use_computer( const tripoint_bub_ms &p )
         add_msg( m_info, _( "You can not read a computer screen!" ) );
         return;
     }
-    if( u.is_blind() ) {
-        // we don't have screen readers in game
-        add_msg( m_info, _( "You can not see a computer screen!" ) );
-        return;
-    }
-    if( u.has_flag( json_flag_HYPEROPIC ) && !u.worn_with_flag( flag_FIX_FARSIGHT ) &&
-        !u.has_effect( effect_contacts ) && !u.has_effect( effect_transition_contacts ) &&
-        !u.has_flag( STATIC( json_character_flag( "ENHANCED_VISION" ) ) ) ) {
-        add_msg( m_info, _( "You'll need to put on reading glasses before you can see the screen." ) );
-        return;
+    if( !u.has_flag( json_flag_BLIND_READ_SLOW ) && !u.has_flag( json_flag_BLIND_READ_FAST ) ) {
+        if( u.is_blind() ) {
+            // we don't have screen readers in game
+            add_msg( m_info, _( "You can not see a computer screen!" ) );
+            return;
+        }
+        if( u.has_flag( json_flag_HYPEROPIC ) && !u.worn_with_flag( flag_FIX_FARSIGHT ) &&
+            !u.has_effect( effect_contacts ) && !u.has_effect( effect_transition_contacts ) &&
+            !u.has_flag( STATIC( json_character_flag( "ENHANCED_VISION" ) ) ) ) {
+            add_msg( m_info, _( "You'll need to put on reading glasses before you can see the screen." ) );
+            return;
+        }
     }
 
     computer *used = m.computer_at( p );
@@ -9690,7 +9695,7 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
         }
         return result.empty() ? "" : ( " " + colorize( result, c_dark_gray ) );
     };
-    const bool enough_light = player_character.fine_detail_vision_mod() <= 4;
+    const bool enough_light = player_character.fine_detail_vision_mod() <= 4 || player_character.has_flag( json_flag_BLIND_CRAFT );
 
     const int factor = player_character.max_quality( qual_BUTCHER, PICKUP_RANGE );
     const std::string msgFactor = factor > INT_MIN

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -85,6 +85,8 @@ static const itype_id fuel_type_battery( "battery" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_plut_cell( "plut_cell" );
 
+static const json_character_flag json_flag_BLIND_CRAFT( "BLIND_CRAFT" );
+
 static const proficiency_id proficiency_prof_aircraft_mechanic( "prof_aircraft_mechanic" );
 
 static const quality_id qual_HOSE( "HOSE" );
@@ -655,7 +657,7 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
             enough_morale = player_character.has_morale_to_craft();
             valid_target = !can_mount.empty();
             //tool checks processed later
-            enough_light = player_character.fine_detail_vision_mod() <= 4;
+            enough_light = player_character.fine_detail_vision_mod() <= 4 || player_character.has_flag( json_flag_BLIND_CRAFT );
             has_tools = true;
             break;
 
@@ -665,7 +667,7 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
             valid_target = !need_repair.empty() && cpart >= 0;
             // checked later
             has_tools = true;
-            enough_light = player_character.fine_detail_vision_mod() <= 4;
+            enough_light = player_character.fine_detail_vision_mod() <= 4 || player_character.has_flag( json_flag_BLIND_CRAFT );
             break;
 
         case 'm': {
@@ -679,7 +681,7 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
                     return pt.part().is_available() && !pt.part().faults().empty();
                 }
             } );
-            enough_light = player_character.fine_detail_vision_mod() <= 4;
+            enough_light = player_character.fine_detail_vision_mod() <= 4 || player_character.has_flag( json_flag_BLIND_CRAFT );
             // checked later
             has_tools = true;
         }
@@ -693,19 +695,19 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
             break;
 
         case 'o':
-            // remove mode
+            // Remove mode.
             enough_morale = player_character.has_morale_to_craft();
             valid_target = cpart >= 0;
             part_free = parts_here.size() > 1 ||
                         ( cpart >= 0 && veh->can_unmount( veh->part( cpart ) ).success() );
-            //tool and skill checks processed later
+            // Tool and skill checks processed later.
             has_tools = true;
             has_skill = true;
-            enough_light = player_character.fine_detail_vision_mod() <= 4;
+            enough_light = player_character.fine_detail_vision_mod() <= 4 || player_character.has_flag( json_flag_BLIND_CRAFT );
             break;
 
         case 's':
-            // siphon mode
+            // Siphon mode.
             valid_target = false;
             for( const vpart_reference &vp : veh->get_any_parts( VPFLAG_FLUIDTANK ) ) {
                 if( vp.part().base.has_item_with( []( const item & it ) {


### PR DESCRIPTION
#### Summary
(Mod Support) Blind read/craft flags

#### Purpose of change
Vegetabs wanted some flags for MoM to allow characters to read and do crafting without being able to see.

#### Describe the solution
Adds the following flags:
- BLIND_READ_SLOW - If your visibility is worse than poor, treat visibility as poor for purposes of reading.
- BLIND_READ_FAST - Always treat visibility as perfect for reading.
- BLIND_CRAFT - Always treat visibility as perfect for crafting, vehicle work, construction, and butchery. This probably needs to cover more tasks, but this is fine for a first pass.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
