### PR TITLE
Fix initialization of upgrade time

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3820,7 +3820,7 @@ void monster::init_from_item( item &itm )
             hp = type->hp;
             set_speed_base( type->speed );
         }
-        upgrade_time = itm.get_var( "upgrade_time", 0 );
+        upgrade_time = itm.get_var( "upgrade_time", -1 );
         for( item *it : itm.all_items_top( pocket_type::CONTAINER ) ) {
             if( it->is_armor() ) {
                 it->set_flag( STATIC( flag_id( "FILTHY" ) ) );

--- a/src/monster.h
+++ b/src/monster.h
@@ -621,7 +621,7 @@ class monster : public Creature
         /** Normal upgrades **/
         int next_upgrade_time();
         bool upgrades = false;
-        int upgrade_time = 0;
+        int upgrade_time = -1;
         bool reproduces = false;
         std::optional<time_point> baby_timer;
         bool biosignatures = false;


### PR DESCRIPTION
#### Summary
Fix initialization of upgrade time

#### Purpose of change
Upgrade_time was being initialized at 0 for monsters which were spawned in by means other than mapgen. This included spawns resulting from corpses reviving. An upgrade_time of 0 results in the monster bypassing all rolls to check its upgrade time and skip directly to upgrading. This is intentional, as that's the normal route monsters take to upgrade when their timer is up.

#### Describe the solution
Change initialization of upgrade_time both in monster.h and init_from_item() to -1. An upgrade_time of < 0 triggers an upgrade time reroll, giving the monster a standard upgrade time when it is revived.

Note that this technically means that any monster which is killed rerolls its upgrade timer when reviving, as upgrade timers are not saved to the corpse object so can't be recovered. I feel like that's probably fine, and if a change was desired, it probably ought to involve some extra code in a future PR.

#### Describe alternatives you've considered

#### Testing
- Used debug text to confirm that monsters were reviving with an upgrade_timer of 0 and triggering an immediate upgrade no matter what.
- Implemented changes.
- Used debug text to confirm that monsters were now actually rolling for an upgrade_timer after reviving.
- Repeatedly spawned mx_science, which usually has several corpses which revive when you approach. Previously, these would almost always be evolved if you found it on day 1. Now, they're only rarely evovled, in line with what you'd see anywhere else on day 1.

#### Additional context
This is tangential to this PR, but while working on it I noticed that all zombies are currently on an evo timer relative to the universal spawn date (fall_of_civilization in TLG). This probably ought to change as it means that a human who dies 3 years in is likely to revive as a hulk or something. Not a huge issue, but it might be worth revisiting at some point.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
