### PR TITLE
Add bash_below to floors

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -17,7 +17,7 @@
       "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
-      "str_min_supported": 150,
+      "str_min_supported": 150, "bash_below": true,
       "items": [
         { "item": "rock", "count": [ 5, 10 ] },
         { "item": "scrap", "count": [ 5, 8 ] },
@@ -44,6 +44,7 @@
       "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 150,
       "items": [
         { "item": "rock", "count": [ 5, 10 ] },
@@ -314,6 +315,7 @@
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
+      "bash_below": true,
       "items": [ { "item": "scrap", "count": [ 5, 8 ] }, { "item": "rebar", "count": [ 0, 2 ] } ]
     }
   },
@@ -336,6 +338,7 @@
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "rock", "count": [ 10, 22 ] },
         { "item": "scrap", "count": [ 10, 12 ] },
@@ -365,6 +368,7 @@
       "str_min": 150,
       "str_max": 400,
       "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "rock", "count": [ 10, 22 ] },
         { "item": "scrap", "count": [ 10, 12 ] },
@@ -388,6 +392,7 @@
       "str_min": 100,
       "str_max": 400,
       "str_min_supported": 150,
+      "bash_below": true,
       "items": [ { "item": "scrap", "count": [ 10, 12 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
   },
@@ -408,6 +413,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "rock", "count": [ 5, 11 ] },
         { "item": "scrap", "count": [ 10, 12 ] },
@@ -479,6 +485,7 @@
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -504,6 +511,7 @@
       "str_min": 200,
       "str_max": 500,
       "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -531,6 +539,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -553,6 +562,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "log", "count": [ 0, 1 ] },
         { "item": "stick", "count": [ 1, 4 ] },
@@ -578,6 +588,7 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
     }
   },
@@ -601,6 +612,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -624,6 +636,7 @@
       "str_max": 6,
       "sound_vol": 8,
       "sound_fail_vol": 8,
+      "bash_below": true,
       "items": [ { "item": "material_soil", "count": [ 1, 2 ] } ]
     }
   },
@@ -649,6 +662,7 @@
       "str_max": 15,
       "sound_vol": 8,
       "sound_fail_vol": 8,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "straw_pile", "count": [ 5, 10 ] } ]
     }
   },
@@ -719,6 +733,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "sheet_cotton", "count": [ 1, 2 ] },
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
@@ -800,6 +815,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "sheet_cotton", "count": [ 1, 2 ] },
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
@@ -887,6 +903,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
     },
     "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
@@ -1042,6 +1059,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
     },
     "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
@@ -1195,6 +1213,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "sheet_cotton", "count": [ 1, 2 ] },
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
@@ -1276,6 +1295,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "sheet_cotton", "count": [ 1, 2 ] },
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
@@ -1357,6 +1377,7 @@
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
     },
     "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
@@ -1457,6 +1478,7 @@
       "str_min": 50,
       "str_max": 400,
       "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -1478,6 +1500,7 @@
       "str_min_supported": 100,
       "ter_set": "t_open_air",
       "sound": "SMASH!",
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     },
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ]
@@ -1535,6 +1558,7 @@
       "sound": "metal screeching!",
       "sound_fail": "clang!",
       "ter_set": "t_dirt",
+      "bash_below": true,
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 40 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -11,7 +11,7 @@
     "connects_to": [ "DIRT", "CLAY", "SAND", "MUD", "DIRTMOUND", "CLAYMOUND", "SANDMOUND", "SANDGLASS", "CONCRETE" ],
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -24,7 +24,7 @@
     "looks_like": "t_railroad_rubble",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -37,7 +37,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -51,7 +51,7 @@
     "connect_groups": "SAND",
     "connects_to": [ "SAND", "SANDMOUND", "SANDGLASS" ],
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -66,7 +66,7 @@
     "connect_groups": "MUD",
     "connects_to": "MUD",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -80,7 +80,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -153,7 +153,7 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE", "TREE_PLANTABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 },
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
     "examine_action": "dirtmound"
   },
   {
@@ -175,7 +175,7 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 100,
-      "str_min_supported": 100,
+      "str_min_supported": 100, "bash_below": true,
       "items": [ { "item": "material_soil", "count": [ 100, 200 ] } ]
     }
   },
@@ -218,7 +218,7 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE" ],
-    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -231,7 +231,7 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "CONTAINER", "SEALED" ],
-    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -247,7 +247,7 @@
     "coverage": 0,
     "roof": "t_open_air",
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -261,7 +261,7 @@
     "connect_groups": "MULCHFLOOR",
     "connects_to": "MULCHFLOOR",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -278,7 +278,7 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -298,7 +298,7 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -318,7 +318,7 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -340,7 +340,7 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100,
+      "str_min_supported": 100, "bash_below": true,
       "items": [ { "item": "rock", "count": [ 2, 10 ] } ]
     }
   },
@@ -361,7 +361,7 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 100,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 150,
       "items": [
         { "item": "rock", "count": [ 5, 10 ] },
@@ -387,7 +387,7 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 150,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 200,
       "items": [
         { "item": "rock", "count": [ 10, 22 ] },
@@ -412,7 +412,7 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 15 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -433,7 +433,7 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 15 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -455,7 +455,7 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400,
+      "str_max": 400, "bash_below": true,
       "str_min_supported": 100,
       "items": [
         { "item": "splinter", "count": [ 2, 32 ] },
@@ -480,7 +480,7 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100,
+      "str_min_supported": 100, "bash_below": true,
       "items": [
         { "item": "splinter", "count": [ 2, 32 ] },
         { "item": "2x4", "count": [ 0, 8 ] },
@@ -506,7 +506,7 @@
       "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
-      "str_min_supported": 200,
+      "str_min_supported": 200, "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -532,7 +532,7 @@
       "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
-      "str_min_supported": 200,
+      "str_min_supported": 200, "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -558,7 +558,7 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100,
+      "str_min_supported": 100, "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -580,7 +580,7 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100,
+      "str_min_supported": 100, "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -596,7 +596,7 @@
     "move_cost": 2,
     "looks_like": "t_dirtfloor",
     "flags": [ "TRANSPARENT", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_open_air", "str_min": 50, "str_max": 400, "str_min_supported": 100 }
+    "bash": { "sound": "SMASH!", "ter_set": "t_open_air", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -608,7 +608,7 @@
     "move_cost": 5,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100 }
+    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -654,7 +654,7 @@
       "ter_set": "t_open_air",
       "str_min": 500,
       "str_max": 1000,
-      "str_min_supported": 200,
+      "str_min_supported": 200, "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -708,7 +708,7 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100 }
+    "bash": { "ter_set": "t_open_air", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -3169,7 +3169,7 @@
     "coverage": 50,
     "concealment": 50,
     "flags": [ "TRANSPARENT", "DIGGABLE", "PLOWABLE", "SMALL_HIDE", "GRAZABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
+    "bash": { "sound": "thump", "ter_set": "t_dirt", "str_min": 5, "str_max": 30, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3181,7 +3181,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 3, "str_max": 25, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3194,7 +3194,7 @@
     "move_cost": 2,
     "transforms_into": "t_grass",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "HARVESTED" ],
-    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 5, "str_max": 30, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3206,7 +3206,7 @@
     "color": "light_green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 5, "str_max": 30, "bash_below": true }
   },
   {
     "type": "terrain",
@@ -3218,7 +3218,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
-    "bash": { "ter_set": "t_dirt", "str_min": 15, "str_max": 40, "bash_below": true }
+    "bash": { "ter_set": "t_dirt", "str_min": 5, "str_max": 30, "bash_below": true }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
#### Summary
Add bash_below to floors

#### Purpose of change
Some floors were missing this, leading to oddities like letting you bash the ground or crashing cars into sand (not sand mounds, just like, the ground is sandy)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
