### PR TITLE
Most zombies sink

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -597,7 +597,7 @@ bool Creature::sees( const map &here, const Creature &critter ) const
 
     if( critter.is_monster() ) {
         has_camouflage = critter.has_flag( mon_flag_CAMOUFLAGE );
-        has_water_camouflage = critter.has_flag( mon_flag_WATER_CAMOUFLAGE );
+        has_water_camouflage = critter.has_flag( mon_flag_WATER_CAMOUFLAGE ) || ( critter.get_size() < creature_size::large && critter.has_flag( mon_flag_NO_BREATHE ) );
         has_night_invisibility = critter.has_flag( mon_flag_NIGHT_INVISIBILITY );
     }
     bool is_underwater = critter.is_likely_underwater( here );


### PR DESCRIPTION
#### Summary
Most zombies sink

#### Purpose of change
Zombies in deep water were always visible. This was a little weird.

#### Describe the solution
Monsters medium sized or smaller with NO_BREATHE who do not have SWIMS now automatically get the benefits of WATER_CAMOUFLAGE in deep water. This is because they are sinking and walking along the bottom. Monsters with SWIMS, like the zombie shark and swimmer zombies, behave according to whether they have the WATER_CAMOUFLAGE flag or not, as before.

Large+ monsters are too big to sink all the way under, so they remain visible.

#### Describe alternatives you've considered
For water with multiple Z levels, they should probably sink all the way to the bottom. This isn't being done at this time as it would necessitate making sure they can walk out again, which would mean I'd need to make slopes generate at each Z transition on the lake bed/sea floor. That's desired, but it sounds like a pain.

#### Testing
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b0f24cca-1d8a-4c44-b227-3f4406489748" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/414a26bc-e850-4c8d-80c8-56897d798433" />
This character was wearing swim goggles. In the first image, he is standing in shallow water. In the second image, he is underwater in deep water, and was able to see all the hidden zombies.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
