### PR TITLE
No blood from a frozen corpse.

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -612,6 +612,12 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
         act.targets.pop_back();
         return;
     }
+    if( action == butcher_type::BLEED && ( corpse_item.has_flag( flag_FROZEN ) ) ) {
+        you.add_msg_if_player( m_info,
+                               _( "The corpse is frozen solid, the blood won't drain in this state." ) );
+        act.targets.pop_back();
+        return;
+    }
 
     if( action == butcher_type::DISSECT && ( corpse_item.has_flag( flag_QUARTERED ) ||
             corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ||


### PR DESCRIPTION
#### Summary
No blood from a frozen corpse.

#### Purpose of change
If a corpse is frozen, you shouldn't be able to drain its blood.

#### Describe the solution
Prevent bleeding frozen corpses.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
