### PR TITLE
Add crustacean samples to TCL crates itemgroup

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -611,6 +611,7 @@
       { "item": "plant_sample", "prob": 10, "count": [ 3, 6 ] },
       { "item": "slime_sample", "prob": 10, "count": [ 3, 6 ] },
       { "item": "bird_sample", "prob": 10, "count": [ 3, 6 ] },
+      { "item": "crustacean_sample", "prob": 10, "count": [ 1, 3 ] },
       { "item": "sweetbread", "prob": 10, "count": [ 4, 12 ] }
     ]
   },


### PR DESCRIPTION
#### Summary
TCL crates from the green zone surface were missing crustacean samples, while lab fridges contain crustacean samples along with other types

#### Purpose of change
Make crustacean samples spawn along with other samples at the TCL

#### Describe the solution
Add crustacean samples to supplies_samples_lab

#### Describe alternatives you've considered
None.

#### Testing
Spawned in a fresh new world, opened TCL crates, found a crustacean sample.

#### Additional context
<img width="1847" height="1056" alt="image" src="https://github.com/user-attachments/assets/7b39828b-87cb-42e4-aa29-5ea40177beb5" />

I'd like to also point out that in supplies_samples_lab, bird, plant and slime samples spawn in higher quantities than all other samples: 3 to 6 compared to the normal 1 to 3. I decided the crustacean sample should have the 1 to 3 amount as it is with the vast majority.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
