### PR TITLE
Remove some boots, fix chitin

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -163,81 +163,108 @@
     "melee_damage": { "bash": 3 }
   },
   {
-    "id": "boots_chitin",
+    "id": "chitin_sollerets",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "chitinous boots", "str_pl": "pairs of chitinous boots" },
-    "description": "Apart from the fasteners and the bits holding the material together, these boots are made entirely from arthropod exoskeleton.",
-    "weight": "1620 g",
-    "volume": "4250 ml",
-    "price": "135 USD",
-    "price_postapoc": "12 USD 50 cent",
+    "name": { "str": "chitin sollerets", "str_pl": "pairs of chitin sollerets" },
+    "description": "A pair of bizarre-looking boot covers made from overlapping layers of giant arthropod shell.",
+    "weight": "900 g",
+    "volume": "500 ml",
+    "price_postapoc": "3 USD",
     "to_hit": -1,
-    "material": [ "chitin" ],
+    "material": [ { "type": "chitin", "portion": 9 }, { "type": "leather", "portion": 1 } ],
     "symbol": "[",
-    "looks_like": "boots",
     "color": "brown",
-    "warmth": 5,
-    "material_thickness": 4,
-    "environmental_protection": 3,
-    "flags": [ "STURDY", "VARSIZE", "RAINPROOF", "NORMAL", "OUTER" ],
+    "flags": [ "STURDY", "BELTED" ],
     "armor": [
       {
         "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l", "foot_toes_l", "foot_toes_r" ],
-        "encumbrance": 30,
-        "coverage": 95
-      },
-      { "coverage": 75, "covers": [ "foot_l", "foot_r" ], "specifically_covers": [ "foot_ankle_l", "foot_ankle_r" ] },
-      {
-        "coverage": 100,
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_sole_l", "foot_sole_r" ],
-        "rigid_layer_only": true
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          { "type": "chitin", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
+        ],
+        "encumbrance": 4,
+        "coverage": 90
       }
     ],
     "melee_damage": { "bash": 3 }
   },
   {
-    "id": "xl_boots_chitin",
+    "id": "chitin_sollerets_xl",
     "type": "ARMOR",
-    "name": { "str": "chitinous boots", "str_pl": "pairs of chitinous boots" },
-    "copy-from": "boots_chitin",
-    "proportional": { "weight": 1.25, "volume": 1.25 },
+    "copy-from": "chitin_sollerets",
+    "name": { "str": "chitin sollerets", "str_pl": "pairs of chitin sollerets" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
-    "id": "xs_boots_chitin",
+    "id": "chitin_sollerets_xs",
     "type": "ARMOR",
-    "copy-from": "boots_chitin",
-    "looks_like": "boots_chitin",
-    "name": { "str": "chitinous boots", "str_pl": "pairs of chitinous boots" },
+    "copy-from": "chitin_sollerets",
+    "name": { "str": "chitin sollerets", "str_pl": "pairs of chitin sollerets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
   {
-    "id": "boots_acidchitin",
-    "copy-from": "boots_chitin",
+    "id": "acidchitin_sollerets",
     "type": "ARMOR",
-    "name": { "str": "biosilicified chitin boots", "str_pl": "pairs of biosilicified chitin boots" },
-    "description": "Boots crafted from glassy-looking arthropod exoskeleton.  The material is a little more brittle, but might withstand fire and acid better than the regular stuff.",
-    "price_postapoc": "17 USD 50 cent",
-    "material": [ "acidchitin" ],
+    "category": "armor",
+    "name": { "str": "biosilicified chitin sollerets", "str_pl": "pairs of biosilicified chitin sollerets" },
+    "description": "A pair of bizarre-looking boot covers made from overlapping layers of giant arthropod shell.  The material seems unusually hard, with an almost glassy sheen.",
+    "weight": "1200 g",
+    "volume": "500 ml",
+    "price_postapoc": "3 USD",
+    "to_hit": -1,
+    "material": [ { "type": "acidchitin", "portion": 9 }, { "type": "leather", "portion": 1 } ],
+    "symbol": "[",
+    "color": "green",
+    "flags": [ "STURDY", "BELTED" ],
+    "armor": [
+      {
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [
+          "foot_toes_r",
+          "foot_toes_l",
+          "foot_ankle_r",
+          "foot_ankle_l",
+          "foot_heel_r",
+          "foot_heel_l",
+          "foot_arch_r",
+          "foot_arch_l"
+        ],
+        "material": [
+          { "type": "acidchitin", "covered_by_mat": 100, "thickness": 3.0 },
+          { "type": "leather", "covered_by_mat": 1, "thickness": 2.0 }
+        ],
+        "encumbrance": 4,
+        "coverage": 90
+      }
+    ],
     "melee_damage": { "bash": 4 }
   },
   {
-    "id": "xl_boots_acidchitin",
+    "id": "acidchitin_sollerets_xl",
     "type": "ARMOR",
-    "name": { "str": "biosilicified chitin boots", "str_pl": "pairs of biosilicified chitin boots" },
-    "copy-from": "boots_acidchitin",
-    "proportional": { "weight": 1.25, "volume": 1.25 },
+    "copy-from": "acidchitin_sollerets",
+    "name": { "str": "biosilicified chitin sollerets", "str_pl": "pairs of biosilicified chitin sollerets" },
+    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
-    "id": "xs_boots_acidchitin",
+    "id": "acidchitin_sollerets_xs",
     "type": "ARMOR",
-    "copy-from": "boots_acidchitin",
-    "name": { "str": "biosilicified chitin boots", "str_pl": "pairs of biosilicified chitin boots" },
+    "copy-from": "acidchitin_sollerets",
+    "name": { "str": "biosilicified chitin sollerets", "str_pl": "pairs of biosilicified chitin sollerets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },
@@ -512,70 +539,6 @@
     "melee_damage": { "bash": 2 }
   },
   {
-    "id": "boots_plate",
-    "type": "ARMOR",
-    "category": "armor",
-    "name": { "str": "armored boots", "str_pl": "pairs of armored boots" },
-    "description": "Leather boots armor-plated with squares of sheet metal.",
-    "weight": "2460 g",
-    "volume": "3250 ml",
-    "price": "50 USD",
-    "price_postapoc": "6 USD",
-    "to_hit": -2,
-    "symbol": "[",
-    "looks_like": "boots_steel",
-    "color": "light_gray",
-    "warmth": 20,
-    "environmental_protection": 1,
-    "flags": [ "VARSIZE", "RAINPROOF", "NORMAL", "OUTER" ],
-    "armor": [
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_ankle_r", "foot_ankle_l" ],
-        "material": [ { "type": "leather_treated", "covered_by_mat": 100, "thickness": 2.0 } ],
-        "encumbrance": 0,
-        "coverage": 98
-      },
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
-        "material": [
-          { "type": "leather", "covered_by_mat": 100, "thickness": 2.0 },
-          { "type": "steel", "covered_by_mat": 90, "thickness": 2.0 }
-        ],
-        "encumbrance": 32,
-        "coverage": 100
-      },
-      {
-        "covers": [ "foot_l", "foot_r" ],
-        "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
-        "material": [
-          { "type": "leather", "covered_by_mat": 100, "thickness": 0.1 },
-          { "type": "rubber", "covered_by_mat": 100, "thickness": 6.0 }
-        ],
-        "encumbrance": 0,
-        "coverage": 100
-      }
-    ],
-    "melee_damage": { "bash": 3, "cut": 1 }
-  },
-  {
-    "id": "xl_boots_plate",
-    "type": "ARMOR",
-    "name": { "str": "armored boots", "str_pl": "pairs of armored boots" },
-    "copy-from": "boots_plate",
-    "proportional": { "weight": 1.25, "volume": 1.25 },
-    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
-  },
-  {
-    "id": "xs_boots_plate",
-    "type": "ARMOR",
-    "copy-from": "boots_plate",
-    "name": { "str": "armored boots", "str_pl": "pairs of armored boots" },
-    "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
-  },
-  {
     "id": "boots_rubber",
     "type": "ARMOR",
     "name": { "str": "rubber boots", "str_pl": "pairs of rubber boots" },
@@ -619,7 +582,7 @@
     "id": "boots_steel",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "steeltoed boots", "str_pl": "pairs of steeltoed boots" },
+    "name": { "str": "steel-toed boots", "str_pl": "pairs of steel-toed boots" },
     "description": "Heavy boots made of chemical-resistant treated leather with steel toecaps.  Great for the jobsite or for stomping the undead",
     "weight": "2220 g",
     "volume": "3 L",
@@ -671,7 +634,7 @@
     "id": "sneakers_steel",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "steeltoed sneakers", "str_pl": "pairs of steeltoed sneakers" },
+    "name": { "str": "steel-toed sneakers", "str_pl": "pairs of steel-toed sneakers" },
     "description": "A descendant of the classic steeltoed boot, this modern footwear has become popular amongst working class people over the last couple of decades.",
     "weight": "900 g",
     "volume": "1500 ml",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -169,7 +169,7 @@
     "id": "gauntlets_chitin",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "chitinous gauntlets", "str_pl": "pairs of chitinous gauntlets" },
+    "name": { "str": "chitin gauntlets", "str_pl": "pairs of chitin gauntlets" },
     "description": "A pair of gauntlets made from arthropod exoskeleton.  Though intricately articulated and padded by unsclerotized material, they do not cover the tips of the fingers.",
     "weight": "760 g",
     "volume": "1750 ml",
@@ -181,7 +181,7 @@
     "looks_like": "leather_gauntlets",
     "color": "green",
     "warmth": 5,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "flags": [ "STURDY", "DURABLE_MELEE", "NORMAL", "OUTER", "ALLOWS_NATURAL_ATTACKS" ],
     "armor": [
       {
@@ -203,7 +203,7 @@
   {
     "id": "xl_gauntlets_chitin",
     "type": "ARMOR",
-    "name": { "str": "chitinous gauntlets", "str_pl": "pairs of chitinous gauntlets" },
+    "name": { "str": "chitin gauntlets", "str_pl": "pairs of chitin gauntlets" },
     "copy-from": "gauntlets_chitin",
     "proportional": { "weight": 1.5, "volume": 1.5 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
@@ -212,7 +212,7 @@
     "id": "xs_gauntlets_chitin",
     "type": "ARMOR",
     "copy-from": "gauntlets_chitin",
-    "name": { "str": "chitinous gauntlets", "str_pl": "pairs of chitinous gauntlets" },
+    "name": { "str": "chitin gauntlets", "str_pl": "pairs of chitin gauntlets" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
   },

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -690,7 +690,7 @@
     "id": "helmet_chitin",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "chitinous helmet" },
+    "name": { "str": "chitin helmet" },
     "description": "A helmet made from the exoskeletons of insects.  Covers the entire head; very light and durable.",
     "weight": "1447 g",
     "volume": "2500 ml",
@@ -732,7 +732,7 @@
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 60, "encumbrance": 12 }
     ],
     "warmth": 5,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "environmental_protection": 4,
     "flags": [ "WATERPROOF", "STURDY", "OUTER" ],
     "melee_damage": { "bash": 1 }
@@ -741,7 +741,7 @@
     "id": "xl_helmet_chitin",
     "type": "ARMOR",
     "copy-from": "helmet_chitin",
-    "name": { "str": "chitinous helmet" },
+    "name": { "str": "chitin helmet" },
     "proportional": { "weight": 1.25, "volume": 1.3, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
@@ -750,7 +750,7 @@
     "type": "ARMOR",
     "copy-from": "helmet_chitin",
     "looks_like": "helmet_chitin",
-    "name": { "str": "chitinous helmet" },
+    "name": { "str": "chitin helmet" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "flags": [ "WATERPROOF", "STURDY", "UNDERSIZE", "PREFIX_XS", "OUTER", "NORMAL" ]
   },

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -110,7 +110,7 @@
     "looks_like": "legguard_hard",
     "color": "green",
     "warmth": 10,
-    "material_thickness": 4,
+    "material_thickness": 3,
     "environmental_protection": 2,
     "flags": [ "STURDY", "OUTER", "WATER_FRIENDLY", "ALLOWS_TAIL" ],
     "armor": [
@@ -150,7 +150,7 @@
     "name": { "str": "biosilicified chitin greaves", "str_pl": "pairs of biosilicified greaves" },
     "description": "A pair of leg guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
-    "melee_damage": { "bash": 5 },
+    "melee_damage": { "bash": 4 },
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -47,7 +47,7 @@
     "id": "armor_chitin",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "chitinous armor" },
+    "name": { "str": "chitin armor" },
     "description": "Lightweight leg and body armor made from the exoskeletons of giant arthropods.",
     "weight": "2632 g",
     "volume": "5800 ml",
@@ -60,7 +60,7 @@
     "color": "brown",
     "warmth": 10,
     "longest_side": "60 cm",
-    "material_thickness": 4,
+    "material_thickness": 3,
     "flags": [ "STURDY", "OUTER", "ALLOWS_TAIL" ],
     "armor": [
       { "covers": [ "torso" ], "coverage": 90, "encumbrance": 11 },
@@ -77,7 +77,7 @@
   {
     "id": "xl_armor_chitin",
     "type": "ARMOR",
-    "name": { "str": "chitinous armor" },
+    "name": { "str": "chitin armor" },
     "copy-from": "armor_chitin",
     "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25 },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
@@ -87,7 +87,7 @@
     "type": "ARMOR",
     "copy-from": "armor_chitin",
     "looks_like": "armor_chitin",
-    "name": { "str": "chitinous armor" },
+    "name": { "str": "chitin armor" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "flags": [ "STURDY", "OUTER", "UNDERSIZE", "PREFIX_XS" ]
   },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3132,5 +3132,50 @@
     "type": "MIGRATION",
     "id": "sparkling_pomegranate",
     "replace": "sparkling"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_plate",
+    "replace": "boots_steel"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "xl_boots_plate",
+    "replace": "xl_boots"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "xs_boots_plate",
+    "replace": "xs_boots"
+  },
+    {
+    "type": "MIGRATION",
+    "id": "boots_chitin",
+    "replace": "chitin_sollerets"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_chitin_xl",
+    "replace": "chitin_sollerets_xl"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_chitin_xs",
+    "replace": "chitin_sollerets_xs"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_acidchitin",
+    "replace": "acidchitin_sollerets"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_acidchitin_xl",
+    "replace": "acidchitin_sollerets_xl"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "boots_acidchitin_xs",
+    "replace": "acidchitin_sollerets_xs"
   }
 ]

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -47,9 +47,9 @@
     "time": "11 h 15 m"
   },
   {
-    "result": "boots_chitin",
+    "result": "chitin_sollerets",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
+    "activity_level": "BRISK_EXERCISE",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
@@ -58,36 +58,32 @@
     "time": "12 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 3 ] ],
-    "using": [ [ "armor_chitin", 18 ], [ "strap_small", 4 ], [ "clasps", 2 ] ],
+    "using": [ [ "sewing_standard", 8 ], [ "armor_chitin", 18 ], [ "strap_small", 4 ], [ "clasps", 2 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "proficiencies": [
-      { "proficiency": "prof_cobbling" },
-      { "proficiency": "prof_leatherworking_basic" },
       { "proficiency": "prof_chitinworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 },
       { "proficiency": "prof_articulation" }
     ]
   },
   {
-    "result": "xs_boots_chitin",
+    "result": "chitin_sollerets_xs",
     "type": "recipe",
-    "copy-from": "boots_chitin",
-    "time": "12 h",
-    "using": [ [ "armor_chitin", 13 ], [ "strap_small", 3 ], [ "clasps", 1 ] ],
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ]
+    "copy-from": "chitin_sollerets",
+    "time": "9 h",
+    "using": [ [ "sewing_standard", 6 ], [ "armor_chitin", 16 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
-    "result": "xl_boots_chitin",
+    "result": "chitin_sollerets_xl",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "copy-from": "boots_chitin",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "using": [ [ "armor_chitin", 23 ], [ "strap_small", 6 ], [ "clasps", 2 ] ],
-    "time": "13 h 30 m"
+    "copy-from": "chitin_sollerets",
+    "time": "16 h",
+    "using": [ [ "sewing_standard", 12 ], [ "armor_chitin", 23 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
-    "result": "boots_acidchitin",
+    "result": "acidchitin_sollerets",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
+    "activity_level": "BRISK_EXERCISE",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
@@ -96,31 +92,27 @@
     "time": "16 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 4 ] ],
-    "using": [ [ "armor_acidchitin", 18 ], [ "strap_small", 4 ], [ "clasps", 2 ] ],
+    "using": [ [ "sewing_standard", 8 ], [ "armor_acidchitin", 18 ], [ "strap_small", 4 ], [ "clasps", 2 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "proficiencies": [
-      { "proficiency": "prof_cobbling" },
-      { "proficiency": "prof_leatherworking_basic" },
       { "proficiency": "prof_chitinworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 },
       { "proficiency": "prof_articulation" }
     ]
   },
   {
-    "result": "xs_boots_acidchitin",
+    "result": "acidchitin_sollerets_xs",
     "type": "recipe",
-    "copy-from": "boots_acidchitin",
-    "time": "16 h",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "using": [ [ "armor_acidchitin", 13 ], [ "strap_small", 3 ], [ "clasps", 1 ] ]
+    "copy-from": "acidchitin_sollerets",
+    "time": "12 h",
+    "using": [ [ "sewing_standard", 6 ], [ "armor_acidchitin", 16 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
-    "result": "xl_boots_acidchitin",
+    "result": "acidchitin_sollerets_xl",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "copy-from": "boots_acidchitin",
-    "using": [ [ "armor_acidchitin", 23 ], [ "strap_small", 6 ], [ "clasps", 2 ] ],
-    "time": "18 h",
-    "qualities": [ { "id": "CUT_FINE", "level": 1 } ]
+    "copy-from": "acidchitin_sollerets",
+    "time": "24 h",
+    "using": [ [ "sewing_standard", 12 ], [ "armor_acidchitin", 23 ], [ "strap_small", 4 ], [ "clasps", 2 ] ]
   },
   {
     "result": "boots_fur",
@@ -234,37 +226,6 @@
       [ "adhesive_rubber", 2 ]
     ],
     "time": "13 h 30 m"
-  },
-  {
-    "result": "boots_plate",
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_FEET",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "time": "8 h",
-    "book_learn": [ [ "dieselpunk_tailor", 2 ] ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_standard", 1 ], [ "tailoring_leather_small", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_metalworking" } ],
-    "qualities": [ { "id": "DRILL", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "boots_steel", 1 ], [ "boots", 1 ] ], [ [ "filament_durable", 20, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ],
-    "byproducts": [ [ "scrap", 3 ] ]
-  },
-  {
-    "result": "xs_boots_plate",
-    "type": "recipe",
-    "copy-from": "boots_plate",
-    "time": "8 h",
-    "components": [ [ [ "xs_boots", 1 ] ], [ [ "filament_durable", 15, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ]
-  },
-  {
-    "result": "xl_boots_plate",
-    "type": "recipe",
-    "copy-from": "boots_plate",
-    "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ], [ "tailoring_leather_small", 3 ] ],
-    "time": "9 h",
-    "components": [ [ [ "xl_boots", 1 ] ], [ [ "filament_durable", 25, "LIST" ] ], [ [ "sheet_metal_small", 2 ] ] ]
   },
   {
     "result": "boots_survivor",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -601,7 +601,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_HEAD",
-    "name": "chitinous helmets",
+    "name": "chitin helmets",
     "description": "Recipes related to constructing durable helmets from chitin.",
     "skill_used": "tailor",
     "nested_category_data": [
@@ -620,7 +620,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_SUIT",
-    "name": "chitinous armor",
+    "name": "chitin armor",
     "description": "Recipes related to constructing durable armor from chitin that covers the body.",
     "skill_used": "tailor",
     "nested_category_data": [
@@ -639,7 +639,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_ARMS",
-    "name": "chitinous arm guards",
+    "name": "chitin arm guards",
     "description": "Recipes related to constructing durable armguards from chitin.",
     "skill_used": "tailor",
     "nested_category_data": [
@@ -658,8 +658,8 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
-    "name": "chitinous leg guards",
-    "description": "Recipes related to constructing durable leg guards from chitin.",
+    "name": "chitin greaves",
+    "description": "Recipes related to constructing durable shin guards from chitin.",
     "skill_used": "tailor",
     "nested_category_data": [
       "legguard_chitin",
@@ -677,7 +677,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_HANDS",
-    "name": "chitinous gauntlets",
+    "name": "chitin gauntlets",
     "description": "Recipes related to constructing durable gauntlets from chitin.",
     "skill_used": "tailor",
     "nested_category_data": [
@@ -691,21 +691,21 @@
     "difficulty": 4
   },
   {
-    "id": "nested_chitinous_boots",
+    "id": "nested_chitin_sollerets",
     "type": "nested_category",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_FEET",
-    "name": "chitinous boots",
-    "description": "Recipes related to constructing durable boots from chitin.",
+    "name": "chitin sollerets",
+    "description": "Recipes related to constructing durable boot covers from chitin.",
     "skill_used": "tailor",
     "nested_category_data": [
-      "boots_chitin",
-      "xs_boots_chitin",
-      "xl_boots_chitin",
-      "boots_acidchitin",
-      "xs_boots_acidchitin",
-      "xl_boots_acidchitin"
+      "chitin_sollerets",
+      "chitin_sollerets_xs",
+      "chitin_sollerets_xl",
+      "acidchitin_sollerets",
+      "acidchitin_sollerets_xs",
+      "acidchitin_sollerets_xl"
     ],
     "difficulty": 4
   },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -5346,7 +5346,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "scrap_aluminum", 1 ], [ "splinter", 2 ] ] ]
+    "components": [ [ [ "splinter", 3 ] ] ]
   },
   {
     "result": "jerrycan_big",


### PR DESCRIPTION
#### Summary
Remove some boots, fix chitin

#### Purpose of change
- Chitin armor was supposed to be 3mm, a bit worse than plate mail but much lighter and easier to make. All pieces except the arm guards were 4mm.
- One or two pieces of the chitin sets had the incorrect melee damage.
- Chitin boots never made sense. There was no padding, no rubbery sole material, etc.
- Armored boots were redundant and a bit nonsensical.

#### Describe the solution
- Chitin boots -> chitin sollerets. These are easier to make and are boot covers, not entire boots.
- Chitin armor 4mm -> 3mm
- Remove armored boots
- Chitin armor is supposed to do 3 bash, biosil 4
- Chitinous -> chitin

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
