### PR TITLE
Fix feeding tentacles

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1822,7 +1822,7 @@
       "PROVIDES_TECHNIQUES",
       "NATURAL_WEAPON"
     ],
-    "techniques": [ "TEC_TENTACLE_RAKE_NATURAL" ],
+    "techniques": [ "TEC_CLAW", "TEC_TENTACLE_RAKE_NATURAL" ],
     "armor": [
       {
         "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 3 } ],

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -1495,7 +1495,6 @@
     "messages": [ "Your tentacles rake %s", "<npcname>'s tentacles rake %s" ],
     "unarmed_allowed": true,
     "basic": true,
-    "weighting": -2,
     "reach_ok": false,
     "crit_ok": true,
     "attack_vectors": [ "vector_claw" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8047,6 +8047,7 @@
     "prereqs": [ "ARM_TENTACLES", "ARM_TENTACLES_4" ],
     "threshreq": [ "THRESH_CEPHALOPOD" ],
     "category": [ "CEPHALOPOD" ],
+    "integrated_armor": [ "integrated_sucker_hooks" ],
     "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 1 } ] } ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix feeding tentacles

#### Purpose of change
Feeding tentacles weren't giving their integrated item.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
