### PR TITLE
Fix skating proficiency training

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5049,7 +5049,7 @@ units::energy vehicle::drain_energy( const itype_id &ftype, units::energy wanted
 void vehicle::consume_fuel( map &here, int load, bool idling )
 {
     double st = strain( here );
-    bool skating;
+    bool skating = false;
     for( const auto &fuel_pr : fuel_usage() ) {
         const itype_id &ft = fuel_pr.first;
         if( idling && ft == fuel_type_battery ) {
@@ -5143,16 +5143,14 @@ void vehicle::consume_fuel( map &here, int load, bool idling )
     }
 }
 
-void practice_pilot_proficiencies( Character &p, bool &boating, bool &skating )
+void practice_pilot_proficiencies( Character &p, bool boating, bool skating )
 {
-    if( !p.has_proficiency( proficiency_prof_skating) && skating ) {
+    if( skating && !boating && !p.has_proficiency( proficiency_prof_skating ) ) {
         p.practice_proficiency( proficiency_prof_skating, 1_seconds );
-    }
-    if( !p.has_proficiency( proficiency_prof_driver ) && !boating && !skating ) {
-        p.practice_proficiency( proficiency_prof_driver, 1_seconds );
-    }
-    if( !p.has_proficiency( proficiency_prof_boat_pilot ) && boating && !skating ) {
+    } else if( boating && !skating && !p.has_proficiency( proficiency_prof_boat_pilot ) ) {
         p.practice_proficiency( proficiency_prof_boat_pilot, 1_seconds );
+    } else if( !boating && !skating && !p.has_proficiency( proficiency_prof_driver ) ) {
+        p.practice_proficiency( proficiency_prof_driver, 1_seconds );
     }
 }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -74,7 +74,7 @@ class vehicle_part_with_feature_range;
 
 void handbrake( map &here );
 
-void practice_pilot_proficiencies( Character &p, bool &boating, bool &skating );
+void practice_pilot_proficiencies( Character &p, bool boating, bool skating );
 
 namespace catacurses
 {


### PR DESCRIPTION
#### Summary
Fix skating proficiency training

#### Purpose of change
The if statements for learning driving/boating were weird, causing skating to be learned at inappropriate times.

#### Describe the solution
Make them if/else instead.

#### Testing
Drove around, learned driving.
Skated around, learned skating.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
