### PR TITLE
Fix dragging furniture w/items

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12054,17 +12054,22 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         if( dst_item_ok && src_item_ok ) {
             // Assume contents of both cells are legal, so we can just swap contents.
             std::list<item> temp;
-            map_stack ms = here.i_at( fpos );
-            std::move( ms.begin(), ms.end(),
-                       std::back_inserter( temp ) );
+            map_stack src_ms = here.i_at( fpos );
+            map_stack dst_ms = here.i_at( fdest );
+            
+            // Move source items to temp.
+            std::move( src_ms.begin(), src_ms.end(), std::back_inserter( temp ) );
             here.i_clear( fpos );
-            for( auto item_iter = ms.begin();
-                 item_iter != ms.end(); ++item_iter ) {
-                ms.insert( *item_iter );
+            
+            // Move destination items to source.
+            for( item &dst_item : dst_ms ) {
+                here.add_item( fpos, dst_item );
             }
             here.i_clear( fdest );
-            for( item &cur_item : temp ) {
-                ms.insert( cur_item );
+            
+            // Move source items (from temp) to destination.
+            for( item &src_item : temp ) {
+                here.add_item( fdest, src_item );
             }
         } else {
             add_msg( _( "Stuff spills from the %s!" ), furntype.name() );


### PR DESCRIPTION
#### Summary
Fix dragging furniture w/items

#### Purpose of change
- Furniture with items in it just dumped everything on the floor when moved.
- If the destination tile had items in it, everything got deleted.

This was due to DDA 77426. Shoutout to Jexyll on discord for spotting it.

#### Describe the solution
Properly index the items in both locations and swap positions without simply deleting stuff.

#### Testing
werks


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
