### PR TITLE
Fix MOLLE holsters

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -754,8 +754,8 @@ class item_location::impl::item_in_container : public item_location::impl
             primary_cost = ch.enchantment_cache->modify_value( enchant_vals::mod::OBTAIN_COST_MULTIPLIER,
                            primary_cost );
             int parent_obtain_cost = container.obtain_cost( ch, qty );
-            // TODO: MOLLE attachments don't get a bonus. Can't we just check the pocket and not get_use?
-            if( container->get_use( "holster" ) ) {
+            // TODO: Can't we just check the pocket and not get_use?
+            if( parent_pocket()->is_holster() ) {
                 if( ch.is_worn( *container ) ) {
                     primary_cost = ch.item_retrieve_cost( *target(), *container, true, container_mv );
                 } else {


### PR DESCRIPTION
#### Summary
Fix MOLLE holsters

#### Purpose of change
Holsters attached to MOLLE gear weren't discounting wield costs because the code was set up to check for the holster action, which is not present in that case.

#### Describe the solution
Check instead for the holster pocket type.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
