### PR TITLE
Backport 83305: Cap multiplication factor in NPC weapon evaluation.

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4124,7 +4124,7 @@ item *npc::evaluate_best_weapon() const
     double best_value = evaluate_weapon( weap, can_use_gun, use_silent );
 
     // To prevent changing to barely better stuff
-    best_value *= std::max<float>( 1.0f, ai_cache.danger_assessment / 10.0f );
+    best_value *= std::max<float>( 1.0f, std::min<float>( 2.0, ai_cache.danger_assessment / 10.0f ) );
 
     // Fists aren't checked below
     double fist_value = evaluate_weapon( null_item_reference(), can_use_gun, use_silent );


### PR DESCRIPTION
#### Summary
Backport 83305: Cap multiplication factor in NPC weapon evaluation.

#### Purpose of change
There were some math issues with how NPC weapon selection was working, The basic method is just wrong - NPCs are refusing to switch to a better weapon if their enemy is too strong, which almost makes sense but not really - but this PR helps a lot with this and is a quick/easy fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
