### PR TITLE
Fix pocket priority crash

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -300,9 +300,9 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         string_input_popup popup;
         popup.title( string_format( _( "Enter Priority (current priority %d)" ),
                                     selected_pocket->settings.priority() ) );
-        const int ret = popup.query_int().value();
-        if( popup.confirmed() ) {
-            selected_pocket->settings.set_priority( ret );
+        auto ret = popup.query_int();
+        if( popup.confirmed() && ret.has_value() ) {
+            selected_pocket->settings.set_priority( ret.value() );
             selected_pocket->settings.set_was_edited();
         }
         return true;


### PR DESCRIPTION
#### Summary
Fix pocket priority crash

#### Purpose of change
When setting pocket priority, if you pressed escape while the popup was open, the game would crash. This is because the code expected that action to always result in a value.

#### Describe the solution
Make it check if there is a value before requiring one.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
