### PR TITLE
Explosions properly interact with terrain

### DIFF
--- a/data/json/furniture_and_terrain/special_use/bullet_trailer.json
+++ b/data/json/furniture_and_terrain/special_use/bullet_trailer.json
@@ -226,7 +226,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "wood_panel", "count": [ 0, 1 ] },
@@ -253,7 +253,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "wood_panel", "count": [ 0, 1 ] },

--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -850,7 +850,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -876,7 +876,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -902,7 +902,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -928,7 +928,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -1179,7 +1179,7 @@
       "sound_fail": "whack!",
       "sound_vol": 16,
       "sound_fail_vol": 10,
-      "ter_set": "t_null",
+      "ter_set": "t_thconc_floor",
       "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
     }
   },
@@ -1204,7 +1204,7 @@
       "sound_fail": "whack!",
       "sound_vol": 16,
       "sound_fail_vol": 10,
-      "ter_set": "t_null",
+      "ter_set": "t_thconc_floor",
       "items": [ { "item": "glass_shard", "count": [ 42, 84 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
     }
   },
@@ -2004,7 +2004,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -2030,7 +2030,7 @@
       "str_max": 25,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_thconc_floor",
       "items": [
         { "item": "2x4", "count": [ 3, 6 ] },
         { "item": "splinter", "count": [ 3, 6 ] },
@@ -2056,7 +2056,7 @@
       "str_max": 75,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_thconc_floor",
       "items": [ { "item": "spike", "count": [ 2, 4 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
     }
   },
@@ -2099,7 +2099,7 @@
       "str_max": 75,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_thconc_floor",
       "items": [ { "item": "spike", "count": [ 2, 4 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-embrasures.json
+++ b/data/json/furniture_and_terrain/terrain-embrasures.json
@@ -28,7 +28,7 @@
       "str_max": 80,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 15 ] }, { "item": "brick", "count": [ 2, 6 ] } ]
     }
   },
@@ -62,7 +62,7 @@
       "str_max": 60,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "material_soil", "count": [ 8, 20 ] }, { "item": "adobe_brick", "count": [ 2, 6 ] } ]
     }
   },
@@ -95,7 +95,7 @@
       "str_max": 150,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 18 ] } ]
     }
   },
@@ -167,7 +167,7 @@
       "str_max": 90,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 2, 7 ] },
         { "item": "wood_panel", "count": [ 0, 3 ] },
@@ -239,7 +239,7 @@
       "str_max": 120,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     }
   },
@@ -262,7 +262,7 @@
       "str_max": 75,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 10, 30 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -14,7 +14,7 @@
     "connects_to": "CONCRETE",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -41,7 +41,7 @@
     "connects_to": "CONCRETE",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -162,7 +162,7 @@
     "coverage": 0,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -310,7 +310,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES" ],
     "bash": {
       "sound": "SCRRRASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -332,7 +332,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
@@ -361,7 +361,7 @@
     "trap": "tr_glimmer_floor",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
@@ -384,7 +384,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES" ],
     "bash": {
       "sound": "SCRRRASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -404,7 +404,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -428,7 +428,7 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -444,7 +444,7 @@
     "move_cost": 2,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -475,7 +475,7 @@
     "flags": [ "TRANSPARENT", "INDOORS", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
@@ -500,7 +500,7 @@
     "flags": [ "TRANSPARENT", "INDOORS" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
@@ -527,7 +527,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -549,7 +549,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -576,7 +576,7 @@
       "str_min": 50,
       "str_max": 400,
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min_supported": 100,
       "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
     }
@@ -597,7 +597,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -619,7 +619,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 1,
       "str_max": 6,
       "sound_vol": 8,
@@ -644,7 +644,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "DIGGABLE" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 5,
       "str_max": 15,
       "sound_vol": 8,
@@ -668,7 +668,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1431,7 +1431,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1453,7 +1453,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1476,7 +1476,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "sound": "SMASH!",
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     },
@@ -1553,7 +1553,7 @@
     "connect_groups": "CONCRETE",
     "connects_to": "CONCRETE",
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -1575,7 +1575,14 @@
     "looks_like": "t_dirt",
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD", "PLOWABLE", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1592,7 +1599,14 @@
     "coverage": 0,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1608,7 +1622,14 @@
     "roof": "t_rock_roof",
     "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1624,7 +1645,14 @@
     "coverage": 0,
     "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1640,7 +1668,14 @@
     "coverage": 0,
     "roof": "t_rock_roof",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "SUPPORTS_ROOF", "INDOORS" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -1685,7 +1720,7 @@
       "sound_fail": "twang!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_null"
+      "ter_set": "t_open_air"
     }
   },
   {
@@ -1708,7 +1743,7 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_null"
+      "ter_set": "t_open_air"
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -11,7 +11,7 @@
     "connects_to": [ "DIRT", "CLAY", "SAND", "MUD", "DIRTMOUND", "CLAYMOUND", "SANDMOUND", "SANDGLASS", "CONCRETE" ],
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100 }
   },
   {
     "type": "terrain",
@@ -24,7 +24,7 @@
     "looks_like": "t_railroad_rubble",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -37,7 +37,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -51,7 +51,7 @@
     "connect_groups": "SAND",
     "connects_to": [ "SAND", "SANDMOUND", "SANDGLASS" ],
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -66,7 +66,7 @@
     "connect_groups": "MUD",
     "connects_to": "MUD",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -80,7 +80,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -139,7 +139,7 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "crunch", "ter_set": "t_sand", "str_min": 25, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "crunch", "ter_set": "t_sand", "str_min": 25, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -153,7 +153,7 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE", "TREE_PLANTABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
     "examine_action": "dirtmound"
   },
   {
@@ -172,7 +172,7 @@
     "flags": [ "TRANSPARENT" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 100,
       "str_min_supported": 100,
@@ -247,7 +247,7 @@
     "coverage": 0,
     "roof": "t_open_air",
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -261,7 +261,7 @@
     "connect_groups": "MULCHFLOOR",
     "connects_to": "MULCHFLOOR",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -276,7 +276,7 @@
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -296,7 +296,7 @@
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -316,7 +316,7 @@
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -337,7 +337,7 @@
     "connect_groups": "CONCRETE",
     "connects_to": "CONCRETE",
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -359,7 +359,7 @@
     "connects_to": "CONCRETE",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
@@ -385,7 +385,7 @@
     "connects_to": "CONCRETE",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
@@ -410,7 +410,7 @@
     "connect_groups": "CONCRETE",
     "connects_to": "CONCRETE",
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -431,7 +431,7 @@
     "connect_groups": "CONCRETE",
     "connects_to": "CONCRETE",
     "bash": {
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -453,7 +453,7 @@
     "connects_to": "WOODFLOOR",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -477,7 +477,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -503,7 +503,7 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
@@ -529,7 +529,7 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
@@ -555,7 +555,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT", "ROAD" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -577,7 +577,7 @@
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT", "ROAD" ],
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
@@ -596,7 +596,7 @@
     "move_cost": 2,
     "looks_like": "t_dirtfloor",
     "flags": [ "TRANSPARENT", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "SMASH!", "ter_set": "t_open_air", "str_min": 50, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -608,7 +608,7 @@
     "move_cost": 5,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
   },
   {
     "type": "terrain",
@@ -651,7 +651,7 @@
     "flags": [ "FLAT", "ROAD", "TRANSPARENT" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 500,
       "str_max": 1000,
       "str_min_supported": 200,
@@ -708,7 +708,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -3102,7 +3102,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3115,7 +3115,7 @@
     "move_cost": 2,
     "fall_damage_reduction": 1,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3127,7 +3127,7 @@
     "move_cost": 2,
     "transforms_into": "t_grass_shorn",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "GRAZABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3139,7 +3139,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3153,7 +3153,7 @@
     "color": "green",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "SMALL_HIDE", "GRAZABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3169,7 +3169,7 @@
     "coverage": 50,
     "concealment": 50,
     "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "SMALL_HIDE", "GRAZABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3181,7 +3181,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3194,7 +3194,7 @@
     "move_cost": 2,
     "transforms_into": "t_grass",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "HARVESTED" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3206,7 +3206,7 @@
     "color": "light_green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3218,7 +3218,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3252,7 +3252,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 2, "str_max": 6 }
   },
   {
     "type": "terrain",
@@ -3264,7 +3264,7 @@
     "color": "green",
     "move_cost": 5,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "SMALL_HIDE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 10, "str_max": 20 }
   },
   {
     "type": "terrain",
@@ -3278,7 +3278,7 @@
     "coverage": 50,
     "concealment": 50,
     "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "SMALL_HIDE", "SMALL_HIDE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 30 }
   },
   {
     "type": "terrain",
@@ -3290,7 +3290,7 @@
     "color": "brown",
     "move_cost": 10,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "SMALL_HIDE" ],
-    "bash": { "ter_set": "t_null", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 10, "str_max": 30 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -27,7 +27,7 @@
     "bash": {
       "sound": "smash",
       "//": "muffled because fungus",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 20,
       "str_max": 400,
       "str_min_supported": 50
@@ -44,7 +44,7 @@
     "move_cost": 2,
     "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": { "sound": "smash", "ter_set": "t_open_air", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
   },
   {
     "type": "terrain",
@@ -56,7 +56,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": { "sound": "smash", "ter_set": "t_open_air", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
   },
   {
     "type": "terrain",
@@ -68,7 +68,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": { "sound": "SMASH!", "ter_set": "t_open_air", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-highways.json
+++ b/data/json/furniture_and_terrain/terrain-highways.json
@@ -17,7 +17,7 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   },
@@ -39,7 +39,7 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   },
@@ -59,7 +59,7 @@
       "str_max": 300,
       "sound": "concrete cracking and metal screeching!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 4, 20 ] }, { "item": "rebar", "count": [ 10, 20 ] } ]
     }
   }

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -415,7 +415,7 @@
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "ROAD", "MINEABLE" ],
     "bash": {
       "sound": "thump",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,

--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -207,7 +207,7 @@
       "str_max": 40,
       "sound": "crunch!",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "rope_makeshift_6", "count": [ 3, 4 ] },
         { "item": "2x4", "count": [ 1, 4 ] },
@@ -239,7 +239,7 @@
       "str_max": 40,
       "sound": "crunch!",
       "sound_fail": "whump.",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "rope_makeshift_6", "count": [ 3, 4 ] },
         { "item": "2x4", "count": [ 1, 4 ] },

--- a/data/json/furniture_and_terrain/terrain-migo.json
+++ b/data/json/furniture_and_terrain/terrain-migo.json
@@ -61,7 +61,7 @@
       "str_max": 700,
       "sound": "boom!",
       "sound_fail": "whack!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "ter_set_bashed_from_above": "t_platform_resin",
       "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ]
     }
@@ -81,7 +81,7 @@
       "str_max": 700,
       "sound": "boom!",
       "sound_fail": "whack!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "resin_chunk", "count": [ 10, 40 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-railroads.json
+++ b/data/json/furniture_and_terrain/terrain-railroads.json
@@ -10,7 +10,7 @@
     "bash": {
       "str_min": 100,
       "str_max": 200,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "sound": "crunch!",
       "sound_fail": "whump!",
       "items": [ { "item": "material_gravel", "count": [ 1, 3 ] }, { "item": "sharp_rock", "count": [ 0, 1 ] } ],

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -110,7 +110,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -122,7 +122,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -134,7 +134,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 28, "str_max": 140, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -146,7 +146,7 @@
     "color": "yellow",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH" ],
-    "bash": { "str_min": 20, "str_max": 60, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 20, "str_max": 60, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -158,7 +158,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 130, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -170,7 +170,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "FLAMMABLE_HARD" ],
-    "bash": { "str_min": 35, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 35, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -203,7 +203,10 @@
     "move_cost": 2,
     "coverage": 0,
     "examine_action": "ledge",
-    "deconstruct": { "ter_set": "t_null", "items": [ { "item": "2x4", "count": [ 3, 4 ] }, { "item": "nail", "charges": [ 12, 16 ] } ] },
+    "deconstruct": {
+      "ter_set": "t_open_air",
+      "items": [ { "item": "2x4", "count": [ 3, 4 ] }, { "item": "nail", "charges": [ 12, 16 ] } ]
+    },
     "bash": {
       "str_min": 1,
       "str_max": 1,
@@ -211,7 +214,7 @@
       "sound_fail": "whack!",
       "sound_vol": 12,
       "sound_fail_vol": 8,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 1, 10 ] },
@@ -230,7 +233,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": { "str_min": 100, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -259,7 +262,7 @@
       "sound_fail": "slap!",
       "sound_vol": 8,
       "sound_fail_vol": 4,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "bash_below": false
     }
   },
@@ -281,7 +284,7 @@
       "sound_fail": "slap!",
       "sound_vol": 15,
       "sound_fail_vol": 10,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "bash_below": false
     }
   },
@@ -295,7 +298,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 100, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -307,7 +310,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": { "str_min": 40, "str_max": 150, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 40, "str_max": 150, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -319,7 +322,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 45, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 45, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -331,7 +334,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -343,7 +346,7 @@
     "color": "red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 100, "str_max": 250, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -355,7 +358,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": { "str_min": 26, "str_max": 120, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 26, "str_max": 120, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -366,7 +369,7 @@
     "color": "red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 48, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 48, "str_max": 160, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -377,7 +380,7 @@
     "color": "blue",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": { "str_min": 3, "str_max": 8, "sound": "rrrrip!", "sound_fail": "slap!", "ter_set": "t_null", "bash_below": false }
+    "bash": { "str_min": 3, "str_max": 8, "sound": "rrrrip!", "sound_fail": "slap!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -8,7 +8,14 @@
     "color": "yellow",
     "move_cost": 8,
     "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -22,7 +29,14 @@
     "move_cost": 10,
     "trap": "tr_pit",
     "flags": [ "TRANSPARENT" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit"
   },
   {
@@ -34,7 +48,14 @@
     "color": "green",
     "move_cost": 5,
     "flags": [ "TRANSPARENT", "DIGGABLE", "PIT_FILLABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "//": "left diggable to clean out corpses-KA101"
   },
   {
@@ -48,7 +69,14 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "ROAD" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit_covered"
   },
   {
@@ -63,7 +91,14 @@
     "move_cost": 10,
     "trap": "tr_spike_pit",
     "flags": [ "TRANSPARENT", "PIT_FILLABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit"
   },
   {
@@ -77,7 +112,14 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "ROAD" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit_covered"
   },
   {
@@ -92,7 +134,14 @@
     "move_cost": 10,
     "trap": "tr_glass_pit",
     "flags": [ "TRANSPARENT", "PIT_FILLABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit"
   },
   {
@@ -106,7 +155,14 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "ROAD" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 40,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "pit_covered"
   },
   {
@@ -137,7 +193,14 @@
         }
       ]
     },
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -149,7 +212,14 @@
     "looks_like": "t_den_large",
     "move_cost": 3,
     "flags": [ "TRANSPARENT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -161,7 +231,14 @@
     "looks_like": "t_pit_shallow",
     "move_cost": 6,
     "flags": [ "TRANSPARENT", "DIGGABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-triffid.json
+++ b/data/json/furniture_and_terrain/terrain-triffid.json
@@ -136,7 +136,7 @@
     "coverage": 40,
     "concealment": 40,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH" ],
-    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_null" }
+    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_open_air" }
   },
   {
     "type": "terrain",
@@ -206,7 +206,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 2, 5 ] } ]
     }
   },
@@ -228,7 +228,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 2, 5 ] } ]
     }
   }

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -126,7 +126,7 @@
       "str_max": 210,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": "wall_bash_results"
     }
   },
@@ -135,8 +135,7 @@
     "abstract": "t_wall_color",
     "copy-from": "t_wall",
     "name": { "str": "abstract colored wall", "//~": "NO_I18N" },
-    "description": "An abstract for t_wall color variants.  If you see this in-game, it's a bug.",
-    "extend": { "flags": [ "CHIP" ] }
+    "description": "An abstract for t_wall color variants.  If you see this in-game, it's a bug."
   },
   {
     "type": "terrain",
@@ -157,7 +156,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "wood_panel", "count": [ 0, 1 ] },
@@ -187,7 +186,7 @@
       "str_max": 20,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": "wall_bash_results"
     }
   },
@@ -821,7 +820,7 @@
       "str_max": 100,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 5, 8 ] }, { "item": "brick", "count": [ 1, 3 ] } ]
     }
   },
@@ -836,7 +835,7 @@
       "str_max": 250,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 15 ] }, { "item": "brick", "count": [ 2, 6 ] } ]
     }
   },
@@ -852,7 +851,7 @@
       "str_max": 300,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 18 ] } ]
     }
   },
@@ -868,7 +867,7 @@
       "str_max": 300,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 18 ] } ]
     }
   },
@@ -891,7 +890,7 @@
       "str_max": 200,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 3, 8 ] } ]
     }
   },
@@ -930,7 +929,7 @@
       "str_max": 90,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "material_soil", "count": [ 4, 10 ] }, { "item": "adobe_brick", "count": [ 1, 3 ] } ]
     }
   },
@@ -946,7 +945,7 @@
       "str_max": 120,
       "sound": "crash!",
       "sound_fail": "bash!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "material_soil", "count": [ 8, 20 ] }, { "item": "adobe_brick", "count": [ 2, 6 ] } ]
     }
   },
@@ -984,7 +983,7 @@
       "str_max": 600,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -1004,7 +1003,7 @@
       "str_max": 210,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "steel_chunk", "count": [ 1, 4 ] }, { "item": "scrap", "count": [ 3, 12 ] } ]
     }
   },
@@ -1175,7 +1174,7 @@
       "str_max": 110,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "2x4", "count": [ 2, 5 ] },
         { "item": "wood_panel", "count": [ 0, 2 ] },
@@ -1203,7 +1202,7 @@
       "str_max": 20,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "ash", "count": [ 200, 500 ] }, { "item": "scrap", "count": [ 2, 5 ] } ]
     },
     "shoot": { "chance_to_hit": 25, "reduce_damage": [ 5, 10 ], "reduce_damage_laser": [ 10, 30 ], "destroy_damage": [ 5, 20 ] }
@@ -1227,7 +1226,7 @@
       "str_max": 120,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     }
   },
@@ -1283,7 +1282,7 @@
       "str_max": 150,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     },
     "shoot": { "chance_to_hit": 25, "reduce_damage": [ 20, 50 ], "reduce_damage_laser": [ 10, 40 ], "destroy_damage": [ 40, 120 ] }
@@ -1307,7 +1306,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 10, 30 ] } ]
     }
   },
@@ -1343,7 +1342,7 @@
     "bash": {
       "str_min": 4,
       "str_max": 110,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "sound": "crash!",
       "sound_fail": "whump!",
       "items": [ { "item": "2x4", "count": [ 0, 3 ] }, { "item": "splinter", "count": [ 3, 6 ] } ]
@@ -1367,7 +1366,7 @@
     "bash": {
       "str_min": 8,
       "str_max": 75,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "sound": "crunch!",
       "sound_fail": "whump!",
       "items": [ { "item": "2x4", "count": [ 1, 3 ] }, { "item": "splinter", "count": 6 } ]
@@ -1700,7 +1699,7 @@
       "sound_fail": "whack!",
       "sound_vol": 16,
       "sound_fail_vol": 10,
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [
         { "item": "glass_shard", "charges": [ 20, 44 ] },
         { "item": "glass_shard_large", "count": [ 0, 3 ] },
@@ -1817,7 +1816,7 @@
       "str_max": 150,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "splinter", "count": [ 2, 5 ] } ]
     }
   },
@@ -1850,7 +1849,7 @@
     "copy-from": "t_abstract_wall_earthen",
     "name": "solid earth",
     "description": "A wall of solid earth.",
-    "extend": { "flags": [ "NATURAL_UNDERGROUND" ] },
+    "extend": { "flags": [ "NATURAL_UNDERGROUND", "SUPPORTS_ROOF" ] },
     "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_dirt",
     "bash": {
@@ -1870,12 +1869,12 @@
     "name": "solid rock",
     "description": "A wall of solid rock, could be full of all kinds of interesting things.  Best grab your pickaxe or equivalent digging implement, and strike the earth!",
     "color": "white",
-    "extend": { "flags": [ "NATURAL_UNDERGROUND" ] },
+    "extend": { "flags": [ "NATURAL_UNDERGROUND", "SUPPORTS_ROOF" ] },
     "delete": { "flags": [ "AUTO_WALL_SYMBOL" ] },
     "roof": "t_rock_floor_no_roof",
     "bash": {
-      "str_min": 100,
-      "str_max": 400,
+      "str_min": 125,
+      "str_max": 450,
       "sound": "crash!",
       "sound_fail": "whump!",
       "ter_set": "t_rock_floor",
@@ -1957,7 +1956,7 @@
       "str_max": 200,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 1, 3 ] }, { "item": "rebar", "count": [ 0, 2 ] } ]
     }
   },
@@ -2107,7 +2106,7 @@
       "str_max": 200,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 8, 18 ] }, { "item": "pebble", "count": [ 20, 38 ] } ]
     }
   },
@@ -2130,7 +2129,7 @@
       "str_max": 120,
       "sound": "crash!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_open_air",
       "items": [ { "item": "rock", "count": [ 3, 8 ] }, { "item": "pebble", "count": [ 20, 38 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -835,7 +835,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "nail", "charges": [ 0, 5 ] },
@@ -867,7 +867,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "nail", "charges": [ 0, 5 ] },
@@ -902,7 +902,7 @@
       "str_max": 70,
       "sound": "crunch!",
       "sound_fail": "whump!",
-      "ter_set": "t_null",
+      "ter_set": "t_floor",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
         { "item": "nail", "charges": [ 0, 5 ] },

--- a/data/json/furniture_and_terrain/terrain_vitrified.json
+++ b/data/json/furniture_and_terrain/terrain_vitrified.json
@@ -579,7 +579,14 @@
     "move_cost": 2,
     "connect_groups": "INDOORFLOOR",
     "flags": [ "SUPPORTS_ROOF", "TRANSPARENT", "INDOORS", "UNSTABLE" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_null", "bash_below": true }
+    "bash": {
+      "str_min": 30,
+      "str_max": 210,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_open_air",
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -54,7 +54,7 @@
     "symbol": ";",
     "color": "light_gray",
     "use_action": { "type": "message", "message": "You've already set the %s's timer, you might want to get away from it." },
-    "countdown_action": { "type": "explosion", "explosion": { "power": 2000 } },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 2800 } },
     "countdown_interval": "6 seconds",
     "flags": [ "NPC_THROW_NOW" ]
   },

--- a/src/map.h
+++ b/src/map.h
@@ -1187,8 +1187,7 @@ class map
          */
         bash_params bash( const tripoint_bub_ms &p, int str, bool silent = false,
                           bool destroy = false, bool bash_floor = false,
-                          const vehicle *bashing_vehicle = nullptr,
-                          bool repair_missing_ground = true );
+                          const vehicle *bashing_vehicle = nullptr );
 
         // Effects of attacks/items
         bool hit_with_acid( const tripoint_bub_ms &p );
@@ -2106,8 +2105,7 @@ class map
 
         // Internal methods used to bash just the selected features
         // Information on what to bash/what was bashed is read from/written to the bash_params struct
-        void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params,
-                            bool repair_missing_ground = true );
+        void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params );
         void bash_items( const tripoint_bub_ms &p, bash_params &params );
         void bash_vehicle( const tripoint_bub_ms &p, bash_params &params );
         void bash_field( const tripoint_bub_ms &p, bash_params &params );


### PR DESCRIPTION
#### Summary
Explosions properly interact with terrain

#### Purpose of change
I have been noticing an increasing amount of weird behavior re: explosions, bashing, and terrain. This appears to be coming from a variety of backports that may be working at cross-purposes. 

#### Describe the solution
- Switch all bash_result in terrain from t_null to t_open_air, unless it really ought to be something else, such as t_dirt.
- Explosion blast waves now interact with cover in the same manner shrapnel does. I'm aware this shouldn't actually protect as well, but explosions tend to be powerful enough to totally overcome most simple cover anyway. If people are hiding from mininukes with couches or something I can turn this down.
- Bombing dirt now correctly creates craters again.
- Removed a bunch of nonsensical/old/bad code from the bash functions

#### Testing
Seems to work OK. There are still a few problematic cases such as sewers not having roofs defined, but those are a separate fix. I also checked out mortars and observed that they seem to work better and leave clearer signs of their use than before.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
