### PR TITLE
Add hemovore flag to bloodfeeder

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7403,7 +7403,7 @@
     "mixed_effect": true,
     "description": "Your craving for blood borders on obsession.  You need the stuff too much to care about whether it came from a human, and your body can filter out most of the toxins in mutant blood.",
     "types": [ "DIET" ],
-    "flags": [ "BLOODFEEDER" ],
+    "flags": [ "BLOODFEEDER", "HEMOVORE" ],
     "cancels": [ "VEGAN" ],
     "prereqs": [ "HEMOVORE" ],
     "vitamins_absorb_multi": [ [ "blood", [ [ "mutant_toxin", 0.25 ] ] ], [ "flesh", [ [ "mutant_toxin", 0.75 ] ] ] ],


### PR DESCRIPTION
#### Summary
Add hemovore flag to bloodfeeder

#### Purpose of change
Some code was written assuming bloodfeeder had the HEMOVORE flag. It didn't.

#### Describe the solution
Now it does.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
