### PR TITLE
fix PIS

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -2035,6 +2035,7 @@
   },
   {
     "id": "UNBREAKABLE_MELEE",
+    "//": "This item cannot be damaged if used to make attacks or to block (as with a weapon).",
     "type": "json_flag"
   },
   {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1376,14 +1376,12 @@
     "material_thickness": 3,
     "flags": [
       "RAD_PROOF",
-      "PORTAL_PROOF",
       "STURDY",
       "WATERPROOF",
       "HYGROMETER",
       "THERMOMETER",
       "RAINPROOF",
-      "WATCH",
-      "ALARMCLOCK",
+      "GROUNDING",
       "SWIM_GOGGLES",
       "SUN_GLASSES",
       "NO_REPAIR",
@@ -1391,8 +1389,7 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE",
-      "UNBREAKABLE_MELEE"
+      "COMBAT_TOGGLEABLE"
     ],
     "relic_data": { "passive_effects": [ { "id": "ench_climate_control_all" } ] },
     "armor": [
@@ -1538,8 +1535,7 @@
       "PADDED",
       "USE_UPS",
       "NO_UNLOAD",
-      "COMBAT_TOGGLEABLE",
-      "UNBREAKABLE_MELEE"
+      "COMBAT_TOGGLEABLE"
     ]
   },
   {


### PR DESCRIPTION
#### Summary
fix PIS

#### Purpose of change
The phase immersion suit wasn't protecting from electricity when turned off. No power is needed to do this with IRL electrical protection clothing, so we can fix that.

#### Describe the solution
- Remove UNBREAKABLE_MELEE from the PIS. This was necessary at one point as people were punching holes in their suits, but it's now much harder to do that and the thing is made of like titanium so I think it's fine.
- Add GROUNDING while it's powered off.
- Remove some of the electronic functions while it's powered off, mainly PORTAL_PROOF.
- Add a comment to UNBREAKABLE_MELEE explaining what it does.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
