### PR TITLE
High dpi fix: support SDL pre-2.26

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3768,6 +3768,7 @@ static std::pair<float,float> get_display_scale( int display_index )
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
     #else
+    (void)display_index; // avoid unused parameter lint
     return std::make_pair( 1.0f, 1.0f );
     #endif
 }


### PR DESCRIPTION
This PR adds support for older versions of SDL to
- #1667 

`SDL_GetWindowSizeInPixels` was added in November of 2022. Most people should have it, but in case they don't the code now defaults to the older `SDL_GetWindowSize` the code used to use.