### PR TITLE
Slightly weaken roofs

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -110,7 +110,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -122,7 +122,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -134,7 +134,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -146,7 +146,7 @@
     "color": "yellow",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 20, "str_max": 60, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -158,7 +158,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -170,7 +170,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "FLAMMABLE_HARD" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 35, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -307,7 +307,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 40, "str_max": 150, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -319,7 +319,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 45, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -331,7 +331,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 200, "str_max": 500, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -343,7 +343,7 @@
     "color": "red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 200, "str_max": 500, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -355,7 +355,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 120, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -366,7 +366,7 @@
     "color": "red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 48, "str_max": 80, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 48, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
#### Summary
Slightly weaken roofs

#### Purpose of change
Roofs had a ton of bash resist, meaning they would basically never get damaged by explosives. They're not structurally super durable irl as they only really need to stand up to the weather.

#### Describe the solution
Reduce the str_min and max on their bash.

#### Describe alternatives you've considered
Reduce them more.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
