### PR TITLE
Fix tutorial batteries and text

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/ammo.json
@@ -860,7 +860,6 @@
     "subtype": "distribution",
     "entries": [
       { "item": "light_battery_cell", "prob": 25, "charges": [ 0, 100 ] },
-      { "item": "light_minus_battery_cell", "prob": 12, "charges": [ 0, 50 ] },
       { "item": "light_battery_cell", "prob": 9, "charges": [ 0, 150 ] },
       { "item": "light_battery_cell", "prob": 50, "charges": [ 0, 300 ] }
     ]
@@ -870,7 +869,6 @@
     "id": "ammo_light_batteries_full",
     "items": [
       { "item": "light_battery_cell", "prob": 25, "charges": 100 },
-      { "item": "light_minus_battery_cell", "prob": 12, "charges": 50 },
       { "item": "light_battery_cell", "prob": 9, "charges": 150 },
       { "item": "light_battery_cell", "prob": 50, "charges": 300 }
     ]

--- a/data/json/mapgen/tutorial.json
+++ b/data/json/mapgen/tutorial.json
@@ -89,7 +89,7 @@
         "Ŗ": { "item": "uzimag", "chance": 100 },
         "Ř": { "item": "9mm", "chance": 100 },
         "$": { "item": "backpack", "chance": 100 },
-        "@": [ { "item": "light_battery_cell", "chance": 100 }, { "item": "flashlight", "chance": 100 } ],
+        "@": [ { "item": "flashlight", "chance": 100 } ],
         "%": { "item": "helmet_ball", "chance": 100 },
         "^": { "item": "mask_dust", "chance": 100 },
         "*": { "item": "paint_brush", "chance": 100 },
@@ -97,7 +97,8 @@
         "_": { "item": "codeine", "chance": 100 },
         "C": [ { "item": "peanutbutter", "chance": 100 }, { "item": "crackers", "chance": 100, "repeat": 2 } ]
       },
-      "items": { "(": { "item": "paint_tutorial", "chance": 100 } },
+      "items": { "(": { "item": "paint_tutorial", "chance": 100 },
+    "@": { "item": "ammo_light_batteries_full", "chance": 100 } },
       "monster": { "d": { "monster": "mon_dummy_tutorial" } },
       "traps": {
         "1": "tr_tutorial_1",

--- a/data/json/snippets/tutorial.json
+++ b/data/json/snippets/tutorial.json
@@ -37,7 +37,7 @@
       },
       {
         "id": "LESSON_PICKUP",
-        "text": "You just stepped on a space with one or more items.  If you wish to pick it up, press <keybind:pickup>.  To select the tile directly underneath you, press <keybind:pause>.\n\nIn the <color_light_cyan>Pickup</color> menu, press:\n<keybind:RIGHT> to select the items you wish to pick up\n<keybind:LEFT> to deselect\n<keybind:CONFIRM> to confirm\n\nNote that you don't need to stand directly on the space with items to pick them up, you can pick them up when standing near them.\n\nIf the item is too big to fit in any of your pockets, or is a weapon that you want to wield, you can press <keybind:wield> to wield it from the ground or from the <color_light_cyan>Pickup</color> menu.\n\nTo continue the tutorial, please pick up the <color_light_cyan>baseball bat</color> you're standing on and move to the door to the south."
+        "text": "You just stepped on a space with one or more items.  If you wish to pick it up, press <keybind:pickup>.  To select the tile directly underneath you, press <keybind:pause>.\n\nIn the <color_light_cyan>Pickup</color> menu, press:\n<keybind:RIGHT> to select the items you wish to pick up\n<keybind:LEFT> to deselect\n<keybind:CONFIRM> to confirm\n\nNote that you don't need to stand directly on the space with items to pick them up, you can pick them up when standing near them.\n\nIf the item is too big to fit in any of your pockets, or is a weapon that you want to wield, you can press <keybind:wield> to wield it from the ground or from the <color_light_cyan>Pickup</color> menu.\n\nTo continue the tutorial, please <color_light_cyan>wield</color> the baseball bat you're standing on and move to the door to the south."
       },
       {
         "id": "LESSON_EXAMINE",
@@ -177,7 +177,7 @@
       },
       {
         "id": "LESSON_FLASHLIGHT",
-        "text": "There is a <color_light_cyan>flashlight</color> and a <color_light_cyan>light disposable battery</color> lying on the rack.  Flashlights are very useful tools as they allow you to see in the dark.\n\nTo continue the tutorial, please reload the flashlight by pressing <keybind:reload_item>.  Take it with you and move to the stairs."
+        "text": "There is a <color_light_cyan>flashlight</color> and a <color_light_cyan>dry cell battery</color> lying on the rack.  Flashlights are very useful tools as they allow you to see in the dark.\n\nTo continue the tutorial, please reload the flashlight by pressing <keybind:reload_item>.  Take it with you and move to the stairs."
       },
       {
         "id": "LESSON_REMOTE_USE",


### PR DESCRIPTION
#### Summary
Fix tutorial batteries and text

#### Purpose of change
- The tutorial wasn't correctly spawning batteries, because the way batteries work was changed.
- The tutorial was telling people to pick up a bat when they actually needed to wield it.

#### Describe the solution
- Instruct the player to wield the bat, not pick it up.
- Fix the flashlight situation so that it spawns next to a full battery.
- Update the text to say dry cell battery and not disposable light battery.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
