### PR TITLE
Fix exponential NPC panic growth bug

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1144,7 +1144,9 @@ void npc::act_on_danger_assessment()
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s still wants to reposition, but they just tried.",
                                name );
             }
-            mem_combat.panic *= ( mem_combat.assess_enemy / ( mem_combat.assess_ally + 0.5f ) );
+            // Changed from *= to += to prevent exponential panic growth (linear scaling instead)
+            mem_combat.panic += std::max( 0, static_cast<int>(
+                                              ( mem_combat.assess_enemy / ( mem_combat.assess_ally + 0.5f ) ) - 1.0f ) );
             mem_combat.panic += std::min(
                                     rng( 1, 3 ) + ( get_pain() / 5 ) - personality.bravery, 1 );
 


### PR DESCRIPTION
## Summary

Fixes a bug where NPC panic values could grow exponentially due to a multiplicative operation in the danger assessment logic.

## Changes

- Changed panic calculation in `src/npcmove.cpp:1147` from multiplicative (`*=`) to additive (`+=`)
- Prevents panic values from spiralling out of control when NPCs are outnumbered
- Uses linear scaling instead: `panic += max(0, (assess_enemy / assess_ally) - 1.0)`

## Context

All other panic modifications in the codebase use additive operations (`+=` or `-=`):
- Line 613: `mem_combat.panic += 1;` (when bleeding and low health)
- Line 922: `mem_combat.panic -= 1;` (when no enemies present)
- Line 1039: `mem_combat.panic -= 1;` (when near player in formation)
- Line 1150: `mem_combat.panic += ...` (pain/bravery modifier)
- Line 1193: `mem_combat.panic -= 1;` (when situation improves)

This multiplicative operation was an outlier that caused exponential rather than linear panic growth.

## Testing Notes

This is a subtle AI behaviour fix that's difficult to reproduce consistently. The change is small and focused - it replaces a single operator that was clearly causing exponential growth with a linear alternative that matches the rest of the codebase.

## Technical Details

**Before:** `panic *= (assess_enemy / (assess_ally + 0.5f))`
- If ratio is 2.0, panic doubles each assessment
- Multiple assessments → exponential growth

**After:** `panic += max(0, (assess_enemy / (assess_ally + 0.5f)) - 1.0f)`
- If ratio is 2.0, panic increases by 1 each assessment  
- Multiple assessments → linear growth