### PR TITLE
Make dissection train properly

### DIFF
--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -149,12 +149,12 @@ bool weakpoint_families::practice_kill( Character &learner ) const
     return practice( learner, time_duration::from_minutes( 1 ) );
 }
 
-bool weakpoint_families::practice_dissect( Character &learner ) const
+bool weakpoint_families::practice_dissect( Character &learner, int size ) const
 {
-    // Proficiency experience is capped at 1000 seconds (~16 minutes), so we split it into two
-    // instances. This should be refactored when butchering becomes an `activity_actor`.
-    bool p1 = practice( learner, time_duration::from_minutes( 15 ) );
-    bool p2 = practice( learner, time_duration::from_minutes( 15 ) );
+    // Since activity_handlers can't properly pass over the time spent on dissection, and since that
+    // time is variable due to helpers, tools, etc., we simply base practice amount off of creature size.
+    bool p1 = practice( learner, time_duration::from_minutes( ( size * 5 ) ) );
+    bool p2 = practice( learner, time_duration::from_minutes( ( size * 5 ) ) );
     bool learned = p1 || p2;
     if( learned ) {
         learner.add_msg_if_player(

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -117,7 +117,7 @@ struct weakpoint_families {
     bool practice( Character &learner, const time_duration &amount ) const;
     bool practice_hit( Character &learner ) const;
     bool practice_kill( Character &learner ) const;
-    bool practice_dissect( Character &learner ) const;
+    bool practice_dissect( Character &learner, int size ) const;
     float modifier( const Character &attacker ) const;
 
     void clear();


### PR DESCRIPTION
#### Summary
Make dissection train properly

#### Purpose of change
Dissection has always been broken: Rather than teaching once per 15 minutes of work, it just teaches 15 minutes' worth of practice at the end of the process, regardless of how long it took. Worse, NPCs that help you don't learn anything!

#### Describe the solution
- Dissecting now provides 15 minutes of proficiency training per step up in creature size at the end of the dissection. So a tiny creature gives 15 minutes, a small one 30, medium 45, large 60, huge 75. Note that this doesn't make dissection time directly tied to training, but it is MUCH better than before.
- NPCs who help you learn one interval less, to a minimum of 15 minutes' worth of practice. Said NPCs learn proficiencies according to what they know, so if they already have principles of biology and you don't, you'll learn the basic stuff and they'll learn more advanced stuff.
- Overall, this makes most dissections much more rewarding than they used to be. The only exception is tiny creatures, who are the same as they used to be.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
