### PR TITLE
Fix segfault when grappled monster dies

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1095,7 +1095,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         * matter if we use volume or weight here. 7% of 4 liters gets us about 250ml of blood.
         * Also obviously don't give blood if we bled the corpse already.
         */
-        if( entry.type == harvest_drop_blood && ( corpse_item->volume() < 4000_ml || corpse_item->has_flag( flag_BLED ) ) ) {
+        if( entry.type == harvest_drop_blood && ( corpse_item->volume() < 4000_ml ||
+                corpse_item->has_flag( flag_BLED ) ) ) {
             roll = 0;
         }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7144,7 +7144,8 @@ void map::place_spawns( const mongroup_id &group, const int chance,
         } while( impassable( p ) && tries > 0 );
 
         // Pick a monster type.
-        std::vector<MonsterGroupResult> spawn_details = MonsterGroupManager::GetResultFromGroup( group, &num );
+        std::vector<MonsterGroupResult> spawn_details = MonsterGroupManager::GetResultFromGroup( group,
+                &num );
 
         for( const MonsterGroupResult &mgr : spawn_details ) {
             // Non-flying monsters cannot spawn in open air.
@@ -7152,7 +7153,7 @@ void map::place_spawns( const mongroup_id &group, const int chance,
                 continue;
             }
             add_spawn( mgr.name, mgr.pack_size, { p, abs_sub.z() },
-                    friendly, -1, mission_id, name, mgr.data );
+                       friendly, -1, mission_id, name, mgr.data );
         }
     }
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2954,16 +2954,17 @@ void monster::die( map *here, Creature *nkiller )
         for( const effect &grab : get_effects_with_flag( json_flag_GRAB ) ) {
             // Is our grabber around?
             for( const tripoint_bub_ms loc : surrounding ) {
-                Creature *someone = creatures.creature_at( loc );
-                if( someone && someone->has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
-                    add_msg_debug( debugmode::DF_MATTACK, "Grabber found: %s", someone->disp_name() );
-                    grabber = someone;
+                Character *guy = creatures.creature_at<Character>( loc );
+                if( guy && guy->grab_1.victim && guy->grab_1.victim.get() == static_cast<Creature *>( this ) ) {
+                    add_msg_debug( debugmode::DF_MONSTER, "Dying monster found grabbing character: %s",
+                                   guy->disp_name() );
+                    grabber = guy;
                     break;
                 }
             }
             if( grabber == nullptr ) {
                 remove_effect( grab.get_id() );
-                add_msg_debug( debugmode::DF_MATTACK, "Orphan grab found and removed from dead monster" );
+                add_msg_debug( debugmode::DF_MONSTER, "Orphan grab found and removed from dead monster" );
                 continue;
             }
             if( grabber && !grabber->is_monster() ) {


### PR DESCRIPTION
#### Summary
Fix segfault when grappled monster dies

#### Purpose of change
If a character was grappling a monster when it died, but was not the only creature adjacent to that monster, it was possible for the wrong creature to get blamed for the grapple. The monster would then die without the character being able to let go, which would trigger a segfault.

#### Describe the solution
Instead of just assuming the nearest creature with a grabbing effect is your grabber, check first for all adjacent characters and find out if you are their grab_1.victim. If so, ensure that they release you before you die.

#### Testing
Spawned 3 dogs, let one grab me, grabbed a different one and beat it to death. It died without the game segfaulting. Prior to this PR, this would always segfault.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
