### PR TITLE
Stone pouch: Absolutely the fuck not

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -236,58 +236,6 @@
     ]
   },
   {
-    "id": "stone_pouch",
-    "type": "ARMOR",
-    "name": { "str": "stone pouch", "str_pl": "stone pouches" },
-    "description": "A medium-sized pouch for storing rocks, with straps for attaching it to your belt or other webbing.",
-    "weight": "180 g",
-    "volume": "500 ml",
-    "price": "59 USD",
-    "price_postapoc": "7 USD 50 cent",
-    "material": [ "cotton", "leather" ],
-    "symbol": "[",
-    "looks_like": "ammo_satchel",
-    "color": "dark_gray",
-    "sided": true,
-    "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "rock": 10, "pebble": 80 }, "moves": 20, "volume_encumber_modifier": 0.3 } ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "PALS_LARGE" ],
-    "armor": [
-      {
-        "encumbrance": 4,
-        "coverage": 25,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
-      }
-    ]
-  },
-  {
-    "id": "leather_stone_pouch",
-    "type": "ARMOR",
-    "name": { "str": "leather stone pouch", "str_pl": "leather stone pouches" },
-    "description": "A medium-sized pouch for storing rocks, made of heavy leather, with straps for attaching it to your belt or other webbing.",
-    "weight": "380 g",
-    "volume": "500 ml",
-    "price": "59 USD",
-    "price_postapoc": "7 USD 50 cent",
-    "material": [ "leather" ],
-    "symbol": "[",
-    "looks_like": "ammo_satchel",
-    "color": "dark_gray",
-    "sided": true,
-    "material_thickness": 1,
-    "pocket_data": [ { "ammo_restriction": { "rock": 10, "pebble": 80 }, "moves": 20, "volume_encumber_modifier": 0.3 } ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "PALS_LARGE" ],
-    "armor": [
-      {
-        "encumbrance": 4,
-        "coverage": 25,
-        "covers": [ "leg_l", "leg_r" ],
-        "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
-      }
-    ]
-  },
-  {
     "id": "grenadebandolier",
     "type": "ARMOR",
     "name": { "str": "large grenade pouch", "str_pl": "large grenade pouches" },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2717,5 +2717,15 @@
     "id": "muzzle_brake_mod",
     "type": "MIGRATION",
     "replace": "muzzle_brake"
+  },
+  {
+    "id": "stone_pouch",
+    "type": "MIGRATION",
+    "replace": "grenade_pouch"
+  },
+  {
+    "id": "leather_stone_pouch",
+    "type": "MIGRATION",
+    "replace": "grenade_pouch"
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -76,35 +76,6 @@
     "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
   },
   {
-    "result": "stone_pouch",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "skills_required": [ [ "throw", 1 ] ],
-    "time": "3 h",
-    "autolearn": true,
-    "reversible": true,
-    "using": [ [ "strap_large", 1 ], [ "tailoring_cotton_patchwork", 5 ], [ "fastener_small", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
-  },
-  {
-    "result": "leather_stone_pouch",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "time": "3 h",
-    "autolearn": true,
-    "reversible": true,
-    "using": [ [ "strap_large", 1 ], [ "tailoring_leather_small", 6 ], [ "fastener_small", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ]
-  },
-  {
     "result": "camera_bag",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Stone pouch: Absolutely the fuck not

#### Purpose of change
Stone pouches were one of the worst examples of backwards logic in the game, being a PALS-compatible pouch which only added 4 encumbrance to one leg and could hold 10 rocks or 80 pebbles and allowed the player to retrieve rocks in 1/5th of a second. What the _fuck_

Just to clarify, a rock is the size of a baseball and weighs 1.5 pounds. A pebble is palm-sized. That's a preposterous amount of stuff to be sticking in a PALS bag and there's no earthly reason such an arrangement should be faster than picking one of these items up out of almost any other container. These seem like items which were implemented by someone who wanted to have a huge super fast low-encumbrance bag of rocks and worked backwards from there, and that's not how we do things.

#### Describe the solution
Gone. Never coming back. Rocks are awkward to store and that's just how it is. Use an all-purpose pouch or whatever else.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
