### PR TITLE
Train dodge on failure, fix training on miss

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2253,6 +2253,27 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
     }
 }
 
+void Character::on_fail_dodge( Creature *source, float difficulty, float training_level )
+{
+    // Make sure we're not practicing dodge in situation where we can't dodge
+    // We can ignore dodges_left because it was already checked in get_dodge()
+    if( !can_try_dodge( true ).success() ) {
+        return;
+    }
+
+    difficulty = std::max( difficulty - 2, 0.0f );
+
+    // If training_level is set, treat that as the difficulty instead
+    if( training_level != 0.0f ) {
+        difficulty = training_level;
+    }
+
+    if( source && source->times_combatted_player <= 50 ) {
+        source->times_combatted_player++;
+        practice( skill_dodge, rng( 1, difficulty ), difficulty );
+    }
+}
+
 float Character::get_melee() const
 {
     return get_skill_level( skill_melee );

--- a/src/character.h
+++ b/src/character.h
@@ -871,6 +871,8 @@ class Character : public Creature, public visitable
 
         /** Called after the player has successfully dodged an attack */
         void on_dodge( Creature *source, float difficulty, float training_level = 0.0f ) override;
+        /** Called after the player has tried but failed to dodge an attack. Mostly just trains a bit. */
+        void on_fail_dodge( Creature *source, float difficulty, float training_level = 0.0f ) override;
         /** Called after the player has tryed to dodge an attack */
         void on_try_dodge() override;
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -983,6 +983,9 @@ int Creature::deal_melee_attack( Creature *source, int hitroll )
     // If attacker missed call targets on_dodge event
     if( dodge > 0.0 && hit_spread <= 0 && source != nullptr && !source->is_hallucination() ) {
         on_dodge( source, source->get_melee() );
+    } else if( !is_monster() && dodge > 0.0 && source != nullptr && !source->is_hallucination() &&
+               one_in( 4 ) ) {
+        on_fail_dodge( source, source->get_melee() );
     }
     add_msg_debug( debugmode::DF_CREATURE, "Final hitspread %d",
                    hit_spread );
@@ -1734,8 +1737,6 @@ bool Creature::dodge_check( float hit_roll, bool force_try, float )
         float attack_roll = hit_roll + rng_normal( 0, 5 );
         return dodge_ability > attack_roll;
     }
-    add_msg_if_player( m_warning,
-                       _( "You don't think you could dodge this attack, and decide to conserve stamina." ) );
 
     return false;
 }

--- a/src/creature.h
+++ b/src/creature.h
@@ -533,9 +533,14 @@ class Creature : public viewer
 
         /**
          * This creature just dodged an attack - possibly special/ranged attack - from source.
-         * Players should train dodge, monsters may use some special defenses.
+         * Characters should train dodge, monsters may use some special defenses.
          */
         virtual void on_dodge( Creature *source, float difficulty, float training_level = 0.0f ) = 0;
+        /**
+         * This creature just failed to dodge an attack - possibly special/ranged attack - from source.
+         * Characters should have a chance to train a small amount of dodge, monsters do nothing for now.
+         */
+        virtual void on_fail_dodge( Creature *source, float difficulty, float training_level = 0.0f ) = 0;
         /**
          * Invoked when the creature attempts to dodge, regardless of success or failure.
          */

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3883,6 +3883,10 @@ void monster::on_dodge( Creature *, float, float )
     }
 }
 
+void monster::on_fail_dodge( Creature *, float, float )
+{
+}
+
 void monster::on_hit( map *here, Creature *source, bodypart_id,
                       float, dealt_projectile_attack const *const proj )
 {

--- a/src/monster.h
+++ b/src/monster.h
@@ -438,6 +438,8 @@ class monster : public Creature
         float stability_roll() const override;
         // We just dodged an attack from something. Penalize further dodge attempts for the rest of this second.
         void on_dodge( Creature *source, float difficulty, float training_level = 0.0 ) override;
+        // Does nothing for monsters, at least right now.
+        void on_fail_dodge( Creature *source, float difficulty, float training_level = 0.0 ) override;
         void on_try_dodge() override {}
         // Something hit us (possibly null source)
         void on_hit( map *here, Creature *source, bodypart_id bp_hit,


### PR DESCRIPTION
#### Summary
Train dodge on failure, fix training on miss

#### Purpose of change
- Some dubious code in melee.cpp was making the player train incorrect skills when they missed an attack.
- Dodge only trained if you successfully dodged an attack. This was leading to all kinds of bizarre and unintended player behavior as players sought out ways to train a skill that would otherwise not really move much.
- NPCs would train all the way up to 10 whatever their skills were.

#### Describe the solution
- If you miss a melee attack, you have a 1/4 chance of training a small amount of melee skill. This has a skill cap 2 lower than what you can train by actually hitting the monster.
- Missing an attack no longer trains any weapon skills. This is by design as those are more about damage than accuracy, but it's also the easiest way to fix the bug that was previously occurring. Attacks which actually hit are unaffected.
- If an enemy attacks you and you try to dodge but fail, as long as you have 0.1 dodge score or higher, you have a 1/4 chance of training a small amount of dodge. This has a skill cap of 2 lower than what you could train by successfully dodging the monster. Note that this is only on attacks which you are able to try and dodge! If you're already grabbed, you're not training this way.
- Attacking or being attacked by NPCs now trains melee and dodge according to their skill level, instead of just all the way up to 10.

#### Describe alternatives you've considered
I was on the fence about the 1/4 thing, but in practice having your focus get eaten up every single time anything hits you or you swing at anything kind of sucks. The 1/4 is both a good penalty for not doing it properly and a way to keep your focus out of the toilet. Successful hits and dodges train more, so having higher focus for those is ideal.

Maybe breaking or attempting to break out of grabs should train dodge a bit? We'll see how this goes first.

#### Testing
- Surrounded myself with mi-go.
- Gained a small amount of dodge XP as I was torn to shreds.
- Punched a goose to death, did not gain any bash xp. Trained a bit of melee on misses.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
