### PR TITLE
Gun tweaks (870 breacher & offset grip)

### DIFF
--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -494,6 +494,7 @@
     "barrel_volume": "0 ml",
     "valid_mod_locations": [
       [ "barrel", 1 ],
+      [ "loading port", 1 ],
       [ "mechanism", 2 ],
       [ "muzzle", 1 ],
       [ "rail mount", 1 ],

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -92,14 +92,12 @@
       "m203_mod",
       "m320_mod",
       "m320_mod_mod",
-      "m6_shotgun",
       "masterkey",
       "masterkey_mod",
       "m26_mass",
       "m26_mass_mod",
       "u_shotgun",
-      "u_shotgun_mod",
-      "robofac_handguard"
+      "u_shotgun_mod"
     ],
     "min_skills": [ [ "gun", 2 ] ]
   }

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -493,33 +493,6 @@
     "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
-    "id": "M6_shotgun",
-    "copy-from": "underbarrel_base",
-    "type": "GUNMOD",
-    "name": { "str": "M6 Survival Gun shotgun" },
-    "description": "The integrated 12 gauge shotgun barrel of the Chiappa M6 Survival Gun.  It's irremovable.",
-    "volume": "0 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "install_time": "0 s",
-    "material": [ "steel" ],
-    "symbol": ":",
-    "color": "light_red",
-    "location": "underbarrel",
-    "mod_targets": [ "rifle" ],
-    "gun_data": {
-      "barrel_length": "470 mm",
-      "ammo": [ "shot" ],
-      "skill": "shotgun",
-      "range": 1,
-      "dispersion": 320,
-      "durability": 10,
-      "clip_size": 1
-    },
-    "flags": [ "RELOAD_EJECT", "ZERO_WEIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 1 } } ]
-  },
-  {
     "id": "masterkey",
     "copy-from": "underbarrel_base",
     "type": "GUNMOD",


### PR DESCRIPTION
#### Summary
The 870 breacher was missing a loading port so it couldn't have it's speedloader chute attached.
This also fixes the error on offset grips that referenced removed weapons.
Lastly removes an integrated underbarrel shotgun for a weapon thats no longer in game. 

#### Purpose of change
The 870 breacher was missing a loading port so it couldn't have it's speedloader chute attached.
This also fixes the error on offset grips that referenced removed weapons.
Lastly removes an integrated underbarrel shotgun for a weapon thats no longer in game. 

#### Describe the solution
Added a loading port location
deleted referenced to removed weapons from offset grips
Lastly removes an integrated underbarrel shotgun for a weapon thats no longer in game. 

#### Describe alternatives you've considered
Cursory online check to see whether a speedloader could be attached to this gun, also noticed that there was a specific gun mod for this item. Checked to make sure the M6 survival gun was gone.

#### Testing
Works fine, mod can now be attached. No errors when used. No errors on offset grips either.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
