### PR TITLE
Fix vision bugs

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -409,7 +409,6 @@
     "name": { "str": "Blackout Lenses" },
     "description": "An additional layer of tinting for the protective lenses CBM which can make the lenses dark enough to effectively blind the user when active.",
     "included": true,
-    "toggled_pseudo_items": [ "armor_bio_eyes" ],
     "flags": [ "BIONIC_TOGGLED", "PARENT_REQUIRED" ],
     "active_flags": [ "BLIND" ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -763,9 +763,7 @@
       "SPIDER",
       "URSINE",
       "TROGLOBITE"
-    ],
-    "active": true,
-    "starts_active": true
+    ]
   },
   {
     "type": "mutation",
@@ -2025,9 +2023,7 @@
     "types": [ "VISION" ],
     "prereqs": [ "NIGHTVISION" ],
     "changes_to": [ "NIGHTVISION3" ],
-    "category": [ "FISH", "BEAST", "INSECT", "RAT", "CHIMERA", "LUPINE", "MOUSE", "TROGLOBITE", "SPIDER" ],
-    "active": true,
-    "starts_active": true
+    "category": [ "FISH", "BEAST", "INSECT", "RAT", "CHIMERA", "LUPINE", "MOUSE", "TROGLOBITE", "SPIDER" ]
   },
   {
     "type": "mutation",
@@ -2038,9 +2034,7 @@
     "prereqs": [ "NIGHTVISION2" ],
     "leads_to": [ "INFRARED" ],
     "types": [ "VISION" ],
-    "category": [ "FISH", "TROGLOBITE", "SPIDER", "INSECT" ],
-    "active": true,
-    "starts_active": true
+    "category": [ "FISH", "TROGLOBITE", "SPIDER", "INSECT" ]
   },
   {
     "type": "mutation",
@@ -2049,7 +2043,7 @@
     "points": 1,
     "visibility": 8,
     "ugliness": 5,
-    "description": "Your eyes still bulge, yet your pupils look different somehow.  Water doesn't seem to cause any trouble at all, though.",
+    "description": "Your pupils have widened into horizontal squiggles.  Water doesn't seem to cause any trouble at all, though.",
     "types": [ "EYES" ],
     "leads_to": [ "CEPH_VISION" ],
     "flags": [ "EYE_MEMBRANE" ],
@@ -2075,9 +2069,7 @@
     "description": "Your brain has caught up with your eyes.  You can see much better in the dark, but sunlight seems much brighter now.  Activate to toggle NV-visible areas on or off.",
     "types": [ "VISION" ],
     "prereqs": [ "CEPH_EYES" ],
-    "category": [ "CEPHALOPOD" ],
-    "active": true,
-    "starts_active": true
+    "category": [ "CEPHALOPOD" ]
   },
   {
     "type": "mutation",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1403,6 +1403,9 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
             item tmparmor( pseudo );
             if( tmparmor.has_flag( flag_INTEGRATED ) ) {
                 remove_worn_items_with( [&]( item & armor ) {
+                    cata::event e = cata::event::make<event_type::character_takeoff_item>( getID(), pseudo );
+                    item_location loc( *this, &tmparmor );
+                    get_event_bus().send_with_talker( this, &loc, e );
                     return armor.typeId() == tmparmor.typeId();
                 } );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2943,10 +2943,10 @@ void Character::recalc_sight_limits()
         sight_max = 2;
     } else if( has_trait( trait_PER_SLIME ) ) {
         sight_max = 8;
-    } else if( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
+    } else if( ( has_flag( json_flag_MYOPIC ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-               !has_effect( effect_transition_contacts ) ) {
+               !has_effect( effect_transition_contacts ) ) || ( ( in_light &&
+                 has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {
         vision_mode_cache.set( DARKNESS );
@@ -2960,29 +2960,26 @@ void Character::recalc_sight_limits()
     if( has_nv_goggles() ) {
         vision_mode_cache.set( NV_GOGGLES );
     }
-    if( has_active_mutation( trait_NIGHTVISION3 ) ||
+    if( has_trait( trait_NIGHTVISION3 ) ||
         ( is_mounted() && mounted_creature->has_flag( mon_flag_MECH_RECON_VISION ) ) ) {
         vision_mode_cache.set( NIGHTVISION_3 );
     }
-    if( has_active_mutation( trait_ELFA_FNV ) ) {
+    if( has_trait( trait_ELFA_FNV ) ) {
         vision_mode_cache.set( FULL_ELFA_VISION );
     }
-    if( has_active_mutation( trait_CEPH_VISION ) ) {
+    if( has_trait( trait_CEPH_VISION ) ) {
         vision_mode_cache.set( CEPH_VISION );
     }
-    if( has_active_mutation( trait_ELFA_NV ) ) {
+    if( has_trait( trait_ELFA_NV ) ) {
         vision_mode_cache.set( ELFA_VISION );
     }
-    if( has_active_mutation( trait_NIGHTVISION2 ) ) {
+    if( has_trait( trait_NIGHTVISION2 ) ) {
         vision_mode_cache.set( NIGHTVISION_2 );
     }
-    if( has_active_mutation( trait_FEL_NV ) ) {
+    if( has_trait( trait_FEL_NV ) ) {
         vision_mode_cache.set( FELINE_VISION );
     }
-    if( has_active_mutation( trait_URSINE_EYE ) ) {
-        vision_mode_cache.set( URSINE_VISION );
-    }
-    if( has_active_mutation( trait_NIGHTVISION ) ) {
+    if( has_trait( trait_NIGHTVISION ) ) {
         vision_mode_cache.set( NIGHTVISION_1 );
     }
     if( has_trait( trait_BIRD_EYE ) ) {


### PR DESCRIPTION
#### Summary
Fix vision bugs

#### Purpose of change
Fix some various issues with vision, including items and mutations.

#### Describe the solution
- Prevent blackout lenses from donning a second pair of protective lenses.
- Bionics now send a character_takeoff_item event when bionic pseudo items are removed, allowing EOCs that rely on this to function. This fixes the sunglasses effect remaining even when deactivating these.
- A long time ago, for reasons I will never understand, someone made all the night vision mutations active. There's no reason for them to be active, they have no negative effects and night vision is not something any animal can just "turn off". These are now passive.
- It was still possible to fix mesopic with corrective sunglasses. That was not intended, that's not how mesopia works. It's not that the light is too bright for them or that they're actually nearsighted, it's that they can't see very well in lit areas, shades or no.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
