### PR TITLE
Four Tentacles Mutation Description

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7946,7 +7946,7 @@
     "points": 0,
     "visibility": 4,
     "ugliness": 4,
-    "description": "Your arms have transformed into four tentacles, giving you +1 Dexterity and the ability to attack while prone at a greatly reduced penalty, however they're not as useful as hands for fine manipulation, resulting in a permanent +30 encumbrance.",
+    "description": "Your arms have transformed into four tentacles, giving you +1 Dexterity and the ability to attack while prone at a greatly reduced penalty, however they're not as useful as hands for fine manipulation, resulting in a permanent +20 encumbrance.",
     "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
     "restricts_gear": [ "hand_l", "hand_r" ],
     "types": [ "ARMS", "HANDS", "CLAWS" ],


### PR DESCRIPTION
Description should say +20 instead of +30

#### Summary
Category "Brief description"

#### Purpose of change
Updates mutation description to be in line with the changes in 
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/878/files

#### Describe the solution
Changes description of the mutation to +20 instead of +30

#### Describe alternatives you've considered
None

#### Testing
Runs without error and is now correct.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
