### PR TITLE
Reduces golf club volume by 99.86%

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -395,7 +395,7 @@
     "techniques": [ "WBLOCK_1" ],
     "weapon_category": [ "HAMMERS" ],
     "weight": "300 g",
-    "volume": "350 L",
+    "volume": "500 ml",
     "longest_side": "110 cm",
     "to_hit": { "grip": "solid", "length": "short", "surface": "line", "balance": "neutral" },
     "flags": [ "SHEATH_GOLF", "FRAGILE_MELEE" ],


### PR DESCRIPTION
Golf clubs were 350L and have now been reduced to 500 ml

#### Summary
Golf clubs were 350L and have now been reduced to 500 ml

#### Purpose of change
Golf clubs were 350L. This was maybe not correct.

#### Describe the solution
The legal (USGA) volume for driver head is 460ml. The average volume of a golf club handle is 50ml. I've rounded this off to 500ml

#### Describe alternatives you've considered
Giggle at mass drivers

#### Testing
Works as intended and runs without error.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
