### PR TITLE
Actually pulp pulped corpses spawned via itemgroups

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/map_extras.json
+++ b/data/json/itemgroups/Locations_MapExtras/map_extras.json
@@ -4,7 +4,7 @@
     "subtype": "collection",
     "id": "map_extra_science",
     "//": "Nested group to damage the container-item",
-    "entries": [ { "group": "map_extra_science_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+    "entries": [ { "group": "map_extra_science_corpse", "prob": 100, "damage": [ 0, 1 ] } ]
   },
   {
     "type": "item_group",
@@ -52,7 +52,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_camping",
-    "entries": [ { "group": "map_extra_college_camping_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+    "entries": [ { "group": "map_extra_college_camping_corpse", "prob": 100, "damage": [ 0, 1 ] } ]
   },
   {
     "type": "item_group",
@@ -78,7 +78,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_sports",
-    "entries": [ { "group": "map_extra_college_sports_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+    "entries": [ { "group": "map_extra_college_sports_corpse", "prob": 100, "damage": [ 0, 1 ] } ]
   },
   {
     "type": "item_group",
@@ -103,7 +103,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_college_lake",
-    "entries": [ { "group": "map_extra_college_lake_corpse", "prob": 100, "damage": [ 3, 4 ] } ]
+    "entries": [ { "group": "map_extra_college_lake_corpse", "prob": 100, "damage": [ 0, 1 ] } ]
   },
   {
     "type": "item_group",
@@ -163,7 +163,7 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "map_extra_police",
-    "entries": [ { "group": "map_extra_police_corpse", "prob": 100, "damage": 4 } ]
+    "entries": [ { "group": "map_extra_police_corpse", "prob": 100, "damage": [ 0, 1 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -4,9 +4,8 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "bone_human", "count": [ 5, 8 ], "prob": 100 },
-      { "item": "human_flesh", "count": [ 5, 8 ], "prob": 100 },
-      { "item": "hstomach", "prob": 50 }
+      { "item": "bone_human", "count": [ 1, 8 ], "prob": 100 },
+      { "item": "human_flesh", "count": [ 1, 8 ], "prob": 100 }
     ]
   },
   {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -562,7 +562,10 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
 
     new_item.set_damage( rng( damage.first, damage.second ) );
     new_item.rand_degradation();
-    // no need for dirt if it's a bow
+    if( new_item.is_corpse() && new_item.damage() == new_item.max_damage() ) {
+        new_item.set_flag( flag_PULPED );
+    }
+    // No need for dirt if it's a bow.
     if( new_item.is_gun() && !new_item.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) &&
         !new_item.has_flag( flag_NON_FOULING ) ) {
         int random_dirt = rng( dirt.first, dirt.second );


### PR DESCRIPTION
#### Summary
Actually pulp pulped corpses spawned via itemgroups

#### Purpose of change
Corpses spawned via itemgroups with damage == 4 were showing up as "pulped human corpse" but didn't have the pulped flag.

#### Describe the solution
Manually set the flag in item_group.cpp

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
