### PR TITLE
fix m38 spawning without mods

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
@@ -50,7 +50,7 @@
     "id": "nested_m27_assault_rifle_no_ammo",
     "type": "item_group",
     "subtype": "collection",
-    "items": [ { "item": "modular_m27_assault_rifle" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
+    "items": [ { "item": "modular_m27_assault_rifle", "variant": "modular_m27iar" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
   },
   {
     "id": "stanag_mags",

--- a/data/json/npcs/NC_OPS.json
+++ b/data/json/npcs/NC_OPS.json
@@ -148,7 +148,7 @@
       { "group": "modular_m4a1", "prob": 50 },
       [ "m14ebr", 35 ],
       [ "m249", 20 ],
-      [ "modular_m27_assault_rifle", 50 ],
+      { "item": "modular_m27_assault_rifle", "variant": "modular_m27iar", "prob": 50 },
       [ "M24", 35 ]
     ]
   },


### PR DESCRIPTION
#### Summary
fix m38 spawning without mods

#### Purpose of change
The m38 is an m27 with a suppressor and scope. They're the same gun. Codewise, they're two variants of the same item which are supposed to only be spawned specifically as the variants with the mods attached to the m38. This was correctly happening in nearly all places, but not all.

#### Describe the solution
Fix the arsenal itemgroup.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
