### PR TITLE
Fix several EOCs

### DIFF
--- a/data/json/effects_on_condition/effects_eocs.json
+++ b/data/json/effects_on_condition/effects_eocs.json
@@ -2,14 +2,25 @@
   {
     "type": "effect_on_condition",
     "id": "eoc_social_satisfied",
-    "condition": { "u_has_effect": "social_satisfied" },
-    "effect": [ { "u_add_morale": "morale_social", "bonus": 6, "max_bonus": 6, "duration": "1 days", "decay_start": "1 days" } ],
-    "false_effect": [ { "u_lose_morale": "morale_social" } ]
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "social_satisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_add_morale": "morale_social", "bonus": 6, "max_bonus": 6, "duration": "1 days", "decay_start": "1 days" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "eoc_social_satisfied_remove",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "compare_string": [ "social_satisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_lose_morale": "morale_social" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "eoc_social_dissatisfied",
-    "condition": { "u_has_effect": "social_dissatisfied" },
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "social_dissatisfied", { "context_val": "effect" } ] },
     "effect": [
       {
         "u_add_morale": "morale_asocial",
@@ -18,20 +29,38 @@
         "duration": "1 days",
         "decay_start": "1 days"
       }
-    ],
-    "false_effect": [ { "u_lose_morale": "morale_social_dissatisfied" } ]
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "eoc_social_dissatisfied_remove",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "compare_string": [ "social_dissatisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_lose_morale": "morale_asocial" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "eoc_asocial_satisfied",
-    "condition": { "u_has_effect": "asocial_satisfied" },
-    "effect": [ { "u_add_morale": "morale_asocial", "bonus": 10, "max_bonus": 10, "duration": "1 days", "decay_start": "1 days" } ],
-    "false_effect": [ { "u_lose_morale": "morale_asocial" } ]
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "asocial_satisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_add_morale": "morale_asocial", "bonus": 10, "max_bonus": 10, "duration": "1 days", "decay_start": "1 days" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "eoc_asocial_satisfied_remove",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "compare_string": [ "asocial_satisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_lose_morale": "morale_asocial" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "eoc_asocial_dissatisfied",
-    "condition": { "u_has_effect": "asocial_dissatisfied" },
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "asocial_dissatisfied", { "context_val": "effect" } ] },
     "effect": [
       {
         "u_add_morale": "morale_social",
@@ -40,12 +69,21 @@
         "duration": "1 days",
         "decay_start": "1 days"
       }
-    ],
-    "false_effect": [ { "u_lose_morale": "morale_asocial_dissatisfied" } ]
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "eoc_asocial_dissatisfied_remove",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "compare_string": [ "asocial_dissatisfied", { "context_val": "effect" } ] },
+    "effect": [ { "u_lose_morale": "morale_social" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "bile_in_eyes",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
     "condition": {
       "and": [
         { "or": [ { "u_has_effect": "bile", "bodypart": "eyes" }, { "u_has_effect": "glowing", "bodypart": "eyes" } ] },
@@ -67,6 +105,8 @@
   {
     "type": "effect_on_condition",
     "id": "bile_stink",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
     "condition": {
       "and": [
         { "u_has_flag": "BILE_AFFLICTED" },
@@ -86,6 +126,8 @@
   {
     "type": "effect_on_condition",
     "id": "acid_in_eyes",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
     "condition": {
       "and": [
         { "u_has_effect": "corroding", "bodypart": "eyes" },

--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -248,12 +248,24 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SUNGLASSES",
+    "eoc_type": "EVENT",
+    "required_event": "character_wears_item",
     "condition": { "and": [ { "u_has_worn_with_flag": "SUN_GLASSES" }, { "not": { "u_has_effect": "SUN_GLASSES" } } ] },
     "effect": [ { "u_add_effect": "SUN_GLASSES", "duration": "PERMANENT", "intensity": 1 } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SUNGLASSES_OFF",
+    "eoc_type": "EVENT",
+    "required_event": "character_takeoff_item",
+    "condition": { "and": [ { "u_has_effect": "SUN_GLASSES" }, { "not": { "u_has_worn_with_flag": "SUN_GLASSES" } } ] },
+    "effect": [ { "u_lose_effect": "SUN_GLASSES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SUNGLASSES_BROKE",
+    "eoc_type": "EVENT",
+    "required_event": "character_armor_destroyed",
     "condition": { "and": [ { "u_has_effect": "SUN_GLASSES" }, { "not": { "u_has_worn_with_flag": "SUN_GLASSES" } } ] },
     "effect": [ { "u_lose_effect": "SUN_GLASSES" } ]
   }

--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -3,10 +3,7 @@
     "id": "remains_human_generic",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [
-      { "item": "bone_human", "count": [ 1, 8 ], "prob": 100 },
-      { "item": "human_flesh", "count": [ 1, 8 ], "prob": 100 }
-    ]
+    "entries": [ { "item": "bone_human", "count": [ 1, 8 ], "prob": 100 }, { "item": "human_flesh", "count": [ 1, 8 ], "prob": 100 } ]
   },
   {
     "id": "remains_pilot",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6476,7 +6476,15 @@
     "name": { "male": "Razor Boy", "female": "Razor Girl" },
     "description": "Through a series of painful and expensive surgeries, you became a walking bionic weapon, your services as a mercenary available to the highest bidder.",
     "points": 5,
-    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_dex_enhancer", "bio_ears", "bio_carbon", "bio_metabolics", "bio_power_storage_mkII" ],
+    "CBMs": [
+      "bio_razors",
+      "bio_armor_eyes",
+      "bio_dex_enhancer",
+      "bio_ears",
+      "bio_carbon",
+      "bio_metabolics",
+      "bio_power_storage_mkII"
+    ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar" ],
     "items": {

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -11,9 +11,7 @@
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "components": [
       [ [ "jar_glass_sealed", 1 ], [ "clay_canister", 2 ], [ "flask_glass", 2 ] ],
-      [
-        [ "any_strong_acid", 2, "LIST" ]
-      ],
+      [ [ "any_strong_acid", 2, "LIST" ] ],
       [ [ "cordage_short", 1, "LIST" ] ]
     ]
   },

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -66,7 +66,9 @@
     "id": "button",
     "type": "requirement",
     "//": "All kinds of clothing buttons.",
-    "components": [ [ [ "button_plastic", 1 ], [ "button_wood", 1 ], [ "button_bone", 1 ], [ "button_steel", 1 ], [ "button_bronze", 1 ] ] ]
+    "components": [
+      [ [ "button_plastic", 1 ], [ "button_wood", 1 ], [ "button_bone", 1 ], [ "button_steel", 1 ], [ "button_bronze", 1 ] ]
+    ]
   },
   {
     "id": "strap_small",
@@ -135,27 +137,13 @@
     "id": "fastener_large",
     "type": "requirement",
     "//": "All kinds of fasteners for jacket-sized soft objects.",
-    "components": [
-      [
-        [ "zipper_long_plastic", 1 ],
-        [ "button", 9, "LIST" ],
-        [ "touch_fastener", 6 ],
-        [ "snapfastener_steel", 9 ]
-      ]
-    ]
+    "components": [ [ [ "zipper_long_plastic", 1 ], [ "button", 9, "LIST" ], [ "touch_fastener", 6 ], [ "snapfastener_steel", 9 ] ] ]
   },
   {
     "id": "fastener_small",
     "type": "requirement",
     "//": "All kinds of fasteners for footwear-sized soft objects, including pockets.",
-    "components": [
-      [
-        [ "button", 3, "LIST" ],
-        [ "zipper_short_plastic", 1 ],
-        [ "snapfastener_steel", 3 ],
-        [ "touch_fastener", 2 ]
-      ]
-    ]
+    "components": [ [ [ "button", 3, "LIST" ], [ "zipper_short_plastic", 1 ], [ "snapfastener_steel", 3 ], [ "touch_fastener", 2 ] ] ]
   },
   {
     "id": "fastener_shoes",
@@ -176,14 +164,7 @@
     "id": "clasps",
     "type": "requirement",
     "//": "All kinds of fasteners for strapped-on objects like belts, per single strap.",
-    "components": [
-      [
-        [ "button", 1, "LIST" ],
-        [ "snapfastener_steel", 2 ],
-        [ "buckle_steel", 1 ],
-        [ "touch_fastener", 2 ]
-      ]
-    ]
+    "components": [ [ [ "button", 1, "LIST" ], [ "snapfastener_steel", 2 ], [ "buckle_steel", 1 ], [ "touch_fastener", 2 ] ] ]
   },
   {
     "id": "plastic_molding",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7714,10 +7714,14 @@ void item::randomize_rot()
 {
     if( is_comestible() && get_comestible()->spoils > 0_turns ) {
         time_duration loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
-                                    rng_float( 0.2, 1.2 );
+                                    rng_float( 0.1, 1.2 );
         set_rot( loot_adjust );
+    } else if( is_corpse() ) {
+        time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
+                                        rng_float( 0.0, 0.15 );
+        time_point birthday = calendar::fall_of_civilization - birthday_adjust;
+        set_birthday( birthday );
     }
-
     for( item_pocket *pocket : contents.get_all_contained_pockets() ) {
         if( pocket->spoil_multiplier() > 0.0f ) {
             for( item *subitem : pocket->all_items_top() ) {


### PR DESCRIPTION
#### Summary
Fix several EOCs

#### Purpose of change
Backport churn broke a bunch of our EOCs, including bile, acid, sunglasses, and introvert/extrovert/social/asocial. These needed immediate attention.

#### Describe the solution
- Update the EOCs using the new event system so that they actually trigger.
- Update the character_removes_item event to take place AFTER the item is actually removed. Previously it was firing before, so in the case of sunglasses, we couldn't check to make sure that the character wasn't wearing any other items with the flag.

#### Describe alternatives you've considered
- I need to go through the seasonal mutation stuff, but IIRC that all uses recurrence so maybe we're fine.

#### Testing
- Sunglasses, asocial, and boomer stink all work.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
