### PR TITLE
Backport DDA 84466 - Stop serializing bad vehicle item_locations

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -483,6 +483,18 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         item_on_vehicle( const vehicle_cursor &cur, int idx ) : impl( idx ), cur( cur ) {}
 
         void serialize( JsonOut &js ) const override {
+            const std::vector<wrapped_vehicle> &vehicles = get_map().get_vehicles();
+            const auto same_veh = [this]( const wrapped_vehicle & wv ) {
+                return wv.v == &cur.veh;
+            };
+            if( std::find_if( vehicles.begin(), vehicles.end(), same_veh ) == vehicles.end() ) {
+                debugmsg( "Could not find vehicle for item_location on vehicle" );
+                // This is intended as a temporary patch, but if you're reading this you know how it goes sometimes.
+                // Serialize exactly like an item_location::nowhere just in case this sticks around long enough for that to change...
+                item_location dummy = item_location::nowhere;
+                dummy.serialize( js );
+                return;
+            }
             js.start_object();
             js.member( "type", "vehicle" );
             js.member( "position", pos_abs() );


### PR DESCRIPTION
#### Summary
Backport DDA 84466 - Stop serializing bad vehicle item_locations

#### Purpose of change
Fix one guy's crash issue, and possibly an issue that has been plaguing the game for years.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
