### PR TITLE
Backport 81186 - Fix load time slowdown from n^2 time vector scans in itemfactory

### DIFF
--- a/src/itype.h
+++ b/src/itype.h
@@ -1567,7 +1567,7 @@ struct itype {
         std::string nname( unsigned int quantity ) const;
 
         // Allow direct access to the type id for the few cases that need it.
-        itype_id get_id() const {
+        const itype_id &get_id() const {
             return id;
         }
 


### PR DESCRIPTION
#### Summary
Backport 81186 - Fix load time slowdown from n^2 time vector scans in itemfactory

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
