### PR TITLE
Fix migration of sheet_felt and sheet_kevlar

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3415,6 +3415,11 @@
   },
   {
     "type": "MIGRATION",
+    "id": "sheet_kevlar",
+    "replace": "kevlar_sheet"
+  },
+  {
+    "type": "MIGRATION",
     "id": "sheet_cotton_patchwork",
     "replace": "cotton_sheet"
   },
@@ -3577,6 +3582,16 @@
     "type": "MIGRATION",
     "id": "kevlar",
     "replace": "ballistic_vest_concealable"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "rigid_kevlar_plate",
+    "replace": "kevlar_plate"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "sheet_felt",
+    "replace": "felt_sheet"
   },
   {
     "type": "MIGRATION",


### PR DESCRIPTION
#### Summary
Fix migration of sheet_felt and sheet_kevlar

#### Purpose of change
These two items got orphaned!

#### Describe the solution
Migrate them to felt_sheet and kevlar_sheet

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
