### PR TITLE
Backport 83182 - fix zzip

### DIFF
--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -395,11 +395,8 @@ std::optional<zzip> zzip::load(
 
     ZSTD_CCtx *cctx;
     ZSTD_DCtx *dctx;
-    if( dictionary_path.empty() ) {
-        cctx = ZSTD_createCCtx();
-        dctx = ZSTD_createDCtx();
-    } else if( auto it = cached_contexts.find( dictionary_path.generic_u8string() );
-               it != cached_contexts.end() ) {
+    if( auto it = cached_contexts.find( dictionary_path.generic_u8string() );
+        it != cached_contexts.end() ) {
         cctx = it->second.cctx;
         dctx = it->second.dctx;
     } else {


### PR DESCRIPTION
#### Summary
Backport 83182 - fix zzip

#### Purpose of change
zzip was a bit broken and couldn't manually uncompress saves.

#### Describe the solution
Backport!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
