### PR TITLE
Nerf the prototype robot

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -287,8 +287,8 @@
     "bodytype": "human",
     "species": [ "ROBOT" ],
     "diff": 100,
-    "hp": 50,
-    "speed": 140,
+    "hp": 90,
+    "speed": 125,
     "material": [ "steel" ],
     "symbol": "@",
     "color": "red",
@@ -297,8 +297,9 @@
     "melee_skill": 6,
     "melee_dice": 3,
     "melee_dice_sides": 8,
-    "melee_damage": [ { "damage_type": "cut", "amount": 10 } ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
     "vision_night": 5,
+    "dodge": 2,
     "path_settings": { "max_dist": 5, "avoid_traps": true, "avoid_sharp": true },
     "special_attacks": [ { "id": "smash", "throw_strength": 72 }, [ "BIO_OP_TAKEDOWN", 20 ] ],
     "death_drops": "mon_robofac_prototype_drops",
@@ -316,7 +317,7 @@
       "LOUDMOVES",
       "STUN_IMMUNE"
     ],
-    "armor": { "bash": 15, "cut": 50, "bullet": 40, "acid": 15 }
+    "armor": { "bash": 8, "cut": 12, "bullet": 20, "acid": 6, "heat": 5 }
   },
   {
     "id": "mon_dispatch",


### PR DESCRIPTION
#### Summary
Nerf the prototype robot

#### Purpose of change
The prototype robot from Hub-01 was basically invincible when dealing with normal zombies and could be eternally kited to wipe out town after town forever.

#### Describe the solution
Slow it down, reduce its damage, greatly reduce its armor, give it a smidge more HP.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
