### PR TITLE
Stop spawning shit in the fucking sky

### DIFF
--- a/data/json/monsters/zed_dormant.json
+++ b/data/json/monsters/zed_dormant.json
@@ -41,7 +41,6 @@
     "description": "Fake zombie used for spawning dormant zombies.  If you see this, open an issue on github.",
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
-    "hp": 5,
     "speed": 1,
     "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
     "zombify_into": "mon_zombie",


### PR DESCRIPTION
#### Summary
Stop spawning shit in the fucking sky.

#### Purpose of change
Ever since way back in https://github.com/CleverRaven/Cataclysm-DDA/issues/38066 there has been an issue of mapgen, specifically map extras, spawning stuff midair. DDA tried several fixes, and to my knowledge none of them have completely worked save barring stuff from spawning at z > 0 at all, but even that only works if there weren't any holes or anything generated in the ground.

#### Describe the solution
Check before placing items or creatures. Do not place items if there's open air, do not place creatures if there's open air unless the creature can fly.

Also boost the dormant zombie dummy monster HP a bit so that they can survive minor random trauma (IE a crater spawning some distance away) at spawn without completely gibbing all over the place. They're dormant, not at death's door, and them dying before completing their whole spawn thing was causing some weird behavior.

#### Describe alternatives you've considered
I didn't bother doing this for vehicles, NPCs, or terrain/furniture because I haven't seen many examples of that stuff going wrong yet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
