### PR TITLE
Revert "Mapgen corpse birthdays"

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7714,14 +7714,10 @@ void item::randomize_rot()
 {
     if( is_comestible() && get_comestible()->spoils > 0_turns ) {
         time_duration loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
-                                    rng_float( 0.1, 1.2 );
+                                    rng_float( 0.2, 1.2 );
         set_rot( loot_adjust );
-    } else if( is_corpse() ) {
-        time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
-                                    rng_float( 0.0, 0.15 );
-        time_point birthday = calendar::fall_of_civilization - birthday_adjust;
-        set_birthday( birthday );
     }
+
     for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
         if( pocket->spoil_multiplier() > 0.0f ) {
             for( item *subitem : pocket->all_items_top() ) {


### PR DESCRIPTION
This didn't need to be done, and the corpses were fine as is. If the whole evo thing gets fixed, we can un-revert this and take another look.