### PR TITLE
Backport 82580 - Make stale data warnings optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
       - name: Build CTLG (linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
-          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} PCH=0 bindist
+          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysm-tlg-1.0.tar.gz ctlg-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build Ctlg (WebAssembly)
         if: matrix.wasm
@@ -284,7 +284,7 @@ jobs:
         env:
           PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc12-
         run: |
-          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} PCH=0 bindist
+          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysm-tlg-1.0.zip ctlg-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build Ctlg (windows msvc)
         if: runner.os == 'Windows'
@@ -300,7 +300,7 @@ jobs:
       - name: Build Ctlg (osx)
         if: runner.os == 'macOS'
         run: |
-          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 dmgdist
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg ctlg-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
         if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,11 @@ SRC_DIR = src
 LOCALIZE = 1
 ASTYLE_BINARY = astyle
 
+# Disable stale game data warning by default
+ifndef WARN_STALE_DATA
+    WARN_STALE_DATA = 0
+endif
+
 # Enable debug by default
 ifndef RELEASE
   RELEASE = 0
@@ -334,6 +339,10 @@ endif
 
 ifeq ($(STRING_ID_DEBUG), 1)
 	DEFINES += -DCATA_STRING_ID_DEBUGGING
+endif
+
+ifeq ($(WARN_STALE_DATA), 0)
+    DEFINES += -DNO_STALE_DATA_WARN
 endif
 
 # This sets CXX and so must be up here

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -326,6 +326,7 @@ class flexbuffer_disk_cache
 
             // Does the source file's mtime match what we cached previously
             if( source_mtime != disk_entry->second.mtime ) {
+#ifndef NO_STALE_DATA_WARN
                 std::string filepath_and_name = disk_entry->first;
                 // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those. Same for achievements.
                 bool stale_game_data = *root_relative_source_path.begin() != std::filesystem::u8path( "config" ) &&
@@ -341,6 +342,7 @@ class flexbuffer_disk_cache
                                                       filepath_and_name;
                     }
                 }
+#endif
                 // Cached flexbuffer on disk is out of date, remove it.
                 remove_file( disk_entry->second.flexbuffer_path.u8string() );
                 cached_flexbuffers_.erase( disk_entry );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2862,11 +2862,13 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+#ifndef NO_STALE_DATA_WARN
     add( "WARN_ON_MODIFIED", "debug", to_translation( "Warn if file integrity check fails" ),
          to_translation( "This option controls whether the game will warn when it detects that the game's data has been modified." ),
          true );
 
     add_empty_line();
+#endif
 
     add( "SKIP_VERIFICATION", "debug", to_translation( "Skip verification step during loading" ),
          to_translation( "If enabled, this skips the JSON verification step during loading.  This may give a faster loading time, but risks JSON errors not being caught until runtime." ),


### PR DESCRIPTION
#### Summary
Backport 82580 - Make stale data warnings optional

#### Purpose of change
The stale data warning thing is good, but it was annoying on my end because it was yelling at me whenever I changed anything.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
