### PR TITLE
Backport DDA 81189 - Fixes freeze when npc is recalled from mission

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5922,10 +5922,9 @@ nutrients faction_template::consume_food_supply( const nutrients &consumed )
         // whatever remains was not consumed
         return to_supply;
     }
-    for( auto it = _food_supply.begin(); it != _food_supply.end(); ) {
+    for( auto it = _food_supply.begin(); it != _food_supply.end(); ++it ) {
         // start by skipping the non-perishable food
         if( it == _food_supply.begin() ) {
-            ++it;
             continue;
         }
         it->second = consume_left_behind( to_supply, it->second );


### PR DESCRIPTION
#### Summary
Backport DDA 81189 - Fixes freeze when npc is recalled from mission

#### Purpose of change
The larder updates were making the game freeze under certain conditions.

#### Describe the solution
Do not do that

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
