### PR TITLE
Mapgen corpse birthdays

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7714,7 +7714,7 @@ void item::randomize_rot()
 {
     if( is_comestible() && get_comestible()->spoils > 0_turns ) {
         time_duration loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
-                                    rng_float( 0.2, 1.2 );
+                                    rng_float( 0.1, 1.2 );
         set_rot( loot_adjust );
     } else if( is_corpse() ) {
         time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7718,9 +7718,9 @@ void item::randomize_rot()
         set_rot( loot_adjust );
     } else if( is_corpse() ) {
         time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
-                                    rng_float( 0.0, 0.5 );
-        time_point birthday = calendar::turn - birthday_adjust;
-            set_birthday( birthday );
+                                    rng_float( 0.0, 0.15 );
+        time_point birthday = calendar::fall_of_civilization - birthday_adjust;
+        set_birthday( birthday );
     }
     for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
         if( pocket->spoil_multiplier() > 0.0f ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7716,8 +7716,12 @@ void item::randomize_rot()
         time_duration loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
                                     rng_float( 0.2, 1.2 );
         set_rot( loot_adjust );
+    } else if( is_corpse() ) {
+        time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
+                                    rng_float( 0.0, 0.5 );
+        time_point birthday = calendar::turn - birthday_adjust;
+            set_birthday( birthday );
     }
-
     for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
         if( pocket->spoil_multiplier() > 0.0f ) {
             for( item *subitem : pocket->all_items_top() ) {


### PR DESCRIPTION
#### Summary
Mapgen corpse birthdays

#### Purpose of change
Because of the fact that we spawn items at start_of_cataclysm, which is 20 days before fall_of_civilization (game start), corpses placed by place_items or similar methods in mapgen were already 20 days old. This meant that they would immediately revive if possible and would usually immediately evolve, sometimes more than once! The whole purpose of splitting the two dates up was to give some time for comestibles to decay while keeping zombie evo pinned to the presumed date of game start.

#### Describe the solution
- Add a section to randomize_rot() which randomizes the birthdays of corpses, making them between 0 and 3 days old at game start.
- Adjust the minimum random decay timer on food, allowing it to be just 2 days old at game start. Its maximum of 24 days remains unchanged.

#### Describe alternatives you've considered
I considered just setting corpses to spawn at fall_of_civilization as they do in hardcoded corpse spawn instances, but having some jitter on it helps keep the player from knowing exactly how long they have to run around and loot e.g. dead soldiers at game start.

#### Testing
Went to a mass grave, it was not full of evolved zombies.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
