### PR TITLE
Prevent monsters from being both underwater and in a boat

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -465,7 +465,7 @@ bool Creature::is_likely_underwater( const map &here ) const
 {
     return is_underwater() ||
            ( has_flag( mon_flag_AQUATIC ) &&
-             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub( here ) ) );
+             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub( here ) ) && !here.has_vehicle_floor( pos_bub() ) );
 }
 
 // Detects whether a target is sapient or not (or barely sapient, since ferals count)


### PR DESCRIPTION
#### Summary
Prevent monsters from being both underwater and in a boat

#### Purpose of change
Aquatic monsters shouldn't really ever be entering vehicle tiles, but somehow Gura got a shark to do it and it caused some weirdness as it was acting like it was both in the boat and underwater simultaneously.

#### Describe the solution
If your tile has a vehicle floor, you are not underwater.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
