### PR TITLE
Kilt & workshop typos

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -392,7 +392,7 @@
     "id": "kilt_utility",
     "type": "ARMOR",
     "name": { "str": "utility kilt" },
-    "description": "Common among American nerds and rivetheads, the utility kilt is a durabable canvas kilt with a large front pocket.",
+    "description": "Common among American nerds and rivetheads, the utility kilt is a durable canvas kilt with a large front pocket.",
     "weight": "500 g",
     "volume": "1500 ml",
     "price": "35 USD",

--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -178,7 +178,7 @@
     "type": "vehicle_part",
     "id": "veh_tools_workshop",
     "copy-from": "veh_tools_part_abstract",
-    "description": "A table rig with drawers and fixtures for storing tools, wiring for high power electric connectors and valves for for fuel tank connections.",
+    "description": "A table rig with drawers and fixtures for storing tools, wiring for high power electric connectors and valves for fuel tank connections.",
     "looks_like": "welding_rig",
     "item": "veh_tools_workshop",
     "//": "allow tools here that require high power draw but no fume hood",


### PR DESCRIPTION
Typo fixes to utility kilt and mounted workshop

#### Summary
Typo fixes to utility kilt and mounted workshop

#### Purpose of change
Typo fixes to utility kilt and mounted workshop

#### Describe the solution
Fixed the typos

#### Describe alternatives you've considered
None

#### Testing
Runs fine, typos are gone. 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
