### PR TITLE
Reduce hulk vision

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -898,7 +898,7 @@
     "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_hulk" ],
     "bleed_rate": 10,
-    "vision_day": 83,
+    "vision_day": 50,
     "vision_night": 4,
     "harvest": "zombie_hulk",
     "grab_strength": 50,

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -148,7 +148,7 @@
     "weakpoint_sets": [ "wps_humanoid_body", "wps_bone_armor", "wps_humanoid_head_small" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_wp_skeleton", "prof_wp_hulk" ],
     "bleed_rate": 0,
-    "vision_day": 50,
+    "vision_day": 45,
     "vision_night": 4,
     "harvest": "big_mr_bones",
     "grab_strength": 50,


### PR DESCRIPTION
#### Summary
Reduce hulk vision

#### Purpose of change
Zombie hulks and other huge zeds had like 85 sight range, which is almost twice what a normal zomboid has, meaning it wasn't too hard to kite them away from their pals.

#### Describe the solution
They now have around 50. That's higher than average but they're not eagle-eyed scouts.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
