### PR TITLE
Tentatively re-enable NPC needs

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -88,7 +88,7 @@
     "name": "NO_NPC_FOOD",
     "info": "Disables tracking food, thirst and ( partially ) fatigue for NPCs.  If true, NPCs won't need to eat or drink and will only get tired enough to sleep, not to get penalties.",
     "stype": "bool",
-    "value": true
+    "value": false
   },
   {
     "type": "EXTERNAL_OPTION",


### PR DESCRIPTION
#### Summary
Tentatively re-enable NPC needs

#### Purpose of change
I was originally going to leave NPC needs off in TLG, but I'm pretty impressed with how painless the system's become in DDA. Ours is still a bit simpler, but all the pieces are there so why not give it a whirl.

#### Describe the solution
true -> false

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
