### PR TITLE
Fix vehicle interact display

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2349,7 +2349,7 @@ void veh_interact::display_veh( map &here )
     //Iterate over structural parts so we only hit each square once
     for( const int structural_part_idx : veh->all_parts_at_location( "structure" ) ) {
         const vehicle_part &vp = veh->part( structural_part_idx );
-        const vpart_display vd = veh->get_display_of_tile( vp.mount, false, false );
+        const vpart_display vd = veh->get_display_of_tile( vp.mount, false, true );
         const point_rel_ms q = ( vp.mount + dd ).rotate( 3 );
 
         if( q != point_rel_ms::zero ) { // cursor is not on this part


### PR DESCRIPTION
#### Summary
Fix vehicle interact display

#### Purpose of change
The display of vehicle parts in the interact menu was broken. This was because a bool was accidentally given as false.

#### Describe the solution
true

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
