### PR TITLE
Fix dense and light bones

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6739,7 +6739,7 @@
         "values": [
           { "value": "MOVE_COST", "multiply": 0.05 },
           { "value": "ATTACK_SPEED", "multiply": 0.05 },
-          { "value": "MAX_HP", "add": 4 },
+          { "value": "MAX_HP", "multiply": 0.05 },
           { "value": "MOVECOST_SWIM_MOD", "multiply": 0.2 },
           { "value": "DODGE_CHANCE", "add": -1 },
           { "value": "CARRY_WEIGHT", "multiply": 0.15 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -191,7 +191,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
         adjust_taken_damage_by_enchantments( elem );
 
         // Early exit if we're not taking damage.
-        if( elem.amount > 0.0 ) {
+        if( elem.amount >= 1.0 ) {
             worn.absorb_damage( *this, elem, bp, worn_remains, armor_destroyed );
             passive_absorb_hit( bp, elem );
             adjust_taken_damage_by_enchantments_post_absorbed( elem );


### PR DESCRIPTION
#### Summary
Fix dense and light bones

#### Purpose of change
- Dense bones was for some reason just adding a flat 4 hp instead of 5% of your total.
- Light bones was applying extra damage even if you took only fractional damage.

#### Describe the solution
- You only take extra bash damage from light bones if you took at least 1.0 after armor.
- Dense bones now properly gives 5% hp.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
