### PR TITLE
Migrate yet another horribly named battery ID

### DIFF
--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3757,5 +3757,10 @@
     "type": "MIGRATION",
     "id": "hallula",
     "replace": "bread"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "medium_plus_battery_cell",
+    "replace": "medium_battery_cell"
   }
 ]


### PR DESCRIPTION
#### Summary
Migrate yet another horribly named battery ID

#### Purpose of change
medium_plus_battery_cell wasn't caught during the migrations.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
