### PR TITLE
Fix rot randomization

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7713,9 +7713,10 @@ void item::set_rot( time_duration val )
 void item::randomize_rot()
 {
     if( is_comestible() && get_comestible()->spoils > 0_turns ) {
-        time_duration loot_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
+        time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
                                     rng_float( 0.1, 1.2 );
-        set_rot( loot_adjust );
+        time_point birthday = calendar::fall_of_civilization - birthday_adjust;
+        set_birthday( birthday );
     } else if( is_corpse() ) {
         time_duration birthday_adjust = ( calendar::fall_of_civilization - calendar::start_of_cataclysm ) *
                                         rng_float( 0.0, 0.15 );


### PR DESCRIPTION
#### Summary
Fix rot randomization

#### Purpose of change
randomize_rot() was just adding 2 to 24 days to the rot timer of generated items. It wasn't actually properly setting their birthday.

#### Describe the solution
Change randomize_rot() to change the birthday of the item, not just add to its rot.

#### Describe alternatives you've considered
Rename randomize_rot() to randomize_birthday(). Meh.

#### Testing
Seems to work!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
