### PR TITLE
Properly check vehicle coverage for spells

### DIFF
--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -239,7 +239,7 @@ static bool in_spell_aoe( const tripoint_bub_ms &start, const tripoint_bub_ms &e
     tripoint_bub_ms last_point = start;
     const std::vector<tripoint_bub_ms> trajectory = line_to( start, end );
     for( const tripoint_bub_ms &pt : trajectory ) {
-        if( ( here.coverage( pt ) > 0 && rng( 1, 100 ) < here.coverage( pt ) ) ||
+        if( ( here.coverage( pt ) > 0 && rng( 1, 100 ) <= here.coverage( pt ) ) ||
             here.obstructed_by_vehicle_rotation( pt, last_point ) ) {
             return false;
         }
@@ -290,7 +290,7 @@ static std::set<tripoint_bub_ms> spell_effect_cone_range_override(
         for( const tripoint_bub_ms &ep : end_points ) {
             std::vector<tripoint_bub_ms> trajectory = line_to( source, ep );
             for( const tripoint_bub_ms &tp : trajectory ) {
-                if( here.obstructed_by_vehicle_rotation( tp, last_point ) || here.coverage( tp ) == 0 ||
+                if( !here.obstructed_by_vehicle_rotation( tp, last_point ) || here.coverage( tp ) == 0 ||
                     rng( 1, 100 ) > here.coverage( tp ) ) {
                     targets.emplace( tp );
                 } else {
@@ -321,7 +321,7 @@ static bool test_coverage( const tripoint_bub_ms &p, const tripoint_bub_ms &prev
 {
     map &here = get_map();
     return here.coverage( p ) == 0 || rng( 1, 100 ) > here.coverage( p ) ||
-           here.obstructed_by_vehicle_rotation( prev, p );
+           !here.obstructed_by_vehicle_rotation( prev, p );
 }
 
 std::set<tripoint_bub_ms> spell_effect::spell_effect_line( const override_parameters &params,
@@ -927,7 +927,7 @@ int area_expander::run( const tripoint_bub_ms &center )
             node &best = area[best_index];
             const tripoint_bub_ms &pt = best.position + point( x_offset[ i ], y_offset[ i ] );
 
-            if( ( here.coverage( pt ) > 0 && rng( 1, 100 ) < here.coverage( pt ) ) ||
+            if( ( here.coverage( pt ) > 0 && rng( 1, 100 ) <= here.coverage( pt ) ) ||
                 here.obstructed_by_vehicle_rotation( best.position, pt ) ) {
                 continue;
             }


### PR DESCRIPTION
#### Summary
Properly check vehicle coverage for spells

#### Purpose of change
Someone noticed ants were spraying acid through diagonal car gaps. This is because I did some (but not all) of these checks wrong.

#### Describe the solution
- Some of the checks were supposed to be checking for if it WASN'T obstructed. they now do that properly.
- I noticed some coverage checks were just < coverage instead of <= coverage. You have to beat a coverage roll to get through, not meet it, so that's been fixed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
