### PR TITLE
Fix android32 build

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -554,7 +554,7 @@ void overmap::unserialize( const JsonObject &jsobj )
                 optional( river_json, false, "control1", control_1, point_om_omt::invalid );
                 optional( river_json, false, "control2", control_2, point_om_omt::invalid );
                 mandatory( river_json, false, "size", size );
-                rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, size } );
+                rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, static_cast<size_t>( size ) } );
             }
         } else if( name == "connections_out" ) {
             om_member.read( connections_out );


### PR DESCRIPTION
It complains about narrowing here, but mac needs uint64_t for deserializing - use a cast to silence it.

#### Summary
Fix android32 build

#### Purpose of change
81199
```
changeset:   98a88b8e1f09066648c11353a710db3776885327
user:        ehughsbaird <44244083+ehughsbaird@users.noreply.github.com>
date:        Sat, 07 Jun 2025 08:33:48 -0700
summary:     Fix emscripten build
```
#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
