### PR TITLE
Fix farm activity deep water warning

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -185,6 +185,9 @@ static bool check_water_affect_items( avatar &you )
     menu.query();
     if( menu.ret != 1 ) {
         you.add_msg_if_player( _( "You back away from the water." ) );
+        // End any ongoing activities so we don't get stuck in an infinite loop when e.g. farming.
+        you.activity.set_to_null();
+        you.cancel_activity();
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Fix farm activity deep water warning

#### Purpose of change
Farming via zones could get you stuck in an infinite loop if it tried to path through deep water and you had water-damageable items on you, because the activity would not stop if you selected "no" to the prompt.

#### Describe the solution
Cancel activity and set activity to null when the player hits no on this prompt.

#### Testing
https://cdn.discordapp.com/attachments/1437946367090757793/1438033925434904667/image.png?ex=691568f5&is=69141775&hm=87fbbd566d2bff403f82f1c0c2cf24fbf9b207a79a5b08707775924e8a878b68&

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
