### PR TITLE
Fix retirement community

### DIFF
--- a/data/json/mapgen/retirement_community.json
+++ b/data/json/mapgen/retirement_community.json
@@ -42,7 +42,7 @@
         "|ssgg#WwwwJi...D```W```D...YJwwwWwwwJY...D```W```D...YJwwwWwwwww...D```W```D...YJwwwWwwwCCcccD```W```D...YJwwwWwwwJY...D```W```D...iJwwwWwwwiY...D```W```D...YqwwwW#gss|",
         "|ssgg#Wv^wwww..wAk&W&kAw..wwww^vWv^wwww..wAk&W&kAw..wwww^vWv^Eeww..wAk&W&kAw..wwww^vWv^wwwwCcwAk&W&kAw..wwww^vWv^wwww..wAk&W&kAw..wwww^vWv^wwww..wAk&W&kAw..wwww^vW#gss|",
         "|ssgg#W..SSS...wwwwWwwww........W..blxl..wwwwWwwww..SSSS..W........wwwwWwwww..lxli..WccccccccwwwwWwwww..SSSS..W..SSS...wwwwWwwww...SSH..W........wwwwWwwww..SSSS..W#gss|",
-        "|ssgg#Wb...........W........bS.lW............W............Wl.Hb..S.....W............WxcHCCCCcccccW............Wb....H......W...........bWt.S.lb......W...........HW#gss|",
+        "|ssgg#Wb...........W........bS.lW............W............Wl.Hb..S.....W............WxcHCCCccccccW............Wb....H......W...........bWt.S.lb......W...........HW#gss|",
         "|ssggЯWb.lxli..iwj.W.jwi.HH.bS.lW..HSSS..iwj.W.jwi.bllxlliWx.Sb..S..wj.W..w...SSSH..WCCCCCCCCCwCcW.jwi..HllHbbWb.ix....iwj.W.jw....lxl.bWt.S.xb.Hiwj.W.jw...SSSi.bWЯgss|",
         "|ssgg#WWWWoWWWWoWWLWLWWoWWWWoWWWWWWWoWWWWoWWLWLWWoWWWWoWWWWWWWoWWWWoWWLWLWWoWWWWoWWWWWWWoWWWWoWWLWLWWoWWWWoWWWWWWWoWWWWoWWLWLWWoWWWWoWWWWWWWoWWWWoWWLWLWWoWWWWoWWWW#gss|",
         "|ssgg#%###########sss###########%###########sss###########%###########sss###########%###########sss###########%###########sss###########%###########sss###########%#gss|",
@@ -97,44 +97,44 @@
         { "chance": 15, "rotation": 90, "vehicle": "parking_garage", "x": 162, "y": 44 }
       ],
       "items": {
-        "c": { "item": "hoarder", "chance": 50 },
-        "C": { "item": "hoarder", "chance": 100, "repeat": [ 1, 2 ] },
-        "R": { "item": "SUS_fridge", "chance": 100 },
+        "c": { "item": "hoarder", "chance": 20 },
+        "C": { "item": "hoarder", "chance": 45, "repeat": [ 1, 2 ] },
+        "R": { "item": "SUS_fridge", "chance": 70 },
         "+": { "item": "SUS_dishwasher", "chance": 100 },
         "K": { "item": "SUS_kitchen_sink", "chance": 100 },
         "k": { "item": "SUS_bathroom_sink", "chance": 100 },
-        "A": { "item": "SUS_bathroom_medicine", "chance": 100 },
+        "A": { "item": "SUS_bathroom_medicine", "chance": 70 },
         "z": [
           { "item": "SUS_silverware", "chance": 100 },
           { "item": "SUS_utensils", "chance": 100 },
-          { "item": "SUS_knife_drawer", "chance": 100 }
+          { "item": "SUS_knife_drawer", "chance": 70 }
         ],
         "Z": { "item": "SUS_dishes", "chance": 100 },
         "q": { "item": "SUS_junk_drawer", "chance": 100 },
         "M": { "item": "SUS_oven", "chance": 100 },
         "j": { "item": "coat_rack", "chance": 50 },
         "Y": { "item": "trash", "chance": 50 },
-        "-": [ { "item": "SUS_appliances_cupboard", "chance": 100 }, { "item": "SUS_cookware", "chance": 100 } ],
-        "J": [ { "item": "SUS_pantry", "chance": 100 }, { "item": "SUS_spice_collection", "chance": 100 } ],
+        "-": [ { "item": "SUS_appliances_cupboard", "chance": 100 }, { "item": "SUS_cookware", "chance": 70 } ],
+        "J": [ { "item": "SUS_pantry", "chance": 100 }, { "item": "SUS_spice_collection", "chance": 70 } ],
         "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] },
-        "P": { "item": "trash", "chance": 100, "repeat": [ 2, 6 ] }
+        "P": { "item": "trash", "chance": 100, "repeat": [ 0, 4 ] }
       },
       "place_item": [
-        { "item": "television", "x": 10, "y": 17, "chance": 100 },
-        { "item": "television", "x": 22, "y": 9, "chance": 100 },
-        { "item": "stereo", "x": 22, "y": 9, "chance": 100 },
-        { "item": "television", "x": 37, "y": 15, "chance": 100 },
-        { "item": "television", "x": 54, "y": 17, "chance": 100 },
-        { "item": "television", "x": 59, "y": 17, "chance": 100 },
-        { "item": "television", "x": 79, "y": 15, "chance": 100 },
-        { "item": "television", "x": 85, "y": 16, "chance": 100 },
-        { "item": "television", "x": 98, "y": 10, "chance": 100 },
-        { "item": "television", "x": 114, "y": 17, "chance": 100 },
-        { "item": "stereo", "x": 127, "y": 9, "chance": 100 },
-        { "item": "television", "x": 132, "y": 17, "chance": 100 },
-        { "item": "television", "x": 141, "y": 17, "chance": 100 },
-        { "item": "television", "x": 151, "y": 11, "chance": 100 },
-        { "item": "stereo", "x": 152, "y": 11, "chance": 100 }
+        { "item": "television", "x": 10, "y": 17, "chance": 80 },
+        { "item": "television", "x": 22, "y": 9, "chance": 80 },
+        { "item": "stereo", "x": 22, "y": 9, "chance": 80 },
+        { "item": "television", "x": 37, "y": 15, "chance": 80 },
+        { "item": "television", "x": 54, "y": 17, "chance": 80 },
+        { "item": "television", "x": 59, "y": 17, "chance": 80 },
+        { "item": "television", "x": 79, "y": 15, "chance": 80 },
+        { "item": "television", "x": 85, "y": 16, "chance": 80 },
+        { "item": "television", "x": 98, "y": 10, "chance": 80 },
+        { "item": "television", "x": 114, "y": 17, "chance": 80 },
+        { "item": "stereo", "x": 127, "y": 9, "chance": 80 },
+        { "item": "television", "x": 132, "y": 17, "chance": 80 },
+        { "item": "television", "x": 141, "y": 17, "chance": 80 },
+        { "item": "television", "x": 151, "y": 11, "chance": 80 },
+        { "item": "stereo", "x": 152, "y": 11, "chance": 80 }
       ]
     }
   },
@@ -167,12 +167,12 @@
         "      ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ     ",
         "      Z&kwcccccf###ZZwwwwwÆÆÆÆÆ1Z11..........ZZZ2.........Z.....3....ZZZZ2..........Z1111111111ZZZ2..........1Z1....WWWWWWWZBc55cBwBc5cBZ1......3....Z2........1.1Z     ",
         "      Z..wc₸₸ccccccZZwdcdwÆÆÆÆÆ1Zk...........ZZZ..........Z..........ZZZZ...........ZCCCCCCCCCCZZZ...........1Z1....Wi@!bbWZBccccBwBcccBZ1...........Z...........1Z     ",
-        "      ZwDwc₸₸cc----ZZwcccwÆÆÆÆÆTZT......a....ZZZ..........Z..........ZZZZ...........ZCCCCCCCCCCZZZ...........TZT....WgggggWZccccccwcccccZT...........Z...........TZ     ",
-        "      Zcccc₸₸ccooooZZwMcMwÆÆÆÆÆtZt......SSS11ZZZ..........Z..........ZZZZ...........ZCCCCCCCCCCZZZ...........tZt....Wg!*~~WZBB_cccwc_5BBZt...........Z...........tZ     ",
-        "      ZccccccccccccZZwdcdwÆÆÆÆÆÆZ.......aaa11ZZZ..........Z..........ZZZZ...........ZCCCCCCCCCCZZZ............Z.....WGWWWWWZwwwwwDwDwwwwZ............Z............Z     ",
-        "      Z^cccPclcsslcZZwwDwwÆÆÆÆÆ^Z^.........OOZZZ.........^Z^1EeZ.....ZZZZ.........1^Z^CCCCCCCCCZZZ..........1^Z^1..........Z55_cDccc...^Z^1..........Z..........1^Z     ",
-        "      ZZZ.wwwsccccxZZwwXwwÆÆÆÆZZZZZ........OOZZZ.........ZZZZZZZ.....ZZZZ.........ZZZZZCCCCCCCCZZZ..........ZZZZZ..........Zccccwsss.1ZZZZZ..........Z..........ZZZ     ",
-        "      Zh...twsclccxZZÆÆÆÆÆÆÆÆÆÆhZh..........1ZZZ.........hZh.........ZZZZ..........hZhCCCCCCCCCZZZ...........hZh...........ZBccBwccc.11hZh..........1Z...........hZ     ",
+        "      ZwDwc₸₸cc----ZZwcccwÆÆÆÆÆTZT......a....ZZZ..........Z..........ZZZZ...........ZCcccCccCCCZZZ...........TZT....WgggggWZccccccwcccccZT...........Z...........TZ     ",
+        "      Zcccc₸₸ccooooZZwMcMwÆÆÆÆÆtZt......SSS11ZZZ..........Z..........ZZZZ...........ZCcccccccCCZZZ...........tZt....Wg!*~~WZBB_cccwc_5BBZt...........Z...........tZ     ",
+        "      ZccccccccccccZZwdcdwÆÆÆÆÆÆZ.......aaa11ZZZ..........Z..........ZZZZ...........ZccCcccccCCZZZ............Z.....WGWWWWWZwwwwwDwDwwwwZ............Z............Z     ",
+        "      Z^cccPclcsslcZZwwDwwÆÆÆÆÆ^Z^.........OOZZZ.........^Z^1EeZ.....ZZZZ.........1^Z^CCccCcccCZZZ..........1^Z^1..........Z55_cDccc...^Z^1..........Z..........1^Z     ",
+        "      ZZZ.wwwsccccxZZwwXwwÆÆÆÆZZZZZ........OOZZZ.........ZZZZZZZ.....ZZZZ.........ZZZZZccccccccZZZ..........ZZZZZ..........Zccccwsss.1ZZZZZ..........Z..........ZZZ     ",
+        "      Zh...twsclccxZZÆÆÆÆÆÆÆÆÆÆhZh..........1ZZZ.........hZh.........ZZZZ..........hZhCCcCccCCCZZZ...........hZh...........ZBccBwccc.11hZh..........1Z...........hZ     ",
         "      ZH...TwsclccxZZÆÆÆÆÆÆÆÆÆÆHZH..........1ZZZ11.......HZH.........ZZZZ11........HZH111111111ZZZ111........HZH...........ZBccBwxxxTt1HZH..........1Z11...SSS...HZ     ",
         "      ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ     ",
         "                                                                                                                                                                        ",
@@ -220,15 +220,15 @@
       "items": {
         "C": { "item": "hoarder", "chance": 100, "repeat": [ 1, 2 ] },
         "M": [
-          { "item": "museum_armor_torso", "chance": 80 },
-          { "item": "museum_armor_legs", "chance": 80 },
-          { "item": "museum_armor_feet", "chance": 80 },
-          { "item": "museum_armor_head", "chance": 80 },
-          { "item": "museum_armor_arms", "chance": 80 }
+          { "item": "museum_armor_torso", "chance": 40 },
+          { "item": "museum_armor_legs", "chance": 40 },
+          { "item": "museum_armor_feet", "chance": 20 },
+          { "item": "museum_armor_head", "chance": 40 },
+          { "item": "museum_armor_arms", "chance": 30 }
         ],
         "#": [
-          { "item": "liquor_and_spirits", "chance": 100, "repeat": [ 1, 2 ] },
-          { "item": "wines_worthy", "chance": 100, "repeat": [ 1, 2 ] }
+          { "item": "liquor_and_spirits", "chance": 80, "repeat": [ 0, 2 ] },
+          { "item": "wines_worthy", "chance": 80, "repeat": [ 0, 2 ] }
         ],
         "l": [
           { "item": "misc_smoking_legal", "chance": 20, "repeat": [ 0, 2 ] },
@@ -237,24 +237,24 @@
         ],
         "T": [ { "item": "pants_male", "chance": 20 }, { "item": "pants_female", "chance": 20 }, { "item": "shirts", "chance": 20 } ],
         "t": [ { "item": "pants_male", "chance": 20 }, { "item": "pants_female", "chance": 20 }, { "item": "shirts", "chance": 20 } ],
-        "d": { "item": "museum_melee", "chance": 100 },
-        "f": { "item": "SUS_fridge_bachelor", "chance": 100 },
-        "k": { "item": "SUS_bathroom_sink", "chance": 100 },
-        "!": { "item": "gear_survival", "chance": 100, "repeat": [ 1, 2 ] },
-        "~": { "item": "preserved_food", "chance": 100, "repeat": [ 1, 2 ] },
-        "i": { "item": "SUS_bathroom_medicine", "chance": 100 },
+        "d": { "item": "museum_melee", "chance": 70 },
+        "f": { "item": "SUS_fridge_bachelor", "chance": 70 },
+        "k": { "item": "SUS_bathroom_sink", "chance": 70 },
+        "!": { "item": "gear_survival", "chance": 70, "repeat": [ 0, 2 ] },
+        "~": { "item": "preserved_food", "chance": 60, "repeat": [ 0, 2 ] },
+        "i": { "item": "SUS_bathroom_medicine", "chance": 70 },
         "b": { "item": "bed", "chance": 100 },
         "B": { "item": "bed", "chance": 75 },
         "_": { "item": "toy_box", "chance": 75 },
         "5": [ { "item": "SUS_dresser_mens", "chance": 30 }, { "item": "SUS_dresser_womens", "chance": 30 } ]
       },
       "place_item": [
-        { "item": "wine_glass", "x": 15, "y": 11, "chance": 100, "repeat": [ 1, 4 ] },
-        { "item": "wine_glass", "x": 16, "y": 11, "chance": 100, "repeat": [ 1, 4 ] },
-        { "item": "glass", "x": 17, "y": 11, "chance": 100, "repeat": [ 1, 4 ] },
-        { "item": "glass", "x": 18, "y": 11, "chance": 100, "repeat": [ 1, 4 ] },
-        { "item": "television", "x": 18, "y": 16, "chance": 100 },
-        { "item": "stereo", "x": 18, "y": 17, "chance": 100 },
+        { "item": "wine_glass", "x": 15, "y": 11, "chance": 100, "repeat": [ 0, 4 ] },
+        { "item": "wine_glass", "x": 16, "y": 11, "chance": 100, "repeat": [ 0, 4 ] },
+        { "item": "glass", "x": 17, "y": 11, "chance": 100, "repeat": [ 0, 4 ] },
+        { "item": "glass", "x": 18, "y": 11, "chance": 100, "repeat": [ 0, 4 ] },
+        { "item": "television", "x": 18, "y": 16, "chance": 80 },
+        { "item": "stereo", "x": 18, "y": 17, "chance": 80 },
         { "item": "pool_cue", "x": 11, "y": 10, "chance": 100 },
         { "item": "pool_cue", "x": 11, "y": 11, "chance": 100 }
       ]
@@ -297,14 +297,14 @@
         "Q     Я                         Я                         Я                         Я                         Я                         Я                         Я    Q",
         "Q     WWWoWWWWWoWoWWWWoWWWWWoWoWWWWoWWWWWoWoWWWoWoWWWWoWWWWWWoWWWWWoWoWWWoWoWWWWoWWWWWWoWWWWWoWoWWWoWoWWWWWoWWWWWoWWWWWoWoWWWoWoWWWWWoWWWWWoWWWWWoWoWWWoWoWWWWoWWWW    Q",
         "Q     Ww4888ww3....Wn...lww0999wWw4888ww3....W.nn.iww0999wWw4888ww3....W2....ww0999wWwCCC5wwnncc5W2....ww0999wWw4888wwi...lW2....ww0999wWw4888ww3....W2....ww0999wW    Q",
-        "Q     Ww8888ww.....Wn...xww9999wWw8888ww.....W.nn..ww9999wWw8888ww.....W.....ww9999wWwCCC7wwcCCCCW.....ww9999wWw8888wwl..nnW.....ww9999wWw8888ww.....W.....ww9999wW    Q",
-        "Q     Ww8888ww.....W7...lww9999wWw8888ww.....W.....ww9999wWw8888ww.....W.....ww9999wWwCCC7wwcCCCCW.....ww9999wWw8888wwx..nnW.....ww9999wWw8888ww.....W.....ww9999wW    Q",
-        "Q     Ww8888ww.....W..H..ww9999wWw8888ww.....W.....ww9999wWw8888ww.....W.....ww9999wWw_ttcwwcCCCCW.....ww9999wWw8888wwl....W.....ww9999wWw8888ww.....W.....ww9999wW    Q",
-        "Q     WwwwwDww.....Wbd-d.wwwwwDwWwwwwDww.....W5ll..wwwwwDwWwwwwDww.....W.....wwwwwDwWwwwwDwwcCCCCW.....wwwwwDwWwwwwDww...57W.....wwwwwDwWwwwwDww.....W.....wwwwwDwW    Q",
+        "Q     Ww8888ww.....Wn...xww9999wWw8888ww.....W.nn..ww9999wWw8888ww.....W.....ww9999wWwCCC7wwcccccW.....ww9999wWw8888wwl..nnW.....ww9999wWw8888ww.....W.....ww9999wW    Q",
+        "Q     Ww8888ww.....W7...lww9999wWw8888ww.....W.....ww9999wWw8888ww.....W.....ww9999wWwCCC7wwcccccW.....ww9999wWw8888wwx..nnW.....ww9999wWw8888ww.....W.....ww9999wW    Q",
+        "Q     Ww8888ww.....W..H..ww9999wWw8888ww.....W.....ww9999wWw8888ww.....W.....ww9999wWw_ttcwwccccCW.....ww9999wWw8888wwl....W.....ww9999wWw8888ww.....W.....ww9999wW    Q",
+        "Q     WwwwwDww.....Wbd-d.wwwwwDwWwwwwDww.....W5ll..wwwwwDwWwwwwDww.....W.....wwwwwDwWwwwwDwwccccCW.....wwwwwDwWwwwwDww...57W.....wwwwwDwWwwwwDww.....W.....wwwwwDwW    Q",
         "Q     Wv.....wDwwwwWwwwwDww....vWv.....wDwwwwWwwwwDww....vWvEew.bwDwwwwWwwwwDww....vWvcccccwDwwwwWwwwwDww....vWv.....wDwwwwWwwwwDww....vWv.....wDwwwwWwwwwDww....vW    Q",
-        "Q     Ww1......wN`6W6`Nw....1..wWw1......wN`6W6.Nw....1..wW........wN`6W6.Nw....1..wWwCCCCccCwN`6W6`Nw....1..wWw1......wN`6W6`Nw....1..wWw1......wN`6W6`Nw....1..wW    Q",
-        "Q     Ww......iwA`kWk`Aw.......wWw.......wA`kWk.Aw.......wWw..h....wA`kWk.Aw.......wWwCCCCccCwA`kWk`Aw.......wWw.......wA`kWk`Awi......wWw.......wA`kWk`Aw.......wW    Q",
-        "Q     Ww.......D``&W&``D.......wWw.......D``&W&..D.......wWwitttb..D``&W&..D.......wWwCCCCcccD``&W&``D.......wWw.......D``&W&``D.......wWw.......D``&W&``D.......wW    Q",
+        "Q     Ww1......wN`6W6`Nw....1..wWw1......wN`6W6.Nw....1..wW........wN`6W6.Nw....1..wWwCccCccCwN`6W6`Nw....1..wWw1......wN`6W6`Nw....1..wWw1......wN`6W6`Nw....1..wW    Q",
+        "Q     Ww......iwA`kWk`Aw.......wWw.......wA`kWk.Aw.......wWw..h....wA`kWk.Aw.......wWwCCccccCwA`kWk`Aw.......wWw.......wA`kWk`Awi......wWw.......wA`kWk`Aw.......wW    Q",
+        "Q     Ww.......D``&W&``D.......wWw.......D``&W&..D.......wWwitttb..D``&W&..D.......wWwCcCCcccD``&W&``D.......wWw.......D``&W&``D.......wWw.......D``&W&``D.......wW    Q",
         "Q    ЯWWoWWWWoWWWoWWWoWWWWoWWoWWWWWWoWWoWWWoWWWoWWWoWWWoWWWWWWoWWoWWWoWWWoWWWoWWWoWWWWWoWWWoWWWoWWWoWWWWoWWoWWWWWoWWWoWWWWWWWWWWWoWWoWWWWWWoWWWoWWWoWWWoWWWoWWWoWWWЯ   Q",
         "Q                                                                                                                                                                      Q",
         "Q                                                                                                                                                                      Q",
@@ -339,12 +339,12 @@
       "palettes": [ "retirement_community_palette" ],
       "place_monster": [ { "monster": "mon_feral_human_pipe", "x": [ 68 ], "y": [ 12 ], "chance": 100 } ],
       "items": {
-        "A": { "item": "SUS_bathroom_cabinet", "chance": 100 },
-        "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] },
-        "C": { "item": "hoarder", "chance": 100, "repeat": [ 1, 2 ] },
-        "c": { "item": "hoarder", "chance": 50 },
+        "A": { "item": "SUS_bathroom_cabinet", "chance": 80 },
+        "b": { "item": "homebooks", "chance": 80, "repeat": [ 0, 2 ] },
+        "C": { "item": "hoarder", "chance": 40, "repeat": [ 1, 2 ] },
+        "c": { "item": "hoarder", "chance": 25 },
         "l": { "item": "nightstand", "chance": 50, "repeat": [ 0, 2 ] },
-        "k": { "item": "SUS_bathroom_sink", "chance": 100 },
+        "k": { "item": "SUS_bathroom_sink", "chance": 80 },
         "5": [ { "item": "SUS_dresser_mens", "chance": 50 }, { "item": "SUS_dresser_womens", "chance": 50 } ],
         "6": { "item": "shower", "chance": 100, "repeat": [ 1, 2 ] },
         "7": [ { "item": "SUS_wardrobe_mens", "chance": 50 }, { "item": "SUS_wardrobe_womens", "chance": 50 } ]
@@ -545,32 +545,32 @@
       },
       "terrain": { "1": "t_grass" },
       "items": {
-        "R": { "item": "SUS_fridge", "chance": 100 },
+        "R": { "item": "SUS_fridge", "chance": 80 },
         "+": { "item": "SUS_dishwasher", "chance": 100 },
         "K": { "item": "SUS_kitchen_sink", "chance": 100 },
         "k": { "item": "SUS_bathroom_sink", "chance": 100 },
         "z": [
           { "item": "SUS_silverware", "chance": 100 },
           { "item": "SUS_utensils", "chance": 100 },
-          { "item": "SUS_knife_drawer", "chance": 100 }
+          { "item": "SUS_knife_drawer", "chance": 80 }
         ],
         "Z": { "item": "SUS_dishes", "chance": 100 },
         "q": { "item": "SUS_junk_drawer", "chance": 100 },
         "M": { "item": "SUS_oven", "chance": 100 },
         "7": { "item": "coats_unisex", "chance": 50 },
         "Y": { "item": "trash", "chance": 50 },
-        "-": [ { "item": "SUS_appliances_cupboard", "chance": 100 }, { "item": "SUS_cookware", "chance": 100 } ],
-        "J": [ { "item": "SUS_pantry", "chance": 100 }, { "item": "SUS_spice_collection", "chance": 100 } ],
-        "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] }
+        "-": [ { "item": "SUS_appliances_cupboard", "chance": 80 }, { "item": "SUS_cookware", "chance": 90 } ],
+        "J": [ { "item": "SUS_pantry", "chance": 70 }, { "item": "SUS_spice_collection", "chance": 70 } ],
+        "b": { "item": "homebooks", "chance": 80, "repeat": [ 0, 2 ] }
       },
       "place_item": [
-        { "item": "television", "x": 18, "y": 4, "chance": 100 },
-        { "item": "television", "x": 18, "y": 26, "chance": 100 },
-        { "item": "stereo", "x": 19, "y": 26, "chance": 100 },
-        { "item": "television", "x": 18, "y": 42, "chance": 100 },
-        { "item": "television", "x": 19, "y": 51, "chance": 100 },
-        { "item": "television", "x": 18, "y": 66, "chance": 100 },
-        { "item": "stereo", "x": 17, "y": 66, "chance": 100 }
+        { "item": "television", "x": 18, "y": 4, "chance": 80 },
+        { "item": "television", "x": 18, "y": 26, "chance": 80 },
+        { "item": "stereo", "x": 19, "y": 26, "chance": 80 },
+        { "item": "television", "x": 18, "y": 42, "chance": 80 },
+        { "item": "television", "x": 19, "y": 51, "chance": 80 },
+        { "item": "television", "x": 18, "y": 66, "chance": 80 },
+        { "item": "stereo", "x": 17, "y": 66, "chance": 80 }
       ]
     }
   },
@@ -695,7 +695,7 @@
         "t": [ { "item": "pants_male", "chance": 20 }, { "item": "pants_female", "chance": 20 }, { "item": "shirts", "chance": 20 } ],
         "b": { "item": "bed", "chance": 100 }
       },
-      "place_item": [ { "item": "television", "x": 16, "y": 60, "chance": 100 } ]
+      "place_item": [ { "item": "television", "x": 16, "y": 60, "chance": 80 } ]
     }
   },
   {
@@ -803,17 +803,17 @@
         }
       },
       "items": {
-        "A": [ { "item": "SUS_bathroom_cabinet", "chance": 100 }, { "item": "SUS_bathroom_medicine", "chance": 100 } ],
-        "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] },
+        "A": [ { "item": "SUS_bathroom_cabinet", "chance": 80 }, { "item": "SUS_bathroom_medicine", "chance": 80 } ],
+        "b": { "item": "homebooks", "chance": 80, "repeat": [ 0, 2 ] },
         "n": { "item": "bed", "chance": 50 },
-        "C": { "item": "hoarder", "chance": 100, "repeat": [ 1, 2 ] },
+        "C": { "item": "hoarder", "chance": 45, "repeat": [ 1, 2 ] },
         "l": { "item": "nightstand", "chance": 50, "repeat": [ 0, 2 ] },
         "k": { "item": "SUS_bathroom_sink", "chance": 100 },
         "5": [ { "item": "SUS_dresser_mens", "chance": 50 }, { "item": "SUS_dresser_womens", "chance": 50 } ],
         "6": { "item": "shower", "chance": 100, "repeat": [ 1, 2 ] },
         "7": [ { "item": "SUS_wardrobe_mens", "chance": 50 }, { "item": "SUS_wardrobe_womens", "chance": 50 } ]
       },
-      "place_item": [ { "item": "television", "x": 9, "y": 62, "chance": 100 } ]
+      "place_item": [ { "item": "television", "x": 9, "y": 62, "chance": 80 } ]
     }
   },
   {
@@ -1032,21 +1032,21 @@
       "items": {
         "R": { "item": "SUS_fridge", "chance": 100 },
         "+": { "item": "SUS_dishwasher", "chance": 100 },
-        "K": { "item": "SUS_kitchen_sink", "chance": 100 },
-        "k": { "item": "SUS_bathroom_sink", "chance": 100 },
+        "K": { "item": "SUS_kitchen_sink", "chance": 80 },
+        "k": { "item": "SUS_bathroom_sink", "chance": 80 },
         "z": [
           { "item": "SUS_silverware", "chance": 100 },
           { "item": "SUS_utensils", "chance": 100 },
-          { "item": "SUS_knife_drawer", "chance": 100 }
+          { "item": "SUS_knife_drawer", "chance": 80 }
         ],
         "Z": { "item": "SUS_dishes", "chance": 100 },
-        "q": { "item": "SUS_junk_drawer", "chance": 100 },
+        "q": { "item": "SUS_junk_drawer", "chance": 80 },
         "M": { "item": "SUS_oven", "chance": 100 },
         "j": { "item": "coat_rack", "chance": 50 },
         "Y": { "item": "trash", "chance": 50 },
-        "-": [ { "item": "SUS_appliances_cupboard", "chance": 100 }, { "item": "SUS_cookware", "chance": 100 } ],
-        "J": [ { "item": "SUS_pantry", "chance": 100 }, { "item": "SUS_spice_collection", "chance": 100 } ],
-        "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] }
+        "-": [ { "item": "SUS_appliances_cupboard", "chance": 80 }, { "item": "SUS_cookware", "chance": 80 } ],
+        "J": [ { "item": "SUS_pantry", "chance": 70 }, { "item": "SUS_spice_collection", "chance": 80 } ],
+        "b": { "item": "homebooks", "chance": 70, "repeat": [ 0, 2 ] }
       }
     }
   },
@@ -1253,7 +1253,7 @@
         "                       Q"
       ],
       "palettes": [ "retirement_community_palette" ],
-      "place_item": [ { "item": "television", "x": 6, "y": 53, "chance": 100 } ],
+      "place_item": [ { "item": "television", "x": 6, "y": 53, "chance": 80 } ],
       "place_loot": [ { "group": "memorial", "x": 4, "y": 54, "chance": 100 } ],
       "nested": {
         "1": {
@@ -1291,12 +1291,12 @@
         }
       },
       "items": {
-        "A": [ { "item": "SUS_bathroom_cabinet", "chance": 100 }, { "item": "SUS_bathroom_medicine", "chance": 100 } ],
-        "b": { "item": "homebooks", "chance": 100, "repeat": [ 0, 2 ] },
+        "A": [ { "item": "SUS_bathroom_cabinet", "chance": 80 }, { "item": "SUS_bathroom_medicine", "chance": 80 } ],
+        "b": { "item": "homebooks", "chance": 80, "repeat": [ 0, 2 ] },
         "l": { "item": "nightstand", "chance": 50, "repeat": [ 0, 2 ] },
-        "k": { "item": "SUS_bathroom_sink", "chance": 100 },
+        "k": { "item": "SUS_bathroom_sink", "chance": 80 },
         "6": { "item": "shower", "chance": 100, "repeat": [ 1, 2 ] },
-        ";": { "item": "home_display_case", "chance": 100 }
+        ";": { "item": "home_display_case", "chance": 80 }
       }
     }
   },
@@ -1488,16 +1488,16 @@
         "5": { "item": "SUS_office_filing_cabinet", "chance": 100 },
         "@": { "item": "SUS_office_desk", "chance": 50 },
         "7": { "item": "SUS_fridge", "chance": 50 },
-        "k": { "item": "SUS_bathroom_sink", "chance": 100 },
+        "k": { "item": "SUS_bathroom_sink", "chance": 80 },
         "z": [
           { "item": "SUS_silverware", "chance": 100 },
           { "item": "SUS_utensils", "chance": 100 },
-          { "item": "SUS_knife_drawer", "chance": 100 }
+          { "item": "SUS_knife_drawer", "chance": 80 }
         ],
         "Z": { "item": "SUS_dishes", "chance": 100 },
         "R": { "item": "SUS_kitchen_sink", "chance": 100 },
         "r": { "item": "SUS_dishes", "chance": 100 },
-        "P": { "item": "trash", "chance": 100, "repeat": [ 2, 6 ] }
+        "P": { "item": "trash", "chance": 100, "repeat": [ 0, 4 ] }
       },
       "place_vehicles": [
         { "chance": 15, "rotation": 270, "vehicle": "parking_garage", "x": 4, "y": 3 },
@@ -1748,7 +1748,7 @@
         "Y": { "item": "trash", "chance": 70, "repeat": [ 2, 7 ] },
         "T": { "item": "trash", "chance": 70, "repeat": [ 2, 7 ] },
         "t": { "item": "barbecue", "chance": 20 },
-        "₸": { "item": "liquor_and_spirits", "chance": 100, "repeat": 2 },
+        "₸": { "item": "liquor_and_spirits", "chance": 80, "repeat": 2 },
         "R": [ { "item": "tools_plumbing", "chance": 50 }, { "item": "tools_general", "chance": 50 } ]
       },
       "place_item": [


### PR DESCRIPTION
#### Summary
Fix retirement community

#### Purpose of change
Retirement communities had way too much loot, and the hoarder house in particular was ridiculous, completely carpeted with large cardboard boxes uniformly filled with stuff.

#### Describe the solution
Reduce across the board. Remove some large cardboard boxes. Ideally hoarder houses would have random furniture and stuff scattered around, but this is fine for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
