### PR TITLE
Backport bugfix npc wield message ( DDA 82931)

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1002,6 +1002,7 @@ void add_msg( const game_message_params &params, std::string msg )
     Messages::add_msg( params, std::move( msg ) );
 }
 
+// msg argument will not expand name place holders
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
     const map &here = get_map();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1542,7 +1542,8 @@ bool npc::wield( item &it )
         return false;
     }
     if( get_wielded_item() ) {
-        add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
+        // add_msg_if_player_sees does no internal npc name replacement
+        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
                                 get_wielded_item()->tname() );
     }
 
@@ -1556,8 +1557,11 @@ bool npc::wield( item_location loc, bool remove_old )
     if( !Character::wield( std::move( loc ), remove_old ) ) {
         return false;
     }
-    add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
-                            get_wielded_item()->tname() );
+    if( get_wielded_item() ) {
+        // add_msg_if_player_sees does no internal npc name replacement
+        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
+                                get_wielded_item()->tname() );
+    }
 
     invalidate_range_cache();
     return true;


### PR DESCRIPTION
#### Summary
Backport bugfix npc wield message ( DDA 82931)

#### Purpose of change
Fix <npcname> wields X

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
