### PR TITLE
Innawood bronze fix

### DIFF
--- a/data/mods/innawood/recipes/recipe_others.json
+++ b/data/mods/innawood/recipes/recipe_others.json
@@ -165,6 +165,22 @@
     ]
   },
   {
+    "result": "anvil_bronze",
+    "type": "recipe",
+    "activity_level": "ACTIVE_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "6 h",
+    "autolearn": true,
+    "using": [ [ "forging_standard", 45 ] ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
+    "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "DIGGING", "level": 2 } ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "scrap_bronze", 90 ] ] ]
+  },
+  {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "mop",


### PR DESCRIPTION
#### Summary
Innawood bronze fix

#### Purpose of change
fixes #1698 

The bronze anvil recipe required planks, which are necessary in mainline because we can't check that the player is standing on diggable soil, so we need a box mold. You can't get planks in innawood before you have bronze, so we're going back to DDA's method of just requiring a digging tool as suggested in #1698 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
