### PR TITLE
Skewer knuckles have 1 less to-hit

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -399,7 +399,7 @@
     "volume": "300 ml",
     "price": "11 USD",
     "price_postapoc": "2 USD 50 cent",
-    "to_hit": { "grip": "weapon", "length": "hand", "surface": "line", "balance": "neutral" },
+    "to_hit": { "grip": "weapon", "length": "hand", "surface": "point", "balance": "neutral" },
     "material": [ "steel" ],
     "symbol": "[",
     "color": "light_gray",


### PR DESCRIPTION
#### Summary
Skewer knuckles have 1 less to-hit

#### Purpose of change
To-hit is usually calculated automatically based on a few factors. Skewer knuckles were using LINE as their strike area instead of POINT, despite the fact that they are long spikes for stabbin'.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
