### PR TITLE
Fix animations = false forcing real-time

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -342,13 +342,8 @@ input_context game::get_player_input( std::string &action )
         } while( action == "TIMEOUT" );
         ctxt.reset_timeout();
     } else {
-        ctxt.set_timeout( 125 );
-        while( handle_mouseview( ctxt, action ) ) {
-            if( action == "TIMEOUT" ) {
-                break;
-            }
-        }
         ctxt.reset_timeout();
+        handle_mouseview( ctxt, action );
     }
     return ctxt;
 }


### PR DESCRIPTION
#### Summary
Fix animations = false forcing real-time

#### Purpose of change
When animations were false, it was forcing real-time turn progression because of some unexpected behavior with animation timeout.

#### Describe the solution
There shouldn't be any animation timeout when animations are false, so just delete that part.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
