### PR TITLE
Spears for sojutsu

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1307,7 +1307,7 @@
       {
         "id": "buff_sojutsu_static",
         "name": "Sōjutsu Stance",
-        "description": "Your training grants better defense while using a polearm.\n\n+1 block attempt, +2 blocking effectiveness.",
+        "description": "Your training grants better defense while using a spear.\n\n+1 block attempt, +2 blocking effectiveness.",
         "melee_allowed": true,
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 2.0 } ]
@@ -1329,7 +1329,7 @@
       }
     ],
     "techniques": [ "tec_sojutsu_feint", "tec_sojutsu_shove", "tec_sojutsu_trip", "tec_sojutsu_jab" ],
-    "weapon_category": [ "POLEARMS" ]
+    "weapon_category": [ "SPEARS" ]
   },
   {
     "type": "martial_art",


### PR DESCRIPTION
#### Summary
Spears for sojutsu

#### Purpose of change
sojutsu for some reason was using polearms. It's literally the spear style.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
