### PR TITLE
Silence two common error messages

### DIFF
--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -83,7 +83,8 @@ bool creature_tracker::add( const shared_ptr_fast<monster> &critter_ptr )
         } else if( critter.is_hallucination() ) {
             return false;
         } else {
-            debugmsg( "there's already a monster at %s", critter.pos_abs().to_string_writable() );
+            // TODO: Is this literally ever something the player needs to know about?
+            // debugmsg( "there's already a monster at %s", critter.pos_abs().to_string_writable() );
             return false;
         }
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3431,31 +3431,32 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                 dat.m.i_clear( p );
             }
 
-            if( chosen_id != terrain_here ) {
-                std::string error;
-                trap_str_id trap_here = dat.m.tr_at( p ).id;
-                if( act_furn != apply_action::act_ignore && dat.m.furn( p ) != furn_str_id::NULL_ID() ) {
-                    // NOLINTNEXTLINE(cata-translate-string-literal)
-                    error = string_format( "furniture was %s", dat.m.furn( p ).id().str() );
-                } else if( act_trap != apply_action::act_ignore && !trap_here.is_null() &&
-                           trap_here.id() != terrain_here->trap ) {
-                    // NOLINTNEXTLINE(cata-translate-string-literal)
-                    error = string_format( "trap %s existed", trap_here.str() );
-                } else if( act_item != apply_action::act_ignore && !dat.m.i_at( p ).empty() ) {
-                    // NOLINTNEXTLINE(cata-translate-string-literal)
-                    error = string_format( "item %s existed",
-                                           dat.m.i_at( p ).begin()->typeId().str() );
-                }
-                if( !error.empty() ) {
-                    debugmsg( "In %s on %s, setting terrain to %s (from %s) at %s when %s.  "
-                              "Resolve this either by removing the terrain from this mapgen, "
-                              "adding suitable removal commands to the mapgen, or by adding an "
-                              "appropriate clearing flag to the innermost layered mapgen.  "
-                              "Consult the \"mapgen flags\" section in MAPGEN.md for options.",
-                              context, dat.terrain_type().id().str(), chosen_id.id().str(),
-                              terrain_here.id().str(), p.to_string(), error );
-                }
-            }
+            // TODO: Make this less annoying and restore it?
+            // if( chosen_id != terrain_here ) {
+            //     std::string error;
+            //     trap_str_id trap_here = dat.m.tr_at( p ).id;
+            //     if( act_furn != apply_action::act_ignore && dat.m.furn( p ) != furn_str_id::NULL_ID() ) {
+            //         // NOLINTNEXTLINE(cata-translate-string-literal)
+            //         error = string_format( "furniture was %s", dat.m.furn( p ).id().str() );
+            //     } else if( act_trap != apply_action::act_ignore && !trap_here.is_null() &&
+            //                trap_here.id() != terrain_here->trap ) {
+            //         // NOLINTNEXTLINE(cata-translate-string-literal)
+            //         error = string_format( "trap %s existed", trap_here.str() );
+            //     } else if( act_item != apply_action::act_ignore && !dat.m.i_at( p ).empty() ) {
+            //         // NOLINTNEXTLINE(cata-translate-string-literal)
+            //         error = string_format( "item %s existed",
+            //                                dat.m.i_at( p ).begin()->typeId().str() );
+            //     }
+            //     if( !error.empty() ) {
+            //         debugmsg( "In %s on %s, setting terrain to %s (from %s) at %s when %s.  "
+            //                   "Resolve this either by removing the terrain from this mapgen, "
+            //                   "adding suitable removal commands to the mapgen, or by adding an "
+            //                   "appropriate clearing flag to the innermost layered mapgen.  "
+            //                   "Consult the \"mapgen flags\" section in MAPGEN.md for options.",
+            //                   context, dat.terrain_type().id().str(), chosen_id.id().str(),
+            //                   terrain_here.id().str(), p.to_string(), error );
+            //     }
+            // }
             dat.m.ter_set( p, chosen_id );
         }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3326,7 +3326,8 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
             }
             tripoint_bub_ms p( x.get(), y.get(), dat.zlevel() + z.get() );
 
-            const ter_id &terrain_here = dat.m.ter( p );
+            //  TODO: Restore this if the warning message is ever restored.
+            //  const ter_id &terrain_here = dat.m.ter( p );
             const ter_t &chosen_ter = *chosen_id;
             const bool is_wall = chosen_ter.has_flag( ter_furn_flag::TFLAG_WALL );
             const bool place_item = chosen_ter.has_flag( ter_furn_flag::TFLAG_PLACE_ITEM );


### PR DESCRIPTION
#### Summary
Silence two common error messages

#### Purpose of change
Silence two common error messages

#### Describe the solution
Silence two common error messages

#### Describe alternatives you've considered
Silence one or zero common error messages

#### Testing
Two common error messages silenced

#### Additional context
The "furniture exists at x" thing is a constant bane of nested mapgen, often popping up even when the nested map is flagged to ignore it. It's also annoying when you knock down a building or something. Like yeah OK the terrain changed, who cares.

"There's already a monster at pos" was similarly unhelpful. This mostly happens when monsters try to use invalid movement because they're packed in too tightly or fall on top of each other. It almost always immediately resolves itself and the player never really needs to know about this.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
