### PR TITLE
Fix NPCs running out of ereader power

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1670,6 +1670,13 @@ static bool cancel_if_book_invalid(
         act.set_to_null();
         return true;
     }
+    if( book->is_estorage() && !book->ammo_sufficient( &who ) ) {
+        who.add_msg_player_or_npc(
+            _( "You can't read an unpowered ebook." ),
+            _( "<npcname> can't read an unpowered ebook." ) );
+        act.set_to_null();
+        return true;
+    }
     return false;
 }
 
@@ -1690,6 +1697,7 @@ void read_activity_actor::start( player_activity &act, Character &who )
 
     add_msg_debug( debugmode::DF_ACT_READ, "reading time = %s",
                    to_string_writable( time_duration::from_moves( moves_total ) ) );
+
 
     // starting the activity should cost a charge to boot up the ebook app
     if( using_ereader ) {
@@ -3063,6 +3071,8 @@ void efile_activity_actor::do_turn( player_activity &act, Character &who )
                 add_msg_if_player_sees(
                     who, m_warning, string_format( _( "The %s ran out of batteries!" ),
                                                    edevice->display_name() ) );
+                                                   
+                who.cancel_activity();
                 return false;
             }
             edevice->ammo_consume( edevice->ammo_required(), here, edevice.pos_bub( here ), &who );


### PR DESCRIPTION
#### Summary
Fix NPCs running out of ereader power

#### Purpose of change
NPCs would hit an infinite loop if they were reading an ebook and it ran out of power. This was because one of the catches for it didn't actually cancel their activity.

#### Describe the solution
Add a third failsafe (currently unused, but it might catch edge cases) and fix the one that was failing.

#### Describe alternatives you've considered
I suppose it wouldn't be too hard to get them to see if they had any replacement batteries or could find a place to plug in their device.

#### Testing
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d77b09c2-82bd-4dec-bf1b-0cc16258f83d" />
Werks

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
