### PR TITLE
Megafauna - Fix some errors

### DIFF
--- a/data/mods/Megafauna/monstergroups/wilderness.json
+++ b/data/mods/Megafauna/monstergroups/wilderness.json
@@ -2059,23 +2059,23 @@
         "monster": "mon_bullfrog",
         "weight": 30,
         "cost_multiplier": 2,
-        "ends": 24,
+        "ends": "1 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_bullfrog",
         "weight": 35,
         "cost_multiplier": 2,
-        "starts": 24,
-        "ends": 95,
+        "starts": "1 days",
+        "ends": "4 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {
         "monster": "mon_bullfrog",
         "weight": 40,
         "cost_multiplier": 2,
-        "starts": 95,
-        "ends": 180,
+        "starts": "4 days",
+        "ends": "4 days",
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
       {

--- a/data/mods/Megafauna/recipes/recipe_others.json
+++ b/data/mods/Megafauna/recipes/recipe_others.json
@@ -19,7 +19,7 @@
     ],
     "components": [
       [ [ "large_bone", 8 ], [ "mammoth_tusk", 2 ] ],
-      [ [ "leather", 64 ], [ "sheet_leather_patchwork", 8 ], [ "tanned_hide", 8 ], [ "tanned_pelt", 8 ] ],
+      [ [ "leather", 64 ], [ "sheet_leather_patchwork", 8 ], [ "sheet_leather", 8 ], [ "tanned_pelt", 8 ] ],
       [ [ "filament", 40, "LIST" ] ]
     ]
   },
@@ -43,7 +43,7 @@
     ],
     "components": [
       [ [ "large_bone", 24 ], [ "mammoth_tusk", 6 ] ],
-      [ [ "leather", 192 ], [ "sheet_leather_patchwork", 24 ], [ "tanned_hide", 24 ], [ "tanned_pelt", 24 ] ],
+      [ [ "leather", 192 ], [ "sheet_leather_patchwork", 24 ], [ "sheet_leather", 24 ], [ "tanned_pelt", 24 ] ],
       [ [ "filament", 120, "LIST" ] ]
     ]
   }


### PR DESCRIPTION
#### Summary
Fix mammoth shelter kits looking for an obsolete tanned hide item.
Fix bullfrog entries.

#### Purpose of change
Both were throwing errors, but bullfrog entries were preventing world loading.

#### Testing
Loads and no errors :)
#### Additional context
I have no idea if I did the bullfrog start and end values correctly. Let me know what they need to be adjusted to if they are incorrect.
I will be doing a backport of #75551 Clean up Megafauna wilderness spawns. Soon.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
