### PR TITLE
Fix NPCs unable to find items in furniture containers

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6017,7 +6017,7 @@ void map::process_items_in_vehicle( vehicle &cur_veh, submap &current_submap )
 bool map::sees_some_items( const tripoint_bub_ms &p, const Creature &who ) const
 {
     // Can only see items if there are any items.
-    return has_items( p ) && could_see_items( p, who.pos_bub() );
+    return has_items( p ) && could_see_items( p, who );
 }
 
 bool map::sees_some_items( const tripoint_bub_ms &p, const tripoint_bub_ms &from ) const
@@ -6027,6 +6027,18 @@ bool map::sees_some_items( const tripoint_bub_ms &p, const tripoint_bub_ms &from
 
 bool map::could_see_items( const tripoint_bub_ms &p, const Creature &who ) const
 {
+    static const std::string container_string( "CONTAINER" );
+    const bool container = has_flag_ter_or_furn( container_string, p );
+    const bool sealed = has_flag_ter_or_furn( ter_furn_flag::TFLAG_SEALED, p );
+    if( sealed && container ) {
+        // never see inside of sealed containers
+        return false;
+    }
+    // NPCs can see inside non-sealed containers from any visible distance
+    // This allows them to path to and pick up items from furniture like fridges
+    if( who.is_npc() && container && !sealed ) {
+        return true;
+    }
     return could_see_items( p, who.pos_bub() );
 }
 


### PR DESCRIPTION
## Summary

NPCs could not detect items inside furniture containers (fridges, counters, lockers) because `could_see_items()` enforced adjacency for viewing into containers. When NPCs scan for items at range, they couldn't "see" items unless already adjacent to the container.

## Changes

Modified `could_see_items(tripoint, Creature)` to allow NPCs to see inside non-sealed containers from any visible distance. This enables NPCs to path toward and pick up items from furniture containers.

- Sealed containers still block vision for all creatures
- Player vision unchanged (still requires adjacency for containers)
- Position-based overload preserves original behaviour for other callers

## Testing

- [x] NPCs can path to and pick up items from furniture containers
- [x] Player still needs to be adjacent to see inside containers
- [x] Sealed containers block vision for all creatures including NPCs