### PR TITLE
Rapid Metabolism Typo and Nail Punch Recipe Update

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6856,7 +6856,7 @@
     "id": "MET_RAT",
     "name": { "str": "Rapid Metabolism" },
     "points": 0,
-    "description": "You require more food than most, but you recover stamina and heal from qounds more quickly.",
+    "description": "You require more food than most, but you recover stamina and heal from wounds more quickly.",
     "types": [ "HEALING", "METABOLISM" ],
     "prereqs": [ "HUNGER" ],
     "prereqs2": [ "SLEEPY" ],

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -120,7 +120,7 @@
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "stick", 1 ], [ "2x4", 1 ] ], [ [ "nails", 1, "LIST" ], [ "crude_bronze_nail", 1 ] ] ]
+    "components": [ [ [ "stick", 2 ] ], [ [ "nails", 1, "LIST" ], [ "crude_bronze_nail", 1 ] ], [ [ "cordage_36", 1 ], [ "string_36", 1 ], [ "cordage_36_leather", 1 ] ] ]
   },
   {
     "result": "shed_stick",


### PR DESCRIPTION
Fixes a typo in rapid metabolism and updates the recipe for the nail punch.

#### Summary
Fixes a typo in the rapid metabolism mutation and updates the nail punch recipe to be more accurate. 

#### Purpose of change
There was a typo in rapid metabolism.

A nail punch is described as "Two pieces of wood with a steel nail secured between them with some cordage.  Usually used in flintknapping for indirect percussion and pressure flaking."

However the recipe called for just a single plank/stick and a nail.

#### Describe the solution
I've updated the recipe to require two sticks, any nail, and a piece of long string/ long cordage 

#### Describe alternatives you've considered
None.

#### Testing
Runs fine and without error. 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
