### PR TITLE
Better occupied lumbermill obsoletion

### DIFF
--- a/data/json/obsoletion_and_migration/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration/obsolete_overmap_special.json
@@ -16,7 +16,7 @@
   },
   {
     "type": "overmap_special_migration",
-    "id": "bandit_work_camp",
-    "new_id": "sand_pit"
+    "id": "Occupied Lumbermill",
+    "new_id": "Lumbermill"
   }
 ]


### PR DESCRIPTION
#### Summary
Better occupied lumbermill obsoletion

#### Purpose of change
The occupied lumbermill had one lingering obsoletion/migration task that I hadn't done which was causing issues for a few old saves.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
