### PR TITLE
Remove NPC faction camp takeover

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2013,7 +2013,7 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
             //     temp_camp->handle_takeover_by( you.get_faction()->id, plunder );
             //     return;
             // }
-            you.add_msg_if_player( _( "You don't run this camp, the board is useless to you." ) );
+            you.add_msg_if_player( _( "You don't run this settlement, the board is useless to you." ) );
             return;
         }
 
@@ -2031,7 +2031,7 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
             temp_camp->handle_mission( mission_key.cur_key.id );
         }
     } else {
-        you.add_msg_if_player( _( "This bulletin board is not inside a camp." ) );
+        you.add_msg_if_player( _( "This bulletin board is not inside a settlement." ) );
     }
 }
 


### PR DESCRIPTION
#### Summary
Remove NPC faction camp takeover

#### Purpose of change
If you interact with a faction camp board in a place that isn't yours, you will be prompted to loot the place and take it over, which instantly flips all NPCs to hostile and gives you a bunch of virtual resources you didn't really do anything to get access to. We're doing away with faction camps as such and so this isn't really desired, especially as this prompt has tricked people into breaking quest chains and making otherwise friendly people permanently hostile.

#### Describe the solution
Comment out the function for now. If you want to rob the place and kill everyone, that is still an option. Interacting with a camp board outside of your own faction camp no longer does anything.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
