### PR TITLE
Block Gradual Mutation from genetic chaos

### DIFF
--- a/data/json/mutations/mutation_gradual.json
+++ b/data/json/mutations/mutation_gradual.json
@@ -9,6 +9,8 @@
     "time": 3600,
     "processed_eocs": [ "EOC_AM_BECOME_MUTANT" ],
     "random_at_chargen": false,
+    "starting_trait": false,
+    "valid": false,
     "cancels": [
       "MUTATING_GRADUAL_BATRACHIAN",
       "MUTATING_GRADUAL_AVIAN",


### PR DESCRIPTION
#### Summary
Block Gradual Mutation from genetic chaos

#### Purpose of change
Gradual mutation was able to be acquired with genetic chaos, which was unintended.

#### Describe the solution
Set it to valid = false.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
