### PR TITLE
Remove "hold the line" rule

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -434,15 +434,6 @@
         "topic": "TALK_COMBAT_COMMANDS",
         "effect": { "toggle_npc_rule": "avoid_friendly_fire" }
       },
-      {
-        "truefalsetext": {
-          "condition": { "npc_rule": "hold_the_line" },
-          "true": "Move wherever you need to go to fight an enemy.",
-          "false": "Hold the line: don't move onto obstacles adjacent to me."
-        },
-        "topic": "TALK_COMBAT_COMMANDS",
-        "effect": { "toggle_npc_rule": "hold_the_line" }
-      },
       { "text": "Never mind.", "topic": "TALK_NONE" }
     ]
   },

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -2274,11 +2274,6 @@
   },
   {
     "type": "snippet",
-    "category": "<ally_rule_hold_the_line_true_text>",
-    "text": "<mypronoun> will hold the line by not moving into doorways or obstructions adjacent to you."
-  },
-  {
-    "type": "snippet",
     "category": "<ally_rule_hold_the_line_false_text>",
     "text": "<mypronoun> will move freely to attack enemies."
   },

--- a/data/json/npcs/talk_tags_chat.json
+++ b/data/json/npcs/talk_tags_chat.json
@@ -4,7 +4,7 @@
     "category": "<chitchat_prefix_booze>",
     "//": "Used when chit-chatting while the avatar has a beer; goes before a general chitchat message",
     "text": [
-      "Yeah sure, want to crack open one of them beers?",
+      "Yeah sure, want to crack open one of those beers?",
       "Oh definitely, how about one of those beers you got?",
       "Yeah you share those beers I see you hoarding and then we chat all you like!  Only joking, heh.",
       "Hey <name_g>, I bet a chat would be all the sweeter with a nice, cold beer in hand.",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3588,11 +3588,6 @@ std::function<bool( const tripoint_bub_ms & )> npc::get_path_avoid() const
         if( here.is_open_air( p ) ) {
             return true;
         }
-        if( rules.has_flag( ally_rule::hold_the_line ) &&
-            ( here.close_door( p, true, true ) ||
-              here.move_cost( p ) > 2 ) ) {
-            return true;
-        }
         if( sees_dangerous_field( p ) ) {
             return true;
         }
@@ -3875,7 +3870,6 @@ npc_follower_rules::npc_follower_rules()
     set_flag( ally_rule::close_doors );
     set_flag( ally_rule::follow_close );
     clear_flag( ally_rule::avoid_doors );
-    clear_flag( ally_rule::hold_the_line );
     set_flag( ally_rule::ignore_noise );
     clear_flag( ally_rule::forbid_engage );
     clear_flag( ally_rule::follow_distance_2 );
@@ -3973,12 +3967,10 @@ void npc_follower_rules::set_danger_overrides()
     override_enable = ally_rule::DEFAULT;
     set_override( ally_rule::follow_close );
     set_override( ally_rule::avoid_doors );
-    set_override( ally_rule::hold_the_line );
     enable_override( ally_rule::follow_close );
     enable_override( ally_rule::allow_sleep );
     enable_override( ally_rule::close_doors );
     enable_override( ally_rule::avoid_doors );
-    enable_override( ally_rule::hold_the_line );
 }
 
 void npc_follower_rules::clear_overrides()

--- a/src/npc.h
+++ b/src/npc.h
@@ -326,12 +326,11 @@ enum class ally_rule : int {
     close_doors = 512,
     follow_close = 1024,
     avoid_doors = 2048,
-    hold_the_line = 4096,
-    ignore_noise = 8192,
-    forbid_engage = 16384,
-    follow_distance_2 = 32768,
-    lock_doors = 65536,
-    avoid_locks = 131072
+    ignore_noise = 4096,
+    forbid_engage = 8192,
+    follow_distance_2 = 16384,
+    lock_doors = 32768,
+    avoid_locks = 65536
 };
 
 struct ally_rule_data {
@@ -437,13 +436,6 @@ const std::unordered_map<std::string, ally_rule_data> ally_rule_strs = { {
                 ally_rule::avoid_locks,
                 "<ally_rule_avoid_locks_true_text>",
                 "<ally_rule_avoid_locks_false_text>"
-            }
-        },
-        {
-            "hold_the_line", {
-                ally_rule::hold_the_line,
-                "<ally_rule_hold_the_line_true_text>",
-                "<ally_rule_hold_the_line_false_text>"
             }
         },
         {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -828,7 +828,7 @@ static void npc_temp_orders_menu( const std::vector<npc *> &npc_list )
         nmenu.addentry( NPC_CHAT_NO_GUNS, true, 'g', guy->rules.has_override_enable( ally_rule::use_guns ) ?
                         _( "Use whatever weapon you normally would" ) : _( "Don't use ranged weapons for a while" ) );
         nmenu.addentry( NPC_CHAT_PULP, true, 'p', guy->rules.has_override_enable( ally_rule::allow_pulp ) ?
-                        _( "Pulp zombies if you like" ) : _( "Hold off on pulping zombies for a while" ) );
+                        _( "Pulp zombies if you like" ) : _( "Hold off on pulping corpses for a while" ) );
         nmenu.addentry( NPC_CHAT_AVOID_DOORS, true, 'w',
                         guy->rules.has_override_enable( ally_rule::avoid_doors ) ?
                         _( "Open doors to get where you're going" ) : _( "Don't walk through closed doors" ) );


### PR DESCRIPTION
#### Summary
Remove "hold the line" rule

#### Purpose of change
NPCs are confusing to control. They have too many rules, and they're missing rules they really ought to have. "Hold the line" is an obscure rule that doesn't really make a ton of sense, and it's been a frequent source of confusion.

#### Describe the solution
Remove it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
