### PR TITLE
Backport 80642 - put vehicles inbound

### DIFF
--- a/data/json/mapgen/nested/road_vehicles_nested.json
+++ b/data/json/mapgen/nested/road_vehicles_nested.json
@@ -589,7 +589,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_north_facing" ], "x": 0, "y": 12 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_north_facing" ], "x": 0, "y": 7 } ]
     }
   },
   {
@@ -599,7 +599,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_south_facing" ], "x": 0, "y": 12 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_south_facing" ], "x": 0, "y": 7 } ]
     }
   },
   {
@@ -609,7 +609,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_east_facing" ], "x": 12, "y": 0 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_east_facing" ], "x": 7, "y": 0 } ]
     }
   },
   {
@@ -619,7 +619,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_west_facing" ], "x": 12, "y": 0 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_west_facing" ], "x": 7, "y": 0 } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Backport 80642 - put vehicles inbound

#### Purpose of change
Vehicles were spawning with weird errors sometimes, like just a corner floating in space, but vision blocked as though the whole vehicle was there.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
