### PR TITLE
Saneify goggle protection and fix chin guard

### DIFF
--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -93,7 +93,7 @@
     "material": [ "plastic" ],
     "symbol": "[",
     "color": "light_gray",
-    "material_thickness": 0.1,
+    "material_thickness": 1,
     "flags": [ "HELMET_MANDIBLE_GUARD_STRAPPED", "CANT_WEAR" ],
     "armor": [ { "coverage": 60, "covers": [ "mouth" ], "specifically_covers": [ "mouth_chin" ] } ]
   },

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -1214,7 +1214,7 @@
     "looks_like": "goggles_welding",
     "color": "light_blue",
     "warmth": 10,
-    "environmental_protection": 16,
+    "environmental_protection": 10,
     "flags": [ "WATER_FRIENDLY", "WATERPROOF", "SWIM_GOGGLES", "SKINTIGHT", "OVERSIZE" ],
     "armor": [
       {


### PR DESCRIPTION
#### Summary
Saneify goggle protection and fix chin guard

#### Purpose of change
- Swim goggles had 16 enviro protection. I'm sorry but I don't think they're rated for poison gas and stuff.
- The chin guard was 0.1mm instead of 1mm

#### Describe the solution
fix,

#### Describe alternatives you've considered
no.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
