### PR TITLE
Map backports

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -387,12 +387,12 @@
   {
     "id": "EXPLOSIVE_60mmHE",
     "type": "ammo_effect",
-    "explosion": { "power": 250, "shrapnel": { "casing_mass": 500, "fragment_mass": 0.2 } }
+    "explosion": { "power": 450, "shrapnel": 500 }
   },
   {
     "id": "EXPLOSIVE_60mmHE2",
     "type": "ammo_effect",
-    "explosion": { "power": 358, "shrapnel": { "casing_mass": 430, "fragment_mass": 0.2 } }
+    "explosion": { "power": 658, "shrapnel": 430 }
   },
   {
     "id": "FLASHBANG",

--- a/data/json/items/comestibles/egg.json
+++ b/data/json/items/comestibles/egg.json
@@ -941,6 +941,7 @@
     "price": "95 cent",
     "price_postapoc": "50 cent",
     "material": [ "egg" ],
+    "spoils_in": "2 hours",
     "fun": 4,
     "flags": [ "FREEZERBURN" ],
     "vitamins": [ [ "egg_allergen", 1 ] ]
@@ -1079,6 +1080,7 @@
     "price_postapoc": "3 USD",
     "material": [ "bread", "egg" ],
     "primary_material": "bread",
+    "spoils_in": "4 hours",
     "volume": "649 ml",
     "fun": 10,
     "vitamins": [ [ "egg_allergen", 1 ], [ "bread_allergen", 1 ] ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -35,6 +35,7 @@
 #include "construction.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
+#include "current_map.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "disease.h"
@@ -10894,6 +10895,8 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
 {
     tinymap bay;
     bay.load( om_target, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *bay.cast_to_map() );
     point_omt_ms fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map

--- a/src/current_map.cpp
+++ b/src/current_map.cpp
@@ -1,0 +1,21 @@
+#include <memory>
+
+#include "current_map.h"
+#include "game.h"
+
+map &current_map::get_map()
+{
+    return *current;
+}
+
+swap_map::swap_map( map &new_map )
+{
+    previous = g->current_map.current;
+    g->current_map.set( &new_map );
+}
+
+swap_map::~swap_map()
+{
+    g->current_map.set( previous );
+}
+

--- a/src/current_map.h
+++ b/src/current_map.h
@@ -1,0 +1,39 @@
+#pragma once
+#ifndef CATA_SRC_CURRENT_MAP_H
+#define CATA_SRC_CURRENT_MAP_H
+
+class map;
+
+// The purpose of this class is to contain a reference to the current map.
+// This map is typically the reality bubble map, but will differ e.g. when
+// mapgen is invoked. Its only intended use is to be kept by the game object.
+class current_map
+{
+        friend class game;
+        friend class swap_map;
+
+    protected:
+        void set( map *new_map ) {
+            current = new_map;
+        }
+
+    public:
+        map &get_map();
+    protected:
+        map *current;
+};
+
+// The purpose of this class is to swap out the current map for the duration of
+// this object's lifetime. This will typically be for the processing of some map
+// that's not the reality bubble one, such as one used during mapgen.
+class swap_map
+{
+    public:
+        explicit swap_map( map &new_map );
+        ~swap_map();
+
+    private:
+        map *previous;
+};
+
+#endif // CATA_SRC_CURRENT_MAP_H

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -46,6 +46,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
+#include "current_map.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "dialogue.h"
@@ -3506,6 +3507,7 @@ static void map_extra()
                                               _( "Select location to spawn map extra." ), true ) );
         if( !where_omt.is_invalid() ) {
             smallmap mx_map;
+            swap_map swap( *mx_map.cast_to_map() );
             mx_map.load( where_omt, false );
             MapExtras::apply_function( mx_str[mx_choice], mx_map, where_omt );
             g->load_npcs();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -25,6 +25,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
+#include "current_map.h"
 #include "damage.h"
 #include "debug.h"
 #include "enums.h"
@@ -985,6 +986,7 @@ void process_explosions()
             // or have a vehicle run into a crater suddenly appearing just in front of it.
             process_explosions_in_progress = true;
             m.load( origo, true, false );
+            swap_map swap( m );
             m.spawn_monsters( true, true );
             g->load_npcs( &m );
             process_explosions_in_progress = false;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -22,6 +22,9 @@
 #include "colony.h"
 #include "color.h"
 #include "coordinates.h"
+#include "crafting.h"
+#include "crafting_gui.h"
+#include "current_map.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "enums.h"
@@ -2614,6 +2617,8 @@ void basecamp::start_relay_hide_site( const mission_id &miss_id, float exertion_
         //Check items in improvised shelters at hide site
         tinymap target_bay;
         target_bay.load( forest, false );
+        // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+        swap_map swap( *target_bay.cast_to_map() );
 
         units::volume total_import_volume;
         units::mass total_import_mass;
@@ -4771,6 +4776,8 @@ int om_harvest_ter( npc &comp, const tripoint_abs_omt &omt_tgt, const ter_id &t,
     const ter_t &ter_tgt = t.obj();
     tinymap target_bay;
     target_bay.load( omt_tgt, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *target_bay.cast_to_map() );
     int harvested = 0;
     int total = 0;
     const tripoint_omt_ms mapmin{ 0, 0, omt_tgt.z() };
@@ -4817,6 +4824,8 @@ int om_cutdown_trees( const tripoint_abs_omt &omt_tgt, int chance, bool estimate
                       bool force_cut_trunk )
 {
     smallmap target_bay;
+    // Redundant as long as map operations used aren't using get_map() transitively, but this makes it safe to do so later.
+    swap_map swap( *target_bay.cast_to_map() );
     target_bay.load( omt_tgt, false );
     int harvested = 0;
     int total = 0;
@@ -4861,6 +4870,8 @@ mass_volume om_harvest_itm( const npc_ptr &comp, const tripoint_abs_omt &omt_tgt
 {
     tinymap target_bay;
     target_bay.load( omt_tgt, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *target_bay.cast_to_map() );
     units::mass harvested_m = 0_gram;
     units::volume harvested_v = 0_ml;
     units::mass total_m = 0_gram;
@@ -5018,6 +5029,8 @@ bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
 {
     tinymap target_bay;
     target_bay.load( omt_tgt, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *target_bay.cast_to_map() );
     target_bay.ter_set( relay_site_stash, ter_t_improvised_shelter );
     for( drop_location it : itms_rem ) {
         item *i = it.first.get_item();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -74,6 +74,7 @@
 #include "coordinates.h"
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
+#include "current_map.h"
 #include "cursesport.h" // IWYU pragma: keep
 #include "damage.h"
 #include "debug.h"
@@ -450,6 +451,7 @@ game::game() :
     scent_ptr( *this ),
     achievements_tracker_ptr( *stats_tracker_ptr, achievement_attained, achievement_failed, true ),
     m( *map_ptr ),
+    current_map( *current_map_ptr ),
     u( *u_ptr ),
     scent( *scent_ptr ),
     timed_events( *timed_event_manager_ptr ),
@@ -462,6 +464,7 @@ game::game() :
     tileset_zoom( DEFAULT_TILESET_ZOOM ),
     last_mouse_edge_scroll( std::chrono::steady_clock::now() )
 {
+    current_map.set( &m );
     first_redraw_since_waiting_started = true;
     reset_light_level();
     events().subscribe( &*stats_tracker_ptr );
@@ -14537,7 +14540,7 @@ avatar &get_avatar()
 
 map &get_map()
 {
-    return g->m;
+    return g->current_map.get_map();
 }
 
 map &reality_bubble()

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1211,6 +1211,8 @@ vehicle *game::place_vehicle_nearby(
             // try place vehicle there.
             tinymap target_map;
             target_map.load( goal, false );
+            // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+            swap_map swap( *target_map.cast_to_map() );
             const tripoint_omt_ms tinymap_center( SEEX, SEEY, goal.z() );
             static constexpr std::array<units::angle, 4> angles = {{
                     0_degrees, 90_degrees, 180_degrees, 270_degrees

--- a/src/game.h
+++ b/src/game.h
@@ -72,6 +72,7 @@ class achievements_tracker;
 class avatar;
 class cata_path;
 class creature_tracker;
+class current_map;
 class eoc_events;
 class event_bus;
 class faction_manager;
@@ -145,6 +146,7 @@ class game
         friend class editmap;
         friend class main_menu;
         friend class exosuit_interact;
+        friend class swap_map;
         friend achievements_tracker &get_achievements();
         friend event_bus &get_event_bus();
         friend map &get_map();
@@ -1086,6 +1088,7 @@ class game
         // ########################## DATA ################################
         // May be a bit hacky, but it's probably better than the header spaghetti
         pimpl<map> map_ptr; // NOLINT(cata-serialize)
+        pimpl<::current_map> current_map_ptr; // NOLINT(cata-serialize)
         pimpl<avatar> u_ptr; // NOLINT(cata-serialize)
         pimpl<live_view> liveview_ptr; // NOLINT(cata-serialize)
         live_view &liveview; // NOLINT(cata-serialize)
@@ -1100,6 +1103,8 @@ class game
         pimpl<eoc_events> eoc_events_ptr; // NOLINT(cata-serialize)
 
         map &m; // NOLINT(cata-serialize)
+        // 'current_map' will be identical to 'm' as you can save only at the top of the main loop.
+        ::current_map &current_map; // NOLINT(cata-serialize)
         avatar &u;
         scent_map &scent;
         // scenario is saved in avatar::store

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -37,6 +37,7 @@
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
+#include "current_map.h"
 #include "damage.h"
 #include "debug.h"
 #include "do_turn.h"
@@ -8577,6 +8578,7 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
 
     if( map_incomplete ) {
         smallmap tmp_map;
+        swap_map swap( *tmp_map.cast_to_map() );
         tmp_map.main_cleanup_override( false );
         tmp_map.generate( grid_abs_omt, calendar::turn, true );
         _main_requires_cleanup |= main_inbounds && tmp_map.is_main_cleanup_queued();
@@ -9283,10 +9285,8 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
                                tmp.wander_pos.to_string_writable() );
             }
 
-            // This usage of get_map() rather than the actual map used is due to the called operation's hidden usage of
-            // the reality bubble map, so the reference has to be adjusted to match that.
             monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ),
-                                    get_map().get_bub( abs_pos ) );
+                                    local_pos );
             if( placed ) {
                 placed->on_load();
             }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -22,6 +22,7 @@
 #include "colony.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
+#include "current_map.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "enums.h"
@@ -501,6 +502,9 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
     }
 
     tinymap m;
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *m.cast_to_map() );
+
     if( bridge_at_north && road_at_south ) {
         // Remove vehicles. They don't make sense here, and may cause collision crashes.
         m.load( abs_omt + point::south, true );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7441,8 +7441,7 @@ void map::rotate( int turns )
             continue;
         }
 
-        // Translate bubble -> global -> current map.
-        const point_bub_ms old( get_bub( get_map().get_abs( np.pos_bub() ).xy() ) );
+        const point_bub_ms old( get_bub( np.pos_abs().xy() ) );
 
         const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
         np.spawn_at_precise( get_abs( tripoint_bub_ms( new_pos, sq.z() ) ) );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -23,6 +23,7 @@
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
+#include "current_map.h"
 #include "cursesdef.h"
 #include "debug.h"
 #include "enums.h"
@@ -1581,6 +1582,9 @@ void talk_function::field_plant( npc &p, const std::string &place )
                                       player_character.pos_abs_omt(), place, 20, false );
     tinymap bay;
     bay.load( site, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+
+    swap_map swap( *bay.cast_to_map() );
     for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         if( bay.ter( plot ) == ter_t_dirtmound ) {
             empty_plots++;
@@ -1653,6 +1657,9 @@ void talk_function::field_harvest( npc &p, const std::string &place )
     std::vector<itype_id> plant_types;
     std::vector<std::string> plant_names;
     bay.load( site, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *bay.cast_to_map() );
+
     for( const tripoint_omt_ms &plot : bay.points_on_zlevel() ) {
         map_stack items = bay.i_at( plot );
         if( bay.furn( plot ) == furn_f_plant_harvest && !items.empty() ) {
@@ -2798,6 +2805,8 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
 {
     tinymap bay;
     bay.load( site, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *bay.cast_to_map() );
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
     for( const tripoint_omt_ms &p : bay.points_on_zlevel() ) {

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -9,6 +9,7 @@
 #include "character.h"
 #include "computer.h"
 #include "coordinates.h"
+#include "current_map.h"
 #include "debug.h"
 #include "enum_traits.h"
 #include "game.h"
@@ -181,6 +182,8 @@ void mission_start::place_npc_software( mission *miss )
 
     tinymap compmap;
     compmap.load( place, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *compmap.cast_to_map() );
     tripoint_omt_ms comppoint;
 
     oter_id oter = overmap_buffer.ter( place );
@@ -223,6 +226,8 @@ void mission_start::place_deposit_box( mission *miss )
 
     tinymap compmap;
     compmap.load( site, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *compmap.cast_to_map() );
     std::vector<tripoint_omt_ms> valid;
     for( const tripoint_omt_ms &p : compmap.points_on_zlevel() ) {
         if( compmap.ter( p ) == ter_t_floor ) {
@@ -358,6 +363,8 @@ void static create_lab_consoles(
 
         tinymap compmap;
         compmap.load( om_place, false );
+        // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+        swap_map swap( *compmap.cast_to_map() );
 
         tripoint_omt_ms comppoint = find_potential_computer_point( compmap );
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -31,6 +31,8 @@
 #include "condition.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
+#include "current_map.h"
+#include "damage.h"
 #include "debug.h"
 #include "dialogue_helpers.h"
 #include "effect_on_condition.h"
@@ -3558,6 +3560,8 @@ void map_add_item( item &it, tripoint_abs_ms target_pos )
     } else {
         tinymap target_bay;
         target_bay.load( project_to<coords::omt>( target_pos ), false );
+        // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+        swap_map swap( *target_bay.cast_to_map() );
         target_bay.add_item_or_charges( target_bay.get_omt( target_pos ), it );
     }
 }

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -11,6 +11,7 @@
 #include "colony.h"
 #include "coordinates.h"
 #include "creature.h"
+#include "current_map.h"
 #include "debug.h"
 #include "effect_source.h"
 #include "enum_conversions.h"
@@ -367,6 +368,8 @@ void start_location::prepare_map( const tripoint_abs_omt &omtstart ) const
     // Now prepare the initial map (change terrain etc.)
     tinymap player_start;
     player_start.load( omtstart, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *player_start.cast_to_map() );
     prepare_map( player_start );
     player_start.save();
 }
@@ -527,6 +530,8 @@ void start_location::burn( const tripoint_abs_omt &omtstart, const size_t count,
 {
     tinymap m;
     m.load( omtstart, false );
+    // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
+    swap_map swap( *m.cast_to_map() );
     m.build_outside_cache( m.get_abs_sub().z() );
     point_bub_ms player_pos = get_player_character().pos_bub().xy();
     const point_bub_ms u( player_pos.x() % HALF_MAPSIZE_X, player_pos.y() % HALF_MAPSIZE_Y );


### PR DESCRIPTION
#### Summary
Map backports

#### Purpose of change
80548 - swap map returned by get_map()
80773 - translate coords correctly
80782 - added swap safeguard to temp map access

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
