### PR TITLE
Backport 78888 and 78515 - wiring stuff

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -61,7 +61,8 @@
     "name": { "str": "abstract concrete wall", "//~": "NO_I18N" },
     "description": "Encompasses most concrete-like walls.  If you see this in-game, it's a bug.",
     "roof": "t_concrete_roof",
-    "color": "light_gray"
+    "color": "light_gray",
+    "extend": { "flags": [ "WIRED_WALL" ] }
   },
   {
     "type": "terrain",
@@ -70,7 +71,8 @@
     "name": { "str": "abstract brick wall", "//~": "NO_I18N" },
     "description": "Encompasses most brick-like walls.  If you see this in-game, it's a bug.",
     "roof": "t_brick_roof",
-    "color": "brown"
+    "color": "brown",
+    "extend": { "flags": [ "WIRED_WALL" ] }
   },
   {
     "type": "terrain",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1781,13 +1781,6 @@
   },
   {
     "type": "keybinding",
-    "id": "HIDE",
-    "category": "APP_INTERACT",
-    "name": "Hide/Unhide wiring",
-    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
-  },
-  {
-    "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1781,6 +1781,13 @@
   },
   {
     "type": "keybinding",
+    "id": "HIDE",
+    "category": "APP_INTERACT",
+    "name": "Hide/Unhide wiring",
+    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4986,7 +4986,8 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
         link_menu.text = string_format( _( "What to do with the %s?%s" ), it.link_name(), t_veh ?
                                         string_format( _( "\nAttached to: %s" ), t_veh->name ) : "" );
         if( targets.count( link_state::vehicle_port ) > 0 ) {
-            link_menu.addentry( 0, has_loose_end, -1, _( "Attach to vehicle controls or appliance" ) );
+            link_menu.addentry( 0, has_loose_end, -1,
+                                _( "Attach to dashboard, electronics control unit or appliance" ) );
         }
         if( targets.count( link_state::vehicle_battery ) > 0 ) {
             link_menu.addentry( 1, has_loose_end, -1, _( "Attach to vehicle battery or appliance" ) );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3286,6 +3286,7 @@ void vehicle_part::deserialize( const JsonObject &data )
     data.read( "locked", locked );
     data.read( "last_disconnected", last_disconnected );
     data.read( "last_charged", last_charged );
+    data.read( "hidden", hidden );
 
     if( migration != nullptr ) {
         for( const itype_id &it : migration->add_veh_tools ) {
@@ -3341,6 +3342,7 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "locked", locked );
     json.member( "last_disconnected", last_disconnected );
     json.member( "last_charged", last_charged );
+    json.member( "hidden", hidden );
     json.end_object();
 }
 

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -1,3 +1,4 @@
+#include "cached_options.h"
 #include "game.h"
 #include "handle_liquid.h"
 #include "inventory.h"
@@ -596,11 +597,12 @@ void veh_app_interact::populate_app_actions( map &here )
                                    veh->is_powergrid() ? _( " / merge power grid" ) : "" ) );
 #if defined(TILES)
     // Hide
-    app_actions.emplace_back( [this]() {
-        hide();
-    } );
-    imenu.addentry( -1, use_tiles && vp->info().has_flag( flag_WIRING ),
-                    ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+    if( use_tiles && vp->info().has_flag( flag_WIRING ) ) {
+        app_actions.emplace_back( [this]() {
+            hide();
+        } );
+        imenu.addentry( -1, true, ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+    }
 #endif
 
     if( veh->is_powergrid() && veh->part_count() > 1 && !vp->info().has_flag( VPFLAG_WALL_MOUNTED ) ) {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -601,7 +601,7 @@ void veh_app_interact::populate_app_actions( map &here )
         app_actions.emplace_back( [this]() {
             hide();
         } );
-        imenu.addentry( -1, true, ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+        imenu.addentry( -1, true, 0, "Hide/Unhide wiring" );
     }
 #endif
 

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -539,6 +539,13 @@ void veh_app_interact::plug( map &here )
     }
 }
 
+void veh_app_interact::hide()
+{
+    const int part_idx = veh->part_at( veh->coord_translate( a_point ) );
+    vehicle_part &vp = veh->part( part_idx );
+    vp.hidden = !vp.hidden;
+}
+
 void veh_app_interact::populate_app_actions( map &here )
 {
     vehicle_part *vp;
@@ -587,6 +594,14 @@ void veh_app_interact::populate_app_actions( map &here )
                     string_format( "%s%s", ctxt.get_action_name( "PLUG" ),
                                    //~ An addendum to Plug In's description, as in: Plug in appliance / merge power grid".
                                    veh->is_powergrid() ? _( " / merge power grid" ) : "" ) );
+#if defined(TILES)
+    // Hide
+    app_actions.emplace_back( [this]() {
+        hide();
+    } );
+    imenu.addentry( -1, use_tiles && vp->info().has_flag( flag_WIRING ),
+                    ctxt.keys_bound_to( "HIDE" ).front(), ctxt.get_action_name( "HIDE" ) );
+#endif
 
     if( veh->is_powergrid() && veh->part_count() > 1 && !vp->info().has_flag( VPFLAG_WALL_MOUNTED ) ) {
         // Disconnect from power grid

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -140,6 +140,11 @@ class veh_app_interact
         */
         void plug( map &here );
         /**
+        * Function associated with the "HIDE" action.
+        * Hides the selected tiles sprite.
+        */
+        void hide();
+        /**
          * The main loop of the appliance UI. Redraws windows, checks for input, and
          * performs selected actions. The loop exits once an activity is assigned
          * (either directly to the player or to 'act'), or when QUIT input is received.

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -522,6 +522,9 @@ struct vehicle_part {
         /** door is locked */
         bool locked = false;
 
+        // If the part's sprite/symbol shouldn't be shown
+        bool hidden = false;
+
         /** direction the part is facing */
         units::angle direction = 0_degrees;
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -66,6 +66,9 @@ vpart_display vehicle::get_display_of_tile( const point_rel_ms &dp, bool rotate,
     }
 
     const vehicle_part &vp = part( part_idx );
+    if( vp.hidden ) {
+        return {};
+    }
     const vpart_info &vpi = vp.info();
 
     auto variant_it = vpi.variants.find( vp.variant );


### PR DESCRIPTION
#### Summary
Backport 78888 and 78515 - wiring stuff

#### Purpose of change
Clarify the text for plugging in tools and give wall wiring displays a toggle.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
