### PR TITLE
Remove weird fragile_melee code

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -240,8 +240,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     itype_id big_comp = itype_id::NULL_ID();
     // Fragile items that fall apart easily when used as a weapon due to poor construction quality
     if( shield->has_flag( flag_FRAGILE_MELEE ) ) {
-        const float fragile_factor = 6.0f;
-        material_factor = ( shield->chip_resistance( true ) ) / 6.0f;
+        material_factor = ( shield->chip_resistance( true ) ) / 6.0f; // 6.0f is a magic number carried over from DDA. Adjust it for more or less overall fragility.
     } else {
         material_factor = shield->chip_resistance();
     }


### PR DESCRIPTION
#### Summary
Remove weird fragile_melee code

#### Purpose of change
When blocking with fragile_melee, there was some really weird code that was trying to individually look at all the components of the weapon and determine the weakest one, but was for some reason filtering out fur patches, leather patches, and cotton sheets, and only those items.

#### Describe the solution
It just uses chip_resist( false ).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
