### PR TITLE
Backport DDA 83387 - Bump up dmg size limit in macOS release build

### DIFF
--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -37,7 +37,7 @@ def icon_from_app(app_path):
 format = defines.get('format', 'UDBZ')
 
 # Volume size (must be large enough for your files)
-size = defines.get('size', '400M')
+size = defines.get('size', '500M')
 
 # Files to include
 files = [application]


### PR DESCRIPTION
#### Summary
Backport DDA 83387 - Bump up dmg size limit in macOS release build

#### Purpose of change
mac build fail because limit too small

#### Describe the solution
make limit big


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
