### PR TITLE
Add NPC healing rules

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -362,16 +362,6 @@
             }
           ]
         },
-        {
-          "concatenate": [
-            { "npc_override": "hold_the_line", "yes": "  OVERRIDE: ", "no": "  " },
-            {
-              "npc_rule": "hold_the_line",
-              "yes": "<ally_rule_hold_the_line_true_text>",
-              "no": "<ally_rule_hold_the_line_false_text>"
-            }
-          ]
-        },
         "  What should <mypronoun> do?"
       ]
     },
@@ -756,6 +746,16 @@
         },
         {
           "concatenate": [
+            { "npc_override": "heal_others", "yes": "  OVERRIDE: ", "no": "  " },
+            {
+              "npc_rule": "heal_others",
+              "yes": "<ally_rule_heal_others_true_text>",
+              "no": "<ally_rule_heal_others_false_text>"
+            }
+          ]
+        },
+        {
+          "concatenate": [
             { "npc_override": "allow_pulp", "yes": "  OVERRIDE: ", "no": "  " },
             {
               "npc_rule": "allow_pulp",
@@ -852,6 +852,15 @@
         "truefalsetext": { "condition": { "npc_rule": "allow_complain" }, "true": "Stay quiet.", "false": "Tell me when you need something." },
         "topic": "TALK_MISC_RULES",
         "effect": { "toggle_npc_rule": "allow_complain" }
+      },
+      {
+        "truefalsetext": {
+          "condition": { "npc_rule": "heal_others" },
+          "true": "Save your medical supplies for yourself.",
+          "false": "Use your medical supplies to heal others."
+        },
+        "topic": "TALK_MISC_RULES",
+        "effect": { "toggle_npc_rule": "heal_others" }
       },
       {
         "truefalsetext": { "condition": { "npc_rule": "allow_pulp" }, "true": "Leave corpses alone.", "false": "Smash zombie corpses." },

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -2194,6 +2194,16 @@
   },
   {
     "type": "snippet",
+    "category": "<ally_rule_heal_others_true_text>",
+    "text": "<mypronoun> will use medical supplies on allies."
+  },
+  {
+    "type": "snippet",
+    "category": "<ally_rule_heal_others_false_text>",
+    "text": "<mypronoun> will not use medical supplies on others."
+  },
+  {
+    "type": "snippet",
     "category": "<ally_rule_allow_pulp_true_text>",
     "text": "<mypronoun> will smash nearby zombie corpses."
   },
@@ -2271,11 +2281,6 @@
     "type": "snippet",
     "category": "<ally_rule_avoid_locks_false_text>",
     "text": "<mypronoun> will unlock doors to open them."
-  },
-  {
-    "type": "snippet",
-    "category": "<ally_rule_hold_the_line_false_text>",
-    "text": "<mypronoun> will move freely to attack enemies."
   },
   {
     "type": "snippet",

--- a/src/npc.h
+++ b/src/npc.h
@@ -326,11 +326,12 @@ enum class ally_rule : int {
     close_doors = 512,
     follow_close = 1024,
     avoid_doors = 2048,
-    ignore_noise = 4096,
-    forbid_engage = 8192,
-    follow_distance_2 = 16384,
-    lock_doors = 32768,
-    avoid_locks = 65536
+    heal_others = 4096,
+    ignore_noise = 8192,
+    forbid_engage = 16384,
+    follow_distance_2 = 32768,
+    lock_doors = 65536,
+    avoid_locks = 131072
 };
 
 struct ally_rule_data {
@@ -394,6 +395,13 @@ const std::unordered_map<std::string, ally_rule_data> ally_rule_strs = { {
                 ally_rule::allow_complain,
                 "<ally_rule_allow_complain_true_text>",
                 "<ally_rule_allow_complain_false_text>"
+            }
+        },
+        {
+            "heal_others", {
+                ally_rule::heal_others,
+                "<ally_rule_heal_others_true_text>",
+                "<ally_rule_heal_others_false_text>"
             }
         },
         {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2458,7 +2458,8 @@ npc_action npc::address_needs( float danger )
         } else {
             deactivate_bionic_by_id( bio_nanobots );
         }
-        if( static_cast<int>( get_skill_level( skill_firstaid ) ) > 0 ) {
+        // The danger check here is redundant, but serves as an early exit to save some cycles.
+        if( rules.has_flag( ally_rule::heal_others ) && danger < 0.01 ) {
             if( is_player_ally() ) {
                 healing_options try_to_fix_other = patient_assessment( player_character );
                 if( try_to_fix_other.any_true() ) {


### PR DESCRIPTION
#### Summary
Add NPC healing rules

#### Purpose of change
NPCs were healing themselves and others even in the middle of combat, and there was no way to disable this besides taking away their supplies.

#### Describe the solution
NPCs will no longer attempt to do any healing if there is danger around. If the coast is clear, they will always heal themselves if supplies are available, and they will heal allies if they have a rule set to do so.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
