### PR TITLE
Fix EOC queue crash bug

### DIFF
--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -252,7 +252,7 @@ void effect_on_conditions::queue_effect_on_condition( time_duration duration,
 static void process_eocs( queued_eocs &eoc_queue, std::vector<effect_on_condition_id> &eoc_vector,
                           dialogue &d )
 {
-    static std::vector<queued_eocs::storage_iter> eocs_to_queue;
+    static std::vector<std::pair<queued_eoc *, queued_eocs::storage_iter>> eocs_to_queue;
     eocs_to_queue.clear();
 
     while( !eoc_queue.empty() &&
@@ -269,12 +269,12 @@ static void process_eocs( queued_eocs &eoc_queue, std::vector<effect_on_conditio
         if( top.eoc->type == eoc_type::RECURRING ) {
             if( activated ) { // It worked so add it back
                 it->time = calendar::turn + next_recurrence( top.eoc, d );
-                eocs_to_queue.emplace_back( it );
+                eocs_to_queue.emplace_back( &( *it ), it );
             } else {
                 if( !top.eoc->check_deactivate(
                         nested_d ) ) { // It failed but shouldn't be deactivated so add it back
                     it->time = calendar::turn + next_recurrence( top.eoc, d );
-                    eocs_to_queue.emplace_back( it );
+                    eocs_to_queue.emplace_back( &( *it ), it );
                 } else { // It failed and should be deactivated for now
                     eoc_vector.push_back( top.eoc );
                     eoc_queue.list.erase( it );
@@ -284,8 +284,10 @@ static void process_eocs( queued_eocs &eoc_queue, std::vector<effect_on_conditio
             eoc_queue.list.erase( it );
         }
     }
-    for( queued_eocs::storage_iter &q_eoc : eocs_to_queue ) {
-        eoc_queue.queue.emplace( q_eoc );
+    for( auto &[ptr, iter] : eocs_to_queue ) {
+        if( iter != eoc_queue.list.end() && &( *iter ) == ptr ) {
+            eoc_queue.queue.emplace( iter );
+        }
     }
 }
 

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1297,9 +1297,9 @@ void Character::hardcoded_effects( effect &it )
                 mod_pain( 1 );
             } else if( one_in( 3000 ) ) {
                 if( one_in( 10 ) ) {
-                add_msg_if_player( m_bad, _( "The bugs are back." ) );
+                    add_msg_if_player( m_bad, _( "The bugs are back." ) );
                 } else {
-                add_msg_if_player( m_bad, _( "It feels like there are tiny bugs crawling over your body." ) );
+                    add_msg_if_player( m_bad, _( "It feels like there are tiny bugs crawling over your body." ) );
                 }
                 const bodypart_id &itch = random_body_part( true );
                 schedule_effect( effect_formication, 60_minutes * rng_float( 0.75f, 1.25f ), itch );
@@ -1317,7 +1317,8 @@ void Character::hardcoded_effects( effect &it )
         } else if( int_cur < 14 ) {
             add_msg_if_player( m_bad, _( "Something is tracking you from a direction you can't perceive." ) );
         } else {
-            add_msg_if_player( m_bad, _( "Something stalks you across the angles of spacetime.  It will come from the corners!" ) );
+            add_msg_if_player( m_bad,
+                               _( "Something stalks you across the angles of spacetime.  It will come from the corners!" ) );
         }
         for( const tripoint_bub_ms &dest : here.points_in_radius( pos, 6 ) ) {
             if( here.is_cornerfloor( dest ) ) {
@@ -1400,9 +1401,9 @@ void Character::hardcoded_effects( effect &it )
                 add_msg_if_player( m_bad, _( "Your muscles are tight and sore." ) );
             } else if( msg == 2 ) {
                 add_msg_if_player( m_bad, _( "Your muscles feel like they're knotted and tired." ) );
-            } else if( msg == 3 ) {                
+            } else if( msg == 3 ) {
                 add_msg_if_player( m_bad, _( "You can't stop clenching your jaw." ) );
-            } else if( msg == 4 ) {                
+            } else if( msg == 4 ) {
                 add_msg_if_player( m_bad, _( "You feel a general malaise." ) );
             }
         }


### PR DESCRIPTION
#### Summary
Fix EOC queue crash bug

#### Purpose of change
A longstanding issue with queued EoCs was causing EoCs to sometimes get accessed after being deleted from their list, resulting in a segfault.

#### Describe the solution
Ensure we aren't deleting EoCs immediately before using them!

#### Testing
- Loaded a save that was having repeated crashes, no problem.
- Started a new character with gradual mutation. It worked.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
