### PR TITLE
Remove real-time turn progression

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1626,13 +1626,6 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
-    add( "TURN_DURATION", "general", to_translation( "Realtime turn progression" ),
-         to_translation( "If higher than 0, monsters will take periodic gameplay turns.  This value is the delay between each turn, in seconds.  Works best with Safe Mode disabled.  0 = disabled.  If you can manage to successfully play for any length of time like this, please post it on Youtube or the Discord." ),
-         0.0, 10.0, 0.0, 0.05
-       );
-
-    add_empty_line();
-
     add_option_group( "general", Group( "auto_save_opts", to_translation( "Autosave Options" ),
                                         to_translation( "Options regarding autosave." ) ),
     [&]( const std::string & page_id ) {


### PR DESCRIPTION
#### Summary
Remove real-time turn progression

#### Purpose of change
Real-time turn progression was a joke option left in by the DDA devs mostly so that people who asked for it to be implemented could turn it on and see how it was pure dogshit. Two people in one week accidentally turned it on and thought their game was bugged, so I guess that's the end of that.

#### Describe the solution
It's gone.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
