### PR TITLE
Backport 75447 - Use CC-Sounds as default soundpack if it's present on first launch

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1710,9 +1710,15 @@ void options_manager::add_options_general()
              true, COPT_NO_SOUND_HIDE
            );
 
+
+        std::vector<id_and_option> const soundpacks = build_soundpacks_list();
         add( "SOUNDPACKS", page_id, to_translation( "Choose soundpack" ),
              to_translation( "Choose the soundpack you want to use.  Requires restart." ),
-             build_soundpacks_list(), "basic", COPT_NO_SOUND_HIDE
+             soundpacks, std::any_of( soundpacks.begin(), soundpacks.end(),
+        []( const id_and_option & option ) {
+            return option.first == "CC-Sounds";
+        } )  ? "CC-Sounds" : "basic",
+        COPT_NO_SOUND_HIDE
            ); // populate the options dynamically
 
         get_option( "SOUNDPACKS" ).setPrerequisite( "SOUND_ENABLED" );


### PR DESCRIPTION
#### Summary
Backport 75447 - Use CC-Sounds as default soundpack if it's present on first launch

#### Purpose of change
People didn't know how to enable their soundpack.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
