### PR TITLE
fix ponderous name

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7372,7 +7372,7 @@
   {
     "type": "mutation",
     "id": "PONDEROUS3",
-    "name": { "str": "PONDEROUS1" },
+    "name": { "str": "Ponderous" },
     "points": -4,
     "description": "You have a hard time getting anywhere in a hurry.  This affects only your movement, not your actions.",
     "types": [ "RUNNING" ],


### PR DESCRIPTION
#### Summary
Ponderous was renamed to PONDEROUS1 in https://github.com/Cataclysm-TLG/Cataclysm-TLG/commit/35bbf981f483b72acb825c64374de279e92f2fdc

#### Purpose of change
Rename PONDEROUS1 name on trait with id PONDEROUS3 to Ponderous

#### Describe the solution
Rename PONDEROUS1 name on trait with id PONDEROUS3 to Ponderous

#### Describe alternatives you've considered
None.

#### Testing
Before:
<img width="1172" height="306" alt="image" src="https://github.com/user-attachments/assets/a9ea1082-5ca3-46f6-bfef-e95dc6d55a83" />

After:
<img width="1163" height="303" alt="image" src="https://github.com/user-attachments/assets/416ae716-0e1c-48af-9667-084ae6da9744" />

#### Additional context
None.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
