### PR TITLE
Backport DDA 80611 - Replace `const std::string_view &` with `std::string_view`

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -653,7 +653,7 @@ void display_bodygraph( const Character &u, const bodygraph_id &id )
 
 std::vector<std::string> get_bodygraph_lines( const Character &u,
         const bodygraph_callback &fragment_cb, const bodygraph_id &id, int width, int height,
-        const std::string_view &label )
+        std::string_view label )
 {
     width = ( width <= 0 || width > BPGRAPH_MAXCOLS ) ? BPGRAPH_MAXCOLS : width;
     height = ( height <= 0 || height > BPGRAPH_MAXROWS ) ? BPGRAPH_MAXROWS : height;

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -88,6 +88,6 @@ using bodygraph_callback =
  */
 std::vector<std::string> get_bodygraph_lines( const Character &u,
         const bodygraph_callback &fragment_cb, const bodygraph_id &id = bodygraph_id::NULL_ID(),
-        int width = 0, int height = 0, const std::string_view &label = "" );
+        int width = 0, int height = 0, std::string_view label = "" );
 
 #endif // CATA_SRC_BODYGRAPH_H

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -288,7 +288,7 @@ duration_or_var_part get_duration_or_var_part( const JsonValue &jv )
     return ret_val;
 }
 
-duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_view &member,
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string_view member,
                                      bool required,
                                      time_duration default_val )
 {

--- a/src/condition.h
+++ b/src/condition.h
@@ -50,7 +50,7 @@ dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view member,
                                      bool required = true,
                                      double default_val = 0.0 );
-duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_view &member,
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string_view member,
                                      bool required = true,
                                      time_duration default_val = 0_seconds );
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv );

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -46,7 +46,7 @@ bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
     return true;
 }
 
-float read_proportional_entry( const JsonObject &jo, const std::string_view &key )
+float read_proportional_entry( const JsonObject &jo, std::string_view key )
 {
     if( jo.has_float( key ) ) {
         float scalar = jo.get_float( key );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -939,7 +939,7 @@ bool unicode_codepoint_from_symbol_reader(
     const JsonObject &jo, std::string_view member_name, uint32_t &member, bool );
 
 //Reads a standard single-float "proportional" entry
-float read_proportional_entry( const JsonObject &jo, const std::string_view &key );
+float read_proportional_entry( const JsonObject &jo, std::string_view key );
 
 namespace reader_detail
 {

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -63,7 +63,7 @@ class global_variables
         void serialize( JsonOut &jsout ) const;
 
         std::map<std::string, std::string> migrations; // NOLINT(cata-serialize)
-        static void load_migrations( const JsonObject &jo, const std::string_view &src );
+        static void load_migrations( const JsonObject &jo, std::string_view src );
 
     private:
         impl_t global_values;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3962,7 +3962,7 @@ class jmapgen_variable : public jmapgen_piece
 {
     public:
         std::string name;
-        jmapgen_variable( const JsonObject &jsi, const std::string_view &/*context*/ ) {
+        jmapgen_variable( const JsonObject &jsi, std::string_view /*context*/ ) {
             name = jsi.get_string( "name" );
         }
         mapgen_phase phase() const override {

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -25,7 +25,7 @@ void profession_group::load_profession_group( const JsonObject &jo, const std::s
     profession_group_factory.load( jo, src );
 }
 
-void profession_group::load( const JsonObject &jo, const std::string_view & )
+void profession_group::load( const JsonObject &jo, std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "professions", profession_list );

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -8,7 +8,7 @@
 struct profession_group {
 
         static void load_profession_group( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string_view & );
+        void load( const JsonObject &jo, std::string_view );
         static const std::vector<profession_group> &get_all();
         static void check_profession_group_consistency();
         bool was_loaded = false;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1716,7 +1716,7 @@ void global_variables::serialize( JsonOut &jsout ) const
     jsout.member( "global_vals", global_values );
 }
 
-void global_variables::load_migrations( const JsonObject &jo, const std::string_view & )
+void global_variables::load_migrations( const JsonObject &jo, std::string_view )
 {
     const std::string from( jo.get_string( "from" ) );
     const std::string to = jo.has_string( "to" )

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -212,7 +212,7 @@ static void parse_vp_reqs( const JsonObject &obj, const vpart_id &id, const std:
 }
 
 static void parse_vp_control_reqs( const JsonObject &obj, const vpart_id &id,
-                                   const std::string_view &key,
+                                   std::string_view key,
                                    vp_control_req &req )
 {
     if( !obj.has_object( key ) ) {


### PR DESCRIPTION
#### Summary
Backport DDA 80611 - Replace `const std::string_view &` with `std::string_view`

#### Purpose of change
Doing more things backwards (its just code cleanup though)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
