### PR TITLE
Correct lead amounts in batteries

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -918,7 +918,7 @@
     "description": "A car battery wired into a static power grid.",
     "item": "battery_car",
     "breaks_into": [
-      { "item": "lead", "count": [ 1680, 2380 ] },
+      { "item": "lead", "count": [ 450, 900 ] },
       { "item": "chem_sulphuric_acid", "count": [ 5, 8 ], "container-item": "null" },
       { "item": "plastic_chunk", "count": [ 14, 20 ] },
       { "item": "scrap", "count": [ 2, 3 ] },
@@ -939,7 +939,7 @@
     "description": "A motorbike battery wired into a static power grid.",
     "item": "battery_motorbike",
     "breaks_into": [
-      { "item": "lead", "count": [ 149, 159 ] },
+      { "item": "lead", "count": [ 85, 175 ] },
       { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
       { "item": "plastic_chunk", "count": [ 2, 3 ] },
       { "item": "scrap", "count": [ 0, 1 ] },
@@ -960,7 +960,7 @@
     "description": "A small motorbike battery wired into a static power grid.",
     "item": "battery_motorbike_small",
     "breaks_into": [
-      { "item": "lead", "count": [ 69, 79 ] },
+      { "item": "lead", "count": [ 45, 90 ] },
       { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
       { "item": "plastic_chunk" },
       { "item": "scrap", "count": [ 0, 1 ] },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -383,7 +383,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "chem_sulphuric_acid", 13 ] ], [ [ "lead", 1061 ] ], [ [ "plastic_chunk", 3 ] ] ]
+    "components": [ [ [ "chem_sulphuric_acid", 13 ] ], [ [ "lead", 900 ] ], [ [ "plastic_chunk", 3 ] ] ]
   },
   {
     "result": "battery_motorbike",
@@ -391,7 +391,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "chem_sulphuric_acid", 3 ] ], [ [ "lead", 159 ] ], [ [ "plastic_chunk", 2 ] ] ]
+    "components": [ [ [ "chem_sulphuric_acid", 3 ] ], [ [ "lead", 175 ] ], [ [ "plastic_chunk", 2 ] ] ]
   },
   {
     "result": "battery_motorbike_small",
@@ -399,7 +399,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "components": [ [ [ "chem_sulphuric_acid", 1 ] ], [ [ "lead", 79 ] ], [ [ "plastic_chunk", 1 ] ] ]
+    "components": [ [ [ "chem_sulphuric_acid", 1 ] ], [ [ "lead", 90 ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
     "result": "bindle",

--- a/data/json/vehicleparts/battery.json
+++ b/data/json/vehicleparts/battery.json
@@ -12,7 +12,7 @@
     "description": "A battery for storing electrical power, and discharging it to power electrical devices built into the vehicle.",
     "folded_volume": "10 L",
     "breaks_into": [
-      { "item": "lead", "count": [ 1680, 2380 ] },
+      { "item": "lead", "count": [ 450, 900 ] },
       { "item": "chem_sulphuric_acid", "count": [ 5, 8 ], "container-item": "null" },
       { "item": "plastic_chunk", "count": [ 14, 20 ] },
       { "item": "scrap", "count": [ 2, 3 ] },
@@ -36,7 +36,7 @@
     "durability": 100,
     "folded_volume": "1500 ml",
     "breaks_into": [
-      { "item": "lead", "count": [ 252, 357 ] },
+      { "item": "lead", "count": [ 85, 175 ] },
       { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
       { "item": "plastic_chunk", "count": [ 2, 3 ] },
       { "item": "scrap", "count": [ 0, 1 ] },
@@ -52,7 +52,7 @@
     "durability": 30,
     "folded_volume": "750 ml",
     "breaks_into": [
-      { "item": "lead", "count": [ 126, 178 ] },
+      { "item": "lead", "count": [ 45, 90 ] },
       { "item": "chem_sulphuric_acid", "count": [ 0, 1 ], "container-item": "null" },
       { "item": "plastic_chunk" },
       { "item": "scrap", "count": [ 0, 1 ] },


### PR DESCRIPTION
#### Summary
Correct lead amounts in batteries

#### Purpose of change
Car and motorbike batteries had way too much lead in them, and the amounts were inconsistent.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
