### PR TITLE
Smartphone Recovery Typo

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -74,7 +74,7 @@
         "title": "Pick the recovery type",
         "descriptions": [
           "Reset the smartphone completely, erasing all the data inside, but allowing to use it without restrictions.",
-          "Use your computer knowledge, computer, and hackPRO, to bypass the restrictions while preserving the data inside.  Requires computer skill 4, copy fo hackPRO, and laptop with at least 10 charges."
+          "Use your computer knowledge, computer, and hackPRO, to bypass the restrictions while preserving the data inside.  Requires computer skill 4, copy of hackPRO, and laptop with at least 10 charges."
         ]
       }
     ]


### PR DESCRIPTION
Fixes a typo for smartphone recovery.

#### Summary
Just fixes a typo when recovering smartphones 

#### Purpose of change
Typo fix

#### Describe the solution
Correct typo

#### Describe alternatives you've considered
None

#### Testing
Runs without error. Typo fixed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
