### PR TITLE
Fix auto features executing during combat

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -246,7 +246,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     }
 
     item_location weapon = you.get_wielded_item();
-    if( m.has_flag( ter_furn_flag::TFLAG_MINEABLE, dest_loc ) && g->mostseen == 0 &&
+    if( m.has_flag( ter_furn_flag::TFLAG_MINEABLE, dest_loc ) &&
+        !you.get_mon_visible().has_dangerous_creature_in_proximity &&
         get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MINING" ) &&
         !m.veh_at( dest_loc ) && !you.is_underwater() && !you.has_effect( effect_stunned ) &&
         !you.has_effect( effect_psi_stunned ) && !is_riding && !you.has_effect( effect_incorporeal ) &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11442,7 +11442,8 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
     // adjusted_pos = ( old_pos.x - submap_shift.x * SEEX, old_pos.y - submap_shift.y * SEEY, old_pos.z )
 
     //Auto pulp or butcher and Auto foraging
-    if( !quick && get_option<bool>( "AUTO_FEATURES" ) && mostseen == 0  && !u.is_mounted() ) {
+    if( !quick && get_option<bool>( "AUTO_FEATURES" ) &&
+        !u.get_mon_visible().has_dangerous_creature_in_proximity && !u.is_mounted() ) {
         static constexpr std::array<direction, 8> adjacentDir = {
             direction::NORTH, direction::NORTHEAST, direction::EAST, direction::SOUTHEAST,
             direction::SOUTH, direction::SOUTHWEST, direction::WEST, direction::NORTHWEST

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2427,6 +2427,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 }
 
                 if( get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MOPPING" ) &&
+                    !player_character.get_mon_visible().has_dangerous_creature_in_proximity &&
                     weapon && weapon->has_flag( json_flag_MOP ) ) {
                     const bool is_blind = player_character.is_blind();
                     for( const tripoint_bub_ms &point : here.points_in_radius( player_character.pos_bub(), 1 ) ) {


### PR DESCRIPTION
#### Summary
Behaviour "Standardise enemy detection across all auto features"

#### Purpose of change
Auto foraging, auto pulp/butcher, auto mining, and auto mopping were incorrectly executing when enemies were in sight. The issue occurred because these features used `mostseen == 0` to check for enemies, which only tracks monsters that triggered safe mode alerts. When players ignore enemies in safe mode during combat (necessary to continue acting), `mostseen` becomes 0 even with dangerous creatures present, allowing these auto features to execute mid-combat.

AUTO_PICKUP already correctly used the more reliable `has_dangerous_creature_in_proximity` flag, which accurately tracks dangerous creatures regardless of safe mode ignore status. This change brings the other auto features in line with that correct implementation.

#### Describe the solution
Replaced the flawed `mostseen == 0` check with `has_dangerous_creature_in_proximity` across all affected auto features to match AUTO_PICKUP's behaviour. This ensures consistent and reliable enemy detection across all automated actions.

**Changes:**
- `src/game.cpp:11445` - Fixed auto foraging and auto pulp/butcher to use `has_dangerous_creature_in_proximity`
- `src/avatar_action.cpp:249` - Fixed auto mining to use `has_dangerous_creature_in_proximity`
- `src/handle_action.cpp:2429` - Added enemy check to auto mopping (previously had no enemy check at all)

#### Describe alternatives you've considered
- Keeping the `mostseen == 0` check: This would leave the fundamental flaw in place, where ignoring enemies in safe mode allows auto features to execute during combat.
- Fixing the `mostseen` tracking: This would be more invasive and wouldn't address why different auto features used different safety checks in the first place.
- Creating a new unified safety function: Whilst potentially cleaner long-term, `has_dangerous_creature_in_proximity` already exists and is proven to work correctly in AUTO_PICKUP.

The current solution standardises on the existing, correct implementation with minimal code change.

#### Testing
- ✓ Verified auto foraging no longer triggers when enemies are visible
- ✓ Verified auto pulp/butcher halts when dangerous creatures are nearby
- ✓ Verified auto mining stops when enemies appear
- ✓ Verified auto mopping now properly respects enemy proximity
- ✓ Confirmed all auto features work normally when no enemies are present
- ✓ Tested with safe mode ignore active to ensure `has_dangerous_creature_in_proximity` correctly detects enemies regardless of ignore status

#### Additional context
This change brings consistency to the codebase by having all auto features use the same, reliable enemy detection method. AUTO_PICKUP already demonstrated the correct approach; this change simply extends that pattern to the remaining auto features.