### PR TITLE
Updates johnnycakes

### DIFF
--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -291,12 +291,12 @@
     "description": "A dense and tasty fried bread treat.",
     "price": "45 cent",
     "price_postapoc": "50 cent",
-    "material": [ "wheat", "junk" ],
-    "primary_material": "wheat",
+    "material": [ "vegetable", "junk" ],
+    "primary_material": "vegetable",
     "volume": "41 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 2,
-    "vitamins": [ [ "calcium", 4 ], [ "iron", 7 ], [ "wheat_allergen", 1 ], [ "junk_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 4 ], [ "iron", 7 ], [ "vegetable_allergen", 1 ], [ "junk_allergen", 1 ] ]
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION
Updates johnnycakes to be made of vegetables (corn) rather than wheat in the final craft.

#### Summary
Johnnycakes were made of wheat in the final craft rather than vegetables. This corrects that.

#### Purpose of change
Lets people with gluten allergies eat johnnycakes

#### Describe the solution
Changes the vitamins & material of johnnycakes from wheat to vegetable

#### Describe alternatives you've considered
None

#### Testing
Runs fine & without error. Wheat intolerant characters can now eat johnnycakes without negative effects.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
