### PR TITLE
Sky Island fixes

### DIFF
--- a/data/mods/Sky_Island/monstergroups.json
+++ b/data/mods/Sky_Island/monstergroups.json
@@ -103,7 +103,6 @@
       { "monster": "mon_zombear_skeleton", "weight": 10 },
       { "monster": "mon_zoose_thorny", "weight": 5 },
       { "monster": "mon_dog_skeleton_brute", "weight": 50 },
-      { "monster": "mon_devourer", "weight": 25 },
       { "monster": "mon_zombullfrog", "weight": 10 },
       { "monster": "mon_zombie_survivor_elite", "weight": 15 },
       { "monster": "mon_zombie_spitter", "weight": 75 },

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -131,7 +131,7 @@
       [ [ "warptoken", 2 ] ],
       [ [ "cu_pipe", 5 ] ],
       [ [ "duct_tape", 20 ] ],
-      [ [ "light_plus_battery_cell", 5 ], [ "light_battery_cell", 10 ], [ "light_disposable_cell", 15 ] ],
+      [ [ "light_battery_cell", 5 ], [ "light_cell_rechargeable", 15 ] ],
       [ [ "cordage", 1, "LIST" ] ]
     ]
   },
@@ -196,7 +196,7 @@
       [ [ "warptoken", 5 ] ],
       [ [ "scrap_aluminum", 12 ] ],
       [ [ "super_glue", 1 ], [ "bone_glue", 1 ] ],
-      [ [ "medium_battery_cell", 2 ], [ "medium_plus_battery_cell", 4 ], [ "medium_disposable_cell", 6 ] ],
+      [ [ "medium_battery_cell", 2 ] ],
       [ [ "extension_cable", 1 ], [ "long_extension_cable", 1 ], [ "jumper_cable", 1 ] ]
     ]
   },
@@ -262,7 +262,7 @@
       [ [ "microscope", 1 ] ],
       [ [ "silver_small", 20 ] ],
       [ [ "brazing_rod_bronze", 5 ], [ "brazing_rod_alloy", 5 ] ],
-      [ [ "heavy_plus_battery_cell", 1 ], [ "heavy_battery_cell", 2 ], [ "heavy_disposable_cell", 4 ] ],
+      [ [ "heavy_plus_battery_cell", 1 ], [ "heavy_battery_cell", 2 ] ],
       [ [ "rope_30", 1 ] ]
     ]
   },


### PR DESCRIPTION
#### Summary
Sky Island fixes

#### Purpose of change
Some bad IDs still lingered in Sky Island.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
