### PR TITLE
Backport 83099 - Prevent precip effects when under roof but outdoors

### DIFF
--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -509,8 +509,10 @@ void handle_weather_effects( const weather_type_id &w )
             wetness = 60;
         }
         here.decay_fields_and_scent( decay_time );
-        // Coarse correction to get us back to previously intended soaking rate.
-        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) ) {
+        const bool no_roof_above = here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR,
+                                   target.pos_bub() + tripoint::above );
+        // This runs every 6 seconds for legacy reasons.
+        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) && no_roof_above ) {
             wet_character( target, wetness );
         }
     }


### PR DESCRIPTION
#### Summary
Backport 83099 - Prevent precip effects when under roof but outdoors

#### Purpose of change
Prevents you from seeing raindrops or getting wet if you're standing under an overpass or something. Does not currently work if the roof is more than one level above you, that probably needs a more holistic solution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
