### PR TITLE
No acid blood for acid bombs

### DIFF
--- a/data/json/recipes/practice/applied_science.json
+++ b/data/json/recipes/practice/applied_science.json
@@ -17,7 +17,7 @@
     "time": "1 h",
     "tools": [ [ [ "chemistry_set", 50 ] ] ],
     "components": [ [ [ "blood_acid", 1 ], [ "blood_acid_insect", 1 ], [ "blood_acid_plant", 1 ], [ "blood_acid_underground", 1 ] ] ],
-    "autolearn": [ [ "chemistry", 5 ] ]
+    "book_learn": [ [ "textbook_chemistry", 5 ], [ "adv_chemistry", 5 ], [ "recipe_labchem", 5 ] ]
   },
   {
     "id": "research_biochemistry_chemistry_set_basic",
@@ -37,6 +37,6 @@
     "time": "1 h",
     "tools": [ [ [ "chemistry_set_basic", -1 ] ], [ [ "surface_heat", 60, "LIST" ] ] ],
     "components": [ [ [ "blood_acid", 1 ], [ "blood_acid_insect", 1 ], [ "blood_acid_plant", 1 ], [ "blood_acid_underground", 1 ] ] ],
-    "autolearn": [ [ "chemistry", 5 ] ]
+    "book_learn": [ [ "textbook_chemistry", 6 ], [ "adv_chemistry", 6 ], [ "recipe_labchem", 6 ] ]
   }
 ]

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -12,11 +12,7 @@
     "components": [
       [ [ "jar_glass_sealed", 1 ], [ "clay_canister", 2 ], [ "flask_glass", 2 ] ],
       [
-        [ "any_strong_acid", 2, "LIST" ],
-        [ "blood_acid", 2 ],
-        [ "blood_acid_underground", 2 ],
-        [ "blood_acid_plant", 2 ],
-        [ "blood_acid_insect", 2 ]
+        [ "any_strong_acid", 2, "LIST" ]
       ],
       [ [ "cordage_short", 1, "LIST" ] ]
     ]


### PR DESCRIPTION
#### Summary
No acid blood for acid bombs

#### Purpose of change
It was possible to make acid bombs out of acid blood, and these bombs would be good forever despite the fact that the blood is rapidly breaking down and becoming useless. There are recipes to convert acid blood into pure acid, so the player ought to be using those.

#### Describe the solution
- Remove acid blood from the acid bomb recipes.
- Make the acid blood related practice recipes require some sort of chemistry textbook.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
