### PR TITLE
Bronze anvil fix

### DIFF
--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2568,7 +2568,7 @@
     "difficulty": 4,
     "time": "6 h",
     "autolearn": true,
-    "using": [ [ "forging_standard", 45 ], [ "metal_casting_large", 1 ], [ "metal_casting_large_improvised", 1 ] ],
+    "using": [ [ "forging_standard", 45 ], [ "metal_casting_large", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "scrap_bronze", 90 ] ] ]


### PR DESCRIPTION
#### Summary
Bronze anvil fix

#### Purpose of change
Bronze anvils required hammers and weren't using our casting tools, instead requiring a digging tool. I get the idea, but the game doesn't have a way to check if you're also in an area where you can dig a hole in the ground, so...

#### Describe the solution
Remove hammer requirement, use the casting tools instead. I also moved the fabrication requirement from 3 to 4. Melting a huge amount of metal and pouring it into a mold is simple...if you know what you're doing. 3 isn't gonna cut it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
