### PR TITLE
Improve mortar fragment modeling

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -387,12 +387,12 @@
   {
     "id": "EXPLOSIVE_60mmHE",
     "type": "ammo_effect",
-    "explosion": { "power": 1050, "shrapnel": 500 }
+    "explosion": { "power": 1050, "shrapnel": { "casing_mass": 1000, "fragment_mass": 0.08 } }
   },
   {
     "id": "EXPLOSIVE_60mmHE2",
     "type": "ammo_effect",
-    "explosion": { "power": 1258, "shrapnel": 430 }
+    "explosion": { "power": 1258, "shrapnel": { "casing_mass": 1000, "fragment_mass": 0.08 } }
   },
   {
     "id": "FLASHBANG",


### PR DESCRIPTION
#### Summary
Improve mortar fragment modeling

#### Purpose of change
Mortar frags were just using a default value and not the distinct casing mass and fragment mass values.

#### Describe the solution
Plug those in according to real-life data.

#### Testing
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f2392018-10d8-41d7-b4d5-ef3086da041d" />
Looks good

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
