### PR TITLE
Improve grapple code when the grabber gets moved

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11545,7 +11545,8 @@ void Character::process_effects()
         remove_effect( effect_infected );
         remove_effect( effect_recover );
     }
-    if( ( has_effect( effect_winded ) || in_sleep_state() ) && has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+    if( ( has_effect( effect_winded ) || in_sleep_state() ) &&
+        has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
         release_grapple();
     }
     // Clear hardcoded bonuses from last turn

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12248,10 +12248,10 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
     tripoint_bub_ms pt = pos;
     creature_tracker &creatures = get_creature_tracker();
     c->add_effect( effect_airborne, 1_turns );
-        if( !c->is_monster() && c->has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
-            // I'm afraid you're going to have to put down the zombie dog before you go flying.
-            c->as_character()->release_grapple();
-        }
+    if( !c->is_monster() && c->has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+        // I'm afraid you're going to have to put down the zombie dog before you go flying.
+        c->as_character()->release_grapple();
+    }
     while( range > 0 ) {
         c->underwater = false;
         // TODO: Check whenever it is actually in the viewport


### PR DESCRIPTION
#### Summary
Improve grapple code when the grabber gets moved

#### Purpose of change
- Some old grapple code was not being very picky about who it assumed the player was grappling. We have better functionality for that now, so let's use it.
- The code for when the player got moved via being flung or teleported or whatever else was also not really great. We have better functionality now, so let's use it to ensure that if our victim is not adjacent or either of us is incorporeal, they're always released.
- There was no check for if you got winded or fell asleep, which could cause grapples to get stuck in odd cases. Now you automatically release when that happens.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
