### PR TITLE
Gradual mutation and retractable claws fixes

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
@@ -32,6 +32,7 @@
     "id": "EOC_LOSE_MUTATING_GRADUAL",
     "effect": [
       { "u_message": "The everpresent churning in your tortured flesh finally ceases.  Is it over?" },
+      { "u_lose_trait": "MUTATING_GRADUAL_ABSTRACT" },
       { "u_lose_trait": "MUTATING_GRADUAL_BATRACHIAN" },
       { "u_lose_trait": "MUTATING_GRADUAL_BIRD" },
       { "u_lose_trait": "MUTATING_GRADUAL_CATTLE" },
@@ -86,8 +87,7 @@
     "effect": [
       {
         "if": { "math": [ "u_has_trait(u_MUTATING_GRADUAL_threshold)" ] },
-        "then": { "u_message": "You are new born, complete." },
-        "else": [ { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
+        "then": [ { "u_message": "You are new born, complete." }, { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
       }
     ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3644,6 +3644,7 @@
   {
     "type": "mutation",
     "id": "CLAWS_RETRACT_active",
+    "copy-from": "CLAWS_RETRACT",
     "name": { "str": "Extended Claws" },
     "points": 2,
     "active": true,


### PR DESCRIPTION
#### Summary
Gradual mutation and retractable claws fixes

#### Purpose of change
- Gradual mutation wasn't properly removing when you crossed the threshold.
- More retractable claws problems.

#### Describe the solution
- Remove "else" in the gradual mutation removal EOC.
- Make extended claws copy-from retractable claws and give both a prevented_by.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
