### PR TITLE
Weapons inherit the replica flag when crafted

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -2678,6 +2678,7 @@
     "id": "REPLICA_EQUIPMENT",
     "type": "json_flag",
     "info": "This item is only a <info>shoddy replica</info>, and is <bad>far less effective</bad> than the real thing.",
+    "craft_inherit": true,
     "conflicts": [ "STURDY", "DURABLE_MELEE" ],
     "item_prefix": "replica "
   },


### PR DESCRIPTION
#### Summary
Weapons inherit the replica flag when crafted

#### Purpose of change
If you make something (e.g. a short steel spear) out of a replica weapon (e.g. a replica steel spear), the product will inherit the replica status.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
