### PR TITLE
More battery life fixes

### DIFF
--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -9,7 +9,7 @@
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "material": [ "plastic" ],
     "charges_per_use": 1,
-    "turns_per_charge": 5,
+    "turns_per_charge": 60,
     "weight": "670 g",
     "volume": "500 ml",
     "price": "60 USD",
@@ -51,8 +51,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_ULTRA_LIGHT" ],
-        "default_magazine": "light_minus_disposable_cell"
+        "flag_restriction": [ "BATTERY_LIGHT" ],
+        "default_magazine": "light_battery_cell"
       }
     ],
     "tool_ammo": [ "battery" ]
@@ -63,7 +63,7 @@
     "type": "TOOL",
     "name": { "str": "RC car (on)", "str_pl": "RC cars (on)" },
     "description": "A remote-controlled toy car.  It is turned on and draining its batteries just like a real electric car!  Use a remote control to drive it around.",
-    "turns_per_charge": 5,
+    "turns_per_charge": 60,
     "revert_to": "radio_car",
     "use_action": [ "RADIOCARON" ],
     "tick_action": [
@@ -126,8 +126,9 @@
     "type": "TOOL",
     "name": { "str": "radio (on)", "str_pl": "radios (on)" },
     "description": "A portable radio that is turned on and continually draining its batteries.  It is playing the broadcast being sent from any nearby radio towers.",
-    "power_draw": "500 mW",
+    "power_draw": "150 mW",
     "revert_to": "radio",
+    "charges_per_use": 0,
     "use_action": [
       "RADIO_ON",
       { "type": "link_up", "menu_text": "Plug in / Unplug", "ammo_scale": 0, "cable_length": 3, "charge_rate": "5 W" },
@@ -177,7 +178,7 @@
     "color": "yellow",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "charges_per_use": 1,
-    "turns_per_charge": 5,
+    "turns_per_charge": 60,
     "use_action": [ "REMOTEVEH" ],
     "tick_action": "REMOTEVEH_TICK",
     "pocket_data": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -863,7 +863,7 @@
       "target": "wearable_light_on",
       "active": true,
       "need_charges": 1,
-      "need_charges_msg": "The headlamp batteries are dead."
+      "need_charges_msg": "The headlamp's batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [
@@ -937,6 +937,7 @@
     "description": "An LED headlamp with an adjustable strap so as to be comfortably worn on your head or attached to your helmet.  It is turned on, and continually draining batteries.  Use it to turn it off.",
     "flags": [ "LIGHT_300", "CHARGEDIM", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRADER_AVOID" ],
     "power_draw": "750 mW",
+    "charges_per_use": 0,
     "revert_to": "wearable_light",
     "use_action": {
       "ammo_scale": 0,

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6434,7 +6434,7 @@
     "id": "drone_op",
     "name": "Drone Operator",
     "npc_background": "BG_survival_story_WORKER_PUBLIC",
-    "description": "You had a job programming machines such as automatic street cleaners, newsbots, and pizza delivery drones.  Bionic implants helped you control them remotely.  Now all the drones carry guns instead of pizza.  At least you still have a… RC car?",
+    "description": "You had a job programming machines such as automatic street cleaners, newsbots, and pizza delivery drones.  Bionic implants helped you control them remotely.  Now all the drones carry guns instead of pizza.  At least you still have an… RC car?",
     "points": 1,
     "CBMs": [ "bio_cable", "bio_power_storage", "bio_remote" ],
     "skills": [ { "level": 2, "name": "computer" } ],


### PR DESCRIPTION
#### Summary
More battery life fixes

#### Purpose of change
A bunch of devices had bad battery life amounts.

#### Describe the solution
- RC cars and RC controllers should both last about 10 minutes. The cars now use dry cell batteries.
- Radios now use about 1/4 of the power they did previously.
- Radios and headlamps no longer cost power to turn off.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
