### PR TITLE
Backport DDA 83071 - Don't trash the light cache for the PCs Z level

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -299,7 +299,11 @@ void map::build_sunlight_cache( int pzlev )
 
     // Iterate top to bottom because sunlight cache needs to construct in that order.
     for( int zlev = zlev_max; zlev >= zlev_min; zlev-- ) {
-
+        if( pzlev != get_avatar().posz() && zlev == get_avatar().posz() ) {
+            // Don't trash the lighting for the PC when this is called for someone else at a different
+            // Z level, as only the specified Z level is being rebuilt with light sources by the caller.
+            continue;
+        }
         level_cache &map_cache = get_cache( zlev );
         map_cache.natural_light_level_cache = g->natural_light_level( zlev );
         auto &lm = map_cache.lm;


### PR DESCRIPTION
#### Summary
Backport DDA 83071 - Don't trash the light cache for the PCs Z level

#### Purpose of change
NPCs moving to different Z levels were deleting the light cache on the player's, causing many, many problems.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
