### PR TITLE
Stop craft helper messaging spam

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -983,6 +983,36 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ),
         craft.tname() );
+
+    const int batch_size = craft.get_making_batch_size();
+    // Characters assisting or watching should gain experience...
+    for( Character *helper : get_crafting_helpers() ) {
+        // If the Character can understand what you are doing, they gain more exp
+        if( helper->get_skill_level( making.skill_used ) >= making.difficulty ) {
+            if( batch_size > 1 ) {
+                if( is_avatar() ) {
+                    add_msg( m_info, _( "%s assists with crafting…" ), helper->get_name() );
+                } else {
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
+                }
+            }
+            if( batch_size == 1 ) {
+                if( is_avatar() ) {
+                    add_msg( m_info, _( "%s could assist you with a batch…" ), helper->get_name() );
+                } else {
+                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s could assist %2s with a batch…" ),
+                                            helper->get_name(), get_name() );
+                }
+            }
+        } else {
+            if( is_avatar() ) {
+                add_msg( m_info, _( "%s watches you craft…" ), helper->get_name() );
+            } else {
+                add_msg_if_player_sees( pos_bub(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
+                                        get_name() );
+            }
+        }
+    }
 }
 
 bool Character::craft_skill_gain( const item &craft, const int &num_practice_ticks )
@@ -998,39 +1028,15 @@ bool Character::craft_skill_gain( const item &craft, const int &num_practice_tic
     }
 
     const int skill_cap = making.get_skill_cap();
-    const int batch_size = craft.get_making_batch_size();
     // Characters assisting or watching should gain experience...
     for( Character *helper : get_crafting_helpers() ) {
         // If the Character can understand what you are doing, they gain more exp
         if( helper->get_skill_level( making.skill_used ) >= making.difficulty ) {
             helper->practice( making.skill_used, roll_remainder( num_practice_ticks / 2.0 ),
                               skill_cap );
-            if( batch_size > 1 && one_in( 300 ) ) {
-                if( is_avatar() ) {
-                    add_msg( m_info, _( "%s assists with crafting…" ), helper->get_name() );
-                } else {
-                    add_msg_if_player_sees( pos_bub(), m_info, _( "%s assists with crafting…" ), helper->get_name() );
-                }
-            }
-            if( batch_size == 1 && one_in( 300 ) ) {
-                if( is_avatar() ) {
-                    add_msg( m_info, _( "%s could assist you with a batch…" ), helper->get_name() );
-                } else {
-                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s could assist %2s with a batch…" ),
-                                            helper->get_name(), get_name() );
-                }
-            }
         } else {
             helper->practice( making.skill_used, roll_remainder( num_practice_ticks / 10.0 ),
                               skill_cap );
-            if( one_in( 300 ) ) {
-                if( is_avatar() ) {
-                    add_msg( m_info, _( "%s watches you craft…" ), helper->get_name() );
-                } else {
-                    add_msg_if_player_sees( pos_bub(), m_info, _( "%1s watches %2s crafts…" ), helper->get_name(),
-                                            get_name() );
-                }
-            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Stop craft helper messaging spam

#### Purpose of change
Craft helper messaging had a 1/300 chance to go off every second, which was unnecessary and kind of dumb. You don't need constant updates on this as it's obvious when it's happening.

#### Describe the solution
Move the messaging to the start of crafting. Now it only fires once.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
