### PR TITLE
Backport DDA 84658 - Add more safety and sanity checks around zzip loading

### DIFF
--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -380,9 +380,15 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
             if( !file_exist( zzip_name ) ) {
                 return false;
             }
+
             std::optional<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
                                                 ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
-            if( !z || !z->has_file( file_name_path ) ) {
+            if( !z ) {
+                debugmsg( "Failed to load submaps from %s, could not open zzip.",
+                          zzip_name.generic_u8string().c_str() );
+                return false;
+            }
+            if( !z->has_file( file_name_path ) ) {
                 return false;
             }
             std::vector<std::byte> contents = z->get_file( file_name_path );


### PR DESCRIPTION
#### Summary
Backport DDA 84658 - Add more safety and sanity checks around zzip loading

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
