### PR TITLE
Rename second intestinal fortitude trait

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4422,7 +4422,7 @@
   {
     "type": "mutation",
     "id": "EATPOISON_WEAK",
-    "name": { "str": "Intestinal Fortitude" },
+    "name": { "str": "Obligate Digestion" },
     "points": 2,
     "description": "While it is by no means pleasant, your body has adapted to handle the toxic contaminants in mutant meat a little better.  You can eat a bit more of the stuff before suffering ill effects.",
     "types": [ "CONSTITUTION" ],


### PR DESCRIPTION
#### Summary
Rename second intestinal fortitude trait

#### Purpose of change
There were two traits called intestinal fortitude, one of them was only 1/3 as good as the other. That's confusing.

#### Describe the solution
The weaker (newer) Intestinal Fortitude has been renamed to Obligate Digestion.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
