### PR TITLE
Passengers learn piloting (including helicopters!)

### DIFF
--- a/data/json/proficiencies/vehicles.json
+++ b/data/json/proficiencies/vehicles.json
@@ -4,8 +4,12 @@
     "id": "prof_helicopter_pilot",
     "category": "prof_vehicles",
     "name": { "str": "Helicopter Piloting" },
-    "description": "Before the Cataclysm, you were a helicopter pilot.  Now, you just hope you can fly again.",
-    "can_learn": false
+    "time_to_learn": "20 h",
+    "can_learn": true,
+    "default_time_multiplier": 1.5,
+    "default_skill_penalty": 0.2,
+    "description": "You are able to operate helicopters of all shapes and sizes.",
+    "ignore_focus": true
   },
   {
     "type": "proficiency",


### PR DESCRIPTION
#### Summary
Passengers learn piloting (including helicopters!)

#### Purpose of change
- There was previously no way at all to learn helicopter proficiency. You either started with it or no.
- It is reasonable that you could learn through intensive training by a proficient teacher.
- It is also reasonable that if you were on a ride-along with such a person, you could learn by observation. Neither of these would come quickly, but you could conceivably do it.

#### Describe the solution
- If a character is not proficient in the proficiency used for a vehicle (driving, skating, helicopter piloting, boating) and is a passenger in that vehicle, they will learn at approximately 1/5th the rate that they would if they were driving. This currently only applies to NPCs, but if NPCs can ever drive, it would also work for the player should they go for a ride-along.
- Helicopter piloting takes a base time of 20 hours to learn. That means 100 hours of ride-along practice, though you can save on fuel by asking NPCs to train you. This is not meant to be the primary way you learn (a flight sim would be best), but for now it's at least something.

#### Describe alternatives you've considered
I need to add a recruitable static NPC who is a helicopter pilot, that way you can do a quest or two, get this person on your team, then switch to them to have them ferry you around or ask them to teach you as-needed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
