### PR TITLE
Fix migration

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2563,44 +2563,9 @@
     "warmth": 30,
     "material_thickness": 0.5,
     "environmental_protection": 2,
-    "use_action": {
-      "target": "turtleneck_rolled",
-      "menu_text": "Roll neck",
-      "msg": "You adjust the neck and collar of the turtleneck.",
-      "type": "transform"
-    },
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS", "COLLAR" ],
     "armor": [
       { "encumbrance": 3, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r", "mouth" ] },
-      { "encumbrance": 1, "coverage": 100, "covers": [ "head" ], "specifically_covers": [ "head_throat" ] }
-    ]
-  },
-  {
-    "id": "turtleneck_rolled",
-    "type": "TOOL_ARMOR",
-    "name": { "str": "turtleneck (rolled)", "str_pl": "turtlenecks (rolled)" },
-    "description": "This wool turtleneck's neck is rolled out of the way of the mouth.",
-    "category": "clothing",
-    "weight": "478 g",
-    "volume": "2500 ml",
-    "price": "50 USD",
-    "price_postapoc": "60 cent",
-    "material": [ "wool" ],
-    "symbol": "[",
-    "looks_like": "sweater",
-    "color": "white",
-    "warmth": 30,
-    "material_thickness": 0.5,
-    "environmental_protection": 2,
-    "use_action": {
-      "target": "turtleneck",
-      "menu_text": "Unroll neck",
-      "msg": "You adjust the neck and collar of the turtleneck.",
-      "type": "transform"
-    },
-    "flags": [ "VARSIZE", "FANCY", "ALLOWS_NATURAL_ATTACKS" ],
-    "armor": [
-      { "encumbrance": 3, "coverage": 100, "covers": [ "torso", "arm_l", "arm_r" ] },
       { "encumbrance": 1, "coverage": 100, "covers": [ "head" ], "specifically_covers": [ "head_throat" ] }
     ]
   },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3780,6 +3780,11 @@
   },
   {
     "type": "MIGRATION",
+    "id": "turtleneck_rolled",
+    "replace": "turtleneck"
+  },
+  {
+    "type": "MIGRATION",
     "id": "hallula",
     "replace": "bread"
   },

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -16,8 +16,7 @@
         [ "cornbread", 1 ],
         [ "biscuit", 1 ],
         [ "hardtack", 1 ],
-        [ "crackers", 1 ],
-        [ "hallula", 1 ]
+        [ "crackers", 1 ]
       ]
     ]
   },
@@ -31,8 +30,7 @@
         [ "wastebread", 1 ],
         [ "sourdough_bread", 1 ],
         [ "brioche", 1 ],
-        [ "brown_bread", 1 ],
-        [ "hallula", 1 ],
+        [ "brown_bread", 1 ]
         [ "snack_bread", 1 ]
       ]
     ]
@@ -682,7 +680,6 @@
         [ "hardtack", 1 ],
         [ "wastebread", 1 ],
         [ "sourdough_bread", 1 ],
-        [ "hallula", 1 ],
         [ "brioche", 1 ],
         [ "flour", 2 ],
         [ "cornmeal", 2 ],
@@ -748,7 +745,6 @@
         [ "wastebread", 1 ],
         [ "sourdough_bread", 1 ],
         [ "brioche", 1 ],
-        [ "hallula", 1 ],
         [ "flour", 2 ],
         [ "cornmeal", 2 ],
         [ "milk_powder", 1 ],


### PR DESCRIPTION
#### Summary
Fix migration

#### Purpose of change
Hallula still existed in requirements, which may have been causing some crashes.

#### Describe the solution
Finish killing hallula, remove rolled turtleneck and give it COLLAR instead.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
