### PR TITLE
Fix liquid fields in vehicles

### DIFF
--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1499,9 +1499,10 @@ void map::player_in_field( Character &you )
         // Do things based on what fields we are currently in.
         const field_type_id ft = cur.get_field_type();
 
-        // Cast spells. Skip if we're in a vehicle or on a mount (though the mount itself is not safe!), unless the field is a gas.
-        if( ft->spell_data.id != spell_id::NULL_ID() && ( !you.in_vehicle && !you.is_mounted() &&
-                ft.obj().phase != phase_id::GAS ) ) {
+        // Cast spells. Skip if the field is liquid and we're not touching the ground (safer if enclosed), or if we're inside and it's a gas.
+        if( ft->spell_data.id != spell_id::NULL_ID() &&
+            !( ( ( ft.obj().phase == phase_id::LIQUID ) && ( ( !inside && ( !you.in_vehicle || one_in( 2 ) ) ) )
+               ) || ( inside && ft.obj().phase == phase_id::GAS ) ) ) {
             map &here = get_map();
             here.cast_field_spell( you.pos_bub(), you, cur );
             you.check_dead_state( &here );


### PR DESCRIPTION
#### Summary
Fix liquid fields in vehicles

#### Purpose of change
Spellcasting liquid fields (acid, mostly) were incorrectly affecting the player when they were in a vehicle.

#### Describe the solution
You have a 50% chance to avoid the effect if you're in any vehicle, 100% if you're in an enclosed vehicle.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
