### PR TITLE
Nerf plastic padding material a bit

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1139,7 +1139,7 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "covers": [ "head" ],
         "coverage": 100,
@@ -1151,7 +1151,7 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "covers": [ "head" ],
         "coverage": 40,
@@ -1184,7 +1184,7 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "covers": [ "mouth" ],
         "coverage": 100,
@@ -1207,7 +1207,7 @@
     ],
     "use_action": { "type": "transform", "menu_text": "Raise visor", "target": "helmet_motor_raised", "msg": "You raise your visor." },
     "warmth": 30,
-    "environmental_protection": 1,
+    "environmental_protection": 2,
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "WATERPROOF", "STURDY", "PADDED", "SUN_GLASSES", "OUTER", "NORMAL", "CUSHION_FALL" ],
     "melee_damage": { "bash": 2 }
@@ -1234,7 +1234,7 @@
           { "type": "hard_plastic_transp", "covered_by_mat": 40, "thickness": 2.0 },
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "encumbrance": 32,
         "coverage": 100,
@@ -1246,7 +1246,7 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "covers": [ "head" ],
         "encumbrance": 0,
@@ -1258,10 +1258,10 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 90, "thickness": 16 }
         ],
         "covers": [ "mouth" ],
-        "coverage": 100,
+        "coverage": 90,
         "specifically_covers": [ "mouth_chin" ],
         "encumbrance": 4,
         "rigid_layer_only": true
@@ -1270,10 +1270,10 @@
         "material": [
           { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 },
           { "type": "epoxy", "covered_by_mat": 100, "thickness": 0.5 },
-          { "type": "plastic_pad", "covered_by_mat": 100, "thickness": 16 }
+          { "type": "plastic_pad", "covered_by_mat": 50, "thickness": 16 }
         ],
         "covers": [ "mouth" ],
-        "coverage": 50,
+        "coverage": 90,
         "specifically_covers": [ "mouth_cheeks", "mouth_lips" ],
         "encumbrance": 2,
         "rigid_layer_only": true

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1750,7 +1750,7 @@
       { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
       { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
-    "resist": { "bash": 0.6, "cut": 0.3, "acid": 8, "heat": 1, "bullet": 0.3 },
+    "resist": { "bash": 0.5, "cut": 0.15, "acid": 8, "heat": 1, "bullet": 0.15 },
     "repair_difficulty": 5
   },
   {


### PR DESCRIPTION
#### Summary
Nerf plastic padding material a bit

#### Purpose of change
Plastic padding was offering .3 ballistic protection per mm. Given that it's frequently >10mm, and it's always combined with other materials, it was making things like the football helmet and full-face motorcycle helmet perform better than the army helmet.

#### Describe the solution
- Reduce the cut and ballistic protection of this material by half.
- Somewhat reduce the material portion of this material on the full-face motorcycle helmet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
