### PR TITLE
Fix scaling factor for high-dpi displays

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3744,7 +3744,7 @@ int projected_window_height()
 }
 
 // Measures scaling factor for high-dpi displays
-std::pair<float,float> get_display_scale( int display_index )
+static std::pair<float,float> get_display_scale( int display_index )
 {
     int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
     int y = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );


### PR DESCRIPTION
#### Summary
This PR fixes the scaling factor for high-dpi displays. 

#### Purpose of change

The number of pixels returned by `SDL_GetWindowSize` do not take into account dpi scaling, like on Apple Retina displays. Thankfully SDL2 provides a `SDL_GetWindowSizeInPixels` for accounting for exactly this.

Additionally, even in full screen mode the dimensions of `SDL_DisplayMode` are incorrect due to `SDL_GetDesktopDisplayMode` similarly not factoring in dpi scale.

#### Describe the solution

Switch to `SDL_GetWindowSizeInPixels` and implement a new `get_display_scale` function for measuring the dpi scaling ratios. The measurement creates a small, hidden window to quickly measure the horizontal and vertical stretch necessary to account for dpi. On failure the return values are 1x, ensuring no logical change.

#### Describe alternatives you've considered

One could perhaps imagine a larger refactor where we always perform window measurements, but even in this case we'd want precisely the same affordance provided by `get_display_scale`. This keeps things minimal and known to not break other platforms.

#### Testing

I've tested this on my MacBook in each mode, though given it's backend agnostic it should work cross-platform. Nevertheless when I have access to my other devices I'll try the changes there too.
