### PR TITLE
Fix: Prevent haul mode activation when no items are selected

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -919,7 +919,12 @@ static void haul()
             if( haulable_items != player_character.haul_list ) {
                 player_character.suppress_autohaul = true;
             }
-            player_character.start_hauling( haulable_items );
+            // Only start hauling if items were selected; stop if all items were deselected
+            if( !haulable_items.empty() ) {
+                player_character.start_hauling( haulable_items );
+            } else if( player_character.is_hauling() ) {
+                player_character.stop_hauling();
+            }
         }
         break;
         case 3:


### PR DESCRIPTION
#### Summary
Bugfix "Prevent haul mode from activating with an empty item list"

#### Purpose of change
When a player opened the haul menu and selected "Choose items to haul" but didn't select any items (either by cancelling or deselecting all), the game would still activate haul mode with an empty haul list. This created an invalid state that triggered error messages when reopening the haul menu: "Invalid hauling state: hauling enabled, nothing is being hauled, autohaul is off."

#### Describe the solution
The root cause was in `handle_action.cpp:922` where `start_hauling()` was called unconditionally, even with an empty item list. This would set `hauling=true` with `haul_list={}`, creating the invalid state.

The fix adds a conditional check before calling `start_hauling()` to only activate haul mode when items are actually selected. If the user was already hauling and deselected all items, `stop_hauling()` is called instead.

**Changes:**
- Added check: `if( !haulable_items.empty() )` before calling `start_hauling()`
- Added `else if( player_character.is_hauling() )` case to call `stop_hauling()` when all items are deselected

#### Describe alternatives you've considered
- Allowing haul mode to remain active with an empty list: This would still trigger the error message and represent an invalid game state.
- Validating the state in the error-checking code: This would suppress the symptom but not fix the root cause.
- Preventing the menu from closing without selections: This would reduce user control and flexibility.

The current solution is the most logical, as haul mode should only be active when there are actually items to haul.

#### Testing
- ✓ Opened haul menu and selected "Choose items to haul" without selecting any items — haul mode no longer activates
- ✓ Selected items then deselected all items — haul mode properly deactivates
- ✓ Selected items and confirmed — haul mode activates correctly
- ✓ Verified auto haul functionality continues to work as expected
- ✓ Confirmed no error messages appear when reopening haul menu after cancelling

#### Additional context
This fix prevents the invalid state whilst maintaining expected behaviour for all use cases, including normal item selection, cancellation, and auto haul mode.