### PR TITLE
NPCs aren't all emaciated

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -868,6 +868,7 @@ class npc : public Character
         npc_opinion get_opinion_values( const Character &you ) const;
         std::string pick_talk_topic( const Character &u );
         std::string const &get_specified_talk_topic( std::string const &topic_id );
+        float generate_weight_percent();
         float character_danger( const Character &u ) const;
         float vehicle_danger( int radius ) const;
         void pretend_fire( npc *source, int shots, item &gun ); // fake ranged attack for hallucination


### PR DESCRIPTION
#### Summary
NPCs aren't all emaciated

#### Purpose of change
DDA's code for generating NPC body weights was making like 40% of them emaciated. I fixed it, but my fix was insufficient. Let's try again!

#### Describe the solution
Redo the whole system. It now generally produces people of normal weight (1.0), but can go as low as 0.5 (underweight) and as high as 1.2 (overweight). This skews toward the lower end as time goes on, but never goes below 0.5.

I do want to be able to generate obese or starving random NPCs as well, but these probably ought to be filtered by profession or generated under special circumstances. So for now we'll keep everyone toward the middle.

#### Testing
Generated a bunch of NPCs, looked at their stored kcal. Nobody was emaciated.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
