### PR TITLE
Improve and add billboard snippets.

### DIFF
--- a/data/json/snippets/billboard.json
+++ b/data/json/snippets/billboard.json
@@ -3,7 +3,7 @@
     "type": "snippet",
     "category": "billboard_ad_snippets",
     "text": [
-      "A billboard ad for English muffins.  It reads: \"This year, give her English muffins\".",
+      "A billboard ad for English muffins.  It reads: \"This year, give her.....English muffins\".",
       "A billboard ad for a luxury car dealership: \"Drive the future.  Get your next electric car from <family_name>'s car dealership!\"",
       "A billboard ad for a security company, \"SecuriCorp\": \"Keeping you safe since 1993\".",
       "A billboard for a personal injury lawyer.",


### PR DESCRIPTION
#### Summary
Improve and add billboard snippets.

#### Purpose of change
One of the billboards referenced foodplace. There also weren't enough of them, and they didn't really feel apocalypsey enough, and needed some more variety.

#### Describe the solution
- Generify, add some ominous ones, add some more that would reasonably exist, remove the Foodplace thing. Add exactly one joke.

#### Additional context
<img width="512" height="384" alt="image" src="https://github.com/user-attachments/assets/4c1293ac-0618-417f-ac5e-538ed2018967" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
