### PR TITLE
Vehicle workshops are workbenches

### DIFF
--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -9,7 +9,8 @@
     "price": "400 USD",
     "price_postapoc": "20 USD",
     "material": [ "steel" ],
-    "flags": [ "NO_COVER" ],
+    "flags": [ "NO_COVER", "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH" ],
+    "workbench": { "multiplier": 1.1, "mass": 150000, "volume": "20 L" },
     "symbol": "&",
     "color": "light_cyan"
   },


### PR DESCRIPTION
#### Summary
Vehicle workshops are workbenches

#### Purpose of change
Vehicle workstations, like the kitchen station, workshop, etc. are described as a table or counter with lots of drawers and outlets/pipes/whatever. That means they ought to be a work surface, but probably not as good of one as a proper workbench.

#### Describe the solution
Make them identical to tables. 20L capacity, 10% work speed bonus.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
