### PR TITLE
Recover invalidated bubble coordinate (Backport 80479)

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12183,7 +12183,7 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                            bool intentional )
 {
     map &here = get_map();
-    const tripoint_bub_ms pos = c->pos_bub( here );
+    tripoint_bub_ms pos = c->pos_bub( here );
 
     if( c == nullptr ) {
         debugmsg( "game::fling_creature invoked on null target" );
@@ -12305,6 +12305,8 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                 // If we're flinging the player around, make sure the map stays centered on them.
                 if( is_u ) {
                     update_map( pt.x(), pt.y() );
+                    // update_map invalidates all bubble coordinates if it shifts the map.
+                    pos = c->pos_bub( here );
                 } else {
                     you->setpos( here, pt );
                 }


### PR DESCRIPTION
#### Summary
Recover invalidated bubble coordinate (Backport 80479)

#### Purpose of change
- Throw distances for hulks and other monsters were all messed up. They'd either knock you a single tile or like 80. This was because in the middle of the function, the map was being reset so they were losing track of the target coordinates before sending you there.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
