### PR TITLE
fix result of maid dress recipe

### DIFF
--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2047,7 +2047,8 @@
     "using": [ [ "tailoring_cotton", 8 ] ]
   },
   {
-    "result": "maid_dress_short",
+    "result": "dress_costume_skimpy",
+    "variant": "maid_dress",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",


### PR DESCRIPTION
#### Summary
The French maid outfit was migrated to "dress_costume_skimpy" in its variant form "maid_dress", but its recipe was not updated. So the only way to obtain one was to have one at chargen or to loot it in the world, even though the maid hat is craftable.

#### Purpose of change
Enable players to craft their own maid outfits

#### Describe the solution
Replace the result of the obsoleted "maid_dress_short" with "dress_costume_skimpy" in its variant form "maid_dress"

#### Describe alternatives you've considered
Adding a new recipe instead of replacing the result of the obsoleted one

#### Testing
Spawned in a new character, debug unlocked all recipes, maid outfit was there

#### Additional context
Test:
<img width="1270" height="975" alt="image" src="https://github.com/user-attachments/assets/699f50ef-97a3-4165-b6eb-a8df2167fd82" />

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/88a0e7dd38a7baf388894ba9cbedccef38240c14/data/json/obsoletion_and_migration/migration_items.json#L455
<img width="461" height="340" alt="image" src="https://github.com/user-attachments/assets/f830fa16-df17-491a-a0d0-a54554ac7881" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
