### PR TITLE
Devariantize manuals

### DIFF
--- a/data/json/items/book/archery.json
+++ b/data/json/items/book/archery.json
@@ -22,28 +22,6 @@
     "type": "BOOK",
     "name": { "str": "Lessons for the Novice Bowhunter", "str_pl": "copies of Lessons for the Novice Bowhunter" },
     "description": "This hefty paperback book contains all the information needed for novice archers to get started hunting with a variety of bows and crossbows.",
-    "variants": [
-      {
-        "id": "book_archery",
-        "name": { "str": "Lessons for the Novice Bowhunter", "str_pl": "copies of Lessons for the Novice Bowhunter" },
-        "description": "This hefty paperback book contains all the information needed for novice archers to get started hunting with a variety of bows and crossbows."
-      },
-      {
-        "id": "book_archery_1",
-        "name": { "str": "Archery Anatomy", "str_pl": "copies of Archery Anatomy" },
-        "description": "A book that highlights archery techniques from the point of view of the relationship between the anatomy of the human body and the anatomy of the bow.",
-        "//": "978-0285632653"
-      },
-      {
-        "id": "book_archery_2",
-        "name": {
-          "str": "Way of Archery: A 1637 Chinese Military Training Manual",
-          "str_pl": "copies of Way of Archery: A 1637 Chinese Military Training Manual"
-        },
-        "description": "The Way of Archery provides a detailed introduction to practicing archery in the traditional Chinese military style.  It explains the basics of how to shoot using the Asian thumb ring, proper posture, training regimen, equipment, and avoiding pitfalls in shooting.",
-        "//": "978-0764347917"
-      }
-    ],
     "max_level": 2,
     "copy-from": "book_nonf_hard_arch_tpl",
     "relative": { "price": "1 USD", "price_postapoc": "25 USD" }
@@ -53,25 +31,6 @@
     "type": "BOOK",
     "name": { "str": "Zen and the Art of Archery", "str_pl": "copies of Zen and the Art of Archery" },
     "description": "This massive book contains a wealth of vital information for the novice archer.",
-    "variants": [
-      {
-        "id": "manual_archery",
-        "name": { "str": "Zen and the Art of Archery", "str_pl": "copies of Zen and the Art of Archery" },
-        "description": "This massive book contains a wealth of vital information for the novice archer."
-      },
-      {
-        "id": "manual_archery_1",
-        "name": { "str": "Beginner's Guide to Traditional Archery", "str_pl": "copies of Beginner's Guide to Traditional Archery" },
-        "description": "An easy-to-understand instruction manual for traditional archery.  Covers both target shooting and bow hunting.",
-        "//": "978-0811731331"
-      },
-      {
-        "id": "manual_archery_2",
-        "name": { "str": "The Theory And Practice Of Archery", "str_pl": "copies of The Theory And Practice Of Archery" },
-        "description": "Authored by Horace Ford, the champion archer of England for the years 1850 to 1859 and 1867, and known as one of the greatest archers of all time, this book holds all of his experience in archery, which is still relevant by modern standards.",
-        "//": "978-1332070824"
-      }
-    ],
     "max_level": 3,
     "copy-from": "book_nonf_hard_arch_tpl"
   },
@@ -81,31 +40,6 @@
     "category": "manuals",
     "name": { "str": "Archery for Kids", "str_pl": "issues of Archery for Kids" },
     "description": "Will you be able to place the arrow right into the bullseye?  It is not that easy, but once you know how it's done, you will have a lot of fun with archery.",
-    "variants": [
-      {
-        "id": "mag_archery",
-        "name": { "str": "Archery for Kids", "str_pl": "issues of Archery for Kids" },
-        "description": "Will you be able to place the arrow right into the bullseye?  It is not that easy, but once you know how it's done, you will have a lot of fun with archery."
-      },
-      {
-        "id": "mag_archery_1",
-        "name": { "str": "Archery Drill Book", "str_pl": "copies of Archery Drill Book" },
-        "description": "\"Become a more consistent and accurate archer!\", The Archery Drill Book covers all aspects of the sport, with 130 of the best drills for developing superior technique, skill, physical stamina, and the focused mindset needed to shoot under pressure.",
-        "//": "978-1492588344"
-      },
-      {
-        "id": "mag_archery_2",
-        "name": { "str": "Archery from A to Z", "str_pl": "copies of Archery from A to Z" },
-        "description": "A beginner's guide to the equipment and shooting fundamentals that new shooters of all ages will benefit from.",
-        "//": "978-0811738347"
-      },
-      {
-        "id": "mag_archery_2",
-        "name": { "str": "Anecdotes of Archery", "str_pl": "copies of Anecdotes of Archery" },
-        "description": "\"Anecdotes of Archery - From the Earliest Ages to the Year 1791\" - This vintage book contains a comprehensive guide to archery, with historical details, information on archery in different cultures throughout the ages, anecdotes of notable events and battles, a glossary of archery terms, and much more.",
-        "//": "978-1440091070"
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 80 cent",

--- a/data/json/items/book/barter.json
+++ b/data/json/items/book/barter.json
@@ -24,25 +24,6 @@
     "category": "manuals",
     "name": { "str": "How to Succeed in Business", "str_pl": "copies of How to Succeed in Business" },
     "description": "Useful if you want to get a good deal when purchasing goods.",
-    "variants": [
-      {
-        "id": "manual_business",
-        "name": { "str": "How to Succeed in Business", "str_pl": "copies of How to Succeed in Business" },
-        "description": "Useful if you want to get a good deal when purchasing goods."
-      },
-      {
-        "id": "manual_business_1",
-        "name": { "str": "How To Day Trade For A Living", "str_pl": "copies of How To Day Trade For A Living" },
-        "description": "The fundamentals of day trading, and how it differs from other styles of trading and investment, with elaboration on important trading strategies that many traders use every day.",
-        "//": "978-1535585958"
-      },
-      {
-        "id": "manual_business_2",
-        "name": { "str": "Trading Psychology For Dummies", "str_pl": "copies of Trading Psychology For Dummies" },
-        "description": "A guide to help you develop a mindset to trade on a rapidly changing stock market.  Not very useful in current moment, when the main stock you have is a stock of ammo, or maybe just soup.",
-        "//": "978-1119879589"
-      }
-    ],
     "weight": "454 g",
     "volume": "750 ml",
     "price": "19 USD",
@@ -62,27 +43,7 @@
     "type": "BOOK",
     "category": "manuals",
     "name": { "str": "Advanced Economics", "str_pl": "copies of Advanced Economics" },
-    "//": "Biz majors can afford it.  Surely you're gonna make US$60K/yr out of school, and twice that in five years?",
     "description": "A college textbook on economics.",
-    "variants": [
-      {
-        "id": "textbook_business",
-        "name": { "str": "Advanced Economics", "str_pl": "copies of Advanced Economics" },
-        "description": "A college textbook on economics."
-      },
-      {
-        "id": "textbook_business_1",
-        "name": { "str": "Peer to Peer Bartering", "str_pl": "copies of Peer to Peer Bartering" },
-        "description": "In this work, David Cabanillas adopts bartering incentive pattern as an attractive foundation in the age of the internet for a simple and robust form of exchange to reallocate resources.",
-        "//": "978-3838338194"
-      },
-      {
-        "id": "textbook_business_2",
-        "name": { "str": "Trading Basics", "str_pl": "copies of Trading Basics" },
-        "description": "Comprehensive coverage of most major stock trading styles.",
-        "//": "978-1118464212"
-      }
-    ],
     "weight": "1587 g",
     "volume": "1750 ml",
     "price": "98 USD",

--- a/data/json/items/book/bashing.json
+++ b/data/json/items/book/bashing.json
@@ -5,37 +5,6 @@
     "category": "manuals",
     "name": { "str": "Batter Up!", "str_pl": "issues of Batter Up!" },
     "description": "A baseball magazine that focuses on batting tips.  There are lots of colorful, full-page photos of skilled athletes demonstrating proper form and technique.",
-    "variants": [
-      {
-        "id": "mag_bashing",
-        "name": { "str": "Batter Up!", "str_pl": "issues of Batter Up!" },
-        "description": "A baseball magazine that focuses on batting tips.  There are lots of colorful, full-page photos of skilled athletes demonstrating proper form and technique."
-      },
-      {
-        "id": "mag_bashing_1",
-        "name": {
-          "str": "Bludgeons and Broken Bones: A Reference Guide",
-          "str_pl": "copies of Bludgeons and Broken Bones: A Reference Guide"
-        },
-        "description": "Written with hard prison slang, this book says a lot about how to use maximum power from your muscles and weight of your weapon."
-      },
-      {
-        "id": "mag_bashing_2",
-        "name": {
-          "str": "Bash Weapons for Self-Defense: A Practical Guide",
-          "str_pl": "copies of Bash Weapons for Self-Defense: A Practical Guide"
-        },
-        "description": "A small brochure from an unknown self-defense shop, focused on using bash weapons for self-defense in real-world situations.  It covers topics like assessing threats, using verbal commands and body language to de-escalate situations, and legal considerations for using force in self-defense.  It also includes techniques for using bash weapons to defend against attackers armed with knives, guns, and other weapons."
-      },
-      {
-        "id": "mag_bashing_3",
-        "name": {
-          "str": "Ultra Tactics: The Ways of the Modern Warrior",
-          "str_pl": "copies of Ultra Tactics: the Ways of the Modern Warrior"
-        },
-        "description": "This book researches the long, international story of ultras - fanatical football fans ready to defend the prestige of their football team in any possible way, including with brutal violence and heavy bats."
-      }
-    ],
     "weight": "80 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -56,30 +25,6 @@
     "category": "manuals",
     "name": { "str": "tactical baton defense manual", "str_pl": "copies of tactical baton defense manual" },
     "description": "An informative guide to self-defense using clubs and batons.  Aimed at the law enforcement and military market, it is packed with time tested, no-nonsense information and written to be understandable for beginners.",
-    "variants": [
-      {
-        "id": "manual_bashing",
-        "name": { "str": "tactical baton defense manual", "str_pl": "copies of tactical baton defense manual" },
-        "description": "An informative guide to self-defense using clubs and batons.  Aimed at the law enforcement and military market, it is packed with time tested, no-nonsense information and written to be understandable for beginners."
-      },
-      {
-        "id": "manual_bashing_1",
-        "name": { "str": "The Art and Science of Stick Fighting", "str_pl": "copies of The Art and Science of Stick Fighting" },
-        "description": "A non-style specific guide to fighting with the short stick, with a few levels of instructions from easy to master, and a lot of photos showing movements with motion arrows.",
-        "//": "978-1594397332"
-      },
-      {
-        "id": "manual_bashing_2",
-        "name": { "str": "Demolition Man", "str_pl": "copies of Demolition Man" },
-        "description": "A comprehensive guide on how to do demolition on your own piece of land - from replacing the pavement to total house deconstruction - using only common instruments.  Surprisingly not so hard, as you just need to know how and when hit the thing."
-      },
-      {
-        "id": "manual_bashing_3",
-        "name": { "str": "Cane Fighting", "str_pl": "copies of Cane Fighting" },
-        "description": "\"The Authoritative Guide to Using the Cane or Walking Stick for Self-Defense\", this book provides plenty of ways to use an everyday tool as a sturdy weapon.",
-        "//": "978-1941845738"
-      }
-    ],
     "weight": "454 g",
     "volume": "250 ml",
     "price": "20 USD",

--- a/data/json/items/book/chemistry.json
+++ b/data/json/items/book/chemistry.json
@@ -5,44 +5,6 @@
     "category": "manuals",
     "name": { "str": "Advanced Physical Chemistry", "str_pl": "copies of Advanced Physical Chemistry" },
     "description": "A university-level textbook on advanced principles of physical chemistry and all its branches: thermochemistry, electrochemistry, solid-state chemistry, photochemistry, quantum chemistry et cetera.",
-    "variants": [
-      {
-        "id": "adv_chemistry",
-        "name": { "str": "Advanced Physical Chemistry", "str_pl": "copies of Advanced Physical Chemistry" },
-        "description": "A university-level textbook on advanced principles of physical chemistry and all its branches: thermochemistry, electrochemistry, solid-state chemistry, photochemistry, quantum chemistry et cetera."
-      },
-      {
-        "id": "adv_chemistry_1",
-        "name": {
-          "str": "Physical Chemistry: Principles and Applications",
-          "str_pl": "copies of Physical Chemistry: Principles and Applications"
-        },
-        "description": "Fifth Edition of a best-selling book about using physical chemistry in various branches, with real examples.",
-        "//": "978-0136056065"
-      },
-      {
-        "id": "adv_chemistry_2",
-        "name": { "str": "Physical Chemistry: A Molecular Approach", "str_pl": "copies of Physical Chemistry: A Molecular Approach" },
-        "description": "A textbook that covers more specialized topics in physical chemistry, including quantum chemistry, statistical mechanics, and surface science.",
-        "//": "978-8184959888"
-      },
-      {
-        "id": "adv_chemistry_3",
-        "name": {
-          "str": "Physical Chemistry: From Quantum Mechanics to Statistical Thermodynamics",
-          "str_pl": "copies of Physical Chemistry: From Quantum Mechanics to Statistical Thermodynamics"
-        },
-        "description": "This book provides a comprehensive introduction to the principles of physical chemistry, covering topics such as quantum mechanics, thermodynamics, and statistical mechanics."
-      },
-      {
-        "id": "adv_chemistry_4",
-        "name": {
-          "str": "Physical Chemistry for Scientists and Engineers",
-          "str_pl": "copies of Physical Chemistry for Scientists and Engineers"
-        },
-        "description": "This book is designed for students in engineering and the physical sciences who are interested in applying physical chemistry concepts to real-world problems.  It covers topics such as thermodynamics, statistical mechanics, and transport phenomena, and includes examples and problems drawn from engineering and scientific applications."
-      }
-    ],
     "weight": "1712 g",
     "volume": "2 L",
     "price": "79 USD 50 cent",
@@ -65,37 +27,6 @@
     "category": "manuals",
     "name": { "str": "The Modern Tanner", "str_pl": "copies of The Modern Tanner" },
     "description": "An in-depth and easy to read guide that details a very modern take on the ancient art of leather tanning.",
-    "variants": [
-      {
-        "id": "modern_tanner",
-        "name": { "str": "The Modern Tanner", "str_pl": "copies of The Modern Tanner" },
-        "description": "An in-depth and easy to read guide that details a very modern take on the ancient art of leather tanning."
-      },
-      {
-        "id": "modern_tanner_1",
-        "name": {
-          "str": "Leathercraft: Traditional Handcrafted Leatherwork Skills and Projects",
-          "str_pl": "copies of Leathercraft: Traditional Handcrafted Leatherwork Skills and Projects"
-        },
-        "description": "A guide by Nigel Armitage offering traditional leatherworking techniques with modern applications, creating durable goods able to last generations.",
-        "//": "978-0764360398"
-      },
-      {
-        "id": "modern_tanner_2",
-        "name": { "str": "Leatherworking Handbook", "str_pl": "copies of Leatherworking Handbook" },
-        "description": "A leatherworking book for amateurs by a top professional, with some key techniques and various projects.",
-        "//": "978-1844034741"
-      },
-      {
-        "id": "modern_tanner_3",
-        "name": {
-          "str": "The Leather Manufacture in the United States",
-          "str_pl": "copies of The Leather Manufacture in the United States"
-        },
-        "description": "This vintage book contains a detailed treatise on the leather industry in late-nineteenth century America, being a dissertation on the methods employed in and the economics of tanning.",
-        "//": "978-3337106478"
-      }
-    ],
     "weight": "568 g",
     "volume": "750 ml",
     "price": "20 USD",
@@ -337,31 +268,6 @@
     "category": "manuals",
     "name": { "str": "chemistry textbook", "str_pl": "copies of chemistry textbook" },
     "description": "A college textbook on chemistry.",
-    "variants": [
-      {
-        "id": "textbook_chemistry",
-        "name": { "str": "chemistry textbook", "str_pl": "copies of chemistry textbook" },
-        "description": "A college textbook on chemistry."
-      },
-      {
-        "id": "textbook_chemistry_1",
-        "name": { "str": "Chemistry Essentials For Dummies", "str_pl": "copies of Chemistry Essentials For Dummies" },
-        "description": "Invaluable quick reference guide to the fundamentals of chemistry for students.",
-        "//": "978-1119591146"
-      },
-      {
-        "id": "textbook_chemistry_2",
-        "name": { "str": "General Chemistry", "str_pl": "copies of General Chemistry" },
-        "description": "The revised third edition of a classic first-year text by Nobel laureate.  Covers atomic and molecular structure, quantum mechanics, statistical mechanics, and thermodynamics correlated with descriptive chemistry problems.",
-        "//": "978-0486656229"
-      },
-      {
-        "id": "textbook_chemistry_3",
-        "name": { "str": "Modern Chemistry: Student Edition", "str_pl": "copies of Modern Chemistry: Student Edition" },
-        "description": "A giant, almost 1000 page book that covers anything a student may want (and may not want) to know about chemistry, from foundations to an intermediate level.",
-        "//": "978-0554023557"
-      }
-    ],
     "weight": "1587 g",
     "volume": "2 L",
     "price": "79 USD 50 cent",
@@ -385,27 +291,6 @@
     "category": "manuals",
     "name": { "str": "The Essential Oil Enthusiasts Handbook", "str_pl": "copies of The Essential Oil Enthusiasts Handbook" },
     "description": "A heavy hardback book explaining the process of essential oil making, with schematics for the equipment to do it.  Good luck, and don't blow yourself up!",
-    "variants": [
-      {
-        "id": "textbook_extraction",
-        "name": { "str": "The Essential Oil Enthusiasts Handbook", "str_pl": "copies of The Essential Oil Enthusiasts Handbook" },
-        "description": "A heavy hardback book explaining the process of essential oil making, with schematics for the equipment to do it.  Good luck, and don't blow yourself up!"
-      },
-      {
-        "id": "textbook_extraction_1",
-        "name": {
-          "str": "Handbook of Essential Oils: Science, Technology, and Applications",
-          "str_pl": "copies of Handbook of Essential Oils: Science, Technology, and Applications"
-        },
-        "description": "This book presents the development, use and marketing of essential oils, with a wide range of topics, sources, as well as production and analysis techniques.",
-        "//": "978-0815370963"
-      },
-      {
-        "id": "textbook_extraction_2",
-        "name": { "str": "Essential Oil Distillation", "str_pl": "copies of Essential Oil Distillation" },
-        "description": "This book provides a detailed guide to the process of distilling essential oils, including information on equipment and processes for extracting them from plant materials.  It also includes tips for selecting and storing essential oils, as well as using the byproducts of manufacturing."
-      }
-    ],
     "looks_like": "textbook_chemistry",
     "weight": "1420 g",
     "volume": "1 L",
@@ -450,46 +335,6 @@
       "str_pl": "copies of Chemistry for Kids: Awesome Science Experiments that Really Work"
     },
     "description": "A book with comprehensive and accurate step-by-step illustrated instructions for many scientific experiments, for young researchers and anyone else who wants to delve into the amazing world of chemistry.",
-    "variants": [
-      {
-        "id": "basic_chemistry",
-        "name": {
-          "str": "Chemistry for Kids: Awesome Science Experiments that Really Work",
-          "str_pl": "copies of Chemistry for Kids: Awesome Science Experiments that Really Work"
-        },
-        "description": "A book with comprehensive and accurate step-by-step illustrated instructions for many scientific experiments, for young researchers and anyone else who wants to delve into the amazing world of chemistry."
-      },
-      {
-        "id": "basic_chemistry_1",
-        "name": {
-          "str": "The Chemistry Book: Big Ideas Simply Explained",
-          "str_pl": "copies of The Chemistry Book: Big Ideas Simply Explained"
-        },
-        "description": "Short, pithy explanations of some of the most historic moments in science, from the birth of alchemy to modern chemistry state.  Simple graphics, such as flowcharts and mind maps, support the text and make the explanation of key concepts easy to follow.",
-        "//": "978-0241515549"
-      },
-      {
-        "id": "basic_chemistry_2",
-        "name": { "str": "Basic Chemistry", "str_pl": "copies of Basic Chemistry" },
-        "description": "The fifth edition of a textbook to help students master math and problem solving they will use in their future chemistry classes.",
-        "//": "978-0134138046"
-      },
-      {
-        "id": "basic_chemistry_3",
-        "name": { "str": "Basic Chemistry Concepts and Exercises", "str_pl": "copies of Basic Chemistry Concepts and Exercises" },
-        "description": "This book communicates the fundamentals of chemistry in a practical, down-to-earth manner, with simple language and detailed images.",
-        "//": "978-1439813379"
-      },
-      {
-        "id": "basic_chemistry_4",
-        "name": {
-          "str": "Everything You Need to Ace Chemistry in One Big Fat Notebook",
-          "str_pl": "copies of Everything You Need to Ace Chemistry in One Big Fat Notebook"
-        },
-        "description": "This book provides plenty of info about high school-level chemistry, with lot of additional tables and formulas, though lacking many additional pictures.",
-        "//": "978-1523504251"
-      }
-    ],
     "weight": "362 g",
     "volume": "500 ml",
     "price": "5 USD 50 cent",
@@ -511,36 +356,6 @@
     "category": "manuals",
     "name": { "str": "Catalytic Cracking at Home for Solarpunks", "str_pl": "copies of Catalytic Cracking at Home for Solarpunks" },
     "description": "A colorful textbook that proclaims to teach one how to bootstrap kerosene and diesel production from waste products.  Despite the hip title, the information contained within is highly advanced and technical.",
-    "variants": [
-      {
-        "id": "catalytic_cracking_handbook",
-        "name": { "str": "Catalytic Cracking at Home for Solarpunks", "str_pl": "copies of Catalytic Cracking at Home for Solarpunks" },
-        "description": "A colorful textbook that proclaims to teach one how to bootstrap kerosene and diesel production from waste products.  Despite the hip title, the information contained within is highly advanced and technical."
-      },
-      {
-        "id": "catalytic_cracking_handbook_1",
-        "name": {
-          "str": "Modeling and Simulation of Fluid Catalytic Cracking Riser",
-          "str_pl": "copies of Modeling and Simulation of Fluid Catalytic Cracking Riser"
-        },
-        "description": "Describing the problems that may occur while refining oil, this book is an excellent reference and teaching material for students and researchers in chemical engineering and chemistry.",
-        "//": "978-3659713538"
-      },
-      {
-        "id": "catalytic_cracking_handbook_2",
-        "name": { "str": "Fluid Catalytic Cracking Handbook", "str_pl": "copies of Fluid Catalytic Cracking Handbook" },
-        "description": "This handbook provides practical information and tools that engineers can use to maximize the profitability and reliability of their fluid catalytic cracking operations."
-      },
-      {
-        "id": "catalytic_cracking_handbook_3",
-        "name": {
-          "str": "A Literature Review on Cold Cracking of Petroleum Crude Oil",
-          "str_pl": "copies of A Literature Review on Cold Cracking of Petroleum Crude Oil"
-        },
-        "description": "This book describes cold petroleum cracking - a type of process that occurs below the freezing point, compared the common process that occurs at nearly 400 centigrade.  You can't really use this type of process without a lot of additional equipment, but the book provides plenty of information about common methods that you can do by hand.",
-        "//": "978-1523389322"
-      }
-    ],
     "weight": "1200 g",
     "volume": "2 L",
     "price": "15 USD",
@@ -561,69 +376,6 @@
     "category": "manuals",
     "name": { "str": "Biodiesel: Renewable Fuel Resource", "str_pl": "copies of Biodiesel: Renewable Fuel Resource" },
     "description": "A large textbook for college students about biodiesel.",
-    "variants": [
-      {
-        "id": "textbook_biodiesel",
-        "name": { "str": "Biodiesel: Renewable Fuel Resource", "str_pl": "copies of Biodiesel: Renewable Fuel Resource" },
-        "description": "A large textbook for college students about biodiesel."
-      },
-      {
-        "id": "textbook_biodiesel_1",
-        "name": {
-          "str": "Biodiesel Production: Technologies, Challenges, and Future Prospects",
-          "str_pl": "copies of Biodiesel Production: Technologies, Challenges, and Future Prospects"
-        },
-        "description": "Sponsored by the American Society of Civil Engineers, this book presents approaches, technologies, and source materials for biodiesel production, as well as socioeconomic and political impacts of its applications.  You surely don't need the second part anymore.",
-        "//": "978-0784415344"
-      },
-      {
-        "id": "textbook_biodiesel_2",
-        "name": { "str": "The Biodiesel Handbook", "str_pl": "copies of The Biodiesel Handbook" },
-        "description": "A big, 500-page book that provides plenty of info about the history of different fuels, methods to apply them, and properties required for each.  It's mainly centered on biodiesel and another biofuels.",
-        "//": "978-1893997622"
-      },
-      {
-        "id": "textbook_biodiesel_3",
-        "name": {
-          "str": "Biodiesel: a Realistic Fuel Alternative for Diesel Engines",
-          "str_pl": "copies of Biodiesel: a Realistic Fuel Alternative for Diesel Engines"
-        },
-        "description": "A small book offering insights into plant-based fuels, with detailed analyses of biodiesel types, and possible scenarios for their implementation.  Sadly most of the book just repeats itself, writing the same text over and over again, which makes you feel you stuck in a constant loop.",
-        "//": "978-1846289941"
-      },
-      {
-        "id": "textbook_biodiesel_4",
-        "name": {
-          "str": "Biodiesel Science and Technology: From Soil to Oil",
-          "str_pl": "copies of Biodiesel Science and Technology: From Soil to Oil"
-        },
-        "description": "This book contains different techniques for producing biofuels in different scales - from home-made work in your backyard to large manufacturing - with different issues you may meet in the process, and ways to resolve them.",
-        "//": "978-1845695910"
-      },
-      {
-        "id": "textbook_biodiesel_5",
-        "name": {
-          "str": "Biodiesel Basics and Beyond: A Comprehensive Guide to Production and Use for the Home and Farm",
-          "str_pl": "copies of Biodiesel Basics and Beyond: A Comprehensive Guide to Production and Use for the Home and Farm"
-        },
-        "description": "A comprehensive guide by William Kemp to produce biodiesel at small scale while avoiding common failures of fuel quality and byproduct waste management, with accuracies of data and process backed by government or university verification.",
-        "//": "978-1505404630"
-      },
-      {
-        "id": "textbook_biodiesel_6",
-        "name": {
-          "str": "Handbook of Biofuels Production: Process and Technologies",
-          "str_pl": "copies of Handbook of Biofuels Production: Process and Technologies"
-        },
-        "description": "A book about different types of biofuels, issues in their production and application, and different processes and technologies that are used in their manufacturing.",
-        "//": "978-0323911931"
-      },
-      {
-        "id": "textbook_biodiesel_7",
-        "name": { "str": "Bean Diesel", "str_pl": "copies of Bean Diesel" },
-        "description": "The original cover of this book was replaced with a white sheet of paper with a hand-made \"Bean Diesel\" label and simplified image of Vin Diesel, drawn in pen.  Excluding this, it is a pretty mundane handbook about biofuel production."
-      }
-    ],
     "weight": "1200 g",
     "volume": "2 L",
     "price": "15 USD",

--- a/data/json/items/book/cutting.json
+++ b/data/json/items/book/cutting.json
@@ -5,40 +5,6 @@
     "category": "manuals",
     "name": { "str": "All About Swords", "str_pl": "issues of All About Swords" },
     "description": "An interesting magazine that contains information about swords and sword fighting techniques from all across the world.",
-    "variants": [
-      {
-        "id": "mag_cutting",
-        "name": { "str": "All About Swords", "str_pl": "issues of All About Swords" },
-        "description": "An interesting magazine that contains information about swords and sword fighting techniques from all across the world."
-      },
-      {
-        "id": "mag_cutting_1",
-        "name": {
-          "str": "Swordfighting, for Writers, Game Designers, and Martial Artists",
-          "str_pl": "copies of Swordfighting, for Writers, Game Designers, and Martial Artists"
-        },
-        "description": "Answers for questions you may have if you've never held a sword in your hands.",
-        "//": "978-9526793481"
-      },
-      {
-        "id": "mag_cutting_2",
-        "name": { "str": "The Beginner's Guide to the Long Sword", "str_pl": "copies of The Beginner's Guide to the Long Sword" },
-        "description": "Based on different Europeans' martial arts, this book describes the main principles of swordsmanship.",
-        "//": "978-0897501781"
-      },
-      {
-        "id": "mag_cutting_3",
-        "name": { "str": "Basics Of Stage Combat", "str_pl": "copies of Basics Of Stage Combat" },
-        "description": "Foundation of using single handed sword on stage and on screen, with different tricks how to make a good show of it.",
-        "//": "978-1612331720"
-      },
-      {
-        "id": "mag_cutting_4",
-        "name": { "str": "Medieval Combat in Colour", "str_pl": "copies of Medieval Combat in Colour" },
-        "description": "An ancient fencing manual with updated illustrations of techniques.  Sometimes it just looks silly, describing how to fight if you have sword in one hand and a spear in another.",
-        "//": "978-1784382858"
-      }
-    ],
     "weight": "80 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -57,45 +23,8 @@
     "id": "manual_cutting",
     "type": "BOOK",
     "category": "manuals",
-    "name": { "str": "knife fighter's notes", "str_pl": "collections of knife fighter's notes" },
+    "name": { "str": "blade fighter's notes", "str_pl": "collections of blade fighter's notes" },
     "description": "It seems to be a guide to edged weapon combat, poorly photocopied and released on spiral-bound paper.  Still, there are lots of useful tips for beginners.",
-    "variants": [
-      {
-        "id": "manual_cutting",
-        "name": { "str": "knife fighter's notes", "str_pl": "collections of knife fighter's notes" },
-        "description": "It seems to be a guide to edged weapon combat, poorly photocopied and released on spiral-bound paper.  Still, there are lots of useful tips for beginners."
-      },
-      {
-        "id": "manual_cutting_1",
-        "name": { "str": "The Medieval Dagger", "str_pl": "copies of The Medieval Dagger" },
-        "description": "Principles and guides to Italian dagger combat, with useful drills and advice for novices.",
-        "//": "978-1937439033"
-      },
-      {
-        "id": "manual_cutting_2",
-        "name": { "str": "Knife Fighting Techniques for the Street", "str_pl": "copies of Knife Fighting Techniques for the Street" },
-        "description": "A small book that contain pretty simple and easy to follow movements to use against your enemy or enemies.",
-        "//": "978-1941845523"
-      },
-      {
-        "id": "manual_cutting_3",
-        "name": { "str": "Knife Offense", "str_pl": "copies of Knife Offense" },
-        "description": "Complete methodology for using knives in a real fight, with tips and tricks.",
-        "//": "978-1492935391"
-      },
-      {
-        "id": "manual_cutting_4",
-        "name": { "str": "Blade Combatives", "str_pl": "copies of Blade Combatives" },
-        "description": "This book combines some different blade methodologies from European, Asian, and American martial arts into a unique style.",
-        "//": "978-1387035885"
-      },
-      {
-        "id": "manual_cutting_5",
-        "name": { "str": "Knife Anatomy", "str_pl": "copies of Knife Anatomy" },
-        "description": "Lots of knife training methods and techniques for experienced martial artists.",
-        "//": "978-1480259638"
-      }
-    ],
     "weight": "454 g",
     "volume": "250 ml",
     "price": "20 USD",
@@ -115,43 +44,6 @@
     "category": "manuals",
     "name": { "str": "USMC Sword Manual Procedure", "str_pl": "copies of USMC Sword Manual Procedures" },
     "description": "A text on stationary sword drills in US Marine Corps.",
-    "variants": [
-      {
-        "id": "manual_swords",
-        "name": { "str": "USMC Sword Manual Procedure", "str_pl": "copies of USMC Sword Manual Procedure" },
-        "description": "A text on stationary sword drills in US Marine Corps.  Contains lots of information about how to draw and pose with a sword, but nothing about using it."
-      },
-      {
-        "id": "manual_swords_1",
-        "name": { "str": "Five Rings Illustrated", "str_pl": "copies of Five Rings Illustrated" },
-        "description": "An old Japanese treatise about swordsmanship, translated and polished, with additional illustrations and detailed explanations.",
-        "//": "978-1838862176"
-      },
-      {
-        "id": "manual_swords_2",
-        "name": { "str": "Records of the Medieval Sword", "str_pl": "copies of Records of the Medieval Sword" },
-        "description": "Original research about straight two-edged knightly swords of the European middle ages.",
-        "//": "978-0851155661"
-      },
-      {
-        "id": "manual_swords_3",
-        "name": { "str": "The Unfettered Mind", "str_pl": "copies of The Unfettered Mind" },
-        "description": "An ancient Japanese book of advice about building the proper skills and mind for sword fighting.  Talks too much about Zen, but the sword techniques are worth noting.",
-        "//": "978-1590309865"
-      },
-      {
-        "id": "manual_swords_4",
-        "name": { "str": "The Art of Longsword Fighting", "str_pl": "copies of The Art of Longsword Fighting" },
-        "description": "A grounded work about the history of swordsmanship, ways to teach it, and how to enhance students' experience.",
-        "//": "978-1526768988"
-      },
-      {
-        "id": "manual_swords_5",
-        "name": { "str": "Art of Sword Combat", "str_pl": "copies of Art of Sword Combat" },
-        "description": "Translation of an old German treatise about using a few different cutting weapons in a real fight, with modern comments and clarification.",
-        "//": "978-1473876750"
-      }
-    ],
     "weight": "454 g",
     "volume": "250 ml",
     "price": "52 USD",

--- a/data/json/items/book/dodge.json
+++ b/data/json/items/book/dodge.json
@@ -5,40 +5,6 @@
     "category": "manuals",
     "name": { "str": "Dance Dance Dance!", "str_pl": "issues of Dance Dance Dance!" },
     "description": "Learn the moves of the trendiest dances right now.",
-    "variants": [
-      {
-        "id": "mag_dodge",
-        "name": { "str": "Dance Dance Dance!", "str_pl": "issues of Dance Dance Dance!" },
-        "description": "Learn the moves of the trendiest dances right now."
-      },
-      {
-        "id": "mag_dodge_1",
-        "name": { "str": "How Animals Move", "str_pl": "copies of How Animals Move" },
-        "description": "In this book, zoologist Sir James Gray explores the development of different kinds of animal movement, from swimming to crawling to jumping, and then examines the mechanics of the variety of possible movements made by different creatures, illustrated with both sketches and photographs.",
-        "//": "9781013330865"
-      },
-      {
-        "id": "mag_dodge_2",
-        "name": { "str": "The Art of Movement", "str_pl": "copies of The Art of Movement" },
-        "description": "A collection of photos of different dance movements of the world.  The images are inspiring, and the movements of the dancers are deep.",
-        "//": "978-0275934194"
-      },
-      {
-        "id": "mag_dodge_3",
-        "name": { "str": "Self-Defense for Gentlemen and Ladies", "str_pl": "copies of Self-Defense for Gentlemen and Ladies" },
-        "description": "An old treatise about self defense, with style.",
-        "//": "978-1583948682"
-      },
-      {
-        "id": "mag_dodge_4",
-        "name": {
-          "str": "Self-Defence for Non-Experts: A Book for People Who Can't Fight",
-          "str_pl": "copies of Self-Defence for Non-Experts: A Book for People Who Can't Fight"
-        },
-        "description": "A small guide on self defense for an untrained person - mostly simple tricks and advice like having a knife and how to threaten an enemy into backing down, but contains some more advanced and detailed descriptions of movement techniques.",
-        "//": "978-1533113221"
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 90 cent",
@@ -59,31 +25,6 @@
     "category": "manuals",
     "name": { "str": "The Book of Dances", "str_pl": "copies of The Book of Dances" },
     "description": "This massive antique book documents dances from all around the world in great detail.  A perceptive reader could learn a lot about defensive footwork from some of the war dances.",
-    "variants": [
-      {
-        "id": "manual_dodge",
-        "name": { "str": "The Book of Dances", "str_pl": "copies of The Book of Dances" },
-        "description": "This massive antique book documents dances from all around the world in great detail.  A perceptive reader could learn a lot about defensive footwork from some of the war dances."
-      },
-      {
-        "id": "manual_dodge_1",
-        "name": { "str": "The Complete Book about Dodgeball", "str_pl": "copies of The Complete Book about Dodgeball" },
-        "description": "A small book from a Physical Education and Health teacher about the simple game of dodgeball, its rules and variations, tricks, and what it can teach students.  Sadly, the book contains surprisingly poor grammar, and the informal conversational tone makes it difficult to follow at times.",
-        "//": "978-1420875485"
-      },
-      {
-        "id": "manual_dodge_2",
-        "name": { "str": "When Seconds Count", "str_pl": "copies of When Seconds Count" },
-        "description": "A comprehensive guide on what to do in dangerous situations on the street and beyond - ways to improve your awareness skills, de-escalate the situation or, if it is not possible, defend yourself and your family in every possible manner, violent or not.",
-        "//": "978-0989038270"
-      },
-      {
-        "id": "manual_dodge_3",
-        "name": { "str": "Born to Walk", "str_pl": "copies of Born to Walk" },
-        "description": "This book explores the mechanics, mysteries, and methods of upright walking - why, how, and when.  It includes a big chapter on how different martial arts exploit this mode of movement.",
-        "//": "978-1623174439"
-      }
-    ],
     "weight": "2330 g",
     "volume": "1250 ml",
     "price": "72 USD",
@@ -103,24 +44,6 @@
     "category": "manuals",
     "name": { "str": "Break a Leg!", "str_pl": "copies of Break a Leg!" },
     "description": "The Kids' Guide to Acting and Stagecraft.",
-    "variants": [
-      {
-        "id": "manual_dodge_kid",
-        "name": { "str": "Break a Leg!", "str_pl": "copies of Break a Leg!" },
-        "description": "\"The Kids' Guide to Acting and Stagecraft\".  This book is packed with engaging outdoor games, complete with rules, strategies, and tips for mastering each activity, along with some simple drills to train skills in an easy way."
-      },
-      {
-        "id": "manual_dodge_kid_1",
-        "name": { "str": "Self-defense for Your Child", "str_pl": "copies of Self-defense for Your Child" },
-        "description": "A fully-illustrated practical course of simple techniques to defend your child from bullies or predators.  You doubt it will help much for a real child, but you found some interesting info here.",
-        "//": "978-0874070248"
-      },
-      {
-        "id": "manual_dodge_kid_2",
-        "name": { "str": "Protective Measures: A Graphic Novel", "str_pl": "copies of Protective Measures: A Graphic Novel" },
-        "description": "Modern comics about an unnamed Hero that protects people without any superpowers, using only his body and different martial arts.  The artwork is well-illustrated and shows the movement and strategy of each character, but the plot is fairly simple."
-      }
-    ],
     "copy-from": "book_nonf_hard_dodge_tpl",
     "looks_like": "manual_gun",
     "max_level": 1,
@@ -132,52 +55,6 @@
     "category": "manuals",
     "name": { "str": "Treasury of Legends about Western Dancing", "str_pl": "copies of Western Dancing" },
     "description": "Written by Emanuel Nogueira, a constabulario and historian of Nuevo Laredo, this massive book details the movements and cultural legacies of a variety of North American folk dances.",
-    "variants": [
-      {
-        "id": "book_nonf_hard_dodge_tlwd",
-        "name": { "str": "Treasury of Legends about Western Dancing", "str_pl": "copies of Treasury of Legends about Western Dancing" },
-        "description": "Written by Emanuel Nogueira, a constabulario and historian of Nuevo Laredo, this massive book details the movements and cultural legacies of a variety of North American folk dances."
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_1",
-        "name": { "str": "A Guide To Making Yourself A Hard Target", "str_pl": "copies of A Guide To Making Yourself A Hard Target" },
-        "description": "Written by self-defense instructor Neal Martin, this book describe techniques and movesets you need to train to avoid being a victim, as well as avoid trouble with the law in the aftermath.",
-        "//": "979-8620742561"
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_2",
-        "name": {
-          "str": "The Ultimate Guide to Unarmed Self Defense",
-          "str_pl": "copies of The Ultimate Guide to Unarmed Self Defense"
-        },
-        "description": "This book contains a lot of info about awareness, prevention, and defense in unarmed fights.",
-        "//": "978-1497530201"
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_3",
-        "name": { "str": "Knife Self-Defense for Combat", "str_pl": "copies of Knife Self-Defense for Combat" },
-        "description": "A small manual about skills you need to defend yourself in armed street fights.",
-        "//": "978-0897500227"
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_4",
-        "name": { "str": "Invincible", "str_pl": "copies of Invincible" },
-        "description": "A dark book with a barbarian on the cover, this guide talks about how to obtain skills for the streets, battlefields and… playing fields?",
-        "//": "978-1941845134"
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_5",
-        "name": { "str": "War Machine", "str_pl": "copies of War Machine" },
-        "description": "\"How to Transform Yourself Into A Vicious And Deadly Street Fighter\".  This book, despite having a gladiator on the cover, describes pretty practical ways to obtain the psychology, physiology, and combat potential of a real warrior, ancient or modern.",
-        "//": "978-0981872100"
-      },
-      {
-        "id": "book_nonf_hard_dodge_tlwd_6",
-        "name": { "str": "Understanding the Human Foot", "str_pl": "copies of Understanding the Human Foot" },
-        "description": "A full color, updated overview of the structure of the feet, with essential info about its functions, demonstrating how the foot relates to and interacts with the rest of the body during movement.",
-        "//": "978-1623176570"
-      }
-    ],
     "copy-from": "book_nonf_hard_dodge_tpl",
     "looks_like": "radio_book",
     "weight": "2330 g",

--- a/data/json/items/book/driving.json
+++ b/data/json/items/book/driving.json
@@ -5,31 +5,6 @@
     "category": "manuals",
     "name": { "str": "AAA Guide", "str_pl": "copies of AAA Guide" },
     "description": "A tourist-centric guide to points of interest throughout the country.  Though it focuses on the north-central US, the driving sections contain some practical tips on proper driving techniques.",
-    "variants": [
-      {
-        "id": "decoy_anarch",
-        "name": { "str": "AAA Guide", "str_pl": "copies of AAA Guide" },
-        "description": "A tourist-centric guide to points of interest throughout the country.  Though it focuses on the north-central US, the driving sections contain some practical tips on proper driving techniques."
-      },
-      {
-        "id": "decoy_anarch_1",
-        "name": { "str": "Driving Around", "str_pl": "copies of Driving Around" },
-        "description": "A travelogue about a group of teenagers in the late nineties.",
-        "//": "978-1638607175"
-      },
-      {
-        "id": "decoy_anarch_2",
-        "name": { "str": "Off The Road", "str_pl": "copies of Off The Road" },
-        "description": "A notebook about living off-the-grid, with a wide collection of stories, examples, tips, and advice.",
-        "//": "978-3899555943"
-      },
-      {
-        "id": "decoy_anarch_3",
-        "name": { "str": "Traffic: Why We Drive the Way We Do", "str_pl": "copies of Traffic: Why We Drive the Way We Do" },
-        "description": "A big research book that talks about how roads are built, why they're built in such a manner, and what we can do to improve it.",
-        "//": "978-0307277190"
-      }
-    ],
     "weight": "220 g",
     "volume": "500 ml",
     "price": "20 USD",
@@ -50,63 +25,6 @@
     "category": "manuals",
     "name": { "str": "Top Gear magazine" },
     "description": "Lots of articles about cars and driving techniques.",
-    "variants": [
-      {
-        "id": "mag_cars",
-        "name": { "str": "Top Gear", "str_pl": "issues of Top Gear" },
-        "description": "Lots of articles about cars and driving techniques."
-      },
-      {
-        "id": "mag_cars_1",
-        "name": { "str": "Automobile", "str_pl": "issues of Automobile" },
-        "description": "A nice-looking magazine about the automobile industry, with shiny images and long articles.  Dated 2019."
-      },
-      {
-        "id": "mag_cars_2",
-        "name": { "str": "Automotive Industries", "str_pl": "issues of Automotive Industries" },
-        "description": "A monthly report about recent changes in the transport industry."
-      },
-      {
-        "id": "mag_cars_3",
-        "name": { "str": "Autoweek", "str_pl": "issues of Autoweek" },
-        "description": "A shabby magazine about new and old cars, automobile reviews, general motorsports, and DIY."
-      },
-      {
-        "id": "mag_cars_4",
-        "name": { "str": "Car and Driver", "str_pl": "issues of Car and Driver" },
-        "description": "An absolutely generic monthly magazine about the automotive industry."
-      },
-      {
-        "id": "mag_cars_5",
-        "name": { "str": "Car Craft", "str_pl": "issues of Car Craft" },
-        "description": "Flashy journal about cars, racing, and mechanics."
-      },
-      {
-        "id": "mag_cars_6",
-        "name": { "str": "Diesel Power", "str_pl": "issues of Diesel Power" },
-        "description": "An automotive magazine, focused on heavily modifying trucks, SUVs, and cars powered by diesel."
-      },
-      {
-        "id": "mag_cars_7",
-        "name": { "str": "Cruisin' Style Magazine", "str_pl": "issues of Cruisin' Style Magazine" },
-        "description": "A really old issue about classic car maintenance and restoration."
-      },
-      {
-        "id": "mag_cars_8",
-        "name": { "str": "Hot Rod", "str_pl": "issues of Hot Rod" },
-        "description": "Monthly magazine about hot rodding, drag racing, and muscle cars."
-      },
-      {
-        "id": "mag_cars_9",
-        "name": { "str": "Motor Trend", "str_pl": "issues of Motor Trend" },
-        "description": "Boring automobile magazine with a big shiny label."
-      },
-      {
-        "id": "mag_cars_10",
-        "name": { "str": "Quatro Rodas", "str_pl": "issues of Quatro Rodas" },
-        "description": "It seems to be a car magazine, but you can only understand the images, as the text is written in another language."
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -127,40 +45,6 @@
     "category": "manuals",
     "name": { "str": "The Rules of the Road", "str_pl": "copies of The Rules of the Road" },
     "description": "A thick textbook for beginning drivers.  It contains chapters on laws, safe vehicle operation, and defensive driving concepts.",
-    "variants": [
-      {
-        "id": "manual_driving",
-        "name": { "str": "The Rules of the Road", "str_pl": "copies of The Rules of the Road" },
-        "description": "A thick textbook for beginning drivers.  It contains chapters on laws, safe vehicle operation, and defensive driving concepts."
-      },
-      {
-        "id": "manual_driving_1",
-        "name": { "str": "Guide to Passing the Driving Test", "str_pl": "copies of Guide to Passing the Driving Test" },
-        "description": "A thick, heavy book about every thing you may be asked in your driving exam.  The biggest part of the book contains a 'theory test' with detailed answers, and many how-to's related to driving overall.",
-        "//": "978-1789630473"
-      },
-      {
-        "id": "manual_driving_2",
-        "name": { "str": "The official DVSA guide to driving", "str_pl": "copies of The official DVSA guide to driving" },
-        "description": "This book is packed with comprehensive information about driving, how to do it properly, and take joy in it.  You wonder how this manual made it here, as DVSA is a British organization, and the book contains information about specific British driving rules.",
-        "//": "978-0115537011"
-      },
-      {
-        "id": "manual_driving_3",
-        "name": {
-          "str": "Automated Driving and Driver Assistance Systems",
-          "str_pl": "copies of Automated Driving and Driver Assistance Systems"
-        },
-        "description": "This book explains the technologies and approaches of advanced driving systems, how they are designed, and why it is hard to get a good result.  It is difficult to understand sometimes, but it shows driving from a perspective an average driver wouldn't think about.",
-        "//": "978-0367265595"
-      },
-      {
-        "id": "manual_driving_4",
-        "name": { "str": "The Driving Instructor's Handbook", "str_pl": "copies of The Driving Instructor's Handbook" },
-        "description": "Detailed textbook about how to provide driving lessons, what may be discussed, and how to prevent dangerous situations and collisions.",
-        "//": "978-1398602786"
-      }
-    ],
     "weight": "404 g",
     "volume": "500 ml",
     "price": "22 USD",
@@ -180,31 +64,6 @@
     "category": "manuals",
     "name": { "str": "AAA Guide", "str_pl": "copies of AAA Guide" },
     "description": "A tourist-centric guide to points of interest throughout the country.  This particular copy is apparently the Anonymous Anarchist's Annual: the cover conceals a wealth of ways to help stick it to The Man, along with plenty of advice for avoiding police.",
-    "variants": [
-      {
-        "id": "textbook_anarch",
-        "name": { "str": "AAA Guide", "str_pl": "copies of AAA Guide" },
-        "description": "A tourist-centric guide to points of interest throughout the country.  This particular copy is apparently the Anonymous Anarchist's Annual: the cover conceals a wealth of ways to help stick it to The Man, along with plenty of advice for avoiding police."
-      },
-      {
-        "id": "textbook_anarch_1",
-        "name": { "str": "The Anarchist Cookbook", "str_pl": "copies of The Anarchist Cookbook" },
-        "description": "Classic illegal manual about making weapons and explosives.  The first page contains a quote from its author William Powell, that describes it as \"a youthful indiscretion or mistake that can haunt someone during their early years or even longer\".",
-        "//": "really? you don't know how to find the anarchist cookbook?"
-      },
-      {
-        "id": "textbook_anarch_2",
-        "name": { "str": "Science of Revolutionary Warfare", "str_pl": "copies of Science of Revolutionary Warfare" },
-        "description": "A small, shabby book about making explosives, poisons, and weapons with resources you may find in your backyard.",
-        "//": "978-0879472115"
-      },
-      {
-        "id": "textbook_anarch_3",
-        "name": { "str": "The Poor Man's James Bond", "str_pl": "copies of The Poor Man's James Bond" },
-        "description": "A collection of American paramilitary knowledge throughout history, containing a lot of information about how to make dangerous weapons and explosives in pretty dry language.",
-        "//": "978-0879472306"
-      }
-    ],
     "weight": "223 g",
     "volume": "500 ml",
     "price": "50 USD",

--- a/data/json/items/book/gun.json
+++ b/data/json/items/book/gun.json
@@ -5,38 +5,6 @@
     "category": "manuals",
     "name": { "str": "Guns n Ammo", "str_pl": "issues of Guns n Ammo" },
     "description": "Reviews of firearms, and various useful tips about their use.",
-    "variants": [
-      {
-        "id": "mag_guns",
-        "name": { "str": "Guns n Ammo", "str_pl": "issues of Guns n Ammo" },
-        "description": "Reviews of firearms, and various useful tips about their use."
-      },
-      {
-        "id": "mag_guns_1",
-        "name": { "str": "Gun Digest", "str_pl": "issues of Gun Digest" },
-        "description": "Annual magazine about firearms, weapon collections, self-defense, same as some practical and legal advices."
-      },
-      {
-        "id": "mag_guns_2",
-        "name": { "str": "Recoil", "str_pl": "issues of Recoil" },
-        "description": "A modern magazine about handguns, tactical weapons, knives, and shooting activities.  It says there is a fold-out target, but someone took it off."
-      },
-      {
-        "id": "mag_guns_3",
-        "name": { "str": "SWAT", "str_pl": "issues of SWAT" },
-        "description": "\"Special Weapons And Tactics for the prepared American\", this magazine contains info about firearms, law enforcement, and related interests, with a focus on SWAT police officers."
-      },
-      {
-        "id": "mag_guns_4",
-        "name": { "str": "Bullet Point", "str_pl": "issues of Bullet Point" },
-        "description": "Small magazine about ammo and firearms, and how to choose, use, and maintain them properly."
-      },
-      {
-        "id": "mag_guns_5",
-        "name": { "str": "Trigger Happy", "str_pl": "issues of Trigger Happy" },
-        "description": "Modern magazine for young people about firearms, self-defense, different competitions, and reviews."
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 80 cent",
@@ -56,54 +24,6 @@
     "category": "manuals",
     "name": { "str": "The Gun Owner's Handbook", "str_pl": "copies of The Gun Owner's Handbook" },
     "description": "A thick soft-cover book that claims to be a complete guide to safely operating, maintaining, and repairing firearms.",
-    "variants": [
-      {
-        "id": "manual_gun",
-        "name": { "str": "The Gun Owner's Handbook", "str_pl": "copies of The Gun Owner's Handbook" },
-        "description": "A thick soft-cover book that claims to be a complete guide to safely operating, maintaining, and repairing firearms."
-      },
-      {
-        "id": "manual_gun_1",
-        "name": { "str": "FM 3-90-1: Offense And Defense", "str_pl": "copies of FM 3-90-1: Offense And Defense" },
-        "description": "Official U.S. Army manual about basics and tactics of moving and attacking a target - how to shoot, how to hide, how to retreat, and how to defend."
-      },
-      {
-        "id": "manual_gun_2",
-        "name": { "str": "Surplus Military", "str_pl": "issues of Surplus Military" },
-        "description": "A journal about modern and old firearms, their style, manufacturing, and usage.",
-        "//": "978-1736672723"
-      },
-      {
-        "id": "manual_gun_3",
-        "name": { "str": "Owning a Modern Firearm", "str_pl": "copies of Owning a Modern Firearm" },
-        "description": "Essential handbook detailing how to own, use, and properly maintain a modern-day firearm.",
-        "//": "979-8519992862"
-      },
-      {
-        "id": "manual_gun_4",
-        "name": { "str": "Practical Shooting Training", "str_pl": "copies of Practical Shooting Training" },
-        "description": "Step-by-step instructions on how to use a gun, with lot of drills for each level.",
-        "//": "979-8593500014"
-      },
-      {
-        "id": "manual_gun_5",
-        "name": { "str": "The Illustrated History of Firearms", "str_pl": "copies of The Illustrated History of Firearms" },
-        "description": "A reference book that contains hundreds of images of firearms inside, with lot of comments from professionals and information about each model.",
-        "//": "978-1951115142"
-      },
-      {
-        "id": "manual_gun_6",
-        "name": { "str": "Long Range Shooting Handbook", "str_pl": "copies of Long Range Shooting Handbook" },
-        "description": "\"The Complete Beginner's Guide to Precision Rifle Shooting\", this book contains information about shooting equipment, terminology, principles, and covers the theory of long-range shooting.  It has a lot practical advices about marksmanship.",
-        "//": "978-1518654725"
-      },
-      {
-        "id": "manual_gun_7",
-        "name": { "str": "The Rifle-Musket", "str_pl": "copies of The Rifle-Musket" },
-        "description": "\"A Practical Treatise on the Enfield-Pritchett Rifle, Recently Adopted in the British Service\".  This is a practical guide to using the newly adopted P-1853 Enfield Rifle-Musket.  Despite being written in 1854, it still has lot of useful information about shooting, as well as information about how to maintain this antique rifle.",
-        "//": "978-1480115736"
-      }
-    ],
     "weight": "462 g",
     "volume": "500 ml",
     "price": "38 USD",
@@ -143,61 +63,6 @@
       "str_pl": "copies of Ballistics: Theory, Design, and Application"
     },
     "description": "This hefty, hardbound textbook is written in obtuse, complex language.  If you already knew a bit about engineering and fabrication, it might be a useful reference on gunsmithing and design, but without that knowledge it'd be better used to prop up a table.",
-    "variants": [
-      {
-        "id": "text_gunsmith",
-        "name": {
-          "str": "Ballistics: Theory, Design, and Application",
-          "str_pl": "copies of Ballistics: Theory, Design, and Application"
-        },
-        "description": "This hefty, hardbound textbook is written in obtuse, complex language.  If you already knew a bit about engineering and fabrication, it might be a useful reference on gunsmithing and design, but without that knowledge it'd be better used to prop up a table."
-      },
-      {
-        "id": "text_gunsmith_1",
-        "name": { "str": "The Complete Guide to Gunsmithing", "str_pl": "copies of The Complete Guide to Gunsmithing" },
-        "description": "This fairly old book is a highly detailed and essential reference for any gun enthusiast, and covers everything from the use of proper tools to how to get a gunsmithing job.",
-        "//": "978-1632202697"
-      },
-      {
-        "id": "text_gunsmith_2",
-        "name": { "str": "Professional Gunsmithing", "str_pl": "copies of Professional Gunsmithing" },
-        "description": "A guide for gun shop owners, this book contains lots of information about weapons and weapon maintenance.",
-        "//": "978-1163156063"
-      },
-      {
-        "id": "text_gunsmith_3",
-        "name": { "str": "Gunsmithing - Rifles", "str_pl": "copies of Gunsmithing - Rifles" },
-        "description": "The book contains step-by-step instructions to repair and maintain all major rifle types, from the AR-15 and AK-47 to the M1 Garand.  It also details many different projects and enhancements for gun owners.",
-        "//": "978-1946267467"
-      },
-      {
-        "id": "text_gunsmith_4",
-        "name": {
-          "str": "Gunsmithing: A Manual of Firearm Design, Construction, Alteration and Remodeling",
-          "str_pl": "copies of Gunsmithing: A Manual of Firearm Design, Construction, Alteration and Remodeling"
-        },
-        "description": "This book contains extremely precise instructions for fixing different issues with your gun.  Having lots of modern photos is a huge advantage, though the fact that it's a reprint of a book from the 1950s is not.",
-        "//": "978-1614272373"
-      },
-      {
-        "id": "text_gunsmith_5",
-        "name": { "str": "The Guns of John Moses Browning", "str_pl": "copies of The Guns of John Moses Browning" },
-        "description": "A major biography of John Moses Browning, \"the Thomas Edison of guns\", this book describes his story, and the inventions he made, as well as decisions behind their development, processes, manufacturing, and usage.",
-        "//": "978-1982129224"
-      },
-      {
-        "id": "text_gunsmith_6",
-        "name": { "str": "DIY Guns: Easy DIY Gunsmithing Projects", "str_pl": "issues of DIY Guns: Easy DIY Gunsmithing Projects" },
-        "description": "A big magazine about different gunsmithing projects, from tuning your gun to making a brand new one using common techniques.",
-        "//": "978-1732132764"
-      },
-      {
-        "id": "text_gunsmith_7",
-        "name": { "str": "The Book of the Crossbow", "str_pl": "copies of The Book of the Crossbow" },
-        "description": "This book details the long story of crossbows - a devastating weapon which improved medieval distance warfare drastically - with lot of illustrations and information about additional weapons, like ballistae and catapults.",
-        "//": "978-0486287201"
-      }
-    ],
     "weight": "350 g",
     "volume": "450 ml",
     "longest_side": "25 cm",

--- a/data/json/items/book/launcher.json
+++ b/data/json/items/book/launcher.json
@@ -5,36 +5,6 @@
     "category": "manuals",
     "name": { "str": "High Explosives Quarterly", "str_pl": "issues of High Explosives Quarterly" },
     "description": "An interesting quarterly report about rocket launchers and recoilless rifles.  There are lots of large, exciting photos of explosions and weaponry.",
-    "variants": [
-      {
-        "id": "mag_launcher",
-        "name": { "str": "High Explosives Quarterly", "str_pl": "issues of High Explosives Quarterly" },
-        "description": "An interesting quarterly report about rocket launchers and recoilless rifles.  There are lots of large, exciting photos of explosions and weaponry."
-      },
-      {
-        "id": "mag_launcher_1",
-        "name": { "str": "Launchers, Lobbers and Rockets Engineer", "str_pl": "copies of Launchers, Lobbers and Rockets Engineer" },
-        "description": "DIY guide about different ballistic launchers, how they work, and how to build one.",
-        "//": "978-1631594274"
-      },
-      {
-        "id": "mag_launcher_2",
-        "name": { "str": "Katyusha", "str_pl": "copies of Katyusha" },
-        "description": "This book shows the history of Soviet Multiple Rocket Launcher systems, developed in a late 1930s, the reasons to use it, problems solved while designing them, and tactics for using them.",
-        "//": "978-1472810861"
-      },
-      {
-        "id": "mag_launcher_3",
-        "name": { "str": "The Rocket Propelled Grenade", "str_pl": "copies of The Rocket Propelled Grenade" },
-        "description": "Part of a big series about different small arms, this book details RPGs - how they were created, how they were used, and how they are used now in modern times.",
-        "//": "978-1849081535"
-      },
-      {
-        "id": "mag_launcher_4",
-        "name": { "str": "Field Artillery", "str_pl": "issues of Field Artillery" },
-        "description": "A professional magazine about artillery, published by the US Field Artillery Corps.  Lots of articles analyze using modern artillery in different wars, modern and future technologies, and the most recent discoveries in ballistics and field engineering."
-      }
-    ],
     "weight": "90 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -55,48 +25,6 @@
     "category": "manuals",
     "name": { "str": "Jane's Mortars and Rocket Launchers", "str_pl": "copies of Jane's Mortars and Rocket Launchers" },
     "description": "An incredibly detailed guide to modern rockets, mortars, grenade launchers, and recoilless weaponry.  Lavishly illustrated with color photographs, it contains a wealth of information.",
-    "variants": [
-      {
-        "id": "manual_launcher",
-        "name": { "str": "Jane's Mortars and Rocket Launchers", "str_pl": "copies of Jane's Mortars and Rocket Launchers" },
-        "description": "An incredibly detailed guide to modern rockets, mortars, grenade launchers, and recoilless weaponry.  Lavishly illustrated with color photographs, it contains a wealth of information."
-      },
-      {
-        "id": "manual_launcher_1",
-        "name": { "str": "U.S. Grenade Launchers", "str_pl": "copies of U.S. Grenade Launchers" },
-        "description": "Part of a big series about different small arms, this book tells about the M79.  Created to fill the gap between hand grenade and light mortar, this weapon became an iconic symbol of the Vietnam War, and still serves its role perfectly.",
-        "//": "978-1472819529"
-      },
-      {
-        "id": "manual_launcher_2",
-        "name": {
-          "str": "Catalogue of Standard Ordnance Items: Volume 3 & 4",
-          "str_pl": "copies of Catalogue of Standard Ordnance Items: Volume 3 & 4"
-        },
-        "description": "A giant, comprehensive list of every U.S. Army weapon, munition, and piece of equipment that was used during World War II, with small, but detailed information about each of them.  Volume 3 describes light weapons like grenade launchers, recoilless rifles, man-portable anti-tank and air-defense missiles and mortars, and Volume 4 describes different heavy ammunition from 20mm to 16 inch hand and rifle grenades.",
-        "//": "978-1940453101"
-      },
-      {
-        "id": "manual_launcher_3",
-        "name": {
-          "str": "FM 3-09: Fire Support and Field Artillery Operations",
-          "str_pl": "copies of FM 3-09: Fire Support and Field Artillery Operations"
-        },
-        "description": "Official U.S. Army manual about principles and functions for fire support elements and field artillery.  Most of it is about the functions and operations of artillery, alongside some ballistic calculations.",
-        "//": "979-8642959404"
-      },
-      {
-        "id": "manual_launcher_4",
-        "name": { "str": "FM 3-22.3: Stryker Gunnery", "str_pl": "copies of FM 3-22.3: Stryker Gunnery" },
-        "description": "Official U.S. Army manual about using different light weapons - M203, ITAS M41, TOW and Javelins."
-      },
-      {
-        "id": "manual_launcher_5",
-        "name": { "str": "FM 23-11: 90mm Recoilless Rifle, M67", "str_pl": "copies of FM 23-11: 90mm Recoilless Rifle, M67" },
-        "description": "Official U.S. Army manual for using the M67 anti-tank rifle - theory, practice, and essential information.",
-        "//": "979-8538902606"
-      }
-    ],
     "weight": "650 g",
     "volume": "919 ml",
     "price": "20 USD",

--- a/data/json/items/book/lockpick.json
+++ b/data/json/items/book/lockpick.json
@@ -5,31 +5,6 @@
     "category": "manuals",
     "name": { "str": "MIT Guide to Lock Picking", "str_pl": "copies of MIT Guide to Lock Picking" },
     "description": "A home-made booklet with large black-and-white pictures of several types of modern locks and general information on how to crack them open.",
-    "variants": [
-      {
-        "id": "book_lockpick",
-        "name": { "str": "MIT Guide to Lock Picking", "str_pl": "copies of MIT Guide to Lock Picking" },
-        "description": "A home-made booklet with large black-and-white pictures of several types of modern locks and general information on how to crack them open."
-      },
-      {
-        "id": "book_lockpick_1",
-        "name": { "str": "The CIA Lockpicking Manual", "str_pl": "copies of The CIA Lockpicking Manual" },
-        "description": "It says it is a reproduction of the United States Central Intelligence Agency's Field Operative Training Manual that describes how to lockpick.  For such a big name it has a surprisingly small amount of information, only covering the topic on a very basic level.",
-        "//": "978-1420957556"
-      },
-      {
-        "id": "book_lockpick_2",
-        "name": { "str": "Keys To The Kingdom", "str_pl": "copies of Keys To The Kingdom" },
-        "description": "This book contain lots of information for experienced lockpickers, like possible tools that can be used, different types of locks that were produced, and even some tips to avoid lockpicking - sometimes it's easier to break a lock, door, or even wall itself.",
-        "//": "978-1597499835"
-      },
-      {
-        "id": "book_lockpick_3",
-        "name": { "str": "E-Z Picking Manual", "str_pl": "copies of E-Z Picking Manual" },
-        "description": "The combined experience of a few different locksmiths of how to do it properly, what skillset is required, and where it is legal to use it.  It says it comes with a DVD, but you can't find it anywhere nearby.",
-        "//": "no info"
-      }
-    ],
     "weight": "400 g",
     "volume": "500 ml",
     "price": "1 USD",

--- a/data/json/items/book/melee.json
+++ b/data/json/items/book/melee.json
@@ -5,37 +5,6 @@
     "category": "manuals",
     "name": { "str": "CQB Monthly", "str_pl": "issues of CQB Monthly" },
     "description": "An in-depth look at various styles of close quarters fighting.  There's an amusing essay about dirty tricks in the front section.",
-    "variants": [
-      {
-        "id": "mag_melee",
-        "name": { "str": "CQB Monthly", "str_pl": "issues of CQB Monthly" },
-        "description": "An in-depth look at various styles of close quarters fighting.  There's an amusing essay about dirty tricks in the front section."
-      },
-      {
-        "id": "mag_melee_1",
-        "name": { "str": "Savage Street Fighting", "str_pl": "copies of Savage Street Fighting" },
-        "description": "A barbaric guide detailing how to win a fight in the worst possible scenarios - mostly about how to retreat from such a fight, but it still has some information in case you have no another way.",
-        "//": "978-1941845073"
-      },
-      {
-        "id": "mag_melee_2",
-        "name": { "str": "Maximum Damage", "str_pl": "copies of Maximum Damage" },
-        "description": "This book teaches how to predict enemy attacks, with a nice explanation of how to react to each of them - both defense and counterattacks.",
-        "//": "978-1941845011"
-      },
-      {
-        "id": "mag_melee_3",
-        "name": { "str": "Out of the Cage", "str_pl": "copies of Out of the Cage" },
-        "description": "This book shows lot of techniques to defeat an experienced martial artist - brutal and dirty.",
-        "//": "978-0989038201"
-      },
-      {
-        "id": "mag_melee_4",
-        "name": { "str": "Combat Pressure Points", "str_pl": "copies of Combat Pressure Points" },
-        "description": "An illustrated handbook about the human body, how it works, and how to destroy it with fairly easy steps.",
-        "//": "978-1941845677"
-      }
-    ],
     "weight": "70 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -56,31 +25,6 @@
     "category": "manuals",
     "name": { "str": "Close Quarter Fighting Manual", "str_pl": "copies of Close Quarter Fighting Manual" },
     "description": "A well-thumbed hardbound book which illustrates simple strategies and techniques for close quarters combat encounters.",
-    "variants": [
-      {
-        "id": "manual_melee",
-        "name": { "str": "Close Quarter Fighting Manual", "str_pl": "copies of Close Quarter Fighting Manual" },
-        "description": "A well-thumbed hardbound book which illustrates simple strategies and techniques for close quarters combat encounters."
-      },
-      {
-        "id": "manual_melee_1",
-        "name": { "str": "Survival Weapons", "str_pl": "copies of Survival Weapons" },
-        "description": "\"Will You Be The Last One Standing?\", asks the author on the first page.  You don't know the answer, but this book contains plenty of info to reach this target.",
-        "//": "978-1941845417"
-      },
-      {
-        "id": "manual_melee_2",
-        "name": { "str": "Facing Violence", "str_pl": "copies of Facing Violence" },
-        "description": "Different techniques to end the fight fast, easy, and without going to prison.  Luckily no one can imprison you anymore!",
-        "//": "978-1594392139"
-      },
-      {
-        "id": "manual_melee_3",
-        "name": { "str": "Training for Sudden Violence", "str_pl": "copies of Training for Sudden Violence" },
-        "description": "This book contains professional instructions to prepare and prevail in dangerous situations, both physically and psychologically.",
-        "//": "978-1594392139"
-      }
-    ],
     "weight": "564 g",
     "volume": "250 ml",
     "price": "20 USD",

--- a/data/json/items/book/pistol.json
+++ b/data/json/items/book/pistol.json
@@ -5,45 +5,6 @@
     "category": "manuals",
     "name": { "str": "Tactical Handgun Digest", "str_pl": "issues of Tactical Handgun Digest" },
     "description": "A glossy magazine all about handguns and shooting.  There is a good article about proper sighting near the middle.",
-    "variants": [
-      {
-        "id": "mag_pistol",
-        "name": { "str": "Tactical Handgun Digest", "str_pl": "issues of Tactical Handgun Digest" },
-        "description": "A glossy magazine all about handguns and shooting.  There is a good article about proper sighting near the middle."
-      },
-      {
-        "id": "mag_pistol_1",
-        "name": { "str": "Shooting Handguns", "str_pl": "copies of Shooting Handguns" },
-        "description": "Simple beginner's guide to shooting handguns safely and effectively; simple and effective rules with some key information about handguns themselves.",
-        "//": "978-0764358371"
-      },
-      {
-        "id": "mag_pistol_2",
-        "name": {
-          "str": "The Practical Guide to Guns and Shooting, Handgun Edition",
-          "str_pl": "copies of The Practical Guide to Guns and Shooting, Handgun Edition"
-        },
-        "description": "A practical guide for one who want to buy a gun - how they differ, how to choose the right ammo, shooting techniques, and lot of another info.",
-        "//": "978-0996085342"
-      },
-      {
-        "id": "mag_pistol_3",
-        "name": { "str": "Defensive Handgun for the Armed Citizen", "str_pl": "copies of Defensive Handgun for the Armed Citizen" },
-        "description": "This book takes carrying handguns seriously, and delivers lots of information a user may need to know, including self defense concepts, using deadly force, analyzing confrontation, as well as handgun tactics and techniques.",
-        "//": "9781438948928"
-      },
-      {
-        "id": "mag_pistol_4",
-        "name": { "str": "The Gun Digest Book of the Revolver", "str_pl": "copies of The Gun Digest Book of the Revolver" },
-        "description": "This book covers all aspects of the double-action revolver: shooting, handling, carrying, maintaining, and accessorizing - everything you need to know to operate the quintessential American handgun.",
-        "//": "978-1440218125"
-      },
-      {
-        "id": "mag_pistol_5",
-        "name": { "str": "American Handgunner", "str_pl": "issues of American Handgunner" },
-        "description": "A shiny magazine about handguns and activities around them - handgun hunting, competition shooting, reloading, new brands and gear, ammo, and other similar things."
-      }
-    ],
     "weight": "90 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -64,68 +25,6 @@
     "category": "manuals",
     "name": { "str": "The Tao of the Handgun", "str_pl": "copies of The Tao of the Handgun" },
     "description": "This introspective volume covers proper usage of handguns, from safety and stance, to maintenance and proper sighting technique.",
-    "variants": [
-      {
-        "id": "manual_pistol",
-        "name": { "str": "The Tao of the Handgun", "str_pl": "copies of The Tao of the Handgun" },
-        "description": "This introspective volume covers proper usage of handguns, from safety and stance, to maintenance and proper sighting technique."
-      },
-      {
-        "id": "manual_pistol_1",
-        "name": {
-          "str": "Practical Guide to the Operational Use of the TT-33 Tokarev Pistol",
-          "str_pl": "copies of Practical Guide to the Operational Use of the TT-33 Tokarev Pistol"
-        },
-        "description": "The most current, up to date, full color manual anywhere on the TT-33 Tokarev pistol, from former Special Forces instructor.  Surprisingly easy to follow."
-      },
-      {
-        "id": "manual_pistol_2",
-        "name": {
-          "str": "Gun Safety: For Home Defense And Concealed Carry",
-          "str_pl": "copies of Gun Safety: For Home Defense And Concealed Carry"
-        },
-        "description": "A book for a responsible gun owner, it highlights using weapons in the civil world, with lot of rules and legal recommendations, alongside  how to avoid harm for the gun user and their environment.",
-        "//": "978-0989038232"
-      },
-      {
-        "id": "manual_pistol_3",
-        "name": {
-          "str": "Pistols & Revolvers: From 1400 to the Present Day",
-          "str_pl": "copies of Pistols & Revolvers: From 1400 to the Present Day"
-        },
-        "description": "The book contains a long, detailed history of handguns - from the very first hand cannons to the latest automatics and machine pistols, with photos, technical specifications, and some artwork.",
-        "//": "978-1782741503"
-      },
-      {
-        "id": "manual_pistol_4",
-        "name": { "str": "Pistol & Revolver Handbook", "str_pl": "copies of Pistol & Revolver Handbook" },
-        "description": "A complete guide to maintaining handguns - lots of information about components, reloading, bullet types, and ballistics.",
-        "//": "9780912412122"
-      },
-      {
-        "id": "manual_pistol_5",
-        "name": {
-          "str": "Gun Digest Book of Automatic Pistols Assembly/Disassembly",
-          "str_pl": "copies of Gun Digest Book of Automatic Pistols Assembly/Disassembly"
-        },
-        "description": "A giant, 1000-page manual of with step-by-step instructions for the disassembly of automatic pistols.  Over 100 models are covered, with clear photos and procedure tips.",
-        "//": "978-1951115500"
-      },
-      {
-        "id": "manual_pistol_6",
-        "name": { "str": "Book of Revolvers Assembly/Disassembly", "str_pl": "copies of Book of Revolvers Assembly/Disassembly" },
-        "description": "A 700-page instructional manual of different revolver disassembly processes, with photos, detailed steps, and additional info.",
-        "//": "978-1946267498"
-      },
-      {
-        "id": "manual_pistol_7",
-        "name": {
-          "str": "FM 3-23.35: Combat Training With Pistols, M9 And M11",
-          "str_pl": "copies of FM 3-23.35: Combat Training With Pistols, M9 And M11"
-        },
-        "description": "Official U.S. Army manual detailing how M9 and M11 handguns work, and how to use them safely and effectively."
-      }
-    ],
     "weight": "440 g",
     "volume": "500 ml",
     "price": "22 USD",

--- a/data/json/items/book/rifle.json
+++ b/data/json/items/book/rifle.json
@@ -5,28 +5,6 @@
     "category": "manuals",
     "name": { "str": "Modern Rifleman", "str_pl": "issues of Modern Rifleman" },
     "description": "An informative magazine all about rifles and shooting.  There is an excellent article about proper maintenance in this issue.",
-    "variants": [
-      {
-        "id": "mag_rifle",
-        "name": { "str": "Modern Rifleman", "str_pl": "issues of Modern Rifleman" },
-        "description": "An informative magazine all about rifles and shooting.  There is an excellent article about proper maintenance in this issue."
-      },
-      {
-        "id": "mag_rifle_1",
-        "name": { "str": "American Rifleman", "str_pl": "issues of American Rifleman" },
-        "description": "A monthly shooting and firearms publication, with a lot of articles and comments."
-      },
-      {
-        "id": "mag_rifle_2",
-        "name": { "str": "Shooting Stars", "str_pl": "issues of Shooting Stars" },
-        "description": "An annual magazine for marksmen, with lots of articles and papers, as well as reviews of new rifles, optics, and mods."
-      },
-      {
-        "id": "mag_rifle_3",
-        "name": { "str": "The Precisionist", "str_pl": "issues of The Precisionist" },
-        "description": "A dedicated journal about various firearms, their usage, and news about them.  Different articles review new firearm models, old models, new attachments, hunting, maintenance, and a lot of other topics."
-      }
-    ],
     "weight": "100 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -47,101 +25,6 @@
     "category": "manuals",
     "name": { "str": "FM 23-16 Army marksmanship manual" },
     "description": "A hefty military field manual about automatic rifle usage and techniques which improve marksmanship and proper weapons-handling.",
-    "variants": [
-      {
-        "id": "manual_rifle",
-        "name": { "str": "FM 23-16 Army marksmanship manual", "str_pl": "copies of FM 23-16 Army marksmanship manual" },
-        "description": "A hefty military field manual about automatic rifle usage and techniques which improve marksmanship and proper weapons-handling."
-      },
-      {
-        "id": "manual_rifle_1",
-        "name": { "str": "SAS and Elite Forces Guide Sniper", "str_pl": "copies of SAS and Elite Forces Guide Sniper" },
-        "description": "An unofficial guide about the work and skills of British and NATO snipers.  There are a lot of photos of weapons and equipment, but it has a huge lack of details - the most important information is just mentioned or described without any value.",
-        "//": "978-1493036752"
-      },
-      {
-        "id": "manual_rifle_2",
-        "name": {
-          "str": "Precision Rifle Marksmanship: The Fundamentals",
-          "str_pl": "copies of Precision Rifle Marksmanship: The Fundamentals"
-        },
-        "description": "A small book about the use of a rifle as a marksman's tool.  There is plenty of information, but it is too general, and the author talks more about his experience as a sniper than sniping itself.",
-        "//": "978-1951115104"
-      },
-      {
-        "id": "manual_rifle_3",
-        "name": { "str": "Precision Long Range Shooting And Hunting", "str_pl": "copies of Precision Long Range Shooting And Hunting" },
-        "description": "A book about the basics of long-range shooting, written in fairly simple language.",
-        "//": "978-1979598699"
-      },
-      {
-        "id": "manual_rifle_4",
-        "name": { "str": "The Marine Sniping Handbook", "str_pl": "copies of The Marine Sniping Handbook" },
-        "description": "The Official (or at least so it says) marksmanship guide for scout snipers.  With lots of essential info, it gives a pretty good foundation to anyone who knows how to use a rifle.",
-        "//": "978-1792182938"
-      },
-      {
-        "id": "manual_rifle_5",
-        "name": { "str": "How to Shoot", "str_pl": "copies of How to Shoot" },
-        "description": "A reprint of a 1917 book about rifle shooting and maintenance.  It is surprisingly detailed, and contains lots of information, even if the language is fairly old-fashioned.",
-        "//": "978-0267853731"
-      },
-      {
-        "id": "manual_rifle_6",
-        "name": { "str": "Rifle Shooting for Beginners", "str_pl": "copies of Rifle Shooting for Beginners" },
-        "description": "A guide to shooting sports that explains the basics of equipment usage, judging distance, aiming, breathing, movement, and trigger discipline alongside a lot of other essential info.",
-        "//": "979-8355590895"
-      },
-      {
-        "id": "manual_rifle_7",
-        "name": {
-          "str": "Great Hunting Rifles: Victorian to the Present",
-          "str_pl": "copies of Great Hunting Rifles: Victorian to the Present"
-        },
-        "description": "A history of some of the most exquisite rifles made in the twentieth century, written with a lot of love and attention to detail.",
-        "//": "978-1510731691"
-      },
-      {
-        "id": "manual_rifle_8",
-        "name": {
-          "str": "FM 3-22.9: Rifle Marksmanship M16-/M4- Series",
-          "str_pl": "copies of FM 3-22.9: Rifle Marksmanship M16-/M4- Series"
-        },
-        "description": "An official U.S. Army manual that provides guidance for the planning and execution of training with the 5.56mm M16-series rifle and M4 carbine."
-      },
-      {
-        "id": "manual_rifle_9",
-        "name": {
-          "str": "FM 3-22.68: Crew-Served Machine Guns 5.56-mm And 7.62-mm",
-          "str_pl": "copies of FM 3-22.68: Crew-Served Machine Guns 5.56-mm And 7.62-mm"
-        },
-        "description": "An official U.S. Army manual which is a comprehensive guide about using the M240 and M249 crew-served machine guns, with excellent examples and a lot of theory."
-      },
-      {
-        "id": "manual_gun_10",
-        "name": { "str": "Adaptive Rifle", "str_pl": "copies of Adaptive Rifle" },
-        "description": "A book containing different training methods for carbine users from world champion shooters, aimed toward civilians, law enforcement, and military shooters.",
-        "//": "979-8360280453"
-      },
-      {
-        "id": "manual_gun_11",
-        "name": { "str": "The Art of the Rifle", "str_pl": "copies of The Art of the Rifle" },
-        "description": "This book covers the fundamentals of rifle shooting, including stance, grip, sight alignment, and trigger control.",
-        "//": "978-1581605921"
-      },
-      {
-        "id": "manual_gun_12",
-        "name": { "str": "Shooter's Bible Guide to Rifle Ballistics", "str_pl": "copies of Shooter's Bible Guide to Rifle Ballistics" },
-        "description": "A comprehensive guide to the principles of rifle ballistics, including information on bullet types, trajectory, and wind drift.",
-        "//": "978-1510760042"
-      },
-      {
-        "id": "manual_gun_13",
-        "name": { "str": "The Gun", "str_pl": "copies of The Gun" },
-        "description": "A giant, 500-page history about the AK-47—the most popular firearm in the world—and the information around it: the mechanics of the weapon, its usage, maintenance, modifications, and its impact on global conflicts.",
-        "//": "978-0743270762"
-      }
-    ],
     "weight": "454 g",
     "volume": "250 ml",
     "price": "20 USD",

--- a/data/json/items/book/shotgun.json
+++ b/data/json/items/book/shotgun.json
@@ -5,51 +5,6 @@
     "category": "manuals",
     "name": { "str": "Trap and Field", "str_pl": "issues of Trap and Field" },
     "description": "An in-depth magazine all about shotguns and shooting.  There is an informative article about proper shooting stance in the back pages.",
-    "variants": [
-      {
-        "id": "mag_shotgun",
-        "name": { "str": "Trap and Field", "str_pl": "issues of Trap and Field" },
-        "description": "An in-depth magazine all about shotguns and shooting.  There is an informative article about proper shooting stance in the back pages."
-      },
-      {
-        "id": "mag_shotgun_1",
-        "name": { "str": "Gun Digest Shooter's Guide to Shotguns", "str_pl": "copies of Gun Digest Shooter's Guide to Shotguns" },
-        "description": "A training guide for anyone who never used a shotgun, with simple explanations and drills.",
-        "//": "978-1440240683"
-      },
-      {
-        "id": "mag_shotgun_2",
-        "name": { "str": "Man Magnum", "str_pl": "issues of Man Magnum" },
-        "description": "A modern magazine, published in South Africa, it contains various information about hunting and shooting.  This particular issue has a lot of information about shotguns and drills with them."
-      },
-      {
-        "id": "mag_shotgun_3",
-        "name": { "str": "Texas Parks and Wildlife", "str_pl": "issues of Texas Parks and Wildlife" },
-        "description": "Published by Texas Parks and Wildlife Department, this book contains lots of information and photos about nature and recreation in Texas's fields.  This exact issue is about hunting and gun safety."
-      },
-      {
-        "id": "mag_shotgun_4",
-        "name": { "str": "The Wingshooter's Diary", "str_pl": "issues of The Wingshooter's Diary" },
-        "description": "An annual magazine about bird hunting, including species identification, hunting techniques, and equipment recommendations."
-      },
-      {
-        "id": "mag_shotgun_5",
-        "name": { "str": "The Skeet Shooter's Logbook", "str_pl": "copies of The Skeet Shooter's Logbook" },
-        "description": "A small guide to skeet shooting, including rules, equipment, tips, and techniques for improving accuracy and performance."
-      },
-      {
-        "id": "mag_shotgun_6",
-        "name": { "str": "If It Ain't Broke, Fix It!", "str_pl": "copies of If It Ain't Broke, Fix It!" },
-        "description": "The beginner's guide to clay shooting, with lots of advice, instructions, and drills.",
-        "//": "978-0976020400"
-      },
-      {
-        "id": "mag_shotgun_7",
-        "name": { "str": "Sporting Clays Consistency", "str_pl": "copies of Sporting Clays Consistency" },
-        "description": "A bird and clay shooting manual, this book contains lots of information about proper shotgun shooting like stances, aim, and ballistics.",
-        "//": "978-0976020417"
-      }
-    ],
     "weight": "90 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -70,61 +25,6 @@
     "category": "manuals",
     "name": { "str": "Shotguns: The Art and Science", "str_pl": "copies of Shotguns: The Art and Science" },
     "description": "This book claims to address every problem the shotgunner is likely to face, and offers solutions to ensure that shooters can make every shot count.",
-    "variants": [
-      {
-        "id": "manual_shotgun",
-        "name": { "str": "Shotguns: The Art and Science", "str_pl": "copies of Shotguns: The Art and Science" },
-        "description": "This book claims to address every problem the shotgunner is likely to face, and offers solutions to ensure that shooters can make every shot count."
-      },
-      {
-        "id": "manual_shotgun_1",
-        "name": { "str": "Fine Shotguns", "str_pl": "copies of Fine Shotguns" },
-        "description": "This book shows the history, science and art of the most beautiful shotguns in the world - single and double barrel, combination, hammer shotguns, paired shotguns, special-use guns, and small-bore shotguns from around the world, with detailed information about each of them, and their usage.",
-        "//": "978-1616080891"
-      },
-      {
-        "id": "manual_shotgun_2",
-        "name": { "str": "Shotguns: A Comprehensive Guide", "str_pl": "copies of Shotguns: A Comprehensive Guide" },
-        "description": "Detailed manual about buying, owning, and shooting a shotgun, with additional information like cleaning, safety, and training.",
-        "//": "978-1939473219"
-      },
-      {
-        "id": "manual_shotgun_3",
-        "name": { "str": "Winchester Shotguns", "str_pl": "copies of Winchester Shotguns" },
-        "description": "An illustrated chronicle of every model designed and produced under the Winchester name, with a wealth of facts, figures, and historically relevant information.",
-        "//": "9781510709249"
-      },
-      {
-        "id": "manual_shotgun_4",
-        "name": { "str": "Ordnance Maintenance Shotguns, All Types", "str_pl": "copies of Ordnance Maintenance Shotguns, All Types" },
-        "description": "Part of a 1942 army manual, this book contains lots of information about the proper usage and maintenance of all shotguns that were adopted by the U.S. military, including the Winchester M97 and M12, Stevens M620, M620A and M520, the Ithaca M37, the Remington M31, M11, and Browning Automatic 5.",
-        "//": "978-1940453712"
-      },
-      {
-        "id": "manual_shotgun_5",
-        "name": { "str": "Streetsweepers", "str_pl": "copies of Streetsweepers" },
-        "description": "A comprehensive book about combat shotguns, covering single- and double-barreled, slide-action, semi-auto and rotary-cylinder shotguns, their usage, service, and tactics.",
-        "//": "978-1581604368"
-      },
-      {
-        "id": "manual_shotgun_6",
-        "name": { "str": "Shotguns and Shooting", "str_pl": "copies of Shotguns and Shooting" },
-        "description": "This book has lot of fundamental information about shotguns, their workmanship, engineering, and art, along with lot of practical trainings for them.",
-        "//": "978-0924357480"
-      },
-      {
-        "id": "manual_shotgun_7",
-        "name": { "str": "Shotguns - Their History and Development", "str_pl": "copies of Shotguns - Their History and Development" },
-        "description": "An old magazine about shotguns: their history, models, cartridges, ballistics, accessories, and shooting, along with an appendix on shotgun data and tables.",
-        "//": "978-1905124862"
-      },
-      {
-        "id": "manual_shotgun_8",
-        "name": { "str": "Vintage British Shotguns", "str_pl": "copies of Vintage British Shotguns" },
-        "description": "A good guide for both sportsmen and gun collectors, this book contains information about classic shotguns and their usage.",
-        "//": "978-0892727742"
-      }
-    ],
     "weight": "400 g",
     "volume": "500 ml",
     "price": "21 USD",

--- a/data/json/items/book/smg.json
+++ b/data/json/items/book/smg.json
@@ -5,24 +5,6 @@
     "category": "manuals",
     "name": { "str": "Submachine Gun Enthusiast", "str_pl": "issues of Submachine Gun Enthusiast" },
     "description": "An in-depth magazine about submachine guns and shooting.  There is an exhaustive article about close quarter combat techniques in the front.",
-    "variants": [
-      {
-        "id": "mag_smg",
-        "name": { "str": "Submachine Gun Enthusiast", "str_pl": "issues of Submachine Gun Enthusiast" },
-        "description": "An in-depth magazine about submachine guns and shooting.  There is an exhaustive article about close quarter combat techniques in the front."
-      },
-      {
-        "id": "mag_smg_1",
-        "name": { "str": "The MP5 Submachine Gun", "str_pl": "copies of The MP5 Submachine Gun" },
-        "description": "A small, shiny journal about the most famous machine gun in the world, H&K MP5, and how it is used currently.",
-        "//": "978-1782009177"
-      },
-      {
-        "id": "mag_smg_2",
-        "name": { "str": "Guns & Weapons for Law Enforcement", "str_pl": "issues of Guns & Weapons for Law Enforcement" },
-        "description": "A relatively old magazine about modern automatic firearms police may use.  This issue talks about submachine guns and the brand new KRISS Super V .45 ACP specifically."
-      }
-    ],
     "weight": "90 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -43,64 +25,6 @@
     "category": "manuals",
     "name": { "str": "The Submachine Gun Handbook", "str_pl": "copies of The Submachine Gun Handbook" },
     "description": "This concise guide details the proper care and operation of most forms of machine pistols and submachine guns currently used by regular armed and reserve forces, as well as several obsolete weapons.",
-    "variants": [
-      {
-        "id": "manual_smg",
-        "name": { "str": "The Submachine Gun Handbook", "str_pl": "copies of The Submachine Gun Handbook" },
-        "description": "This concise guide details the proper care and operation of most forms of machine pistols and submachine guns currently used by regular armed and reserve forces, as well as several obsolete weapons."
-      },
-      {
-        "id": "manual_smg_1",
-        "name": { "str": "The Mac Man", "str_pl": "copies of The Mac Man" },
-        "description": "The full story of Gordon Ingram and his revolutionary machine gun designs: the Model 6, MAC-10, MAC-11, and SWD.",
-        "//": "978-0982391815"
-      },
-      {
-        "id": "manual_smg_2",
-        "name": {
-          "str": "The Development of Sub-Machine Guns and their Ammunition from World War 1 to the Present Day",
-          "str_pl": "copies of The Development of Sub-Machine Guns and their Ammunition from World War 1 to the Present Day"
-        },
-        "description": "A comprehensive study of the development and use of the sub-machine gun since World War I, including a country-by-country survey of equipment used, with lots of illustrations and precise information.",
-        "//": "978-1847972934"
-      },
-      {
-        "id": "manual_smg_3",
-        "name": { "str": "American Submachine Guns 1919–1950", "str_pl": "copies of American Submachine Guns 1919–1950" },
-        "description": "A fully illustrated book about famous submachine guns, their design, construction, and testing, as well as their accessories such as magazines, ammunition, webbing, and cleaning kits.",
-        "//": "978-0764354847"
-      },
-      {
-        "id": "manual_smg_4",
-        "name": { "str": "Firearm Anatomy", "str_pl": "copies of Firearm Anatomy" },
-        "description": "Part of a big series about weapons and their complexity, this issue describes the long history of the M1A1 Thompson Submachine gun - when it was created, why, and why it is iconic now.",
-        "//": "978-1493673346"
-      },
-      {
-        "id": "manual_smg_5",
-        "name": {
-          "str": "An Amateur's Guide for the Colt's Thompson Submachine Gun",
-          "str_pl": "copies of An Amateur's Guide for the Colt's Thompson Submachine Gun"
-        },
-        "description": "A 200-page collector's manual advising how to buy a real, old Tommy Gun, with detailed info on each model, info about maintenance and shooting, and stories about its usage in the St. Louis Police Department.",
-        "//": "979-8730435377"
-      },
-      {
-        "id": "manual_smg_6",
-        "name": { "str": "Submachine Guns Caliber .45", "str_pl": "copies of Submachine Guns Caliber .45" },
-        "description": "Part of an old army field manual, this book explains the usage and maintenance of the M3 and M3A1, and how it was adopted into U.S. Army service in 1942.",
-        "//": "978-1940453118"
-      },
-      {
-        "id": "manual_smg_7",
-        "name": {
-          "str": "Maintenance on the MP40, PPSH41, M3A1, and Sten MKII Submachine Guns",
-          "str_pl": "copies of Maintenance on the MP40, PPSH41, M3A1, and Sten MKII Submachine Guns"
-        },
-        "description": "A short manual about the disassembly, reassembly, maintenance, operation, and repair of some old machine guns.  Seems it has lack of some info, but better than nothing.",
-        "//": "978-1733005333"
-      }
-    ],
     "weight": "362 g",
     "volume": "500 ml",
     "price": "21 USD",

--- a/data/json/items/book/stabbing.json
+++ b/data/json/items/book/stabbing.json
@@ -5,49 +5,6 @@
     "category": "manuals",
     "name": { "str": "Duelist's Annual" },
     "description": "An annual publication about fencing and dueling.  There are many good illustrations which describe proper technique and form.",
-    "variants": [
-      {
-        "id": "mag_stabbing",
-        "name": { "str": "Duelist's Annual", "str_pl": "issues of Duelist's Annual" },
-        "description": "An annual publication about fencing and dueling.  There are many good illustrations which describe proper technique and form."
-      },
-      {
-        "id": "mag_stabbing_1",
-        "name": { "str": "Fencer's Start-Up", "str_pl": "copies of Fencer's Start-Up" },
-        "description": "A beginner's guide to traditional and sport fencing - rules, proper defense and offense, movement, etc.",
-        "//": "978-1884654770"
-      },
-      {
-        "id": "mag_stabbing_2",
-        "name": { "str": "Learning Fencing", "str_pl": "copies of Learning Fencing" },
-        "description": "A childish book about fencing, where the mascot Foily guides the reader through the different nuances of fencing with lots of photos and images.",
-        "//": "978-1782551133"
-      },
-      {
-        "id": "mag_stabbing_3",
-        "name": { "str": "The Complete Guide to Fencing", "str_pl": "copies of The Complete Guide to Fencing" },
-        "description": "A thick book, written by professional fencers, that covers every possible aspect of modern sport fencing.",
-        "//": "978-1782551119"
-      },
-      {
-        "id": "mag_stabbing_4",
-        "name": { "str": "Fencing: Skills, Tactics, Training", "str_pl": "copies of Fencing: Skills, Tactics, Training" },
-        "description": "A textbook for fence instructors that fulfills every aspect a fencer must know, from the very basics to a master level, from theory to drill training exercises.",
-        "//": "978-1847973054"
-      },
-      {
-        "id": "mag_stabbing_5",
-        "name": { "str": "Modern Saber Fencing", "str_pl": "copies of Modern Saber Fencing" },
-        "description": "This book highlights the modern technologies used in fencing, with new possible techniques and scientific research that underlies the latest training methods.",
-        "//": "978-0978902230"
-      },
-      {
-        "id": "mag_stabbing_6",
-        "name": { "str": "Fencing: A Renaissance Treatise", "str_pl": "copies of Fencing: A Renaissance Treatise" },
-        "description": "An ancient treatise explaining the fundamental ideas of fencing that are still used today - distance, time, line, blade opposition, counterattacks, countertime, etc.",
-        "//": "978-1599101293"
-      }
-    ],
     "weight": "80 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -68,52 +25,6 @@
     "category": "manuals",
     "name": { "str": "FM 23-25 Army bayonet manual" },
     "description": "A hefty military field manual about bayonet usage and combat theory.",
-    "variants": [
-      {
-        "id": "manual_stabbing",
-        "name": { "str": "FM 23-25 Army bayonet manual", "str_pl": "copies of FM 23-25 Army bayonet manual" },
-        "description": "A hefty military field manual about bayonet usage and combat theory."
-      },
-      {
-        "id": "manual_stabbing_1",
-        "name": {
-          "str": "The Halberd and Other European Pole Arms, 1300-1650",
-          "str_pl": "copies of The Halberd and Other European Pole Arms, 1300-1650"
-        },
-        "description": "Small, but comprehensive introduction to the pole arms of medieval Europe: from the simple pike, through the halberd in its many forms, to the roncone, bardiche, and many others.",
-        "//": "9780919316386"
-      },
-      {
-        "id": "manual_stabbing_2",
-        "name": {
-          "str": "Boarders Away: With Steel-Edged Weapons and Polearms",
-          "str_pl": "copies of Boarders Away: With Steel-Edged Weapons and Polearms"
-        },
-        "description": "An all-encompassing study of naval armament under fighting sail.  This volume covers pikes and fighting blades in use between 1626 and 1826.",
-        "//": "978-0917218507"
-      },
-      {
-        "id": "manual_stabbing_3",
-        "name": { "str": "Polearms of Paulus Hector Mair", "str_pl": "copies of Polearms of Paulus Hector Mair" },
-        "description": "The summarized and preserved experience of Paulus Hector Mair, an ancient German fencing master, using spears, lances, halberds, poleaxes, and similar weapons.",
-        "//": "978-1648371059"
-      },
-      {
-        "id": "manual_stabbing_4",
-        "name": {
-          "str": "Hafted Weapons in Medieval and Renaissance Europe",
-          "str_pl": "copies of Hafted Weapons in Medieval and Renaissance Europe"
-        },
-        "description": "Research about the long history of a huge variety of weapons in medieval times, with lots of illustrations.",
-        "//": "978-9004144095"
-      },
-      {
-        "id": "manual_stabbing_5",
-        "name": { "str": "Japanese Spears", "str_pl": "copies of Japanese Spears" },
-        "description": "A fully illustrated guide to the use of polearms, ranging from the earliest halberds and spears reaching Japan from the Asian mainland to the sophisticated naginata, nagamaki, and various forms of yari used by the Japanese samurai through the medieval period.",
-        "//": "978-1901903560"
-      }
-    ],
     "weight": "454 g",
     "volume": "500 ml",
     "price": "20 USD",
@@ -133,60 +44,6 @@
     "category": "manuals",
     "name": { "str": "Spetsnaz Knife Techniques", "str_pl": "copies of Spetsnaz Knife Techniques" },
     "description": "A classic Soviet text on the art of attacking with a blade.",
-    "variants": [
-      {
-        "id": "manual_knives",
-        "name": { "str": "Spetsnaz Knife Techniques", "str_pl": "copies of Spetsnaz Knife Techniques" },
-        "description": "A classic Soviet text on the art of attacking with a blade."
-      },
-      {
-        "id": "manual_knives_1",
-        "name": { "str": "Knife Fighting Targets", "str_pl": "copies of Knife Fighting Targets" },
-        "description": "Simple, practical and useful martial art techniques to use in a fight.  On the first page the author says they will not be held responsible for any harm caused by using advice from this book.",
-        "//": "978-1941845646"
-      },
-      {
-        "id": "manual_knives_2",
-        "name": { "str": "Book of Knives", "str_pl": "copies of Book of Knives" },
-        "description": "Authored by a state trooper and policeman from Michigan, it contains a lot of experience on real fights with a knife and against a knife.",
-        "//": "978-1451637557"
-      },
-      {
-        "id": "manual_knives_3",
-        "name": { "str": "The Ka-Bar Knife Combat Manual", "str_pl": "copies of The Ka-Bar Knife Combat Manual" },
-        "description": "This manual teaches the reader to use the Ka-Bar, an iconic knife of the U.S. Army that carries the energy and spirit of soldiers.",
-        "//": "978-1678011840"
-      },
-      {
-        "id": "manual_knives_4",
-        "name": { "str": "Put 'Em Down, Take 'Em Out!", "str_pl": "copies of Put 'Em Down, Take 'Em Out!" },
-        "description": "\"Knife Fighting Techniques From Folsom Prison\".  This book describe fighting with a shiv in the tight walls of a jail.",
-        "//": "978-0873644846"
-      },
-      {
-        "id": "manual_knives_5",
-        "name": { "str": "Queen of Knives", "str_pl": "copies of Queen of Knives" },
-        "description": "A small, femme-oriented manual about self-defense with knife."
-      },
-      {
-        "id": "manual_knives_6",
-        "name": { "str": "Secrets of the Karambit", "str_pl": "copies of Secrets of the Karambit" },
-        "description": "This book aspires to describe and explain the history, design, materials, and demonstrate deployment and drills with the unusual Indonesian weapon known as the karambit knife.  The final impression is disappointing.",
-        "//": "978-1530527953"
-      },
-      {
-        "id": "manual_knives_7",
-        "name": { "str": "Combat Knives and Knife Combat", "str_pl": "copies of Combat Knives and Knife Combat" },
-        "description": "A comprehensive compendium about different types of knives and their usage in various martial arts.",
-        "//": "978-0764348341"
-      },
-      {
-        "id": "manual_knives_8",
-        "name": { "str": "The Silent Bodyguard", "str_pl": "copies of The Silent Bodyguard" },
-        "description": "\"The Art of Knife Fencing & the Chronicles of the Modern Fighting Knife and their Wielders\".  This book teaches the reader how to defend against an aggressor with various weapons.",
-        "//": "979-8667992141"
-      }
-    ],
     "weight": "454 g",
     "volume": "500 ml",
     "price": "52 USD",

--- a/data/json/items/book/swimming.json
+++ b/data/json/items/book/swimming.json
@@ -5,38 +5,6 @@
     "category": "manuals",
     "name": { "str": "Swim Planet", "str_pl": "issues of Swim Planet" },
     "description": "The world's leading resource about aquatic sports.",
-    "variants": [
-      {
-        "id": "mag_swimming",
-        "name": { "str": "Swim Planet", "str_pl": "issues of Swim Planet" },
-        "description": "The world's leading resource about aquatic sports."
-      },
-      {
-        "id": "mag_swimming_1",
-        "name": { "str": "Men's Fitness", "str_pl": "issues of Men's Fitness" },
-        "description": "A shiny magazine about fitness, nutrition, and sports, mostly oriented towards men."
-      },
-      {
-        "id": "mag_swimming_2",
-        "name": { "str": "Iron Man", "str_pl": "issues of Iron Man" },
-        "description": "A quarterly issue about natural bodybuilding, weightlifting, and powerlifting."
-      },
-      {
-        "id": "mag_swimming_3",
-        "name": { "str": "Muscle & Fitness", "str_pl": "issues of Muscle & Fitness" },
-        "description": "A magazine about mainstream fitness and simple bodybuilding, containing articles about different training techniques, nutrition tips, and doctor recommendations."
-      },
-      {
-        "id": "mag_swimming_4",
-        "name": { "str": "Muscular Development", "str_pl": "issues of Muscular Development" },
-        "description": "A monthly issue which covers mostly fitness and bodybuilding themes.  Lots of muscular men aggressively poke at you from the cover."
-      },
-      {
-        "id": "mag_swimming_5",
-        "name": { "str": "Bicycling", "str_pl": "issues of Bicycling" },
-        "description": "A small magazine about the bicycle scene, tips about the buying and maintenance of bikes, and different types of training you can do with them."
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 60 cent",
@@ -57,73 +25,6 @@
     "category": "manuals",
     "name": { "str": "Water Survival Training Field Manual", "str_pl": "copies of Water Survival Training Field Manual" },
     "description": "A commercially produced survival guide that details swimming and deep water survival techniques tailored to emergency scenarios.",
-    "variants": [
-      {
-        "id": "manual_swimming",
-        "name": { "str": "Water Survival Training Field Manual", "str_pl": "copies of Water Survival Training Field Manual" },
-        "description": "A commercially produced survival guide that details swimming and deep water survival techniques tailored to emergency scenarios."
-      },
-      {
-        "id": "manual_swimming_1",
-        "name": { "str": "Built from Broken", "str_pl": "copies of Built from Broken" },
-        "description": "\"A Science-Based Guide to Healing Painful Joints, Preventing Injuries, and Rebuilding Your Body\".  This book details a way to build your body without painful and exhausting training, with a proper training program and step-by-step instructions.",
-        "//": "978-1735728506"
-      },
-      {
-        "id": "manual_swimming_2",
-        "name": { "str": "Science of Running", "str_pl": "copies of Science of Running" },
-        "description": "This book contains comprehensive information about how anatomy and physiology function in running, training plans, and many new exercises for new runners.",
-        "//": "978-0241394519"
-      },
-      {
-        "id": "manual_swimming_3",
-        "name": { "str": "Overcoming Gravity", "str_pl": "copies of Overcoming Gravity" },
-        "description": "\"A Systematic Approach to Gymnastics and Bodyweight Strength\", this thick book is a gold mine of information about strength-oriented bodyweight workout, including scientific principles, different routines, methods, detail about progression, and a huge variety of exercises and their modifications.",
-        "//": "978-0990873853"
-      },
-      {
-        "id": "manual_swimming_4",
-        "name": { "str": "Calisthenics for Beginners", "str_pl": "copies of Calisthenics for Beginners" },
-        "description": "A step-by-step guide about fitness and working out using only your body, with a huge variety of difficulties in exercises.",
-        "//": "978-1646111688"
-      },
-      {
-        "id": "manual_swimming_5",
-        "name": { "str": "The Squat Bible", "str_pl": "copies of The Squat Bible" },
-        "description": "200 pages of different squat trainings, with comprehensive info on what each of them is designed to train.",
-        "//": "978-1540395429"
-      },
-      {
-        "id": "manual_swimming_6",
-        "name": { "str": "Functional Training and Beyond", "str_pl": "copies of Functional Training and Beyond" },
-        "description": "The best book for someone who wants to build a better body - from the start to an advanced level.",
-        "//": "978-1642505030"
-      },
-      {
-        "id": "manual_swimming_7",
-        "name": { "str": "New Functional Training for Sports", "str_pl": "copies of New Functional Training for Sports" },
-        "description": "Concepts, methods, exercises and programs for athletes of different sports, with demonstrations, commentary, and analysis of key exercises.",
-        "//": "978-1492530619"
-      },
-      {
-        "id": "manual_swimming_8",
-        "name": { "str": "The World's Fittest Book", "str_pl": "copies of The World's Fittest Book" },
-        "description": "\"How to Train for Anything and Everything, Anywhere and Everywhere\", this book contains different types of trainings for everyone.",
-        "//": "978-0751572544"
-      },
-      {
-        "id": "manual_swimming_9",
-        "name": { "str": "Blueprint", "str_pl": "copies of Blueprint" },
-        "description": "The cutting-edge training program to make you stronger than ever, from zero to superhuman, in a year.",
-        "//": "978-0008487034"
-      },
-      {
-        "id": "manual_swimming_10",
-        "name": { "str": "Hard Work Pays Off", "str_pl": "copies of Hard Work Pays Off" },
-        "description": "A training manual for someone ready to spend lot of time and energy on training, with detailed instructions and comments.",
-        "//": "978-0593233757"
-      }
-    ],
     "weight": "400 g",
     "volume": "500 ml",
     "price": "22 USD",

--- a/data/json/items/book/throw.json
+++ b/data/json/items/book/throw.json
@@ -5,28 +5,6 @@
     "category": "manuals",
     "name": { "str": "Diskobolus", "str_pl": "issues of Diskobolus" },
     "description": "A biannual magazine devoted to the art and science of discus-throwing.",
-    "variants": [
-      {
-        "id": "mag_throwing",
-        "name": { "str": "Diskobolus", "str_pl": "issues of Diskobolus" },
-        "description": "A biannual magazine devoted to the art and science of discus-throwing."
-      },
-      {
-        "id": "mag_throwing_1",
-        "name": { "str": "The Perfect Throw", "str_pl": "copies of The Perfect Throw" },
-        "description": "This book has pretty good information about ways to throw a hatchet, from a World Axe Throwing Championship champion.  You are surprised there was a championship for axe throwing.",
-        "//": "978-0578840550"
-      },
-      {
-        "id": "mag_throwing_2",
-        "name": {
-          "str": "Sergeant Shenk's Comprehensive Book on Knife Throwing",
-          "str_pl": "copies of Sergeant Shenk's Comprehensive Book on Knife Throwing"
-        },
-        "description": "Illustrated booklet, that covers the basics of knife throwing.",
-        "//": "978-1478118169"
-      }
-    ],
     "weight": "60 g",
     "volume": "250 ml",
     "price": "4 USD 80 cent",
@@ -47,46 +25,6 @@
     "category": "manuals",
     "name": { "str": "The Complete Guide to Pitching", "str_pl": "copies of The Complete Guide to Pitching" },
     "description": "A detailed guide for baseball pitchers that combines time-tested techniques and information mixed with a common sense approach to pitching.",
-    "variants": [
-      {
-        "id": "manual_throw",
-        "name": { "str": "The Complete Guide to Pitching", "str_pl": "copies of The Complete Guide to Pitching" },
-        "description": "A detailed guide for baseball pitchers that combines time-tested techniques and information mixed with a common sense approach to pitching."
-      },
-      {
-        "id": "manual_throw_1",
-        "name": { "str": "The Ultimate Guide to Knife Throwing", "str_pl": "copies of The Ultimate Guide to Knife Throwing" },
-        "description": "A precise handbook for someone who wants to win a throwing tournament.",
-        "//": "978-1632205308"
-      },
-      {
-        "id": "manual_throw_2",
-        "name": { "str": "Guide to Knife & Ax Throwing", "str_pl": "copies of Guide to Knife & Ax Throwing" },
-        "description": "A small, simple guide on how to throw a projectile, with different techniques, guides, and tricks.",
-        "//": "978-0764347795"
-      },
-      {
-        "id": "manual_throw_3",
-        "name": {
-          "str": "Knife & Tomahawk Throwing: The Art of the Experts",
-          "str_pl": "copies of Knife & Tomahawk Throwing: The Art of the Experts"
-        },
-        "description": "A small book on the long history of projectile throwing and the people building the sport.  It serves as a guide for someone who wants to get into it, with useful drills and diagrams.",
-        "//": "978-0804815420"
-      },
-      {
-        "id": "manual_throw_4",
-        "name": { "str": "The Science of Baseball", "str_pl": "copies of The Science of Baseball" },
-        "description": "The author and several experts cover topics like what makes a ball break, bounce, and fly; how material science and physics work together to make the bat function; how hitters use physics, geometry, and force to connect; baseball injuries; and much more.",
-        "//": "978-1510768970"
-      },
-      {
-        "id": "manual_throw_5",
-        "name": { "str": "The Complete Knife Throwing Guide", "str_pl": "copies of The Complete Knife Throwing Guide" },
-        "description": "A tiny, though still comprehensive manual of knife throwing from experienced knifemaker.",
-        "//": "978-1886950023"
-      }
-    ],
     "weight": "400 g",
     "volume": "500 ml",
     "price": "28 USD",

--- a/data/json/items/book/unarmed.json
+++ b/data/json/items/book/unarmed.json
@@ -3,47 +3,8 @@
     "id": "mag_unarmed",
     "type": "BOOK",
     "category": "manuals",
-    "name": { "str": "Boxing Monthly", "str_pl": "issues of Boxing Monthly" },
-    "description": "An exciting monthly magazine about boxing.  There are lots of large, colorful photos of pugilistic exploits.",
-    "variants": [
-      {
-        "id": "mag_unarmed",
-        "name": { "str": "Boxing Monthly", "str_pl": "issues of Boxing Monthly" },
-        "description": "An exciting monthly magazine about boxing.  There are lots of large, colorful photos of pugilistic exploits."
-      },
-      {
-        "id": "mag_unarmed_1",
-        "name": { "str": "Feral Fighting", "str_pl": "copies of Feral Fighting" },
-        "description": "A brutal book about using dirty tricks to disrupt your enemies, and using this advantage to knockout or even kill them.",
-        "//": "978-1941845097"
-      },
-      {
-        "id": "mag_unarmed_2",
-        "name": { "str": "Stand And Deliver", "str_pl": "copies of Stand And Deliver" },
-        "description": "\"A Street Warrior's Guide To Tactical Combat Stances\", this book provides plenty of information about how stance changes your movement, and how to use each of them with maximum effect.",
-        "//": "978-1941845059"
-      },
-      {
-        "id": "mag_unarmed_3",
-        "name": {
-          "str": "First Strike: End a Fight in Ten Seconds or Less!",
-          "str_pl": "copies of First Strike: End a Fight in Ten Seconds or Less!"
-        },
-        "description": "Despite having a pretty odd name, this book provides a lot of information about fighting techniques, and different tactics and skills you need to obtain to use them properly.",
-        "//": "978-0985347284"
-      },
-      {
-        "id": "mag_unarmed_4",
-        "name": { "str": "Street Lethal: Unarmed Urban Combat", "str_pl": "copies of Street Lethal: Unarmed Urban Combat" },
-        "description": "This book contains lot of images showing how to use different attacks in close quarters, but someone has hand-written \"lame\" on the cover.",
-        "//": "978-0873645171"
-      },
-      {
-        "id": "mag_unarmed_5",
-        "name": { "str": "Nuclear Strike!", "str_pl": "copies of Nuclear Strike!" },
-        "description": "\"Turn your fist into a weapon of mass destruction!\"  This book details different training programs to train your body overall and to temper your hands and nerves into unstoppable forces."
-      }
-    ],
+    "name": { "str": "MMA Monthly", "str_pl": "issues of MMA Monthly" },
+    "description": "An exciting monthly magazine about mixed martial arts.  There are lots of large, colorful photos of matches and interviews with fighters and trainers.",
     "weight": "90 g",
     "volume": "250 ml",
     "price": "4 USD 50 cent",
@@ -64,48 +25,6 @@
     "category": "manuals",
     "name": { "str": "101 Wrestling Moves", "str_pl": "copies of 101 Wrestling Moves" },
     "description": "It seems to be a wrestling manual, poorly photocopied and released on spiral-bound paper.  Still, there are lots of useful tips for unarmed combat.",
-    "variants": [
-      {
-        "id": "manual_brawl",
-        "name": { "str": "101 Wrestling Moves", "str_pl": "copies of 101 Wrestling Moves" },
-        "description": "It seems to be a wrestling manual, poorly photocopied and released on spiral-bound paper.  Still, there are lots of useful tips for unarmed combat."
-      },
-      {
-        "id": "manual_brawl_1",
-        "name": { "str": "Turn Your Fists Into Sledgehammers!", "str_pl": "copies of Turn Your Fists Into Sledgehammers!" },
-        "description": "A detailed explanation of how to train your hands, arms and fists to crush the heads of your opponents, with lot of photos and instructions."
-      },
-      {
-        "id": "manual_brawl_2",
-        "name": { "str": "Unleash Hell", "str_pl": "copies of Unleash Hell" },
-        "description": "A book with a creepy image of death with a scythe on the cover, it guides the user on different attacks that can be combined to overwhelm and destroy your enemy in seconds.",
-        "//": "978-1941845110"
-      },
-      {
-        "id": "manual_brawl_3",
-        "name": {
-          "str": "Knockout: The Ultimate Guide to Sucker Punching",
-          "str_pl": "copies of Knockout: The Ultimate Guide to Sucker Punching"
-        },
-        "description": "This book shows how to use sucker punches - fast and unexpected attacks - to take advantage in a street fight.  Not as useful as before, but it still contains solid information about certain skills and trainings.",
-        "//": "978-1941845325"
-      },
-      {
-        "id": "manual_brawl_4",
-        "name": {
-          "str": "Killer Instinct: Unarmed Combat for Street Survival",
-          "str_pl": "copies of Killer Instinct: Unarmed Combat for Street Survival"
-        },
-        "description": "A shabby book about possible street dangers the author met in his long life, ways to deal with them, and the skill set that such situations require.",
-        "//": "978-1941845455"
-      },
-      {
-        "id": "manual_brawl_5",
-        "name": { "str": "The Bigger They Are, The Harder They Fall", "str_pl": "copies of The Bigger They Are, The Harder They Fall" },
-        "description": "This book explains simple rules that you need to rely on to fight an enemy of different constitution, with techniques and tactics.",
-        "//": "978-0985347208"
-      }
-    ],
     "weight": "227 g",
     "volume": "500 ml",
     "price": "38 USD",


### PR DESCRIPTION
#### Summary
Devariantize manuals

#### Purpose of change
A ton of skill and recipe books had variants. This was obnoxious and misleading - many of the variants implied they taught things they did not (such as fencing) and especially now that everyone is using e-storage, they just amounted to a ton of clutter you had to pick through whenever you wanted to read something.

#### Describe the solution
Remove all of them. Rename knife fighter's notes to blade fighter's notes. Rename boxing monthly to MMA monthly, as it does not teach boxing and MMA (since it isn't a martial art) is a less confusing topic for a generalized unarmed book.

#### Testing
Stored a bunch of variants on my phone. Removed them from the game. Loaded my file and browsed my phone - I now had 4 copies of the same book on there. Not perfect, but there are no errors and players can delete the extras.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
