### PR TITLE
Better searchlights and less robot ammo

### DIFF
--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -109,7 +109,7 @@
     "vision_night": 3,
     "weakpoint_sets": [ "wps_turret" ],
     "revert_to_itype": "bot_antimateriel",
-    "starting_ammo": { "50bmg": 300 },
+    "starting_ammo": { "50bmg": 50 },
     "special_attacks": [
       {
         "type": "gun",
@@ -171,7 +171,7 @@
     "vision_night": 3,
     "weakpoint_sets": [ "wps_turret" ],
     "revert_to_itype": "bot_rifleturret",
-    "starting_ammo": { "556": 500 },
+    "starting_ammo": { "556": 200 },
     "special_attacks": [
       {
         "type": "gun",
@@ -233,7 +233,7 @@
     "vision_night": 3,
     "weakpoint_sets": [ "wps_turret" ],
     "revert_to_itype": "bot_crows_m240",
-    "starting_ammo": { "762_51": 500 },
+    "starting_ammo": { "762_51": 150 },
     "special_attacks": [
       {
         "type": "gun",

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -3097,8 +3097,9 @@ bool mattack::searchlight( monster *z )
                 t = pos;
             }
         }
-
-        here.add_field( t, field_type_id( "fd_spotlight" ), 1 );
+        if( here.concealment( t ) < z->eye_level() ) {
+            here.add_field( t, field_type_id( "fd_spotlight" ), 1 );
+        }
     }
 
     return true;


### PR DESCRIPTION
#### Summary
Better searchlights and less robot ammo

#### Purpose of change
- Turrets still had too much ammo.
- Searchlights were able to beam their glow fields onto walls, which caused illumination to appear on the other side.

#### Describe the solution
- Less ammo by far.
- Searchlights now do a concealment check to see if they can get a beam over the tile. They're fairly big so they can see over most things, but no longer through walls.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
