### PR TITLE
Morale and antidepressants

### DIFF
--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -24,14 +24,7 @@
 class item;
 struct itype;
 
-static const efftype_id effect_took_prozac( "took_prozac" );
-static const efftype_id effect_took_xanax( "took_xanax" );
-
-static const itype_id itype_foodperson_mask( "foodperson_mask" );
-static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );
-
 static const morale_type morale_perm_fpmode_on( "morale_perm_fpmode_on" );
-static const morale_type morale_perm_noface( "morale_perm_noface" );
 static const morale_type morale_perm_nomad( "morale_perm_nomad" );
 
 static const trait_id trait_CENOBITE( "CENOBITE" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14009,9 +14009,10 @@ void game::animate_weather()
                 const point map_point = screen_point + offset;
                 const tripoint map_point_tripoint( map_point, u.posz() );
                 const tripoint_bub_ms mapp = tripoint_bub_ms( map_point_tripoint );
+                const bool roof_not_blocking = weather_info.static_overlay || here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, mapp + tripoint::above );
 
                 if( m.inbounds( mapp ) &&
-                    m.is_outside( mapp ) &&
+                    m.is_outside( mapp ) && roof_not_blocking &&
                     m.get_visibility( m.get_cache_ref( u.posz() ).visibility_cache[mapp.x()][mapp.y()],
                                       m.get_visibility_variables_cache() ) == visibility_type::CLEAR &&
                     !creatures.creature_at( mapp, true ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -387,7 +387,9 @@ static const trait_id trait_MARLOSS_AVOID( "MARLOSS_AVOID" );
 static const trait_id trait_MARLOSS_BLUE( "MARLOSS_BLUE" );
 static const trait_id trait_MARLOSS_YELLOW( "MARLOSS_YELLOW" );
 static const trait_id trait_M_DEPENDENT( "M_DEPENDENT" );
+static const trait_id trait_PESSIMIST( "PESSIMIST" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
+static const trait_id trait_SEASONAL_AFFECTIVE( "SEASONAL_AFFECTIVE" );
 static const trait_id trait_SPIRITUAL( "SPIRITUAL" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
@@ -1016,11 +1018,12 @@ std::optional<int> iuse::prozac( Character *p, item *, const tripoint_bub_ms & )
 {
     if( !p->has_effect( effect_took_prozac ) ) {
         p->add_effect( effect_took_prozac, 12_hours );
-    } else {
-        p->mod_stim( 3 );
     }
-    if( one_in( 50 ) ) { // adverse reaction, same duration as prozac effect.
-        p->add_msg_if_player( m_warning, _( "You suddenly feel hollow inside." ) );
+    // Antidepressants can backfire, but are more effective in people with endogenous depression.
+    const bool sad_or_pessimist = ( p->has_trait( trait_SEASONAL_AFFECTIVE ) && ( season_of_year( calendar::turn ) == season_type::AUTUMN || season_of_year( calendar::turn ) == season_type::WINTER ) )
+      || p->has_trait( trait_PESSIMIST );
+    if( one_in( sad_or_pessimist ? 50 : 25 ) ) {
+        p->add_msg_if_player( m_warning, _( "A sense of dull ennui washes over you." ) );
         p->add_effect( effect_took_prozac_bad, p->get_effect_dur( effect_took_prozac ) );
     }
     p->add_effect( effect_took_prozac_visible, rng( 9_hours, 15_hours ) );


### PR DESCRIPTION
#### Summary
Morale and antidepressants

#### Purpose of change
Antidepressants are really badly implemented. IRL you need to take them for a week or two to get any effect at all and the effect is quite subtle. IRL antidepressants can work on people whose mood issues are caused by circumstance, but they don't work nearly as well as they do for people who have some endogenous form of depression. This PR doesn't fully fix any of this, but it does improve things a bit.

#### Describe the solution
- Antidepressants now check if you have SAD and it's winter or fall, or if you have Pessimist. If either is true, the chance of a negative reaction is 2% instead of the usual 4%.
- Removed some dead code.

#### Describe alternatives you've considered
- Vitamin-based overhaul. Ughhhh soon I guess.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
