### PR TITLE
Backport DDA 80506 (again?) - explosion/melee item structs

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4143,6 +4143,9 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     }
 
     optional( jo, true, "weapon_category", def.weapon_category, auto_flags_reader<weapon_category_id> {} );
+    optional( jo, def.was_loaded, "melee_damage", def.melee );
+    optional( jo, def.was_loaded, "thrown_damage", def.thrown_damage );
+    optional( jo, def.was_loaded, "explosion", def.explosion );
 
     optional( jo, def.was_loaded, "melee_damage", def.melee );
     optional( jo, def.was_loaded, "thrown_damage", def.thrown_damage );

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -463,7 +463,7 @@ bool item_melee_damage::handle_proportional( const JsonValue &jval )
         rhs.deserialize( jval.get_object() );
         for( const std::pair<const damage_type_id, float> &dt : rhs.damage_map ) {
             const auto iter = damage_map.find( dt.first );
-            if( iter != damage_map.end() ) {
+            if( iter != rhs.damage_map.end() ) {
                 iter->second *= dt.second;
                 // For maintaining legacy behaviour (when melee damage used ints)
                 iter->second = std::floor( iter->second );
@@ -479,7 +479,7 @@ item_melee_damage &item_melee_damage::operator+=( const item_melee_damage &rhs )
 {
     for( const std::pair<const damage_type_id, float> &dt : rhs.damage_map ) {
         const auto iter = damage_map.find( dt.first );
-        if( iter != damage_map.end() ) {
+        if( iter != rhs.damage_map.end() ) {
             iter->second += dt.second;
             // For maintaining legacy behaviour (when melee damage used ints)
             iter->second = std::floor( iter->second );


### PR DESCRIPTION
#### Summary
Backport DDA 80506 (again?) - explosion/melee item structs

#### Purpose of change
Part of the item_factory overhaul

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
