### PR TITLE
Innawood - Update yoke_harness recipe

### DIFF
--- a/data/mods/innawood/recipes/recipe_vehicle.json
+++ b/data/mods/innawood/recipes/recipe_vehicle.json
@@ -80,7 +80,7 @@
     "using": [ [ "sewing_standard", 100 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ],
     "components": [
-      [ [ "leather", 8 ], [ "tanned_hide", 1 ], [ "fur", 8 ], [ "tanned_pelt", 1 ] ],
+      [ [ "leather", 8 ], [ "sheet_leather", 1 ], [ "fur", 8 ], [ "tanned_pelt", 1 ] ],
       [ [ "2x4", 4 ] ],
       [ [ "rope_superior_short", 2, "LIST" ] ]
     ]


### PR DESCRIPTION
#### Summary

Update yoke_harness recipe to replace tanned_hide with sheet_leather.

#### Purpose of change

Tanned hide has been replaced by leather sheets after the consolidation of sheet_leather and tanned_hide in #1469.

#### Describe the solution

Replace tanned_hide with sheet_leather.

#### Describe alternatives you've considered

None

#### Testing

Loads without errors, and recipe works.

#### Additional context
<img width="1587" height="927" alt="cataclysm-tiles_iD45CtkXtD" src="https://github.com/user-attachments/assets/e16b726a-6eb7-45e9-8abe-4dc3da59cf28" />
