### PR TITLE
Remove 3 bad traits

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -10,12 +10,12 @@
     "condition": {
       "and": [
         { "expects_vars": [ "prep_time", "spell_to_cast", "message_success", "message_fail" ] },
-        { "math": [ "u_val('stamina')", ">", "_energy_amount" ] }
+        { "math": [ "u_val('stamina') > _energy_amount" ] }
       ]
     },
     "effect": [
       { "turn_cost": { "context_val": "prep_time" } },
-      { "math": [ "u_val('stamina')", "-=", "_energy_amount" ] },
+      { "math": [ "u_val('stamina') -= _energy_amount" ] },
       { "run_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ] }
     ],
     "false_effect": [ { "u_message": { "context_val": "message_fail" }, "type": "bad" } ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -667,18 +667,17 @@
     "points": 2,
     "description": "Your metabolism is a little slower, and you require less food than most.",
     "starting_trait": true,
-    "cancels": [ "MET_RAT" ],
+    "cancels": [ "MET_RAT", "GOURMAND" ],
     "types": [ "METABOLISM" ],
-    "changes_to": [ "GIZZARD" ],
-    "category": [ "FISH", "BIRD", "TROGLOBITE", "CHIROPTERAN", "GASTROPOD", "CEPHALOPOD", "RAPTOR" ],
-    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.333 } ] } ]
+    "category": [ "FISH", "BIRD", "ELFA", "TROGLOBITE", "CHIROPTERAN", "GASTROPOD", "CEPHALOPOD", "RAPTOR" ],
+    "enchantments": [ { "values": [ { "value": "METABOLISM", "multiply": -0.15 } ] } ]
   },
   {
     "type": "mutation",
     "id": "EASYSLEEPER",
-    "name": { "str": "Accomplished Sleeper" },
+    "name": { "str": "Easy Sleeper" },
     "points": 1,
-    "description": "You have always been able to fall asleep easily, even when sleeping in less than ideal circumstances.",
+    "description": "You're able to fall asleep easily, even in less than ideal circumstances.",
     "types": [ "SLEEPINESS" ],
     "changes_to": [ "EASYSLEEPER2" ],
     "starting_trait": true,
@@ -689,7 +688,7 @@
   {
     "type": "mutation",
     "id": "EASYSLEEPER2",
-    "name": { "str": "Practiced Sleeper" },
+    "name": { "str": "Able Sleeper" },
     "points": 2,
     "description": "Your body's demanding energy needs mean you can fall asleep just about anywhere.",
     "types": [ "SLEEPINESS" ],
@@ -698,26 +697,6 @@
     "threshreq": [ "THRESH_MOUSE", "THRESH_RABBIT" ],
     "category": [ "MOUSE", "RABBIT" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SLEEPY", "add": 40 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "DIRTSLEEPER",
-    "name": { "str": "Earth Sleeper" },
-    "points": 2,
-    "description": "You always sleep better surrounded by earth.",
-    "category": [ "BATRACHIAN" ],
-    "threshreq": [ "THRESH_BATRACHIAN" ],
-    "enchantments": [ { "condition": { "math": [ "u_val('pos_z')", "<", "0" ] }, "values": [ { "value": "SLEEPY", "add": 20 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "WATERSLEEPER",
-    "name": { "str": "Aquatic Sleeper" },
-    "points": 2,
-    "description": "You always sleep better underwater.",
-    "threshreq": [ "THRESH_FISH", "THRESH_BATRACHIAN" ],
-    "category": [ "BATRACHIAN", "FISH" ],
-    "enchantments": [ { "condition": "u_is_underwater", "values": [ { "value": "SLEEPY", "add": 40 } ] } ]
   },
   {
     "type": "mutation",
@@ -977,7 +956,7 @@
     "points": 2,
     "description": "You eat faster, and can eat and drink more in a single sitting.  You also enjoy food more; delicious food is better for your morale, and you don't mind unsavory meals as much.  Activate to skip prompt for overeating.",
     "category": [ "MOUSE", "LUPINE", "RAT" ],
-    "cancels": [ "PICKYEATER" ],
+    "cancels": [ "PICKYEATER", "LIGHTEATER" ],
     "starting_trait": true,
     "active": true,
     "enchantments": [
@@ -4356,20 +4335,6 @@
     "leads_to": [ "CHLOROMORPH" ],
     "category": [ "PLANT" ],
     "flags": [ "IMMUNE_SPOIL" ]
-  },
-  {
-    "type": "mutation",
-    "id": "GIZZARD",
-    "name": { "str": "Gizzard" },
-    "points": -5,
-    "description": "You seem to get full faster now, and food goes through you more rapidly as well.",
-    "purifiable": false,
-    "prereqs": [ "BEAK", "DRILL_BEAK" ],
-    "enchantments": [ { "values": [ { "value": "KCAL", "multiply": -0.4 }, { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": -0.1 } ] } ],
-    "prereqs2": [ "LIGHTEATER" ],
-    "threshreq": [ "THRESH_BIRD" ],
-    "cancels": [ "GOURMAND" ],
-    "category": [ "BIRD" ]
   },
   {
     "type": "mutation",

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -326,6 +326,36 @@
     "valid": false
   },
   {
+    "type": "mutation",
+    "id": "DIRTSLEEPER",
+    "name": { "str": "Earth Sleeper" },
+    "points": 0,
+    "player_display": false,
+    "description": "Obsoleted trait.",
+    "random_at_chargen": false,
+    "valid": false
+  },
+    {
+    "type": "mutation",
+    "id": "WATERSLEEPER",
+    "name": { "str": "Aquatic Sleeper" },
+    "points": 0,
+    "player_display": false,
+    "description": "Obsoleted trait.",
+    "random_at_chargen": false,
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "GIZZARD",
+    "name": { "str": "Gizzard" },
+    "points": 0,
+    "player_display": false,
+    "description": "Obsoleted trait.",
+    "random_at_chargen": false,
+    "valid": false
+  },
+  {
     "id": "scenario_assassin_convict",
     "type": "effect_on_condition"
   },


### PR DESCRIPTION
#### Summary
Remove 3 bad traits

#### Purpose of change
- Earth Sleeper: Batrachian only (not trog??), post-thresh, made it easier to sleep if you were below z0. What is the point of this?
- Aquatic Sleeper: Ditto, but for underwater. Batrachian already has Aqueous Repose. What is the point of this????
- Gizzard: Makes birds get 40% less kcal from food for seemingly no reason. That's not how gizzards work!

#### Describe the solution
- Obsolete Earth and Aquatic Sleeper
- Obsolete Gizzard
- Change Light Eater to only a 15% metabolism reduction, and make it make your stomach 10% smaller too.

#### Describe alternatives you've considered
Redoing all the eating/metabolism traits.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
