### PR TITLE
Innawood: Update lead amounts in recipes

### DIFF
--- a/data/mods/innawood/furniture_and_terrain/appliances.json
+++ b/data/mods/innawood/furniture_and_terrain/appliances.json
@@ -10,7 +10,7 @@
     "flags": [ "OBSTACLE", "APPLIANCE" ],
     "description": "A clay car battery wired into a static power grid.",
     "item": "battery_car_clay",
-    "breaks_into": [ { "item": "ceramic_shard", "count": [ 1, 3 ] }, { "item": "lead", "count": [ 200, 1000 ] } ],
+    "breaks_into": [ { "item": "ceramic_shard", "count": [ 1, 3 ] }, { "item": "lead", "count": [ 100, 500 ] } ],
     "durability": 120,
     "requirements": { "removal": { "time": "6 m" } },
     "variants": [ { "symbols": "B", "symbols_broken": "#" } ]
@@ -28,7 +28,7 @@
     "item": "battery_clay_array",
     "breaks_into": [
       { "item": "ceramic_shard", "count": [ 4, 12 ] },
-      { "item": "lead", "count": [ 800, 4000 ] },
+      { "item": "lead", "count": [ 400, 2000 ] },
       { "item": "2x4", "count": [ 1, 4 ] },
       { "item": "nail", "count": [ 2, 6 ] }
     ],

--- a/data/mods/innawood/mining/recipes/smelting.json
+++ b/data/mods/innawood/mining/recipes/smelting.json
@@ -170,9 +170,9 @@
     "batch_time_factors": [ 90, 4 ],
     "autolearn": true,
     "book_learn": [ [ "recipe_bullets", 2 ], [ "textbook_fabrication", 2 ], [ "welding_book", 2 ] ],
-    "//": "Galena has around 86% yield of lead, yield here is just over 82%, due to one output weighing 300 grams.  Silver output is around double the expected 2% yield due to minimum of 300 grams.  Output volume is still oversize.",
-    "result_mult": 21,
-    "byproducts": [ [ "silver_small" ] ],
+    "//": "Galena has around 86% yield of lead by weight, and around 2% of silver.",
+    "result_mult": 594,
+    "byproducts": [ [ "silver_small", 30 ] ],
     "using": [ [ "forging_standard", 3 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "chunk_galena", 1 ] ] ]

--- a/data/mods/innawood/recipes/electronics/parts.json
+++ b/data/mods/innawood/recipes/electronics/parts.json
@@ -16,7 +16,7 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "scrap", 4 ] ],
-      [ [ "lead", 3200 ] ],
+      [ [ "lead", 1600 ] ],
       [ [ "chem_sulphuric_acid", 13 ] ],
       [ [ "water", 2 ], [ "water_clean", 2 ] ],
       [ [ "clay_lump", 5 ] ]

--- a/data/mods/innawood/uncraft/recipe_deconstruction.json
+++ b/data/mods/innawood/uncraft/recipe_deconstruction.json
@@ -5,7 +5,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "chem_sulphuric_acid", 13 ] ], [ [ "lead", 2247 ] ], [ [ "ceramic_shard", 3 ] ] ]
+    "components": [ [ [ "chem_sulphuric_acid", 13 ] ], [ [ "lead", 1123 ] ], [ [ "ceramic_shard", 3 ] ] ]
   },
   {
     "result": "heavy_dry_cell",

--- a/data/mods/innawood/vehicleparts/battery.json
+++ b/data/mods/innawood/vehicleparts/battery.json
@@ -12,8 +12,7 @@
     "description": "A battery for storing electrical power, and discharging it to power electrical devices built into the vehicle.  Contained in a clay shell.",
     "folded_volume": "6250 ml",
     "breaks_into": [
-      { "item": "chem_sulphuric_acid", "count": [ 6, 9 ] },
-      { "item": "lead", "count": [ 2200, 1800 ] },
+      { "item": "lead", "count": [ 900, 1100 ] },
       { "item": "ceramic_shard", "count": [ 1, 3 ] }
     ],
     "requirements": {


### PR DESCRIPTION
#### Summary
Increase lead and silver yield from galena, halve lead in clay car battery

#### Purpose of change
Since the changes to metals (removal of charges, lead density adjustment), it was requiring a lot of galena in the Innawood mod to get the lead needed to craft a clay car battery.

#### Describe the solution
- Increase the yields from one chunk of galena (7.6kg) from 21 lead + 1 silver to 594 lead (6.53kg) + 30 silver (0.15kg), following the JSON comment in the recipe specifying 86% and 2% yields by mass for lead and silver (the density of silver is still too low though, resulting in way too much volume).
- Decrease the lead needed for the "clay car battery" recipe from 3200 to 1600, halve the yields from disassembly and bashing the appliance and vehicle-part versions.
- Remove the sulfuric acid from destroying a vehicle-installed clay car battery.  In my testing I saw that some of the scattered sulfuric acid was contained in glass bottles spawned from thin air.  This seems like a bug that might need fixing elsewhere, but I didn't want to preserve this exploit (glass is hard to get in Innawood), and neither bashing the clay car battery appliance, nor the regular car battery vehicle part, give sulfuric acid anyways.

#### Describe alternatives you've considered
Before the metal changes (e.g. in C:TLG build 2025-08-05-0423), the "clay car battery" needed 3200 lead, 1/3 more than the regular "car battery", which needed 2400 lead.  In current builds, the "car battery" needs 1061 lead, so to stay consistent with the 1/3 extra cost, it would result in ~1415 lead needed for the "clay car battery", but I wanted to keep the number changes simple.

#### Testing
Set up a test world character with max skills, debug-spawned the required ingredients and tools, crafted lead and silver from galena, crafted a clay car battery, disassembled it, placed it, bashed it, installed it on a light wooden frame, bashed that, checked that the item amounts and weights were reasonable.

#### Additional context
This has been my first time trying the Innawood mod, I didn't play it before the metal changes, or even on C:DDA, so I'm not sure if this is consistent with the design decisions of this mod.