### PR TITLE
Falling items don't get bashed twice.

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2898,8 +2898,8 @@ void map::drop_furniture( const tripoint_bub_ms &p )
             return;
         }
 
-        critter->add_msg_player_or_npc( m_bad, _( "Falling %s hits you!" ),
-                                        _( "Falling %s hits <npcname>" ),
+        critter->add_msg_player_or_npc( m_bad, _( "You are struck by a falling %s!" ),
+                                        _( "<npcname> is struck by a falling %s!" ),
                                         furn_name );
         // TODO: A chance to dodge/uncanny dodge
         Character *pl = critter->as_character();
@@ -3028,16 +3028,9 @@ void map::drop_items( const tripoint_bub_ms &p )
                 creature_below->deal_damage( nullptr, hit_part, damage_instance( damage_bash, damage ) );
             }
         }
-
-        // Bash items at bottom since currently bash_items only bash glass items
-        // FIXME: Hardcoded damage type!
-        int chance = static_cast<int>( 200 * i.resist( damage_bash, true ) / damage + 1 );
-        if( one_in( chance ) ) {
-            i.inc_damage();
-        }
     }
 
-    // Bash terain, furniture and vehicles on tile below
+    // Bash terain, furniture, items (including this one!) and vehicles on tile below
     bash( below, damage_total / 2 );
     i_clear( p );
 }


### PR DESCRIPTION
#### Summary
Falling items don't get bashed twice.

#### Purpose of change
Falling items were getting bashed twice, and taking obnoxious amounts of damage on the first bash.

#### Describe the solution
Remove the first bash.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
