### PR TITLE
add heels to dancer

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3445,7 +3445,7 @@
       "both": { "entries": [ { "item": "socks" }, { "item": "knit_scarf" }, { "group": "charged_smart_phone" } ] },
       "male": { "entries": [ { "item": "briefs" }, { "item": "tux" }, { "item": "dress_shoes" } ] },
       "female": {
-        "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "dress" }, { "item": "purse", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "dress" }, { "item": "heels" }, { "item": "purse", "custom-flags": [ "auto_wield" ] } ]
       }
     },
     "age_lower": 16


### PR DESCRIPTION
#### Summary
Adds heels to female ballroom dancer profession

#### Purpose of change
Female ballroom dancers start with no footwear, while the male has shoes

#### Describe the solution
Adds heels to female ballroom dancer profession

#### Describe alternatives you've considered
Removing socks from both and putting them only on male, but after a bit of search it is normal to wear heels with socks

#### Testing
Before
<img width="918" height="488" alt="image" src="https://github.com/user-attachments/assets/1d6d4c04-bf89-4a94-8d78-3271bd34626c" />

After
<img width="915" height="530" alt="image" src="https://github.com/user-attachments/assets/fa84e353-ee86-4cdc-ba00-56f1a27423b0" />


#### Additional context
None

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
