### PR TITLE
Frerunning is running

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -388,6 +388,7 @@ static const morale_type morale_cold( "morale_cold" );
 static const morale_type morale_hot( "morale_hot" );
 
 static const move_mode_id move_mode_prone( "prone" );
+static const move_mode_id move_mode_run( "run" );
 static const move_mode_id move_mode_walk( "walk" );
 
 static const mtype_id mon_player_blob( "mon_player_blob" );
@@ -10759,7 +10760,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                               1 );
         run_cost_effect_mul( obstacle_mult, _( "Obstacle Muts." ) );
 
-        if( has_proficiency( proficiency_prof_parkour ) && !is_prone() ) {
+        if( has_proficiency( proficiency_prof_parkour ) && is_running() ) {
             run_cost_effect_mul( 0.5, _( "Parkour" ) );
         }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1526,7 +1526,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
 
         if( you.has_proficiency( proficiency_prof_parkour ) ) {
             add_msg( _( "You vault over the obstacle with ease." ) );
-            move_cost = 100; // Not tall enough to warrant spider-climbing, so only relevant trait.
+            move_cost = 150; // Not tall enough to warrant spider-climbing, so only relevant trait.
         } else {
             add_msg( _( "You vault over the obstacle." ) );
             move_cost = 300; // Most common move cost for barricades pre-change.
@@ -1541,14 +1541,14 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
     } else if( you.has_trait( trait_ARACHNID_ARMS_OK ) &&
                !you.wearing_fitting_on( bodypart_id( "torso" ) ) ) {
         add_msg( _( "Climbing this obstacle is trivial for one such as you." ) );
-        move_cost = 75; // Yes, faster than walking.  6-8 limbs are impressive.
+        move_cost = 100;
     } else if( you.has_trait( trait_INSECT_ARMS_OK ) &&
                !you.wearing_fitting_on( bodypart_id( "torso" ) ) ) {
-        add_msg( _( "You quickly scale the fence." ) );
-        move_cost = 90;
+        add_msg( _( "You quickly skitter over the obstacle." ) );
+        move_cost = 100;
     } else if( you.has_proficiency( proficiency_prof_parkour ) ) {
         add_msg( _( "This obstacle is no match for your freerunning abilities." ) );
-        move_cost = 100;
+        move_cost = 200;
     } else {
         move_cost = you.has_trait( trait_BADKNEES ) ? 800 : 400;
         if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_furn_CLIMBABLE ) ) {


### PR DESCRIPTION
#### Summary
Frerunning is running

#### Purpose of change
Parkour was too much of a no brainer as it always provided its bonuses unless you were prone, adding no cost of its own. That isn't really how parkour works!

#### Describe the solution
- Climbing fences etc. is now standardized, and having spider legs doesn't make you climb fences faster than you can walk (???)
- Parkour now only reduces move speed over obstacles when you're running.
- Parkour still reduces fall damage and aids climbing whether you're running or not.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
