### PR TITLE
Digging rocks gets rocks

### DIFF
--- a/data/json/construction/terrain.json
+++ b/data/json/construction/terrain.json
@@ -276,6 +276,24 @@
     "activity_level": "EXTRA_EXERCISE",
     "do_turn_special": "do_turn_shovel"
   },
+    {
+    "type": "construction",
+    "id": "constr_pit_shallow_rocky_soil",
+    "skill": "survival",
+    "group": "dig_a_shallow_pit",
+    "category": "CONSTRUCT",
+    "difficulty": 0,
+    "time": "35m",
+    "on_display": true,
+    "qualities": [ { "id": "DIG", "level": 1 } ],
+    "pre_flags": [ "DIGGABLE", "FLAT" ],
+    "pre_special": "check_empty",
+    "pre_terrain": "t_dirt_rocky",
+    "post_terrain": "t_pit_shallow",
+    "byproducts": [ { "group": "digging_rocky_soil_50L", "count": 1 } ],
+    "activity_level": "EXTRA_EXERCISE",
+    "do_turn_special": "do_turn_shovel"
+  },
   {
     "type": "construction",
     "id": "constr_pit_shallow_gravel",

--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -157,11 +157,27 @@
       { "item": "material_gravel", "count": [ 4000, 4500 ] }
     ]
   },
+    {
+    "id": "digging_rocky_soil_50L",
+    "type": "item_group",
+    "subtype": "collection",
+    "//": "Intended to comprise about 50L of material from digging in rocky soil.",
+    "items": [
+      { "item": "material_soil", "count": [ 3, 5 ] },
+      { "item": "rock", "count": [ 15, 40 ] },
+      { "item": "rock_flaking", "count": [ 1, 4 ], "prob": 10 },
+      { "item": "flint", "prob": 5 },
+      { "item": "material_limestone", "prob": 5 },
+      { "item": "rock_large", "count": [ 5, 10 ] },
+      { "item": "pebble", "count": [ 10, 30 ] },
+      { "item": "material_gravel", "count": [ 200, 400 ] }
+    ]
+  },
   {
     "id": "digging_soil_loam_50L",
     "type": "item_group",
     "subtype": "collection",
-    "//": "~50L of loamy soil, sand, clay, and rocks from digging in generic dirt",
+    "//": "~50L of loamy soil, sand, clay, and rocks from digging in generic dirt.",
     "items": [
       { "item": "material_soil", "count": [ 8, 12 ] },
       { "item": "material_sand", "charges": [ 1, 10 ], "prob": 5 },


### PR DESCRIPTION
#### Summary
Digging rocks gets rocks

#### Purpose of change
Rocky soil exists but was just yielding normal stuff when you dug holes in it.

#### Describe the solution
Digging rocky soil takes 15 minutes longer and yields a bunch of rocks.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
