### PR TITLE
Update recipe_ammo.json

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -574,7 +574,7 @@
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "book_learn": {
       "textbook_gaswarfare": { "skill_level": 8 },
-      "textbook_anarch": { "skill_level": 7, "recipe_name": "Stuff THE MAN doesn't want you to know" },
+      "textbook_anarch": { "skill_level": 7 },
       "recipe_labchem": { "skill_level": 6 }
     },
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_inorganic_chemistry" } ],
@@ -600,7 +600,7 @@
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "book_learn": {
       "textbook_gaswarfare": { "skill_level": 2 },
-      "textbook_anarch": { "skill_level": 2, "recipe_name": "Stuff THE MAN doesn't want you to know" }
+      "textbook_anarch": { "skill_level": 2 }
     },
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_organic_chemistry" } ],
     "components": [ [ [ "gasoline", 100 ] ], [ [ "plastic_chunk", 1 ] ] ]
@@ -618,7 +618,7 @@
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
     "book_learn": {
       "textbook_gaswarfare": { "skill_level": 2 },
-      "textbook_anarch": { "skill_level": 2, "recipe_name": "Stuff THE MAN doesn't want you to know" },
+      "textbook_anarch": { "skill_level": 2 },
       "manual_launcher": { "skill_level": 2 }
     },
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],


### PR DESCRIPTION
Removed recipe names from the AAA book

#### Summary
Category "Brief description"
Removed hiding gelled gasoline, napalm, and flamethrower fuel under their own recipe name

#### Purpose of change
Removed for consistency

#### Describe the solution
Removed hiding gelled gasoline, napalm, and flamethrower fuel under their own recipe name

#### Describe alternatives you've considered
None

#### Testing
Runs fine, recipes show up normally.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
