### PR TITLE
Temporarily disable XXXL

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1238,7 +1238,7 @@
     "points": -1,
     "description": "You gained an awful lot of weight before the Cataclysm.  Whatever the reason, now that mobility is key to survival, your oversized figure presents an additional danger.  You need to lose weight or die trying.",
     "purifiable": false,
-    "starting_trait": true,
+    "starting_trait": false,
     "player_display": false,
     "valid": false,
     "cancels": [ "XS" ]


### PR DESCRIPTION
#### Summary
Temporarily disable XXXL

#### Purpose of change
The XXXL trait is a good idea, but it isn't currently providing the intended challenge, and is instead a tremendous advantage which allows the player to ignore most of the survival mechanics for several months of game time. This is because we don't yet have any notion of hunger, blood sugar, electrolyte balance, ketosis, etc. Entirely avoiding food for weeks should be a fatal risk, and unberable trial, not an easy way to lose weight.

#### Describe the solution
Set starting_trait to false until we have that all sorted.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
