### PR TITLE
Migrate two missed batteries

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3737,5 +3737,15 @@
     "id": "gas_charger",
     "type": "MIGRATION",
     "replace": "UPS_off"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "medium_disposable_cell",
+    "replace": "medium_battery_cell"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "heavy_disposable_cell",
+    "replace": "heavy_battery_cell"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate two missed batteries

#### Purpose of change
Medium and heavy disposable batteries no longer exist, but the PR that removed them didn't migrate them. My bad.

#### Describe the solution
Migrate to the normal version.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
