### PR TITLE
Update and improve acid zombie snippets

### DIFF
--- a/data/json/snippets/zombie_anatomy.json
+++ b/data/json/snippets/zombie_anatomy.json
@@ -238,12 +238,11 @@
     "type": "snippet",
     "category": "<zombie_humanoid_harvest_acid_general>",
     "text": [
-      "The sheer pungent acrid odor of the carcass makes you temporarily recoil and reconsider the safety of delving into its entrails.",
-      "The sputters of acid on your gear you earned by digging into this corpse could maybe warrant the use of some water to douse.",
-      "Pressed against the liver is a swollen gland the size of a golfball, still somewhat functioning, pumping out acrid fluids.",
-      "Most cavities in its anatomy seem to have been filled with an acidic solution mixed with a foul black liquid and pieces of its slowly melting tissues.",
-      "You are almost certain that its flesh should not be able to contain such a virulently aggressive liquid, yet, it does.",
-      "You have to step back as a gland you inadvertently cut into seems to perform a neutralization reaction between its contents and the rest of its fluids."
+      "The sheer pungent acrid odor of the corpse makes you temporarily recoil and reconsider the safety of delving into its entrails.",
+      "The stench coming off of this corpse is immediately reminiscent of vomit.",
+      "This person has undergone a horrific mutation.  Their stomach has ballooned outward to fill almost their entire thoracic cavity, crushing the lungs against the ribs.  Even now, the lining oozes a thin, greasy film of acid.",
+      "Every cavity in this creature's anatomy is puddled with a foaming mixture of acid and half-dissolved tissue.  It seems it wasn't entirely immune to its own secretions.",
+      "An accidental cut opens a gland that spurts clear fluid across the creature's flesh, which bubbles and smokes as some of the acid undergoes a neutralizing reaction."
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Update and improve acid zombie snippets

#### Purpose of change
Acid zombies be having snippets,

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
