### PR TITLE
Pocket segfault fix

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -809,6 +809,7 @@ bool Character::dispose_item( item_location &&obj, const std::string &prompt )
     uilist menu;
     menu.text = prompt.empty() ? string_format( _( "Dispose of %s" ), obj->tname() ) : prompt;
     std::vector<dispose_option> opts;
+    
 
     const bool bucket = obj->will_spill() && !obj->is_container_empty();
 
@@ -823,8 +824,9 @@ bool Character::dispose_item( item_location &&obj, const std::string &prompt )
             }
 
             mod_moves( -item_handling_cost( *obj ) );
-            this->i_add( *obj, true, &*obj, &*obj );
+            item it = *obj;
             obj.remove_item();
+            this->i_add( it, true );
             return true;
         }
     } );


### PR DESCRIPTION
#### Summary
Pocket segfault fix

#### Purpose of change
fill_with() was seemingly doing something unsafe by passing item *this to i_add rather than copying it first. This was causing some unexpected behavior down the line that could crash the game.

#### Describe the solution
Copy it first, then pass it.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
