### PR TITLE
Fix holsters

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1831,30 +1831,6 @@ void avatar::add_pain_msg( int val, const bodypart_id &bp ) const
     }
 }
 
-bool avatar::wield_contents( item &container, item *internal_item, bool penalties, int base_cost )
-{
-    // if index not specified and container has multiple items then ask the player to choose one
-    if( internal_item == nullptr ) {
-        std::vector<std::string> opts;
-        std::list<item *> container_contents = container.all_items_top();
-        std::transform( container_contents.begin(), container_contents.end(),
-        std::back_inserter( opts ), []( const item * elem ) {
-            return elem->display_name();
-        } );
-        if( opts.size() > 1 ) {
-            int pos = uilist( _( "Wield what?" ), opts );
-            if( pos < 0 ) {
-                return false;
-            }
-            internal_item = *std::next( container_contents.begin(), pos );
-        } else {
-            internal_item = container_contents.front();
-        }
-    }
-
-    return Character::wield_contents( container, internal_item, penalties, base_cost );
-}
-
 void avatar::try_to_sleep( const time_duration &dur )
 {
     get_comfort_at( pos_bub() ).add_try_msgs( *this );

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -207,15 +207,6 @@ class avatar : public Character
          * @param target Target NPC to disarm
          */
         void disarm( npc &target );
-        /**
-         * Try to wield a contained item consuming moves proportional to weapon skill and volume.
-         * @param container Container containing the item to be wielded
-         * @param internal_item reference to contained item to wield.
-         * @param penalties Whether item volume and temporary effects (e.g. GRABBED, DOWNED) should be considered.
-         * @param base_cost Cost due to storage type.
-         */
-        bool wield_contents( item &container, item *internal_item = nullptr, bool penalties = true,
-                             int base_cost = INVENTORY_HANDLING_PENALTY );
         /** Handles sleep attempts by the player, starts ACT_TRY_SLEEP activity */
         void try_to_sleep( const time_duration &dur );
         void set_pos_abs_only( const tripoint_abs_ms &loc );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1299,11 +1299,6 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     int pre_obtain_moves = you.get_moves();
     if( loc->has_flag( flag_ALLOWS_REMOTE_USE ) || you.is_worn( *loc ) ) {
         use_in_place = true;
-        // Activate holster on map only if hands are free.
-    } else if( you.can_wield( *loc ).success() && loc->is_holster() && !loc.held_by( you ) ) {
-        use_in_place = true;
-        // Adjustment because in player::wield_contents this amount is refunded.
-        you.mod_moves( -loc.obtain_cost( you ) );
     } else {
         item_location::type loc_where = loc.where_recursive();
         std::string const name = loc->display_name();

--- a/src/character.h
+++ b/src/character.h
@@ -1838,15 +1838,6 @@ class Character : public Creature, public visitable
                               const std::vector<trait_id> &trait_to_rem, const tripoint_bub_ms &patient_pos );
         void bionics_install_failure( const bionic_id &bid, const std::string &installer, int difficulty,
                                       int success, float adjusted_skill, const tripoint_bub_ms &patient_pos );
-        /**
-         * Try to wield a contained item consuming moves proportional to weapon skill and volume.
-         * @param container Container containing the item to be wielded
-         * @param internal_item reference to contained item to wield.
-         * @param penalties Whether item volume and temporary effects (e.g. GRABBED, DOWNED) should be considered.
-         * @param base_cost Cost due to storage type.
-         */
-        bool wield_contents( item &container, item *internal_item = nullptr, bool penalties = true,
-                             int base_cost = INVENTORY_HANDLING_PENALTY );
         /** Uses a tool */
         void use( int inventory_position );
         /** Uses a tool at location */

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -724,10 +724,10 @@ void outfit::holster_opts( std::vector<dispose_option> &opts, item_location obj,
         if( e.get_contents().has_additional_pockets() && e.can_contain( *obj ).success() ) {
             opts.emplace_back( dispose_option{
                 string_format( _( "Store in %s" ), e.tname() ), true, e.invlet,
-                guy.item_store_cost( *obj, e, false, e.insert_cost( *obj ) ),
+                guy.item_store_cost( *obj, e, true, e.insert_cost( *obj ) ),
                 [&guy, &e, obj] {
                     item &it = *item_location( obj );
-                    guy.store( e, it, false, e.insert_cost( it ), pocket_type::CONTAINER, true );
+                    guy.store( e, it, true, e.insert_cost( it ), pocket_type::CONTAINER, true );
                     return !guy.has_item( it );
                 }
             } );
@@ -739,10 +739,10 @@ void outfit::holster_opts( std::vector<dispose_option> &opts, item_location obj,
                 }
                 opts.emplace_back( dispose_option{
                     string_format( "  >%s", it->tname() ), true, it->invlet,
-                    guy.item_store_cost( *obj, *it, false, it->insert_cost( *obj ) ),
+                    guy.item_store_cost( *obj, *it, true, it->insert_cost( *obj ) ),
                     [&guy, it, con, obj] {
                         item &i = *item_location( obj );
-                        guy.store( con, i, false, it->insert_cost( i ) );
+                        guy.store( con, i, true, it->insert_cost( i ) );
                         return !guy.has_item( i );
                     }
                 } );
@@ -752,7 +752,7 @@ void outfit::holster_opts( std::vector<dispose_option> &opts, item_location obj,
                                        ( e.type->get_use( "holster" )->get_actor_ptr() );
             opts.emplace_back( dispose_option{
                 string_format( _( "Store in %s" ), e.tname() ), true, e.invlet,
-                guy.item_store_cost( *obj, e, false, e.insert_cost( *obj ) ),
+                guy.item_store_cost( *obj, e, true, e.insert_cost( *obj ) ),
                 [&guy, ptr, &e, obj] {
                     // *obj by itself attempts to use the const version of the operator (in gcc9),
                     // so construct a new item_location which allows using the non-const version

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1147,7 +1147,9 @@ class activatable_inventory_preset : public pickup_inventory_preset
             if( it.is_medication() && !you.can_use_heal_item( it ) && !it.is_craft() ) {
                 return _( "Your biology is not compatible with that item." );
             }
-
+            if( it.is_holster() && !you.is_worn( it ) ) {
+                return _( "You would need to be wearing that." );
+            }
             if( it.is_broken() ) {
                 return string_format( _( "Your %s was broken and won't turn on." ), it.tname() );
             }

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -754,13 +754,14 @@ class item_location::impl::item_in_container : public item_location::impl
             primary_cost = ch.enchantment_cache->modify_value( enchant_vals::mod::OBTAIN_COST_MULTIPLIER,
                            primary_cost );
             int parent_obtain_cost = container.obtain_cost( ch, qty );
+            // TODO: MOLLE attachments don't get a bonus. Can't we just check the pocket and not get_use?
             if( container->get_use( "holster" ) ) {
                 if( ch.is_worn( *container ) ) {
-                    primary_cost = ch.item_retrieve_cost( *target(), *container, false, container_mv );
+                    primary_cost = ch.item_retrieve_cost( *target(), *container, true, container_mv );
                 } else {
                     primary_cost = ch.item_retrieve_cost( *target(), *container );
                 }
-                // for holsters, we should not include the cost of wielding the holster itself
+                // For holsters, we should not include the cost of wielding the holster itself.
                 parent_obtain_cost = 0;
             } else if( container.where() != item_location::type::container ) {
                 // Worn items don't need to be retrieved, just accessed.


### PR DESCRIPTION
#### Summary
Fix holsters

#### Purpose of change
A player submitted a bug report mentioning that they heard their sfx slow down when they drew a weapon. We soon discovered that the movecost for drawing a weapon was around negative three seconds. This led me down a very deep rabbit hole, but basically holsters and drawing/sheathing were completely broken in general.

#### Describe the solution
- Get rid of avatar::wield_contents and character::wield_contents. These were totally redundant, didn't work properly, and only used when you (a)ctivated a holster. Wielding from a holster using (w)ield was fine, so we can just use the same function if the player uses the activate menu instead of wielding.
- Get rid of any mention of holsters being exempt from speed penalties.
- Make it impossible to activate holsters unless they're worn. They function as containers, so you can just get stuff out of/put stuff into them normally.
- Reduce button presses in a couple of cases where it wasn't necessary to bring up the dialogue menu for activating a holster.

#### Describe alternatives you've considered
- Currently, holsters attached via MOLLE do not benefit from the user's skill like they do when worn normally. This is unintentional, and merely a product of how the game checks for when to assign that bonus. This is not a new bug though, they never gave the bonus. I'll fix this as soon as I figure out how. I guess consider it the cost of getting extra storage. Most holsters have a really fast base obtain cost anyway.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
