### PR TITLE
Fix: Prevent iterator invalidation during NPC trading

### DIFF
--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -58,13 +58,19 @@ std::list<item> npc_trading::transfer_items( trade_selector::select_t &stuff, Ch
         }
         // spill contained, unwanted items
         if( f_wants && gift.is_container() ) {
+            // Collect items to remove to avoid iterator invalidation
+            std::vector<item *> items_to_remove;
             for( item *it : gift.get_contents().all_items_top() ) {
                 int const price =
                     trading_price( giver, receiver, { item_location{ giver, it }, 1 } );
                 if( !f_wants( item_location{ ip.first, it }, price ) ) {
                     giver.i_add_or_drop( *it, 1, ip.first.get_item() );
-                    gift.remove_item( *it );
+                    items_to_remove.push_back( it );
                 }
+            }
+            // Remove unwanted items after iteration completes
+            for( item *it : items_to_remove ) {
+                gift.remove_item( *it );
             }
         }
 


### PR DESCRIPTION
#### Summary
Bugfix "Fix potential iterator invalidation crash in NPC trading"

#### Purpose of change

Fixes a potential crash that could occur during NPC trading when containers contain items the NPC doesn't want. The code was modifying a container's contents whilst iterating over them, causing undefined behaviour and potential crashes.

#### Describe the solution

In `npc_trading::transfer_items` (src/npctrade.cpp), when processing containers with unwanted items:
- Collects pointers to items that need removing during the iteration
- Removes all collected items after the iteration completes
- This prevents iterator invalidation from modifying the container during traversal

The fix uses a two-pass approach: identify items to remove, then remove them.

#### Testing

No issues observed during trading with containers containing mixed wanted/unwanted items.