### PR TITLE
Slow drowned zombies a bit

### DIFF
--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -1642,6 +1642,7 @@
       "BASHES",
       "GROUP_BASH",
       "POISON",
+      "SWIMS",
       "NO_BREATHE",
       "REVIVES",
       "PUSH_MON",


### PR DESCRIPTION
#### Summary
Slow drowned zombies a bit

#### Purpose of change
Drowned zombies were almost as fast as a human for some reason. These are bloated corpses loaded down with water that aren't meant to be graceful on land.

#### Describe the solution
They're now slower than regular zombies, but I gave them SWIMS so they can still get around relatively fast in water. Unlike their older siblings the swimmer zombies, they don't have WATER_CAMOUFLAGE

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
