### PR TITLE
Fix error message when hunting via faction camp

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1954,7 +1954,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
                 popup( _( "You don't have enough food stored to feed your companion for this task." ) );
                 return result;
             } else {
-                popup( _( "You don't have enough food stored to feed a larger work crew." ) );
+                popup( _( "You don't have enough food stored to feed an entire work crew." ) );
                 break;
             }
         }
@@ -3774,7 +3774,10 @@ void basecamp::finish_return( npc &comp, const bool fixed_time, const std::strin
     validate_assignees();
 
     // Missions that are not fixed_time can try to draw more food than is in the food supply
-    feed_workers( comp, camp_food_supply( -need_food ) );
+    if( need_food > 0 ) {
+        nutrients meal = camp_food_supply( -need_food );
+        feed_workers( comp, -meal );
+    }
     if( has_water() ) {
         comp.set_thirst( 0 );
     }


### PR DESCRIPTION
#### Summary
Fix error message when hunting via faction camp

#### Purpose of change
Some faction camp jobs, like hunting, feed the worker before they leave. The code accounts for this when they get back, but fails to guard against an error message prompted by the way it handles the check.

#### Describe the solution
Similar to #1884 , set up a clearer and better meal deduction and don't run it if the kcal to eat are less than 1.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
