### PR TITLE
Fix Guneet's kirpan again

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Guneet_Singh.json
@@ -24,7 +24,6 @@
     "bonus_per": { "rng": [ -2, 2 ] },
     "worn_override": "REFUGEE_Guneet_worn",
     "carry_override": "REFUGEE_Guneet_carried",
-    "weapon_override": "REFUGEE_Guneet_wield",
     "traits": [
       { "group": "NPC_starting_traits" },
       { "group": "Appearance_SouthAsian" },
@@ -45,6 +44,8 @@
       { "item": "tshirt" },
       { "item": "jeans" },
       { "item": "turban" },
+      { "item": "backpack" },
+      { "item": "kirpan", "container-item": "sheath" },
       { "item": "sneakers" }
     ]
   },
@@ -53,12 +54,6 @@
     "id": "REFUGEE_Guneet_carried",
     "subtype": "collection",
     "entries": [ { "item": "portable_game" } ]
-  },
-  {
-    "type": "item_group",
-    "id": "REFUGEE_Guneet_wield",
-    "subtype": "distribution",
-    "entries": [ { "item": "kirpan", "container-item": "sheath" } ]
   },
   {
     "type": "talk_topic",


### PR DESCRIPTION
#### Summary
Fix Guneet's kirpan again

#### Purpose of change
Guneet was spawning holding a sheath that he had nowhere to put and trying to wield a kirpan out of it.

#### Describe the solution
Now he has a backpack and is wearing the sheath, leaving him free to mess with his knife if he wants.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
