### PR TITLE
Hide bio_armor tiles

### DIFF
--- a/data/json/mutations/mutation_ordering.json
+++ b/data/json/mutations/mutation_ordering.json
@@ -84,9 +84,6 @@
           "CRUSTACEAN_CARAPACE",
           "CRUSTACEAN_CARAPACE_MOLTED",
           "bio_deformity",
-          "bio_armor_head",
-          "bio_armor_legs",
-          "bio_armor_torso",
           "bio_armor_eyes",
           "bio_blindfold",
           "bio_face_mask"
@@ -163,7 +160,7 @@
         "order": 3000
       },
       {
-        "id": [ "bio_blade", "bio_blaster", "bio_emp_armgun", "bio_dis_acid", "bio_evap", "bio_ads", "bio_armor_arms" ],
+        "id": [ "bio_blade", "bio_blaster", "bio_emp_armgun", "bio_dis_acid", "bio_evap", "bio_ads" ],
         "order": 3250
       },
       {


### PR DESCRIPTION
#### Summary
Hide bio_armor tiles

#### Purpose of change
As bio_armor (other than eyes) no longer exists on the outside of the body, they shouldn't have tiles anymore.

#### Describe the solution
Remove the torso/head/arms/legs tiles.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
