### PR TITLE
Change smashing priority

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4532,27 +4532,40 @@ bash_params map::bash( const tripoint_bub_ms &p, const int str,
     if( !inbounds( p ) ) {
         return bsh;
     }
+    bool smash_furn = false;
+    bool smashed_sealed = false;
+    bool smash_noitem = false;
 
-    bool bashed_sealed = false;
     if( has_flag( ter_furn_flag::TFLAG_SEALED, p ) ) {
         bash_ter_furn( p, bsh );
-        bashed_sealed = true;
+        smashed_sealed = true;
+    }
+
+    if( has_flag( ter_furn_flag::TFLAG_NOITEM, p ) ) {
+        smash_noitem = true;
     }
 
     bash_field( p, bsh );
 
-    // Don't bash items inside terrain/furniture with SEALED flag
-    if( !bashed_sealed ) {
+    const furn_t &furnid = furn( p ).obj();
+
+    if( has_furn( p ) && furnid.bash ) {
+        smash_furn = true;
+    }
+
+    // Don't smash items if there's smashable furniture here. Don't smash items in SEALED or NOITEM tiles.
+    if( !smashed_sealed && !smash_furn && !smash_noitem ) {
         manually_smash_items( p, str, false, bsh );
     }
-    // Don't bash the vehicle doing the bashing
+
+    // Don't smash the vehicle doing the smashing.
     const vehicle *veh = veh_pointer_or_null( veh_at( p ) );
     if( veh != nullptr && veh != bashing_vehicle ) {
         bash_vehicle( p, bsh );
     }
 
     // If we still didn't bash anything solid (a vehicle) or a tile with SEALED flag, bash ter/furn
-    if( !bsh.bashed_solid && !bashed_sealed ) {
+    if( !bsh.bashed_solid && !smashed_sealed ) {
         bash_ter_furn( p, bsh );
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -240,7 +240,8 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     itype_id big_comp = itype_id::NULL_ID();
     // Fragile items that fall apart easily when used as a weapon due to poor construction quality
     if( shield->has_flag( flag_FRAGILE_MELEE ) ) {
-        material_factor = ( shield->chip_resistance( true ) ) / 6.0f; // 6.0f is a magic number carried over from DDA. Adjust it for more or less overall fragility.
+        material_factor = ( shield->chip_resistance( true ) ) /
+                          6.0f; // 6.0f is a magic number carried over from DDA. Adjust it for more or less overall fragility.
     } else {
         material_factor = shield->chip_resistance();
     }


### PR DESCRIPTION
#### Summary
Change smashing priority

#### Purpose of change
Smashing items is cool, but there were some issues related to how smashing priority was being handled.

#### Describe the solution
Smashing now only targets items if there's no smashable vehicle or furniture in the place. It also will not target items in NOITEM tiles like broken doors, which allegedly sometimes get debris stuck in them. If you need an item smashed, move it out of whatever furniture it's in and onto a regular floor.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
