### PR TITLE
Fix movecost for throwing from sheaths

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1185,7 +1185,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     }
     // you must wield the item to throw it
     if( !you.is_wielding( *orig ) ) {
-        if( !you.wield( *orig ) ) {
+        if( !you.wield( loc ) ) {
             return;
         }
     }


### PR DESCRIPTION
#### Summary
Fix movecost for throwing from sheaths

#### Purpose of change
Throwing was using the generic obtain cost for the item, not checking its location to see what its actual obtain cost should be. This meant sheaths and other specialized carriers were not benefiting the player when throwing from the sheath, but it worked if you wielded the item and then threw it. That's inconsistent and annoying!

#### Describe the solution
Swap the object to the item location in the wield function so that the game now gets the proper movecost.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
