### PR TITLE
Fix megafauna eggs

### DIFF
--- a/data/mods/Megafauna/items/animal_products.json
+++ b/data/mods/Megafauna/items/animal_products.json
@@ -27,7 +27,7 @@
     "quench": 9,
     "calories": 140,
     "volume": "90 ml",
-    "rot_spawn": "GROUP_EGG_AUK"
+    "rot_spawn": { "group": "GROUP_EGG_AUK", "chance": 50 }
   },
   {
     "type": "COMESTIBLE",
@@ -38,7 +38,7 @@
     "quench": 14,
     "calories": 2100,
     "volume": "1800 ml",
-    "rot_spawn": "GROUP_EGG_TITANIS_WALLERI"
+    "rot_spawn": { "group": "GROUP_EGG_TITANIS_WALLERI", "chance": 50 }
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION
#### Summary
Fix megafauna eggs

#### Purpose of change
Titanis walleri and great auk eggs were throwing errors.

#### Describe the solution
Error no more.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
