### PR TITLE
Remove shell from cephalopod, fix colorful skin

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9450,7 +9450,7 @@
     "types": [ "SKIN" ],
     "changes_to": [ "CAMO2" ],
     "category": [ "CEPHALOPOD" ],
-    "enchantments": [ { "values": [ { "value": "STEALTH_MODIFIER", "add": -5 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STEALTH_MODIFIER", "add": -10 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Remove shell from cephalopod, fix colorful skin

#### Purpose of change
- Cephalopod's shell was a great mutation for it before gastropod existed, but now it's a bit at odds with the line's design, which is more octodad.
- Cephalopods should be able to get shells though, since nautiluses exist.
- Colorful skin was incorrectly giving them a stealth bonus.

#### Describe the solution
- Colorful skin now gives a small stealth penalty. As I understand it, on its own this doesn't do much as this enchantment functions as a % reduction in monster vision radius when trying to see the player, but can't make monsters see farther than they normally would. However, if other bonuses are in play, this will work against them.
- Cephalopod no longer gets shell or roomy shell, however roomy shell still has cephalopod in its threshold requirements, meaning that a player who is a post-threshold cephalopod can use gastropod mutagen to try and get this mutation if they want.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
