### PR TITLE
Fix some bizarre elder abuse

### DIFF
--- a/data/json/npcs/Backgrounds/codger.json
+++ b/data/json/npcs/Backgrounds/codger.json
@@ -17,8 +17,7 @@
     "dynamic_line": "That was when I had my old truck, the blue one.  We called 'er ol' yeller.  One time me an' Marty Gumps - or, as he were known to me, Rusty G - were drivin' ol' yeller up Mount Greenwood in the summertime, lookin' fer fireflies to catch.",
     "responses": [
       { "text": "Fireflies.  Got it.", "topic": "BGSS_CODGER_STORY3a" },
-      { "text": "How does this relate to what I asked you?", "topic": "BGSS_CODGER_STORY3b" },
-      { "text": "I need to get going.", "topic": "BGSS_CODGER_STORY3b" }
+      { "text": "How does this relate to what I asked you?", "topic": "BGSS_CODGER_STORY3b" }
     ]
   },
   {
@@ -26,9 +25,8 @@
     "type": "talk_topic",
     "dynamic_line": "Rusty G - that's my ol' pal Marty Gumps - were in the passenger seat with his trusty 18 gauge lyin' on his lap.  That were his dog's name, only we all just called him 18 gauge for short.",
     "responses": [
-      { "text": "18 gauge, the dog.  Got it.", "topic": "BGSS_CODGER_STORY4a" },
-      { "text": "I think I see some zombies coming.  We should cut this short.", "topic": "BGSS_CODGER_STORY4b" },
-      { "text": "Shut up, you old fart.", "topic": "BGSS_CODGER_STORY4b" }
+      { "text": "Go on.", "topic": "BGSS_CODGER_STORY4a" },
+      { "text": "We should cut this short.", "topic": "BGSS_CODGER_STORY4b" }
     ]
   },
   {
@@ -36,9 +34,8 @@
     "type": "talk_topic",
     "dynamic_line": "Dammit I'm gettin' there, bite yer tongue.  As I was sayin', Rusty G - that's my ol' pal Marty Gumps - were in the passenger seat with his trusty 18 gauge lyin' on his lap.  That were his dog's name, only we all just called him 18 gauge for short.",
     "responses": [
-      { "text": "18 gauge, the dog.  Got it.", "topic": "BGSS_CODGER_STORY4a" },
-      { "text": "I think I see some zombies coming.  We should cut this short.", "topic": "BGSS_CODGER_STORY4b" },
-      { "text": "Shut up, you old fart.", "topic": "BGSS_CODGER_STORY4b" }
+      { "text": "Go on.", "topic": "BGSS_CODGER_STORY4a" },
+      { "text": "We should cut this short.", "topic": "BGSS_CODGER_STORY4b" }
     ]
   },
   {
@@ -47,8 +44,7 @@
     "dynamic_line": "Now up the top o' Mount Greenwood there used to be a ranger station, that woulda been before you were born.  It got burnt down that one year, they said it were lightnin' but you an' I both know it were college kids partyin'.  Rusty G an' I left ol' yeller behind and wen' in to check it out.  Burnt out ol' husk looked haunted, we figgered there were some o' them damn kids rummagin' around in it.  Rusty G brought his 18 gauge, and lucky thing cuz o' what we saw.",
     "responses": [
       { "text": "What did you see?", "topic": "BGSS_CODGER_STORY5" },
-      { "text": "We really, really have to go.", "topic": "BGSS_CODGER_STORY5" },
-      { "text": "For fuck's sake, shut UP!", "topic": "BGSS_CODGER_STORY5" }
+      { "text": "We really, really have to go.", "topic": "BGSS_CODGER_STORY5" }
     ]
   },
   {
@@ -57,8 +53,7 @@
     "dynamic_line": "Be patient!  I'm almost done.  Now up the top o' Mount Greenwood there used to be a ranger station, that woulda been before you were born.  It got burnt down that one year, they said it were lightnin' but you an' I both know it were college kids partyin'.  Rusty G an' I left ol' yeller behind and wen' in to check it out.  Burnt out ol' husk looked haunted, we figgered there were some o' them damn kids rummagin' around in it.  Rusty G brought his 18 gauge, and lucky thing cuz o' what we saw.",
     "responses": [
       { "text": "What did you see?", "topic": "BGSS_CODGER_STORY5" },
-      { "text": "We really, really have to go.", "topic": "BGSS_CODGER_STORY5" },
-      { "text": "For fuck's sake, shut UP!", "topic": "BGSS_CODGER_STORY5" }
+      { "text": "We really, really have to go.", "topic": "BGSS_CODGER_STORY5" }
     ]
   },
   {
@@ -66,9 +61,7 @@
     "type": "talk_topic",
     "dynamic_line": "A gorram moose!  Livin' in the ol' ranger station!  It near gored Rusty, but he fired up that 18 gauge and blew a big hole in its hide.  Ol' 18 gauge went headin' for the hills but we tracked him down.  Moose went down like a bag o' potatoes, but a real big bag iff'n y'catch m'drift.",
     "responses": [
-      { "text": "I catch your drift.", "topic": "BGSS_CODGER_STORY6" },
-      { "text": "Are you done yet?  Seriously!", "topic": "BGSS_CODGER_STORY6" },
-      { "text": "For the love of all that is holy, PLEASE shut the hell up!", "topic": "BGSS_CODGER_STORY6" }
+      { "text": "I see.", "topic": "BGSS_CODGER_STORY6" }
     ]
   },
   {
@@ -79,9 +72,8 @@
       "relevant_genders": [ "npc" ]
     },
     "responses": [
-      { "text": "Thanks for the story!", "topic": "TALK_FRIEND_CONVERSATION" },
-      { "text": "…", "topic": "TALK_FRIEND_CONVERSATION" },
-      { "text": "<name_b>.", "topic": "TALK_DONE" }
+      { "text": "That's quite the story.", "topic": "TALK_FRIEND_CONVERSATION" },
+      { "text": "…", "topic": "TALK_DONE" }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Fix some bizarre elder abuse

#### Purpose of change
One of the NPC survivor background stories in codger.json is an old person explaining some adventure they had. The text is meant to imply that they're rambling on and the story isn't really getting to a point, but the available responses from the player were all horribly cruel. While it's fine to allow the player to choose to be cruel, we really, really want to avoid forcing a voice on them in their replies, as they could be playing any kind of person (or mutant!) that you can imagine.

#### Describe the solution
Tone down the replies and make them more neutral. For several responses, there's a patient option and an impatient one.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
