### PR TITLE
Fix nylon patch requirement

### DIFF
--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -172,22 +172,22 @@
     "//": "Materials used for crafting or repairing clothing or sheeting, etc.",
     "components": [
       [
-        [ "cotton_patchwork", 8 ],
         [ "sheet_cotton_patchwork", 1 ],
         [ "sheet_cotton", 1 ],
         [ "sheet_lycra", 1 ],
         [ "sheet_lycra_patchwork", 1 ],
-        [ "lycra_patch", 8 ],
-        [ "nylon", 1 ],
         [ "sheet_nylon_patchwork", 1 ],
-        [ "sheet_nylon", 1 ],
-        [ "leather", 8 ],
-        [ "nomex", 8 ],
+        [ "sheet_neoprene", 1 ],
+        [ "sheet_neoprene_patchwork", 1 ],
         [ "sheet_nomex_patchwork", 1 ],
         [ "sheet_nomex", 1 ],
-        [ "neoprene", 8 ],
-        [ "sheet_neoprene", 1 ],
-        [ "sheet_neoprene_patchwork", 1 ]
+        [ "sheet_nylon", 1 ],
+        [ "cotton_patchwork", 8 ],
+        [ "lycra_patch", 8 ],
+        [ "nylon", 8 ],
+        [ "leather", 8 ],
+        [ "nomex", 8 ],
+        [ "neoprene", 8 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Fix nylon patch requirement

#### Purpose of change
The aborted standardization of tailoring materials continues to be a disaster for all mankind.

#### Describe the solution
"nylon" was set to 1 in a random requirement group. It needs to be 8, as 8 nylon is equivalent to 1 nylon sheet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
