### PR TITLE
Shrapnel no longer hits all furniture/terrain

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -495,13 +495,14 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
                          obstacle_cache[target.x()][target.y()].density;  // Fraction of the tile blocked. 1.0f = all, 0.0f = none.
         float attenuation =
             obstacle_cache[target.x()][target.y()].velocity; // Fraction of velocity retained for blocked fragments.
-
         if( coverage > 0.0f ) {
-            int partial_damage = static_cast<int>( damage * coverage );
+            int partial_damage = static_cast<int>( damage * coverage * rng_float( cloud.density, 1.0f ) );
             if( optional_vpart_position vp = m->veh_at( target ) ) {
                 vp->vehicle().damage( m[0], vp->part_index(), partial_damage );
             } else {
-                m->bash( target, partial_damage, true );
+                if( rng_float( 0.f, 1.f ) > coverage ) {
+                    m->bash( target, partial_damage, true );
+                }
             }
             passing_fraction = 1.0f - coverage;
             blocked_fraction = coverage;


### PR DESCRIPTION
#### Summary
Shrapnel no longer hits all furniture/terrain

#### Purpose of change
Shrapnel was doing enormous damage to terrain, furniture, and vehicles by always smashing everything in its radius. This damage was reduced for smaller bits of coverage, but wasn't randomized in any way. This was very noticeable with homemade grenades, which just obliterated everything thanks to their larger fragment mass.

#### Describe the solution
- Smash damage is now randomized and tied to cloud density a bit better.
- Chance to smash is now relative to cloud density and coverage in the tile rather than just always happening to everything.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
