### PR TITLE
Faster fodder assembly/disassembly

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -8440,7 +8440,7 @@
     "skill_used": "cooking",
     "difficulty": 2,
     "skills_required": [ "survival", 1 ],
-    "time": "10 m",
+    "time": "10 s",
     "autolearn": true,
     "components": [
       [
@@ -8477,7 +8477,7 @@
     "skill_used": "cooking",
     "difficulty": 2,
     "skills_required": [ "survival", 1 ],
-    "time": "10 m",
+    "time": "20 s",
     "autolearn": true,
     "components": [
       [
@@ -8515,7 +8515,7 @@
     "skill_used": "cooking",
     "difficulty": 2,
     "skills_required": [ "survival", 1 ],
-    "time": "10 m",
+    "time": "30 s",
     "autolearn": true,
     "components": [
       [

--- a/data/json/uncraft/comestibles/vegetable.json
+++ b/data/json/uncraft/comestibles/vegetable.json
@@ -74,7 +74,7 @@
     "result": "cattlefodder_medium",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
-    "time": "30 s",
+    "time": "20 s",
     "components": [ [ [ "cattlefodder", 7 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Faster fodder assembly/disassembly

#### Purpose of change
Cattle fodder needed a lot of repetitive crafting/uncrafting to change its portions. This didn't make much sense as you're just kind of shoveling it around.

#### Describe the solution
Reduce time from 10m to 10/20/30s based on fodder size.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
