### PR TITLE
Nerf speedway and rename karting

### DIFF
--- a/data/json/mapgen/speedway.json
+++ b/data/json/mapgen/speedway.json
@@ -68,15 +68,15 @@
     "item": { "X": { "item": "tire_wide_or", "repeat": [ 2, 3 ] } },
     "items": {
       "b": [
-        { "item": "softdrinks_canned", "chance": 1, "repeat": [ 1, 2 ] },
-        { "item": "snacks", "chance": 1, "repeat": [ 1, 2 ] },
+        { "item": "softdrinks_canned", "chance": 1, "repeat": [ 0, 2 ] },
+        { "item": "snacks", "chance": 1, "repeat": [ 0, 2 ] },
         { "item": "jackets", "chance": 1 }
       ],
       "d": { "item": "SUS_office_desk", "chance": 33 },
       "i": { "item": "SUS_office_filing_cabinet", "chance": 25 },
       "a": { "item": "trash", "chance": 66, "repeat": [ 1, 3 ] },
       "A": { "item": "trash", "chance": 66, "repeat": [ 1, 3 ] },
-      "D": { "item": "trash", "chance": 80, "repeat": [ 4, 8 ] },
+      "D": { "item": "trash", "chance": 80, "repeat": [ 0, 4 ] },
       "T": { "item": "SUS_toilet", "chance": 50 }
     },
     "toilets": { "T": {  } },
@@ -84,8 +84,8 @@
     "vehicles": {
       "v": { "vehicle": "cars_only", "chance": 10, "rotation": 90 },
       "^": { "vehicle": "cars_only", "chance": 10, "rotation": 270 },
-      "w": { "vehicle": "cars_only", "chance": 80, "rotation": 90 },
-      "˘": { "vehicle": "cars_only", "chance": 80, "rotation": 270 }
+      "w": { "vehicle": "cars_only", "chance": 30, "rotation": 90 },
+      "˘": { "vehicle": "cars_only", "chance": 30, "rotation": 270 }
     },
     "gaspumps": { "G": { "fuel": "gasoline" } }
   },
@@ -305,9 +305,9 @@
       "palettes": [ "speedway_palette" ],
       "terrain": { "!": "t_guardrail" },
       "place_vehicles": [
-        { "vehicle": "car_sports", "x": 91, "y": 117, "rotation": 0, "chance": 100 },
-        { "vehicle": "car_sports", "x": 91, "y": [ 125, 126 ], "rotation": 0, "chance": 100 },
-        { "vehicle": "car_sports", "x": 91, "y": 134, "rotation": 0, "chance": 100 }
+        { "vehicle": "car_sports", "x": 91, "y": 117, "rotation": 0, "chance": 20 },
+        { "vehicle": "car_sports", "x": 91, "y": [ 125, 126 ], "rotation": 0, "chance": 20 },
+        { "vehicle": "car_sports", "x": 91, "y": 134, "rotation": 0, "chance": 20 }
       ]
     }
   },
@@ -446,13 +446,13 @@
         "             .---------.                        "
       ],
       "palettes": [ "speedway_palette" ],
-      "items": { "R": { "item": "mechanics", "chance": 40, "repeat": [ 1, 6 ] }, "n": { "item": "SUS_welding_gear", "chance": 50 } },
-      "place_vehicles": [ { "vehicle": "rara_x", "x": 36, "y": 55, "rotation": 90, "chance": 20 } ],
+      "items": { "R": { "item": "mechanics", "chance": 40, "repeat": [ 1, 6 ] }, "n": { "item": "SUS_welding_gear", "chance": 20 } },
+      "place_vehicles": [ { "vehicle": "rara_x", "x": 36, "y": 55, "rotation": 90, "chance": 5 } ],
       "place_loot": [
-        { "item": "tire_medium_slick", "x": [ 36, 38 ], "y": 50, "repeat": [ 6, 9 ] },
-        { "item": "tire_medium_slick", "x": [ 41, 43 ], "y": 74, "repeat": [ 6, 9 ] },
-        { "item": "tire_medium_slick", "x": [ 38, 40 ], "y": 79, "repeat": [ 6, 9 ] },
-        { "item": "tire_medium_slick", "x": [ 34, 36 ], "y": 103, "repeat": [ 6, 9 ] }
+        { "item": "tire_medium_slick", "x": [ 36, 38 ], "y": 50, "repeat": [ 0, 6 ] },
+        { "item": "tire_medium_slick", "x": [ 41, 43 ], "y": 74, "repeat": [ 0, 6 ] },
+        { "item": "tire_medium_slick", "x": [ 38, 40 ], "y": 79, "repeat": [ 0, 6 ] },
+        { "item": "tire_medium_slick", "x": [ 34, 36 ], "y": 103, "repeat": [ 0, 6 ] }
       ],
       "place_monster": [
         { "monster": "mon_feral_human_tool", "x": [ 32, 45 ], "y": [ 50, 61 ], "chance": 66 },
@@ -512,7 +512,7 @@
         { "item": "ketchup", "x": 167, "y": 19 },
         { "item": "mustard", "x": 167, "y": 19 },
         { "group": "hotdog_fridge", "x": 167, "y": 20 },
-        { "group": "softdrinks_canned", "x": 167, "y": 21, "repeat": [ 1, 10 ] }
+        { "group": "softdrinks_canned", "x": 167, "y": 21, "repeat": [ 0, 6 ] }
       ],
       "place_monster": [
         { "group": "GROUP_VANILLA", "x": [ 48, 71 ], "y": [ 2, 23 ], "repeat": [ 2, 5 ] },
@@ -581,8 +581,8 @@
         ".......................................                                 "
       ],
       "palettes": [ "speedway_palette" ],
-      "place_vehicles": [ { "vehicle": "golf_cart", "x": 25, "y": 26, "rotation": 0, "chance": 100 } ],
-      "items": { "e": { "item": "SUS_fridge_breakroom", "chance": 33 } },
+      "place_vehicles": [ { "vehicle": "golf_cart", "x": 25, "y": 26, "rotation": 0, "chance": 60 } ],
+      "items": { "e": { "item": "SUS_fridge_breakroom", "chance": 15 } },
       "place_loot": [ { "item": "microwave", "x": 11, "y": 30, "chance": 50 }, { "item": "coffeemaker", "x": 11, "y": 30, "chance": 50 } ]
     }
   },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -755,7 +755,7 @@
       "karting_2_2_2"
     ],
     "copy-from": "generic_city_building",
-    "name": "karting",
+    "name": "go-kart track",
     "sym": "M",
     "color": "i_yellow"
   },


### PR DESCRIPTION
#### Summary
Nerf speedway and rename karting

#### Purpose of change
"Karting" isn't exactly what you'd call a go-kart track, and the speedway had too much good stuff.

#### Describe the solution
- Way fewer cars and tools at the speedway.
- karting -> go-kart track.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
