### PR TITLE
Maybe fix fix_npcs

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -219,7 +219,15 @@ void overmapbuffer::fix_npcs( overmap &new_overmap )
             // bounding box for new_overmap in omt coords
             const half_open_rectangle<point_abs_omt> om_bounds( project_to<coords::omt>( loc ),
                     project_to<coords::omt>( loc + point( 1, 1 ) ) ); // NOLINT(cata-use-named-point-constants)
-            const tripoint_abs_omt adjusted_omt_pos( clamp( npc_omt_pos.xy(), om_bounds ),  npc_omt_pos.z() );
+            const point_abs_omt minp = om_bounds.p_min;
+            const point_abs_omt maxp = om_bounds.p_max - point( 1, 1 ); // Half-open rectangle.
+
+            const point_abs_omt clamped_xy(
+                std::clamp( npc_omt_pos.x(), minp.x(), maxp.x() ),
+                std::clamp( npc_omt_pos.y(), minp.y(), maxp.y() )
+            );
+
+            const tripoint_abs_omt adjusted_omt_pos( clamped_xy, npc_omt_pos.z() );
             np.spawn_at_omt( adjusted_omt_pos );
             new_overmap.npcs.push_back( ptr );
             continue;


### PR DESCRIPTION
#### Summary
Maybe fix fix_npcs

#### Purpose of change
Someone reported that when switching back to an NPC at their base on another OMT, other NPCs in that NPCs vicinity didn't load. At first I thought this might be due to the wrong map being loaded when the function is run, but that doesn't seem to be the case. It now looks like fix_npcs may be clamping omt coords incorrectly.

#### Describe the solution
Switch to a different clamping method.

#### Testing
Spawned in, spawned 2 npcs, recruited them. Told one to guard and left one doing nothing. Teleported more than an overmap away. Switched back to one of my NPCs. Game took a second to load, but they and their buddy both appeared in the proper place.

I don't know if that means everything is fixed, but it looks OK so far.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
