### PR TITLE
Fix nail board destruction message

### DIFF
--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -137,7 +137,6 @@
     "price_postapoc": "10 cent",
     "material": [ "wheat", "powder" ],
     "volume": "24 ml",
-    "//": "240 ml is equivalent to 1 cup of flour.  10 charges is roughly equivalent to a cup of flour for American recipes.",
     "flags": [ "EDIBLE_FROZEN", "RAW" ],
     "vitamins": [ [ "iron", 3 ], [ "wheat_allergen", 1 ] ],
     "fun": -5

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -295,13 +295,13 @@ bool trapfunc::board( const tripoint_bub_ms &p, Creature *c, item * )
     // Weight of 150kg+ is guaranteed to break the trap, linear chance as weight increases.
     if( x_in_y( c->get_weight() / 1_kilogram, 150 ) ) {
         // Destroy trap.
-        here.remove_trap( p );
         if( !c->is_avatar() ) {
             add_msg_if_player_sees( p, _( "%s destroys a %s as they move over it!" ),
                                     c->disp_name( false, true ), here.tr_at( p ).name() );
         } else {
             add_msg( _( "You destroy the %s as you step on it!" ), here.tr_at( p ).name() );
         }
+        here.remove_trap( p );
     } else if( x_in_y( 40, 100 ) ) {
         // 40% chance disarm trap
         here.tr_at( p ).on_disarmed( here, p );


### PR DESCRIPTION
#### Summary
Fix nail board destruction message

#### Purpose of change
The %1s steps on a %2s, destroying it! message was displaying after the trap had been destroyed, resulting in it saying someone stepped on a Nothing

#### Describe the solution
Move the message to before the trap is removed.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
