### PR TITLE
Fix bloodfeeders not drinking human blood.

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -928,7 +928,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     if( !has_flag( json_flag_SAPIOVORE ) &&
         !has_flag( STATIC( json_character_flag( "CANNIBAL" ) ) ) &&
         !has_flag( json_flag_PSYCHOPATH ) &&
-        !( food.has_flag( json_flag_HEMOVORE_FUN ) && has_flag( json_flag_HEMOVORE ) ) &&
+        !( food.has_flag( flag_HEMOVORE_FUN ) && has_flag( json_flag_HEMOVORE ) ) &&
         food.has_vitamin( vitamin_human_flesh_vitamin ) &&
         !food.is_medication() &&
         !has_effect( effect_hunger_near_starving ) &&


### PR DESCRIPTION
#### Summary
Fix bloodfeeders not drinking human blood.

#### Purpose of change
- Bloodfeeders weren't able to drink human blood because of some bad logic in consumption.cpp.
- Hemovores weren't able to drink human blood. That's an oversight. They're meant to be able to do it, just to not like it.

#### Describe the solution
- Both mutations now allow you to drink human blood. Hemovores get a morale penalty because it's weird. Bloodfeeders no longer care and treat it the same as all other blood.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
