### PR TITLE
Fix mutation item duping

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1407,7 +1407,7 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
                     item_location loc( *this, &tmparmor );
                     get_event_bus().send_with_talker( this, &loc, e );
                     return armor.typeId() == tmparmor.typeId();
-                } );
+                }, true );
             }
         }
     }
@@ -3008,7 +3008,7 @@ void Character::remove_bionic( const bionic &bio )
     for( const itype_id &popped_armor : bio.id->passive_pseudo_items ) {
         remove_worn_items_with( [&]( item & armor ) {
             return armor.typeId() == popped_armor;
-        } );
+        }, true );
     }
 
     const bool has_enchantments = !bio.id->enchantments.empty();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3507,10 +3507,10 @@ std::vector<item_location> Character::nearby( const
     return res;
 }
 
-std::list<item> Character::remove_worn_items_with( const std::function<bool( item & )> &filter )
+std::list<item> Character::remove_worn_items_with( const std::function<bool( item & )> &filter, bool unload )
 {
     invalidate_inventory();
-    return worn.remove_worn_items_with( filter, *this );
+    return worn.remove_worn_items_with( filter, *this, unload );
 }
 
 void Character::clear_worn()

--- a/src/character.h
+++ b/src/character.h
@@ -2083,7 +2083,7 @@ class Character : public Creature, public visitable
          * content (@ref item::contents is not checked).
          * If the filter function returns true, the item is removed.
          */
-        std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter );
+        std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter, bool unload );
 
         void clear_worn();
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1191,12 +1191,12 @@ bool outfit::natural_attack_restricted_on( const sub_bodypart_id &bp ) const
 }
 
 std::list<item> outfit::remove_worn_items_with( const std::function<bool( item & )> &filter,
-        Character &guy )
+        Character &guy, bool unload )
 {
     std::list<item> result;
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
-            if( iter->can_unload() ) {
+            if( unload && iter->can_unload() ) {
                 iter->spill_contents( guy );
             }
             iter->on_takeoff( guy );

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -198,7 +198,7 @@ class outfit
         // creates a list of items dependent upon @it
         void add_dependent_item( std::list<item *> &dependent );
         std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter,
-                                                Character &guy );
+                                                Character &guy, bool unload );
         bool takeoff( item_location loc, std::list<item> *res, Character &guy );
         std::list<item> use_amount(
             const itype_id &it, int quantity, std::list<item> &used,

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -624,7 +624,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
             here.add_item_or_charges( pos_bub(), armor );
         }
         return true;
-    } );
+    }, false );
 
     for( const std::pair<const mtype_id, int> &moncam : branch.moncams ) {
         add_moncam( moncam );
@@ -656,7 +656,7 @@ void Character::mutation_loss_effect( const trait_id &mut )
     for( const itype_id &popped_armor : branch.integrated_armor ) {
         remove_worn_items_with( [&]( item & armor ) {
             return armor.typeId() == popped_armor;
-        } );
+        }, true );
     }
 
     if( !branch.enchantments.empty() ) {


### PR DESCRIPTION
#### Summary
Fix mutation item duping

#### Purpose of change
If you gained a mutation that pushed off some of your gear, it would spill the contents of the gear in such a way that they would be duplicated, with one copy of everything still being inside of the item and one copy being on the floor.

I'm not sure why remove_worn_items_with is set up this way. It's only called here and in bionics. The best I can guess is that it's intended for pseudo items such as the battery system CBM. These items of course would not be dropped, but they should dump their contents. Integrated items with pockets don't use the function this way, so I think we only need to worry about bionics.

#### Describe the solution
Add a bool to dump the container or not and only have it be true in bionics.cpp, where we're strictly dealing with pseudo items. Bionic behavior is unchanged, while mutations pushing off bags will no longer also spill them/dupe anything.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
