### PR TITLE
Less pens in offices

### DIFF
--- a/data/json/itemgroups/SUS/office.json
+++ b/data/json/itemgroups/SUS/office.json
@@ -13,7 +13,7 @@
       { "item": "battery_charger", "prob": 80 },
       { "item": "file", "count": [ 1, 8 ], "prob": 50 },
       { "item": "paper", "count": [ 2, 9 ], "prob": 60 },
-      { "group": "pens", "count": [ 1, 10 ], "prob": 95, "charges": [ 0, 100 ] },
+      { "group": "pens", "count": [ 1, 3 ], "prob": 70, "charges": [ 0, 100 ] },
       { "item": "book_binder", "prob": 90 },
       { "item": "stapler", "prob": 60 },
       { "item": "office_holepunch", "prob": 35 },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -5945,14 +5945,6 @@
     "components": [ [ [ "human_meat_scrap", 10 ] ] ]
   },
   {
-    "result": "demihuman_flesh",
-    "type": "uncraft",
-    "activity_level": "NO_EXERCISE",
-    "time": "20 s",
-    "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "demihuman_meat_scrap", 10 ] ] ]
-  },
-  {
     "result": "mutant_meat",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
@@ -5966,7 +5958,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "cotton_patchwork", 4 ] ], [ [ "zipper_short_plastic", 1 ] ] ]
+    "components": [ [ [ "nylon", 2 ] ], [ [ "zipper_short_plastic", 1 ] ] ]
   },
   {
     "result": "scissors_medical",


### PR DESCRIPTION
#### Summary
Less pens in offices

#### Purpose of change
- Too many pens!

#### Describe the solution
- Fewer pens.
- The pencil case is now made of nylon.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
