### PR TITLE
Fix mutant toxin in mutant frog eggs

### DIFF
--- a/data/json/items/comestibles/egg.json
+++ b/data/json/items/comestibles/egg.json
@@ -1265,7 +1265,7 @@
     "price": "50 cent",
     "price_postapoc": "1 USD",
     "fun": -30,
-    "vitamins": [ [ "iron", 29 ], [ "toxin", 38 ] ],
+    "vitamins": [ [ "iron", 29 ], [ "mutant_toxin", 38 ] ],
     "rot_spawn": { "group": "GROUP_EGG_MUTANT_FROG", "chance": 20 }
   }
 ]


### PR DESCRIPTION
#### Summary
Fix mutant toxin in mutant frog eggs

#### Purpose of change
Mutant frog eggs had "toxin" and not "mutant_toxin", resulting in an error message.

#### Describe the solution
Fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
