### PR TITLE
Backport 84244 - Don't allow character to sell their arms or legs

### DIFF
--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -209,6 +209,10 @@ void trade_ui::autobalance()
     int const sign = _cpane == _you ? -1 : 1;
     if( ( sign < 0 && _balance < 0 ) || ( sign > 0 && _balance > 0 ) ) {
         inventory_entry &entry = _panes[_cpane]->get_active_column().get_highlighted();
+        if( !entry.is_selectable() ) {
+            popup( _( "%s cannot be traded." ), entry.any_item()->tname() );
+            return;
+        }
         size_t const avail = entry.get_available_count() - entry.chosen_count;
         double const price = npc_trading::trading_price( *_parties[-_cpane + 1], *_parties[_cpane],
                              entry_t{ entry.any_item(), 1 } ) * sign;


### PR DESCRIPTION
#### Summary
Backport 84244 - Don't allow character to sell their arms or legs

#### Purpose of change
Someone realized the autobalance button in the trade window could sell integrated items as there was no check for their salability. Now there is thanks to RenechCDDA

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
