### PR TITLE
Scythes aren't brutal

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -475,7 +475,7 @@
     "material": [ "steel", "wood" ],
     "symbol": "/",
     "color": "light_gray",
-    "techniques": [ "WIDE", "BRUTAL" ],
+    "techniques": [ "WIDE", "SWEEP" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -22 ] ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND", "WALKING_AID" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -144,7 +144,7 @@
     "material": [ "steel", "wood" ],
     "symbol": "/",
     "color": "light_gray",
-    "techniques": [ "WIDE", "BRUTAL" ],
+    "techniques": [ "WIDE", "SWEEP" ],
     "qualities": [ [ "CUT", 1 ], [ "GRASS_CUT", 2 ], [ "BUTCHER", -22 ] ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],


### PR DESCRIPTION
#### Summary
Scythes aren't brutal

#### Purpose of change
Scythes and war scythes had brutal strike, which represents slamming someone so hard they go flying. That's not how scythes do.

#### Describe the solution
Remove brutal strike and give them sweep, which represents swishing their legs out from underneath with a wide attack. That's literally how scythes do.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
