### PR TITLE
Fix NPC bleed assessment checking wrong character

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -491,7 +491,7 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
     float speed = std::max( 0.25f, candidate.get_speed() / 100.0f );
     bool is_fleeing = candidate.has_effect( effect_npc_run_away );
     int perception_inverted = std::max( ( 20 - get_per() ), 0 );
-    if( has_effect( effect_bleed ) ) {
+    if( candidate.has_effect( effect_bleed ) ) {
         int bleed_intensity = 0;
         for( const bodypart_id &bp : candidate.get_all_body_parts() ) {
             const effect &bleediness = candidate.get_effect( effect_bleed, bp );


### PR DESCRIPTION
## Summary

Fixes a bug where NPCs were checking their own bleed status when evaluating other characters, rather than checking the character being evaluated.

## Changes

- Changed `has_effect( effect_bleed )` to `candidate.has_effect( effect_bleed )` in `src/npcmove.cpp:494`
- Ensures NPCs correctly assess whether the character they're evaluating is bleeding

## Context

This is in the `evaluate_character()` function which assesses allies and enemies. The function was incorrectly using `has_effect()` (checking the NPC doing the evaluation) instead of `candidate.has_effect()` (checking the character being evaluated).

The rest of the bleed assessment logic correctly uses `candidate.get_effect()` and `candidate.get_all_body_parts()`, making this an obvious typo.

## Testing Notes

This is a subtle AI behaviour fix that's difficult to test consistently, as it requires NPCs to be evaluating bleeding characters during combat. However, the fix is a simple one-word change that aligns with the surrounding code, which all correctly references `candidate`.