### PR TITLE
Rainproof audit

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1093,7 +1093,7 @@
     "warmth": 25,
     "material_thickness": 1.0,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "jacket_leather_xs",
@@ -1285,7 +1285,7 @@
     "id": "jacket_light",
     "type": "ARMOR",
     "name": { "str": "light jacket" },
-    "description": "A thin cotton jacket with a hood.  Good for brisk weather.",
+    "description": "A thin cotton jacket with a hood.  It's good for brisk weather, not so much for rain.",
     "weight": "227 g",
     "volume": "2250 ml",
     "price": "45 USD",
@@ -1376,7 +1376,7 @@
     "symbol": "[",
     "warmth": 15,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 90, "encumbrance": [ 14, 18 ] },
       { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 90 },
@@ -1656,7 +1656,7 @@
     "warmth": 30,
     "material_thickness": 1.5,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY" ]
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "STURDY", "RAINPROOF" ]
   },
   {
     "id": "peacoat",
@@ -1709,7 +1709,7 @@
     ],
     "warmth": 50,
     "material_thickness": 1.0,
-    "flags": [ "VARSIZE", "POCKETS", "COLLAR", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "COLLAR", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "robe",
@@ -2707,7 +2707,7 @@
     ],
     "warmth": 50,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "RAINPROOF" ]
   },
   {
     "id": "plaguedoctor_robe",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -37,7 +37,7 @@
     "warmth": 20,
     "material_thickness": 4,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "OVERSIZE", "STURDY", "MITTS" ],
+    "flags": [ "VARSIZE", "OVERSIZE", "STURDY", "MITTS", "RAINPROOF" ],
     "armor": [ { "encumbrance": 70, "coverage": 98, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -257,7 +257,7 @@
     "color": "dark_gray",
     "material_thickness": 0.5,
     "environmental_protection": 4,
-    "flags": [ "WATER_FRIENDLY", "WATERPROOF" ],
+    "flags": [ "WATER_FRIENDLY", "WATERPROOF", "RAINPROOF" ],
     "armor": [ { "encumbrance": 15, "coverage": 98, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "cut": 1 }
   },
@@ -375,7 +375,7 @@
     "color": "light_blue",
     "material_thickness": 0.01,
     "warmth": 2,
-    "flags": [ "WATERPROOF", "UNRESTRICTED", "OVERSIZE", "MITTS", "OUTER", "SOFT", "FRAGILE" ],
+    "flags": [ "WATERPROOF", "UNRESTRICTED", "OVERSIZE", "MITTS", "OUTER", "SOFT", "FRAGILE", "RAINPROOF" ],
     "armor": [ { "encumbrance": 12, "coverage": 98, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -394,7 +394,7 @@
     "color": "dark_gray",
     "warmth": 10,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "VARSIZE", "ALLOWS_NATURAL_ATTACKS" ],
     "armor": [
       {
         "encumbrance": 8,
@@ -480,6 +480,7 @@
     "color": "brown",
     "warmth": 70,
     "material_thickness": 3,
+    "flags": [ "RAINPROOF" ],
     "armor": [ { "encumbrance": 30, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
   },
@@ -516,6 +517,7 @@
     "color": "brown",
     "warmth": 55,
     "material_thickness": 3,
+    "flags": [ "RAINPROOF" ],
     "armor": [ { "encumbrance": 30, "coverage": 98, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
   },
@@ -589,7 +591,7 @@
     "color": "light_blue",
     "warmth": 10,
     "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY" ],
+    "flags": [ "VARSIZE" ],
     "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -625,7 +627,7 @@
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 0.1,
-    "flags": [ "WATER_FRIENDLY", "SKINTIGHT" ],
+    "flags": [ "SKINTIGHT" ],
     "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -660,7 +662,7 @@
     "color": "white",
     "material_thickness": 0.01,
     "environmental_protection": 2,
-    "flags": [ "WATER_FRIENDLY", "WATERPROOF", "SKINTIGHT", "FRAGILE", "NO_REPAIR" ],
+    "flags": [ "RAINPROOF", "WATERPROOF", "SKINTIGHT", "FRAGILE", "NO_REPAIR" ],
     "armor": [ { "encumbrance": 1, "coverage": 98, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -699,7 +701,7 @@
     "warmth": 10,
     "material_thickness": 0.35,
     "environmental_protection": 8,
-    "flags": [ "WATERPROOF" ],
+    "flags": [ "WATERPROOF", "RAINPROOF" ],
     "armor": [ { "encumbrance": 6, "coverage": 97, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
   },
@@ -741,6 +743,7 @@
     "color": "light_blue",
     "warmth": 70,
     "material_thickness": 4,
+    "flags": [ "RAINPROOF" ],
     "armor": [ { "encumbrance": 40, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
@@ -1177,6 +1180,7 @@
     "price_postapoc": "2 USD 50 cent",
     "to_hit": 1,
     "material": [ "nylon", "cotton" ],
+    "flags": [ "RAINPROOF" ],
     "symbol": "[",
     "looks_like": "fire_gauntlets",
     "color": "white",

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -215,7 +215,7 @@
     "color": "dark_gray",
     "warmth": 5,
     "material_thickness": 0.5,
-    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF" ],
     "armor": [
       {
         "coverage": 75,
@@ -1011,7 +1011,7 @@
     ],
     "warmth": 25,
     "material_thickness": 0.75,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "RAINPROOF" ],
     "armor": [
       {
         "encumbrance": [ 15, 17 ],
@@ -1079,7 +1079,7 @@
     "warmth": 70,
     "material_thickness": 1,
     "environmental_protection": 3,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ],
     "armor": [
       {
         "encumbrance": [ 6, 10 ],
@@ -1526,7 +1526,7 @@
     "color": "brown",
     "warmth": 10,
     "material_thickness": 0.6,
-    "flags": [ "VARSIZE" ],
+    "flags": [ "VARSIZE", "RAINPROOF" ],
     "armor": [
       {
         "encumbrance": 8,

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -1238,7 +1238,7 @@
     "warmth": 15,
     "material_thickness": 1.5,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "POCKETS", "OUTER" ],
+    "flags": [ "VARSIZE", "POCKETS", "OUTER", "RAINPROOF" ],
     "armor": [ { "encumbrance": [ 20, 22 ], "coverage": 95, "covers": [ "torso" ] } ]
   },
   {


### PR DESCRIPTION
#### Summary
Rainproof audit

#### Purpose of change
A bunch of items that should have been rainproof were not. A bunch of items were water-friendly that should not be.

#### Describe the solution
Fix flags.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
