### PR TITLE
Remove bayonet lug from marlin

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -86,7 +86,6 @@
     "clip_size": 19,
     "valid_mod_locations": [
       [ "barrel", 1 ],
-      [ "bayonet lug", 1 ],
       [ "brass catcher", 1 ],
       [ "mechanism", 2 ],
       [ "rail mount", 1 ],


### PR DESCRIPTION
#### Summary
Remove bayonet lug from marlin

#### Purpose of change
Someone noticed the marlin had a bayonet lug. This must have been an error because this is a varmint rifle, not a weapon of war.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
