### PR TITLE
Fix NECC sleep permission

### DIFF
--- a/data/json/npcs/godco/members/NPC_Father_Greenwood.json
+++ b/data/json/npcs/godco/members/NPC_Father_Greenwood.json
@@ -17,7 +17,6 @@
         "condition": {
           "and": [
             { "not": { "u_has_effect": "godco_confessed" } },
-            { "not": { "u_has_trait": "KILLER" } },
             { "not": { "u_has_trait": "PSYCHOPATH" } }
           ]
         },

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -153,7 +153,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_Gemma_Joinee",
     "dynamic_line": "You are most welcome here.  In the good old days we would've held a ceremony for you.  Oh well, times have changed.  Accept this blanket, you may choose either bed by the window.  If you're hungry, you can go see Simon for a meal, up to one per day.",
-    "speaker_effect": { "effect": [ { "u_spawn_item": "blanket" }, { "u_add_var": "general_meeting_godco_joinee", "value": "yes" } ] },
+    "speaker_effect": { "effect": [ { "u_set_fac_relation": "share public goods" }, { "u_spawn_item": "blanket" }, { "u_add_var": "general_meeting_godco_joinee", "value": "yes" } ] },
     "responses": [ { "text": "Thank you.  See you around, Gemma.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -114,7 +114,7 @@
     "dynamic_line": {
       "u_has_var": "general_meeting_godco_joinee",
       "value": "yes",
-      "yes": [ "If you have complaints, please don't tell anyone.", "You're still staying here, joinee?", "Need anything, joinee?" ],
+      "yes": [ "If you have complaints, please don't tell anyone.", "You're still staying here?", "Need anything?" ],
       "no": [ "Need anything?", "Go on…" ]
     },
     "responses": [ { "text": "I'd better get going.", "topic": "TALK_DONE" } ]
@@ -133,7 +133,7 @@
     "id": "TALK_GODCO_Julian_Join",
     "dynamic_line": "Aight, here are the rules: don't commit sins, don't litter, and try not to die.  Have some mutual respect, capiche?",
     "responses": [
-      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee", "effect": { "u_set_fac_relation": "share public goods" } },
+      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee", "effect":[ { "u_add_var": "general_meeting_godco_joinee", "value": "yes" }, { "u_set_fac_relation": "share public goods" } ] },
       { "text": "Actually, I had better go.", "topic": "TALK_DONE" }
     ]
   },


### PR DESCRIPTION
#### Summary
Fix NECC sleep permission

#### Purpose of change
#1298 was supposed to fix the permission issue at NECC, and it did do that - if Julian was the one you talked to about joining. The problem is that this PR didn't affect Gemma, who can also let you into the faction, so players who spoke to her were given verbal permission to sleep on-site that the game was not honoring.

#### Describe the solution
- Add a toggle to Gemma's dialogue that gives you permission to sleep there.
- Add a toggle to Julian's dialogue that gives you the joinee var.

Now joining via either NPC should work the same.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
