### PR TITLE
Fix battery form factor names

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -2117,26 +2117,26 @@
   {
     "id": "BATTERY_ULTRA_LIGHT",
     "type": "json_flag",
-    "info": "This item fits in items that use ultra-light batteries.",
-    "name": "ultra-light battery"
+    "info": "This fits in items that use watch batteries.",
+    "name": "watch battery"
   },
   {
     "id": "BATTERY_LIGHT",
     "type": "json_flag",
-    "info": "This item fits in items that use light batteries.",
-    "name": "light battery"
+    "info": "This fits in items that use dry cell batteries.",
+    "name": "dry cell battery"
   },
   {
     "id": "BATTERY_MEDIUM",
     "type": "json_flag",
-    "info": "This item fits in items that use medium batteries.",
-    "name": "medium battery"
+    "info": "This fits in items that use lithium batteries.",
+    "name": "lithium battery"
   },
   {
     "id": "BATTERY_HEAVY",
     "type": "json_flag",
-    "info": "This item fits in items that use heavy batteries.",
-    "name": "heavy battery"
+    "info": "This fits in items that use tool batteries.",
+    "name": "tool battery"
   },
   {
     "id": "METHANOL_TANK",


### PR DESCRIPTION
#### Summary
Fix battery form factor names

#### Purpose of change
The names of batteries were updated, but the magazine entry in the item info panel still used the old names.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
