### PR TITLE
Fix sleep mutation stuff

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3673,7 +3673,6 @@
   {
     "type": "effect_type",
     "id": "lying_down",
-    "apply_message": "You lie down to go to sleep…",
     "rating": "neutral",
     "max_duration": "50 m",
     "flags": [ "PREVENT_TRAINING" ]

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -5,7 +5,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
     "name": { "str": "melatonin tablet" },
-    "description": "An over-the-counter melatonin supplement, commonly prescribed to treat sleep deprivation and to mitigate its effects.  One tablet a day combined with a good night's sleep will help you recover faster.",
+    "description": "An over-the-counter melatonin supplement.  One tablet before bed is commonly recommended to improve sleep quality, especially for those suffering from sleep deprivation.",
     "material": [ "drug_filler" ],
     "weight": "1 g",
     "volume": "8 ml",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -685,7 +685,7 @@
     "changes_to": [ "EASYSLEEPER2" ],
     "starting_trait": true,
     "cancels": [ "INSOMNIA" ],
-    "category": [ "MOUSE", "INSECT", "GASTROPOD", "RABBIT" ],
+    "category": [ "MOUSE", "INSECT", "GASTROPOD", "RABBIT", "FELINE" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SLEEPY", "add": 24 } ] } ]
   },
   {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -934,7 +934,7 @@ void emp_blast( const tripoint_bub_ms &p )
                 !player_character.has_flag( json_flag_EMP_IMMUNE ) ) {
                 add_msg( m_bad, _( "The electromagnetic pulse fries your %s!" ), it->tname() );
                 it->deactivate();
-                if( one_in ( 4 ) ) {
+                if( one_in( 4 ) ) {
                     it->set_random_fault_of_type( "shorted" );
                 } else {
                     it->set_fault( fault_emp_reboot );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -875,7 +875,7 @@ void Character::activate_cached_mutation( const trait_id &mut )
 
     if( mut == trait_WEB_WEAVER ) {
         here.add_field( pos_bub(), fd_web, 1 );
-        add_msg_if_player( _( "You start spinning web with your spinnerets!" ) );
+        add_msg_if_player( _( "You begin spinning web with your spinnerets." ) );
     } else if( mut == trait_SNAIL_TRAIL ) {
         here.add_field( pos_bub(), fd_sludge, 1 );
         add_msg_if_player( _( "You start leaving a trail of sludge as you go." ) );


### PR DESCRIPTION
#### Summary
Fix sleep mutation stuff

#### Purpose of change
- ROOTS and WATERSLEEP had a bunch of very awkwardy implemented hardcoded "benefits" to sleeping that were actually playing havoc with plants and piscines by recovering fatigue faster than sleep deprivation.
- Max sleep time was always 10 hours, even though some characters need more sleep than that.

#### Describe the solution
- Max sleep time is adjusted by any positive fatigue mod. We don't need to worry about characters who need less sleep because you already automatically wake up when you're not tired anymore.
- Fixed up the hardcoded benefits for ROOTS and WATERSLEEP and made them use the existing systems rather than trying to add their own stuff.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
