### PR TITLE
No NPC thirst or sleep deprivation

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5043,7 +5043,7 @@ int Character::get_instant_thirst() const
 
 void Character::mod_thirst( int nthirst )
 {
-    if( has_flag( json_flag_NO_THIRST ) || !needs_food() ) {
+    if( has_flag( json_flag_NO_THIRST ) || !needs_food() || !is_avatar() ) {
         return;
     }
     set_thirst( std::max( -100, thirst + nthirst ) );
@@ -5535,9 +5535,9 @@ void Character::update_needs( int rate_multiplier )
                 mod_sleep_deprivation( fatigue_roll * 5 );
             }
 
-            if( !needs_food() && get_fatigue() > fatigue_levels::TIRED ) {
-                set_fatigue( fatigue_levels::TIRED );
+            if( ( !is_avatar() || !needs_food() ) && get_fatigue() > fatigue_levels::TIRED ) {
                 set_sleep_deprivation( 0 );
+                set_fatigue( fatigue_levels::TIRED );
             }
         }
     } else if( asleep ) {
@@ -5862,7 +5862,7 @@ void Character::check_needs_extremes()
     }
 
     // Check if we're dying of thirst
-    if( needs_food() && get_thirst() >= 600 && ( stomach.get_water() == 0_ml ||
+    if( ( needs_food() && is_avatar() ) && get_thirst() >= 600 && ( stomach.get_water() == 0_ml ||
             guts.get_water() == 0_ml ) ) {
         if( get_thirst() >= 1200 ) {
             add_msg_if_player( m_bad, _( "You have died of dehydration." ) );


### PR DESCRIPTION
#### Summary
No NPC thirst or sleep deprivation

#### Purpose of change
- Thirst is something that needs a lot of babysitting even for the player. It is an extra annoying chore for NPCs.
- NPCs aren't smart about getting water on their own.
- NPCs should need sleep, but if you're not on top of them about it they shouldn't be dead on their feet all the time.

#### Describe the solution
- Do not accumulate thirst for any character who is not currently the avatar. If you switch characters, your previous character will remain as thirst as you let them, and will drink if you give them something, but they won't get thirstier.
- If any character who is not the avatar is very sleepy, reset all their sleep deprivation and set them back to just being sleepy. There's a potential exploit here where you could burn off sleep deprivation by switching characters, but it's not really a super useful thing to do as you're still tired.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
