### PR TITLE
Fix autotravel map highlight

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1127,24 +1127,28 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     }
 
     if( draw_overlays ) {
-        // Draw path for auto-travel
         for( const tripoint_abs_omt &pos : you.omt_path ) {
             if( pos.z() == center_pos.z() ) {
-                draw_from_id_string( "highlight", tripoint_bub_ms( global_omt_to_draw_position( center_pos ) ), 0,
-                                     0, lit_level::LIT,
-                                     false );
+                draw_from_id_string(
+                    "highlight",
+                    tripoint_bub_ms( global_omt_to_draw_position( pos ) ),
+                    0, 0, lit_level::LIT, false
+                );
             }
         }
 
         if( g->follower_path_to_show ) {
             for( const tripoint_abs_omt &pos : g->follower_path_to_show->omt_path ) {
                 if( pos.z() == center_pos.z() ) {
-                    draw_from_id_string( "highlight", tripoint_bub_ms( global_omt_to_draw_position( center_pos ) ), 0,
-                                         0, lit_level::LIT,
-                                         false );
+                    draw_from_id_string(
+                        "highlight",
+                        tripoint_bub_ms( global_omt_to_draw_position( pos ) ),
+                        0, 0, lit_level::LIT, false
+                    );
                 }
             }
         }
+
 
         // only draw in full tiles so it doesn't get cut off
         const std::optional<std::pair<tripoint_abs_omt, std::string>> mission_arrow =


### PR DESCRIPTION
#### Summary
Fix autotravel map highlight

#### Purpose of change
A while back I broke the fast travel highlight thing. I thought this was for a pretty esoteric reason involving backports and the draw_entity_with_overlays() reshuffling, but actually I just put the wrong pos in the function so it was drawing them all where the cursor was instead of where they were supposed to be..

#### Describe the solution
lol

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
