### PR TITLE
Clarify prison quest

### DIFF
--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -725,11 +725,7 @@
     "vision_night": 3,
     "bleed_rate": 0,
     "harvest": "zombie_animal_mushroom",
-    "special_attacks": [
-      [ "scratch", 10 ],
-      { "type": "leap", "cooldown": 5, "max_range": 5 },
-      [ "FUNGUS", 190 ]
-    ],
+    "special_attacks": [ [ "scratch", 10 ], { "type": "leap", "cooldown": 5, "max_range": 5 }, [ "FUNGUS", 190 ] ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "FILTHY" ],
     "armor": { "bash": 1, "electric": 2 }
   },

--- a/data/json/npcs/island_prison/prisoners.json
+++ b/data/json/npcs/island_prison/prisoners.json
@@ -549,7 +549,7 @@
   {
     "id": "MISSION_PRISONER_LEADER_GET_ID_CARD",
     "type": "mission_definition",
-    "name": { "str": "Get The Thing from the chief's office" },
+    "name": { "str": "Get the military ID card from the chief's office" },
     "difficulty": 1,
     "value": 0,
     "goal": "MGOAL_FIND_ITEM",
@@ -557,12 +557,12 @@
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": "Here's the job…",
-      "offer": "My snitch whispered in my ear that the thing I need is located in the chief's safe in his office.  You need to crack it open and bring the contents to me.  Don't try to use anything you find in there!  Just bring all the stuff to me, and I'll help you.  Deal?",
-      "accepted": "Great!  Don't forget that I need all stuff from the safe, try not to lose a thing.",
-      "rejected": "Fine, I'll get the thing in any case, sooner or later.",
+      "offer": "I need the military ID card from the chief's safe in his office.  I don't mean the warden, I mean the chief corrections officer, you hear me?  Just bring that thing to me and I'll help you.  Deal?",
+      "accepted": "Great!  Don't try to use the card now, just bring it straight to me.",
+      "rejected": "Fine, I'll get it sooner or later.",
       "advice": "The chief's office is on the other side of the prison.  I think the road there is full of <zombies>, so you better find a weapon.  Also you probably will need some tools to crack the safe open.",
-      "inquire": "Did you get the stuff already?",
-      "success": "At last!  Give me a few moments to check if it isn't damaged.  Here, take this for your troubles.",
+      "inquire": "Did you get the card already?",
+      "success": "At last!  Give me a second to check if it isn't damaged.  Here, take this for your troubles.",
       "success_lie": "Huh.  This isn't going to work like I thought.",
       "failure": "You're useless.  I should've killed you when I met you."
     },


### PR DESCRIPTION
#### Summary
Clarify prison quest

#### Purpose of change
Despite the fact that the island prison quest clearly tells you to go to the chief's office, every player who has ever done the island prison start has indelibly internalized the belief that they're being told to go the warden's office. These are different places!

The quest was also a bit unclear because for no reason at all, the quest giver was being unhelpfully cagey about what item he actually wanted. He wants a military ID card. There's no reason to hide that information from the player.

#### Describe the solution
- Update the title of the mission to clarify that the player is looking for a military ID card.
- Update the mission text to be more clear that the player is looking for the chief corrections officer and not the warden.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
