### PR TITLE
Remove mutation conduct and achievement

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -334,8 +334,7 @@
         "is": "<=",
         "target": 0,
         "visible": "when_achievement_completed"
-      },
-      { "event_statistic": "num_gains_mutation", "is": "<=", "target": 0, "visible": "when_achievement_completed" }
+      }
     ]
   },
   {
@@ -589,7 +588,7 @@
   {
     "id": "achievement_mutation_threshold_beast",
     "type": "achievement",
-    "name": "The nature of the me",
+    "name": "A veritable hunt unending",
     "requirements": [
       {
         "event_statistic": "avatar_last_crosses_mutation_threshold",
@@ -687,13 +686,13 @@
   {
     "id": "achievement_mutation_threshold_lizard",
     "type": "achievement",
-    "name": "Yer a lizard, Harry",
+    "name": "Snake people, or \"sneople...\"",
     "requirements": [
       {
         "event_statistic": "avatar_last_crosses_mutation_threshold",
         "is": "==",
         "target": [ "mutation_category_id", "LIZARD" ],
-        "description": "crossed lizard mutation threshold",
+        "description": "crossed reptilian mutation threshold",
         "visible": "when_achievement_completed"
       }
     ]
@@ -743,7 +742,7 @@
   {
     "id": "achievement_mutation_threshold_alpha",
     "type": "achievement",
-    "name": "Thus spake zombiethustra",
+    "name": "More human than human",
     "requirements": [
       {
         "event_statistic": "avatar_last_crosses_mutation_threshold",
@@ -820,6 +819,20 @@
         "is": "==",
         "target": [ "mutation_category_id", "MOUSE" ],
         "description": "crossed mouse mutation threshold",
+        "visible": "when_achievement_completed"
+      }
+    ]
+  },
+  {
+    "id": "achievement_mutation_threshold_chiropteran",
+    "type": "achievement",
+    "name": "I am the night",
+    "requirements": [
+      {
+        "event_statistic": "avatar_last_crosses_mutation_threshold",
+        "is": "==",
+        "target": [ "mutation_category_id", "CHIROPTERAN" ],
+        "description": "crossed chiropteran mutation threshold",
         "visible": "when_achievement_completed"
       }
     ]

--- a/data/json/conducts.json
+++ b/data/json/conducts.json
@@ -1,11 +1,5 @@
 [
   {
-    "id": "conduct_no_smash",
-    "type": "conduct",
-    "name": "Mouse in a china shop",
-    "requirements": [ { "event_statistic": "num_avatar_smash", "is": "<=", "target": 0, "description": "Smash no tiles" } ]
-  },
-  {
     "id": "conduct_no_attacks",
     "type": "conduct",
     "name": "Nonviolence",
@@ -58,30 +52,9 @@
     "requirements": [ { "event_statistic": "num_avatar_character_kills", "is": "<=", "target": 0, "description": "Kill no characters" } ]
   },
   {
-    "id": "conduct_zero_cut_trees",
-    "type": "conduct",
-    "name": "The Elven Path",
-    "requirements": [ { "event_statistic": "num_cuts_tree", "is": "<=", "target": 0, "description": "Cut no trees" } ]
-  },
-  {
-    "id": "conduct_pure_human",
-    "type": "conduct",
-    "name": "Homo Sapiens",
-    "requirements": [
-      { "event_statistic": "num_installs_cbm", "is": "<=", "target": 0, "description": "Install no bionic implants" },
-      {
-        "event_statistic": "num_installs_faulty_cbm",
-        "is": "<=",
-        "target": 0,
-        "description": "Install no faulty bionic implants"
-      },
-      { "event_statistic": "num_gains_mutation", "is": "<=", "target": 0, "description": "No mutations" }
-    ]
-  },
-  {
     "id": "conduct_no_cbm",
     "type": "conduct",
-    "name": "Clean on X-ray",
+    "name": "Unmodded",
     "requirements": [
       { "event_statistic": "num_installs_cbm", "is": "<=", "target": 0, "description": "Install no bionic implants" },
       {
@@ -90,15 +63,7 @@
         "target": 0,
         "description": "Install no faulty bionic implants"
       }
-    ],
-    "hidden_by": [ "conduct_pure_human" ]
-  },
-  {
-    "id": "conduct_no_mutations",
-    "type": "conduct",
-    "name": "Pure Blood",
-    "requirements": [ { "event_statistic": "num_gains_mutation", "is": "<=", "target": 0, "description": "No mutations" } ],
-    "hidden_by": [ "conduct_pure_human" ]
+    ]
   },
   {
     "id": "conduct_no_broken_bones",

--- a/data/json/recipes/practice/melee.json
+++ b/data/json/recipes/practice/melee.json
@@ -72,7 +72,7 @@
     "description": "Practice unarmed combat against a punching bag or a training dummy.",
     "skill_used": "unarmed",
     "time": "1 h",
-    "skills_required": [[ "melee", 1 ]],
+    "skills_required": [ [ "melee", 1 ] ],
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "unarmed", 2 ] ],
     "book_learn": [ [ "mag_unarmed", 1 ], [ "manual_brawl", 1 ] ],


### PR DESCRIPTION
#### Summary
Remove mutation conduct and achievement

#### Purpose of change
- The mutation conduct and achievement were tripping every single time anyone gained a trait, even if it wasn't a mutation.

#### Describe the solution
- You gain traits a lot, and they're often not actually mutations. There's no easy way to fix this and I don't care about that stuff, so they're just getting deleted. You still get cheevos for crossing the threshold.
- Remove a Harry Potter reference from the Reptilian threshold achievement and replace it with a Steven Universe reference.
- Change the Alpha achievement to a White Zombie reference. Yes I know it's technically a Blade Runner reference and Alphas aren't replicants, but shut up.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
