### PR TITLE
Contraband efiles in the wild

### DIFF
--- a/data/json/itemgroups/efiles.json
+++ b/data/json/itemgroups/efiles.json
@@ -49,7 +49,8 @@
       { "item": "efile_lore", "prob": 10 },
       { "item": "efile_map", "prob": 10 },
       { "item": "efile_recipes", "prob": 80 },
-      { "item": "efile_junk", "prob": 100, "count": [ 12, 24 ] }
+      { "item": "efile_junk", "prob": 100, "count": [ 12, 24 ] },
+      { "group": "efiles_contraband", "prob": 2 }
     ]
   },
   {
@@ -57,11 +58,12 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "software_hacking", "prob": 1 },
+      { "item": "software_hacking", "prob": 2 },
       { "item": "efile_lore", "prob": 10 },
       { "item": "efile_map", "prob": 5 },
       { "item": "efile_recipes", "prob": 5 },
-      { "item": "efile_junk", "prob": 100, "count": [ 24, 36 ] }
+      { "item": "efile_junk", "prob": 100, "count": [ 24, 36 ] },
+      { "group": "efiles_contraband", "prob": 2 }
     ]
   },
   {
@@ -72,7 +74,8 @@
       { "group": "book_school", "prob": 80, "count": [ 1, 3 ] },
       { "item": "efile_map", "prob": 10 },
       { "item": "efile_recipes", "prob": 5 },
-      { "item": "efile_junk", "prob": 100, "count": [ 24, 36 ] }
+      { "item": "efile_junk", "prob": 100, "count": [ 24, 36 ] },
+      { "group": "efiles_contraband", "prob": 1 }
     ]
   },
   {
@@ -100,7 +103,8 @@
       { "group": "novels", "prob": 50 },
       { "group": "literature", "prob": 50 },
       { "item": "photo_album", "prob": 25, "count": [ 1, 5 ] },
-      { "item": "efile_recipes", "prob": 25 }
+      { "item": "efile_recipes", "prob": 25 },
+      { "group": "efiles_contraband", "prob": 1 }
     ]
   },
   {
@@ -112,7 +116,8 @@
       { "item": "efile_lore", "prob": 50 },
       { "group": "novels", "prob": 50, "count": [ 1, 3 ] },
       { "group": "literature", "prob": 50, "count": [ 1, 3 ] },
-      { "item": "efile_recipes", "prob": 25 }
+      { "item": "efile_recipes", "prob": 25 },
+      { "group": "efiles_contraband", "prob": 1 }
     ]
   },
   {
@@ -125,7 +130,8 @@
       { "group": "novels", "prob": 50, "count": [ 1, 3 ] },
       { "group": "literature", "prob": 50, "count": [ 1, 3 ] },
       { "item": "efile_recipes", "prob": 40 },
-      { "item": "software_useless", "prob": 20 }
+      { "item": "software_useless", "prob": 20 },
+      { "group": "efiles_contraband", "prob": 2 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Contraband efiles in the wild

#### Purpose of change
HackPRO was too hard to find, and also it was weird that contraband wasn't appearing generally out in the world. Most criminals, anarchists, etc. are just walking around like normal people, especially considering that there was recently mass rioting!

#### Describe the solution
Add contraband efiles with a very low drop rate to a few of the general efile loot pools.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
