### PR TITLE
Backport 80773 again

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7445,8 +7445,7 @@ void map::rotate( int turns )
             continue;
         }
 
-        // Translate bubble -> global -> current map.
-        const point_bub_ms old( get_bub( reality_bubble().get_abs( np.pos_bub() ).xy() ) );
+        const point_bub_ms old( get_bub( np.pos_abs().xy() ) );
 
         const point_bub_ms new_pos( old.rotate( turns, {SEEX * 2, SEEY * 2} ) );
         np.spawn_at_precise( get_abs( tripoint_bub_ms( new_pos, sq.z() ) ) );


### PR DESCRIPTION
#### Summary
Backport 80773 again

#### Purpose of change
Due to a reversion or ommission, 80773 wasn't properly backported before, resulting in NPCs spawning outside of their faction bases.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/459941d3-792d-4d25-be2a-c146b54a31c5" />
works

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
