### PR TITLE
Blankets cover wings

### DIFF
--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -326,7 +326,7 @@
         ],
         "encumbrance": 45,
         "coverage": 90,
-        "covers": [ "torso", "arm_l", "arm_r" ]
+        "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ]
       },
       {
         "material": [

--- a/data/json/items/generic/bedding.json
+++ b/data/json/items/generic/bedding.json
@@ -64,7 +64,7 @@
     "material_thickness": 0.1,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 15, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 15, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 15,
         "coverage": 90,
@@ -92,7 +92,7 @@
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 35, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 35, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 35,
         "coverage": 90,
@@ -120,7 +120,7 @@
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 45, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 45, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 45,
         "coverage": 90,
@@ -148,7 +148,7 @@
     "environmental_protection": 1,
     "flags": [ "OVERSIZE", "BELTED", "RAINPROOF", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 55, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 55, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 55,
         "coverage": 90,
@@ -175,7 +175,7 @@
     "environmental_protection": 2,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 40, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 40, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 40,
         "coverage": 90,
@@ -194,7 +194,7 @@
     "warmth": 70,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 50, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 50, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 50,
         "coverage": 90,
@@ -221,7 +221,7 @@
     "environmental_protection": 1,
     "material_thickness": 0.1,
     "armor": [
-      { "encumbrance": 30, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 30, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 30,
         "coverage": 90,
@@ -247,7 +247,7 @@
     "warmth": 80,
     "material_thickness": 3,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "BELTED" ],
+    "flags": [ "OVERSIZE", "BELTED", "COLLAR", "POCKETS", "HOOD" ],
     "use_action": {
       "menu_text": "Roll up",
       "type": "transform",
@@ -258,7 +258,12 @@
       {
         "encumbrance": 80,
         "coverage": 100,
-        "covers": [ "torso", "head", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r" ]
+      },
+      {
+        "encumbrance": 60,
+        "coverage": 80,
+        "covers": [ "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ]
       }
     ]
   },
@@ -278,12 +283,17 @@
     "warmth": 30,
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "OVERSIZE", "BELTED", "SOFT" ],
+    "flags": [ "OVERSIZE", "BELTED", "SOFT", "COLLAR", "POCKETS", "HOOD" ],
     "armor": [
       {
         "encumbrance": 80,
         "coverage": 100,
-        "covers": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+        "covers": [ "torso", "leg_l", "leg_r", "foot_l", "foot_r" ]
+      },
+      {
+        "encumbrance": 60,
+        "coverage": 80,
+        "covers": [ "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ]
       }
     ]
   },
@@ -305,10 +315,10 @@
     "material_thickness": 0.2,
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 15, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 15, "coverage": 80, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 15,
-        "coverage": 90,
+        "coverage": 80,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ]
       }
@@ -332,7 +342,7 @@
     "material_thickness": 0.4,
     "flags": [ "OVERSIZE", "BELTED", "RAINPROOF", "ALLOWS_NATURAL_ATTACKS", "HOOD", "COLLAR", "POCKETS" ],
     "armor": [
-      { "encumbrance": 30, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] },
+      { "encumbrance": 30, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
         "encumbrance": 30,
         "coverage": 90,


### PR DESCRIPTION
#### Summary
Blankets cover wings

#### Purpose of change
Blankets weren't covering wings, making it hard for birds and bats to keep warm.

#### Describe the solution
- Now they do.
- Sleeping bags also work, and sleeping bag coverage has been made a bit less silly in general.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
