### PR TITLE
Restore You could use it to craft...

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -564,6 +564,11 @@ class item : public visitable
         void final_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                          bool debug ) const;
 
+        // Build the crafting list for the item actions menu.
+        std::string crafting_applications() const;
+        // Used in the above and elsewhere.
+        bool can_craft_recipe( const recipe *r, const inventory &crafting_inv ) const;
+
         /**
          * @return human readable, translated string.
          */


### PR DESCRIPTION
#### Summary
Category "Brief description"

#### Purpose of change
Back in #1253 I removed the "You can use it to craft..." list, which I assumed nobody cared about. I was very wrong. I don't want to bring it back as-is, because I'm trying to slim down the item panel, but there's plenty of room for it in the item actions context menu. In fact, that lets us fit more recipes!

#### Describe the solution
Add a new option, crafting, to the item actions context menu (seen when pushing enter on an item). This option will be gray if you know no recipes, pink if you know recipes but don't have the tools or components for any of them, and green if you have at least one recipe that you could make right now. Pressing the option will pull up the list.

#### Additional context
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/4b2658df-cfd4-4b29-b145-2e2dbdfafeb0" />
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/b9ee6441-084b-43d9-9858-9b2fe48ccb39" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
