### PR TITLE
Fix carry weight not updating

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7486,8 +7486,8 @@ void longsalvage_activity_actor::start( player_activity &act, Character & )
 {
     act.index = index;
 
-    //todo: refactor the actor to process items in ::do_turn, then remove setting the moves to 0
-    //this currently still can't get interrupted before you get attacked
+    // todo: refactor the actor to process items in ::do_turn, then remove setting the moves to 0
+    // this currently still can't get interrupted before you get attacked
     act.moves_left = 0;
 }
 

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1247,7 +1247,7 @@ bool advanced_inventory::move_all_items()
                                              relative_destination );
         player_character.assign_activity( act );
     }
-
+    player_character.invalidate_inventory();
     return true;
 }
 

--- a/src/character.h
+++ b/src/character.h
@@ -2446,7 +2446,7 @@ class Character : public Creature, public visitable
         void clear_inventory_search_cache();
 
         void drop_invalid_inventory();
-        // this cache is for checking if items in the character's inventory can't actually fit into other items they are inside of
+        // this cache is for checking if items in the character's inventory can't actually fit into other items they are inside of.
         void invalidate_inventory_validity_cache();
 
         void invalidate_weight_carried_cache();
@@ -3587,6 +3587,11 @@ class Character : public Creature, public visitable
                                              const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
                                              int radius = PICKUP_RANGE, bool clear_path = true ) const;
         void invalidate_crafting_inventory();
+
+        /** Simply runs all the cache-invalidating functions at once to make sure the character's
+         * weight and crafting cache and stuff are all updated. Use whenever a function updates
+         * what a character is carrying or wearing. */
+        void invalidate_inventory();
 
         /** Some of the worst code I have ever written. Gins up a modifier to
          * fine_detail_vision_mod() which lets people with night vision mutations

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -705,7 +705,7 @@ void Character::drop_invalid_inventory()
         }
     }
     if( dropped_liquid ) {
-        add_msg_if_player( m_bad, _( "Liquid from your inventory has leaked onto the ground." ) );
+        add_msg_if_player( m_bad, _( "Liquid you were carrying has been spilled." ) );
     }
 
     item_location weap = get_wielded_item();

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -711,6 +711,7 @@ void Character::invalidate_crafting_inventory()
 {
     crafting_cache.valid = false;
     crafting_cache.crafting_inventory->clear();
+    invalidate_weight_carried_cache();
 }
 
 void Character::make_craft( const recipe_id &id_to_make, int batch_size,

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4817,7 +4817,7 @@ static void reload_furniture( Character &you, const tripoint_bub_ms &examp, bool
 
     add_msg( _( "You reload the %s." ), here.furnname( examp ) );
 
-    you.invalidate_crafting_inventory();
+    you.invalidate_inventory();
 }
 
 void iexamine::reload_furniture( Character &you, const tripoint_bub_ms &examp )
@@ -5083,7 +5083,6 @@ bool iexamine::toPumpFuel( const tripoint_bub_ms &src, const tripoint_bub_ms &ds
             if( item_it->charges < 1 ) {
                 items.erase( item_it );
             }
-
             return true;
         }
     }
@@ -5830,7 +5829,7 @@ void iexamine::autodoc( Character &you, const tripoint_bub_ms &examp )
                     for( const auto &e : req_anesth.get_tools() ) {
                         you.consume_tools( e );
                     }
-                    you.invalidate_crafting_inventory();
+                    you.invalidate_inventory();
                 }
                 installer.mod_moves( -to_moves<int>( 1_minutes ) );
 
@@ -6569,6 +6568,7 @@ static void smoker_load_food( Character &you, const tripoint_bub_ms &examp,
             original->charges -= copy.charges;
         }
     }
+    you.invalidate_inventory();
 }
 
 static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
@@ -6706,7 +6706,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
         add_msg( m_info, _( "You carefully place %1$d %2$s in the mill." ), m.count(),
                  m.tname( m.count() ) );
     }
-    you.invalidate_crafting_inventory();
+    you.invalidate_inventory();
 }
 
 void iexamine::on_smoke_out( const tripoint_bub_ms &examp, const time_point &start_time )


### PR DESCRIPTION
#### Summary
Fix carry weight not updating

#### Purpose of change
Carry weight wasn't being updated during some AIM actions or when adding food to a charcoal kiln. This is because the functions to invalidate the cached values had to be manually run, and didn't automatically happen whenever inventory was edited.

#### Describe the solution
Create a function that invalidates the inventory validity, weight carried, leak level, and crafting inventory caches, and run it in a bunch of functions that modify the character's inventory. I am certain some have been missed, but this at least fixes a couple of the cases we were seeing.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
