### PR TITLE
Updates Prototype Cyborgs

### DIFF
--- a/data/json/monsters/cyborgs.json
+++ b/data/json/monsters/cyborgs.json
@@ -53,7 +53,7 @@
     "description": "A human fused with a mess of metal parts and wires.  While their eyes are empty, the flashes of pain that occasionally cross their face remind you that, deep down, there is a person still trapped in this grotesque body.  Someone with enough surgical skills might be able to restore some of their humanity, but they'd first need to subdue them somehow.",
     "default_faction": "science",
     "bodytype": "human",
-    "species": [ "HUMAN" ],
+    "species": [ "HUMAN", "CYBORG" ],
     "volume": "75000 ml",
     "weight": "74000 g",
     "hp": 60,


### PR DESCRIPTION
Makes prototype cyborgs bleed human blood and zombify into broken cyborgs.

#### Summary
Prototype cyborgs are old monsters that bled mechanical fluid and didn't zombify into anything. This makes them bleed human blood and zombify into broken cyborgs.

#### Purpose of change
Make prototype cyborgs bleed human blood and zombify into broken cyborgs.

#### Describe the solution
Prototype cyborgs bleed human blood and zombify into broken cyborgs.

#### Describe alternatives you've considered
None.

#### Testing
Works as intended and runs without error.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
