### PR TITLE
Backport 80848 - Fix harvest_plant no product when not from_activity

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2687,6 +2687,8 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
                     if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
+                } else {
+                    here.add_item_or_charges( you.pos_bub(), i );
                 }
             }
             here.furn_set( examp, furn_str_id( fp->base ) );


### PR DESCRIPTION
#### Summary
Backport 80848 - Fix harvest_plant no product when not from_activity

#### Purpose of change
Fixes an issue where harvesting crops was not producing anything.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
