### PR TITLE
Slime globs are inedible

### DIFF
--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -10,14 +10,14 @@
     "description": "A vegetable from the gourd family, bottle gourds were brought to the Americas by the first Native American settlers crossing the Bering strait.  This one has been dried for processing into a watertight container.",
     "volume": "1250 ml",
     "container": "bag_plastic",
-    "flags": [ "INEDIBLE" ]
+    "flags": [ "INEDIBLE", "NO_TEMP" ]
   },
   {
     "id": "gum",
     "type": "COMESTIBLE",
     "comestible_type": "FOOD",
     "name": { "str_sp": "chewing gum" },
-    "description": "Sugar-free chewing gum.",
+    "description": "That gum you liked is probably not going to come back in style.",
     "category": "food",
     "weight": "3 g",
     "volume": "2 ml",
@@ -26,7 +26,7 @@
     "symbol": "*",
     "color": "pink",
     "fun": 2,
-    "flags": [ "NO_INGEST" ],
+    "flags": [ "NO_INGEST", "NO_TEMP" ],
     "use_action": [ "CHEW" ]
   },
   {
@@ -36,7 +36,7 @@
     "name": { "str": "slime glob" },
     "weight": "238 g",
     "color": "dark_gray",
-    "use_action": [ "POISON" ],
+    "flag": [ "INEDIBLE" ],
     "comestible_type": "FOOD",
     "symbol": "%",
     "calories": 174,


### PR DESCRIPTION
#### Summary
Slime globs are inedible

#### Purpose of change
- Slime globs are not food
- Chewing gum is NO_TEMP

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
