### PR TITLE
Fix: Correctly remove dead NPC in caravan return

### DIFF
--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1426,7 +1426,7 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const missi
     for( const auto &elem : caravan_party ) {
         //Scrub temporary party members and the dead
         if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 && elem->has_companion_mission() ) {
-            overmap_buffer.remove_npc( comp->getID() );
+            overmap_buffer.remove_npc( elem->getID() );
             merch_amount += ( time / 600 ) * 4;
         } else if( elem->has_companion_mission() ) {
             merch_amount += ( time / 600 ) * 7;


### PR DESCRIPTION
## Summary

Fixes a bug where the wrong NPC was being removed when caravan party members died during missions.

## Changes

- Changed `overmap_buffer.remove_npc( comp->getID() )` to `overmap_buffer.remove_npc( elem->getID() )` in `src/mission_companion.cpp:1429`
- Ensures the correct dead NPC is removed from the game

## Context

In the `caravan_return()` function:
- `comp` is the companion chosen/leading the mission return (line 1373)
- `caravan_party` includes temporary guards and all companion party members (line 1386+)
- The loop iterates through each `elem` in `caravan_party` (line 1426)
- When checking if `elem` is dead (torso HP == 0), the code was incorrectly removing `comp` instead of `elem`

## Bug Impact

**Before:** When any caravan party member died, the mission leader (`comp`) would be removed instead of the dead party member (`elem`). This would:
- Remove the wrong NPC from the game (the mission leader)
- Leave dead NPCs in the game world
- Potentially crash or cause other issues if `comp` was referenced later

**After:** The correct dead NPC is removed from the game.

## Testing Notes

This is difficult to test consistently as it requires caravan missions where party members die. However, the fix is a simple one-word change that aligns with the loop logic - when iterating over `elem`, we should be operating on `elem`, not `comp`.