### PR TITLE
Fix chain lightning

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -615,10 +615,10 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             if( &z == origin ) {
                 return false;
             }
-            // search for creatures in radius 4 around impact site
+            // Search for creatures in radius 4 around impact site.
             if( static_cast<int>( std::round( trig_dist_z_adjust( z.pos_bub( *here ), tp ) ) ) <= 4 &&
-                here->sees( z.pos_bub( *here ), tp, -1 ) ) {
-                // don't hit targets that have already been hit
+                here->clear_path( z.pos_bub( *here ), tp, 4, 1, 100 ) && ( z.pos_bub( *here ) != tp ) ) {
+                // Don't hit targets that have already been hit
                 for( auto it : attack.targets_hit ) {
                     if( &z == it.first ) {
                         return false;
@@ -630,7 +630,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         } );
         if( mon_ptr ) {
             Creature &z = *mon_ptr;
-            add_msg( _( "The attack bounced to %s!" ), z.get_name() );
+            add_msg( _( "The attack bounced to %s!" ), z.disp_name() );
             projectile_attack( attack, proj, here, tp, z.pos_bub(), dispersion, origin, in_veh );
             // TODO: Refine to handle overlapping maps
             if( here == &reality_bubble() ) {


### PR DESCRIPTION
#### Summary
Fix chain lightning

#### Purpose of change
Chain lightning (and anything with AMMO_EFFECT_BOUNCE) was just working on whether line of sight existed, it didn't care about walkable paths. It also didn't have a safeguard for self-targeting.

#### Describe the solution
- Check for a walkable path rather than LoS.
- Ensure the destination isn't the same as the origin.

#### Describe alternatives you've considered
There should probably be some other method here so that the lightning can go through prison bars and whatever, but this is fine for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
