### PR TITLE
Fix ebook scanning segfault

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2846,11 +2846,11 @@ int ebooksave_activity_actor::required_charges(
 
 void ebooksave_activity_actor::start_scanning_next_book( player_activity &act )
 {
-while( !books.empty() && !books.back() ) {
-    add_msg_debug( debugmode::DF_ACT_EBOOK,
-                   "Skipping unavailable book" );
-    books.pop_back();
-}
+    while( !books.empty() && !books.back() ) {
+        add_msg_debug( debugmode::DF_ACT_EBOOK,
+                       "Skipping unavailable book" );
+        books.pop_back();
+    }
 
     if( books.empty() ) {
         act.moves_left = 0;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -809,7 +809,7 @@ bool Character::dispose_item( item_location &&obj, const std::string &prompt )
     uilist menu;
     menu.text = prompt.empty() ? string_format( _( "Dispose of %s" ), obj->tname() ) : prompt;
     std::vector<dispose_option> opts;
-    
+
 
     const bool bucket = obj->will_spill() && !obj->is_container_empty();
 

--- a/src/map.h
+++ b/src/map.h
@@ -1179,7 +1179,8 @@ class map
         /** Tries to smash the items at the given tripoint. Used by the explosion code */
         void smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message );
         /** Manually smash one item at the given tripoint, as with a weapon. */
-        void manually_smash_items( const tripoint_bub_ms &p, int power, bool hit_all, bash_params &params, bool crystalline_only );
+        void manually_smash_items( const tripoint_bub_ms &p, int power, bool hit_all, bash_params &params,
+                                   bool crystalline_only );
         /**
          * Returns a pair where first is whether anything was smashed and second is if it was destroyed.
          *


### PR DESCRIPTION
#### Summary
Fix ebook scanning segfault

#### Purpose of change
Scanning books into an electronic storage device would trigger a segfault if the batteries ran out mid-scan. This was due to calling an invalid item location on the device for a debug message.

#### Describe the solution
Just don't call it, there's no real need.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
