### PR TITLE
Fix faction camp meals having negative kcals

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4666,7 +4666,8 @@ bool npc::consume_food_from_camp()
         int kcal_to_eat = std::min( desired_kcal, bcp->get_owner()->food_supply().kcal() );
 
         if( kcal_to_eat > 0 ) {
-            bcp->feed_workers( *this, bcp->camp_food_supply( -kcal_to_eat ) );
+            nutrients meal = bcp->camp_food_supply( -kcal_to_eat );
+            bcp->feed_workers( *this, -meal );
 
             return true;
         } else {


### PR DESCRIPTION
#### Summary
Fix faction camp meals having negative kcals

#### Purpose of change
When I fixed the overflow issue in #1870 I accidentally introduced a new bug where the followers were purging kcals instead of eating them. This is because some of the functions involved require you to pass them the negative kcal value, and others the positive, which is unclear at a glance and really bad practice.

#### Describe the solution
Run camp_food_supply() with -kcal and save it in a variable, then pass that variable as a double negative to feed_workers()

#### Describe alternatives you've considered
Untangle the ball of yarn and make everything accept the positive kcal value and internally do any negative stuff it needs to do.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
