### PR TITLE
Remove packmule

### DIFF
--- a/data/json/npcs/starting_traits.json
+++ b/data/json/npcs/starting_traits.json
@@ -19,7 +19,6 @@
       { "group": "trait_group_WAKEFUL", "prob": 10 },
       { "group": "trait_group_LIGHTSTEP", "prob": 10 },
       { "group": "trait_group_OPTIMISTIC", "prob": 10 },
-      { "group": "trait_group_PACKMULE", "prob": 10 },
       { "group": "trait_group_PARKOUR", "prob": 10 },
       { "group": "trait_group_PRETTY", "prob": 10 },
       { "group": "trait_group_PSYCHOPATH", "prob": 10 },
@@ -38,7 +37,6 @@
       { "trait": "ADRENALINE", "prob": 10 },
       { "trait": "INFRESIST", "prob": 15 },
       { "trait": "MASOCHIST", "prob": 10 },
-      { "trait": "NIGHTVISION", "prob": 10 },
       { "trait": "OUTDOORSMAN", "prob": 10 },
       { "trait": "POISRESIST", "prob": 10 },
       { "trait": "ROBUST", "prob": 10 },
@@ -55,7 +53,6 @@
       { "trait": "GLASSJAW", "prob": 10 },
       { "trait": "ANTIFRUIT", "prob": 10 },
       { "trait": "MEATARIAN", "prob": 5 },
-      { "trait": "HOARDER", "prob": 10 },
       { "trait": "JITTERY", "prob": 10 },
       { "trait": "LACTOSE", "prob": 10 },
       { "trait": "VEGETARIAN", "prob": 15 },
@@ -148,12 +145,6 @@
     "id": "trait_group_OPTIMISTIC",
     "subtype": "distribution",
     "traits": [ { "trait": "OPTIMISTIC" }, { "trait": "PESSIMISTIC" } ]
-  },
-  {
-    "type": "trait_group",
-    "id": "trait_group_PACKMULE",
-    "subtype": "distribution",
-    "traits": [ { "trait": "PACKMULE" }, { "trait": "DISORGANIZED" } ]
   },
   {
     "type": "trait_group",

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -285,6 +285,16 @@
     "random_at_chargen": false,
     "valid": false
   },
+    {
+    "type": "mutation",
+    "id": "PACKMULE",
+    "name": { "str": "Pack Mule" },
+    "points": 0,
+    "player_display": false,
+    "description": "Obsoleted trait.",
+    "random_at_chargen": false,
+    "valid": false
+  },
   {
     "type": "mutation",
     "id": "TRUTHTELLER",


### PR DESCRIPTION
#### Summary
Remove packmule

#### Purpose of change
Packmule gave you a blanket 10% buff to retrieval time, all the time. This is a relic of old, bad design that existed in simpler times when there weren't other methods of boosting this. Now there are, so bye bye.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
