### PR TITLE
Add aluminum to M110A1 material list

### DIFF
--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -441,7 +441,7 @@
     "price": "3200 USD",
     "price_postapoc": "60 USD",
     "to_hit": -1,
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel", "aluminum", "plastic" ],
     "symbol": "(",
     "color": "dark_gray",
     "ammo": [ "308" ],


### PR DESCRIPTION
#### Summary
The description says it has an aluminum upper like the rifle it's named after, the materials list didn't agree, now it does.

#### Purpose of change
Consistency.

#### Describe the solution
Adding aluminum to the material section of the M110A1 in the 308.json file.

#### Describe alternatives you've considered
Ignoring it.

#### Testing
The game didn't complain when I loaded my save and aluminum showed up on the material list of the item description.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
