### PR TITLE
Consolidate tanned_hide and sheet_leather

### DIFF
--- a/data/json/construction/furniture_tools.json
+++ b/data/json/construction/furniture_tools.json
@@ -90,7 +90,7 @@
     "time": "60m",
     "on_display": false,
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "2x4", 4 ] ], [ [ "tanned_hide", 2 ] ], [ [ "scrap", 20 ] ], [ [ "wire", 8 ] ] ],
+    "components": [ [ [ "2x4", 4 ] ], [ [ "sheet_leather", 2 ] ], [ [ "scrap", 20 ] ], [ [ "wire", 8 ] ] ],
     "pre_flags": [ "FLAT" ],
     "post_terrain": "f_bellows"
   },

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -379,7 +379,7 @@
     "flags": [ "TRANSPARENT" ],
     "deconstruct": {
       "items": [
-        { "item": "tanned_hide", "count": [ 1, 2 ] },
+        { "item": "sheet_leather", "count": [ 1, 2 ] },
         { "item": "2x4", "count": [ 2, 4 ] },
         { "item": "spring", "count": [ 1, 2 ] },
         { "item": "wire", "count": [ 1, 4 ] }

--- a/data/json/furniture_and_terrain/furniture-recreation.json
+++ b/data/json/furniture_and_terrain/furniture-recreation.json
@@ -419,7 +419,7 @@
       "items": [
         { "item": "chain", "count": [ 0, 1 ] },
         { "item": "leather", "count": [ 16, 32 ] },
-        { "item": "tanned_hide", "count": [ 0, 4 ] },
+        { "item": "sheet_leather", "count": [ 0, 4 ] },
         { "item": "material_sand", "charges": 4000 },
         { "item": "sheet_cotton", "count": [ 4, 8 ] },
         { "item": "cotton_patchwork", "count": [ 2, 4 ] }

--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -228,7 +228,6 @@
       [ "leather", 10 ],
       [ "fur", 7 ],
       [ "sheet_leather", 20 ],
-      [ "tanned_hide", 20 ],
       [ "tanned_pelt", 20 ]
     ]
   },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -48,7 +48,7 @@
     "items": [
       { "item": "sheet_cotton", "prob": 200 },
       { "item": "sheet_neoprene", "prob": 10 },
-      { "item": "tanned_hide", "prob": 50 },
+      { "item": "sheet_leather", "prob": 50 },
       { "item": "tanned_pelt", "prob": 50 }
     ]
   },

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -952,7 +952,7 @@
   {
     "id": "long_glove_white",
     "type": "ARMOR",
-    "name": { "str": "pair opera gloves", "str_pl": "pairs of opera gloves" },
+    "name": { "str": "opera gloves", "str_pl": "pairs of opera gloves" },
     "description": "Thin gloves which extend up past the elbows.",
     "weight": "300 g",
     "volume": "360 ml",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1057,7 +1057,7 @@
     "type": "GENERIC",
     "id": "drum_skin",
     "name": { "str": "drum skin" },
-    "copy-from": "tanned_hide",
+    "copy-from": "sheet_leather",
     "weight": "10 g",
     "description": "The tanned hide of an animal repurposed to become the head on a percussion drum."
   },

--- a/data/json/items/resources/tailoring.json
+++ b/data/json/items/resources/tailoring.json
@@ -266,20 +266,6 @@
   },
   {
     "type": "GENERIC",
-    "id": "tanned_hide",
-    "symbol": ",",
-    "color": "brown",
-    "name": { "str": "tanned hide" },
-    "description": "A sheet of leather made from carefully tanned animal hide.  Can be cut up or used as is.",
-    "price": "50 USD",
-    "price_postapoc": "5 USD",
-    "material": [ "leather" ],
-    "weight": "296 g",
-    "volume": "186 ml",
-    "category": "spare_parts"
-  },
-  {
-    "type": "GENERIC",
     "id": "sheet_leather",
     "name": { "str": "leather sheet" },
     "description": "A sheet of leather.  Can be cut up or used as is.",

--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -276,7 +276,7 @@
     "symbol": ",",
     "color": "brown",
     "use_action": {
-      "target": "tanned_hide",
+      "target": "sheet_leather",
       "msg": "You carefully unfold the tanning leather hide and shake it clean.",
       "moves": 150,
       "type": "delayed_transform",

--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -1297,7 +1297,7 @@
     "type": "item_group",
     "id": "GODCO_russell_sell",
     "subtype": "collection",
-    "entries": [ { "item": "tanned_hide", "count": [ 10, 12 ] }, { "item": "tanned_pelt", "count": [ 8, 10 ] } ]
+    "entries": [ { "item": "sheet_leather", "count": [ 10, 12 ] }, { "item": "tanned_pelt", "count": [ 8, 10 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2707,5 +2707,10 @@
     "id": "chips3",
     "type": "MIGRATION",
     "replace": "chips"
+  },
+  {
+    "id": "leather_hide",
+    "type": "MIGRATION",
+    "replace": "sheet_leather"
   }
 ]

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -685,7 +685,7 @@
     "using": [ [ "blacksmithing_standard", 48 ], [ "steel_standard", 12 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 16 ], [ "tanned_pelt", 2 ], [ "leather", 16 ], [ "tanned_hide", 2 ] ], [ [ "cotton_patchwork", 16 ] ] ],
+    "components": [ [ [ "fur", 16 ], [ "tanned_pelt", 2 ], [ "leather", 16 ], [ "sheet_leather", 2 ] ], [ [ "cotton_patchwork", 16 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -701,7 +701,7 @@
     "using": [ [ "blacksmithing_standard", 36 ], [ "steel_standard", 9 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 11 ], [ "tanned_pelt", 2 ], [ "leather", 11 ], [ "tanned_hide", 2 ] ], [ [ "cotton_patchwork", 11 ] ] ]
+    "components": [ [ [ "fur", 11 ], [ "tanned_pelt", 2 ], [ "leather", 11 ], [ "sheet_leather", 2 ] ], [ [ "cotton_patchwork", 11 ] ] ]
   },
   {
     "result": "xl_helmet_kabuto",
@@ -711,7 +711,7 @@
     "using": [ [ "blacksmithing_standard", 64 ], [ "steel_standard", 16 ] ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "fur", 20 ], [ "tanned_pelt", 3 ], [ "leather", 20 ], [ "tanned_hide", 3 ] ], [ [ "cotton_patchwork", 20 ] ] ]
+    "components": [ [ [ "fur", 20 ], [ "tanned_pelt", 3 ], [ "leather", 20 ], [ "sheet_leather", 3 ] ], [ [ "cotton_patchwork", 20 ] ] ]
   },
   {
     "result": "leather_helmet",
@@ -943,7 +943,7 @@
     "using": [ [ "sewing_aramids", 20 ], [ "tailoring_kevlar_fabric", 4 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
     "components": [
-      [ [ "leather", 8 ], [ "tanned_hide", 1 ] ],
+      [ [ "leather", 8 ], [ "sheet_leather", 1 ] ],
       [ [ "cotton_patchwork", 4 ] ],
       [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ],
       [ [ "duct_tape", 100 ] ]
@@ -963,7 +963,7 @@
     "using": [ [ "sewing_aramids", 15 ], [ "tailoring_kevlar_fabric", 2 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
     "components": [
-      [ [ "leather", 6 ], [ "tanned_hide", 1 ] ],
+      [ [ "leather", 6 ], [ "sheet_leather", 1 ] ],
       [ [ "cotton_patchwork", 2 ] ],
       [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ],
       [ [ "duct_tape", 75 ] ]
@@ -1038,7 +1038,7 @@
     "using": [ [ "sewing_aramids", 30 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
     "components": [
-      [ [ "leather", 14 ], [ "tanned_hide", 3 ] ],
+      [ [ "leather", 14 ], [ "sheet_leather", 3 ] ],
       [ [ "cotton_patchwork", 6 ] ],
       [ [ "scrap", 2 ] ],
       [ [ "hood_rain", 2 ], [ "plastic_sheet_small", 4 ], [ "hood_gut", 2 ] ],

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -636,7 +636,7 @@
     "using": [ [ "sewing_standard", 160 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ],
     "components": [
-      [ [ "leather", 6 ], [ "tanned_hide", 1 ], [ "leather_belt", 1 ] ],
+      [ [ "leather", 6 ], [ "sheet_leather", 1 ], [ "leather_belt", 1 ] ],
       [ [ "duct_tape", 100 ] ],
       [ [ "sheath", 1 ] ],
       [ [ "legrig", 1 ], [ "tool_belt", 1 ], [ "dump_pouch", 1 ], [ "leather_pouch", 4 ] ],

--- a/data/json/recipes/armor/pets_cow.json
+++ b/data/json/recipes/armor/pets_cow.json
@@ -49,7 +49,7 @@
       [ [ "link_sheet", 42 ] ],
       [ [ "chain_link", 1100 ] ],
       [ [ "wire", 8 ] ],
-      [ [ "fur", 50 ], [ "tanned_pelt", 8 ], [ "leather", 50 ], [ "tanned_hide", 8 ] ]
+      [ [ "fur", 50 ], [ "tanned_pelt", 8 ], [ "leather", 50 ], [ "sheet_leather", 8 ] ]
     ],
     "proficiencies": [
       { "proficiency": "prof_chain_armour" },

--- a/data/json/recipes/armor/pets_dog.json
+++ b/data/json/recipes/armor/pets_dog.json
@@ -49,7 +49,7 @@
       [ [ "link_sheet", 5 ] ],
       [ [ "chain_link", 131 ] ],
       [ [ "wire", 1 ] ],
-      [ [ "fur", 8 ], [ "tanned_pelt", 1 ], [ "leather", 8 ], [ "tanned_hide", 1 ] ]
+      [ [ "fur", 8 ], [ "tanned_pelt", 1 ], [ "leather", 8 ], [ "sheet_leather", 1 ] ]
     ],
     "proficiencies": [
       { "proficiency": "prof_chain_armour" },

--- a/data/json/recipes/armor/pets_horse.json
+++ b/data/json/recipes/armor/pets_horse.json
@@ -49,7 +49,7 @@
       [ [ "link_sheet", 35 ] ],
       [ [ "chain_link", 917 ] ],
       [ [ "wire", 7 ] ],
-      [ [ "fur", 42 ], [ "tanned_pelt", 7 ], [ "leather", 42 ], [ "tanned_hide", 7 ] ]
+      [ [ "fur", 42 ], [ "tanned_pelt", 7 ], [ "leather", 42 ], [ "sheet_leather", 7 ] ]
     ],
     "proficiencies": [
       { "proficiency": "prof_chain_armour" },

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -615,7 +615,7 @@
         [ "sheet_cotton", 1 ],
         [ "sheet_fur_patchwork", 1 ],
         [ "tanned_pelt", 1 ],
-        [ "tanned_hide", 1 ],
+        [ "sheet_leather", 1 ],
         [ "sheet_leather_patchwork", 6 ]
       ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "pool_cue", 1 ], [ "pointy_stick", 1 ], [ "mop", 1 ] ]

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -315,7 +315,7 @@
     "time": "20 m",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "tanned_hide", 1 ], [ "sheet_leather_patchwork", 1 ] ] ],
+    "components": [ [ [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/basecamps/base/recipe_bare_bones_basecamp/bare_bones_basecamp_recipe_groups.json
+++ b/data/json/recipes/basecamps/base/recipe_bare_bones_basecamp/bare_bones_basecamp_recipe_groups.json
@@ -125,7 +125,7 @@
       { "id": "cured_pelt", "description": " Hideworking: Cured Pelt" },
       { "id": "tanning_hide", "description": " Hideworking: Tanning Hide" },
       { "id": "tanning_pelt", "description": " Hideworking: Tanning Pelt" },
-      { "id": "tanned_hide", "description": " Hideworking: Tanned Hide" },
+      { "id": "sheet_leather", "description": " Hideworking: Tanned Hide" },
       { "id": "leather", "description": " Hideworking: Leather" },
       { "id": "welding_rod_steel", "description": " Craft: Welding Rod" },
       { "id": "welding_rod_alloy", "description": " Craft: Aluminum Welding Rod" },

--- a/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/modular_workshop_recipe_groups.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/modular_workshop_recipe_groups.json
@@ -167,7 +167,7 @@
       { "id": "cured_pelt", "description": " Hideworking: Cured Pelt" },
       { "id": "tanning_hide", "description": " Hideworking: Tanning Hide" },
       { "id": "tanning_pelt", "description": " Hideworking: Tanning Pelt" },
-      { "id": "tanned_hide", "description": " Hideworking: Tanned Hide" },
+      { "id": "sheet_leather", "description": " Hideworking: Tanned Hide" },
       { "id": "leather", "description": " Hideworking: Leather" }
     ]
   }

--- a/data/json/recipes/other/cords_and_ropes.json
+++ b/data/json/recipes/other/cords_and_ropes.json
@@ -101,7 +101,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "tanned_hide", 5 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "sheet_leather", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -118,7 +118,7 @@
     "tools": [ [ [ "spinwheelitem", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "tanned_hide", 5 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "sheet_leather", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -191,7 +191,7 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "tanned_hide", 25 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "sheet_leather", 25 ] ] ]
   },
   {
     "type": "recipe",
@@ -208,7 +208,7 @@
     "tools": [ [ [ "spinwheelitem", -1 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "tanned_hide", 25 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "sheet_leather", 25 ] ] ]
   },
   {
     "type": "recipe",
@@ -550,7 +550,7 @@
     "tools": [ [ [ "electric_spinwheel", 7 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "tanned_hide", 5 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 30 ], [ "leather", 30 ], [ "felt_patch", 30 ], [ "sheet_leather", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -599,7 +599,7 @@
     "tools": [ [ [ "electric_spinwheel", 32 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_fibers" }, { "proficiency": "prof_fibers_rope" } ],
-    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "tanned_hide", 25 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 150 ], [ "leather", 150 ], [ "felt_patch", 150 ], [ "sheet_leather", 25 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1155,7 +1155,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "tanned_hide",
+    "result": "sheet_leather",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "survival",
@@ -1168,7 +1168,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "tanned_hide",
+    "result": "sheet_leather",
     "id_suffix": "from_pieces",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -789,7 +789,7 @@
     "components": [
       [ [ "pipe", 4 ] ],
       [ [ "spring", 2 ] ],
-      [ [ "leather", 12 ], [ "fur", 12 ], [ "tanned_hide", 3 ], [ "tanned_pelt", 3 ] ],
+      [ [ "leather", 12 ], [ "fur", 12 ], [ "sheet_leather", 3 ], [ "tanned_pelt", 3 ] ],
       [ [ "pipe_fittings", 4 ] ],
       [ [ "nylon", 8 ] ]
     ]
@@ -837,7 +837,7 @@
     "components": [
       [ [ "pipe", 4 ] ],
       [ [ "spring", 2 ] ],
-      [ [ "leather", 12 ], [ "fur", 12 ], [ "tanned_hide", 3 ], [ "tanned_pelt", 3 ] ],
+      [ [ "leather", 12 ], [ "fur", 12 ], [ "sheet_leather", 3 ], [ "tanned_pelt", 3 ] ],
       [ [ "pipe_fittings", 4 ] ],
       [ [ "nylon", 8 ] ]
     ]

--- a/data/json/recipes/practice/tailoring.json
+++ b/data/json/recipes/practice/tailoring.json
@@ -176,7 +176,7 @@
     "autolearn": [ [ "tailor", 3 ] ],
     "book_learn": [ [ "dieselpunk_tailor", 2 ], [ "manual_tailor", 2 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "leather", 6 ], [ "tanned_hide", 1 ] ] ],
+    "components": [ [ [ "leather", 6 ], [ "sheet_leather", 1 ] ] ],
     "using": [ [ "sewing_standard", 30 ] ]
   },
   {

--- a/data/json/recipes/recipe_music_instruments.json
+++ b/data/json/recipes/recipe_music_instruments.json
@@ -90,6 +90,6 @@
     "qualities": [ { "id": "LUTHIER", "level": 1 }, { "id": "SAW_W", "level": 2 }, { "id": "CHISEL_WOOD", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic" } ],
     "byproducts": [ [ "splinter", 89 ] ],
-    "components": [ [ [ "tonewood", 6 ] ], [ [ "super_glue", 2 ] ], [ [ "tanned_hide", 2 ] ], [ [ "tuning_pegs", 12 ] ] ]
+    "components": [ [ [ "tonewood", 6 ] ], [ [ "super_glue", 2 ] ], [ [ "sheet_leather", 2 ] ], [ [ "tuning_pegs", 12 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -499,7 +499,7 @@
     ],
     "components": [
       [ [ "stick", 10 ], [ "2x4", 5 ] ],
-      [ [ "leather", 64 ], [ "sheet_leather_patchwork", 8 ], [ "tanned_hide", 8 ] ],
+      [ [ "leather", 64 ], [ "sheet_leather_patchwork", 8 ], [ "sheet_leather", 8 ] ],
       [ [ "filament", 40, "LIST" ] ]
     ]
   },
@@ -523,7 +523,7 @@
     ],
     "components": [
       [ [ "stick", 10 ] ],
-      [ [ "sheet_leather_patchwork", 24 ], [ "sheet_leather", 24 ], [ "tanned_hide", 24 ] ],
+      [ [ "sheet_leather_patchwork", 24 ], [ "sheet_leather", 24 ] ],
       [ [ "filament", 500, "LIST" ] ]
     ]
   },
@@ -547,7 +547,7 @@
     ],
     "components": [
       [ [ "stick", 3 ], [ "2x4", 2 ] ],
-      [ [ "leather", 4 ], [ "tanned_hide", 1 ] ],
+      [ [ "leather", 4 ], [ "sheet_leather", 1 ] ],
       [ [ "damaged_shelter_kit", 1 ] ],
       [ [ "filament", 5, "LIST" ] ]
     ]
@@ -572,7 +572,7 @@
     ],
     "components": [
       [ [ "stick", 6 ] ],
-      [ [ "leather", 16 ], [ "sheet_leather", 4 ], [ "sheet_leather_patchwork", 4 ], [ "tanned_hide", 4 ] ],
+      [ [ "leather", 16 ], [ "sheet_leather_patchwork", 4 ], [ "sheet_leather", 4 ] ],
       [ [ "large_damaged_shelter_kit", 1 ] ],
       [ [ "filament", 100, "LIST" ] ]
     ]
@@ -1912,7 +1912,7 @@
     "autolearn": true,
     "using": [ [ "sewing_standard", 10 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" } ],
-    "components": [ [ [ "sheet_leather_patchwork", 1 ], [ "tanned_hide", 1 ], [ "sheet_fur_patchwork", 1 ], [ "tanned_pelt", 1 ] ] ]
+    "components": [ [ [ "sheet_leather_patchwork", 1 ], [ "sheet_leather", 1 ], [ "sheet_fur_patchwork", 1 ], [ "tanned_pelt", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -2144,7 +2144,7 @@
     "book_learn": [ [ "scots_tailor", 3 ], [ "scots_cookbook", 7 ] ],
     "using": [ [ "sewing_standard", 20 ] ],
     "components": [
-      [ [ "large_stomach_sealed", 1 ], [ "tanned_hide", 2 ], [ "leather", 16 ], [ "tanned_pelt", 2 ], [ "fur", 16 ] ],
+      [ [ "large_stomach_sealed", 1 ], [ "sheet_leather", 2 ], [ "leather", 16 ], [ "tanned_pelt", 2 ], [ "fur", 16 ] ],
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
       [ [ "cotton_patchwork", 3 ] ],
       [ [ "adhesive", 1, "LIST" ], [ "medical_tape", 50 ] ]
@@ -2900,7 +2900,7 @@
     "components": [
       [ [ "2x4", 2 ] ],
       [ [ "nails", 12, "LIST" ] ],
-      [ [ "sheet_leather_patchwork", 2 ], [ "tanned_hide", 2 ], [ "sheet_fur_patchwork", 2 ], [ "tanned_pelt", 2 ] ]
+      [ [ "sheet_leather_patchwork", 2 ], [ "sheet_leather", 2 ], [ "sheet_fur_patchwork", 2 ], [ "tanned_pelt", 2 ] ]
     ]
   },
   {

--- a/data/json/recipes/recipe_vehicle.json
+++ b/data/json/recipes/recipe_vehicle.json
@@ -241,7 +241,7 @@
     "using": [ [ "sewing_standard", 100 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ],
     "components": [
-      [ [ "leather", 16 ], [ "tanned_hide", 2 ], [ "fur", 16 ], [ "tanned_pelt", 2 ] ],
+      [ [ "leather", 16 ], [ "sheet_leather", 2 ], [ "fur", 16 ], [ "tanned_pelt", 2 ] ],
       [ [ "cordage_superior", 2, "LIST" ] ]
     ]
   },
@@ -259,7 +259,7 @@
     "using": [ [ "sewing_standard", 100 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ],
     "components": [
-      [ [ "leather", 8 ], [ "tanned_hide", 1 ], [ "fur", 8 ], [ "tanned_pelt", 1 ] ],
+      [ [ "leather", 8 ], [ "sheet_leather", 1 ], [ "fur", 8 ], [ "tanned_pelt", 1 ] ],
       [ [ "2x4", 4 ] ],
       [ [ "rope_superior_short", 2, "LIST" ] ]
     ]
@@ -292,7 +292,7 @@
       [ [ "pipe", 4 ], [ "scrap", 20 ], [ "steel_chunk", 6 ], [ "steel_lump", 3 ] ],
       [ [ "pipe", 2 ] ],
       [ [ "chain", 2 ], [ "hd_tow_cable", 1 ] ],
-      [ [ "spring", 2 ], [ "tanned_hide", 2 ] ],
+      [ [ "spring", 2 ], [ "sheet_leather", 2 ] ],
       [ [ "nuts_bolts", 6 ] ],
       [ [ "rope_superior_short", 2, "LIST" ], [ "sheet_canvas", 4 ], [ "sheet_canvas_patchwork", 4 ] ]
     ]

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -12,7 +12,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "leather", 6 ], [ "tanned_hide", 1 ], [ "fur", 6 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 10, "LIST" ] ] ]
+    "components": [ [ [ "leather", 6 ], [ "sheet_leather", 1 ], [ "fur", 6 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 10, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -27,7 +27,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "leather", 14 ], [ "tanned_hide", 2 ], [ "fur", 14 ], [ "tanned_pelt", 2 ] ], [ [ "filament", 20, "LIST" ] ] ]
+    "components": [ [ [ "leather", 14 ], [ "sheet_leather", 2 ], [ "fur", 14 ], [ "tanned_pelt", 2 ] ], [ [ "filament", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -42,7 +42,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "leather", 24 ], [ "tanned_hide", 4 ], [ "fur", 24 ], [ "tanned_pelt", 4 ] ], [ [ "filament", 30, "LIST" ] ] ]
+    "components": [ [ [ "leather", 24 ], [ "sheet_leather", 4 ], [ "fur", 24 ], [ "tanned_pelt", 4 ] ], [ [ "filament", 30, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1294,7 +1294,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "leather", 3 ], [ "tanned_hide", 1 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 35, "LIST" ] ] ]
+    "components": [ [ [ "leather", 3 ], [ "sheet_leather", 1 ], [ "tanned_pelt", 1 ] ], [ [ "filament", 35, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1309,7 +1309,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "tanned_hide", 9 ] ], [ [ "filament", 80, "LIST" ] ] ]
+    "components": [ [ [ "sheet_leather", 9 ] ], [ [ "filament", 80, "LIST" ] ] ]
   },
   {
     "result": "dry_bag_large",

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -447,7 +447,7 @@
     ],
     "book_learn": [ [ "textbook_tailor", 4 ], [ "manual_tailor", 5 ], [ "tailor_portfolio", 4 ] ],
     "using": [ [ "sewing_standard", 100 ], [ "cordage", 2 ] ],
-    "components": [ [ [ "leather", 30 ], [ "tanned_hide", 5 ], [ "fur", 30 ], [ "tanned_pelt", 5 ] ], [ [ "wire", 2 ] ] ]
+    "components": [ [ [ "leather", 30 ], [ "sheet_leather", 5 ], [ "fur", 30 ], [ "tanned_pelt", 5 ] ], [ [ "wire", 2 ] ] ]
   },
   {
     "result": "jack",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -278,7 +278,7 @@
     "id": "fabric_leather_hide",
     "type": "requirement",
     "//": "Materials used for crafting leather clothing.",
-    "components": [ [ [ "leather", 8 ], [ "sheet_leather_patchwork", 1 ], [ "tanned_hide", 1 ] ] ]
+    "components": [ [ [ "leather", 8 ], [ "sheet_leather_patchwork", 1 ], [ "sheet_leather", 1 ] ] ]
   },
   {
     "id": "fabric_leather_fur_hide",
@@ -288,7 +288,7 @@
       [
         [ "leather", 8 ],
         [ "fur", 8 ],
-        [ "tanned_hide", 1 ],
+        [ "sheet_leather", 1 ],
         [ "tanned_pelt", 1 ],
         [ "sheet_leather_patchwork", 1 ],
         [ "sheet_fur_patchwork", 1 ]

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -387,21 +387,21 @@
     "type": "requirement",
     "//": "275g per unit. Crafting leather items, per 296 g of leather; 21 g + excessive weight of material is wasted, producing leather patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching.",
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "tanned_hide", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
+    "components": [ [ [ "sheet_leather", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_leather_patchwork",
     "type": "requirement",
     "//": "275g per unit. Crafting leather items, per 296 g of leather; 21 g + excessive weight of material is wasted, producing leather patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching.",
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "sheet_leather", 1 ], [ "tanned_hide", 1 ], [ "sheet_leather_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
+    "components": [ [ [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_leather_patchwork_simple",
     "type": "requirement",
     "//": "275g per unit. Crafting leather items, per 296 g of leather; 21 g + excessive weight of material is wasted, producing leather patches as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching.  Used for simpler items where precision cutting is less important.",
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "CUT", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "sheet_leather", 1 ], [ "tanned_hide", 1 ], [ "sheet_leather_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
+    "components": [ [ [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ], [ [ "filament", 7, "LIST" ] ] ]
   },
   {
     "id": "tailoring_leather_small",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2172,7 +2172,7 @@
     "//": "Thread is odd so we're just kind of giving you some whole pieces of thread, when it shouldn't be near that, but we need a source."
   },
   {
-    "result": "tanned_hide",
+    "result": "sheet_leather",
     "type": "uncraft",
     "time": "2 m",
     "activity_level": "LIGHT_EXERCISE",
@@ -4954,7 +4954,7 @@
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
     "time": "30 m",
-    "components": [ [ [ "leather", 16 ] ], [ [ "tanned_hide", 8 ] ] ],
+    "components": [ [ [ "leather", 16 ] ], [ [ "sheet_leather", 8 ] ] ],
     "qualities": [ { "id": "CUT", "level": 1 } ]
   },
   {
@@ -5020,14 +5020,6 @@
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "faux_fur", 8 ] ] ]
-  },
-  {
-    "result": "sheet_leather",
-    "type": "uncraft",
-    "activity_level": "NO_EXERCISE",
-    "time": "30 s",
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "leather", 8 ] ] ]
   },
   {
     "result": "sheet_felt",


### PR DESCRIPTION
#### Summary
Consolidate tanned_hide and sheet_leather

#### Purpose of change
The great aborted tailoring refactor left us with three dubious 12x24 inch leather items: the patchwork sheet, the leather sheet, and the tanned hide. While an argument could be made for the patchwork sheet, the same could not be said of the other two. Many recipes arbitrarily called for one or the other, making leather crafting annoying in a way that was not realistic or even intended, it was just bad json.

#### Describe the solution
Remove tanned hide, replace in all cases with leather sheet.

#### Describe alternatives you've considered
This will need to be done for fur as well. I should probably also remove all "scraps" items.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
