### PR TITLE
make ankle holsters a holster

### DIFF
--- a/data/json/items/armor/holster.json
+++ b/data/json/items/armor/holster.json
@@ -127,6 +127,7 @@
     "flags": [ "BELTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS" ],
     "pocket_data": [
       {
+        "holster": true,
         "magazine_well": "200 ml",
         "pocket_type": "CONTAINER",
         "min_item_volume": "100 ml",


### PR DESCRIPTION
#### Summary
Ankle holsters can fit more than one item if they are small enough

#### Purpose of change
Make ankle holsters behave like a holster

#### Describe the solution
Add holster equals true to the ankle holster pocket definition

#### Describe alternatives you've considered
None.

#### Testing
Got an ankle holster which used to have two items inside, unloaded, put one inside, now it cannot fit another

#### Additional context
<img width="1900" height="428" alt="image" src="https://github.com/user-attachments/assets/2c7204ce-6ef8-4294-8ba4-71e161b14ab5" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
