### PR TITLE
Fix typo in function name

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -872,7 +872,7 @@ void Item_group::add_entry( std::unique_ptr<Item_spawn_data> ptr )
         return;
     }
     if( type == G_COLLECTION ) {
-        ptr->set_probablility( std::min( 100, ptr->get_probability( true ) ) );
+        ptr->set_probability( std::min( 100, ptr->get_probability( true ) ) );
     }
     sum_prob += ptr->get_probability( true );
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -187,7 +187,7 @@ class Item_spawn_data
         }
 
         int get_probability( bool skip_event_check ) const;
-        void set_probablility( int prob ) {
+        void set_probability( int prob ) {
             probability = prob;
         }
         bool is_event_based() const {


### PR DESCRIPTION
#### Summary
Fix typo in function name

#### Purpose of change
Somebody misspelled probability as probabliltiy a million years ago

#### Describe the solution
fix

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
