### PR TITLE
Minor Alonso fixes

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -24,8 +24,6 @@
     "bonus_int": { "rng": [ -2, 2 ] },
     "bonus_per": { "rng": [ -2, 2 ] },
     "worn_override": "REFUGEE_Alonso_worn",
-    "carry_override": "REFUGEE_Alonso_carried",
-    "weapon_override": "REFUGEE_Alonso_wield",
     "traits": [
       { "trait": "PRETTY" },
       { "group": "Appearance_demographics" },
@@ -49,18 +47,6 @@
       { "item": "fancy_sunglasses" },
       { "item": "dress_shoes" }
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "REFUGEE_Alonso_carried",
-    "subtype": "collection",
-    "entries": [ { "item": "mag_porn" }, { "item": "vibrator" }, { "item": "condom" } ]
-  },
-  {
-    "type": "item_group",
-    "id": "REFUGEE_Alonso_wield",
-    "subtype": "collection",
-    "entries": [ { "item": "cudgel" } ]
   },
   {
     "type": "effect_type",


### PR DESCRIPTION
#### Summary
Minor Alonso fixes

#### Purpose of change
Alonso has always spawned with a vibrator, a porno mag, and a condom, but he's never had anywhere to keep them, so the vibrator falls on the floor when he spawns. He also had a cudgel, which seems like an odd thing for a man under guard with no pants hiding in a bathroom to be wielding. It gave the wrong impression.

#### Describe the solution
Get rid of his items and his cudgel.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
