### PR TITLE
Buff dungeon master's guide fun

### DIFF
--- a/data/json/items/book/speech.json
+++ b/data/json/items/book/speech.json
@@ -63,13 +63,12 @@
     "id": "dnd_handbook",
     "type": "BOOK",
     "category": "manuals",
-    "name": { "str": "Dungeon Master's Guide: 6th Edition", "str_pl": "copies of Dungeon Master's Guide: 6th Edition" },
+    "name": { "str": "Dungeon Master's Guide", "str_pl": "copies of Dungeon Master's Guide" },
     "description": "A thick, hardcover volume with everything needed to weave legendary stories.  It's full of information, but finding the things you're looking for can be a chore.",
     "weight": "2267 g",
     "volume": "2500 ml",
     "price": "30 USD",
     "price_postapoc": "5 USD",
-    "//": "Have you held one of these things? Bastards have some real weight behind 'em",
     "material": [ "paper", "cardboard" ],
     "symbol": "?",
     "looks_like": "textbook_firstaid",
@@ -78,7 +77,8 @@
     "max_level": 5,
     "intelligence": 9,
     "time": "30 m",
-    "melee_damage": { "bash": 7 }
+    "melee_damage": { "bash": 7 },
+    "fun": 2
   },
   {
     "id": "book_nonf_soft_speech_naillaw",


### PR DESCRIPTION
#### Summary
Buff dungeon master's guide fun

#### Purpose of change
The DMG's fun was too low.

#### Describe the solution
Buff it to 2 and remove any reference to edition.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
