### PR TITLE
Fs zstd fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,8 +591,8 @@ endif
 # OSX
 ifeq ($(NATIVE), osx)
   DEFINES += -DMACOSX
-  CXXFLAGS += -mmacosx-version-min=10.13
-  LDFLAGS += -mmacosx-version-min=10.13 -framework CoreFoundation -Wl,-headerpad_max_install_names
+  CXXFLAGS += -mmacosx-version-min=10.15
+  LDFLAGS += -mmacosx-version-min=10.15 -framework CoreFoundation -Wl,-headerpad_max_install_names
   LDFLAGS += -liconv 
   ifeq ($(UNIVERSAL_BINARY), 1)
     CXXFLAGS += -arch x86_64 -arch arm64

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -47,17 +47,15 @@ At the time of writing:
   12.0](https://fedora.pkgs.org/36/fedora-x86_64/gcc-12.0.1-0.16.fc36.x86_64.rpm.html).
 * MSYS [offers gcc 12.2](https://packages.msys2.org/base).
 * macOS 10.15+ (macOS Catalina) has 96.0% [market
-  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)
+  share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)[^1]
   and that corresponds to [XCode 11.4](https://xcodereleases.com/).
+
+[^1]: [macOS releases past 10.15 series can not be estimated faithfully](https://bugs.webkit.org/show_bug.cgi?id=216593)
 
 In practice, compiler support is often determined by what is covered in our
 automated testing.
 
-At time of writing, the oldest relevant compiler is XCode 10.1, the latest
-supported on macOS 10.13, which is based on LLVM 6.
-[^2]: [macOS releases past 10.15 series can not be estimated faithfully](https://bugs.webkit.org/show_bug.cgi?id=216593)
-
-With gcc 9.3, clang 10, and XCode 10.1 we can get all the C++17 language
+With the supported compilers we can get all the C++17 language
 features and [most but not all of the C++17 library
 features](https://en.cppreference.com/w/cpp/compiler_support/17).  The
 following C++17 features are not supported widely enough for us to use:

--- a/doc/COMPILING/COMPILER_SUPPORT.md
+++ b/doc/COMPILING/COMPILER_SUPPORT.md
@@ -6,7 +6,7 @@
 | [clang](https://clang.llvm.org)                      |                          10.0 |
 | [MinGW-w64](https://www.mingw-w64.org)               |         10.0.0 <br/> GCC 11.2 |
 | [Visual Studio](https://visualstudio.microsoft.com/) | [2019](COMPILING-VS-VCPKG.md) |
-| [XCode](https://developer.apple.com/xcode)           | 10.1 <br/> [macOS 10.13](https://en.wikipedia.org/wiki/MacOS_High_Sierra) |
+| [XCode](https://developer.apple.com/xcode)           | [11.4](https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4-release-notes) <br/> [macOS 10.15](https://en.wikipedia.org/wiki/MacOS_Catalina) |
 
 ## Mingw and Mingw-w64
 
@@ -46,15 +46,16 @@ At the time of writing:
   which uses [gcc
   12.0](https://fedora.pkgs.org/36/fedora-x86_64/gcc-12.0.1-0.16.fc36.x86_64.rpm.html).
 * MSYS [offers gcc 12.2](https://packages.msys2.org/base).
-* macOS 10.13+ has 96.0% [market
+* macOS 10.15+ (macOS Catalina) has 96.0% [market
   share](https://gs.statcounter.com/os-version-market-share/macos/desktop/worldwide)
-  and that corresponds to [XCode 10.1](https://xcodereleases.com/).
+  and that corresponds to [XCode 11.4](https://xcodereleases.com/).
 
 In practice, compiler support is often determined by what is covered in our
 automated testing.
 
 At time of writing, the oldest relevant compiler is XCode 10.1, the latest
 supported on macOS 10.13, which is based on LLVM 6.
+[^2]: [macOS releases past 10.15 series can not be estimated faithfully](https://bugs.webkit.org/show_bug.cgi?id=216593)
 
 With gcc 9.3, clang 10, and XCode 10.1 we can get all the C++17 language
 features and [most but not all of the C++17 library


### PR DESCRIPTION
#### Summary
Backport fixes for save compression

#### Purpose of change
79098
```
changeset:   e22e4b2db388cfcf4b1b256a129714f8c699c54a
user:        moxian <moxian@users.noreply.github.com>
date:        Mon, 29 Sep 2025 09:24:01 -0700
summary:     Bump minimum supported macOS version to 10.15 (macOS Catalina) (#79098)
```

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
