### PR TITLE
Fix hardhat/riding helmet

### DIFF
--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -445,7 +445,8 @@
         "encumbrance_modifiers": [ "NONE" ],
         "coverage": 100,
         "covers": [ "head" ],
-        "specifically_covers": [ "head_crown", "head_forehead" ]
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "rigid_layer_only": true
       }
     ],
     "pocket_data": [
@@ -538,7 +539,8 @@
         "encumbrance_modifiers": [ "NONE" ],
         "coverage": 100,
         "covers": [ "head" ],
-        "specifically_covers": [ "head_crown", "head_forehead" ]
+        "specifically_covers": [ "head_crown", "head_forehead" ],
+        "rigid_layer_only": true
       }
     ],
     "pocket_data": [

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1330,7 +1330,7 @@
       }
     ],
     "warmth": 20,
-    "flags": [ "WATERPROOF", "STURDY", "PADDED", "SUN_SHADE", "OUTER", "CUSHION_FALL" ],
+    "flags": [ "WATERPROOF", "STURDY", "PADDED", "SUN_SHADE", "CUSHION_FALL" ],
     "melee_damage": { "bash": 2 }
   },
   {


### PR DESCRIPTION
#### Summary
Fix hardhat/riding helmet

#### Purpose of change
It was possible to wear a hard hat and riding helmet at the same time because rigid_layer_only wasn't set.

#### Describe the solution
Set it and move riding helmets to the NORMAL layer.

#### Describe alternatives you've considered
OUTER? But NORMAL is what hard hats are, so,

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
