### PR TITLE
Fix a bad get_map()

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10412,7 +10412,8 @@ bool map::try_fall( const tripoint_bub_ms &p, Creature *c )
     item jetpack = you->item_worn_with_flag( json_flag_JETPACK );
     // TODO: Typify this whole function
     tripoint_bub_ms p_bub = tripoint_bub_ms( p );
-    if( you->has_flag( json_flag_WALL_CLING ) &&  get_map().is_clingable_wall_adjacent( p_bub ) ) {
+    const map &here = *this;
+    if( you->has_flag( json_flag_WALL_CLING ) &&  here.is_clingable_wall_adjacent( p_bub ) ) {
         you->add_msg_player_or_npc( _( "You cling to the nearby wall." ),
                                     _( "<npcname> clings to the wall." ) );
         return false;
@@ -10845,7 +10846,7 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
     const ter_t &terrain = tile.get_ter_t();
     const furn_t &furniture = tile.get_furn_t();
     const field &field = tile.get_field();
-    const map &here = get_map();
+    const map &here = *this;
     int part;
     const vehicle *veh = veh_at_internal( p, part );
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7756,7 +7756,12 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         leak_fuel( here, vp );
 
         for( const item &e : vp.items ) {
-            here.add_item_or_charges( vppos, e );
+            if( !e.is_null() && e.typeId().is_valid() ) {
+                here.add_item_or_charges( vppos, e );
+            } else {
+                debugmsg( "damage_direct() skipping invalid item: %s",
+                        e.is_null() ? "(null)" : e.typeId().c_str() );
+            }
         }
         vp.items.clear();
 


### PR DESCRIPTION
#### Summary
Fix a bad get_map()

#### Purpose of change
Players were infrequently experiencing segfaults. While looking into the crash reports, I discovered the issue was one reported on DDA's github. Mapifying some functions meant that calling get_map() inside of them was getting the player's map instead of the one they were trying to work on.

A separate issue appeared to be caused by vehicle bashing. In some unknown circumstance I cannot reproduce, items stored within a vehicle tile were somehow causing a segfault when that tile was destroyed and its contents were to be placed on the ground. It's possible the items were being destroyed or they hadn't loaded in yet or some other thing (in this instance it was caused by riot damage, which was briefly enabled).

#### Describe the solution
Issue 1: get_map() -> *this

Issue 2:  Since I don't know what's going on yet, I just added a null guard to the function and a debugmsg in case it happens again.

#### Testing
Compiles and runs, climbing walls and falling off of them appears to work fine.

#### Additional context
Based on comments in: https://github.com/CleverRaven/Cataclysm-DDA/issues/77502

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
