### PR TITLE
Bionic Profession Update & Dog Tag Edit

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6117,7 +6117,7 @@
     "npc_background": "BG_survival_story_TOURIST",
     "description": "You always had to have the latest and best gadgets and gizmos, so is it any wonder that you upgraded your flesh along with your smart phone?",
     "points": 5,
-    "CBMs": [ "bio_flashlight", "bio_tools", "bio_ups", "bio_watch", "bio_batteries", "bio_power_storage_mkII" ],
+    "CBMs": [ "bio_flashlight", "bio_tools", "bio_ups", "bio_watch", "bio_cable", "bio_power_storage" ],
     "skills": [ { "level": 4, "name": "electronics" }, { "level": 2, "name": "fabrication" } ],
     "items": {
       "both": {
@@ -6149,7 +6149,7 @@
       "bio_adrenaline",
       "bio_night_vision",
       "bio_face_mask",
-      "bio_metabolics",
+      "bio_torsionratchet",
       "bio_power_storage_mkII"
     ],
     "skills": [ { "level": 3, "name": "dodge" } ],
@@ -6224,8 +6224,8 @@
       "bio_blood_anal",
       "bio_blood_filter",
       "bio_nanobots",
-      "bio_metabolics",
-      "bio_power_storage_mkII",
+      "bio_cable",
+      "bio_power_storage",
       "bio_sleep_shutdown"
     ],
     "items": {
@@ -6382,7 +6382,7 @@
       "bio_face_mask",
       "bio_alarm",
       "bio_night_vision",
-      "bio_batteries",
+      "bio_metabolics",
       "bio_power_storage_mkII"
     ],
     "skills": [ { "level": 2, "name": "speech" } ],
@@ -6452,7 +6452,7 @@
     "npc_background": "BG_survival_story_WORKER_PUBLIC",
     "description": "You had a job programming machines such as automatic street cleaners, newsbots, and pizza delivery drones.  Bionic implants helped you control them remotely.  Now all the drones carry guns instead of pizza.  At least you still have a… RC car?",
     "points": 1,
-    "CBMs": [ "bio_batteries", "bio_power_storage", "bio_remote" ],
+    "CBMs": [ "bio_cable", "bio_power_storage", "bio_remote" ],
     "skills": [ { "level": 2, "name": "computer" } ],
     "items": {
       "both": {
@@ -6476,7 +6476,7 @@
     "name": { "male": "Razor Boy", "female": "Razor Girl" },
     "description": "Through a series of painful and expensive surgeries, you became a walking bionic weapon, your services as a mercenary available to the highest bidder.",
     "points": 5,
-    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_dex_enhancer", "bio_ears", "bio_carbon" ],
+    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_dex_enhancer", "bio_ears", "bio_carbon", "bio_metabolics", "bio_power_storage_mkII" ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar" ],
     "items": {

--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -649,7 +649,7 @@
       { "id": "catholic", "text": "CATHOLIC", "weight": 23 },
       { "id": "christian", "text": "CHRISTIAN", "weight": 11 },
       { "id": "mormon", "text": "MORMON", "weight": 2 },
-      { "id": "jew", "text": "JEW", "weight": 2 },
+      { "id": "jew", "text": "JEWISH", "weight": 2 },
       { "id": "atheist", "text": "ATHEIST", "weight": 21 },
       { "id": "norelpref", "text": "NORELPREF", "weight": 7 }
     ]


### PR DESCRIPTION
Changed which bionic professions get MK1 or MK2 batteries and what powers them.

Edit to Dog Tags so that they read Jewish instead of Jew.

#### Summary
Changed which bionic professions get MK1 or MK2 batteries and what powers them.

Edit to Dog Tags so that they read Jewish instead of Jew.

#### Purpose of change
Razor girl had two bionics that previously did not require power that now do. 
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1360

I've added power storage and a form of power generation to the razor girl.

I've also changed which professions get tier 1 or 2 batteries and what powers them.

#### Describe the solution
Profession changes as follows:

High tech - government funded/ described as costing millions of dollars
Have MK2 battery

1) Razor Girl - metabolic
2) Bionic Agent - metabolic
3) Bionic Operator - metabolic
4) Bionic Sniper - torsion ratchet
5) Bionic Assassin - torsion ratchet

—————————
Mid/low tech
Have Mk1 battery
1) Commercial Cyborg - cables
2) Drone Operator - cables
3) Bionic Patient - cables
4) Prototype Cyborg - no power source


Dog tags now read Jewish instead of Jew.

#### Describe alternatives you've considered
none

#### Testing
works well, no errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
