### PR TITLE
Fix bash cap math

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1462,13 +1462,13 @@ static void roll_melee_damage_internal( const Character &u, const damage_type_id
             // scale the post-armor damage down halfway between damage and cap
             dmg_mul *= ( 1.0f + ( bash_cap / weap_dam ) ) / 2.0f;
         }
-
+        float low_cap = 1.f;
         if( whip ) {
             /** The average of intelligence and strength boost low cap on bashing damage */
-            const float low_cap = std::min( 1.0f, ( ( u.get_int() + u.get_arm_str() ) / 2 ) / 20.0f );
+            low_cap = std::min( 1.0f, ( ( u.get_int() + u.get_arm_str() ) / 2 ) / 20.0f );
         } else {
             /** @ARM_STR boosts low cap on bashing damage */
-            const float low_cap = std::min( 1.0f, u.get_arm_str() / 20.0f );
+            low_cap = std::min( 1.0f, u.get_arm_str() / 20.0f );
         }
         const float bash_min = low_cap * weap_dam;
         weap_dam = average ? ( bash_min + weap_dam ) * 0.5f : rng_float( bash_min, weap_dam );


### PR DESCRIPTION
#### Summary
Fix bash cap math

#### Purpose of change
Fixes some iffy math/confusing code related to the melee bash cap.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
