### PR TITLE
(Mostly) fix the (W)ear menu protection estimates

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -366,7 +366,7 @@ class armor_inventory_preset: public inventory_selector_preset
                     continue;
                 }
                 const damage_type_id &dtid = dt.id;
-                append_cell( [ this, dtid ]( const item_location &loc ) {
+                append_cell( [ this, dtid ]( const item_location & loc ) {
                     Character &you = get_player_character();
                     double weighted_sum = 0.0;
                     double total_weight = 0.0;
@@ -390,7 +390,7 @@ class armor_inventory_preset: public inventory_selector_preset
                     return get_decimal_string( average_resist );
                 }, to_upper_case( dt.name.translated() ) );
 
-                }
+            }
 
             append_cell( [ this ]( const item_location & loc ) {
                 return get_number_string( loc->get_env_resist() );


### PR DESCRIPTION
#### Summary
(Mostly) fix the (W)ear menu protection estimates

#### Purpose of change
The (W)ear menu has been in trouble for quite some time as its code for displaying protection values was written before material portions even became a thing. It was returning the sum of protection for an item which only worked on items which did not have variable values, like (at the time of this writing) the leather jacket, which has uniform protection all over.

#### Describe the solution
Tally up protection values across all body parts that the item covers and the player character has. Weight these by body part hit_size (to keep e.g. a super-armored codpiece from making a spandex suit seem really powerful) and average everything to get some kind of an approximate value.

#### Describe alternatives you've considered
See below.

#### Testing
See below.

#### Additional context
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cccdbc8f-75af-43dd-b7f2-4b8397e69ff0" />
These values are all very reasonable descriptions of the items, save for the high heels. The heels have a tiny portion of astronomical value because they have high heels, which are counted as something like 40mm of plastic. This skews the average and there's not currently a way to fix it because the method we used goes by body part, not by sub-body part. Going by SBP is significantly more challenging, so in the interest of not letting the perfect be the enemy of the good, this is a partial fix that works for almost all items in the game for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
