### PR TITLE
Revert of Fungal Tiger Change

### DIFF
--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -725,21 +725,9 @@
     "vision_night": 3,
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
-    "grab_strength": 45,
     "special_attacks": [
       [ "scratch", 10 ],
       { "type": "leap", "cooldown": 5, "max_range": 5 },
-      {
-        "id": "bite_grab",
-        "move_cost": 188,
-        "cooldown": 2,
-        "accuracy": 5,
-        "infection_chance": 2,
-        "min_mul": 1.0,
-        "max_mul": 2.0
-      },
-      { "id": "drag_followup" },
-      { "id": "scratch_grab_required" },
       [ "FUNGUS", 190 ]
     ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "FILTHY" ],


### PR DESCRIPTION
Removes the bite grab and drag from fungal tigers.

#### Summary
I was overzealous and added a bite and grab to zombie tigers. They're supposed to be more sluggish and not agile like that.

#### Purpose of change
Removes a coordinated movement from fungal tigers

#### Describe the solution
Removes the bite grab and drag

#### Describe alternatives you've considered
None

#### Testing
Runs without error, no more bite & dragging

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
