### PR TITLE
Fix arrows rarely phasing through walls

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4576,6 +4576,7 @@ void map::crush( const tripoint_bub_ms &p )
         vp->vehicle().damage( *this, vp->part_index(), rng( 100, 1000 ), damage_bash, false );
     }
 }
+
 void map::shoot( const tripoint_bub_ms &p, const tripoint_bub_ms &source, projectile &proj,
                  const bool hit_items, double dispersion )
 {
@@ -4622,10 +4623,11 @@ void map::shoot( const tripoint_bub_ms &p, const tripoint_bub_ms &source, projec
     int veh_coverage = 0;
     if( const optional_vpart_position vp = veh_at( p ) ) {
         const bool is_obstacle = vp->obstacle_at_part().has_value();
-        const bool is_aisle = vp->part_with_feature( VPFLAG_AISLE, true ).has_value();
+        const bool is_quarterpanel =  vp->part_with_feature( VPFLAG_HALF_BOARD, false, true ).has_value();
+        const bool is_aisle = vp->part_with_feature( VPFLAG_AISLE, false, false ).has_value();
         if( is_obstacle ) {
             veh_coverage = 100;
-        } else if( is_obstacle ) {
+        } else if( is_quarterpanel ) {
             veh_coverage = 60;
         } else if( !is_aisle ) {
             veh_coverage = 45;
@@ -4684,7 +4686,7 @@ void map::shoot( const tripoint_bub_ms &p, const tripoint_bub_ms &source, projec
     // Check again so we can skip if the result was zero.
     if( coverage > 0 || ter( p )->has_flag( ter_furn_flag::TFLAG_HIT_WITHOUT_COVER ) ) {
         int coverage_roll = rng( 1, 100 );
-        if( ( coverage > 0 && coverage_roll < coverage ) ||
+        if( ( coverage > 0 && coverage_roll <= coverage ) ||
             ter( p )->has_flag( ter_furn_flag::TFLAG_HIT_WITHOUT_COVER ) ) {
             furn_id furniture = furn( p );
             ter_id terrain = ter( p );


### PR DESCRIPTION
#### Summary
Fix arrows rarely phasing through walls

#### Purpose of change
There was a 1/100 chance of a projectile passing through a solid wall even if it didn't do enough damage because the rng roll was a d100 < coverage.

#### Describe the solution
d100 <= coverage

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
