### PR TITLE
Chargen fixes

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -17,7 +17,8 @@
       "ter_set": "t_open_air",
       "str_min": 100,
       "str_max": 400,
-      "str_min_supported": 150, "bash_below": true,
+      "str_min_supported": 150,
+      "bash_below": true,
       "items": [
         { "item": "rock", "count": [ 5, 10 ] },
         { "item": "scrap", "count": [ 5, 8 ] },

--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -24,7 +24,14 @@
     "looks_like": "t_railroad_rubble",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -37,7 +44,14 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -51,7 +65,14 @@
     "connect_groups": "SAND",
     "connects_to": [ "SAND", "SANDMOUND", "SANDGLASS" ],
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -66,7 +87,14 @@
     "connect_groups": "MUD",
     "connects_to": "MUD",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -80,7 +108,14 @@
     "move_cost": 2,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -153,7 +188,14 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE", "TREE_PLANTABLE" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    },
     "examine_action": "dirtmound"
   },
   {
@@ -175,7 +217,8 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 100,
-      "str_min_supported": 100, "bash_below": true,
+      "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "material_soil", "count": [ 100, 200 ] } ]
     }
   },
@@ -218,7 +261,14 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -231,7 +281,14 @@
     "move_cost": 3,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "CONTAINER", "SEALED" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -261,7 +318,14 @@
     "connect_groups": "MULCHFLOOR",
     "connects_to": "MULCHFLOOR",
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -278,7 +342,8 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -298,7 +363,8 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -318,7 +384,8 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 10 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -340,7 +407,8 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100, "bash_below": true,
+      "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "rock", "count": [ 2, 10 ] } ]
     }
   },
@@ -361,7 +429,8 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 100,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 150,
       "items": [
         { "item": "rock", "count": [ 5, 10 ] },
@@ -387,7 +456,8 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 150,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 200,
       "items": [
         { "item": "rock", "count": [ 10, 22 ] },
@@ -412,7 +482,8 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 15 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -433,7 +504,8 @@
     "bash": {
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [ { "item": "rock", "count": [ 2, 15 ] }, { "item": "rebar", "count": [ 0, 4 ] } ]
     }
@@ -455,7 +527,8 @@
       "sound": "SMASH!",
       "ter_set": "t_open_air",
       "str_min": 50,
-      "str_max": 400, "bash_below": true,
+      "str_max": 400,
+      "bash_below": true,
       "str_min_supported": 100,
       "items": [
         { "item": "splinter", "count": [ 2, 32 ] },
@@ -480,7 +553,8 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100, "bash_below": true,
+      "str_min_supported": 100,
+      "bash_below": true,
       "items": [
         { "item": "splinter", "count": [ 2, 32 ] },
         { "item": "2x4", "count": [ 0, 8 ] },
@@ -506,7 +580,8 @@
       "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
-      "str_min_supported": 200, "bash_below": true,
+      "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -532,7 +607,8 @@
       "ter_set": "t_open_air",
       "str_min": 200,
       "str_max": 500,
-      "str_min_supported": 200, "bash_below": true,
+      "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -558,7 +634,8 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100, "bash_below": true,
+      "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -580,7 +657,8 @@
       "ter_set": "t_open_air",
       "str_min": 50,
       "str_max": 400,
-      "str_min_supported": 100, "bash_below": true,
+      "str_min_supported": 100,
+      "bash_below": true,
       "items": [ { "item": "splinter", "count": [ 2, 8 ] }, { "item": "nail", "charges": [ 5, 10 ] } ]
     }
   },
@@ -596,7 +674,14 @@
     "move_cost": 2,
     "looks_like": "t_dirtfloor",
     "flags": [ "TRANSPARENT", "FLAT", "DIGGABLE" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_open_air", "str_min": 50, "str_max": 400, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 400,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -608,7 +693,14 @@
     "move_cost": 5,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_open_air",
+      "str_min": 50,
+      "str_max": 100,
+      "str_min_supported": 100,
+      "bash_below": true
+    }
   },
   {
     "type": "terrain",
@@ -654,7 +746,8 @@
       "ter_set": "t_open_air",
       "str_min": 500,
       "str_max": 1000,
-      "str_min_supported": 200, "bash_below": true,
+      "str_min_supported": 200,
+      "bash_below": true,
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -705,18 +705,18 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
     }
 
     const tripoint_bub_ms pos = pos_bub( here );
-    
+
     // Check for adjacent high-concealment tiles that would block vision.
     if( rl_dist( pos, t ) > 2 ) {
         // Get the direction to the target.
         const int dx = t.x() - pos.x();
         const int dy = t.y() - pos.y();
-        
-        const int adj_x = pos.x() + (dx > 0 ? 1 : (dx < 0 ? -1 : 0));
-        const int adj_y = pos.y() + (dy > 0 ? 1 : (dy < 0 ? -1 : 0));
+
+        const int adj_x = pos.x() + ( dx > 0 ? 1 : ( dx < 0 ? -1 : 0 ) );
+        const int adj_y = pos.y() + ( dy > 0 ? 1 : ( dy < 0 ? -1 : 0 ) );
         const tripoint_bub_ms adjacent( adj_x, adj_y, pos.z() );
-        
-        if( adjacent != pos && here.inbounds( adjacent ) && 
+
+        if( adjacent != pos && here.inbounds( adjacent ) &&
             eye_level() < here.concealment( adjacent ) ) {
             return false;
         }
@@ -728,7 +728,7 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );
     const int wanted_range = rl_dist( pos, t );
-    
+
     if( wanted_range <= range_min ||
         ( wanted_range <= range_max &&
           here.ambient_light_at( t ) > here.get_cache_ref( t.z() ).natural_light_level_cache ) ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -72,7 +72,6 @@
 static const std::string flag_CHALLENGE( "CHALLENGE" );
 static const std::string flag_CITY_START( "CITY_START" );
 static const std::string flag_SECRET( "SECRET" );
-static const std::string flag_SKIP_DEFAULT_BACKGROUND( "SKIP_DEFAULT_BACKGROUND" );
 
 static const flag_id json_flag_auto_wield( "auto_wield" );
 static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
@@ -80,9 +79,6 @@ static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 
 static const matype_id style_none( "style_none" );
-
-static const profession_group_id
-profession_group_adult_basic_background( "adult_basic_background" );
 
 static const trait_id trait_SMELLY( "SMELLY" );
 static const trait_id trait_WEAKSCENT( "WEAKSCENT" );
@@ -785,12 +781,6 @@ bool avatar::create( character_type type, const std::string &tempname )
             }
             tabs.position.last();
             break;
-    }
-
-    // Don't apply the default backgrounds on a template
-    if( type != character_type::TEMPLATE &&
-        !get_scenario()->has_flag( flag_SKIP_DEFAULT_BACKGROUND ) ) {
-        add_default_background();
     }
 
     auto nameExists = [&]( const std::string & name ) {
@@ -2613,6 +2603,18 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
                 cur_id = iStartPos + ( iContentHeight - 1 ) / 2;
             }
         } else if( action == "CONFIRM" ) {
+            u.random_start_location = true;
+            u.str_max = 8;
+            u.dex_max = 8;
+            u.int_max = 8;
+            u.per_max = 8;
+
+            u.hobbies.clear();
+            u.clear_mutations();
+            u.recalc_hp();
+            u.empty_skills();
+            u.add_traits();
+
             // Selecting a profession will, under certain circumstances, change the detail text
             details_recalc = true;
 
@@ -4924,17 +4926,6 @@ void avatar::character_to_template( const std::string &name )
     save_template( name, pool_type::TRANSFER );
 }
 
-void Character::add_default_background()
-{
-    for( const profession_group &prof_grp : profession_group::get_all() ) {
-        if( prof_grp.get_id() == profession_group_adult_basic_background ) {
-            for( const profession_id &hobb : prof_grp.get_professions() ) {
-                hobbies.insert( &hobb.obj() );
-            }
-        }
-    }
-}
-
 void avatar::save_template( const std::string &name, pool_type pool )
 {
     write_to_file( PATH_INFO::templatedir() + name + ".template", [&]( std::ostream & fout ) {
@@ -5029,7 +5020,6 @@ void reset_scenario( avatar &u, const scenario *scen )
     u.prof = &default_prof.obj();
 
     u.hobbies.clear();
-    u.add_default_background();
     u.clear_mutations();
     u.recalc_hp();
     u.empty_skills();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -705,7 +705,6 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
         add_proficiency( prof, false, true );
     }
     if( myclass->is_common() ) {
-        add_default_background();
         set_skills_from_hobbies( true ); // Only trains skills that are still at 0 at this point
         set_proficiencies_from_hobbies();
         set_recipes_from_hobbies();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3744,33 +3744,35 @@ int projected_window_height()
 }
 
 // Measures scaling factor for high-dpi displays
-static std::pair<float,float> get_display_scale( int display_index )
+static std::pair<float, float> get_display_scale( int display_index )
 {
-    #if SDL_VERSION_ATLEAST(2,26,0)
+#if SDL_VERSION_ATLEAST(2,26,0)
     int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
     int y = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
 
     SDL_Window *w = SDL_CreateWindow(
-        "probe",
-        x, y,
-        16, 16,
-        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
-    );
+                        "probe",
+                        x, y,
+                        16, 16,
+                        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
+                    );
     if( !w ) {
-      return std::make_pair( 1.0f, 1.0f );
+        return std::make_pair( 1.0f, 1.0f );
     }
 
-    int lw, lh; SDL_GetWindowSize( w, &lw, &lh );
-    int pw, ph; SDL_GetWindowSizeInPixels( w, &pw, &ph );
+    int lw, lh;
+    SDL_GetWindowSize( w, &lw, &lh );
+    int pw, ph;
+    SDL_GetWindowSizeInPixels( w, &pw, &ph );
     SDL_DestroyWindow( w );
 
     float scale_w = lw ? static_cast<float>( pw ) / static_cast<float>( lw ) : 1.0f;
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
-    #else
-    (void)display_index; // avoid unused parameter lint
+#else
+    ( void )display_index; // avoid unused parameter lint
     return std::make_pair( 1.0f, 1.0f );
-    #endif
+#endif
 }
 
 static void init_term_size_and_scaling_factor()
@@ -3807,11 +3809,11 @@ static void init_term_size_and_scaling_factor()
                                                      SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_MAXIMIZED
                                                    ) );
 
-                #if SDL_VERSION_ATLEAST(2,26,0)
+#if SDL_VERSION_ATLEAST(2,26,0)
                 SDL_GetWindowSizeInPixels( test_window.get(), &max_width, &max_height );
-                #else
+#else
                 SDL_GetWindowSize( test_window.get(), &max_width, &max_height );
-                #endif
+#endif
 
                 // If the video subsystem isn't reset the test window messes things up later
                 test_window.reset();


### PR DESCRIPTION
#### Summary
Chargen fixes

#### Purpose of change
People were in some cases able to cause bizarre things to happen by behaving bizarrely. Particularly, changing professions a bunch of times after selecting tons of traits could result in some errors as the trait point count would in some cases not add up properly.

#### Describe the solution
- Changing professions now resets everything except your scenario.
- Removes some unused vestiges of the default_background system which was removed recently.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
