### PR TITLE
Remove "have a meal"

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -257,7 +257,7 @@ class basecamp
                            bool is_player_meal = false );
         /// Helper, forwards to above
         void feed_workers( Character &worker, nutrients food, bool is_player_meal = false );
-        void player_eats_meal();
+        // void player_eats_meal();
         /// Takes all the food from the camp_food zone and increases the faction
         /// food_supply
         bool distribute_food( bool player_command = true );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -373,8 +373,8 @@ static std::string mission_ui_activity_of( const mission_id &miss_id )
         case Camp_Determine_Leadership:
             return _( "Switch to follower" );
 
-        case Camp_Have_Meal:
-            return _( "Have a meal" );
+        // case Camp_Have_Meal:
+        //     return _( "Have a meal" );
 
         case Camp_Hide_Mission:
             return _( "Hide mission(s)" );
@@ -1514,16 +1514,16 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
             mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                              entry );
         }
-        {
-            const mission_id miss_id = { Camp_Have_Meal, "", {}, base_dir };
-            entry = string_format( _( "Notes:\n"
-                                      "Eat some food from the larder.\n"
-                                      "Nutritional value depends on food stored in the larder.\n"
-                                      "Difficulty: N/A\n"
-                                      "Risk: None\n" ) );
-            mission_key.add( { miss_id, false }, name_display_of( miss_id ),
-                             entry );
-        }
+        // {
+        //     const mission_id miss_id = { Camp_Have_Meal, "", {}, base_dir };
+        //     entry = string_format( _( "Notes:\n"
+        //                               "Eat some food from the larder.\n"
+        //                               "Nutritional value depends on food stored in the larder.\n"
+        //                               "Difficulty: N/A\n"
+        //                               "Risk: None\n" ) );
+        //     mission_key.add( { miss_id, false }, name_display_of( miss_id ),
+        //                      entry );
+        // }
         {
             validate_assignees();
             const mission_id miss_id = { Camp_Assign_Jobs, "", {}, base_dir };
@@ -1588,36 +1588,36 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
     }
 }
 
-void basecamp::player_eats_meal()
-{
-    uilist smenu;
-    smenu.text = _( "Have a meal?" );
-    int i = 1;
-    smenu.addentry( i++, true, '1', _( "Snack" ) );
-    smenu.addentry( i++, true, '2', _( "Meal" ) );
-    smenu.addentry( i++, true, '3', _( "Just stuff your face.  You're hungry!" ) );
-    smenu.query();
-    if( smenu.ret_act != "CONFIRM" ) {
-        popup( _( "You decide not to have anything after all." ) );
-        return;
-    }
-    int kcal_to_eat = smenu.ret * 750 - 250; // 500, 1250, 2000 kcal
-    Character &you = get_player_character();
-    const int &food_available = fac()->food_supply.kcal();
-    if( you.stomach.contains() >= ( you.stomach.capacity( you ) / 2 ) ) {
-        popup( _( "You're way too full to eat a full meal right now." ) );
-        return;
-    }
-    if( food_available <= 0 ) {
-        popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );
-        return;
-    } else if( food_available <= kcal_to_eat ) {
-        add_msg( _( "There's only one meal left.  Guess that's dinner!" ) );
-        kcal_to_eat = food_available;
-    }
-    nutrients dinner = camp_food_supply( -kcal_to_eat );
-    feed_workers( you, dinner, true );
-}
+// void basecamp::player_eats_meal()
+// {
+//     uilist smenu;
+//     smenu.text = _( "Have a meal?" );
+//     int i = 1;
+//     smenu.addentry( i++, true, '1', _( "Snack" ) );
+//     smenu.addentry( i++, true, '2', _( "Meal" ) );
+//     smenu.addentry( i++, true, '3', _( "Just stuff your face.  You're hungry!" ) );
+//     smenu.query();
+//     if( smenu.ret_act != "CONFIRM" ) {
+//         popup( _( "You decide not to have anything after all." ) );
+//         return;
+//     }
+//     int kcal_to_eat = smenu.ret * 750 - 250; // 500, 1250, 2000 kcal
+//     Character &you = get_player_character();
+//     const int &food_available = fac()->food_supply.kcal();
+//     if( you.stomach.contains() >= ( you.stomach.capacity( you ) / 2 ) ) {
+//         popup( _( "You're way too full to eat a full meal right now." ) );
+//         return;
+//     }
+//     if( food_available <= 0 ) {
+//         popup( _( "You check storage for some food, but there is nothing but dust and cobwebs…" ) );
+//         return;
+//     } else if( food_available <= kcal_to_eat ) {
+//         add_msg( _( "There's only one meal left.  Guess that's dinner!" ) );
+//         kcal_to_eat = food_available;
+//     }
+//     nutrients dinner = camp_food_supply( -kcal_to_eat );
+//     feed_workers( you, dinner, true );
+// }
 
 bool basecamp::handle_mission( const ui_mission_id &miss_id )
 {
@@ -1637,9 +1637,9 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
             player_character.control_npc_menu( false );
             break;
 
-        case Camp_Have_Meal:
-            player_eats_meal();
-            break;
+        // case Camp_Have_Meal:
+        //     player_eats_meal();
+        //     break;
 
         case Camp_Hide_Mission:
             handle_hide_mission( miss_id.id.dir.value() );
@@ -5797,7 +5797,7 @@ std::string basecamp::name_display_of( const mission_id &miss_id )
         //  Faction camp tasks
         case Camp_Distribute_Food:
         case Camp_Determine_Leadership:
-        case Camp_Have_Meal:
+        // case Camp_Have_Meal:
         case Camp_Hide_Mission:
         case Camp_Reveal_Mission:
         case Camp_Assign_Jobs:

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -189,7 +189,7 @@ std::string enum_to_string<mission_kind>( mission_kind data )
         case mission_kind::Caravan_Commune_Center_Job: return "Caravan_Commune_Center_Job";
         case mission_kind::Camp_Distribute_Food: return "Camp_Distribute_Food";
 		case mission_kind::Camp_Determine_Leadership: return "Camp_Determine_Leadership";
-		case mission_kind::Camp_Have_Meal: return "Camp_Have_Meal";
+		// case mission_kind::Camp_Have_Meal: return "Camp_Have_Meal";
         case mission_kind::Camp_Hide_Mission: return "Camp_Hide_Mission";
         case mission_kind::Camp_Reveal_Mission: return "Camp_Reveal_Mission";
         case mission_kind::Camp_Assign_Jobs: return "Camp_Assign_Jobs";
@@ -269,10 +269,10 @@ static const std::array < miss_data, Camp_Harvest + 1 > miss_info = { {
             "Camp_Determine_Leadership",
             no_translation( "" )
         },
-        {
-            "Camp_Have_Meal",
-            no_translation( "" )
-        },
+        // {
+        //     "Camp_Have_Meal",
+        //     no_translation( "" )
+        // },
         {
             "Hide_Mission",
             no_translation( "" )
@@ -1246,7 +1246,7 @@ bool talk_function::handle_outpost_mission( const mission_entry &cur_key, npc &p
 
         case Camp_Distribute_Food:
         case Camp_Determine_Leadership:
-        case Camp_Have_Meal:
+        // case Camp_Have_Meal:
         case Camp_Hide_Mission:
         case Camp_Reveal_Mission:
         case Camp_Assign_Jobs:

--- a/src/mission_companion.h
+++ b/src/mission_companion.h
@@ -49,7 +49,7 @@ enum mission_kind : int {
     //  Faction camp tasks
     Camp_Distribute_Food,        //  Direct action, not serialized
     Camp_Determine_Leadership,   //  Direct action, not serialized
-    Camp_Have_Meal,              //  Direct action, not serialized
+    // Camp_Have_Meal,              //  Direct action, not serialized
     Camp_Hide_Mission,           //  Direct action, not serialized
     Camp_Reveal_Mission,         //  Direct action, not serialized
     Camp_Assign_Jobs,


### PR DESCRIPTION
#### Summary
Remove "have a meal"

#### Purpose of change
A while back, the ability to have the player eat out of the abstracted faction camp supply was added. This isn't ideal for many reasons, but it was also broken in TLG, and wasn't deducting kcal from storage.

#### Describe the solution
Simply remove the option.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
