### PR TITLE
fix camera storage

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -102,7 +102,21 @@
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
     "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" } ],
     "//": "swappable, but proprietary 80g Li-Ion battery",
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } } ],
+    "pocket_data": [ 
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 50 }
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "32 GB"
+      }
+    ],
     "melee_damage": { "bash": 1 }
   },
   {
@@ -122,7 +136,21 @@
     "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 3, "charge_rate": "50 W" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "CAMERA_PRO", "ALWAYS_TWOHAND", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
     "//": "swappable, but proprietary 160g Li-Ion battery",
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ],
+    "pocket_data": [ 
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 100 }
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "64 GB"
+      }
+    ],
     "melee_damage": { "bash": 1 }
   },
   {

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -931,10 +931,24 @@
     "price_postapoc": "50 cent",
     "material": [ "plastic", "steel" ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "WATER_BREAK", "ELECTRONIC" ],
-    "weight": "520 g",
-    "volume": "500 ml",
+    "weight": "943 g",
+    "volume": "256 ml",
     "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" } ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } } ],
+    "pocket_data": [ 
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 50 }
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "32 GB"
+      }
+    ],
     "armor": [ { "encumbrance": 2, "coverage": 15, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_front" ] } ],
     "melee_damage": { "bash": 1 },
     "tool_ammo": "battery"
@@ -963,10 +977,24 @@
       "WATER_BREAK",
       "ELECTRONIC"
     ],
-    "weight": "520 g",
-    "volume": "500 ml",
+    "weight": "2304 g",
+    "volume": "1256 ml",
     "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 3, "charge_rate": "50 W" } ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ],
+    "pocket_data": [ 
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "ammo_restriction": { "battery": 100 }
+      },
+      {
+        "pocket_type": "E_FILE_STORAGE",
+        "rigid": true,
+        "max_contains_volume": "1 ml",
+        "max_contains_weight": "1 g",
+        "weight_multiplier": 0.0,
+        "ememory_max": "64 GB"
+      }
+    ],
     "armor": [ { "encumbrance": 2, "coverage": 15, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_front" ] } ],
     "melee_damage": { "bash": 1 },
     "tool_ammo": "battery"


### PR DESCRIPTION
#### Summary
Cameras, professional cameras and wearables had no data storage and couldn't take photos. This was caused by this commit https://github.com/Cataclysm-TLG/Cataclysm-TLG/commit/42dfe812131f4d0deebd2b4b9480e0c360ec982a

#### Purpose of change
Allow cameras to take photos again. Also updated the weight and volume of wearable cameras which were reverted.

#### Describe the solution
Added a file storage pocket like smartphones did, based on https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1441

#### Describe alternatives you've considered
None

#### Testing
Started as a photojournalist, wanted to take pictures, game said your camera cannot hold any more photos.
Made these changes, reloaded the world, could take photos again. Tested with my starting camera and a spawned wearable non professional camera.

#### Additional context
The picture taken at 4 second mark used my smartphone to make sure it wasn't the camera function which broke. The game was reloaded with the changes at the 3 second mark.
<img width="776" height="228" alt="image" src="https://github.com/user-attachments/assets/50b4b608-5e4f-4ffa-a6cd-e46efd992c65" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
