### PR TITLE
Blinded monsters won't shoot

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -22,6 +22,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "modular_m16a4",
@@ -78,6 +79,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "m202_flash",
@@ -133,6 +135,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 8,
         "move_cost": 80,
         "gun_type": "firework_cannon",
@@ -178,6 +181,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "modular_m16a4",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -44,7 +44,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -122,7 +123,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -168,7 +170,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -289,7 +292,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -421,7 +425,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -499,7 +504,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -537,7 +543,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -612,7 +619,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -684,7 +692,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,
@@ -816,7 +825,8 @@
           "and": [
             { "not": { "u_has_effect": "maimed_arm" } },
             { "not": { "u_has_flag": "grab" } },
-            { "not": { "u_has_flag": "grab_filter" } }
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } }
           ]
         },
         "require_targeting_player": false,

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -23,6 +23,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "hk_mp5",
@@ -112,6 +113,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "m2browning",
@@ -173,6 +175,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "m249",
@@ -234,6 +237,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "m240",
@@ -297,6 +301,7 @@
     "special_attacks": [
       {
         "type": "gun",
+        "condition": { "not": { "u_has_effect": "blind" } },
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "pseudo_m203",

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5002,7 +5002,7 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
             !critter->dodge_check( hit_roll ) ) {
             blind = true;
             if( critter->in_species( species_ROBOT ) ) {
-                critter->add_effect( effect_blind, rng( 4_seconds, 8_seconds ) );
+                critter->add_effect( effect_blind, rng( 5_seconds, 10_seconds ) );
             } else {
                 critter->add_effect( effect_blind, rng( 3_seconds, 6_seconds ) );
             }


### PR DESCRIPTION
#### Summary
Blinded monsters won't shoot

#### Purpose of change
Blind monsters could still shoot you if you were adjacent to them, which sort of defeats the point of doing something like spraypainting a turret.

#### Describe the solution
- Increase robot blind time from spraypaint from 4-8 seconds to 4-10 seconds. There's an attack roll and you have to be in melee, so it is by no means risk-free.
- All monsters which use guns (so, ferals and robots) will now not use them if they have the blind effect.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
