### PR TITLE
Decouple fatigue mods from weariness recovery

### DIFF
--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -18,23 +18,18 @@ int activity_tracker::weariness() const
 }
 
 // Called every 5 minutes, when activity level is logged
-void activity_tracker::try_reduce_weariness( int bmr, float fatigue_mod, float fatigue_regen_mod )
+void activity_tracker::try_reduce_weariness( int bmr )
 {
     const float recovery_mult = get_option<float>( "WEARY_RECOVERY_MULT" );
     // As sleepiness_mod approaches zero, low_activity_ticks and reduction approach infinity which in turn make tracker approach - infinity before being capped at 0.
     // Skip the math and just automatically set tracker to 0.
-    if( fatigue_mod <= 0.0f ) {
-        tracker = 0;
-    } else {
         if( average_activity() < LIGHT_EXERCISE ) {
             // cata_assert( sleepiness_mod > 0.0f );
             low_activity_ticks += std::min( 1.0f,
-                                            ( ( LIGHT_EXERCISE - average_activity() ) / ( LIGHT_EXERCISE - NO_EXERCISE ) ) ) / fatigue_mod;
+                                            ( ( LIGHT_EXERCISE - average_activity() ) / ( LIGHT_EXERCISE - NO_EXERCISE ) ) );
             // Recover (by default) twice as fast while sleeping
             if( average_activity() < NO_EXERCISE ) {
-                low_activity_ticks += ( ( NO_EXERCISE - average_activity() ) / ( NO_EXERCISE - SLEEP_EXERCISE ) ) *
-                                      fatigue_regen_mod;
-            }
+                low_activity_ticks += ( NO_EXERCISE - average_activity() ) / ( NO_EXERCISE - SLEEP_EXERCISE );
         }
 
         const int bmr_cal = bmr * 1000;

--- a/src/activity_tracker.h
+++ b/src/activity_tracker.h
@@ -52,7 +52,7 @@ class activity_tracker
         float instantaneous_activity_level() const;
 
         int weariness() const;
-        void try_reduce_weariness( int bmr, float fatigue_mod, float fatigue_regen_mod );
+        void try_reduce_weariness( int bmr );
         void calorie_adjust( int ncal );
         void weary_clear();
         int debug_get_tracker() const;

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -258,9 +258,7 @@ void Character::update_body( const time_point &from, const time_point &to )
     }
     const int five_mins = ticks_between( from, to, 5_minutes );
     if( five_mins > 0 ) {
-        float fatigue_mod = enchantment_cache->modify_value( enchant_vals::mod::FATIGUE, 1 );
-        float fatigue_regen_mod = enchantment_cache->modify_value( enchant_vals::mod::FATIGUE_REGEN, 1 );
-        activity_history.try_reduce_weariness( base_bmr(), fatigue_mod, fatigue_regen_mod );
+        activity_history.try_reduce_weariness( base_bmr() );
 
         check_needs_extremes();
         update_needs( five_mins );


### PR DESCRIPTION
#### Summary
Decouple fatigue mods from weariness recovery

#### Purpose of change
Fatigue mods from mutations were affecting weariness recovery in ways that weren't working properly because of how the system uses multipliers which weren't playing nice with the existing math. Fatigue and weariness are two totallly unrelated systems, so there's no reason they ought to interact at all.

#### Describe the solution
Delete the modifiers from weariness recovery. Sleepy characters sleep more, so they have more time to recover from weariness. Good for them. Characters who need less sleep get less rapid weariness recovery. Oh noooo. Sylvans can read a book or something and lizards will be glad of the extra time to recover since they're always getting wiped out.

#### Testing
Got to extremely weary. Recovered in about 5 hours of sleep while very sleepy. Took the mutation off and did it again, same result.

#### Additional context
If it's a problem, I can manually add a weariness recovery multiplier to the mutations in question.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
