### PR TITLE
Silence "no display part" error message.

### DIFF
--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -61,7 +61,6 @@ vpart_display vehicle::get_display_of_tile( const point_rel_ms &dp, bool rotate,
 {
     const int part_idx = part_displayed_at( dp, include_fake, below_roof, roof );
     if( part_idx == -1 ) {
-        debugmsg( "no display part at mount (%d, %d)", dp.x(), dp.y() );
         return {};
     }
 


### PR DESCRIPTION
#### Summary
Silence "no display part" error message.

#### Purpose of change
Ever since sentinel parts were added, the "no display part at x, y" error message has been spamming players a lot more often. This message is not useful to the player and the situation generally immediately resolves itself.

#### Describe the solution
Remove the message.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
