### PR TITLE
Fix shark teeth flags

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1849,7 +1849,7 @@
     "color": "white",
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 4 ] ],
     "techniques": [ "SHARKTEETH_BITE", "SHARKTEETH_BITE_NATURAL" ],
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PROVIDES_TECHNIQUES", "NATURAL_WEAPON" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "PROVIDES_TECHNIQUES", "PADDED", "NATURAL_WEAPON" ],
     "armor": [
       {
         "material": [ { "type": "bone", "covered_by_mat": 100, "thickness": 5 } ],
@@ -2382,7 +2382,7 @@
     "material": [ "titanium_alloy" ],
     "symbol": ",",
     "color": "dark_gray",
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "ALLOWS_NATURAL_ATTACKS", "TRANSPARENT", "PERSONAL", "CUSHION_FALL" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRANSPARENT", "PERSONAL", "CUSHION_FALL" ],
     "armor": [
       {
         "material": [ { "type": "titanium_alloy_implant", "covered_by_mat": 100, "thickness": 1.5 } ],


### PR DESCRIPTION
#### Summary
Fix shark teeth flags

#### Purpose of change
Shark teeth lacked the PADDED flag, and were irritating, despite being your own damb teeth

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
