### PR TITLE
Nerf bone broth

### DIFF
--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -6,7 +6,7 @@
     "name": { "str_sp": "vegetable broth" },
     "weight": "253 g",
     "color": "yellow",
-    "spoils_in": "6 days 16 hours",
+    "spoils_in": "3 days 12 hours",
     "container": "can_medium",
     "comestible_type": "DRINK",
     "symbol": "~",
@@ -20,7 +20,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT" ],
-    "fun": 1,
+    "fun": 2,
     "vitamins": [ [ "vegetable_allergen", 1 ] ]
   },
   {
@@ -29,12 +29,11 @@
     "looks_like": "water",
     "name": { "str_sp": "meat broth" },
     "conditional_names": [
-      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "human %s" } },
-      { "type": "FLAG", "condition": "STRICT_HUMANITARIANISM", "name": { "str_sp": "demihuman %s" } }
+      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "human %s" } }
     ],
     "weight": "253 g",
     "color": "yellow",
-    "spoils_in": "6 days 16 hours",
+    "spoils_in": "3 days 12 hours",
     "container": "can_medium",
     "comestible_type": "DRINK",
     "symbol": "~",
@@ -48,7 +47,7 @@
     "charges": 2,
     "phase": "liquid",
     "flags": [ "EATEN_HOT" ],
-    "fun": 1,
+    "fun": 2,
     "vitamins": [ [ "vitC", "1 mg" ], [ "iron", "1 mg" ], [ "calcium", "19 mg" ], [ "meat_allergen", 1 ] ]
   },
   {
@@ -57,11 +56,11 @@
     "looks_like": "broth",
     "name": { "str_sp": "bone broth" },
     "conditional_names": [
-      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "human %s" } },
+      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "human %s" } }
     ],
     "weight": "253 g",
     "color": "yellow",
-    "spoils_in": "6 days 16 hours",
+    "spoils_in": "3 days 12 hours",
     "container": "can_medium",
     "comestible_type": "DRINK",
     "symbol": "~",
@@ -101,7 +100,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "vegetable_allergen", 1 ] ],
-    "fun": 1
+    "fun": 3
   },
   {
     "type": "COMESTIBLE",
@@ -125,7 +124,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "vegetable_allergen", 1 ] ],
-    "fun": 2
+    "fun": 4
   },
   {
     "type": "COMESTIBLE",
@@ -154,7 +153,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 36 ], [ "calcium", 3 ], [ "iron", 13 ], [ "meat_allergen", 1 ] ],
-    "fun": 1
+    "fun": 4
   },
   {
     "type": "COMESTIBLE",
@@ -227,7 +226,7 @@
     "charges": 1,
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 30 ], [ "calcium", 5 ], [ "iron", 28 ], [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ],
-    "fun": 8
+    "fun": 6
   },
   {
     "type": "COMESTIBLE",
@@ -252,7 +251,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 9 ], [ "iron", 3 ], [ "meat_allergen", 1 ], [ "vegetable_allergen", 1 ] ],
-    "fun": 1
+    "fun": 2
   },
   {
     "type": "COMESTIBLE",
@@ -277,7 +276,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 9 ], [ "iron", 3 ], [ "vegetable_allergen", 1 ], [ "egg_allergen", 1 ] ],
-    "fun": 1
+    "fun": 2
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION
#### Summary
Nerf bone broth

#### Purpose of change
Bone broth was pretty wacky, with almost 50 kcal per serving, 10 enjoyability, and a week-long spoil timer. On review, a bunch of soups had weird enjoyability values.

#### Describe the solution
- Nerf it to 5 kcal since it's literally just 2 cups of boiled bone water and there's no guarantee that these are fresh bones.
- Reduce the spoil timer on broths. These things get moldy pretty fast.
- Normalize all soup spoilage. Most were way too long and the instant soups went bad very fast once prepared (??)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
