### PR TITLE
Reduce power consumption of e-ink tablets

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -250,7 +250,7 @@
     "id": "eink_tablet_pc_on",
     "copy-from": "eink_tablet_pc",
     "name": { "str": "e-ink tablet PC (on)", "str_pl": "e-ink tablet PCs (on)" },
-    "power_draw": "2 W",
+    "power_draw": "600 mW",
     "revert_to": "eink_tablet_pc",
     "use_action": [
       "E_FILE_DEVICE",


### PR DESCRIPTION
#### Summary
Reduce power consumption of e-ink tablets

#### Purpose of change
E-ink tablets had a power consumption of 2W. This is accurate when the lights are on, wifi is in use, music's going, you're using the camera, etc., but it's like 1/5th of that when the thing is just idling, like it would be most of the time you were reading it. We can't differentiate between the two types of use so we just need to average them.

#### Describe the solution
Cut power to 750mW.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
