### PR TITLE
Fix chitin recipes

### DIFF
--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -23,7 +23,6 @@
     "skill_used": "tailor",
     "difficulty": 1,
     "time": "60 m",
-    "//": "Time has gotten shorter but is double requirement time due to making a pair",
     "autolearn": true,
     "byproducts": [ [ "scrap_cotton", 3 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 1 ] ]
@@ -53,33 +52,32 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "skills_required": [ [ "fabrication", 3 ] ],
-    "time": "390 m",
+    "time": "10 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 4 ] ],
-    "byproducts": [ [ "scrap_leather", 4 ] ],
     "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_leatherworking" },
       { "proficiency": "prof_articulation" }
     ],
-    "using": [ [ "armor_chitin", 3 ], [ "tailoring_leather_small", 2 ] ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 6 ], [ "filament", 4 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xs_armguard_chitin",
     "type": "recipe",
     "copy-from": "armguard_chitin",
-    "time": "390 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_chitin", 2 ], [ "tailoring_leather_small", 1 ] ]
+    "time": "8 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 4 ], [ "filament", 2 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xl_armguard_chitin",
     "type": "recipe",
     "copy-from": "armguard_chitin",
-    "time": "440 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_chitin", 4 ], [ "tailoring_leather_small", 3 ] ]
+    "time": "12 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 8 ], [ "filament", 8 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "armguard_acidchitin",
@@ -90,33 +88,32 @@
     "skill_used": "tailor",
     "difficulty": 6,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
-    "time": "390 m",
+    "time": "12 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 5 ] ],
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_acidchitin", 3 ], [ "tailoring_leather_small", 2 ] ],
     "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_leatherworking" },
       { "proficiency": "prof_articulation" }
-    ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 6 ], [ "filament", 4 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xs_armguard_acidchitin",
     "type": "recipe",
     "copy-from": "armguard_acidchitin",
-    "time": "390 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_acidchitin", 2 ], [ "tailoring_leather_small", 1 ] ]
+    "time": "10 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 4 ], [ "filament", 2 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xl_armguard_acidchitin",
     "type": "recipe",
     "copy-from": "armguard_acidchitin",
-    "time": "440 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_acidchitin", 4 ], [ "tailoring_leather_small", 3 ] ]
+    "time": "14 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 8 ], [ "filament", 8 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
   },
   {
     "result": "armguard_hard",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -23,33 +23,32 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "skills_required": [ [ "fabrication", 3 ] ],
-    "time": "520 m",
+    "time": "8 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 4 ] ],
-    "byproducts": [ [ "scrap_leather", 92 ] ],
     "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_leatherworking" },
       { "proficiency": "prof_articulation" }
     ],
-    "using": [ [ "armor_chitin", 6 ], [ "tailoring_leather_small", 4 ] ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 3 ], [ "filament", 4 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xs_legguard_chitin",
     "type": "recipe",
     "copy-from": "legguard_chitin",
-    "time": "520 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_chitin", 5 ], [ "tailoring_leather_small", 3 ] ]
+    "time": "6 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 2 ], [ "filament", 2 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xl_legguard_chitin",
     "type": "recipe",
     "copy-from": "legguard_chitin",
-    "time": "580 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_chitin", 7 ], [ "tailoring_leather_small", 5 ] ]
+    "time": "10 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_chitin", 6 ], [ "filament", 8 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "legguard_acidchitin",
@@ -60,33 +59,32 @@
     "skill_used": "tailor",
     "difficulty": 6,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
-    "time": "520 m",
+    "time": "10 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 5 ] ],
-    "byproducts": [ [ "scrap_leather", 92 ] ],
-    "using": [ [ "armor_acidchitin", 6 ], [ "tailoring_leather_small", 4 ] ],
     "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_closures" },
       { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_leatherworking" },
       { "proficiency": "prof_articulation" }
-    ]
+    ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 3 ], [ "filament", 4 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xs_legguard_acidchitin",
     "type": "recipe",
     "copy-from": "legguard_acidchitin",
-    "time": "520 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_acidchitin", 5 ], [ "tailoring_leather_small", 3 ] ]
+    "time": "8 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 2 ], [ "filament", 2 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xl_legguard_acidchitin",
     "type": "recipe",
     "copy-from": "legguard_acidchitin",
-    "time": "580 m",
-    "byproducts": [ [ "scrap_leather", 4 ] ],
-    "using": [ [ "armor_acidchitin", 7 ], [ "tailoring_leather_small", 5 ] ]
+    "time": "12 h",
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "using": [ [ "armor_acidchitin", 6 ], [ "filament", 8 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "bikini_bottom",

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -77,7 +77,7 @@
     "skill_used": "tailor",
     "difficulty": 8,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
-    "time": "8 h 20 m",
+    "time": "14 h",
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 7 ] ],
     "using": [ [ "cordage", 2 ] ],
@@ -94,7 +94,7 @@
     "result": "armor_acidchitin_xs",
     "type": "recipe",
     "copy-from": "armor_acidchitin",
-    "time": "8 h 20 m",
+    "time": "12 h",
     "using": [ [ "cordage", 1 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "components": [ [ [ "acidchitin_piece", 54 ] ] ]
@@ -103,7 +103,7 @@
     "result": "xl_armor_acidchitin",
     "type": "recipe",
     "copy-from": "armor_acidchitin",
-    "time": "9 h 20m",
+    "time": "18 h",
     "using": [ [ "cordage", 3 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "components": [ [ [ "acidchitin_piece", 96 ] ] ]


### PR DESCRIPTION
#### Summary
Fix chitin recipes

#### Purpose of change
Chitin armor took too long to make and involved a bunch of leather. It's not leather armor, it's chitin!

#### Describe the solution
Remove leatherworking profs, add closures and straps, update recipes, update work time.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
