### PR TITLE
Fix gravel in rock deconstruction

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -30,7 +30,7 @@
     "skill_used": "fabrication",
     "time": "5 m",
     "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 5 ], [ "elec_jackhammer", 66 ] ] ],
-    "components": [ [ [ "rock", 8 ] ], [ [ "gravel", 32 ] ], [ [ "pebble", 12 ] ] ]
+    "components": [ [ [ "rock", 8 ] ], [ [ "material_gravel", 32 ] ], [ [ "pebble", 12 ] ] ]
   },
   {
     "result": "sheet_metal",


### PR DESCRIPTION
#### Summary
Fix gravel in rock deconstruction

#### Purpose of change
In #1894 I accidentally put "gravel" instead of "material_gravel".

#### Describe the solution
put

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
