### PR TITLE
Fix TOUGH2 mutation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -852,6 +852,7 @@
     "points": 2,
     "description": "Your body has grown accustomed to physical trauma.  You get a 20% bonus to all hit points.",
     "types": [ "DURABILITY" ],
+    "prereqs": [ "TOUGH" ],
     "changes_to": [ "TOUGH3" ],
     "category": [ "MEDICAL" ],
     "threshreq": [ "THRESH_MEDICAL" ],


### PR DESCRIPTION
#### Summary
Fix TOUGH2 mutation

#### Purpose of change
TOUGH2 was attempting and failing to mutate in pre-thresh medical mutants, and deleting TOUGH in the process. No good!

#### Describe the solution
Add TOUGH to TOUGH2's prereqs, which should prevent it from doing that.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
