### PR TITLE
Fix copper axe and bronze mace recipes

### DIFF
--- a/data/json/recipes/tools/tools_primitive.json
+++ b/data/json/recipes/tools/tools_primitive.json
@@ -123,7 +123,7 @@
     "autolearn": true,
     "book_learn": [ [ "mag_survival", 1 ], [ "atomic_survival", 1 ], [ "textbook_carpentry", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "using": [ [ "redsmithing_standard", 2 ], [ "metal_casting_small", 1 ] ],
+    "using": [ [ "redsmithing_standard", 2 ], [ "metal_casting_small", -1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
     "components": [
       [ [ "stick", 1 ], [ "2x4", 1 ] ],

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -769,7 +769,7 @@
       { "proficiency": "prof_redsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 }
     ],
-    "using": [ [ "redsmithing_standard", 3 ], [ "metal_casting", 1 ] ],
+    "using": [ [ "redsmithing_standard", 3 ], [ "metal_casting", -1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ], [ [ "scrap_bronze", 3 ] ] ]
   },


### PR DESCRIPTION
#### Summary
Fix copper axe and bronze mace recipes

#### Purpose of change
The copper axe and bronze mace had metal_casting set to 1 instead of -1, so the recipes required nonexistent charges.

#### Describe the solution
-1

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
