### PR TITLE
Rescue pilot can fly

### DIFF
--- a/data/json/npcs/refugee_center/surface_visitors/NPC_rescue_pilot.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_rescue_pilot.json
@@ -33,6 +33,7 @@
     "worn_override": "NC_RESCUE_PILOT_worn",
     "carry_override": "NC_RESCUE_PILOT_carry",
     "weapon_override": "NC_RESCUE_PILOT_wield",
+    "proficiencies": [ "prof_helicopter_pilot" ],
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -4 ] } ] } ] } },
       { "skill": "driving", "bonus": { "rng": [ 3, 7 ] } },


### PR DESCRIPTION
#### Summary
Rescue pilot can fly

#### Purpose of change
they couldnt fly

#### Describe the solution
now they fly,

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
