### PR TITLE
Make flintlocks repairable

### DIFF
--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -66,6 +66,7 @@
     "blackpowder_tolerance": 96,
     "clip_size": 1,
     "reload": 2000,
+    "use_action": [ "GUN_REPAIR" ],
     "valid_mod_locations": [ [ "grip mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK", "NEVER_JAMS", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 1 } } ],
@@ -97,6 +98,7 @@
     "blackpowder_tolerance": 96,
     "clip_size": 1,
     "reload": 2250,
+    "use_action": [ "GUN_REPAIR" ],
     "valid_mod_locations": [
       [ "sling", 1 ],
       [ "bayonet lug", 1 ],


### PR DESCRIPTION
#### Summary
Make flintlocks repairable

#### Purpose of change
Flintlocks were unable to be repaired due to an omission of the GUN_REPAIR use action.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
