### PR TITLE
Backport DDA 80040 - Cache item factory all to speed up d: filter by ~2s or ~10%

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5242,17 +5242,6 @@ const std::vector<const itype *> &Item_factory::all() const
     return templates_all_cache;
 }
 
-std::vector<const itype *> Item_factory::get_runtime_types() const
-{
-    std::vector<const itype *> res;
-    res.reserve( m_runtimes.size() );
-    for( const auto &e : m_runtimes ) {
-        res.push_back( e.second.get() );
-    }
-
-    return res;
-}
-
 /** Find all templates matching the UnaryPredicate function */
 std::vector<const itype *> Item_factory::find( const std::function<bool( const itype & )> &func )
 {

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -282,9 +282,6 @@ class Item_factory
         /** Get all item templates (both static and runtime) */
         const std::vector<const itype *> &all() const;
 
-        /** Get item types created at runtime. */
-        std::vector<const itype *> get_runtime_types() const;
-
         /** Find all item templates (both static and runtime) matching UnaryPredicate function */
         static std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
 


### PR DESCRIPTION
#### Summary
Backport DDA 80040 - Cache item factory all to speed up d: filter by ~2s or ~10%

#### Purpose of change
Performance and item_factory updates

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
