### PR TITLE
Fix large rock disassembly

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -30,7 +30,7 @@
     "skill_used": "fabrication",
     "time": "5 m",
     "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
-    "components": [ [ [ "rock", 24 ] ] ]
+    "components": [ [ [ "rock", 8 ] ], [ [ "gravel", 32 ] ], [ [ "pebble", 12 ] ] ]
   },
   {
     "result": "sheet_metal",

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2900,15 +2900,18 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             // Compress liquids and counted-by-charges items into one item,
             // they are added together on the map anyway and handle_liquid
             // should only be called once to put it all into a container at once.
-            if( newit.count_by_charges() || is_liquid ) {
+            if( ( newit.count_by_charges() && newit.type->stack_max != 1 ) || is_liquid ) {
                 newit.charges = compcount;
                 compcount = 1;
-            } else if( !newit.craft_has_charges() && newit.charges > 0 ) {
+            } else if( !newit.craft_has_charges() && newit.charges != 0 ) {
                 // tools that can be unloaded should be created unloaded,
                 // tools that can't be unloaded will keep their default charges.
                 newit.charges = 0;
             }
-
+            if( newit.type->stack_max > 1 ) {
+                compcount = newit.charges / newit.type->stack_max;
+                newit.charges = newit.type->stack_max;
+            }
             // If the recipe has a `FULL_MAGAZINE` flag, spawn any magazines full of ammo
             if( newit.is_magazine() && dis.has_flag( flag_FULL_MAGAZINE ) ) {
                 newit.ammo_set( newit.ammo_default(),

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8669,7 +8669,10 @@ bool item::count_by_charges() const
 
 int item::count() const
 {
-    return count_by_charges() ? charges : 1;
+    if( count_by_charges() && type->stack_max != 1 ) {
+        return charges;
+    }
+    return 1;
 }
 
 bool item::craft_has_charges() const


### PR DESCRIPTION
#### Summary
Fix large rock disassembly

#### Purpose of change
Disassembling a large rock with a pickaxe was producing one buggy rock with 24 charges, even though the item has a stack_max of 1.

#### Describe the solution
- Fix this
- Reduce the number of rocks you get when breaking a large rock, and add some gravel and pebbles. Rock-breaking doesn't perfectly divide a stone into smaller stones.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
