### PR TITLE
Remove hardcoded STRICT_HUMANITARIAN stuff

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -123,7 +123,6 @@ static const json_character_flag json_flag_PRED4( "PRED4" );
 static const json_character_flag json_flag_PSYCHOPATH( "PSYCHOPATH" );
 static const json_character_flag json_flag_SAPIOVORE( "SAPIOVORE" );
 static const json_character_flag json_flag_SPIRITUAL( "SPIRITUAL" );
-static const json_character_flag json_flag_STRICT_HUMANITARIAN( "STRICT_HUMANITARIAN" );
 
 static const material_id material_alcohol( "alcohol" );
 static const material_id material_all( "all" );
@@ -1383,9 +1382,7 @@ void Character::modify_morale( item &food, const int nutr )
         }
     }
 
-    const bool food_is_human_flesh = food.has_vitamin( vitamin_human_flesh_vitamin ) ||
-                                     ( food.has_flag( flag_STRICT_HUMANITARIANISM ) &&
-                                       !has_flag( json_flag_STRICT_HUMANITARIAN ) );
+    const bool food_is_human_flesh = food.has_vitamin( vitamin_human_flesh_vitamin );
     if( food_is_human_flesh ) {
         // Sapiovores don't recognize humans as the same species, and are totally fine with it.
         // For everyone else, there are two factors: One is that it's gross, the other is that it's immoral.

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -332,7 +332,6 @@ const flag_id flag_SPEEDLOADER_CLIP( "SPEEDLOADER_CLIP" );
 const flag_id flag_SPLINT( "SPLINT" );
 const flag_id flag_STAB( "STAB" );
 const flag_id flag_STAB_IMMUNE( "STAB_IMMUNE" );
-const flag_id flag_STRICT_HUMANITARIANISM( "STRICT_HUMANITARIANISM" );
 const flag_id flag_STR_DRAW( "STR_DRAW" );
 const flag_id flag_STR_RELOAD( "STR_RELOAD" );
 const flag_id flag_STURDY( "STURDY" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -335,7 +335,6 @@ extern const flag_id flag_SPEEDLOADER_CLIP;
 extern const flag_id flag_SPLINT;
 extern const flag_id flag_STAB;
 extern const flag_id flag_STAB_IMMUNE;
-extern const flag_id flag_STRICT_HUMANITARIANISM;
 extern const flag_id flag_STR_DRAW;
 extern const flag_id flag_STR_RELOAD;
 extern const flag_id flag_STURDY;


### PR DESCRIPTION
#### Summary
Remove hardcoded STRICT_HUMANITARIAN stuff

#### Purpose of change
There was some stuff left over in consumption.cpp

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
