### PR TITLE
Fix hazard warning and pathfinding

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -574,7 +574,7 @@
     "flags": [ "ECHOLOCATION_DETECTABLE", "PIT", "SONAR_DETECTABLE" ],
     "symbol": "0",
     "visibility": -1,
-    "avoidance": 8,
+    "avoidance": 99,
     "difficulty": 99,
     "action": "pit",
     "vehicle_data": { "damage": 500 }
@@ -589,7 +589,7 @@
     "flags": [ "ECHOLOCATION_DETECTABLE", "PIT", "SONAR_DETECTABLE" ],
     "symbol": "0",
     "visibility": -1,
-    "avoidance": 8,
+    "avoidance": 99,
     "difficulty": 99,
     "action": "pit_spikes",
     "vehicle_data": { "damage": 500 }

--- a/data/json/vehicles/cars.json
+++ b/data/json/vehicles/cars.json
@@ -2250,7 +2250,7 @@
       { "x": -2, "y": 1, "chance": 50, "item_groups": [ "spare_tire_kit_small_jack" ] }
     ]
   },
-    {
+  {
     "id": "suv_electric_solars",
     "type": "vehicle",
     "name": "Electric SUV",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7942,13 +7942,12 @@ tripoint_bub_ms Character::adjacent_tile() const
         }
         const trap &curtrap = here.tr_at( p );
         const ter_id target_ter = here.ter( p );
+        const bool trap_visible = curtrap.can_see( p, *this );
+        const bool known_dangerous_trap = trap_visible && !curtrap.is_benign();
+        const bool see_pit_below = ( ( target_ter == ter_t_pit || target_ter == ter_t_pit_spiked || target_ter == ter_t_pit_glass ) || ( trap_visible && curtrap.has_flag( json_flag_PIT ) ) ) && !has_effect( effect_in_pit );
         // If we don't known a trap here, the spot "appears" to be good, so consider it.
         // Same if we know a benign trap (as it's not dangerous), or we're in a pit and it's a pit.
-        if( !curtrap.can_see( p, *this ) ||
-            curtrap.is_benign() ||
-            ( ( target_ter == ter_t_pit || target_ter == ter_t_pit_spiked || target_ter == ter_t_pit_glass ||
-                curtrap.has_flag( json_flag_PIT ) ) && has_effect( effect_in_pit ) ) ) {
-        } else {
+        if( known_dangerous_trap || see_pit_below ) {
             continue;
         }
         // Only consider tile if unoccupied, passable and has no traps

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10833,12 +10833,14 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
                 return harmful_stuff;
             }
         }
-    } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !veh_dest &&
-               !u.has_effect_with_flag( json_flag_LEVITATION ) && ( !u.has_effect( effect_in_pit ) &&
-                       trap_there.has_flag( json_flag_PIT ) ) ) {
-        harmful_stuff.push_back( tr.name() );
-        if( harmful_stuff.size() == max ) {
-            return harmful_stuff;
+    } else if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !veh_dest ) {
+        const bool pit_there = trap_there.has_flag( json_flag_PIT );
+        const bool pit_is_harmless = u.has_effect( effect_in_pit ) || u.has_effect_with_flag( json_flag_LEVITATION );
+        if( !pit_there || !pit_is_harmless ) {
+            harmful_stuff.push_back( tr.name() );
+            if( harmful_stuff.size() == max ) {
+                return harmful_stuff;
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Fix hazard warning and pathfinding

#### Purpose of change
Many traps and hazards were not properly warning before you stepped on them, even if you saw them. NPCs could similarly ignore them in some cases. Also, pits were avoidable(?)

#### Describe the solution
- Pits are no longer avoidable via skill. It's a hole in the ground. You can't float over it unless you are actually levitating.
- Character pathfinding now correctly assesses landmines etc. as bad to step on.
- The player is now properly warned about traps they're about to step on.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
