### PR TITLE
More battery fixes

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -18,7 +18,6 @@
     "name": { "str": "laptop" },
     "material": [ { "type": "aluminum", "portion": 75 }, { "type": "plastic", "portion": 25 } ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 8,
     "etransfer_rate": "30 MB",
     "e_port": "laptop",
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "CAN_USE_IN_DARK" ],
@@ -32,7 +31,6 @@
     "material": [ { "type": "aluminum", "portion": 5 }, { "type": "plastic", "portion": 5 } ],
     "tool_ammo": [ "battery" ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 5,
     "etransfer_rate": "30 MB",
     "e_port": "phone",
     "flags": [
@@ -53,7 +51,6 @@
     "type": "TOOL",
     "name": { "str": "e-ink tablet" },
     "charges_per_use": 1,
-    "charges_per_use_one_in": 8,
     "etransfer_rate": "30 MB",
     "e_port": "tablet",
     "e_ports_banned": [ "USB-A" ],
@@ -134,7 +131,6 @@
     "symbol": ";",
     "color": "light_gray",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 10,
     "use_action": [
       {
         "target": "cell_phone_flashlight",
@@ -435,7 +431,6 @@
     "color": "green",
     "flags": [ "WATER_BREAK" ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 10,
     "use_action": [ "GEIGER" ],
     "pocket_data": [
       {
@@ -623,7 +618,6 @@
     "symbol": ";",
     "color": "dark_gray",
     "use_action": [ "MP3", { "type": "link_up", "cable_length": 2, "charge_rate": "5 W" } ],
-    "charges_per_use_one_in": 8,
     "charges_per_use": 1,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } } ],
@@ -708,7 +702,6 @@
     "symbol": ";",
     "color": "yellow",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 8,
     "use_action": {
       "type": "transform",
       "msg": "You turn the EMF detector on.",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -198,7 +198,6 @@
     "price": "9 USD",
     "price_postapoc": "15 cent",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 8,
     "flags": [ "BELT_CLIP", "WATER_BREAK_ACTIVE", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ],
     "use_action": {
       "type": "transform",
@@ -225,6 +224,7 @@
     "name": { "str": "flashlight (on)", "str_pl": "flashlights (on)" },
     "power_draw": "750 mW",
     "revert_to": "flashlight",
+    "charges_per_use": 0,
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
@@ -249,7 +249,6 @@
     "price": "5 USD",
     "price_postapoc": "1 USD",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 8,
     "flags": [ "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ],
     "use_action": {
       "type": "transform",
@@ -455,7 +454,6 @@
     "symbol": ";",
     "color": "blue",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 3,
     "tool_ammo": [ "battery" ],
     "use_action": [
       {

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -9,7 +9,6 @@
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "material": [ "plastic" ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 5,
     "turns_per_charge": 5,
     "weight": "670 g",
     "volume": "500 ml",
@@ -110,7 +109,6 @@
     "color": "light_gray",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 10,
     "use_action": [ "RADIO_OFF", { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" } ],
     "pocket_data": [
       {
@@ -151,7 +149,6 @@
     "symbol": ";",
     "color": "green",
     "charges_per_use": 1,
-    "charges_per_use_one_in": 10,
     "flags": [ "TWO_WAY_RADIO", "WATER_BREAK", "ELECTRONIC" ],
     "use_action": [ { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" } ],
     "pocket_data": [
@@ -180,7 +177,6 @@
     "color": "yellow",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "charges_per_use": 1,
-    "charges_per_use_one_in": 5,
     "turns_per_charge": 5,
     "use_action": [ "REMOTEVEH" ],
     "tick_action": "REMOTEVEH_TICK",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1012,15 +1012,11 @@
     "looks_like": "glasses_safety",
     "color": "light_gray",
     "charges_per_use": 1,
-    "use_action": [ "CAMERA" ],
+    "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" } ],
     "etransfer_rate": "20 MB",
+    "tool_ammo": [ "battery" ],
     "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT" ],
-        "default_magazine": "light_battery_cell"
-      },
+      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } },
       {
         "pocket_type": "E_FILE_STORAGE",
         "rigid": true,
@@ -1033,8 +1029,7 @@
     "armor": [ { "encumbrance": 5, "coverage": 95, "covers": [ "eyes" ], "rigid_layer_only": true } ],
     "material_thickness": 1,
     "environmental_protection": 1,
-    "flags": [ "WATCH", "ALARMCLOCK", "FRAGILE", "WATER_BREAK", "PADDED", "ELECTRONIC", "SKINTIGHT" ],
-    "tool_ammo": "battery"
+    "flags": [ "WATCH", "ALARMCLOCK", "FRAGILE", "WATER_BREAK", "PADDED", "ELECTRONIC", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD" ]
   },
   {
     "id": "ar_glasses_advanced",
@@ -1051,16 +1046,17 @@
     "looks_like": "glasses_safety",
     "color": "light_gray",
     "charges_per_use": 1,
-    "use_action": [ "CAMERA", "PORTABLE_GAME", "EBOOKSAVE", "E_FILE_DEVICE" ],
+    "use_action": [
+      "CAMERA",
+      "PORTABLE_GAME",
+      "EBOOKSAVE",
+      "E_FILE_DEVICE",
+      { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
+    ],
     "etransfer_rate": "30 MB",
     "tick_action": [ "EPIC_MUSIC" ],
     "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT" ],
-        "default_magazine": "light_battery_cell"
-      },
+      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } },
       {
         "pocket_type": "E_FILE_STORAGE",
         "rigid": true,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7238,7 +7238,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
             it.remove_item();
         }
     } else if( used_tool->is_tool() ) {
-        if( used_tool->type->charges_to_use() ) {
+        if( used_tool->type->charges_to_use() > 0 ) {
             it->activation_consume( charges_consumed, it.pos_bub( here ), &who );
         }
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1927,7 +1927,6 @@ void activity_handlers::start_fire_finish( player_activity *act, Character *you 
         act->set_to_null();
         return;
     }
-
     it.activation_consume( 1, you->pos_bub(), you );
 
     you->practice( skill_survival, act->index, 5 );
@@ -4009,7 +4008,10 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
             if( !act->targets.empty() ) {
                 item *it = act->targets.front().get_item();
                 if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
-                    you->consume_charges( *it, it->type->charges_to_use() );
+                    int consumed = it->type->charges_to_use();
+                    if( consumed > 0 ) {
+                        you->consume_charges( *it, consumed );
+                    }
                 }
             }
             get_event_bus().send<event_type::spellcasting_finish>( you->getID(), true, sp,

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1884,19 +1884,12 @@ static bool consume_med( item &target, Character &you )
 
     if( req_tool->tool ) {
         if( !( you.has_amount( tool_type, 1 ) &&
-            you.has_charges( tool_type, req_tool->tool->charges_per_use ) ) ) {
+               you.has_charges( tool_type, req_tool->tool->charges_per_use ) ) ) {
             you.add_msg_if_player( m_info,
-                _( "You need a %s to consume that!" ), req_tool->nname( 1 ) );
+                                   _( "You need a %s to consume that!" ), req_tool->nname( 1 ) );
             return false;
         }
-
-        const int one_in_val = req_tool->tool->charges_per_use_one_in;
-
-        if( one_in_val < 2 ) {
-            you.use_charges( tool_type, req_tool->tool->charges_per_use );
-        } else if( one_in( one_in_val ) ) {
-            you.use_charges( tool_type, req_tool->tool->charges_per_use );
-        }
+        you.use_charges( tool_type, req_tool->tool->charges_per_use );
     }
 
     int amount_used = 1;

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -147,14 +147,7 @@ int itype::charges_default() const
 int itype::charges_to_use() const
 {
     if( tool ) {
-        const int one_in_val = tool->charges_per_use_one_in;
-        if( one_in_val < 2 ) {
-            return tool->charges_per_use;
-        }
-        if( one_in( one_in_val ) ) {
-            return tool->charges_per_use;
-        }
-        return 0;
+        return tool->charges_per_use;
     } else if( comestible ) {
         return 1;
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -9081,6 +9081,7 @@ std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoi
     // Different messages for different resonance levels? Dangerous resonance levels are in suffer::from_artifact_resonance
     popup( _( "Detected resonance approximately equal to %i units." ), detected_resonance );
 
+
     p->consume_charges( *it, it->type->charges_to_use() );
     p->mod_moves( -to_moves<int>( 2_minutes ) );
 


### PR DESCRIPTION
#### Summary
More battery fixes

#### Purpose of change
The AR glasses needed fixing and the charges_per_use_one_in thing didn't work like I wanted.

#### Describe the solution
- Revert charges_per_use_one_in. It may not be all that necessary after all anyway.
- Both types of AR glasses now use internal batteries with a fairly substantial charge.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
