### PR TITLE
Clean up gunsmith kit references

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -2769,7 +2769,7 @@ class item : public visitable
          */
         int get_free_mod_locations( const gunmod_location &location ) const;
         /**
-         * Does it require gunsmithing tools to repair.
+         * Does it use (for now) a bespoke system to repair?
          */
         bool is_firearm() const;
         /**

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3271,9 +3271,10 @@ bool repair_item_actor::can_repair_target( Character &pl, const item &fix, bool 
         }
         return false;
     }
+    // TODO: fix this
     if( fix.is_firearm() ) {
         if( print_msg ) {
-            pl.add_msg_if_player( m_info, _( "That requires gunsmithing tools." ) );
+            pl.add_msg_if_player( m_info, _( "Try activating that to repair it." ) );
         }
         return false;
     }


### PR DESCRIPTION
#### Summary
Clean up gunsmith kit references

#### Purpose of change
Remove a few stray references to the gunsmith's kit, move the neutral int/dex for gun modding from 12 to 10, make manipulation count, adding a small bonus if it's high. Add some notes in places so I can remove the special casing later.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
