### PR TITLE
Lips to mouth and battery migration

### DIFF
--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -1281,7 +1281,7 @@
     "parent": "mouth",
     "opposite": "sub_limb_debug",
     "side": 0,
-    "name": "lips"
+    "name": "mouth"
   },
   {
     "id": "mouth_nose",

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3654,6 +3654,31 @@
     "replace": "light_battery_cell"
   },
   {
+    "id": "light_minus_atomic_battery_cell",
+    "type": "MIGRATION",
+    "replace": "light_minus_battery_cell"
+  },
+  {
+    "id": "light_atomic_battery_cell",
+    "type": "MIGRATION",
+    "replace": "light_battery_cell"
+  },
+  {
+    "id": "medium_atomic_battery_cell",
+    "type": "MIGRATION",
+    "replace": "medium_battery_cell"
+  },
+  {
+    "id": "medium_dry_cell",
+    "type": "MIGRATION",
+    "replace": "medium_battery_cell"
+  },
+  {
+    "id": "heavy_dry_cell",
+    "type": "MIGRATION",
+    "replace": "heavy_battery_cell"
+  },
+  {
     "type": "MIGRATION",
     "id": "wearable_big_light",
     "replace": "wearable_light"


### PR DESCRIPTION
#### Summary
Lips to mouth and battery migration

#### Purpose of change
The "mouth" part was changed to "face" as it does encompass the entire face, so let's change the lips subpart to mouth, 'cause not everyone has lips.

Some leftover battery IDs were still haunting old saves.

#### Describe the solution
Lips -> Mouth
Fix old batteries.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
