### PR TITLE
Fix mutation cost display and kcal threshold

### DIFF
--- a/data/json/snippets/health_msgs.json
+++ b/data/json/snippets/health_msgs.json
@@ -138,23 +138,22 @@
   },
   {
     "type": "snippet",
-    "category": "empty_malnutrition",
+    "category": "empty_malnourished",
     "text": [
       "You feel weak due to malnutrition.",
-      "Your body feels starved of essential nutrients, leaving you feeling weak and sick.",
-      "You feel a persistent ache in your bones, a sign of severe malnutrition.",
-      "You feel a constant sense of fatigue, your body struggling to function."
+      "You have got to get something to eat.",
+      "You feel sluggish and you can't stop thinking about food.",
+      "You feel achey and tired."
     ]
   },
   {
     "type": "snippet",
-    "category": "malnutrition",
+    "category": "malnourished",
     "text": [
-      "Despite having something in your stomach, you still feel like you haven't eaten in days…",
-      "You feel a persistent sense of hunger, even after eating.",
-      "Your body feels weak and frail, a sign of severe malnutrition.",
-      "You feel a constant sense of fatigue, your body struggling to function.",
-      "You feel a persistent ache in your bones, a sign of severe malnutrition."
+      "Despite having something in your stomach, you're still craving more.",
+      "You can tell you're not getting enough to eat lately.",
+      "Your thoughts keep drifting back to food.",
+      "You feel achey and tired."
     ]
   },
   {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5858,7 +5858,7 @@ void Character::check_needs_extremes()
                     } else if( get_kcal_percent() < 0.25f ) {
                         category = "emaciated";
                     } else if( get_kcal_percent() < 0.5f ) {
-                        category = "malnutrition";
+                        category = "malnourished";
                     } else if( get_kcal_percent() < 0.8f ) {
                         category = "low_cal";
                     }
@@ -5868,7 +5868,7 @@ void Character::check_needs_extremes()
                     } else if( get_kcal_percent() < 0.25f ) {
                         category = "empty_emaciated";
                     } else if( get_kcal_percent() < 0.5f ) {
-                        category = "empty_malnutrition";
+                        category = "empty_malnourished";
                     } else if( get_kcal_percent() < 0.8f ) {
                         category = "empty_low_cal";
                     }

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -303,38 +303,11 @@ void avatar::power_mutations()
                         type = has_base_trait( active[i] ) ? c_red : c_light_red;
                     }
                 }
-                // TODO: track resource(s) used and specify
                 mvwputch( wBio, point( second_column, list_start_y + i - scroll_position ),
                           type, td.key );
                 std::string mut_desc;
-                std::string resource_unit;
-                int number_of_resource = 0;
-                if( md.hunger ) {
-                    resource_unit += _( " kcal" );
-                    number_of_resource++;
-                }
-                if( md.thirst ) {
-                    if( number_of_resource > 0 ) {
-                        //~ Resources consumed by a mutation: "kcal & thirst & fatigue"
-                        resource_unit += _( " &" );
-                    }
-                    resource_unit += _( " thirst" );
-                    number_of_resource++;
-                }
-                if( md.fatigue ) {
-                    if( number_of_resource > 0 ) {
-                        //~ Resources consumed by a mutation: "kcal & thirst & fatigue"
-                        resource_unit += _( " &" );
-                    }
-                    resource_unit += _( " fatigue" );
-                }
                 mut_desc += mutation_name( md.id );
-                if( md.cost > 0 && md.cooldown > 0_turns ) {
-                    mut_desc += string_format( _( " - %d%s / %s" ),
-                                               md.cost, resource_unit, to_string_clipped( md.cooldown ) );
-                } else if( md.cost > 0 ) {
-                    mut_desc += string_format( _( " - %d%s" ), md.cost, resource_unit );
-                } else if( md.cooldown > 0_turns ) {
+                if( md.cooldown > 0_turns ) {
                     mut_desc += string_format( _( " - %s" ), to_string_clipped( md.cooldown ) );
                 }
                 if( td.powered ) {
@@ -439,7 +412,7 @@ void avatar::power_mutations()
                                 deactivate_mutation( mut_id );
                                 // Action done, leave screen
                                 exit = true;
-                            } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
+                            } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.45f ) &&
                                        ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                        ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
                                 add_msg_if_player( m_neutral,
@@ -613,7 +586,7 @@ void avatar::power_mutations()
                                     deactivate_mutation( mut_id );
                                     // Action done, leave screen
                                     exit = true;
-                                } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
+                                } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.5f ) &&
                                            ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                            ( !mut_data.fatigue || get_fatigue() <= 400 ) ) {
                                     add_msg_if_player( m_neutral,


### PR DESCRIPTION
#### Summary
Fix mutation cost display and kcal threshold

#### Purpose of change
Mutations that cost kcal were crapping out when you hit 80% of your starting kcal, which was still firmly in "normal".

#### Describe the solution
- Remove the displayed cost in the mutation activation menu. Costs are self-evident.
- Lower the threshold to 45%. You can still leap around or whatever until you're really dipping down toward emaciated.
- Improve some of the message spam for malnourishment because I'm here and I remembered.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
