### PR TITLE
Update and fix more leather and chitin recipes

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -30,11 +30,16 @@
         "coverage": 100,
         "encumbrance": [ 18, 18 ]
       },
-      { "material": [
+      {
+        "material": [
           { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 },
           { "type": "nylon", "covered_by_mat": 95, "thickness": 0.4 },
           { "type": "kevlar", "covered_by_mat": 95, "thickness": 1.0 }
-        ], "coverage": 50, "covers": [ "head" ], "specifically_covers": [ "head_forehead" ] }
+        ],
+        "coverage": 50,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead" ]
+      }
     ]
   },
   {
@@ -67,11 +72,16 @@
         "coverage": 100,
         "encumbrance": [ 20, 20 ]
       },
-      {         "material": [
+      {
+        "material": [
           { "type": "nomex", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "cotton", "covered_by_mat": 95, "thickness": 0.5 },
           { "type": "kevlar", "covered_by_mat": 95, "thickness": 1.0 }
-        ], "coverage": 50, "covers": [ "head" ], "specifically_covers": [ "head_forehead" ] }
+        ],
+        "coverage": 50,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_forehead" ]
+      }
     ]
   },
   {
@@ -186,7 +196,7 @@
         "coverage": 100,
         "encumbrance": [ 9, 9 ]
       },
-            {
+      {
         "material": [
           { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.4 },
           { "type": "nylon", "covered_by_mat": 95, "thickness": 0.4 },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -811,7 +811,7 @@
     "symbol": "[",
     "color": "dark_gray",
     "warmth": 15,
-    "material_thickness": 0.1,    
+    "material_thickness": 0.1,
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -819,11 +819,7 @@
         "covers": [ "head", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
         "encumbrance": 14
       },
-      {
-        "coverage": 100,
-        "covers": [ "mouth", "eyes" ],
-        "encumbrance": 30
-      }
+      { "coverage": 100, "covers": [ "mouth", "eyes" ], "encumbrance": 30 }
     ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5124,7 +5124,15 @@
     "types": [ "HUMAN_EMPATHY" ],
     "prereqs": [ "CARNIVORE", "CARNIVORE_FAKE" ],
     "prereqs2": [ "PRED3", "PRED4" ],
-    "threshreq": [ "THRESH_BEAST", "THRESH_RAPTOR", "THRESH_FELINE", "THRESH_CHIMERA", "THRESH_URSINE", "THRESH_LIZARD", "THRESH_SPIDER" ],
+    "threshreq": [
+      "THRESH_BEAST",
+      "THRESH_RAPTOR",
+      "THRESH_FELINE",
+      "THRESH_CHIMERA",
+      "THRESH_URSINE",
+      "THRESH_LIZARD",
+      "THRESH_SPIDER"
+    ],
     "cancels": [ "VEGETARIAN", "HERBIVORE", "RUMINANT", "GRAZER" ],
     "category": [ "BEAST", "RAPTOR", "FELINE", "CHIMERA", "URSINE", "LIZARD", "SPIDER" ],
     "flags": [ "SAPIOVORE" ]

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -57,7 +57,7 @@
     "book_learn": [ [ "textbook_arthropod", 5 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_articulation" } ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_chitin", 6 ], [ "filament", 4 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_chitin", 6 ], [ "filament", 4 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xs_armguard_chitin",
@@ -65,7 +65,7 @@
     "copy-from": "armguard_chitin",
     "time": "6 h",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_chitin", 4 ], [ "filament", 2 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_chitin", 4 ], [ "filament", 2 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xl_armguard_chitin",
@@ -73,7 +73,7 @@
     "copy-from": "armguard_chitin",
     "time": "10 h",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_chitin", 8 ], [ "filament", 8 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_chitin", 8 ], [ "filament", 8 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "armguard_acidchitin",
@@ -82,14 +82,14 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
-    "difficulty": 6,
+    "difficulty": 7,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
     "time": "12 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_arthropod", 5 ] ],
+    "book_learn": [ [ "textbook_arthropod", 6 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_articulation" } ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_acidchitin", 6 ], [ "filament", 4 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_acidchitin", 6 ], [ "filament", 4 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xs_armguard_acidchitin",
@@ -97,7 +97,7 @@
     "copy-from": "armguard_acidchitin",
     "time": "10 h",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_acidchitin", 4 ], [ "filament", 2 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_acidchitin", 4 ], [ "filament", 2 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "xl_armguard_acidchitin",
@@ -105,7 +105,7 @@
     "copy-from": "armguard_acidchitin",
     "time": "14 h",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
-    "using": [ [ "armor_acidchitin", 8 ], [ "filament", 8 ], [ "strap_small", 8 ], [ "clasps", 8 ] ]
+    "using": [ [ "armor_acidchitin", 8 ], [ "filament", 8 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
   },
   {
     "result": "armguard_hard",
@@ -148,15 +148,15 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "6 h",
-    "book_learn": [
-      [ "textbook_armwest", 4 ],
-      [ "textbook_armschina", 4 ],
-      [ "textbook_mesoam", 4 ]
-    ],
+    "book_learn": [ [ "textbook_armwest", 4 ], [ "textbook_armschina", 4 ], [ "textbook_mesoam", 4 ] ],
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 5 ] ],
     "using": [ [ "tailoring_leather_patchwork", 4 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" },
-      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 } ]
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 }
+    ]
   },
   {
     "result": "leather_arm_guards_xs",
@@ -164,6 +164,7 @@
     "copy-from": "leather_arm_guards",
     "time": "5 h",
     "byproducts": [ [ "leather", 6 ], [ "scrap_leather", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "tailoring_leather_patchwork", 3 ], [ "clasps", 4 ], [ "strap_small", 4 ] ]
   },
   {
@@ -172,6 +173,7 @@
     "copy-from": "leather_arm_guards",
     "time": "8 h",
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "tailoring_leather_patchwork", 5 ], [ "clasps", 4 ], [ "strap_small", 4 ] ]
   },
   {
@@ -393,12 +395,39 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_ARMS",
     "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "180 m",
-    "autolearn": true,
-    "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 2 ] ],
-    "using": [ [ "tailoring_leather_patchwork", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ]
+    "difficulty": 4,
+    "time": "3 h",
+    "book_learn": [ [ "textbook_armwest", 3 ], [ "textbook_armschina", 3 ], [ "textbook_mesoam", 3 ] ],
+    "using": [ [ "tailoring_leather_patchwork", 2 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 }
+    ]
+  },
+  {
+    "result": "leather_pauldrons_xs",
+    "type": "recipe",
+    "copy-from": "leather_pauldrons",
+    "time": "2 h",
+    "using": [ [ "tailoring_leather_patchwork", 2 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 }
+    ]
+  },
+  {
+    "result": "leather_pauldrons_xl",
+    "type": "recipe",
+    "copy-from": "leather_pauldrons",
+    "time": "5 h",
+    "using": [ [ "tailoring_leather_patchwork", 4 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 }
+    ]
   },
   {
     "result": "chainmail_sleeves",

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -6,11 +6,11 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
-    "difficulty": 4,
+    "difficulty": 6,
     "skills_required": [ [ "fabrication", 3 ] ],
     "time": "10 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_arthropod", 3 ] ],
+    "book_learn": [ [ "textbook_arthropod", 5 ] ],
     "reversible": true,
     "using": [ [ "armor_chitin", 8 ], [ "strap_small", 2 ], [ "clasps", 2 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
@@ -43,18 +43,14 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
-    "difficulty": 5,
+    "difficulty": 7,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
-    "time": "12 h",
+    "time": "10 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_arthropod", 4 ] ],
+    "book_learn": [ [ "textbook_arthropod", 6 ] ],
     "reversible": true,
     "using": [ [ "armor_acidchitin", 8 ], [ "strap_small", 2 ], [ "clasps", 2 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
-      { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_articulation" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_articulation" } ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "cordage_superior", 1, "LIST" ] ] ]
   },
@@ -62,7 +58,7 @@
     "result": "xs_gauntlets_acidchitin",
     "type": "recipe",
     "copy-from": "gauntlets_acidchitin",
-    "time": "12 h",
+    "time": "9 h",
     "using": [ [ "armor_acidchitin", 6 ], [ "strap_small", 1 ], [ "clasps", 1 ] ],
     "components": [ [ [ "cordage_superior", 2, "LIST" ] ] ]
   },
@@ -70,7 +66,7 @@
     "result": "xl_gauntlets_acidchitin",
     "type": "recipe",
     "copy-from": "gauntlets_acidchitin",
-    "time": "13 h 30 m",
+    "time": "12 h",
     "using": [ [ "armor_acidchitin", 12 ], [ "strap_small", 2 ], [ "clasps", 2 ] ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "cordage_superior", 2, "LIST" ] ] ]
@@ -82,9 +78,9 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_HANDS",
     "skill_used": "tailor",
-    "difficulty": 2,
+    "difficulty": 5,
     "time": "9 h",
-    "autolearn": true,
+    "book_learn": [ [ "textbook_armwest", 4 ], [ "textbook_armschina", 4 ], [ "textbook_mesoam", 4 ] ],
     "using": [ [ "sewing_standard", 12 ], [ "tailoring_leather_small", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },
@@ -96,14 +92,14 @@
     "result": "leather_gauntlets_xs",
     "type": "recipe",
     "copy-from": "leather_gauntlets",
-    "time": "9 h",
+    "time": "8 h",
     "using": [ [ "sewing_standard", 9 ], [ "tailoring_leather_small", 3 ] ]
   },
   {
     "result": "leather_gauntlets_xl",
     "type": "recipe",
     "copy-from": "leather_gauntlets",
-    "time": "10 h 10 m",
+    "time": "10 h",
     "using": [ [ "sewing_standard", 16 ], [ "tailoring_leather_small", 6 ] ]
   },
   {

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -531,10 +531,7 @@
     "difficulty": 5,
     "skills_required": [ "chemistry", 4 ],
     "time": "5 h",
-    "book_learn": [
-      [ "textbook_armwest", 6 ],
-      [ "textbook_armschina", 6 ]
-    ],
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_armschina", 6 ] ],
     "using": [ [ "tailoring_leather_patchwork", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_articulation" },
@@ -593,10 +590,7 @@
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "book_learn": [ [ "textbook_arthropod", 5 ] ],
     "using": [ [ "armor_chitin", 12 ], [ "strap_small", 4 ], [ "sewing_standard", 8 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_closures" }
-    ]
+    "proficiencies": [ { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_closures" } ]
   },
   {
     "result": "helmet_chitin_xs",
@@ -794,7 +788,6 @@
       { "proficiency": "prof_carving" }
     ]
   },
-  
   {
     "result": "hood_leather",
     "type": "recipe",
@@ -928,10 +921,7 @@
     "autolearn": true,
     "using": [ [ "sewing_aramids", 20 ], [ "tailoring_nylon_patchwork", 2 ], [ "tailoring_kevlar_fabric", 4 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "faux_fur", 8 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ]
-    ],
+    "components": [ [ [ "faux_fur", 8 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_millinery" },
       { "proficiency": "prof_leatherworking_basic" },
@@ -947,11 +937,7 @@
     "time": "6 h",
     "using": [ [ "sewing_aramids", 15 ], [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_kevlar_fabric", 3 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "faux_fur", 6 ] ],
-      [ [ "cotton_patchwork", 4 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ]
-    ],
+    "components": [ [ [ "faux_fur", 6 ] ], [ [ "cotton_patchwork", 4 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ] ],
     "byproducts": [ [ "scrap_faux_fur", 3 ] ]
   },
   {
@@ -961,11 +947,7 @@
     "time": "8 h",
     "using": [ [ "sewing_aramids", 30 ], [ "tailoring_nylon_patchwork", 4 ], [ "tailoring_kevlar_fabric", 6 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "faux_fur", 10 ] ],
-      [ [ "cotton_patchwork", 8 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ]
-    ],
+    "components": [ [ [ "faux_fur", 10 ] ], [ [ "cotton_patchwork", 8 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ] ] ],
     "byproducts": [ [ "scrap_faux_fur", 5 ] ]
   },
   {
@@ -995,9 +977,7 @@
     "autolearn": true,
     "using": [ [ "sewing_aramids", 20 ], [ "tailoring_nylon_patchwork", 2 ], [ "tailoring_kevlar_fabric", 4 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ]
-    ],
+    "components": [ [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_millinery" },
       { "proficiency": "prof_leatherworking_basic" },
@@ -1012,9 +992,7 @@
     "time": "6 h",
     "using": [ [ "sewing_aramids", 15 ], [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_kevlar_fabric", 2 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ]
-    ]
+    "components": [ [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ] ]
   },
   {
     "result": "hood_wsurvivor",
@@ -1029,10 +1007,7 @@
     "autolearn": true,
     "using": [ [ "sewing_aramids", 20 ], [ "tailoring_nylon_patchwork", 2 ], [ "tailoring_kevlar_fabric", 4 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "fur", 8 ], [ "tanned_pelt", 1 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ]
-    ],
+    "components": [ [ [ "fur", 8 ], [ "tanned_pelt", 1 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_furriery" },
       { "proficiency": "prof_millinery" },
@@ -1048,10 +1023,7 @@
     "time": "6 h",
     "using": [ [ "sewing_aramids", 15 ], [ "tailoring_nylon_patchwork", 1 ], [ "tailoring_kevlar_fabric", 3 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "fur", 6 ], [ "tanned_pelt", 1 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ]
-    ]
+    "components": [ [ [ "fur", 6 ], [ "tanned_pelt", 1 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ] ]
   },
   {
     "result": "hood_wsurvivor_xl",
@@ -1060,10 +1032,7 @@
     "time": "6 h 45 m",
     "using": [ [ "sewing_aramids", 40 ], [ "tailoring_nylon_patchwork", 4 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "fur", 10 ], [ "tanned_pelt", 2 ] ],
-      [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ]
-    ]
+    "components": [ [ [ "fur", 10 ], [ "tanned_pelt", 2 ] ], [ [ "hood_rain", 1 ], [ "plastic_sheet_small", 2 ], [ "hood_gut", 1 ] ] ]
   },
   {
     "result": "hood_survivor_xl",
@@ -1078,9 +1047,7 @@
     "autolearn": true,
     "using": [ [ "sewing_aramids", 30 ], [ "tailoring_nylon_patchwork", 4 ], [ "tailoring_kevlar_fabric", 5 ] ],
     "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [
-      [ [ "hood_rain", 2 ], [ "plastic_sheet_small", 4 ], [ "hood_gut", 2 ] ]
-    ],
+    "components": [ [ [ "hood_rain", 2 ], [ "plastic_sheet_small", 4 ], [ "hood_gut", 2 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_millinery" },
       { "proficiency": "prof_leatherworking_basic" },

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -53,11 +53,11 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "tailor",
-    "difficulty": 6,
+    "difficulty": 7,
     "skills_required": [ [ "fabrication", 3 ], [ "chemistry", 2 ] ],
     "time": "10 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_arthropod", 5 ] ],
+    "book_learn": [ [ "textbook_arthropod", 6 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_articulation" } ],
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "armor_acidchitin", 3 ], [ "filament", 4 ], [ "strap_small", 4 ], [ "clasps", 4 ] ]
@@ -1017,11 +1017,7 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "6 h",
-    "book_learn": [
-      [ "textbook_armwest", 4 ],
-      [ "textbook_armschina", 4 ],
-      [ "textbook_mesoam", 4 ]
-    ],
+    "book_learn": [ [ "textbook_armwest", 4 ], [ "textbook_armschina", 4 ], [ "textbook_mesoam", 4 ] ],
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 5 ] ],
     "using": [ [ "tailoring_leather_patchwork", 5 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ]

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -9,10 +9,7 @@
     "difficulty": 4,
     "skills_required": [ "tailor", 3 ],
     "time": "3 h",
-    "book_learn": [
-      [ "textbook_armwest", 6 ],
-      [ "textbook_armschina", 6 ]
-    ],
+    "book_learn": [ [ "textbook_armwest", 6 ], [ "textbook_armschina", 6 ] ],
     "using": [ [ "sewing_standard", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_articulation" },
@@ -40,27 +37,25 @@
     "skills_required": [ [ "fabrication", 3 ] ],
     "time": "12 h",
     "autolearn": true,
-    "book_learn": [ [ "textbook_tailor", 5 ], [ "tailor_portfolio", 5 ], [ "textbook_arthropod", 6 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_articulation" },
-      { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_closures" },
-      { "proficiency": "prof_leatherworking_basic" }
-    ],
+    "book_learn": [ [ "textbook_arthropod", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_articulation" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_closures" } ],
+    "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "armor_chitin", 72 ] ]
   },
   {
     "result": "armor_chitin_xs",
     "type": "recipe",
     "copy-from": "armor_chitin",
-    "time": "9 h",
+    "time": "10 h",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "armor_chitin", 54 ] ]
   },
   {
     "result": "xl_armor_chitin",
     "type": "recipe",
     "copy-from": "armor_chitin",
-    "time": "16 h",
+    "time": "14 h",
+    "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "using": [ [ "armor_chitin", 96 ] ]
   },
   {
@@ -76,12 +71,7 @@
     "autolearn": true,
     "book_learn": [ [ "textbook_arthropod", 7 ] ],
     "using": [ [ "cordage", 2 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_articulation" },
-      { "proficiency": "prof_chitinworking" },
-      { "proficiency": "prof_closures" },
-      { "proficiency": "prof_leatherworking_basic" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_articulation" }, { "proficiency": "prof_chitinworking" }, { "proficiency": "prof_closures" } ],
     "qualities": [ { "id": "CUT_FINE", "level": 1 }, { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
     "components": [ [ [ "acidchitin_piece", 72 ] ] ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2666,11 +2666,7 @@
     "skill_used": "tailor",
     "difficulty": 5,
     "time": "10 h",
-    "book_learn": [
-      [ "textbook_armwest", 4 ],
-      [ "textbook_armschina", 4 ],
-      [ "textbook_mesoam", 4 ]
-    ],
+    "book_learn": [ [ "textbook_armwest", 4 ], [ "textbook_armschina", 4 ], [ "textbook_mesoam", 4 ] ],
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 5 ] ],
     "using": [ [ "tailoring_leather_patchwork", 7 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ]

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -130,10 +130,7 @@
     "id": "redsmithing_simple",
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for melting copper or bronze, but this assumes we need no grinding.",
-    "tools": [
-      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
-      [ [ "forge", 13 ], [ "oxy_torch", 13 ] ]
-    ]
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 13 ], [ "oxy_torch", 13 ] ] ]
   },
   {
     "id": "metal_casting_small",
@@ -222,10 +219,7 @@
     "type": "requirement",
     "//": "Includes forging resources as well as tools needed for most blacksmithing. Per forging_scrap energy cost balanced for one scrap metal.",
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "tools": [
-      [ [ "forge", 4 ], [ "oxy_torch", 4 ] ],
-      [ [ "metalworking_tongs_any", 1, "LIST" ] ]
-    ]
+    "tools": [ [ [ "forge", 4 ], [ "oxy_torch", 4 ] ], [ [ "metalworking_tongs_any", 1, "LIST" ] ] ]
   },
   {
     "id": "mutagen_production_standard",

--- a/data/mods/innawood/recipes/armor/other.json
+++ b/data/mods/innawood/recipes/armor/other.json
@@ -15,7 +15,7 @@
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [ [ [ "gold_small", 12 ] ] ]
   },
-    {
+  {
     "result": "leather_leg_guards",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
@@ -29,7 +29,7 @@
     "using": [ [ "tailoring_leather_patchwork", 5 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ]
   },
-    {
+  {
     "result": "leather_arm_guards",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
@@ -41,8 +41,11 @@
     "autolearn": true,
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 5 ] ],
     "using": [ [ "tailoring_leather_patchwork", 4 ], [ "clasps", 4 ], [ "strap_small", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" },
-      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 } ]
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures", "time_multiplier": 1.25, "skill_penalty": 0.15 }
+    ]
   },
   {
     "result": "copper_bracelet",

--- a/data/mods/innawood/recipes/armor/torso.json
+++ b/data/mods/innawood/recipes/armor/torso.json
@@ -27,7 +27,7 @@
     "reversible": { "time": "5 m" },
     "using": [ [ "tailoring_cotton_patchwork_simple", 8 ] ]
   },
-    {
+  {
     "result": "leather_cuirass",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Update and fix more leather and chitin recipes

#### Purpose of change
Continue standardizing these recipes. Make leather pauldrons and gauntlets require the books.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
