### PR TITLE
Fix horse mount weight ratio; also, adjust horse weight to be 500 kg ( ~1,100 lbs) instead of 450 kg (  ~990 lbs)

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1131,7 +1131,7 @@
     "categories": [ "WILDLIFE" ],
     "species": [ "MAMMAL" ],
     "volume": "475000 ml",
-    "weight": "450 kg",
+    "weight": "500 kg",
     "hp": 260,
     "speed": 260,
     "attack_cost": 230,
@@ -1160,6 +1160,7 @@
     "special_attacks": [ { "id": "smash", "throw_strength": 49 }, [ "EAT_CROP", 100 ], [ "GRAZE", 50 ] ],
     "zombify_into": "mon_zombie_horse",
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
+    "mountable_weight_ratio": 0.35,    
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
#### Summary
Adds a missing line to the json object entry for horses to have their mountable_weight _ratio be the (seemingly standard) 0.35. As well, I added 50kg to horses' weight to facilitate people playing taller characters ( me, presumably others who like to self-insert ) being able to ride horses for their roleplaying satisfaction without having to be naked.

#### Purpose of change

Horses are one of the only seemingly intentional mounts who have their weight ratio set to the default 0.2 rather than 0.35, which comes out to 200 total lbs ( including gear ). This was an unwelcome surprise to my string of self insert tall survivors, since more than a couple inches over the default height of 5'9" causes you to weigh more than that butt-naked.

The intent is to let people play tall cowboys and cattle rusters and whatnot, or average height cowpokes who carry a lot of stuff, or to just let people ride horses without micromanaging their weight to a decidedly unfun degree. 

#### Describe the solution

Increase horse weight to 500 kg to put their .35 mount_weight_ratio at 385 lbs, which lets a hefty character mount up with a solid kit.

#### Describe alternatives you've considered

I considered leaving the weight at 450, but the extra 50 kgs buts their mountable ratio at a rounder 175kg instead, while also facilitating playstyle freedom without significantly disturbing gameplay balance otherwise.

#### Testing

##### Without change


https://github.com/user-attachments/assets/3646acec-43ca-42a6-a07f-2d6db3e4f9e0



##### With change


https://github.com/user-attachments/assets/33dc3d4b-312e-4139-9b8a-4dc7f06ee1cd



#### Additional context



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
