### PR TITLE
Backport 80633 - Remove unnecessary const modifiers from function parameters

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -430,7 +430,7 @@ void achievement::reset()
     achievement_factory.reset();
 }
 
-void achievement::load( const JsonObject &jo, const std::string_view )
+void achievement::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     is_conduct_ = jo.get_string( "type" ) == "conduct";

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -362,7 +362,7 @@ bool addiction::run_effect( Character &u )
     return ret;
 }
 
-void add_type::load( const JsonObject &jo, const std::string_view )
+void add_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "type_name", _type_name );

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -62,7 +62,7 @@ int_id<ammo_effect>::int_id( const ammo_effect_str_id &id ) : _id( id.id() )
 {
 }
 
-void ammo_effect::load( const JsonObject &jo, const std::string_view )
+void ammo_effect::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "trigger_chance", trigger_chance, 1 );
 

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -59,7 +59,7 @@ void anatomy::load_anatomy( const JsonObject &jo, const std::string &src )
     anatomy_factory.load( jo, src );
 }
 
-void anatomy::load( const JsonObject &jo, const std::string_view )
+void anatomy::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "parts", unloaded_bps );

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -8,7 +8,7 @@
 #include "json_error.h"
 
 void report_strict_violation( const JsonObject &jo, const std::string &message,
-                              const std::string_view name )
+                              std::string_view name )
 {
     try {
         // Let the json class do the formatting, it includes the context of the JSON data.
@@ -19,7 +19,7 @@ void report_strict_violation( const JsonObject &jo, const std::string &message,
     }
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, bool &val, bool strict )
+bool assign( const JsonObject &jo, std::string_view name, bool &val, bool strict )
 {
     bool out;
 
@@ -37,7 +37,7 @@ bool assign( const JsonObject &jo, const std::string_view name, bool &val, bool 
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::volume &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::volume &val, bool strict,
              const units::volume lo, const units::volume hi )
 {
     const auto parse = [name]( const JsonObject & obj, units::volume & out ) {
@@ -102,7 +102,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::volume &v
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::mass &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::mass &val, bool strict,
              const units::mass lo, const units::mass hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::mass & out ) {
@@ -166,7 +166,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::mass &val
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::length &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::length &val, bool strict,
              const units::length lo, const units::length hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::length & out ) {
@@ -230,7 +230,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::length &v
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::money &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::money &val, bool strict,
              const units::money lo, const units::money hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::money & out ) {
@@ -294,7 +294,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::money &va
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::energy &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::energy &val, bool strict,
              const units::energy lo, const units::energy hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
@@ -363,7 +363,7 @@ bool assign( const JsonObject &jo, const std::string_view name, units::energy &v
     return true;
 }
 
-bool assign( const JsonObject &jo, const std::string_view name, units::power &val, bool strict,
+bool assign( const JsonObject &jo, std::string_view name, units::power &val, bool strict,
              const units::power lo, const units::power hi )
 {
     const auto parse = [&name]( const JsonObject & obj, units::power & out ) {

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -755,7 +755,7 @@ bool player_settings::empty() const
     return global_rules.empty() && character_rules.empty();
 }
 
-bool check_special_rule( const std::map<material_id, int> &materials, const std::string_view rule )
+bool check_special_rule( const std::map<material_id, int> &materials, std::string_view rule )
 {
     char type = ' ';
     std::vector<std::string> filter;
@@ -771,7 +771,7 @@ bool check_special_rule( const std::map<material_id, int> &materials, const std:
     if( type == 'm' ) {
         return std::any_of( materials.begin(),
         materials.end(), [&filter]( const std::pair<material_id, int> &mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string_view search ) {
+            return std::any_of( filter.begin(), filter.end(), [&mat]( std::string_view search ) {
                 return lcmatch( mat.first->name(), search );
             } );
         } );
@@ -779,7 +779,7 @@ bool check_special_rule( const std::map<material_id, int> &materials, const std:
     } else if( type == 'M' ) {
         return std::all_of( materials.begin(),
         materials.end(), [&filter]( const std::pair<material_id, int> &mat ) {
-            return std::any_of( filter.begin(), filter.end(), [&mat]( const std::string_view search ) {
+            return std::any_of( filter.begin(), filter.end(), [&mat]( std::string_view search ) {
                 return lcmatch( mat.first->name(), search );
             } );
         } );

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -288,13 +288,13 @@ const memorized_tile &avatar::get_memorized_tile( const tripoint_abs_ms &p ) con
     return mm_submap::default_tile;
 }
 
-void avatar::memorize_terrain( const tripoint_abs_ms &p, const std::string_view id,
+void avatar::memorize_terrain( const tripoint_abs_ms &p, std::string_view id,
                                int subtile, int rotation )
 {
     player_map_memory->set_tile_terrain( p, id, subtile, rotation );
 }
 
-void avatar::memorize_decoration( const tripoint_abs_ms &p, const std::string_view id,
+void avatar::memorize_decoration( const tripoint_abs_ms &p, std::string_view id,
                                   int subtile, int rotation )
 {
     player_map_memory->set_tile_decoration( p, id, subtile, rotation );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -79,7 +79,7 @@ std::string base_camps::faction_encode_abs( const expansion_data &e, int number 
     return faction_encode_short( e.type ) + std::to_string( number );
 }
 
-std::string base_camps::faction_decode( const std::string_view full_type )
+std::string base_camps::faction_decode( std::string_view full_type )
 {
     if( full_type.size() < ( prefix_len + 2 ) ) {
         return "camp";
@@ -153,7 +153,7 @@ void basecamp::set_by_radio( bool access_by_radio )
 // find the last underbar, strip off the prefix of faction_base_ (which is 13 chars),
 // and the pull out the $TYPE and $CURLEVEL
 // This is legacy support for existing camps; future camps don't use cur_level at all
-expansion_data basecamp::parse_expansion( const std::string_view terrain,
+expansion_data basecamp::parse_expansion( std::string_view terrain,
         const tripoint_abs_omt &new_pos )
 {
     expansion_data e;
@@ -189,7 +189,7 @@ void basecamp::add_expansion( const std::string &bldg, const tripoint_abs_omt &n
     update_resources( bldg );
 }
 
-void basecamp::define_camp( const tripoint_abs_omt &p, const std::string_view camp_type,
+void basecamp::define_camp( const tripoint_abs_omt &p, std::string_view camp_type,
                             bool player_founded )
 {
     if( player_founded ) {

--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -134,7 +134,7 @@ void behavior::load_behavior( const JsonObject &jo, const std::string &src )
     behavior_factory.load( jo, src );
 }
 
-void node_t::load( const JsonObject &jo, const std::string_view )
+void node_t::load( const JsonObject &jo, std::string_view )
 {
     // We don't initialize the node unless it has no children (opportunistic optimization).
     // Instead we initialize a parallel struct that holds the labels until finalization.

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -11,7 +11,7 @@
 namespace behavior
 {
 
-status_t return_running( const oracle_t *, const std::string_view )
+status_t return_running( const oracle_t *, std::string_view )
 {
     return status_t::running;
 }
@@ -20,7 +20,7 @@ status_t return_running( const oracle_t *, const std::string_view )
 static std::function < status_t( const oracle_t *, std::string_view ) >
 make_function( status_t ( character_oracle_t::* fun )( std::string_view ) const )
 {
-    return static_cast<status_t ( oracle_t::* )( const std::string_view ) const>( fun );
+    return static_cast<status_t ( oracle_t::* )( std::string_view ) const>( fun );
 }
 
 static std::function < status_t( const oracle_t *, std::string_view ) >

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -312,7 +312,7 @@ static social_modifiers load_bionic_social_mods( const JsonObject &jo )
     return ret;
 }
 
-void bionic_data::load( const JsonObject &jsobj, const std::string_view src )
+void bionic_data::load( const JsonObject &jsobj, std::string_view src )
 {
 
     mandatory( jsobj, was_loaded, "id", id );
@@ -455,7 +455,7 @@ void bionic_data::load_bionic( const JsonObject &jo, const std::string &src )
 
 std::map<bionic_id, bionic_id> bionic_data::migrations;
 
-void bionic_data::load_bionic_migration( const JsonObject &jo, const std::string_view )
+void bionic_data::load_bionic_migration( const JsonObject &jo, std::string_view )
 {
     const bionic_id from( jo.get_string( "from" ) );
     const bionic_id to = jo.has_string( "to" )

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -87,7 +87,7 @@ void bodygraph::check_all()
     bodygraph_factory.check();
 }
 
-void bodygraph::load( const JsonObject &jo, const std::string_view )
+void bodygraph::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "parent_bodypart", parent_bp );
     optional( jo, was_loaded, "fill_sym", fill_sym );
@@ -343,7 +343,7 @@ void bodygraph_display::draw_borders()
     bh_borders.draw_border( w_border, c_white );
 
     const int first_win_width = partlist_width;
-    auto center_txt_start = [&first_win_width]( const std::string_view txt ) {
+    auto center_txt_start = [&first_win_width]( std::string_view txt ) {
         return 2 + first_win_width + ( BPGRAPH_MAXCOLS / 2 - utf8_width( txt, true ) / 2 );
     };
 

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -161,7 +161,7 @@ const std::vector<limb_score> &limb_score::get_all()
     return limb_score_factory.get_all();
 }
 
-void limb_score::load( const JsonObject &jo, const std::string_view )
+void limb_score::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", _name );
@@ -288,7 +288,7 @@ const std::vector<body_part_type> &body_part_type::get_all()
     return body_part_factory.get_all();
 }
 
-void body_part_type::load( const JsonObject &jo, const std::string_view )
+void body_part_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
 

--- a/src/butchery_requirements.cpp
+++ b/src/butchery_requirements.cpp
@@ -53,7 +53,7 @@ bool butchery_requirements::is_valid() const
     return butchery_req_factory.is_valid( this->id );
 }
 
-void butchery_requirements::load( const JsonObject &jo, const std::string_view )
+void butchery_requirements::load( const JsonObject &jo, std::string_view )
 {
     for( const JsonMember member : jo.get_object( "requirements" ) ) {
         float modifier = std::stof( member.name() );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1223,7 +1223,7 @@ tile_type &tileset_cache::loader::load_tile( const JsonObject &entry, const std:
 
 void tileset_cache::loader::load_tile_spritelists( const JsonObject &entry,
         weighted_int_list<std::vector<int>> &vs,
-        const std::string_view objname ) const
+        std::string_view objname ) const
 {
     // json array indicates rotations or variations
     if( entry.has_array( objname ) ) {
@@ -2327,7 +2327,7 @@ cata_tiles::find_tile_with_season( const std::string &id ) const
 
 template<typename T>
 std::optional<tile_lookup_res>
-cata_tiles::find_tile_looks_like_by_string_id( const std::string_view id, TILE_CATEGORY category,
+cata_tiles::find_tile_looks_like_by_string_id( std::string_view id, TILE_CATEGORY category,
         const int looks_like_jumps_limit ) const
 {
     const string_id<T> s_id( id );

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -88,7 +88,7 @@ bool isBetween( int test, int down, int up )
     return test > down && test < up;
 }
 
-bool lcmatch( const std::string_view str, const std::string_view qry )
+bool lcmatch( std::string_view str, std::string_view qry )
 {
     // It will be quite common for the query string to be empty.  Anything will
     // match in that case, so short-circuit and avoid the expensive
@@ -117,12 +117,12 @@ bool lcmatch( const std::string_view str, const std::string_view qry )
     return false;
 }
 
-bool lcmatch( const translation &str, const std::string_view qry )
+bool lcmatch( const translation &str, std::string_view qry )
 {
     return lcmatch( str.translated(), qry );
 }
 
-bool match_include_exclude( const std::string_view text, std::string filter )
+bool match_include_exclude( std::string_view text, std::string filter )
 {
     size_t iPos;
     bool found = false;
@@ -712,7 +712,7 @@ bool string_empty_or_whitespace( const std::string &s )
     } );
 }
 
-int string_view_cmp( const std::string_view l, const std::string_view r )
+int string_view_cmp( std::string_view l, std::string_view r )
 {
     size_t min_len = std::min( l.size(), r.size() );
     int result = memcmp( l.data(), r.data(), min_len );
@@ -726,7 +726,7 @@ int string_view_cmp( const std::string_view l, const std::string_view r )
 }
 
 template<typename Integer>
-Integer svto( const std::string_view s )
+Integer svto( std::string_view s )
 {
     Integer result = 0;
     const char *end = s.data() + s.size();
@@ -739,7 +739,7 @@ Integer svto( const std::string_view s )
 
 template int svto<int>( std::string_view );
 
-std::vector<std::string> string_split( const std::string_view string, char delim )
+std::vector<std::string> string_split( std::string_view string, char delim )
 {
     std::vector<std::string> elems;
 

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -110,7 +110,7 @@ uint32_t UTF8_getch( const char **src, int *srclen )
 //Calculate width of a Unicode string
 //Latin characters have a width of 1
 //CJK characters have a width of 2, etc
-int utf8_width( const std::string_view s, const bool ignore_tags )
+int utf8_width( std::string_view s, const bool ignore_tags )
 {
     if( ignore_tags ) {
         return utf8_width( remove_color_tags( s ) );
@@ -521,7 +521,7 @@ std::string utf32_to_utf8( const std::u32string_view str )
     return ret;
 }
 
-std::u32string utf8_to_utf32( const std::string_view str )
+std::u32string utf8_to_utf32( std::string_view str )
 {
     int len = str.length();
     const char *dat = str.data();

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -104,7 +104,7 @@ static float load_float_or_maxmovecost( const JsonObject &jo, const std::string 
     return val;
 }
 
-void character_modifier::load( const JsonObject &jo, const std::string_view )
+void character_modifier::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "description", desc );

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -21,7 +21,7 @@ namespace behavior
 // To avoid a local minima when the character has access to warmth in a shelter but gets cold
 // when they go outside, this method needs to only alert when travel time to known shelter
 // approaches time to freeze.
-status_t character_oracle_t::needs_warmth_badly( const std::string_view ) const
+status_t character_oracle_t::needs_warmth_badly( std::string_view ) const
 {
     // Use player::temp_conv to predict whether the Character is "in trouble".
     for( const bodypart_id &bp : subject->get_all_body_parts() ) {
@@ -32,7 +32,7 @@ status_t character_oracle_t::needs_warmth_badly( const std::string_view ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::needs_water_badly( const std::string_view ) const
+status_t character_oracle_t::needs_water_badly( std::string_view ) const
 {
     // Check thirst threshold.
     if( subject->get_thirst() > 520 ) {
@@ -41,7 +41,7 @@ status_t character_oracle_t::needs_water_badly( const std::string_view ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::needs_food_badly( const std::string_view ) const
+status_t character_oracle_t::needs_food_badly( std::string_view ) const
 {
     // Check hunger threshold.
     if( subject->get_hunger() >= 300 && subject->get_starvation() > base_metabolic_rate ) {
@@ -50,7 +50,7 @@ status_t character_oracle_t::needs_food_badly( const std::string_view ) const
     return status_t::success;
 }
 
-status_t character_oracle_t::can_wear_warmer_clothes( const std::string_view ) const
+status_t character_oracle_t::can_wear_warmer_clothes( std::string_view ) const
 {
     // Check inventory for wearable warmer clothes, greedily.
     // Don't consider swapping clothes yet, just evaluate adding clothes.
@@ -61,7 +61,7 @@ status_t character_oracle_t::can_wear_warmer_clothes( const std::string_view ) c
     return found_clothes ? status_t::running : status_t::failure;
 }
 
-status_t character_oracle_t::can_make_fire( const std::string_view ) const
+status_t character_oracle_t::can_make_fire( std::string_view ) const
 {
     // Check inventory for firemaking tools and fuel
     bool tool = false;
@@ -83,14 +83,14 @@ status_t character_oracle_t::can_make_fire( const std::string_view ) const
     return found_fire_stuff ? status_t::running : status_t::success;
 }
 
-status_t character_oracle_t::can_take_shelter( const std::string_view ) const
+status_t character_oracle_t::can_take_shelter( std::string_view ) const
 {
     // There be no shelter here.
     // The frontline is everywhere.
     return status_t::failure;
 }
 
-status_t character_oracle_t::has_water( const std::string_view ) const
+status_t character_oracle_t::has_water( std::string_view ) const
 {
     // Check if we know about water somewhere
     bool found_water = subject->has_item_with( []( const item & cand ) {
@@ -99,7 +99,7 @@ status_t character_oracle_t::has_water( const std::string_view ) const
     return found_water ? status_t::running : status_t::failure;
 }
 
-status_t character_oracle_t::has_food( const std::string_view ) const
+status_t character_oracle_t::has_food( std::string_view ) const
 {
     // Check if we know about food somewhere
     bool found_food = subject->has_item_with( []( const item & cand ) {

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -71,7 +71,7 @@ void city::reset()
     get_city_factory().reset();
 }
 
-void city::load( const JsonObject &jo, const std::string_view )
+void city::load( const JsonObject &jo, std::string_view )
 {
 
     mandatory( jo, was_loaded, "id", id );

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -64,7 +64,7 @@ std::string enum_to_string<clothing_mod_type>( clothing_mod_type data )
 
 } // namespace io
 
-void clothing_mod::load( const JsonObject &jo, const std::string_view )
+void clothing_mod::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "flag", flag );
     mandatory( jo, was_loaded, "item", item_string );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -158,7 +158,7 @@ void zone_type::reset()
     zone_type_factory.reset();
 }
 
-void zone_type::load( const JsonObject &jo, const std::string_view )
+void zone_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "id", id );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -617,7 +617,7 @@ std::string hilite_string( const std::string &text )
  * @param color The color to get, as a std::string.
  * @return The nc_color constant that matches the input.
  */
-nc_color color_from_string( const std::string_view color,
+nc_color color_from_string( std::string_view color,
                             const report_color_error color_error )
 {
     if( color.empty() ) {
@@ -700,7 +700,7 @@ nc_color bgcolor_from_string( const std::string &color )
     return i_white;
 }
 
-color_tag_parse_result get_color_from_tag( const std::string_view s,
+color_tag_parse_result get_color_from_tag( std::string_view s,
         const report_color_error color_error )
 {
     if( s.empty() || s[0] != '<' ) {
@@ -764,7 +764,7 @@ std::string get_note_string_from_color( const nc_color &color )
     return "Y";
 }
 
-nc_color get_note_color( const std::string_view note_id )
+nc_color get_note_color( std::string_view note_id )
 {
     // TODO in C++20 we can pass a string_view in directly rather than
     // constructing a string to use as the find argument

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -833,7 +833,7 @@ conditional_t::func f_has_item( const JsonObject &jo, std::string_view member, b
     };
 }
 
-conditional_t::func f_has_items( const JsonObject &jo, const std::string_view member,
+conditional_t::func f_has_items( const JsonObject &jo, std::string_view member,
                                  bool is_npc )
 {
     JsonObject has_items = jo.get_object( member );
@@ -864,7 +864,7 @@ conditional_t::func f_has_items( const JsonObject &jo, const std::string_view me
     }
 }
 
-conditional_t::func f_has_items_sum( const JsonObject &jo, const std::string_view member,
+conditional_t::func f_has_items_sum( const JsonObject &jo, std::string_view member,
                                      bool is_npc )
 {
     std::vector<std::pair<str_or_var, dbl_or_var>> item_and_amount;
@@ -1827,7 +1827,7 @@ conditional_t::func f_query( const JsonObject &jo, std::string_view member, bool
     };
 }
 
-conditional_t::func f_x_in_y_chance( const JsonObject &jo, const std::string_view member )
+conditional_t::func f_x_in_y_chance( const JsonObject &jo, std::string_view member )
 {
     const JsonObject &var_obj = jo.get_object( member );
     dbl_or_var dovx = get_dbl_or_var( var_obj, "x" );
@@ -2004,7 +2004,7 @@ conditional_t::func f_has_ammo()
     };
 }
 
-conditional_t::func f_math( const JsonObject &jo, const std::string_view member )
+conditional_t::func f_math( const JsonObject &jo, std::string_view member )
 {
     eoc_math math;
     math.from_json( jo, member, math_type_t::compare );
@@ -2051,7 +2051,7 @@ conditional_t::func f_has_reason()
     };
 }
 
-conditional_t::func f_roll_contested( const JsonObject &jo, const std::string_view member )
+conditional_t::func f_roll_contested( const JsonObject &jo, std::string_view member )
 {
     dbl_or_var get_check = get_dbl_or_var( jo, member );
     dbl_or_var difficulty = get_dbl_or_var( jo, "difficulty", true );
@@ -2731,7 +2731,7 @@ conditional_t::conditional_t( const JsonObject &jo )
 {
     // improve the clarity of NPC setter functions
     bool found_sub_member = false;
-    const auto parse_array = []( const JsonObject & jo, const std::string_view type ) {
+    const auto parse_array = []( const JsonObject & jo, std::string_view type ) {
         std::vector<conditional_t> conditionals;
         for( const JsonValue entry : jo.get_array( type ) ) {
             if( entry.test_string() ) {

--- a/src/construction_category.cpp
+++ b/src/construction_category.cpp
@@ -53,7 +53,7 @@ const string_id<construction_category> &int_id<construction_category>::id() cons
     return all_construction_categories.convert( *this );
 }
 
-void construction_category::load( const JsonObject &jo, const std::string_view )
+void construction_category::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }

--- a/src/construction_group.cpp
+++ b/src/construction_group.cpp
@@ -53,7 +53,7 @@ const string_id<construction_group> &int_id<construction_group>::id() const
     return all_construction_groups.convert( *this );
 }
 
-void construction_group::load( const JsonObject &jo, const std::string_view )
+void construction_group::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -139,7 +139,7 @@ static int related_menu_fill( uilist &rmenu,
 static item get_recipe_result_item( const recipe &rec, Character &crafter );
 static void compare_recipe_with_item( const item &recipe_item, Character &crafter );
 
-static std::string get_cat_unprefixed( const std::string_view prefixed_name )
+static std::string get_cat_unprefixed( std::string_view prefixed_name )
 {
     return std::string( prefixed_name.substr( 3, prefixed_name.size() - 3 ) );
 }
@@ -149,7 +149,7 @@ void load_recipe_category( const JsonObject &jsobj, const std::string &src )
     craft_cat_list.load( jsobj, src );
 }
 
-void crafting_category::load( const JsonObject &jo, const std::string_view )
+void crafting_category::load( const JsonObject &jo, std::string_view )
 {
     // Ensure id is correct
     if( id.str().find( "CC_" ) != 0 ) {
@@ -180,7 +180,7 @@ void crafting_category::load( const JsonObject &jo, const std::string_view )
     }
 }
 
-static std::string get_subcat_unprefixed( const std::string_view cat,
+static std::string get_subcat_unprefixed( std::string_view cat,
         const std::string &prefixed_name )
 {
     std::string prefix = "CSC_" + get_cat_unprefixed( cat ) + "_";
@@ -391,7 +391,7 @@ static std::vector<std::string> recipe_info(
     const recipe &recp,
     const availability &avail,
     Character &guy,
-    const std::string_view qry_comps,
+    std::string_view qry_comps,
     const int batch_size,
     const int fold_width,
     const nc_color &color,
@@ -943,7 +943,7 @@ struct item_info_cache {
 };
 
 static recipe_subset filter_recipes( const recipe_subset &available_recipes,
-                                     const std::string_view qry,
+                                     std::string_view qry,
                                      const Character &crafter,
                                      const std::function<void( size_t, size_t )> &progress_callback )
 {
@@ -2339,7 +2339,7 @@ static void compare_recipe_with_item( const item &recipe_item, Character &crafte
     } while( true );
 }
 
-static bool query_is_yes( const std::string_view query )
+static bool query_is_yes( std::string_view query )
 {
     const std::string_view subquery = query.substr( 2 );
 

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -29,7 +29,7 @@ void disease_type::load_disease_type( const JsonObject &jo, const std::string &s
     disease_factory.load( jo, src );
 }
 
-void disease_type::load( const JsonObject &jo, const std::string_view )
+void disease_type::load( const JsonObject &jo, std::string_view )
 {
     disease_type new_disease;
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1020,7 +1020,7 @@ std::pair<std::string, nc_color> display::carry_weight_value_color( const avatar
     return std::make_pair( weight_text, weight_color );
 }
 
-std::pair<std::string, nc_color> display::overmap_note_symbol_color( const std::string_view
+std::pair<std::string, nc_color> display::overmap_note_symbol_color( std::string_view
         note_text )
 {
     std::string ter_sym = "N";

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -692,7 +692,7 @@ bool effect_type::is_show_in_info() const
 {
     return show_in_info;
 }
-bool effect_type::load_miss_msgs( const JsonObject &jo, const std::string_view member )
+bool effect_type::load_miss_msgs( const JsonObject &jo, std::string_view member )
 {
     return jo.read( member, miss_msgs );
 }
@@ -730,7 +730,7 @@ static void load_msg_help( const JsonArray &ja,
     apply_msgs.emplace_back( msg, rate.value() );
 }
 
-bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string_view member )
+bool effect_type::load_decay_msgs( const JsonObject &jo, std::string_view member )
 {
     if( jo.has_array( member ) ) {
         for( JsonArray inner : jo.get_array( member ) ) {
@@ -741,7 +741,7 @@ bool effect_type::load_decay_msgs( const JsonObject &jo, const std::string_view 
     return false;
 }
 
-bool effect_type::load_apply_msgs( const JsonObject &jo, const std::string_view member )
+bool effect_type::load_apply_msgs( const JsonObject &jo, std::string_view member )
 {
     if( jo.has_array( member ) ) {
         JsonArray ja = jo.get_array( member );
@@ -1503,7 +1503,7 @@ static const std::unordered_set<efftype_id> hardcoded_movement_impairing = {{
     }
 };
 
-void load_effect_type( const JsonObject &jo, const std::string_view src )
+void load_effect_type( const JsonObject &jo, std::string_view src )
 {
     effect_type new_etype;
     new_etype.id = efftype_id( jo.get_string( "id" ) );

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -78,7 +78,7 @@ void effect_on_conditions::check_consistency()
 {
 }
 
-void effect_on_condition::load( const JsonObject &jo, const std::string_view src )
+void effect_on_condition::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "eoc_type", type, eoc_type::NUM_EOC_TYPES );
@@ -120,7 +120,7 @@ void effect_on_condition::load( const JsonObject &jo, const std::string_view src
 }
 
 effect_on_condition_id effect_on_conditions::load_inline_eoc( const JsonValue &jv,
-        const std::string_view src )
+        std::string_view src )
 {
     if( jv.test_string() ) {
         return effect_on_condition_id( jv.get_string() );

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -701,7 +701,7 @@ std::unique_ptr<stats_tracker_state> event_transformation::watch( stats_tracker 
     return impl_->watch( stats );
 }
 
-void event_transformation::load( const JsonObject &jo, const std::string_view )
+void event_transformation::load( const JsonObject &jo, std::string_view )
 {
     std::map<std::string, new_field> new_fields;
     optional( jo, was_loaded, "new_fields", new_fields );
@@ -1217,7 +1217,7 @@ std::unique_ptr<stats_tracker_state> event_statistic::watch( stats_tracker &stat
     return impl_->watch( stats );
 }
 
-void event_statistic::load( const JsonObject &jo, const std::string_view )
+void event_statistic::load( const JsonObject &jo, std::string_view )
 {
     std::string type;
     mandatory( jo, was_loaded, "stat_type", type );
@@ -1297,7 +1297,7 @@ cata_variant score::value( stats_tracker &stats ) const
     return stats.value_of( stat_ );
 }
 
-void score::load( const JsonObject &jo, const std::string_view )
+void score::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "description", description_ );
     mandatory( jo, was_loaded, "statistic", stat_ );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -555,7 +555,7 @@ static bool extract_and_check_orientation_flags( const recipe_id &recipe,
         bool &mirror_horizontal,
         bool &mirror_vertical,
         int &rotation,
-        const std::string_view base_error_message,
+        std::string_view base_error_message,
         const std::string &actor )
 {
     mirror_horizontal = recipe->has_flag( "MAP_MIRROR_HORIZONTAL" );
@@ -647,7 +647,7 @@ static bool extract_and_check_orientation_flags( const recipe_id &recipe,
 }
 
 static std::optional<basecamp *> get_basecamp( npc &p,
-        const std::string_view camp_type = "default" )
+        std::string_view camp_type = "default" )
 {
     tripoint_abs_omt omt_pos = p.pos_abs_omt();
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( omt_pos.xy() );

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -177,7 +177,7 @@ const field_intensity_level &field_type::get_intensity_level( int level ) const
     return intensity_levels[level];
 }
 
-void field_type::load( const JsonObject &jo, const std::string_view )
+void field_type::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
     optional( jo, was_loaded, "substance_name", substance_name );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -424,7 +424,7 @@ const json_flag &json_flag::get( const std::string &id )
     return f_id.is_valid() ? *f_id : null_value;
 }
 
-void json_flag::load( const JsonObject &jo, const std::string_view )
+void json_flag::load( const JsonObject &jo, std::string_view )
 {
     // TODO: mark fields as mandatory where appropriate
     optional( jo, was_loaded, "info", info_ );

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -300,7 +300,7 @@ void JsonObject::report_unvisited() const
 #endif
 }
 
-void JsonObject::error_no_member( const std::string_view member ) const
+void JsonObject::error_no_member( std::string_view member ) const
 {
     std::unique_ptr<std::istream> original_json = root_->get_source_stream();
     std::string source_path = [&] {
@@ -361,7 +361,7 @@ void JsonObject::throw_error( const std::string &err ) const
     Json::throw_error( path_, 0, err );
 }
 
-void JsonObject::throw_error_at( const std::string_view member, const std::string &err ) const
+void JsonObject::throw_error_at( std::string_view member, const std::string &err ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( member );
     if( member_opt.has_value() ) {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -83,7 +83,7 @@ generic_factory<gate_data> gates_data( "gate type" );
 
 } // namespace
 
-void gate_data::load( const JsonObject &jo, const std::string_view )
+void gate_data::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "door", door );
     mandatory( jo, was_loaded, "floor", floor );

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -1,6 +1,6 @@
 #include "generic_factory.h"
 
-bool one_char_symbol_reader( const JsonObject &jo, const std::string_view member_name, int &sym,
+bool one_char_symbol_reader( const JsonObject &jo, std::string_view member_name, int &sym,
                              bool )
 {
     std::string sym_as_string;
@@ -25,7 +25,7 @@ bool one_char_symbol_reader( const JsonObject &jo, const std::string_view member
 }
 
 bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
-        const std::string_view member_name, uint32_t &member, bool )
+        std::string_view member_name, uint32_t &member, bool )
 {
     int sym_as_int;
     std::string sym_as_string;

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -108,7 +108,7 @@ void harvest_drop_type::reset()
     harvest_drop_type_factory.reset();
 }
 
-void harvest_drop_type::load( const JsonObject &jo, const std::string_view )
+void harvest_drop_type::load( const JsonObject &jo, std::string_view )
 {
     harvest_skills.clear();
     optional( jo, was_loaded, "group", is_group_, false );
@@ -193,7 +193,7 @@ void harvest_list::finalize_all()
     }
 }
 
-void harvest_list::load( const JsonObject &obj, const std::string_view )
+void harvest_list::load( const JsonObject &obj, std::string_view )
 {
     mandatory( obj, was_loaded, "id", id );
     mandatory( obj, was_loaded, "entries", entries_, harvest_entry_reader{} );

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1102,7 +1102,7 @@ void input_context::set_iso( bool mode )
 }
 
 std::vector<std::string> input_context::filter_strings_by_phrase(
-    const std::vector<std::string> &strings, const std::string_view phrase ) const
+    const std::vector<std::string> &strings, std::string_view phrase ) const
 {
     std::vector<std::string> filtered_strings;
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1610,7 +1610,7 @@ int inventory_column::reassign_custom_invlets( const Character &p, int min_invle
     return cur_invlet;
 }
 
-int inventory_column::reassign_custom_invlets( int cur_idx, const std::string_view pickup_chars )
+int inventory_column::reassign_custom_invlets( int cur_idx, std::string_view pickup_chars )
 {
     for( inventory_entry &elem : entries ) {
         // Only items on map/in vehicles: those that the player does not possess.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5819,7 +5819,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
         const auto print_parts = [&info, &player_character](
                                      const std::vector<vpart_info> &vparts,
-                                     const std::string_view install_where,
+                                     std::string_view install_where,
                                      const std::function<bool( const vpart_info & )> &predicate
         ) {
             std::vector<std::string> result_parts;

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -50,7 +50,7 @@ void item_category::reset()
     item_category_factory.reset();
 }
 
-void item_category::load( const JsonObject &jo, const std::string_view )
+void item_category::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name_header", name_header_ );

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -143,7 +143,7 @@ std::function<bool( const item & )> item_filter_from_string( const std::string &
     return filter_from_string<item>( filter, basic_item_filter );
 }
 
-std::pair<std::string, std::string> get_both( const std::string_view a )
+std::pair<std::string, std::string> get_both( std::string_view a )
 {
     size_t split_mark = a.find( ';' );
     return std::pair( std::string( a.substr( 0, split_mark ) ),

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -121,7 +121,7 @@ int itype::damage_level( int damage ) const
     return std::clamp( 1 + 4 * damage / damage_max(), 0, 5 );
 }
 
-bool itype::has_any_quality( const std::string_view quality ) const
+bool itype::has_any_quality( std::string_view quality ) const
 {
     return std::any_of( qualities.begin(),
     qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5725,7 +5725,7 @@ std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bu
     return 0;
 }
 
-static int get_quality_from_string( const std::string_view s )
+static int get_quality_from_string( std::string_view s )
 {
     const ret_val<int> try_quality = try_parse_integer<int>( s, false );
     if( try_quality.success() ) {

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -131,7 +131,7 @@ TextJsonObject::TextJsonObject( TextJsonIn &j )
     final_separator = jsin->get_ate_separator();
 }
 
-void TextJsonObject::mark_visited( const std::string_view name ) const
+void TextJsonObject::mark_visited( std::string_view name ) const
 {
 #ifndef CATA_IN_TOOL
     visited_members.emplace( name );
@@ -203,7 +203,7 @@ void TextJsonObject::copy_visited_members( const TextJsonObject &rhs ) const
 #endif
 }
 
-int TextJsonObject::verify_position( const std::string_view name,
+int TextJsonObject::verify_position( std::string_view name,
                                      const bool throw_exception ) const
 {
     if( !jsin ) {
@@ -251,7 +251,7 @@ std::string TextJsonObject::str() const
     }
 }
 
-void TextJsonObject::throw_error_at( const std::string_view name, const std::string &err ) const
+void TextJsonObject::throw_error_at( std::string_view name, const std::string &err ) const
 {
     mark_visited( name );
     if( !jsin ) {
@@ -301,7 +301,7 @@ void TextJsonObject::throw_error( const std::string &err ) const
     jsin->error( err );
 }
 
-TextJsonIn *TextJsonObject::get_raw( const std::string_view name ) const
+TextJsonIn *TextJsonObject::get_raw( std::string_view name ) const
 {
     int pos = verify_position( name );
     mark_visited( name );
@@ -326,12 +326,12 @@ json_source_location TextJsonObject::get_source_location() const
 
 /* returning values by name */
 
-bool TextJsonObject::get_bool( const std::string_view name ) const
+bool TextJsonObject::get_bool( std::string_view name ) const
 {
     return get_member( name ).get_bool();
 }
 
-bool TextJsonObject::get_bool( const std::string_view name, const bool fallback ) const
+bool TextJsonObject::get_bool( std::string_view name, const bool fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -342,12 +342,12 @@ bool TextJsonObject::get_bool( const std::string_view name, const bool fallback 
     return jsin->get_bool();
 }
 
-int TextJsonObject::get_int( const std::string_view name ) const
+int TextJsonObject::get_int( std::string_view name ) const
 {
     return get_member( name ).get_int();
 }
 
-int TextJsonObject::get_int( const std::string_view name, const int fallback ) const
+int TextJsonObject::get_int( std::string_view name, const int fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -358,12 +358,12 @@ int TextJsonObject::get_int( const std::string_view name, const int fallback ) c
     return jsin->get_int();
 }
 
-double TextJsonObject::get_float( const std::string_view name ) const
+double TextJsonObject::get_float( std::string_view name ) const
 {
     return get_member( name ).get_float();
 }
 
-double TextJsonObject::get_float( const std::string_view name, const double fallback ) const
+double TextJsonObject::get_float( std::string_view name, const double fallback ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -374,12 +374,12 @@ double TextJsonObject::get_float( const std::string_view name, const double fall
     return jsin->get_float();
 }
 
-std::string TextJsonObject::get_string( const std::string_view name ) const
+std::string TextJsonObject::get_string( std::string_view name ) const
 {
     return get_member( name ).get_string();
 }
 
-std::string TextJsonObject::get_string( const std::string_view name,
+std::string TextJsonObject::get_string( std::string_view name,
                                         const std::string &fallback ) const
 {
     int pos = verify_position( name, false );
@@ -393,7 +393,7 @@ std::string TextJsonObject::get_string( const std::string_view name,
 
 /* returning containers by name */
 
-TextJsonArray TextJsonObject::get_array( const std::string_view name ) const
+TextJsonArray TextJsonObject::get_array( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -404,7 +404,7 @@ TextJsonArray TextJsonObject::get_array( const std::string_view name ) const
     return TextJsonArray( *jsin );
 }
 
-std::vector<int> TextJsonObject::get_int_array( const std::string_view name ) const
+std::vector<int> TextJsonObject::get_int_array( std::string_view name ) const
 {
     std::vector<int> ret;
     for( const int entry : get_array( name ) ) {
@@ -413,7 +413,7 @@ std::vector<int> TextJsonObject::get_int_array( const std::string_view name ) co
     return ret;
 }
 
-std::vector<std::string> TextJsonObject::get_string_array( const std::string_view name ) const
+std::vector<std::string> TextJsonObject::get_string_array( std::string_view name ) const
 {
     std::vector<std::string> ret;
     for( const std::string entry : get_array( name ) ) {
@@ -422,7 +422,7 @@ std::vector<std::string> TextJsonObject::get_string_array( const std::string_vie
     return ret;
 }
 
-std::vector<std::string> TextJsonObject::get_as_string_array( const std::string_view name ) const
+std::vector<std::string> TextJsonObject::get_as_string_array( std::string_view name ) const
 {
     std::vector<std::string> ret;
     if( has_array( name ) ) {
@@ -435,7 +435,7 @@ std::vector<std::string> TextJsonObject::get_as_string_array( const std::string_
     return ret;
 }
 
-TextJsonObject TextJsonObject::get_object( const std::string_view name ) const
+TextJsonObject TextJsonObject::get_object( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -448,7 +448,7 @@ TextJsonObject TextJsonObject::get_object( const std::string_view name ) const
 
 /* non-fatal member existence and type testing */
 
-bool TextJsonObject::has_null( const std::string_view name ) const
+bool TextJsonObject::has_null( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -459,7 +459,7 @@ bool TextJsonObject::has_null( const std::string_view name ) const
     return jsin->test_null();
 }
 
-bool TextJsonObject::has_bool( const std::string_view name ) const
+bool TextJsonObject::has_bool( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -469,7 +469,7 @@ bool TextJsonObject::has_bool( const std::string_view name ) const
     return jsin->test_bool();
 }
 
-bool TextJsonObject::has_number( const std::string_view name ) const
+bool TextJsonObject::has_number( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -479,7 +479,7 @@ bool TextJsonObject::has_number( const std::string_view name ) const
     return jsin->test_number();
 }
 
-bool TextJsonObject::has_string( const std::string_view name ) const
+bool TextJsonObject::has_string( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -489,7 +489,7 @@ bool TextJsonObject::has_string( const std::string_view name ) const
     return jsin->test_string();
 }
 
-bool TextJsonObject::has_array( const std::string_view name ) const
+bool TextJsonObject::has_array( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -499,7 +499,7 @@ bool TextJsonObject::has_array( const std::string_view name ) const
     return jsin->test_array();
 }
 
-bool TextJsonObject::has_object( const std::string_view name ) const
+bool TextJsonObject::has_object( std::string_view name ) const
 {
     int pos = verify_position( name, false );
     if( !pos ) {
@@ -799,7 +799,7 @@ bool TextJsonArray::has_object( const size_t i ) const
 }
 
 void add_array_to_set( std::set<std::string> &s, const TextJsonObject &json,
-                       const std::string_view name )
+                       std::string_view name )
 {
     for( const std::string line : json.get_array( name ) ) {
         s.insert( line );
@@ -1987,7 +1987,7 @@ static uint32_t UTF8_getch_raw( const char **src, int *srclen )
 // This is a copy of the function in catacharset.cpp but without
 // dependencies on catacharset.h => output.h => more dependencies...
 // TODO: untangle the dependencies and remove this copy and UTF8_getch_raw
-static int utf8_width_raw( const std::string_view s )
+static int utf8_width_raw( std::string_view s )
 {
     int len = s.size();
     const char *ptr = s.data();
@@ -2360,7 +2360,7 @@ void JsonOut::write_null()
     need_separator = true;
 }
 
-void JsonOut::write( const std::string_view val )
+void JsonOut::write( std::string_view val )
 {
     if( need_separator ) {
         write_separator();
@@ -2419,13 +2419,13 @@ void JsonOut::write( const std::bitset<N> &b )
     need_separator = true;
 }
 
-void JsonOut::member( const std::string_view name )
+void JsonOut::member( std::string_view name )
 {
     write( name );
     write_member_separator();
 }
 
-void JsonOut::null_member( const std::string_view name )
+void JsonOut::null_member( std::string_view name )
 {
     member( name );
     write_null();
@@ -2453,7 +2453,7 @@ TextJsonIn &TextJsonValue::seek() const
     return jsin_;
 }
 
-TextJsonValue TextJsonObject::get_member( const std::string_view name ) const
+TextJsonValue TextJsonObject::get_member( std::string_view name ) const
 {
     const auto iter = positions.find( name );
     if( !jsin || iter == positions.end() ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -298,7 +298,7 @@ static std::string moves_to_string( const int moves )
     }
 }
 
-void spell_type::load( const JsonObject &jo, const std::string_view src )
+void spell_type::load( const JsonObject &jo, std::string_view src )
 {
     src_mod = mod_id( src );
     mandatory( jo, was_loaded, "name", name );

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -190,7 +190,7 @@ bool string_id<enchantment>::is_valid() const
 
 template<typename TKey>
 void load_add_and_multiply( const JsonObject &jo, const bool &is_child,
-                            const std::string_view array_key, const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
+                            std::string_view array_key, const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
                             std::map<TKey, dbl_or_var> &mult_map )
 {
     if( !is_child && jo.has_array( array_key ) ) {
@@ -220,7 +220,7 @@ void load_add_and_multiply( const JsonObject &jo, const bool &is_child,
 }
 
 template<typename TKey>
-void load_add_and_multiply( const JsonObject &jo, const std::string_view array_key,
+void load_add_and_multiply( const JsonObject &jo, std::string_view array_key,
                             const std::string &type_key, std::map<TKey, double> &add_map, std::map<TKey, double> &mult_map )
 {
     if( jo.has_array( array_key ) ) {
@@ -253,7 +253,7 @@ void enchantment::reset()
 }
 
 enchantment_id enchantment::load_inline_enchantment( const JsonValue &jv,
-        const std::string_view src,
+        std::string_view src,
         std::string &inline_id )
 {
     if( jv.test_string() ) {
@@ -394,7 +394,7 @@ void enchantment::bodypart_changes::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
-void enchantment::load( const JsonObject &jo, const std::string_view,
+void enchantment::load( const JsonObject &jo, std::string_view,
                         const std::optional<std::string> &inline_id, bool is_child )
 {
     optional( jo, was_loaded, "id", id, enchantment_id( inline_id.value_or( "" ) ) );
@@ -493,7 +493,7 @@ void enchantment::load( const JsonObject &jo, const std::string_view,
     }
 }
 
-void enchant_cache::load( const JsonObject &jo, const std::string_view,
+void enchant_cache::load( const JsonObject &jo, std::string_view,
                           const std::optional<std::string> &inline_id )
 {
     enchantment::load( jo, "", inline_id, true );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -83,7 +83,7 @@ void ter_furn_data<T>::load( const JsonObject &jo )
     message_good = jo.get_bool( "message_good", true );
 }
 
-void ter_furn_transform::load( const JsonObject &jo, const std::string_view )
+void ter_furn_transform::load( const JsonObject &jo, std::string_view )
 {
     std::string input;
     mandatory( jo, was_loaded, "id", input );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -2176,7 +2176,7 @@ bool map_extra::is_valid_for( const mapgendata &md ) const
     return true;
 }
 
-void map_extra::load( const JsonObject &jo, const std::string_view )
+void map_extra::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "description", description_ );

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -117,12 +117,12 @@ const std::string &memorized_tile::get_dec_id() const
     return dec_id;
 }
 
-void memorized_tile::set_ter_id( const std::string_view id )
+void memorized_tile::set_ter_id( std::string_view id )
 {
     ter_id = ter_str_id( id );
 }
 
-void memorized_tile::set_dec_id( const std::string_view id )
+void memorized_tile::set_dec_id( std::string_view id )
 {
     dec_id = id;
 }
@@ -215,7 +215,7 @@ const memorized_tile &map_memory::get_tile( const tripoint_abs_ms &pos ) const
     return sm.get_tile( p.loc );
 }
 
-void map_memory::set_tile_terrain( const tripoint_abs_ms &pos, const std::string_view id,
+void map_memory::set_tile_terrain( const tripoint_abs_ms &pos, std::string_view id,
                                    int subtile, int rotation )
 {
     const coord_pair p( pos );
@@ -230,7 +230,7 @@ void map_memory::set_tile_terrain( const tripoint_abs_ms &pos, const std::string
     sm.set_tile( p.loc, mt );
 }
 
-void map_memory::set_tile_decoration( const tripoint_abs_ms &pos, const std::string_view id,
+void map_memory::set_tile_decoration( const tripoint_abs_ms &pos, std::string_view id,
                                       int subtile, int rotation )
 {
     const coord_pair p( pos );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -447,7 +447,7 @@ bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view membe
 furn_workbench_info::furn_workbench_info() : multiplier( 1.0f ), allowed_mass( units::mass::max() ),
     allowed_volume( units::volume::max() ) {}
 
-bool furn_workbench_info::load( const JsonObject &jsobj, const std::string_view member )
+bool furn_workbench_info::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -461,7 +461,7 @@ bool furn_workbench_info::load( const JsonObject &jsobj, const std::string_view 
 plant_data::plant_data() : transform( furn_str_id::NULL_ID() ), base( furn_str_id::NULL_ID() ),
     growth_multiplier( 1.0f ), harvest_multiplier( 1.0f ) {}
 
-bool plant_data::load( const JsonObject &jsobj, const std::string_view member )
+bool plant_data::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -581,7 +581,7 @@ void map_data_common_t::load_symbol_color( const JsonObject &jo, const std::stri
     const bool no_copy_symbol_color = jo.has_member( "copy-from" );
 
     load_season_array( jo, "symbol", context, no_copy_symbol_color,
-    symbol_, [&jo]( const std::string_view str ) {
+    symbol_, [&jo]( std::string_view str ) {
         if( str.length() != 1 ) {
             jo.throw_error_at( "symbol", "Symbol string must be exactly 1 character long." );
         }
@@ -594,7 +594,7 @@ void map_data_common_t::load_symbol_color( const JsonObject &jo, const std::stri
         jo.throw_error( "Found both color and bgcolor, only one of these is allowed." );
     } else if( has_color ) {
         load_season_array( jo, "color", context, no_copy_symbol_color,
-        color_, []( const std::string_view str ) {
+        color_, []( std::string_view str ) {
             // has to use a lambda because of default params
             return color_from_string( str );
         } );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1455,7 +1455,7 @@ mapgen_function_json_nested::mapgen_function_json_nested(
 {
 }
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag )
+jmapgen_int::jmapgen_int( const JsonObject &jo, std::string_view tag )
 {
     if( jo.has_array( tag ) ) {
         JsonArray sparray = jo.get_array( tag );
@@ -1481,7 +1481,7 @@ jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag )
     }
 }
 
-jmapgen_int::jmapgen_int( const JsonObject &jo, const std::string_view tag, const int &def_val,
+jmapgen_int::jmapgen_int( const JsonObject &jo, std::string_view tag, const int &def_val,
                           const int &def_valmax )
     : val( def_val )
     , valmax( def_valmax )
@@ -1706,7 +1706,7 @@ static bool is_null_helper( const int_id<T> &id )
     return id.id().is_null();
 }
 
-static bool is_null_helper( const std::string_view )
+static bool is_null_helper( std::string_view )
 {
     return false;
 }
@@ -1764,7 +1764,7 @@ static bool is_valid_helper( const int_id<T> & )
     return true;
 }
 
-static bool is_valid_helper( const std::string_view )
+static bool is_valid_helper( std::string_view )
 {
     return true;
 }
@@ -2413,7 +2413,7 @@ class jmapgen_field : public jmapgen_piece
         std::vector<int> intensities;
         time_duration age;
         bool remove;
-        jmapgen_field( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_field( const JsonObject &jsi, std::string_view/*context*/ ) :
             ftype( jsi.get_member( "field" ) )
             , age( time_duration::from_turns( jsi.get_int( "age", 0 ) ) )
             , remove( jsi.get_bool( "remove", false ) ) {
@@ -2457,7 +2457,7 @@ class jmapgen_npc : public jmapgen_piece
         bool target;
         std::vector<trait_id> traits;
         std::string unique_id;
-        jmapgen_npc( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_npc( const JsonObject &jsi, std::string_view/*context*/ ) :
             npc_class( jsi.get_member( "class" ) )
             , target( jsi.get_bool( "target", false ) ) {
             if( jsi.has_string( "add_trait" ) ) {
@@ -2513,7 +2513,7 @@ class jmapgen_faction : public jmapgen_piece
 {
     public:
         mapgen_value<faction_id> id;
-        jmapgen_faction( const JsonObject &jsi, const std::string_view/*context*/ )
+        jmapgen_faction( const JsonObject &jsi, std::string_view/*context*/ )
             : id( jsi.get_member( "id" ) ) {
         }
         mapgen_phase phase() const override {
@@ -2548,7 +2548,7 @@ class jmapgen_sign : public jmapgen_piece_with_has_vehicle_collision
     public:
         translation signage;
         std::string snippet;
-        jmapgen_sign( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_sign( const JsonObject &jsi, std::string_view/*context*/ ) :
             snippet( jsi.get_string( "snippet", "" ) ) {
             jsi.read( "signage", signage );
             optional( jsi, false, "furniture", sign_furniture, furn_f_sign );
@@ -2601,7 +2601,7 @@ class jmapgen_graffiti : public jmapgen_piece
     public:
         translation text;
         std::string snippet;
-        jmapgen_graffiti( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_graffiti( const JsonObject &jsi, std::string_view/*context*/ ) :
             snippet( jsi.get_string( "snippet", "" ) ) {
             jsi.read( "text", text );
             if( text.empty() && snippet.empty() ) {
@@ -2649,7 +2649,7 @@ class jmapgen_vending_machine : public jmapgen_piece_with_has_vehicle_collision
         mapgen_value<item_group_id> group_id;
         bool powered;
         bool networked;
-        jmapgen_vending_machine( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_vending_machine( const JsonObject &jsi, std::string_view/*context*/ ) :
             reinforced( jsi.get_bool( "reinforced", false ) )
             , powered( jsi.get_bool( "powered", false ) )
             , networked( jsi.get_bool( "networked", false ) ) {
@@ -2684,7 +2684,7 @@ class jmapgen_toilet : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         jmapgen_int amount;
-        jmapgen_toilet( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_toilet( const JsonObject &jsi, std::string_view/*context*/ ) :
             amount( jsi, "amount", 0, 0 ) {
         }
         mapgen_phase phase() const override {
@@ -2711,7 +2711,7 @@ class jmapgen_gaspump : public jmapgen_piece_with_has_vehicle_collision
     public:
         jmapgen_int amount;
         mapgen_value<itype_id> fuel;
-        jmapgen_gaspump( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_gaspump( const JsonObject &jsi, std::string_view/*context*/ ) :
             amount( jsi, "amount", 0, 0 ) {
             if( jsi.has_member( "fuel" ) ) {
                 jsi.read( "fuel", fuel );
@@ -2759,7 +2759,7 @@ class jmapgen_liquid_item : public jmapgen_piece
         jmapgen_int amount;
         mapgen_value<itype_id> liquid;
         jmapgen_int chance;
-        jmapgen_liquid_item( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_liquid_item( const JsonObject &jsi, std::string_view/*context*/ ) :
             amount( jsi, "amount", -1, -1 )
             , liquid( jsi.get_member( "liquid" ) )
             , chance( jsi, "chance", 1, 1 ) {
@@ -2813,7 +2813,7 @@ class jmapgen_corpse : public jmapgen_piece
     public:
         mongroup_id group;
         time_duration age;
-        jmapgen_corpse( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_corpse( const JsonObject &jsi, std::string_view/*context*/ ) :
             group( jsi.get_member( "group" ) )
             , age( time_duration::from_days( jsi.get_int( "age", 0 ) ) ) {
         }
@@ -2842,7 +2842,7 @@ class jmapgen_item_group : public jmapgen_piece
         item_group_id group_id;
         jmapgen_int chance;
         std::string faction;
-        jmapgen_item_group( const JsonObject &jsi, const std::string_view context ) :
+        jmapgen_item_group( const JsonObject &jsi, std::string_view context ) :
             chance( jsi, "chance", 100, 100 ) {
             JsonValue group = jsi.get_member( "item" );
             group_id = item_group::load_item_group( group, "collection",
@@ -2940,7 +2940,7 @@ class jmapgen_monster_group : public jmapgen_piece
         mapgen_value<mongroup_id> id;
         float density;
         jmapgen_int chance;
-        jmapgen_monster_group( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_monster_group( const JsonObject &jsi, std::string_view/*context*/ ) :
             id( jsi.get_member( "monster" ) )
             , density( jsi.get_float( "density", -1.0f ) )
             , chance( jsi, "chance", 1, 1 ) {
@@ -2988,7 +2988,7 @@ class jmapgen_monster : public jmapgen_piece
         bool target;
         bool use_pack_size;
         struct spawn_data data;
-        jmapgen_monster( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_monster( const JsonObject &jsi, std::string_view/*context*/ ) :
             chance( jsi, "chance", 100, 100 )
             , pack_size( jsi, "pack_size", 1, 1 )
             , one_or_none( jsi.get_bool( "one_or_none",
@@ -3160,7 +3160,7 @@ class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
         int fuel;
         int status;
         std::string faction;
-        jmapgen_vehicle( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_vehicle( const JsonObject &jsi, std::string_view/*context*/ ) :
             type( jsi.get_member( "vehicle" ) )
             , chance( jsi, "chance", 1, 1 )
             //, rotation( jsi.get_int( "rotation", 0 ) ) // unless there is a way for the json parser to
@@ -3343,7 +3343,7 @@ class jmapgen_spawn_item : public jmapgen_piece
         jmapgen_int amount;
         jmapgen_int chance;
         std::set<flag_id> flags;
-        jmapgen_spawn_item( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_spawn_item( const JsonObject &jsi, std::string_view/*context*/ ) :
             type( jsi.get_member( "item" ) )
             , amount( jsi, "amount", 1, 1 )
             , chance( jsi, "chance", 100, 100 )
@@ -3393,7 +3393,7 @@ class jmapgen_trap : public jmapgen_piece_with_has_vehicle_collision
         mapgen_value<trap_id> id;
         bool remove = false;
 
-        jmapgen_trap( const JsonObject &jsi, const std::string_view/*context*/ ) {
+        jmapgen_trap( const JsonObject &jsi, std::string_view/*context*/ ) {
             init( jsi.get_member( "trap" ) );
             remove = jsi.get_bool( "remove", false );
         }
@@ -3441,7 +3441,7 @@ class jmapgen_furniture : public jmapgen_piece_with_has_vehicle_collision
 {
     public:
         mapgen_value<furn_id> id;
-        jmapgen_furniture( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_furniture( const JsonObject &jsi, std::string_view/*context*/ ) :
             jmapgen_furniture( jsi.get_member( "furn" ) ) {}
         explicit jmapgen_furniture( const JsonValue &fid ) : id( fid ) {}
         mapgen_phase phase() const override {
@@ -3476,7 +3476,7 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
         };
     public:
         mapgen_value<ter_id> id;
-        jmapgen_terrain( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_terrain( const JsonObject &jsi, std::string_view/*context*/ ) :
             jmapgen_terrain( jsi.get_member( "ter" ) ) {}
         explicit jmapgen_terrain( const JsonValue &tid ) : id( mapgen_value<ter_id>( tid ) ) {}
 
@@ -3644,7 +3644,7 @@ class jmapgen_ter_furn_transform: public jmapgen_piece
 {
     public:
         mapgen_value<ter_furn_transform_id> id;
-        jmapgen_ter_furn_transform( const JsonObject &jsi, const std::string_view/*context*/ ) :
+        jmapgen_ter_furn_transform( const JsonObject &jsi, std::string_view/*context*/ ) :
             id( jsi.get_member( "transform" ) ) {}
 
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
@@ -3677,7 +3677,7 @@ class jmapgen_make_rubble : public jmapgen_piece
         bool items = false;
         mapgen_value<ter_id> floor_type = mapgen_value<ter_id>( ter_t_dirt );
         bool overwrite = false;
-        jmapgen_make_rubble( const JsonObject &jsi, const std::string_view/*context*/ ) {
+        jmapgen_make_rubble( const JsonObject &jsi, std::string_view/*context*/ ) {
             if( jsi.has_member( "rubble_type" ) ) {
                 rubble_type = mapgen_value<furn_id>( jsi.get_member( "rubble_type" ) );
             }
@@ -3726,7 +3726,7 @@ class jmapgen_computer : public jmapgen_piece_with_has_vehicle_collision
         std::vector<std::string> chat_topics;
         std::vector<effect_on_condition_id> eocs;
         bool target;
-        jmapgen_computer( const JsonObject &jsi, const std::string_view/*context*/ ) {
+        jmapgen_computer( const JsonObject &jsi, std::string_view/*context*/ ) {
             jsi.read( "name", name );
             jsi.read( "access_denied", access_denied );
             security = jsi.get_int( "security", 0 );
@@ -3923,7 +3923,7 @@ class jmapgen_zone : public jmapgen_piece
         mapgen_value<faction_id> faction;
         std::string name;
         std::string filter;
-        jmapgen_zone( const JsonObject &jsi, const std::string_view/*context*/ )
+        jmapgen_zone( const JsonObject &jsi, std::string_view/*context*/ )
             : zone_type( jsi.get_member( "type" ) )
             , faction( jsi.get_member( "faction" ) ) {
             if( jsi.has_string( "name" ) ) {
@@ -3982,7 +3982,7 @@ class jmapgen_remove_vehicles : public jmapgen_piece
 {
     public:
         std::vector<vproto_id> vehicles_to_remove;
-        jmapgen_remove_vehicles( const JsonObject &jo, const std::string_view/*context*/ ) {
+        jmapgen_remove_vehicles( const JsonObject &jo, std::string_view/*context*/ ) {
             for( std::string vehicle_prototype_id : jo.get_string_array( "vehicles" ) ) {
                 vehicles_to_remove.emplace_back( vehicle_prototype_id );
             }
@@ -4013,7 +4013,7 @@ class jmapgen_remove_npcs : public jmapgen_piece
     public:
         std::string npc_class;
         std::string unique_id;
-        jmapgen_remove_npcs( const JsonObject &jsi, const std::string_view /*context*/ ) {
+        jmapgen_remove_npcs( const JsonObject &jsi, std::string_view /*context*/ ) {
             optional( jsi, false, "class", npc_class );
             optional( jsi, false, "unique_id", unique_id );
         }
@@ -4044,7 +4044,7 @@ class jmapgen_remove_npcs : public jmapgen_piece
 class jmapgen_remove_all : public jmapgen_piece
 {
     public:
-        jmapgen_remove_all( const JsonObject &/*jo*/, const std::string_view/*context*/ ) {
+        jmapgen_remove_all( const JsonObject &/*jo*/, std::string_view/*context*/ ) {
         }
         mapgen_phase phase() const override {
             return mapgen_phase::removal;
@@ -4154,7 +4154,7 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
 
-                void check( const std::string_view, const mapgen_parameters & ) const {
+                void check( std::string_view, const mapgen_parameters & ) const {
                     // TODO: check join ids are valid
                 }
 
@@ -4304,7 +4304,7 @@ class jmapgen_nested : public jmapgen_piece
         neighbor_flag_any_check neighbor_flags_any;
         predecessor_oter_check predecessors;
         correct_z_level_check correct_z_level;
-        jmapgen_nested( const JsonObject &jsi, const std::string_view/*context*/ )
+        jmapgen_nested( const JsonObject &jsi, std::string_view/*context*/ )
             : neighbor_oters( jsi.get_object( "neighbors" ) )
             , neighbor_joins( jsi.get_object( "joins" ) )
             , neighbor_flags( jsi.get_object( "flags" ) )
@@ -4501,7 +4501,7 @@ void jmapgen_objects::add( const jmapgen_place &place,
 }
 
 template<typename PieceType>
-void jmapgen_objects::load_objects( const JsonArray &parray, const std::string_view context )
+void jmapgen_objects::load_objects( const JsonArray &parray, std::string_view context )
 {
     for( JsonObject jsi : parray ) {
         jmapgen_place where( jsi );
@@ -4517,7 +4517,7 @@ void jmapgen_objects::load_objects( const JsonArray &parray, const std::string_v
 
 template<>
 void jmapgen_objects::load_objects<jmapgen_loot>(
-    const JsonArray &parray, const std::string_view/*context*/ )
+    const JsonArray &parray, std::string_view/*context*/ )
 {
     for( JsonObject jsi : parray ) {
         jmapgen_place where( jsi );
@@ -4812,13 +4812,13 @@ void mapgen_palette::check() const
     }
 }
 
-mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, const std::string_view src,
+mapgen_palette mapgen_palette::load_temp( const JsonObject &jo, std::string_view src,
         const std::string &context )
 {
     return load_internal( jo, src, context, false, true );
 }
 
-void mapgen_palette::load( const JsonObject &jo, const std::string_view src )
+void mapgen_palette::load( const JsonObject &jo, std::string_view src )
 {
     mapgen_palette ret = load_internal( jo, src, "", true, false );
     if( ret.id.is_empty() ) {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -85,7 +85,7 @@ void attack_vector::reset()
     attack_vector_factory.reset();
 }
 
-void attack_vector::load( const JsonObject &jo, const std::string_view )
+void attack_vector::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "weapon", weapon, false );
@@ -124,7 +124,7 @@ void weapon_category::reset()
     weapon_category_factory.reset();
 }
 
-void weapon_category::load( const JsonObject &jo, const std::string_view )
+void weapon_category::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
     optional( jo, was_loaded, "proficiencies", proficiencies_ );
@@ -235,7 +235,7 @@ class tech_effect_reader : public generic_typed_reader<tech_effect_reader>
         }
 };
 
-void ma_requirements::load( const JsonObject &jo, const std::string_view )
+void ma_requirements::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "unarmed_allowed", unarmed_allowed, false );
     optional( jo, was_loaded, "melee_allowed", melee_allowed, false );
@@ -263,7 +263,7 @@ void ma_requirements::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "weapon_damage_requirements", min_damage, ma_weapon_damage_reader {} );
 }
 
-void ma_technique::load( const JsonObject &jo, const std::string_view src )
+void ma_technique::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "description", description, translation() );
@@ -352,7 +352,7 @@ bool string_id<ma_technique>::is_valid() const
     return ma_techniques.is_valid( *this );
 }
 
-void ma_buff::load( const JsonObject &jo, const std::string_view src )
+void ma_buff::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );
@@ -409,7 +409,7 @@ class ma_buff_reader : public generic_typed_reader<ma_buff_reader>
         }
 };
 
-void martialart::load( const JsonObject &jo, const std::string_view src )
+void martialart::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "description", description );

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -79,7 +79,7 @@ static mat_burn_data load_mat_burn_data( const JsonObject &jsobj )
     return bd;
 }
 
-void material_type::load( const JsonObject &jsobj, const std::string_view )
+void material_type::load( const JsonObject &jsobj, std::string_view )
 {
     mandatory( jsobj, was_loaded, "name", _name );
 

--- a/src/math_parser_jmath.cpp
+++ b/src/math_parser_jmath.cpp
@@ -47,7 +47,7 @@ void jmath_func::load_func( const JsonObject &jo, std::string const &src )
     get_all_jmath_func().load( jo, src );
 }
 
-void jmath_func::load( JsonObject const &jo, const std::string_view /*src*/ )
+void jmath_func::load( JsonObject const &jo, std::string_view /*src*/ )
 {
     optional( jo, was_loaded, "num_args", num_params );
     optional( jo, was_loaded, "return", _str );

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -116,8 +116,8 @@ void memorial_logger::clear()
  * the character dies. The message should contain only the informational string,
  * as the timestamp and location will be automatically prepended.
  */
-void memorial_logger::add( const std::string_view male_msg,
-                           const std::string_view female_msg )
+void memorial_logger::add( std::string_view male_msg,
+                           std::string_view female_msg )
 {
     Character &player_character = get_player_character();
     const std::string_view msg = player_character.male ? male_msg : female_msg;
@@ -249,7 +249,7 @@ void memorial_logger::write_text_memorial( std::ostream &file,
     //HP
 
     const auto limb_hp =
-    [&file, &indent, &u]( const std::string_view desc, const bodypart_id & bp ) {
+    [&file, &indent, &u]( std::string_view desc, const bodypart_id & bp ) {
         file << indent <<
              string_format( desc, u.get_part_hp_cur( bp ), u.get_part_hp_max( bp ) ) << eol;
     };

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -526,7 +526,7 @@ bool mission_util::load_funcs( const JsonObject &jo,
     return true;
 }
 
-bool mission_type::parse_funcs( const JsonObject &jo, const std::string_view src,
+bool mission_type::parse_funcs( const JsonObject &jo, std::string_view src,
                                 std::function<void( mission * )> &phase_func )
 {
     std::vector<std::function<void( mission *miss )>> funcs;

--- a/src/mod_tileset.cpp
+++ b/src/mod_tileset.cpp
@@ -7,7 +7,7 @@
 
 std::vector<mod_tileset> all_mod_tilesets;
 
-void load_mod_tileset( const JsonObject &jsobj, const std::string_view, const cata_path &base_path,
+void load_mod_tileset( const JsonObject &jsobj, std::string_view, const cata_path &base_path,
                        const cata_path &full_path )
 {
     // This function only checks whether mod tileset is compatible.

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -182,7 +182,7 @@ void monfactions::finalize()
     }
 }
 
-void monfaction::load( const JsonObject &jo, const std::string_view )
+void monfaction::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "base_faction", base_faction, mfaction_str_id() );
     optional( jo, was_loaded, "by_mood", _att_by_mood, string_id_reader<monfaction>() );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1046,7 +1046,7 @@ std::string monster::extended_description() const
 
     using flag_description = std::pair<const mon_flag_id, std::string>;
     const auto describe_flags = [this, &ss](
-                                    const std::string_view format,
+                                    std::string_view format,
                                     const std::vector<flag_description> &flags_names,
     const std::string &if_empty = "" ) {
         std::string flag_descriptions = enumerate_as_string( flags_names.begin(),
@@ -1062,7 +1062,7 @@ std::string monster::extended_description() const
 
     using property_description = std::pair<bool, std::string>;
     const auto describe_properties = [&ss](
-                                         const std::string_view format,
+                                         std::string_view format,
                                          const std::vector<property_description> &property_names,
     const std::string &if_empty = "" ) {
         std::string property_descriptions = enumerate_as_string( property_names.begin(),
@@ -2782,7 +2782,7 @@ void monster::disable_special( const std::string &special_name )
     special_attacks.at( special_name ).enabled = false;
 }
 
-bool monster::special_available( const std::string_view special_name ) const
+bool monster::special_available( std::string_view special_name ) const
 {
     std::map<std::string, mon_special_attack>::const_iterator iter = special_attacks.find(
                 special_name );

--- a/src/monster_oracle.cpp
+++ b/src/monster_oracle.cpp
@@ -10,12 +10,12 @@ struct tripoint;
 namespace behavior
 {
 
-status_t monster_oracle_t::not_hallucination( const std::string_view ) const
+status_t monster_oracle_t::not_hallucination( std::string_view ) const
 {
     return subject->is_hallucination() ? status_t::failure : status_t::running;
 }
 
-status_t monster_oracle_t::split_possible( const std::string_view ) const
+status_t monster_oracle_t::split_possible( std::string_view ) const
 {
     // check if subject has split to support inverting this predicate for absorb monsters without split
     if( subject->has_special( "SPLIT" ) && ( subject->get_hp() / 2 ) > subject->get_hp_max() ) {
@@ -24,7 +24,7 @@ status_t monster_oracle_t::split_possible( const std::string_view ) const
     return status_t::failure;
 }
 
-status_t monster_oracle_t::items_available( const std::string_view ) const
+status_t monster_oracle_t::items_available( std::string_view ) const
 {
     map &here = get_map();
 
@@ -86,7 +86,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
 }
 
 // TODO: Have it select a target and stash it somewhere.
-status_t monster_oracle_t::adjacent_plants( const std::string_view ) const
+status_t monster_oracle_t::adjacent_plants( std::string_view ) const
 {
     map &here = get_map();
 
@@ -98,7 +98,7 @@ status_t monster_oracle_t::adjacent_plants( const std::string_view ) const
     return status_t::failure;
 }
 
-status_t monster_oracle_t::special_available( const std::string_view special_name ) const
+status_t monster_oracle_t::special_available( std::string_view special_name ) const
 {
     bool only_if_present = false;
     std::string mspecial_name;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1250,7 +1250,7 @@ void MonsterGenerator::load_species( const JsonObject &jo, const std::string &sr
     mon_species->load( jo, src );
 }
 
-void species_type::load( const JsonObject &jo, const std::string_view )
+void species_type::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "description", description );
     optional( jo, was_loaded, "footsteps", footsteps, to_translation( "footsteps." ) );
@@ -1464,7 +1464,7 @@ void mtype::add_special_attack( const JsonObject &obj, const std::string &src )
     special_attacks_names.push_back( new_attack->id );
 }
 
-void mtype::add_special_attack( const JsonArray &inner, const std::string_view )
+void mtype::add_special_attack( const JsonArray &inner, std::string_view )
 {
     MonsterGenerator &gen = MonsterGenerator::generator();
     const std::string name = inner.get_string( 0 );
@@ -1495,7 +1495,7 @@ void mtype::add_special_attack( const JsonArray &inner, const std::string_view )
     special_attacks_names.push_back( name );
 }
 
-void mtype::add_special_attacks( const JsonObject &jo, const std::string_view member,
+void mtype::add_special_attacks( const JsonObject &jo, std::string_view member,
                                  const std::string &src )
 {
 
@@ -1514,8 +1514,8 @@ void mtype::add_special_attacks( const JsonObject &jo, const std::string_view me
     }
 }
 
-void mtype::remove_special_attacks( const JsonObject &jo, const std::string_view member_name,
-                                    const std::string_view )
+void mtype::remove_special_attacks( const JsonObject &jo, std::string_view member_name,
+                                    std::string_view )
 {
     for( const std::string &name : jo.get_tags( member_name ) ) {
         special_attacks.erase( name );
@@ -1526,7 +1526,7 @@ void mtype::remove_special_attacks( const JsonObject &jo, const std::string_view
     }
 }
 
-void mtype::add_regeneration_modifier( const JsonArray &inner, const std::string_view )
+void mtype::add_regeneration_modifier( const JsonArray &inner, std::string_view )
 {
     const std::string effect_name = inner.get_string( 0 );
     const efftype_id effect( effect_name );
@@ -1544,8 +1544,8 @@ void mtype::add_regeneration_modifier( const JsonArray &inner, const std::string
     regeneration_modifiers.emplace( effect, amount );
 }
 
-void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string_view member,
-                                        const std::string_view src )
+void mtype::add_regeneration_modifiers( const JsonObject &jo, std::string_view member,
+                                        std::string_view src )
 {
     if( !jo.has_array( member ) ) {
         return;
@@ -1563,8 +1563,8 @@ void mtype::add_regeneration_modifiers( const JsonObject &jo, const std::string_
     }
 }
 
-void mtype::remove_regeneration_modifiers( const JsonObject &jo, const std::string_view member_name,
-        const std::string_view )
+void mtype::remove_regeneration_modifiers( const JsonObject &jo, std::string_view member_name,
+        std::string_view )
 {
     for( const std::string &name : jo.get_tags( member_name ) ) {
         const efftype_id effect( name );

--- a/src/mood_face.cpp
+++ b/src/mood_face.cpp
@@ -38,7 +38,7 @@ void mood_face::reset()
     mood_face_factory.reset();
 }
 
-void mood_face::load( const JsonObject &jo, const std::string_view )
+void mood_face::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/morale_types.cpp
+++ b/src/morale_types.cpp
@@ -44,7 +44,7 @@ void morale_type_data::reset()
     morale_data.reset();
 }
 
-void morale_type_data::load( const JsonObject &jo, const std::string_view )
+void morale_type_data::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "text", text );

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -47,7 +47,7 @@ void move_mode::load_move_mode( const JsonObject &jo, const std::string &src )
     move_mode_factory.load( jo, src );
 }
 
-void move_mode::load( const JsonObject &jo, const std::string_view/*src*/ )
+void move_mode::load( const JsonObject &jo, std::string_view/*src*/ )
 {
     mandatory( jo, was_loaded, "character", _letter, unicode_codepoint_from_symbol_reader );
     mandatory( jo, was_loaded, "name",  _name );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -188,7 +188,7 @@ void mutation_branch::load_trait( const JsonObject &jo, const std::string &src )
 
 mut_transform::mut_transform() = default;
 
-bool mut_transform::load( const JsonObject &jsobj, const std::string_view member )
+bool mut_transform::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -203,7 +203,7 @@ bool mut_transform::load( const JsonObject &jsobj, const std::string_view member
 
 mut_personality_score::mut_personality_score() = default;
 
-bool mut_personality_score::load( const JsonObject &jsobj, const std::string_view member )
+bool mut_personality_score::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
@@ -289,7 +289,7 @@ void mutation_variant::deserialize( const JsonObject &jo )
     load( jo );
 }
 
-void mutation_branch::load( const JsonObject &jo, const std::string_view src )
+void mutation_branch::load( const JsonObject &jo, std::string_view src )
 {
     mandatory( jo, was_loaded, "name", raw_name );
     mandatory( jo, was_loaded, "description", raw_desc );

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -43,7 +43,7 @@ static void draw_exam_window( const catacurses::window &win, const int border_y 
     wattroff( win, BORDER_COLOR );
 }
 
-static const auto shortcut_desc = []( const std::string_view comment, const std::string &keys )
+static const auto shortcut_desc = []( std::string_view comment, const std::string &keys )
 {
     return string_format( comment, string_format( "[<color_yellow>%s</color>]", keys ) );
 };

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1098,7 +1098,7 @@ static void draw_points( const catacurses::window &w, pool_type pool, const avat
 
 template <class Compare>
 static void draw_filter_and_sorting_indicators( const catacurses::window &w,
-        const input_context &ctxt, const std::string_view filterstring, const Compare &sorter )
+        const input_context &ctxt, std::string_view filterstring, const Compare &sorter )
 {
     const char *const sort_order = sorter.sort_by_points ? _( "default" ) : _( "name" );
     const std::string sorting_indicator = string_format( "[%1$s] %2$s: %3$s",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -326,7 +326,7 @@ npc &npc::operator=( npc && ) noexcept( list_is_noexcept ) = default;
 
 static std::map<string_id<npc_template>, npc_template> npc_templates;
 
-void npc_template::load( const JsonObject &jsobj, const std::string_view src )
+void npc_template::load( const JsonObject &jsobj, std::string_view src )
 {
     npc_template tem;
     npc &guy = tem.guy;

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -171,7 +171,7 @@ static distribution load_distribution( const JsonObject &jo )
     jo.throw_error( "Invalid distribution" );
 }
 
-static distribution load_distribution( const JsonObject &jo, const std::string_view name )
+static distribution load_distribution( const JsonObject &jo, std::string_view name )
 {
     if( !jo.has_member( name ) ) {
         return distribution();
@@ -224,7 +224,7 @@ void shopkeeper_item_group::deserialize( const JsonObject &jo )
     }
 }
 
-void npc_class::load( const JsonObject &jo, const std::string_view )
+void npc_class::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "job_description", job_description );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -142,23 +142,23 @@ using item_menu_mul = std::function<drop_locations( const item_location_filter &
 
 struct sub_effect_parser {
     using f_t = talk_effect_fun_t::func( * )( const JsonObject &, std::string_view,
-                const std::string_view src );
+                std::string_view src );
     using f_t_beta = talk_effect_fun_t::func( * )( const JsonObject &, std::string_view,
-                     const std::string_view src, bool );
+                     std::string_view src, bool );
     using f_t_effect = talk_effect_fun_t ( * )( const JsonObject &, std::string_view,
-                       const std::string_view src );
+                       std::string_view src );
     using f_t_beta_effect = talk_effect_fun_t ( * )( const JsonObject &, std::string_view,
-                            const std::string_view src, bool );
+                            std::string_view src, bool );
 
     sub_effect_parser( std::string_view key_alpha_, jarg arg_, f_t f_ ) : key_alpha( key_alpha_ ),
         arg( arg_ ) {
-        f = [f_]( const JsonObject & jo, std::string_view key, const std::string_view src, bool ) {
+        f = [f_]( const JsonObject & jo, std::string_view key, std::string_view src, bool ) {
             return talk_effect_fun_t( f_( jo, key, src ) );
         };
     }
     sub_effect_parser( std::string_view key_alpha_, std::string_view key_beta_, jarg arg_,
                        f_t_beta f_ ) : key_alpha( key_alpha_ ), key_beta( key_beta_ ), arg( arg_ ) {
-        f = [f_]( const JsonObject & jo, std::string_view key, const std::string_view src, bool beta ) {
+        f = [f_]( const JsonObject & jo, std::string_view key, std::string_view src, bool beta ) {
             return talk_effect_fun_t( f_( jo, key, src, beta ) );
         };
         has_beta = true;
@@ -166,7 +166,7 @@ struct sub_effect_parser {
     sub_effect_parser( std::string_view key_alpha_,
                        jarg arg_, f_t_effect f_ )
         : key_alpha( key_alpha_ ), arg( arg_ ) {
-        f = [f_]( const JsonObject & jo, std::string_view key, const std::string_view src, bool ) {
+        f = [f_]( const JsonObject & jo, std::string_view key, std::string_view src, bool ) {
             return f_( jo, key, src );
         };
     }
@@ -186,7 +186,7 @@ struct sub_effect_parser {
     std::string_view key_alpha;
     std::string_view key_beta;
     jarg arg;
-    std::function<talk_effect_fun_t( const JsonObject &, std::string_view, const std::string_view src, bool )>
+    std::function<talk_effect_fun_t( const JsonObject &, std::string_view, std::string_view src, bool )>
     f;
 };
 
@@ -434,7 +434,7 @@ static void run_eoc_vector( const std::vector<effect_on_condition_id> &eocs, con
 }
 
 static std::vector<effect_on_condition_id> load_eoc_vector( const JsonObject &jo,
-        const std::string_view member, const std::string_view src )
+        std::string_view member, std::string_view src )
 {
     std::vector<effect_on_condition_id> eocs;
     if( jo.has_array( member ) ) {
@@ -453,7 +453,7 @@ struct eoc_entry {
 };
 static std::vector<eoc_entry>
 load_eoc_vector_id_and_var(
-    const JsonObject &jo, const std::string_view member, const std::string_view src )
+    const JsonObject &jo, std::string_view member, std::string_view src )
 {
     std::vector<eoc_entry> eocs_entries;
     auto process_jv = [member, &eocs_entries, &src]( const JsonValue & jv ) {
@@ -3176,7 +3176,7 @@ talk_trial::talk_trial( const JsonObject &jo )
     }
 }
 
-static talk_topic load_inline_topic( const JsonObject &jo, const std::string_view src )
+static talk_topic load_inline_topic( const JsonObject &jo, std::string_view src )
 {
     const std::string id = jo.get_string( "id" );
     json_talk_topics[id].load( jo, src );
@@ -3327,7 +3327,7 @@ namespace talk_effect_fun
 namespace
 {
 talk_effect_fun_t::func f_companion_mission( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var id = get_str_or_var( jo.get_member( member ), member, true );
     return [id]( dialogue const & d ) {
@@ -3337,7 +3337,7 @@ talk_effect_fun_t::func f_companion_mission( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_add_effect( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     str_or_var new_effect = get_str_or_var( jo.get_member( member ), member, true );
     bool permanent = false;
@@ -3372,7 +3372,7 @@ talk_effect_fun_t::func f_add_effect( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_remove_effect( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     std::vector<str_or_var> old_effects;
     if( jo.has_string( member ) ) {
@@ -3409,7 +3409,7 @@ talk_effect_fun_t::func f_remove_effect( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_add_trait( const JsonObject &jo, std::string_view member,
-                                     const std::string_view, bool is_npc )
+                                     std::string_view, bool is_npc )
 {
     str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
     str_or_var new_variant;
@@ -3429,7 +3429,7 @@ talk_effect_fun_t::func f_add_trait( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_activate_trait( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, new_trait]( dialogue const & d ) {
@@ -3438,7 +3438,7 @@ talk_effect_fun_t::func f_activate_trait( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_deactivate_trait( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, new_trait]( dialogue const & d ) {
@@ -3447,7 +3447,7 @@ talk_effect_fun_t::func f_deactivate_trait( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_remove_trait( const JsonObject &jo, std::string_view member,
-                                        const std::string_view, bool is_npc )
+                                        std::string_view, bool is_npc )
 {
     str_or_var old_trait = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, old_trait]( dialogue const & d ) {
@@ -3458,7 +3458,7 @@ talk_effect_fun_t::func f_remove_trait( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_learn_martial_art( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var ma_to_learn = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, ma_to_learn]( dialogue const & d ) {
@@ -3467,7 +3467,7 @@ talk_effect_fun_t::func f_learn_martial_art( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_forget_martial_art( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var ma_to_forget = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, ma_to_forget]( dialogue const & d ) {
@@ -3476,7 +3476,7 @@ talk_effect_fun_t::func f_forget_martial_art( const JsonObject &jo, std::string_
 }
 
 talk_effect_fun_t::func f_mutate( const JsonObject &jo, std::string_view member,
-                                  const std::string_view, bool is_npc )
+                                  std::string_view, bool is_npc )
 {
     dbl_or_var highest_cat = get_dbl_or_var( jo, member, true, 0 );
     const bool use_vitamins = jo.get_bool( "use_vitamins", true );
@@ -3486,7 +3486,7 @@ talk_effect_fun_t::func f_mutate( const JsonObject &jo, std::string_view member,
 }
 
 talk_effect_fun_t::func f_mutate_category( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var mut_cat = get_str_or_var( jo.get_member( member ), member, true, "" );
     const bool use_vitamins = jo.get_bool( "use_vitamins", true );
@@ -3498,7 +3498,7 @@ talk_effect_fun_t::func f_mutate_category( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_mutate_towards( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var trait = get_str_or_var( jo.get_member( member ), member, true, "" );
     str_or_var mut_cat;
@@ -3516,7 +3516,7 @@ talk_effect_fun_t::func f_mutate_towards( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_set_trait_purifiability( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var trait = get_str_or_var( jo.get_member( member ), member, true, "" );
     const bool purifiable = jo.get_bool( "purifiable", true );
@@ -3527,7 +3527,7 @@ talk_effect_fun_t::func f_set_trait_purifiability( const JsonObject &jo, std::st
 }
 
 talk_effect_fun_t::func f_add_bionic( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     str_or_var new_bionic = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, new_bionic]( dialogue const & d ) {
@@ -3536,7 +3536,7 @@ talk_effect_fun_t::func f_add_bionic( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_lose_bionic( const JsonObject &jo, std::string_view member,
-                                       const std::string_view, bool is_npc )
+                                       std::string_view, bool is_npc )
 {
     str_or_var old_bionic = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, old_bionic]( dialogue const & d ) {
@@ -3545,7 +3545,7 @@ talk_effect_fun_t::func f_lose_bionic( const JsonObject &jo, std::string_view me
 }
 
 talk_effect_fun_t::func f_add_var( const JsonObject &jo, std::string_view member,
-                                   const std::string_view, bool is_npc )
+                                   std::string_view, bool is_npc )
 {
     dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member );
@@ -3569,7 +3569,7 @@ talk_effect_fun_t::func f_add_var( const JsonObject &jo, std::string_view member
 }
 
 talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     const std::string var_name = get_talk_varname( jo, member );
     return [is_npc, var_name]( dialogue const & d ) {
@@ -3680,7 +3680,7 @@ void receive_item( itype_id &item_name, int count, std::string_view container_na
 }
 
 talk_effect_fun_t f_spawn_item( const JsonObject &jo, std::string_view member,
-                                const std::string_view )
+                                std::string_view )
 {
     str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
     str_or_var container_name;
@@ -3735,7 +3735,7 @@ talk_effect_fun_t f_spawn_item( const JsonObject &jo, std::string_view member,
 }
 
 talk_effect_fun_t::func f_u_buy_item( const JsonObject &jo, std::string_view member,
-                                      const std::string_view src )
+                                      std::string_view src )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
@@ -3780,7 +3780,7 @@ talk_effect_fun_t::func f_u_buy_item( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_u_sell_item( const JsonObject &jo, std::string_view member,
-                                       const std::string_view src )
+                                       std::string_view src )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
@@ -3827,7 +3827,7 @@ talk_effect_fun_t::func f_u_sell_item( const JsonObject &jo, std::string_view me
 }
 
 talk_effect_fun_t::func f_consume_item( const JsonObject &jo, std::string_view member,
-                                        const std::string_view, bool is_npc )
+                                        std::string_view, bool is_npc )
 {
     str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var charges = get_dbl_or_var( jo, "charges", false, 0 );
@@ -3882,7 +3882,7 @@ talk_effect_fun_t::func f_consume_item( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_consume_item_sum( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     // Only after i implemented it, i realised it is a bad way to make it
     // What it should be is an expansion of f_run_inv_eocs
@@ -3942,7 +3942,7 @@ talk_effect_fun_t::func f_consume_item_sum( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_remove_item_with( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var item_name = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, item_name]( dialogue const & d ) {
@@ -3954,7 +3954,7 @@ talk_effect_fun_t::func f_remove_item_with( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_u_spend_cash( const JsonObject &jo, std::string_view member,
-                                        const std::string_view src )
+                                        std::string_view src )
 {
     dbl_or_var amount = get_dbl_or_var( jo, member );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
@@ -3969,7 +3969,7 @@ talk_effect_fun_t::func f_u_spend_cash( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_npc_change_faction( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var faction_name = get_str_or_var( jo.get_member( member ), member, true );
     return [faction_name]( dialogue const & d ) {
@@ -3978,7 +3978,7 @@ talk_effect_fun_t::func f_npc_change_faction( const JsonObject &jo, std::string_
 }
 
 talk_effect_fun_t::func f_npc_change_class( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var class_name = get_str_or_var( jo.get_member( member ), member, true );
     return [class_name]( dialogue const & d ) {
@@ -3987,7 +3987,7 @@ talk_effect_fun_t::func f_npc_change_class( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_change_faction_rep( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     dbl_or_var rep_change = get_dbl_or_var( jo, member );
     return [rep_change]( dialogue & d ) {
@@ -3996,7 +3996,7 @@ talk_effect_fun_t::func f_change_faction_rep( const JsonObject &jo, std::string_
 }
 
 talk_effect_fun_t::func f_add_debt( const JsonObject &jo, std::string_view member,
-                                    const std::string_view )
+                                    std::string_view )
 {
     std::vector<trial_mod> debt_modifiers;
     for( JsonArray jmod : jo.get_array( member ) ) {
@@ -4019,7 +4019,7 @@ talk_effect_fun_t::func f_add_debt( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_toggle_npc_rule( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4028,7 +4028,7 @@ talk_effect_fun_t::func f_toggle_npc_rule( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_set_npc_rule( const JsonObject &jo, std::string_view member,
-                                        const std::string_view )
+                                        std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4037,7 +4037,7 @@ talk_effect_fun_t::func f_set_npc_rule( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_clear_npc_rule( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4046,7 +4046,7 @@ talk_effect_fun_t::func f_clear_npc_rule( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_npc_engagement_rule( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4055,7 +4055,7 @@ talk_effect_fun_t::func f_npc_engagement_rule( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_npc_aim_rule( const JsonObject &jo, std::string_view member,
-                                        const std::string_view )
+                                        std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4064,7 +4064,7 @@ talk_effect_fun_t::func f_npc_aim_rule( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_npc_cbm_reserve_rule( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4073,7 +4073,7 @@ talk_effect_fun_t::func f_npc_cbm_reserve_rule( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_npc_cbm_recharge_rule( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     str_or_var rule = get_str_or_var( jo.get_member( member ), member, true );
     return [rule]( dialogue const & d ) {
@@ -4082,7 +4082,7 @@ talk_effect_fun_t::func f_npc_cbm_recharge_rule( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_view member,
-        const std::string_view src, bool is_npc )
+        std::string_view src, bool is_npc )
 {
     dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 0 );
     dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 0 );
@@ -4284,7 +4284,7 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     dbl_or_var dov_z_adjust = get_dbl_or_var( jo, "z_adjust", false, 0 );
     dbl_or_var dov_x_adjust = get_dbl_or_var( jo, "x_adjust", false, 0 );
@@ -4323,7 +4323,7 @@ talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var transform = get_str_or_var( jo.get_member( "ter_furn_transform" ),
                                            "ter_furn_transform", true );
@@ -4372,7 +4372,7 @@ talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view member,
-                                     const std::string_view, bool is_npc )
+                                     std::string_view, bool is_npc )
 {
     map &here = get_map();
 
@@ -4442,7 +4442,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_query_tile( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     std::string type = jo.get_string( member.data() );
     var_info target_var = read_var_info( jo.get_object( "target_var" ) );
@@ -4508,7 +4508,7 @@ talk_effect_fun_t::func f_query_tile( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view member,
-                                     const std::string_view, bool is_npc )
+                                     std::string_view, bool is_npc )
 {
     std::optional<var_info> output_var;
     if( jo.has_member( "output_var" ) ) {
@@ -4554,7 +4554,7 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_choose_adjacent_highlight( const JsonObject &jo, std::string_view member,
-        const std::string_view src, bool is_npc )
+        std::string_view src, bool is_npc )
 {
     map &here = get_map();
 
@@ -4618,7 +4618,7 @@ talk_effect_fun_t::func f_choose_adjacent_highlight( const JsonObject &jo, std::
 }
 
 talk_effect_fun_t::func f_mirror_coordinates( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     // remove it once we get proper coordinate operations in math
     var_info center_var;
@@ -4647,7 +4647,7 @@ talk_effect_fun_t::func f_mirror_coordinates( const JsonObject &jo, std::string_
 }
 
 talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var transform = get_str_or_var( jo.get_member( member ), member, true );
     var_info first = read_var_info( jo.get_object( "first" ) );
@@ -4664,7 +4664,7 @@ talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_place_override( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     translation_or_var new_place = get_translation_or_var( jo.get_member( member ), member );
     duration_or_var dov_length = get_duration_or_var( jo, "length", true );
@@ -4683,7 +4683,7 @@ talk_effect_fun_t::func f_place_override( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     mission_target_params target_params = mission_util::parse_mission_om_target( jo );
     std::vector<str_or_var> update_ids;
@@ -4739,7 +4739,7 @@ talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_alter_timed_events( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var key = get_str_or_var( jo.get_member( member ), member, true );
     duration_or_var time_in_future = get_duration_or_var( jo, "time_in_future", false,
@@ -4750,7 +4750,7 @@ talk_effect_fun_t::func f_alter_timed_events( const JsonObject &jo, std::string_
 }
 
 talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", true );
     str_or_var key;
@@ -4790,7 +4790,7 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_npc_goal( const JsonObject &jo, std::string_view member,
-                                    const std::string_view src, bool is_npc )
+                                    std::string_view src, bool is_npc )
 {
     mission_target_params dest_params = mission_util::parse_mission_om_target( jo.get_object(
                                             member ) );
@@ -4821,7 +4821,7 @@ talk_effect_fun_t::func f_npc_goal( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_guard_pos( const JsonObject &jo, std::string_view member,
-                                     const std::string_view, bool is_npc )
+                                     std::string_view, bool is_npc )
 {
     var_info target_var = read_var_info( jo.get_object( member ) );
     bool unique_id = jo.get_bool( "unique_id", false );
@@ -4839,7 +4839,7 @@ talk_effect_fun_t::func f_guard_pos( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_bulk_trade_accept( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     dbl_or_var dov_quantity;
     if( jo.has_member( member ) ) {
@@ -4996,7 +4996,7 @@ talk_effect_fun_t::func f_npc_gets_item( bool to_use )
 }
 
 talk_effect_fun_t::func f_add_mission( const JsonObject &jo, std::string_view member,
-                                       const std::string_view )
+                                       std::string_view )
 {
     str_or_var mission_id = get_str_or_var( jo.get_member( member ), member, true );
     return [mission_id]( dialogue const & d ) {
@@ -5005,7 +5005,7 @@ talk_effect_fun_t::func f_add_mission( const JsonObject &jo, std::string_view me
 }
 
 talk_effect_fun_t::func f_u_buy_monster( const JsonObject &jo, std::string_view member,
-        const std::string_view src )
+        std::string_view src )
 {
     str_or_var monster_type_id = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var cost = get_dbl_or_var( jo, "cost", false, 0 );
@@ -5034,7 +5034,7 @@ talk_effect_fun_t::func f_u_buy_monster( const JsonObject &jo, std::string_view 
 
 
 talk_effect_fun_t::func f_level_spell_class( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var spell_class = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var levels = get_dbl_or_var( jo, "levels", false, 1 );
@@ -5068,7 +5068,7 @@ talk_effect_fun_t::func f_level_spell_class( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_learn_recipe( const JsonObject &jo, std::string_view member,
-                                        const std::string_view, bool is_npc )
+                                        std::string_view, bool is_npc )
 {
     str_or_var learned_recipe_id = get_str_or_var( jo.get_member( member ), member, true );
     return [learned_recipe_id, is_npc]( dialogue const & d ) {
@@ -5078,7 +5078,7 @@ talk_effect_fun_t::func f_learn_recipe( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_forget_recipe( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var forgotten_recipe_id = get_str_or_var( jo.get_member( member ), member, true );
     return [forgotten_recipe_id, is_npc]( dialogue const & d ) {
@@ -5088,7 +5088,7 @@ talk_effect_fun_t::func f_forget_recipe( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_turn_cost( const JsonObject &jo, std::string_view member,
-                                     const std::string_view )
+                                     std::string_view )
 {
     duration_or_var cost = get_duration_or_var( jo, member, true );
     return [cost]( dialogue & d ) {
@@ -5100,7 +5100,7 @@ talk_effect_fun_t::func f_turn_cost( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_npc_first_topic( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var chat_topic = get_str_or_var( jo.get_member( member ), member, true );
     return [chat_topic]( dialogue const & d ) {
@@ -5109,7 +5109,7 @@ talk_effect_fun_t::func f_npc_first_topic( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_message( const JsonObject &jo, std::string_view member,
-                                   const std::string_view, bool is_npc )
+                                   std::string_view, bool is_npc )
 {
     const bool snippet = jo.get_bool( "snippet", false );
     str_or_var snip_id;
@@ -5245,7 +5245,7 @@ talk_effect_fun_t::func f_message( const JsonObject &jo, std::string_view member
 }
 
 talk_effect_fun_t::func f_assign_activity( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     duration_or_var dov = get_duration_or_var( jo, "duration", true );
     str_or_var act = get_str_or_var( jo.get_member( member ), member, true );
@@ -5258,7 +5258,7 @@ talk_effect_fun_t::func f_assign_activity( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_add_wet( const JsonObject &jo, std::string_view member,
-                                   const std::string_view, bool is_npc )
+                                   std::string_view, bool is_npc )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
     return [is_npc, dov]( dialogue & d ) {
@@ -5270,7 +5270,7 @@ talk_effect_fun_t::func f_add_wet( const JsonObject &jo, std::string_view member
 }
 
 talk_effect_fun_t::func f_open_dialogue( const JsonObject &jo, std::string_view member,
-        const std::string_view src )
+        std::string_view src )
 {
     std::vector<effect_on_condition_id> true_eocs;
     std::vector<effect_on_condition_id> false_eocs;
@@ -5302,7 +5302,7 @@ talk_effect_fun_t::func f_open_dialogue( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_take_control( const JsonObject &jo, std::string_view,
-                                        const std::string_view src )
+                                        std::string_view src )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
@@ -5325,7 +5325,7 @@ talk_effect_fun_t::func f_take_control_menu()
 }
 
 talk_effect_fun_t::func f_sound_effect( const JsonObject &jo, std::string_view member,
-                                        const std::string_view )
+                                        std::string_view )
 {
     str_or_var variant = get_str_or_var( jo.get_member( member ), member, true );
     str_or_var id = get_str_or_var( jo.get_member( "id" ), "id", true );
@@ -5360,7 +5360,7 @@ talk_effect_fun_t::func f_sound_effect( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_give_achievment( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var achieve = get_str_or_var( jo.get_member( member ), member, true );
     return [achieve]( dialogue const & d ) {
@@ -5380,7 +5380,7 @@ talk_effect_fun_t::func f_give_achievment( const JsonObject &jo, std::string_vie
 }
 
 talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view member,
-                                      const std::string_view src, bool is_npc )
+                                      std::string_view src, bool is_npc )
 {
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs", src );
@@ -5461,7 +5461,7 @@ talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_attack( const JsonObject &jo, std::string_view member,
-                                  const std::string_view, bool is_npc )
+                                  std::string_view, bool is_npc )
 {
     str_or_var force_technique = get_str_or_var( jo.get_member( member ), member, true );
     bool allow_special = jo.get_bool( "allow_special", true );
@@ -5491,7 +5491,7 @@ talk_effect_fun_t::func f_die( bool is_npc )
 }
 
 talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view member,
-                                        const std::string_view, bool is_npc )
+                                        std::string_view, bool is_npc )
 {
     JsonObject job = jo.get_object( member );
     std::optional<bool> remove_corpse;
@@ -5567,7 +5567,7 @@ talk_effect_fun_t::func f_next_weather()
 }
 
 talk_effect_fun_t::func f_copy_var( const JsonObject &jo, std::string_view member,
-                                    const std::string_view /* src */ )
+                                    std::string_view /* src */ )
 {
     var_info from = read_var_info( jo.get_member( member ) );
     var_info to = read_var_info( jo.get_member( "target_var" ) );
@@ -5579,7 +5579,7 @@ talk_effect_fun_t::func f_copy_var( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_set_string_var( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     const bool i18n = jo.get_bool( "i18n", false );
     std::optional<string_input_params> input_params;
@@ -5640,7 +5640,7 @@ talk_effect_fun_t::func f_set_string_var( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_set_condition( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var value;
     value = get_str_or_var( jo.get_member( member ), member );
@@ -5653,7 +5653,7 @@ talk_effect_fun_t::func f_set_condition( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_assign_mission( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var deadline = get_dbl_or_var( jo, "deadline", false );
@@ -5673,7 +5673,7 @@ talk_effect_fun_t::func f_assign_mission( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_finish_mission( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
     bool success = false;
@@ -5704,7 +5704,7 @@ talk_effect_fun_t::func f_finish_mission( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_remove_active_mission( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     str_or_var mission_name = get_str_or_var( jo.get_member( member ), member, true );
     return [mission_name]( dialogue const & d ) {
@@ -5721,7 +5721,7 @@ talk_effect_fun_t::func f_remove_active_mission( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_offer_mission( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     std::vector<std::string> mission_names;
 
@@ -5748,7 +5748,7 @@ talk_effect_fun_t::func f_offer_mission( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_set_flag( const JsonObject &jo, std::string_view member,
-                                    const std::string_view, bool is_npc )
+                                    std::string_view, bool is_npc )
 {
     str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
 
@@ -5765,7 +5765,7 @@ talk_effect_fun_t::func f_set_flag( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_unset_flag( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
 
@@ -5782,7 +5782,7 @@ talk_effect_fun_t::func f_unset_flag( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view member,
-                                    const std::string_view, bool is_npc )
+                                    std::string_view, bool is_npc )
 {
     map &here = get_map();
 
@@ -5822,7 +5822,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_math( const JsonObject &jo, std::string_view member,
-                                const std::string_view )
+                                std::string_view )
 {
     eoc_math math;
     math.from_json( jo, member, math_type_t::assign );
@@ -5833,7 +5833,7 @@ talk_effect_fun_t::func f_math( const JsonObject &jo, std::string_view member,
 
 
 talk_effect_fun_t::func f_transform_item( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     str_or_var target_id = get_str_or_var( jo.get_member( member ), member, true );
     bool activate = jo.get_bool( "active", false );
@@ -5852,7 +5852,7 @@ talk_effect_fun_t::func f_transform_item( const JsonObject &jo, std::string_view
 }
 
 talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     dbl_or_var volume = get_dbl_or_var( jo, "volume", true );
     bool ambient = jo.get_bool( "ambient", false );
@@ -6027,7 +6027,7 @@ std::unique_ptr<talker> get_talker( dialogue const &d, std::optional<str_or_var>
 }
 
 talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view member,
-                                    const std::string_view src )
+                                    std::string_view src )
 {
     std::vector<eoc_entry> eocs = load_eoc_vector_id_and_var( jo, member, src );
     if( eocs.empty() ) {
@@ -6111,7 +6111,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
 }
 
 talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_view member,
-        const std::string_view src )
+        std::string_view src )
 {
 
     std::vector<eoc_entry> eocs = load_eoc_vector_id_and_var( jo, member, src );
@@ -6267,7 +6267,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
-                                        std::string_view member, const std::string_view src, bool is_npc )
+                                        std::string_view member, std::string_view src, bool is_npc )
 {
     const map &here = get_map();
 
@@ -6331,7 +6331,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
-        std::string_view member, const std::string_view src, bool is_npc )
+        std::string_view member, std::string_view src, bool is_npc )
 {
     const map &here = get_map();
 
@@ -6381,7 +6381,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_run_vehicle_eocs( const JsonObject &jo,
-        std::string_view member, const std::string_view src, bool is_npc )
+        std::string_view member, std::string_view src, bool is_npc )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::optional<int> vehicle_range;
@@ -6404,7 +6404,7 @@ talk_effect_fun_t::func f_run_vehicle_eocs( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_run_inv_eocs( const JsonObject &jo,
-                                        std::string_view member, const std::string_view src, bool is_npc )
+                                        std::string_view member, std::string_view src, bool is_npc )
 {
     str_or_var option = get_str_or_var( jo.get_member( member ), member );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
@@ -6436,7 +6436,7 @@ talk_effect_fun_t::func f_run_inv_eocs( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_view member,
-        const std::string_view src, bool is_npc )
+        std::string_view src, bool is_npc )
 {
     str_or_var option = get_str_or_var( jo.get_member( member ), member );
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs", src );
@@ -6522,7 +6522,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view member,
-                                        const std::string_view src, bool is_npc )
+                                        std::string_view src, bool is_npc )
 {
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::optional<var_info> target_var;
@@ -6566,7 +6566,7 @@ talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_set_talker( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     var_info var = read_var_info( jo.get_object( member ) );
     var_type type = var.type;
@@ -6579,7 +6579,7 @@ talk_effect_fun_t::func f_set_talker( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_weighted_list_eocs( const JsonObject &jo,
-        std::string_view member, const std::string_view src )
+        std::string_view member, std::string_view src )
 {
     std::vector<std::pair<effect_on_condition_id, dbl_or_var>> eoc_pairs;
     for( JsonArray ja : jo.get_array( member ) ) {
@@ -6606,7 +6606,7 @@ talk_effect_fun_t::func f_weighted_list_eocs( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_if( const JsonObject &jo, std::string_view member,
-                              const std::string_view src )
+                              std::string_view src )
 {
     std::function<bool( const_dialogue const & )> cond;
     talk_effect_t then_effect;
@@ -6627,7 +6627,7 @@ talk_effect_fun_t::func f_if( const JsonObject &jo, std::string_view member,
 }
 
 talk_effect_fun_t::func f_switch( const JsonObject &jo, std::string_view member,
-                                  const std::string_view src )
+                                  std::string_view src )
 {
     dbl_or_var eoc_switch = get_dbl_or_var( jo, member );
     std::vector<std::pair<dbl_or_var, talk_effect_t>> case_pairs;
@@ -6651,7 +6651,7 @@ talk_effect_fun_t::func f_switch( const JsonObject &jo, std::string_view member,
 }
 
 talk_effect_fun_t::func f_foreach( const JsonObject &jo, std::string_view member,
-                                   const std::string_view src )
+                                   std::string_view src )
 {
     std::string type = jo.get_string( member.data() );
     var_info itr = read_var_info( jo.get_object( "var" ) );
@@ -6711,7 +6711,7 @@ talk_effect_fun_t::func f_foreach( const JsonObject &jo, std::string_view member
 }
 
 talk_effect_fun_t::func f_roll_remainder( const JsonObject &jo,
-        std::string_view member, const std::string_view src, bool is_npc )
+        std::string_view member, std::string_view src, bool is_npc )
 {
     std::vector<str_or_var> list;
     for( JsonValue jv : jo.get_array( member ) ) {
@@ -6788,7 +6788,7 @@ talk_effect_fun_t::func f_roll_remainder( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_set_fac_relation( const JsonObject &jo, std::string_view member,
-        const std::string_view, bool is_npc )
+        std::string_view, bool is_npc )
 {
     str_or_var new_relation = get_str_or_var( jo.get_member( member ), member, true );
     const bool should_set_value = jo.get_bool( "set_value_to", true );
@@ -6806,7 +6806,7 @@ talk_effect_fun_t::func f_set_fac_relation( const JsonObject &jo, std::string_vi
 }
 
 talk_effect_fun_t::func f_add_morale( const JsonObject &jo, std::string_view member,
-                                      const std::string_view, bool is_npc )
+                                      std::string_view, bool is_npc )
 {
     str_or_var new_type = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var dov_bonus = get_dbl_or_var( jo, "bonus" );
@@ -6826,7 +6826,7 @@ talk_effect_fun_t::func f_add_morale( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_lose_morale( const JsonObject &jo, std::string_view member,
-                                       const std::string_view, bool is_npc )
+                                       std::string_view, bool is_npc )
 {
     str_or_var old_morale = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, old_morale]( dialogue const & d ) {
@@ -6835,7 +6835,7 @@ talk_effect_fun_t::func f_lose_morale( const JsonObject &jo, std::string_view me
 }
 
 talk_effect_fun_t::func f_add_faction_trust( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
     return [dov]( dialogue & d ) {
@@ -6844,7 +6844,7 @@ talk_effect_fun_t::func f_add_faction_trust( const JsonObject &jo, std::string_v
 }
 
 talk_effect_fun_t::func f_lose_faction_trust( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member );
     return [dov]( dialogue & d ) {
@@ -6853,7 +6853,7 @@ talk_effect_fun_t::func f_lose_faction_trust( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_custom_light_level( const JsonObject &jo,
-        std::string_view member, const std::string_view )
+        std::string_view member, std::string_view )
 {
     dbl_or_var dov = get_dbl_or_var( jo, member, true );
     duration_or_var dov_length = get_duration_or_var( jo, "length", false, 0_seconds );
@@ -6872,7 +6872,7 @@ talk_effect_fun_t::func f_custom_light_level( const JsonObject &jo,
 }
 
 talk_effect_fun_t::func f_knockback( const JsonObject &jo, std::string_view member,
-                                     const std::string_view, bool is_npc )
+                                     std::string_view, bool is_npc )
 {
     dbl_or_var force = get_dbl_or_var( jo, member, false, 0 );
     dbl_or_var stun = get_dbl_or_var( jo, "stun", false, 0 );
@@ -6921,7 +6921,7 @@ talk_effect_fun_t::func f_knockback( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_give_equipment( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     JsonObject jobj = jo.get_object( member );
     int allowance = 0;
@@ -6953,7 +6953,7 @@ talk_effect_fun_t::func f_give_equipment( const JsonObject &jo, std::string_view
 
 
 talk_effect_fun_t::func f_deal_damage( const JsonObject &jo, std::string_view member,
-                                       const std::string_view, bool is_npc )
+                                       std::string_view, bool is_npc )
 {
     str_or_var dmg_type = get_str_or_var( jo.get_member( member ), member );
     dbl_or_var dmg_amount = get_dbl_or_var( jo, "amount", false, 0 );
@@ -7008,7 +7008,7 @@ talk_effect_fun_t::func f_deal_damage( const JsonObject &jo, std::string_view me
 }
 
 talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view member,
-        const std::string_view src, bool is_npc )
+        std::string_view src, bool is_npc )
 {
     const map &here = get_map();
 
@@ -7190,7 +7190,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
 }
 
 talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view member,
-                                     const std::string_view src, bool is_npc )
+                                     std::string_view src, bool is_npc )
 {
     const map &here = get_map();
 
@@ -7306,7 +7306,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
 }
 
 talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
-                                 const std::string_view, bool is_npc )
+                                 std::string_view, bool is_npc )
 {
     str_or_var new_field = get_str_or_var( jo.get_member( member ), member, true );
     dbl_or_var dov_intensity = get_dbl_or_var( jo, "intensity", false, 1 );
@@ -7345,7 +7345,7 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
 }
 
 talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view member,
-                                      const std::string_view )
+                                      std::string_view )
 {
     var_info target_var = read_var_info( jo.get_object( member ) );
     dbl_or_var radius = get_dbl_or_var( jo, "radius", false, 0 );
@@ -7357,7 +7357,7 @@ talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view mem
 }
 
 talk_effect_fun_t::func f_reveal_route( const JsonObject &jo, std::string_view member,
-                                        const std::string_view )
+                                        std::string_view )
 {
     var_info from = read_var_info( jo.get_object( member ) );
     var_info to = read_var_info( jo.get_object( "target_var" ) );
@@ -7375,7 +7375,7 @@ talk_effect_fun_t::func f_reveal_route( const JsonObject &jo, std::string_view m
 }
 
 talk_effect_fun_t::func f_closest_city( const JsonObject &jo, std::string_view member,
-                                        const std::string_view )
+                                        std::string_view )
 {
     var_info var = read_var_info( jo.get_object( member ) );
     var_type type = var.type;
@@ -7476,7 +7476,7 @@ talk_effect_fun_t::func f_wants_to_talk( bool is_npc )
 }
 
 talk_effect_fun_t::func f_trigger_event( const JsonObject &jo, std::string_view member,
-        const std::string_view )
+        std::string_view )
 {
     std::string const type_str = jo.get_string( member.data() );
     JsonArray const &jargs = jo.get_array( "args" );
@@ -7585,7 +7585,7 @@ void talk_effect_t::update_missions( dialogue &d )
 }
 
 talk_effect_t::talk_effect_t( const JsonObject &jo, const std::string &member_name,
-                              const std::string_view src )
+                              std::string_view src )
 {
     load_effect( jo, member_name, src );
     if( jo.has_object( "topic" ) ) {
@@ -7718,7 +7718,7 @@ parsers = {
     { "message", "message", jarg::member, &talk_effect_fun::f_message },
 };
 
-void talk_effect_t::parse_sub_effect( const JsonObject &jo, const std::string_view src )
+void talk_effect_t::parse_sub_effect( const JsonObject &jo, std::string_view src )
 {
     for( const sub_effect_parser &p : parsers ) {
         if( p.has_beta ) {
@@ -7738,7 +7738,7 @@ void talk_effect_t::parse_sub_effect( const JsonObject &jo, const std::string_vi
 }
 
 void talk_effect_t::parse_string_effect( const std::string &effect_id, const JsonObject &jo,
-        const std::string_view src )
+        std::string_view src )
 {
     static const std::unordered_map<std::string, void( * )( npc & )> static_functions_map = {
         {
@@ -7916,7 +7916,7 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
 }
 
 void talk_effect_t::load_effect( const JsonObject &jo, const std::string &member_name,
-                                 const std::string_view src )
+                                 std::string_view src )
 {
     if( jo.has_member( "opinion" ) ) {
         JsonValue jv = jo.get_member( "opinion" );
@@ -7969,7 +7969,7 @@ talk_response::talk_response()
     dialogue_spell = spell_id();
 }
 
-talk_response::talk_response( const JsonObject &jo, const std::string_view src )
+talk_response::talk_response( const JsonObject &jo, std::string_view src )
 {
     if( jo.has_member( "truefalsetext" ) ) {
         JsonObject truefalse_jo = jo.get_object( "truefalsetext" );
@@ -8021,7 +8021,7 @@ talk_response::talk_response( const JsonObject &jo, const std::string_view src )
 }
 
 json_talk_repeat_response::json_talk_repeat_response( const JsonObject &jo,
-        const std::string_view src )
+        std::string_view src )
 {
     if( jo.has_bool( "is_npc" ) ) {
         is_npc = true;
@@ -8055,7 +8055,7 @@ json_talk_repeat_response::json_talk_repeat_response( const JsonObject &jo,
     }
 }
 
-json_talk_response::json_talk_response( const JsonObject &jo, const std::string_view src )
+json_talk_response::json_talk_response( const JsonObject &jo, std::string_view src )
     : actual_response( jo, src )
 {
     load_condition( jo, src );
@@ -8063,7 +8063,7 @@ json_talk_response::json_talk_response( const JsonObject &jo, const std::string_
     actual_response.condition = condition;
 }
 
-void json_talk_response::load_condition( const JsonObject &jo, const std::string_view )
+void json_talk_response::load_condition( const JsonObject &jo, std::string_view )
 {
     has_condition_ = jo.has_member( "condition" );
     is_switch = jo.get_bool( "switch", false );
@@ -8150,7 +8150,7 @@ static std::string translate_gendered_line(
 }
 
 dynamic_line_t dynamic_line_t::from_member( const JsonObject &jo,
-        const std::string_view member_name )
+        std::string_view member_name )
 {
     if( jo.has_array( member_name ) ) {
         return dynamic_line_t( jo.get_array( member_name ) );
@@ -8321,7 +8321,7 @@ dynamic_line_t::dynamic_line_t( const JsonArray &ja )
 }
 
 json_dynamic_line_effect::json_dynamic_line_effect( const JsonObject &jo,
-        const std::string &id, const std::string_view src )
+        const std::string &id, std::string_view src )
 {
     std::function<bool( const_dialogue const & )> tmp_condition;
     read_condition( jo, "condition", tmp_condition, true );
@@ -8356,7 +8356,7 @@ void json_dynamic_line_effect::apply( dialogue &d ) const
     effect.apply( d );
 }
 
-void json_talk_topic::load( const JsonObject &jo, const std::string_view src )
+void json_talk_topic::load( const JsonObject &jo, std::string_view src )
 {
     if( jo.has_member( "dynamic_line" ) ) {
         dynamic_line = dynamic_line_t::from_member( jo, "dynamic_line" );
@@ -8496,7 +8496,7 @@ void unload_talk_topics()
     json_talk_topics.clear();
 }
 
-void load_talk_topic( const JsonObject &jo, const std::string_view src )
+void load_talk_topic( const JsonObject &jo, std::string_view src )
 {
     if( jo.has_array( "id" ) ) {
         for( auto &id : jo.get_string_array( "id" ) ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -107,7 +107,7 @@ void option_slider::check_consistency()
     }
 }
 
-void option_slider::load( const JsonObject &jo, const std::string_view )
+void option_slider::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     optional( jo, was_loaded, "default", _default_level, 0 );

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -183,7 +183,7 @@ std::vector<std::string> foldstring( const std::string &str, int width, const ch
     return lines;
 }
 
-std::vector<std::string> split_by_color( const std::string_view s )
+std::vector<std::string> split_by_color( std::string_view s )
 {
     std::vector<std::string> ret;
     std::vector<size_t> tag_positions = get_tag_positions( s );
@@ -197,7 +197,7 @@ std::vector<std::string> split_by_color( const std::string_view s )
     return ret;
 }
 
-std::string remove_color_tags( const std::string_view s )
+std::string remove_color_tags( std::string_view s )
 {
     std::string ret;
     std::vector<size_t> tag_positions = get_tag_positions( s );
@@ -216,7 +216,7 @@ std::string remove_color_tags( const std::string_view s )
 }
 
 color_tag_parse_result::tag_type update_color_stack(
-    std::stack<nc_color> &color_stack, const std::string_view seg,
+    std::stack<nc_color> &color_stack, std::string_view seg,
     const report_color_error color_error )
 {
     color_tag_parse_result tag = get_color_from_tag( seg, color_error );
@@ -237,7 +237,7 @@ color_tag_parse_result::tag_type update_color_stack(
 }
 
 void print_colored_text( const catacurses::window &w, const point &p, nc_color &color,
-                         const nc_color &base_color, const std::string_view text,
+                         const nc_color &base_color, std::string_view text,
                          const report_color_error color_error )
 {
     if( p.y > -1 && p.x > -1 ) {
@@ -921,7 +921,7 @@ bool query_int( int &result, bool show_default, const std::string &text )
     return true;
 }
 
-std::vector<std::string> get_hotkeys( const std::string_view s )
+std::vector<std::string> get_hotkeys( std::string_view s )
 {
     std::vector<std::string> hotkeys;
     size_t start = s.find_first_of( '<' );
@@ -1392,7 +1392,7 @@ static std::string trim( std::string_view s, Predicate pred )
 }
 
 template<typename Prep>
-std::string trim_trailing( const std::string_view s, Prep prep )
+std::string trim_trailing( std::string_view s, Prep prep )
 {
     return std::string( s.begin(), std::find_if_not(
     s.rbegin(), s.rend(), [&prep]( int c ) {
@@ -1400,14 +1400,14 @@ std::string trim_trailing( const std::string_view s, Prep prep )
     } ).base() );
 }
 
-std::string trim( const std::string_view s )
+std::string trim( std::string_view s )
 {
     return trim( s, []( int c ) {
         return isspace( c );
     } );
 }
 
-std::string trim_trailing_punctuations( const std::string_view s )
+std::string trim_trailing_punctuations( std::string_view s )
 {
     return trim_trailing( s, []( int c ) {
         // '<' and '>' are used for tags and should not be removed
@@ -1435,7 +1435,7 @@ std::string to_upper_case( const std::string &s )
 }
 
 // find the position of each non-printing tag in a string
-std::vector<size_t> get_tag_positions( const std::string_view s )
+std::vector<size_t> get_tag_positions( std::string_view s )
 {
     std::vector<size_t> ret;
     size_t pos = s.find( "<color_", 0, 7 );
@@ -1532,7 +1532,7 @@ std::string word_rewrap( const std::string &in, int width, const uint32_t split 
     return o;
 }
 
-void draw_tab( const catacurses::window &w, int iOffsetX, const std::string_view sText,
+void draw_tab( const catacurses::window &w, int iOffsetX, std::string_view sText,
                bool bSelected )
 {
     int iOffsetXRight = iOffsetX + utf8_width( sText, true ) + 1;
@@ -3245,7 +3245,7 @@ std::string wildcard_trim_rule( const std::string &pattern_in )
 }
 
 // find substring (case insensitive)
-int ci_find_substr( const std::string_view str1, const std::string_view str2,
+int ci_find_substr( std::string_view str1, std::string_view str2,
                     const std::locale &loc )
 {
     std::string_view::const_iterator it =

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4045,7 +4045,7 @@ void overmap::generate_bridgeheads( const std::vector<point_om_omt> &bridge_poin
     }
 }
 
-std::vector<point_abs_omt> overmap::find_terrain( const std::string_view term, int zlevel ) const
+std::vector<point_abs_omt> overmap::find_terrain( std::string_view term, int zlevel ) const
 {
     std::vector<point_abs_omt> found;
     for( int x = 0; x < OMAPX; x++ ) {
@@ -8046,7 +8046,7 @@ void overmap_special_migration::reset()
     migrations.reset();
 }
 
-void overmap_special_migration::load( const JsonObject &jo, const std::string_view )
+void overmap_special_migration::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     optional( jo, was_loaded, "new_id", new_id, overmap_special_id() );

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -98,7 +98,7 @@ bool overmap_connection::has( const int_id<oter_t> &oter ) const
     } ) != subtypes.cend();
 }
 
-void overmap_connection::load( const JsonObject &jo, const std::string_view )
+void overmap_connection::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, false, "subtypes", subtypes );
 }

--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -40,7 +40,7 @@ oter_type_id overmap_location::get_random_terrain() const
     return random_entry( terrains );
 }
 
-void overmap_location::load( const JsonObject &jo, const std::string_view )
+void overmap_location::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "flags", flags );
     optional( jo, was_loaded, "terrains", terrains );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -109,7 +109,7 @@ static bool create_note( const tripoint_abs_omt &curs,
                          std::optional<std::string> context = std::nullopt );
 
 // {note symbol, note color, offset to text}
-std::tuple<char, nc_color, size_t> get_note_display_info( const std::string_view note )
+std::tuple<char, nc_color, size_t> get_note_display_info( std::string_view note )
 {
     std::tuple<char, nc_color, size_t> result {'N', c_yellow, 0};
     bool set_color  = false;
@@ -174,7 +174,7 @@ static std::array<std::pair<nc_color, std::string>, npm_width *npm_height> get_o
     return map_around;
 }
 
-static void update_note_preview( const std::string_view note,
+static void update_note_preview( std::string_view note,
                                  const std::array<std::pair<nc_color, std::string>, npm_width *npm_height> &map_around,
                                  const std::tuple<catacurses::window *, catacurses::window *, catacurses::window *>
                                  &preview_windows )

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1671,7 +1671,7 @@ void overmapbuffer::despawn_monster( const monster &critter )
     }
 }
 
-overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string_view pattern )
+overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, std::string_view pattern )
 {
     t_notes_vector result;
     for( auto &it : overmaps ) {
@@ -1697,7 +1697,7 @@ overmapbuffer::t_notes_vector overmapbuffer::get_notes( int z, const std::string
     return result;
 }
 
-overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, const std::string_view pattern )
+overmapbuffer::t_extras_vector overmapbuffer::get_extras( int z, std::string_view pattern )
 {
     overmapbuffer::t_extras_vector result;
     for( auto &it : overmaps ) {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -131,7 +131,7 @@ bool player_activity::is_multi_type() const
     return type->multi_activity();
 }
 
-std::string player_activity::get_str_value( size_t index, const std::string_view def ) const
+std::string player_activity::get_str_value( size_t index, std::string_view def ) const
 {
     return std::string( index < str_values.size() ? str_values[index] : def );
 }

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -91,12 +91,12 @@ bool string_id<profession>::is_valid() const
 static profession_blacklist prof_blacklist;
 
 void profession_blacklist::load_profession_blacklist( const JsonObject &jo,
-        const std::string_view src )
+        std::string_view src )
 {
     prof_blacklist.load( jo, src );
 }
 
-void profession_blacklist::load( const JsonObject &jo, const std::string_view )
+void profession_blacklist::load( const JsonObject &jo, std::string_view )
 {
     if( !professions.empty() ) {
         DebugLog( D_INFO, DC_ALL ) << "Loading profession black with one already loaded, resetting";
@@ -207,7 +207,7 @@ class item_reader : public generic_typed_reader<item_reader>
         }
 };
 
-void profession::load( const JsonObject &jo, const std::string_view )
+void profession::load( const JsonObject &jo, std::string_view )
 {
     //If the "name" is an object then we have to deal with gender-specific titles,
     if( jo.has_object( "name" ) ) {

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -95,7 +95,7 @@ void proficiency_category::reset()
     proficiency_category_factory.reset();
 }
 
-void proficiency::load( const JsonObject &jo, const std::string_view )
+void proficiency::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );
@@ -121,7 +121,7 @@ void proficiency::load( const JsonObject &jo, const std::string_view )
     }
 }
 
-void proficiency_category::load( const JsonObject &jo, const std::string_view )
+void proficiency_category::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "description", _description );

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -88,7 +88,7 @@ const recipe &recipe_dictionary::get_craft( const itype_id &id )
 
 // searches for left-anchored partial match in the relevant recipe requirements set
 template <class group>
-bool search_reqs( const group &gp, const std::string_view txt )
+bool search_reqs( const group &gp, std::string_view txt )
 {
     return std::any_of( gp.begin(), gp.end(), [&]( const typename group::value_type & opts ) {
         return std::any_of( opts.begin(),
@@ -100,7 +100,7 @@ bool search_reqs( const group &gp, const std::string_view txt )
 // template specialization to make component searches easier
 template<>
 bool search_reqs( const std::vector<std::vector<item_comp> > &gp,
-                  const std::string_view txt )
+                  std::string_view txt )
 {
     return std::any_of( gp.begin(), gp.end(), [&]( const std::vector<item_comp> &opts ) {
         return std::any_of( opts.begin(), opts.end(), [&]( const item_comp & ic ) {
@@ -190,7 +190,7 @@ static std::unordered_set<sub_bodypart_id> filtered_sub_bodyparts;
 static std::unordered_set<layer_level> filtered_layers;
 
 std::vector<const recipe *> recipe_subset::search(
-    const std::string_view txt, const search_type key,
+    std::string_view txt, const search_type key,
     const std::function<void( size_t, size_t )> &progress_callback ) const
 {
     auto predicate = [&]( const recipe * r ) {
@@ -382,7 +382,7 @@ recipe_subset::recipe_subset( const recipe_subset &src, const std::vector<const 
 }
 
 recipe_subset recipe_subset::reduce(
-    const std::string_view txt, const search_type key,
+    std::string_view txt, const search_type key,
     const std::function<void( size_t, size_t )> &progress_callback ) const
 {
     return recipe_subset( *this, search( txt, key, progress_callback ) );

--- a/src/recipe_groups.cpp
+++ b/src/recipe_groups.cpp
@@ -43,7 +43,7 @@ generic_factory<recipe_group_data> recipe_groups_data( "recipe group type" );
 
 } // namespace
 
-void recipe_group_data::load( const JsonObject &jo, const std::string_view )
+void recipe_group_data::load( const JsonObject &jo, std::string_view )
 {
     building_type = jo.get_string( "building_type" );
     for( JsonObject ordering : jo.get_array( "recipes" ) ) {

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -754,7 +754,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     cityjo.read( "park_radius", region.city_spec.park_radius );
     cityjo.read( "park_sigma", region.city_spec.park_sigma );
 
-    const auto load_building_types = [&cityjo]( const std::string_view type, building_bin & dest ) {
+    const auto load_building_types = [&cityjo]( std::string_view type, building_bin & dest ) {
         for( const JsonMember member : cityjo.get_object( type ) ) {
             if( member.is_comment() ) {
                 continue;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -166,7 +166,7 @@ void relic_procgen_data::enchantment_active::deserialize( const JsonObject &jobj
     load( jobj );
 }
 
-void relic_procgen_data::load( const JsonObject &jo, const std::string_view )
+void relic_procgen_data::load( const JsonObject &jo, std::string_view )
 {
     for( const JsonObject jo_inner : jo.get_array( "passive_add_procgen_values" ) ) {
         int weight = 0;

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -107,7 +107,7 @@ void quality::load_static( const JsonObject &jo, const std::string &src )
     quality_factory.load( jo, src );
 }
 
-void quality::load( const JsonObject &jo, const std::string_view )
+void quality::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
 
@@ -751,7 +751,7 @@ void requirement_data::reset()
 std::vector<std::string> requirement_data::get_folded_components_list( int width, nc_color col,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
         int batch,
-        const std::string_view hilite, requirement_display_flags flags ) const
+        std::string_view hilite, requirement_display_flags flags ) const
 {
     std::vector<std::string> out_buffer;
     if( components.empty() ) {
@@ -769,7 +769,7 @@ std::vector<std::string> requirement_data::get_folded_components_list( int width
 template<typename T>
 std::vector<std::string> requirement_data::get_folded_list( int width,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
-        const std::vector< std::vector<T> > &objs, int batch, const std::string_view hilite,
+        const std::vector< std::vector<T> > &objs, int batch, std::string_view hilite,
         requirement_display_flags flags ) const
 {
     // hack: ensure 'cached' availability is up to date

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -609,7 +609,7 @@ void safemode::add_rule( const std::string &rule_in, const Creature::Attitude at
     }
 }
 
-bool safemode::has_rule( const std::string_view rule_in, const Creature::Attitude attitude_in )
+bool safemode::has_rule( std::string_view rule_in, const Creature::Attitude attitude_in )
 {
     for( safemode::rules_class &elem : character_rules ) {
         if( rule_in.length() == elem.rule.length()
@@ -621,7 +621,7 @@ bool safemode::has_rule( const std::string_view rule_in, const Creature::Attitud
     return false;
 }
 
-void safemode::remove_rule( const std::string_view rule_in, const Creature::Attitude attitude_in )
+void safemode::remove_rule( std::string_view rule_in, const Creature::Attitude attitude_in )
 {
     for( auto it = character_rules.begin();
          it != character_rules.end(); ++it ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4641,7 +4641,7 @@ void stats_tracker::deserialize( const JsonObject &jo )
 namespace
 {
 
-void _write_rle_terrain( JsonOut &jsout, const std::string_view ter, int num )
+void _write_rle_terrain( JsonOut &jsout, std::string_view ter, int num )
 {
     jsout.start_array();
     jsout.write( ter );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -56,7 +56,7 @@ void scenario::load_scenario( const JsonObject &jo, const std::string &src )
     all_scenarios.load( jo, src );
 }
 
-void scenario::load( const JsonObject &jo, const std::string_view )
+void scenario::load( const JsonObject &jo, std::string_view )
 {
     // TODO: pretty much the same as in profession::load, but different contexts for pgettext.
     // TODO: maybe combine somehow?
@@ -360,12 +360,12 @@ bool scenario::scen_is_blacklisted() const
     return sc_blacklist.scenarios.count( id ) != 0;
 }
 
-void scen_blacklist::load_scen_blacklist( const JsonObject &jo, const std::string_view src )
+void scen_blacklist::load_scen_blacklist( const JsonObject &jo, std::string_view src )
 {
     sc_blacklist.load( jo, src );
 }
 
-void scen_blacklist::load( const JsonObject &jo, const std::string_view )
+void scen_blacklist::load( const JsonObject &jo, std::string_view )
 {
     if( !scenarios.empty() ) {
         DebugLog( D_INFO, DC_ALL ) <<

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -288,7 +288,7 @@ void scent_type::load_scent_type( const JsonObject &jo, const std::string &src )
     scent_factory.load( jo, src );
 }
 
-void scent_type::load( const JsonObject &jo, const std::string_view )
+void scent_type::load( const JsonObject &jo, std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "receptive_species", receptive_species );

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -131,12 +131,12 @@ bool shopkeeper_cons_rate_entry::operator==( shopkeeper_cons_rate_entry const &r
     return icg_entry::operator==( rhs ) && rate == rhs.rate;
 }
 
-void shopkeeper_blacklist::load( JsonObject const &jo, const std::string_view/*src*/ )
+void shopkeeper_blacklist::load( JsonObject const &jo, std::string_view/*src*/ )
 {
     optional( jo, was_loaded, "entries", entries, icg_entry_reader {} );
 }
 
-void shopkeeper_cons_rates::load( JsonObject const &jo, const std::string_view/*src*/ )
+void shopkeeper_cons_rates::load( JsonObject const &jo, std::string_view/*src*/ )
 {
     optional( jo, was_loaded, "default_rate", default_rate );
     optional( jo, was_loaded, "junk_threshold", junk_threshold, money_reader {}, 1_cent );

--- a/src/skill_boost.cpp
+++ b/src/skill_boost.cpp
@@ -34,7 +34,7 @@ void skill_boost::load_boost( const JsonObject &jo, const std::string &src )
     all_skill_boosts.load( jo, src );
 }
 
-void skill_boost::load( const JsonObject &jo, const std::string_view )
+void skill_boost::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "skills", _skills );
     mandatory( jo, was_loaded, "skill_offset", _offset );

--- a/src/speed_description.cpp
+++ b/src/speed_description.cpp
@@ -32,7 +32,7 @@ void speed_description::reset()
     speed_description_factory.reset();
 }
 
-void speed_description::load( const JsonObject &jo, const std::string_view )
+void speed_description::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "values", values_ );
     std::sort( values_.begin(), values_.end(),

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -314,7 +314,7 @@ void stomach_contents::serialize( JsonOut &json ) const
     json.end_object();
 }
 
-static units::volume string_to_ml( const std::string_view str )
+static units::volume string_to_ml( std::string_view str )
 {
     return units::from_milliliter( svto<int>( str.substr( 0, str.size() - 3 ) ) );
 }

--- a/src/string_formatter.cpp
+++ b/src/string_formatter.cpp
@@ -102,7 +102,7 @@ std::optional<int> cata::string_formatter::read_precision()
     return read_number_or_argument_index();
 }
 
-void cata::string_formatter::throw_error( const std::string_view msg ) const
+void cata::string_formatter::throw_error( std::string_view msg ) const
 {
     throw std::runtime_error(
         str_cat( msg, " at: \"", format.substr( 0, current_index_in_format ), "|",

--- a/src/subbodypart.cpp
+++ b/src/subbodypart.cpp
@@ -71,7 +71,7 @@ void sub_body_part_type::load_bp( const JsonObject &jo, const std::string &src )
     sub_body_part_factory.load( jo, src );
 }
 
-void sub_body_part_type::load( const JsonObject &jo, const std::string_view )
+void sub_body_part_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name );

--- a/src/system_locale.cpp
+++ b/src/system_locale.cpp
@@ -28,7 +28,7 @@ namespace
 // Try to match language code to a supported game language by prefix
 // For example, "fr_CA.UTF-8" -> "fr"
 // Returns std::nullopt if the language is not supported by the game
-std::optional<std::string> matchGameLanguage( const std::string_view lang )
+std::optional<std::string> matchGameLanguage( std::string_view lang )
 {
     const std::vector<options_manager::id_and_option> available_languages =
         get_options().get_option( "USE_LANG" ).getItems();

--- a/src/translation_manager_impl.cpp
+++ b/src/translation_manager_impl.cpp
@@ -39,7 +39,7 @@ std::optional<std::pair<std::size_t, std::size_t>> TranslationManager::Impl::Loo
     return std::nullopt;
 }
 
-std::string TranslationManager::Impl::LanguageCodeOfPath( const std::string_view path )
+std::string TranslationManager::Impl::LanguageCodeOfPath( std::string_view path )
 {
     const std::size_t end = path.rfind( "/LC_MESSAGES" );
     if( end == std::string::npos ) {

--- a/src/translation_plural_evaluator.cpp
+++ b/src/translation_plural_evaluator.cpp
@@ -210,7 +210,7 @@ Token TranslationPluralRulesEvaluator::GetNextToken( const char *&p )
     }
 }
 
-std::vector<Token> TranslationPluralRulesEvaluator::Lexer( const std::string_view expr )
+std::vector<Token> TranslationPluralRulesEvaluator::Lexer( std::string_view expr )
 {
     std::vector<ExprToken> tokens;
     const char *p = expr.data();

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -112,7 +112,7 @@ void trap::load_trap( const JsonObject &jo, const std::string &src )
     trap_factory.load( jo, src );
 }
 
-void trap::load( const JsonObject &jo, const std::string_view )
+void trap::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name_ );

--- a/src/try_parse_integer.cpp
+++ b/src/try_parse_integer.cpp
@@ -5,7 +5,7 @@
 #include "translations.h"
 
 template<typename T>
-ret_val<T> try_parse_integer( const std::string_view s, bool use_locale )
+ret_val<T> try_parse_integer( std::string_view s, bool use_locale )
 {
     // Using stringstream-based parsing because that's the only one in the
     // standard library for which it's possible to turn off the
@@ -40,6 +40,6 @@ ret_val<T> try_parse_integer( const std::string_view s, bool use_locale )
     return ret_val<T>::make_success( result );
 }
 
-template ret_val<int> try_parse_integer<int>( const std::string_view, bool use_locale );
-template ret_val<long> try_parse_integer<long>( const std::string_view, bool use_locale );
-template ret_val<long long> try_parse_integer<long long>( const std::string_view, bool use_locale );
+template ret_val<int> try_parse_integer<int>( std::string_view, bool use_locale );
+template ret_val<long> try_parse_integer<long>( std::string_view, bool use_locale );
+template ret_val<long long> try_parse_integer<long long>( std::string_view, bool use_locale );

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -91,7 +91,7 @@ void VehicleGroup::reset()
     vgroups.clear();
 }
 
-VehicleFacings::VehicleFacings( const JsonObject &jo, const std::string_view key )
+VehicleFacings::VehicleFacings( const JsonObject &jo, std::string_view key )
 {
     if( jo.has_array( key ) ) {
         for( const int i : jo.get_array( key ) ) {
@@ -224,10 +224,10 @@ void VehicleSpawn::apply( const vspawn_id &id, map &m, const std::string &terrai
 namespace VehicleSpawnFunction
 {
 
-static void builtin_no_vehicles( map &, const std::string_view )
+static void builtin_no_vehicles( map &, std::string_view )
 {}
 
-static void builtin_parkinglot( map &m, const std::string_view )
+static void builtin_parkinglot( map &m, std::string_view )
 {
     for( int v = 0; v < rng( 1, 4 ); v++ ) {
         tripoint_bub_ms pos_p;

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -689,7 +689,7 @@ void weakpoints::remove( const JsonArray &ja )
     }
 }
 
-void weakpoints::load( const JsonObject &jo, const std::string_view )
+void weakpoints::load( const JsonObject &jo, std::string_view )
 {
     load( jo.get_array( "weakpoints" ) );
 }

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -96,7 +96,7 @@ void weather_type::check() const
     }
 }
 
-void weather_type::load( const JsonObject &jo, const std::string_view )
+void weather_type::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "id",  id );

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -442,7 +442,7 @@ int widget_custom_var::get_var_value( const avatar &ava ) const
     return static_cast<int>( value.evaluate( d ) );
 }
 
-void widget::load( const JsonObject &jo, const std::string_view )
+void widget::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "width", _width, 0 );
     optional( jo, was_loaded, "height", _height_max, 1 );


### PR DESCRIPTION
#### Summary
Backport 80633 - Remove unnecessary const modifiers from function parameters

#### Purpose of change
Fixes that should have been done before the last of the itemfactory stuff

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
