### PR TITLE
Stop applying riot damage to unflagged terrain

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -653,9 +653,15 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             if( any_missing || !save_results ) {
                 const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
                 oter_id omt = overmap_buffer.ter( omt_point );
+            /*
+            * DDA applies the riot damage quite broadly. We don't want to apply any at all,
+            * but when we do, it should be by flag and not just willy-nilly.
+            */
+                // if( omt->has_flag(
+                //         oter_flags::pp_generate_riot_damage ) || ( omt->has_flag( oter_flags::road ) &&
+                //                 overmap_buffer.is_in_city( omt_point ) ) ) {
                 if( omt->has_flag(
-                        oter_flags::pp_generate_riot_damage ) || ( omt->has_flag( oter_flags::road ) &&
-                                overmap_buffer.is_in_city( omt_point ) ) ) {
+                        oter_flags::pp_generate_riot_damage ) ) {
                     GENERATOR_riot_damage( *this, omt_point );
                 }
             }


### PR DESCRIPTION
#### Summary
Stop applying riot damage to unflagged terrain

#### Purpose of change
I removed all the PP_GENERATE_RIOT_DAMAGE flags, but it turns out the postprocessor was designed to run on all road tiles, which we don't want.

#### Describe the solution
Comment out the road thing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
