### PR TITLE
Remove bad monster reference from sky island

### DIFF
--- a/data/mods/Sky_Island/monstergroups.json
+++ b/data/mods/Sky_Island/monstergroups.json
@@ -68,7 +68,6 @@
       { "monster": "mon_dog_zombie_brute", "weight": 25 },
       { "monster": "mon_zombie_dog_acidic", "weight": 15 },
       { "monster": "mon_zombie_swat", "weight": 20 },
-      { "monster": "mon_zombie_skull", "weight": 10 },
       { "monster": "mon_zpig_brute", "weight": 5 },
       { "monster": "mon_zombie_biter", "weight": 15 },
       { "monster": "mon_zombie_soldier", "weight": 50 },


### PR DESCRIPTION
#### Summary
Remove bad monster reference from sky island

#### Purpose of change
Sky Island had a skull zombie in one of its monstergroups. That enemy has been removed, so


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
