### PR TITLE
Improve NPC pulping behavior

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3932,10 +3932,6 @@ bool npc::find_corpse_to_pulp()
             player_character.in_vehicle || is_hallucination() ) {
             return false;
         }
-        if( rl_dist( pos_bub(), player_character.pos_bub() ) >= mem_combat.engagement_distance ) {
-            // don't start to pulp corpses if you're already far from the player.
-            return false;
-        }
     }
 
     // Pathing with overdraw can get expensive, limit it
@@ -3973,9 +3969,11 @@ bool npc::find_corpse_to_pulp()
 
         return nullptr;
     };
-
-    const int range = mem_combat.engagement_distance;
-
+    int range = 8;
+    // This does not strictly follow the follow_close rules but it's probably good enough if the player wants the NPC pulping.
+    if( rules.has_flag( ally_rule::follow_close ) ) {
+        int follow_distance();
+    }
     const item *corpse = nullptr;
     if( pulp_location && square_dist( pos_abs(), *pulp_location ) <= range ) {
         corpse = check_tile( here.get_bub( *pulp_location ) );
@@ -4003,7 +4001,7 @@ bool npc::find_corpse_to_pulp()
         }
     }
 
-    if( corpse != nullptr && corpse != old_target && is_walking_with() ) {
+    if( corpse != nullptr && corpse != old_target && is_walking_with() && rules.has_flag( ally_rule::allow_complain ) ) {
         std::string talktag = chat_snippets().snip_pulp_zombie.translated();
         parse_tags( talktag, get_player_character(), *this );
         say( string_format( talktag, corpse->tname() ) );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3969,7 +3969,8 @@ bool npc::find_corpse_to_pulp()
 
         return nullptr;
     };
-    int range = 8;
+    // TODO: I'm not sure whether this should be farther.
+    int range = 6;
     // This does not strictly follow the follow_close rules but it's probably good enough if the player wants the NPC pulping.
     if( rules.has_flag( ally_rule::follow_close ) ) {
         int follow_distance();


### PR DESCRIPTION
#### Summary
Improve NPC pulping behavior

#### Purpose of change
- NPCs were using their combat range as their pulping range. This is unintuitive, as combat is not pulping.
- NPCs were complaining about wanting to go pulp corpses even if they had been told to keep quiet.

#### Describe the solution
Pulp range is now 6, which was the previous maximum. It will drops to 4 or 2 if you have the NPC set to follow you closely. This may allow them to step slightly more than 2 or 4 steps away from you, but it's assumed you're OK with that if you have pulping left on.

NPCs will not mention wanting to pulp corpses if you have told them to be quiet.

#### Testing
Seems to work as intended.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
