### PR TITLE
Backport DDA 78831 - Fixed intergrated AR being unable to read books

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1485,7 +1485,9 @@ class read_inventory_preset: public pickup_inventory_preset
         bool is_shown( const item_location &loc ) const override {
             const item_location p_loc = loc.parent_item();
             return ( loc->is_book() || loc->type->can_use( "learn_spell" ) ) &&
-                   ( !p_loc || ( !p_loc->is_estorage() || p_loc->is_estorage_usable( you ) ) );
+                   ( !p_loc || ( !p_loc->is_estorage() || p_loc->is_estorage_usable( you ) ) ||
+                     !p_loc->uses_energy() ||
+                     p_loc->energy_remaining( p_loc.carrier(), false ) >= 1_kJ );
         }
 
         std::string get_denial( const item_location &loc ) const override {


### PR DESCRIPTION
#### Summary
Battery fixes

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
