### PR TITLE
Sane-ify beehives

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -2207,7 +2207,7 @@
       "sound": "crunch!",
       "sound_fail": "whack!",
       "ter_set": "t_tree",
-      "items": [ { "item": "wax", "count": [ 3, 6 ] }, { "item": "honeycomb", "count": [ 3, 6 ] } ]
+      "items": [ { "item": "wax", "count": [ 2, 4 ] }, { "item": "honeycomb", "count": [ 3, 6 ] } ]
     }
   },
   {

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -58,7 +58,7 @@
     "id": "beehive_harv",
     "type": "harvest",
     "message": "You carefully crack open the hive structure and drain the liquid.",
-    "entries": [ { "drop": "honeycomb", "base_num": [ 30, 180 ] }, { "drop": "wax", "base_num": [ 4, 5 ] } ]
+    "entries": [ { "drop": "honeycomb", "base_num": [ 10, 40 ] }, { "drop": "wax", "base_num": [ 4, 5 ] } ]
   },
   {
     "id": "jerusalem_artichoke_harv",


### PR DESCRIPTION
#### Summary
Sane-ify beehives

#### Purpose of change
Natural, wild beehives were producing up to 22 liters of honey. That's technically possible at the outside, but often it's far lower IRL. Given that you can raise your own hives, this begins to be a problem.
- There's nothing simulating the bees mutating or dying off.
- There's nothing simulating pests harming your bees.
- The amount of honey is pure RNG and isn't affected by weather or skill or weighted toward a poorer harvest.
- None of the work of maintaining apiaries is simulated.

#### Describe the solution
- Significantly reduce the amount of honey from 30-180 combs to 10-40 combs. This is only about 5 liters of honey max, which is less than you might get from a very large, healthy hive that was very successful in a year, but reasonable for a random hive in the middle of an ecological disaster.

#### Describe alternatives you've considered
Bring this number back up when the concerns in purpose of change are addressed.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
