### PR TITLE
Dragging friends is easier

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3351,7 +3351,7 @@ class Character : public Creature, public visitable
 
         /** Modifies the movement cost and returns a list of effects */
         std::vector<run_cost_effect> run_cost_effects( float &movecost ) const;
-        /** Returns the player's modified base movement cost */
+        /** Returns the character's modified base movement cost */
         int run_cost( int base_cost, bool diag = false ) const;
 
         const pathfinding_settings &get_pathfinding_settings() const override;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1671,13 +1671,42 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 
 bool Creature::grapple_drag( Creature *c )
 {
+    if( !has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+        return false;
+    }
     const Character *ch = as_character();
     const monster *mon = as_monster();
-    const int str = ch != nullptr ? ch->get_str() : mon != nullptr ? mon->get_grab_strength() : 10;
+    float str = 0.f;
+    if( !is_monster() && ch != nullptr && ch->grab_1.victim != nullptr ) {
+        str = static_cast<float>( ch->grab_1.grab_strength );
+    } else if( mon != nullptr ) {
+        str = static_cast<float>( mon->get_grab_strength() );
+    } else {
+        return false;
+    }
+    // Somehow we lost the grab.  Bail out.
+    if( str < 1.f ) {
+        return false;
+    }
     // Medium is 3.
     int your_size = static_cast<std::underlying_type_t<creature_size>>( get_size() );
-    const int odds = units::to_kilogram( c->get_weight() ) / ( str * your_size );
-    if( one_in( clamp<int>( odds * odds, 1, 1000 ) ) ) {
+    float odds = units::to_kilogram( c->get_weight() ) / ( str * your_size );
+    // Allies will try to move with you if they can, making things easier.
+    // TODO: Make NPCs able to drag the player.
+    
+    if( ch && c->is_npc() && ( c->as_npc()->is_walking_with() || c->as_npc()->is_player_ally() ) && !c->in_sleep_state() ) {
+        int target_movecost = ch->run_cost( 100, false );
+        if( target_movecost < 200 ) {
+            odds *= target_movecost / 200.f;
+        }
+    }
+    if( mon && c->as_monster()->is_pet() ) {
+        odds /= 2.f;
+    }
+    float threshold = ( odds + 0.25f ) * ( odds + 0.25f );
+    threshold = std::clamp( threshold, 1.0f, 1000.0f );
+
+    if( x_in_y( 1.0, threshold ) ) {
         return true;
     } else {
         add_msg_if_player( m_bad, _( "You strain to drag %s." ),
@@ -1687,7 +1716,6 @@ bool Creature::grapple_drag( Creature *c )
         }
         return false;
     }
-    return false;
 }
 
 bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11091,9 +11091,21 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
             u.burn_move_stamina( 0.50 * ( previous_moves - u.get_moves() ) );
         }
     }
-    // Try and fail to drag someone with us.
+    // Try and to drag someone with us.
     if( u.grab_1.victim != nullptr ) {
-        if( u.grab_1.victim.get() && !u.grapple_drag( u.grab_1.victim.get() ) ) {
+        Creature* victim_ptr = u.grab_1.victim.get();
+        if( victim_ptr != nullptr ) {
+            if( victim_ptr->is_dead_state() ) {
+                u.grab_1.victim = nullptr;
+                return false;
+            }
+            if( u.is_adjacent( victim_ptr, true ) ) {
+                if( !u.grapple_drag( victim_ptr ) ) {
+                    return false;
+                }
+            }
+        } else {
+            u.grab_1.victim = nullptr;
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Dragging friends is easier

#### Purpose of change
- Dragging creatures around was too hard. This is because it was using the player's strength and not grab_strength, even though monsters got to use their grab_strength to do the same thing.
- Friendly creatures shouldn't be fighting you.

#### Describe the solution
- Now uses grab_strength, meaning your unarmed, strength, and melee all count. For most characters this should make it at least twice as easy to move all creatures around.
- Friendly creatures now give you a bonus. For NPCs, this is tied to their move speed - a healthy person will run along with you, an unconscious or badly slowed one is dead weight. For monsters, if they're your pet, you're just flat out 50% likelier to drag them.
- Fixed a bug where teleporting away from a grabbed creature and then trying to move could cause a segfault.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
