### PR TITLE
Redo backport of 83784

### DIFF
--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -263,7 +263,7 @@ static void process_eocs( queued_eocs &eoc_queue, std::vector<effect_on_conditio
         static std::list<std::vector<queued_eocs::storage_iter>> cached_queues;
         if( reentrancy_depth < 0 )
         {
-            debugmsg( "How can we unrecurse more than we recurse?" );
+            debugmsg( "EOC: reentrancy depth < 0, something has gone horribly wrong." );
         }
         while( cached_queues.size() < static_cast<size_t>( reentrancy_depth ) )
         {


### PR DESCRIPTION
#### Summary
Redo backport of 83784

#### Purpose of change
I backported DDA 83784 already, but it hadn't been merged over there yet and as it turned out there were still some fixes/improvements to be made. Now it's finished on the DDA side, so...

#### Describe the solution
Revert the prior backport and re-backport it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
