### PR TITLE
Fix recipes for armored_boots

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -517,7 +517,7 @@
     "category": "armor",
     "name": { "str": "armored boots", "str_pl": "pairs of armored boots" },
     "description": "Leather boots armor-plated with squares of sheet metal.",
-    "weight": "2200 g",
+    "weight": "2460 g",
     "volume": "3250 ml",
     "price": "50 USD",
     "price_postapoc": "6 USD",
@@ -541,7 +541,7 @@
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
         "material": [
           { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
-          { "type": "steel", "covered_by_mat": 100, "thickness": 2.0 }
+          { "type": "steel", "covered_by_mat": 90, "thickness": 2.0 }
         ],
         "encumbrance": 32,
         "coverage": 100

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -245,29 +245,26 @@
     "difficulty": 3,
     "time": "8 h",
     "book_learn": [ [ "dieselpunk_tailor", 2 ] ],
-    "using": [ [ "blacksmithing_standard", 32 ], [ "steel_standard", 8 ], [ "tailoring_leather_small", 16 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_standard", 1 ], [ "tailoring_leather_small", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_metalworking" } ],
     "qualities": [ { "id": "DRILL", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "boots_steel", 1 ], [ "boots", 1 ] ], [ [ "filament_durable", 100, "LIST" ] ], [ [ "sheet_metal_small", 10 ] ] ]
+    "components": [ [ [ "boots_steel", 1 ], [ "boots", 1 ] ], [ [ "filament_durable", 20, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ],
+    "byproducts": [ [ "scrap", 3 ] ]
   },
   {
     "result": "xs_boots_plate",
     "type": "recipe",
     "copy-from": "boots_plate",
     "time": "8 h",
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ], [ "tailoring_leather_small", 12 ] ],
-    "tools": [ [ [ "swage", -1 ] ] ]
+    "components": [ [ [ "xs_boots", 1 ] ], [ [ "filament_durable", 15, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ]
   },
   {
     "result": "xl_boots_plate",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "copy-from": "boots_plate",
-    "using": [ [ "blacksmithing_standard", 40 ], [ "steel_standard", 10 ], [ "tailoring_leather_small", 20 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ], [ "tailoring_leather_small", 3 ] ],
     "time": "9 h",
-    "qualities": [ { "id": "CHISEL", "level": 3 } ],
-    "tools": [ [ [ "swage", -1 ] ] ]
+    "components": [ [ [ "xl_boots", 1 ] ], [ [ "filament_durable", 25, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ]
   },
   {
     "result": "boots_survivor",


### PR DESCRIPTION

#### Summary
Category "Fix plate_boot recipes"

#### Purpose of change

Plate boots require more metal than a plate cuirass and the xl and xs versions don't require boots as input.

#### Describe the solution

Compare plate boots with plate_mail_sollerets, which are a better version of the metal that goes around the boot:
```json
"result": "platemail_sollerets",
"using": [ [ "strap_small", 2 ], [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],

"id": "platemail_sollerets",
"weight": "1801 g",
"volume": "500 ml",
```

The sollerets cover the whole foot except sole with the same armor thickness and coverage (after boot nerf from 100 -> 90 metal coverage). These boots do not cover the ankle or sole with steel, so the new boot metal should add:
1801 g * 55 / 75 = 1320 g
where 75 is the foot coverage except sole and 55 is that minus ankle. Including the tailoring, it should be about 1400 g more than boots.

Compare mass of components and results:
```
"id": "boots",
"weight": "1060 g",
"volume": "2500 ml",

"id": "boots_plate",
"weight": "2460 g",
"volume": "3250 ml",

"id": "steel_lump", // 1 from steel_standard
"weight": "1000 g",
"volume": "250 ml",

"id": "sheet_metal_small",
"weight": "250 g", // 2 from components
"volume": "250 ml",

"id": "scrap",
"weight": "50 g",
"volume": "250 ml",
```
we give back 3 scrap to (almost) conserve mass.

#### Describe alternatives you've considered

Play the game instead.

#### Testing

Loaded it up:
<img width="937" height="790" alt="image" src="https://github.com/user-attachments/assets/ed6a3206-9af0-4b47-a305-91ed873e58f0" />

- [x] byproduct 3 scrap top right
- [x] right amount of material input
- [x] right tools required
- [x] grams to pounds is 5.4 lbs as pictured

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
