### PR TITLE
Fix "battery charger" vehicle part

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2036,7 +2036,6 @@
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "30 m", "using": [ [ "adhesive", 1 ], [ "soldering_standard", 4 ] ] }
     },
     "folded_volume": "250 ml",
-    "flags": [ "NO_COVER" ],
     "breaks_into": "ig_vp_device",
     "copy-from": "recharge_station"
   },


### PR DESCRIPTION
#### Summary
Make battery charger work again

#### Purpose of change
The vehicle-installed battery charger has not been working, probably since commit afa28a27d52d19865585e658e012e436a9a8b249 which overrode the RECHARGE flag it copied from the recharging station.

#### Describe the solution
Remove the "flags" field from battery_charger, leaving it to be copied from recharge_station again.
This should also give it its INTERNAL flag back.

#### Describe alternatives you've considered
Duplicate the flags instead of relying on copy-from.

#### Testing
Observed the "Turn on recharger" vehicle control option appearing again on a vehicle equipped with a battery charger on a cargo carrier, observed it draining 15W and slowly charging batteries.

#### Additional context
The recharging station was still working, but it's less common loot than battery chargers.