### PR TITLE
Fixed ranged targeting default keybind

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1325,8 +1325,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "BACKTAB" },
       { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
-      { "input_method": "mouse", "key": "SCROLL_UP" },
-      { "input_method": "keyboard_any", "key": "PPAGE" }
+      { "input_method": "mouse", "key": "SCROLL_UP" }
     ]
   },
   {
@@ -1336,8 +1335,7 @@
     "name": "Next target",
     "bindings": [
       { "input_method": "keyboard_any", "key": "TAB" },
-      { "input_method": "mouse", "key": "SCROLL_DOWN" },
-      { "input_method": "keyboard_any", "key": "NPAGE" }
+      { "input_method": "mouse", "key": "SCROLL_DOWN" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Fixed ranged targeting default keybind

#### Purpose of change
Players were unaware of the fact that you could look up and down while aiming because the little gremlins were using pgup and pgdn instead of angle brackets like normal people. For reasons unknown, these keys were bound to next target and last target as well, despite the fact that tab and backtab are also bound to those functions.

#### Describe the solution
Remove pgup and pgdn from previous target and next target in the default keybinding scheme. pgup and pgdn should now work fine for looking up and down if that's how you want to play it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
