### PR TITLE
Adjust wooden spear size and damage

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -395,7 +395,6 @@
     "to_hit": { "grip": "solid", "length": "short", "surface": "point", "balance": "neutral" },
     "price": "2 USD",
     "price_postapoc": "10 cent",
-    "flags": [ "SPEAR" ],
     "techniques": [ "WBLOCK_1" ],
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],


### PR DESCRIPTION
#### Summary
Adjust wooden spear size and damage

#### Purpose of change
Fire-hardened wooden spears were still counted as polearms and had way too much damage compared to the regular kind.

#### Describe the solution
Slightly improve crude wooden spears, nerf fire-hardened wooden spears, make pointy sticks count as short spears.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
