### PR TITLE
Fix: NPCs now reload empty guns instead of repeatedly trying to fire

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2745,7 +2745,7 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
 bool npc::wont_hit_friend( const tripoint_bub_ms &tar, const item &it, bool throwing ) const
 {
     if( !throwing && it.is_gun() && it.empty() ) {
-        return true;    // Prevent calling nullptr ammo_data
+        return false;    // Empty gun is not safe to shoot, prevents nullptr ammo_data
     }
 
     if( throwing && rl_dist( pos_bub(), tar ) == 1 ) {


### PR DESCRIPTION
#### Summary
Bugfix "Fix NPC reload behaviour for empty ranged weapons"

#### Purpose of change

Partially addresses issue #938, specifically the problem where NPCs would never reload empty guns in combat. NPCs were evaluating empty guns incorrectly, causing them to repeatedly attempt to fire rather than reloading.

#### Describe the solution

Changed the return value in `wont_hit_friend()` (src/npcmove.cpp:2748) from `true` to `false` when checking empty guns.

Previously, the function returned `true` (won't hit friend) for empty guns. This was done to prevent calling `nullptr` on `ammo_data`, but it had the unintended side effect of marking empty guns as "safe to shoot." This prevented the NPC AI from properly recognising that the weapon needed reloading.

**Important**: The `nullptr` check was a safety measure, not a crash fix — it didn't cause crashes, but it did cause incorrect behaviour by marking empty weapons as safe to use.

The fix changes the return to `false` (not safe to shoot) for empty guns, which correctly signals to the NPC AI that the weapon cannot be fired and needs reloading.

#### Describe alternatives you've considered

N/A — this is a straightforward logic fix.

#### Testing

In-game testing has been performed and the change works as expected. Whilst this is a small change, comprehensive testing is difficult as `wont_hit_friend()` is a widespread function used throughout NPC combat logic.