### PR TITLE
Fix NPC pulp loophole

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4019,7 +4019,13 @@ bool npc::can_do_pulp()
     if( !pulp_location ) {
         return false;
     }
-
+    if( is_player_ally() ) {
+        Character &player_character = get_player_character();
+        if( !rules.has_flag( ally_rule::allow_pulp ) ||
+            player_character.in_vehicle || is_hallucination() ) {
+            return false;
+        }
+    }
     if( rl_dist( *pulp_location, pos_abs() ) > 1 || pulp_location->z() != posz() ) {
         return false;
     }


### PR DESCRIPTION
#### Summary
Fix NPC pulp loophole

#### Purpose of change
If one of your followers started pulping a corpse, and before they finished, you set their rules to not pulp, and then told them to stop their current activity, walked them away, and then walked them back to the corpse, they would go back to pulping it. Since pulping is disallowed in their rules at this point, they should not do that.

#### Describe the solution
Add a second check for follower rules re: pulping to npcmove.cpp to catch cases like this.

#### Testing
Did what was outlined above and the NPC did not start pulping. Turned pulping back on and then they resumed. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
