### PR TITLE
Normalize workbench speeds

### DIFF
--- a/data/json/furniture_and_terrain/furniture-fakes.json
+++ b/data/json/furniture_and_terrain/furniture-fakes.json
@@ -22,7 +22,7 @@
     "move_cost_mod": 2,
     "required_str": -1,
     "coverage": 0,
-    "workbench": { "multiplier": 1.0, "mass": 5000, "volume": "10 L" }
+    "workbench": { "multiplier": 1.0, "mass": 10000, "volume": "15 L" }
   },
   {
     "type": "furniture",
@@ -30,7 +30,7 @@
     "id": "f_ground_crafting_spot",
     "name": "ground crafting spot",
     "looks_like": "tr_firewood_source",
-    "description": "A cleared spot on the ground for crafting.  Slower than using a workbench or holding a project in your hands, but readily available.",
+    "description": "A cleared spot on the ground for crafting.",
     "symbol": "x",
     "color": "white",
     "move_cost_mod": 0,
@@ -40,7 +40,7 @@
     "bash": { "str_min": 0, "str_max": 0, "items": [  ] },
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "EASY_DECONSTRUCT", "NOCOLLIDE" ],
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.7, "mass": 10000000, "volume": "1000 L" }
+    "workbench": { "multiplier": 0.85, "mass": 10000000, "volume": "1000 L" }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -195,7 +195,7 @@
       "items": [ { "item": "leather_tarp", "count": 1 } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
+    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500 L" }
   },
   {
     "type": "furniture",
@@ -219,7 +219,7 @@
       "items": [ { "item": "plastic_sheet", "count": 1 } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
+    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500 L" }
   },
   {
     "type": "furniture",
@@ -244,7 +244,7 @@
       "items": [ { "item": "tarp", "count": 1 } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
+    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500 L" }
   },
   {
     "type": "furniture",
@@ -269,7 +269,7 @@
       "items": [ { "item": "gum_blanket", "count": 1 } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
+    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500 L" }
   },
   {
     "type": "furniture",
@@ -293,7 +293,7 @@
       "items": [ { "item": "fiber_mat", "count": 1 } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
+    "workbench": { "multiplier": 1.05, "mass": 500000, "volume": "500 L" }
   },
   {
     "type": "furniture",
@@ -415,7 +415,7 @@
       ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.85, "mass": 200000, "volume": "75 L" }
+    "workbench": { "multiplier": 1.05, "mass": 200000, "volume": "75 L" }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture_vitrified.json
+++ b/data/json/furniture_and_terrain/furniture_vitrified.json
@@ -388,7 +388,7 @@
       "items": [ { "item": "black_glass_shard", "count": [ 40, 80 ] } ]
     },
     "examine_action": "workbench",
-    "workbench": { "multiplier": 0.7, "mass": 2000, "volume": "75 L" }
+    "workbench": { "multiplier": 1.0, "mass": 2000, "volume": "75 L" }
   },
   {
     "type": "furniture",


### PR DESCRIPTION
#### Summary
Normalize workbench speeds

#### Purpose of change
So despite CLEAN_SURFACE existing as a tool quality, crafting speed is still using the ancient hardcoded workbench stuff. Worse, it was set up weirdly so that there were a lot of surfaces which were slower than crafting in your hand if the item was small enough. That doesn't make any god-damned sense to begin with, and since none of it is player-visible, it's just bad!

#### Describe the solution
- Crafting in-hand is now at 100% speed if the item is under 15 liters or 10kg. That's up from 10 liters and 5kg previously.
- Crafting on the ground with no furniture is now at 85% speed. You will be forced to do this if you have no furniture and your item is bigger than 15L or 10kg.
- Crafting on any furniture which works as a crafting surface is now always at least 100% speed. Elevated surfaces like countertops and tables offer 105% or 110% speed.
- Crafting on a purpose-built workbench (so, a workbench, or a vehicle workbench) is 120% speed.

#### Describe alternatives you've considered
- Ripping all this code out and just letting CLEAN_SURFACE handle it.
- Ripping all this code out and replacing it with nothing.
- Allowing bigger/stronger characters to craft bigger items in-hand.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
