### PR TITLE
Review mutant ugly/deformed traits

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1807,12 +1807,11 @@
     "points": -1,
     "visibility": 1,
     "ugliness": 2,
-    "description": "You're not much to look at.  People who care about such things will react poorly to you.",
+    "description": "You're not much to look at.  People who care about such things may react less favorably toward you.",
     "starting_trait": true,
     "types": [ "ATTRACTIVENESS" ],
     "changes_to": [ "DEFORMED" ],
     "category": [
-      "RAPTOR",
       "FELINE",
       "LUPINE",
       "BATRACHIAN",
@@ -1826,8 +1825,13 @@
       "GASTROPOD",
       "SLIME",
       "RAT",
+      "RABBIT",
       "CHIMERA",
+      "MOUSE",
+      "BIRD",
       "SPIDER",
+      "LIZARD",
+      "RAPTOR",
       "CRUSTACEAN",
       "CHIROPTERAN"
     ],
@@ -6438,18 +6442,16 @@
     "changes_to": [ "DEFORMED2" ],
     "category": [
       "FISH",
-      "CATTLE",
       "INSECT",
       "CEPHALOPOD",
-      "FELINE",
-      "LUPINE",
       "BATRACHIAN",
       "BEAST",
-      "URSINE",
       "PLANT",
       "GASTROPOD",
       "SLIME",
       "RAT",
+      "LIZARD",
+      "RAPTOR",
       "CHIMERA",
       "SPIDER",
       "CRUSTACEAN",
@@ -6467,7 +6469,7 @@
     "types": [ "ATTRACTIVENESS" ],
     "prereqs": [ "DEFORMED" ],
     "changes_to": [ "DEFORMED3" ],
-    "category": [ "BEAST", "URSINE", "PLANT", "GASTROPOD", "SLIME", "RAT", "CHIMERA", "CRUSTACEAN" ]
+    "category": [ "CHIMERA", "GASTROPOD", "SLIME", "INSECT", "SPIDER", "BATRACHIAN", "CHIROPTERAN" ]
   },
   {
     "type": "mutation",
@@ -6479,8 +6481,8 @@
     "description": "Your visage is disgusting and liable to induce vomiting.  People will not want to interact with you unless they have a very good reason to.",
     "types": [ "ATTRACTIVENESS" ],
     "prereqs": [ "DEFORMED2" ],
-    "threshreq": [ "THRESH_SLIME", "THRESH_RAT", "THRESH_CHIMERA" ],
-    "category": [ "SLIME", "RAT", "CHIMERA" ]
+    "threshreq": [ "THRESH_SLIME", "THRESH_CHIMERA", "THRESH_GASTROPOD", "THRESH_INSECT" ],
+    "category": [ "SLIME", "CHIMERA", "GASTROPOD", "INSECT" ]
   },
   {
     "type": "mutation",
@@ -6518,7 +6520,7 @@
     "points": 4,
     "visibility": 10,
     "ugliness": -10,
-    "description": "You are incredibly beautiful.  People cannot help themselves due to your charms, and will do whatever they can to please you.",
+    "description": "You possess an unearthly beauty.  Most people cannot help themselves due to your charms, and will do whatever they can to please you.",
     "types": [ "ATTRACTIVENESS" ],
     "prereqs": [ "BEAUTIFUL2" ],
     "category": [ "ELFA" ],


### PR DESCRIPTION
#### Summary
Review mutant ugly/deformed traits

#### Purpose of change
A bunch of arbitrary mutants had ugly or didn't, and that somewhat extended to the deformed mutations as well.

#### Describe the solution
- All animals, chimera, beast, and slime get ugly.
- Deformed extends to those animals which are very different from humans (non-mammals) or who are widely considered scary/gross.
- Badly deformed is the worst of those.
- Grotesque is only for slime, chimera, gastropod, and insect.
- The ugly mutation doesn't actually have that much of an effect, but it hopefully signposts to players how nasty the overall mutation line probably looks, though some mutants look better than others and no two are alike.

#### Additional context
<img width="360" height="480" alt="image" src="https://github.com/user-attachments/assets/2d41de86-820f-44a6-8e4f-40ec58bfd82b" />
<img width="194" height="259" alt="image" src="https://github.com/user-attachments/assets/bd1a6e7d-cc91-46e8-9cc0-a8602bc4253e" />
<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/4af67d34-a527-4ddc-a411-0a426382d915" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
