### PR TITLE
Fix protein powder

### DIFF
--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -24,7 +24,7 @@
     "calories": 100,
     "quench": 40,
     "fun": -1,
-    "vitamins": [ [ "calcium", "73 mg" ] ],
+    "vitamins": [ ],
     "flags": [ "EATEN_COLD" ]
   },
   {
@@ -33,10 +33,10 @@
     "comestible_type": "FOOD",
     "name": { "str_sp": "protein powder" },
     "conditional_names": [
-      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "soylent green powder" } },
+      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "people %s" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
-    "description": "Raw, refined protein.  While quite nutritious, it is impossible to enjoy in its pure form, try adding water.",
+    "description": "A powder consisting chiefly of dried protein.  Eating it in its current state would be an unpleasant experience, to say the least.",
     "//": "1 g of protein powder is 0.959 ml, 1 serving is 28g and 27ml",
     "weight": "28 g",
     "volume": "27 ml",
@@ -48,7 +48,9 @@
     "color": "white",
     "container": "bottle_plastic_small",
     "calories": 100,
+    "quench": -10,
     "freezing_point": -274,
+    "fun": -4,
     "vitamins": [  ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix protein powder

#### Purpose of change
fixes #1659 

Protein powder was edible and there were no drawbacks to this.

#### Describe the solution
- Eating protein powder now dehydrates you, and it's fun -4 instead of 0. The description has been updated accordingly.
- Protein drink had calcium in it for no reason, even though protein powder does not. Removed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
