### PR TITLE
fix cooked meat recipes

### DIFF
--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -550,6 +550,7 @@
     "//": "cooked red meat.",
     "components": [
       [
+        [ "meat_cooked", 1 ],
         [ "meat_fatty_cooked", 1 ],
         [ "meat_scrap_cooked", 10 ],
         [ "mutant_meat_cooked", 1 ],


### PR DESCRIPTION
#### Summary
Fix coooked meat missing as a component in many recipes

#### Purpose of change
Enable player to make meat recipes, currently only 3 are available

#### Describe the solution
Re-add the line removed by this commit https://github.com/Cataclysm-TLG/Cataclysm-TLG/commit/96e8d8d

#### Describe alternatives you've considered
None.

#### Testing
Spawned fresh character, used debug to set all skills to 10 and learn all recipes, open craft menu, filter "c:cooked meat", can sandwiches and burgers again

#### Additional context
Before
<img width="1257" height="807" alt="image" src="https://github.com/user-attachments/assets/d2716176-ee61-4593-a8bd-df9de05a9ee5" />

After
<img width="1858" height="1080" alt="image" src="https://github.com/user-attachments/assets/0e32b6bb-623f-42d7-99ad-d80fdee3be6d" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
