### PR TITLE
Give EARS category to bat ears

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -495,7 +495,7 @@
     "ugliness": 8,
     "visibility": 8,
     "description": "Your broad, pointed ears are like radar dishes.  You can hear even the slightest sounds at great distance, and are less likely to be deafened by loud noises.",
-    "types": [ "HEARING" ],
+    "types": [ "HEARING", "EARS" ],
     "//": "A bat mutant is a bit better at hearing overall than someone with GOODHEARING and a CBM.",
     "flags": [ "HEARING_PROTECTION", "SAFECRACK_NO_TOOL" ],
     "prereqs": [ "GOODHEARING" ],


### PR DESCRIPTION
#### Summary
Give EARS category to bat ears

#### Purpose of change
Bat ears were missing the EARS quality, allowing the mutation to stack with other ear mutations.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
