### PR TITLE
Mine fixes and explosive improvements

### DIFF
--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -221,9 +221,9 @@
   {
     "id": "landmine",
     "type": "TOOL",
-    "name": { "str": "land mine" },
+    "name": { "str": "M14 land mine" },
     "category": "traps",
-    "description": "A military anti-personnel fragmentation mine that is triggered when stepped on.",
+    "description": "A pressure-activated explosive device colloquially known as a \"toepopper.\"  These small land mines were once only found along the Korean demilitarized zone, but were quite controversially deployed en masse across the United States in an attempt to deter the inexorable advance of the walking dead.",
     "weight": "2360 g",
     "volume": "500 ml",
     "price": "50 USD",

--- a/data/json/recipes/recipe_traps.json
+++ b/data/json/recipes/recipe_traps.json
@@ -215,39 +215,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "landmine",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TRAPS",
-    "skill_used": "traps",
-    "skills_required": [ "mechanics", 3 ],
-    "difficulty": 5,
-    "time": "30 m",
-    "reversible": true,
-    "book_learn": [ [ "manual_traps_mil", 5 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_traps" }, { "proficiency": "prof_trapsetting" } ],
-    "components": [
-      [ [ "super_glue", 3 ], [ "duct_tape", 75 ] ],
-      [ [ "scrap", 3 ], [ "steel_fragment", 1 ], [ "canister_empty", 1 ], [ "clay_canister", 1 ], [ "can_food", 1 ] ],
-      [ [ "bb", 200 ], [ "nails", 100, "LIST" ] ],
-      [
-        [ "gunpowder", 720 ],
-        [ "chem_black_powder", 720 ],
-        [ "shot_bird", 24 ],
-        [ "shot_00", 12 ],
-        [ "shot_slug", 12 ],
-        [ "shot_flechette", 12 ],
-        [ "shot_he", 3 ],
-        [ "gasoline", 600 ],
-        [ "diesel", 600 ],
-        [ "biodiesel", 600 ],
-        [ "grenade", 1 ]
-      ]
-    ]
-  },
-  {
-    "type": "recipe",
     "result": "glass_shard_trap",
     "activity_level": "NO_EXERCISE",
     "category": "CC_OTHER",

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -830,7 +830,8 @@ bool trapfunc::landmine( const tripoint_bub_ms &p, Creature *c, item * )
         c->add_msg_player_or_npc( m_bad, _( "You trigger a land mine!" ),
                                   _( "<npcname> triggers a land mine!" ) );
     }
-    explosion_handler::explosion( c, p, 80.0f, 0.5f, false, 30, 0.2f );
+    // Halving the expected casing mass here as the mine (by design) does not function exactly like a grenade.
+    explosion_handler::explosion( c, p, 18.0f, 0.5f, false, 7, 0.02f );
     get_map().remove_trap( p );
     return true;
 }


### PR DESCRIPTION
#### Summary
Mine fixes and explosive improvements

#### Purpose of change
Explosion damage was too swingy. This was partly because it was very difficult to work with the poisson distribution and not come up with results that didn't feel all-or-nothing, but also partly because the individual pieces of shrapnel had very good accuracy, as though they were bullets aimed at the target and not just shit flying randomly away from the epicenter. The base assumption about cloud density and tile size was also wrong. That will require further fixes to address the core issue, but for now I can at least make it less punishing to creatures.

There were also a few bugs lingering around, and vehicles weren't being given the same consideration re:cloud density that terrain and furniture were.

#### Describe the solution
- Vehicles now get a miss chance the same as was introduced recently for terrain/furniture.
- Explosions now properly take creature size into account in all parts of the code.
- Shrapnel hits are now slightly weighted toward the middle. Mostly, this means there is a lower chance a creature will be miraculously unharmed, but it absolutely does still happen.
- This means that going prone next to an explosive is still safer than just standing there, but it's way riskier than before.
- Renamed the land mine item to M14 land mine. Updated its description.
- Brought the land mine's damage and radius down to within what you might expect for such a device, except that currently the casing mass is halved. This is because we don't yet have the ability to call shots. The thing should be destroying your leg and only outright killing you sometimes.
- Made shrapnel far less accurate by heavily skewing its accuracy toward being bad, when previously it was dead even.

#### Testing
- Land mines will often kill an unarmored character or zombie who steps on them. It's still a really bad day even when they don't.
- Grenades kill about as many zombies as before, but will leave fewer uninjured zombies than they used to.
- Going prone 5 tiles away from a grenade on open ground is still sometimes safe, but it's much more likely to result in death or serious injury than before.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
