### PR TITLE
Remove bees from forage tables

### DIFF
--- a/data/json/itemgroups/Agriculture_Forage_Excavation/forage.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/forage.json
@@ -20,8 +20,17 @@
       { "item": "carrot_wild", "prob": 5, "count": [ 3, 6 ] },
       { "item": "bee_balm", "prob": 5, "count": [ 4, 8 ] },
       { "item": "mugwort", "prob": 5, "count": [ 1, 2 ] },
-      { "item": "antler", "prob": 1, "count": [ 1, 2 ] },
-      { "item": "swarm_bees", "prob": 2 }
+      { "item": "rock_flaking", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "rock", "prob": 2, "count": [ 1, 2 ] },
+      { "item": "bone", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "stick_long", "prob": 1 },
+      { "item": "stick", "prob": 1 },
+      { "item": "splinter", "prob": 1 },
+      { "item": "log", "prob": 1 },
+      { "item": "leaves", "prob": 3 },
+      { "item": "pebble", "prob": 2, "charges": [ 1, 10 ] },
+      { "item": "feather", "prob": 2, "charges": [ 1, 10 ] },
+      { "item": "antler", "prob": 1, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -29,6 +38,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
+      { "item": "young_leaves", "prob": 30, "count": [ 1, 4 ] },
       { "item": "mayapple", "prob": 10, "count": [ 1, 3 ] },
       { "item": "plant_stalk", "prob": 10, "count": [ 1, 3 ] },
       { "item": "groundnut", "prob": 3, "count": [ 1, 6 ] },
@@ -44,6 +54,16 @@
       { "item": "dogbane", "prob": 10, "count": [ 1, 3 ] },
       { "item": "bee_balm", "prob": 10, "count": [ 1, 3 ] },
       { "item": "mugwort", "prob": 10, "count": [ 1, 3 ] },
+      { "item": "rock_flaking", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "rock", "prob": 2, "count": [ 1, 2 ] },
+      { "item": "bone", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "stick_long", "prob": 1 },
+      { "item": "stick", "prob": 1 },
+      { "item": "splinter", "prob": 1 },
+      { "item": "log", "prob": 1 },
+      { "item": "leaves", "prob": 3 },
+      { "item": "pebble", "prob": 2, "charges": [ 1, 10 ] },
+      { "item": "feather", "prob": 2, "charges": [ 1, 10 ] },
       { "item": "salsify_raw", "prob": 5, "count": [ 1, 2 ] }
     ]
   },
@@ -67,6 +87,16 @@
       { "item": "bee_balm", "prob": 5, "count": [ 1, 3 ] },
       { "item": "mugwort", "prob": 5, "count": [ 1, 3 ] },
       { "item": "salsify_raw", "prob": 5, "count": [ 1, 3 ] },
+      { "item": "rock_flaking", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "rock", "prob": 2, "count": [ 1, 2 ] },
+      { "item": "bone", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "stick_long", "prob": 1 },
+      { "item": "stick", "prob": 1 },
+      { "item": "splinter", "prob": 1 },
+      { "item": "log", "prob": 1 },
+      { "item": "leaves", "prob": 10 },
+      { "item": "pebble", "prob": 2, "charges": [ 1, 10 ] },
+      { "item": "feather", "prob": 1, "charges": [ 1, 10 ] },
       { "item": "antler", "prob": 1, "count": [ 1, 2 ] }
     ]
   },
@@ -74,7 +104,17 @@
     "id": "forage_winter",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "wintergreen_berry", "prob": 2, "count": [ 1, 3 ] } ]
+    "entries": [ { "item": "wintergreen_berry", "prob": 4, "count": [ 1, 3 ] },
+      { "item": "rock_flaking", "prob": 2, "count": [ 1, 2 ] },
+      { "item": "rock", "prob": 8, "count": [ 1, 2 ] },
+      { "item": "bone", "prob": 1, "count": [ 1, 2 ] },
+      { "item": "stick_long", "prob": 2 },
+      { "item": "stick", "prob": 3 },
+      { "item": "splinter", "prob": 30 },
+      { "item": "log", "prob": 1 },
+      { "item": "leaves", "prob": 5 },
+      { "item": "pebble", "prob": 6, "charges": [ 1, 10 ] },
+      { "item": "feather", "prob": 1, "charges": [ 1, 10 ] } ]
   },
   {
     "id": "forage_mushroom",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1191,7 +1191,6 @@
     "comestible_type": "INVALID",
     "name": { "str": "swarm of bees", "str_pl": "swarms of bees" },
     "description": "A swarm of honey bees, displaced from the hive.  Without the support and nutrients of an apiary, or taking root somewhere, they will die in a few days.",
-    "//": "While bees have mass and volume, it is easier to round to zero for the purposes of the game.",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "spoils_in": "2 days",


### PR DESCRIPTION
#### Summary
Remove bees from forage tables

#### Purpose of change
It was possible, though rare, to find bee swarms while foraging in spring. A determined player was able to find nineteen of these in one week of game time, then built 19 apiaries. This could yield up to 360,000 kcal of honey, or enough for around 200 days of survival.

That is pretty silly, but also bee colonies are really really really spread out IRL. We already have the naturally-occurring beehives to represent this, so adding in random swarms that can be found in any bush vastly increases their density over what is already modeled on real-world numbers.

Additionally, there's just too much food in the loot tables and not enough random crap.

#### Describe the solution
- Remove bees.
- Add some random crap for all seasons. Some of it is potentially useful. Most of it is fairly uncommon so it shouldn't skew the reward for basic foraging too much, and finding a bone or some feathers might actually be really nice for innawood play.

#### Describe alternatives you've considered
Adding more human trash, but that requires checking how far we are from a town or road, so I'll put it off.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
