### PR TITLE
Update cattail mission

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -806,11 +806,10 @@
     "id": "MISSION_LEARN_ABOUT_CATTAIL_JELLY",
     "type": "mission_definition",
     "name": { "str": "Gather cattail stalks to create cattail jelly" },
-    "description": "Gather <color_light_blue>20 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks.  <color_light_blue>Bring back the provided bag</color> as well.",
+    "description": "Gather <color_light_blue>20 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks or foraging in underbrush.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "and": [
-        { "u_has_item": "duffelbag" },
         { "u_has_items": { "item": "cattail_stalk", "count": 20 } },
         { "math": [ "u_skill('survival')", ">=", "1" ] }
       ]
@@ -820,13 +819,11 @@
     "has_generic_rewards": false,
     "origins": [ "ORIGIN_OPENER_NPC", "ORIGIN_ANY_NPC" ],
     "start": {
-      "effect": [ { "u_spawn_item": "duffelbag" } ],
       "assign_mission_target": { "om_terrain": "forest_water", "reveal_radius": 3 }
     },
     "end": {
       "effect": [
         { "u_sell_item": "cattail_stalk", "count": 20 },
-        { "u_sell_item": "duffelbag" },
         { "npc_consume_item": "cattail_stalk", "count": 20 },
         { "u_learn_recipe": "cattail_jelly" },
         { "u_message": "You learn how to craft cattail jelly.", "popup": true },
@@ -835,11 +832,11 @@
     },
     "dialogue": {
       "describe": "Medical services are a little sparse following <the_cataclysm>, but people have been surviving using their wits and the bounty of Mother Nature for a long time.  Care to learn a little?",
-      "offer": "Did you know that cattails are a source of a jelly that works as an antiseptic and analgesic?  Something like that is likely to be mighty helpful out here.  I want you to take this bag, head to the nearest swamp, collect 20 cattail stalks, and bring them back here.  In exchange, I'll show you how to harvest the jelly.",
-      "accepted": "Great!  This bag should be big enough to hold all of the stalks we'll need.  Don't forget to bring it back.",
+      "offer": "Did you know that cattails are a source of a jelly that works as an antiseptic and analgesic?  Something like that is likely to be mighty helpful out here.  I want you to head to the nearest swamp, collect 20 cattail stalks, and bring them back here.  In exchange, I'll show you how to harvest the jelly, provided you can demonstrate you have the skills.",
+      "accepted": "Great!  Be careful out there, and don't be afraid to forage around in any underbrush you pass, too.  You never know what you'll find.",
       "rejected": "Your loss.",
       "advice": "The cattails grow in the fresh water in swamps.  You can't miss them.",
-      "inquire": "Got those cattail stalks yet?  Don't forget to bring back my bag and to work on improving your survival skill as well.",
+      "inquire": "Got those cattail stalks yet?",
       "success": "Great!  Hand them over and I'll show you how this works.",
       "success_lie": "OK, then hand them over.",
       "failure": "Well, that's a shame."


### PR DESCRIPTION
#### Summary
Update cattail mission

#### Purpose of change
fixes #1651 

#### Describe the solution
There was no reason for the cattail job to involve a huge duffel bag since you only need 20 of the things. Most professions start with some kind of storage, and those that don't, well, figure it out!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
