### PR TITLE
Improve sound muffling over Z levels

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -256,7 +256,7 @@ static int sound_distance( const tripoint_bub_ms &source, const tripoint_bub_ms 
     const int lower_z = std::min( source.z(), sink.z() );
     const int upper_z = std::max( source.z(), sink.z() );
     const int vertical_displacement = upper_z - lower_z;
-    int vertical_attenuation = vertical_displacement;
+    int vertical_attenuation = vertical_displacement * 2;
     if( lower_z < 0 && vertical_displacement > 0 ) {
         // Apply a moderate bonus attenuation (5x) for the first level of vertical displacement.
         vertical_attenuation += 4;
@@ -266,7 +266,7 @@ static int sound_distance( const tripoint_bub_ms &source, const tripoint_bub_ms 
     }
     // Regardless of underground effects, scale the vertical distance by 5x.
     vertical_attenuation *= 5;
-    return rl_dist( source.xy(), sink.xy() ) + vertical_attenuation;
+    return static_cast<int>( std::round( trig_dist_z_adjust( source.xy(), sink.xy() ) ) ) + vertical_attenuation;
 }
 
 static std::string season_str( const season_type &season )
@@ -681,7 +681,7 @@ void sounds::process_sound_markers( Character *you )
 
         // skip some sounds to avoid message spam
         const bool from_player = pos == you->pos_bub() || ( sound.category == sound_t::movement &&
-                                 distance_to_sound <= 1 );
+                                 distance_to_sound < 2 );
         if( describe_sound( sound.category, from_player ) ) {
             game_message_type severity = m_info;
             if( sound.category == sound_t::combat || sound.category == sound_t::alarm ) {


### PR DESCRIPTION
#### Summary
Improve sound muffling over Z levels

#### Purpose of change
It was still possible to hear lab bullshit in hardened underground bunkers.

#### Describe the solution
- Double the vertical attenuation for Z levels, whether above or underground.
- Move sound distance to properly use trig_dist_z_adjust and correctly filter sounds adjacent to the player from the message log.

This results in a 10 volume drop per Z level above ground, but makes 120 volume sounds from just 2 z-levels down totally inaudible.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
