### PR TITLE
Remove alternative recipe names and fix footrags

### DIFF
--- a/data/json/itemgroups/trash_and_debris.json
+++ b/data/json/itemgroups/trash_and_debris.json
@@ -343,7 +343,7 @@
       { "item": "brick", "prob": 20, "count": [ 10, 20 ], "damage": [ 0, 3 ] },
       { "item": "pipe", "prob": 5, "count": [ 2, 6 ], "damage": [ 0, 3 ] },
       { "item": "nail", "prob": 2, "count": [ 0, 1 ], "charges": [ 3, 15 ] },
-      { "item": "wire", "prob": 3, "count": [ 2, 6 ], "damage": [ 0, 3 ]  },
+      { "item": "wire", "prob": 3, "count": [ 2, 6 ], "damage": [ 0, 3 ] },
       { "item": "charcoal", "prob": 3, "charges": [ 3, 7 ] },
       { "item": "copper_fragment", "prob": 2, "count": [ 2, 4 ], "damage": [ 0, 3 ] },
       { "item": "sheet_metal", "prob": 2, "count": [ 1, 4 ], "damage": [ 0, 3 ] },

--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -32,7 +32,12 @@
       [ "stock", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_fail_to_feed" }, { "fault": "fault_double_feed" } ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "250 ml", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -72,7 +77,12 @@
       [ "sling", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_fail_to_feed" }, { "fault": "fault_double_feed" } ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_10_mag", "8x40_25_mag" ] } ],
     "melee_damage": { "bash": 10 }
   },
@@ -109,7 +119,12 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-     "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_fail_to_feed" }, { "fault": "fault_double_feed" } ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_25_mag", "8x40_10_mag" ] } ],
     "melee_damage": { "bash": 11 }
   },
@@ -144,7 +159,12 @@
       [ "stock accessory", 1 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_fail_to_feed" }, { "fault": "fault_double_feed" } ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "weapon_category": [ "AUTOMATIC_RIFLES" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "8x40_50_mag", "8x40_100_mag" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/json/items/gun/9x18.json
+++ b/data/json/items/gun/9x18.json
@@ -73,7 +73,6 @@
     "barrel_length": "600 mm",
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
-
     "flags": [ "FIRE_TWOHAND", "RELOAD_EJECT", "NO_TURRET", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "9x18": 1 } } ],
     "melee_damage": { "bash": 10 }

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -569,8 +569,8 @@
     "time": "1 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_sheet_simple", 2 ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "cotton_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_nomex",
@@ -582,8 +582,8 @@
     "time": "1 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_nomex_sheet", 2 ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "nomex_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_fur",
@@ -596,7 +596,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "fur_sheet", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_faux_fur",
@@ -608,7 +608,7 @@
     "time": "1 m 30 s",
     "autolearn": true,
     "components": [ [ [ "faux_fur_sheet", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_leather",
@@ -621,7 +621,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "leather_sheet", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "footrags_wool",
@@ -634,7 +634,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [ [ [ "felt_sheet", 2 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "leathersandals",

--- a/data/json/recipes/food/offal_dishes.json
+++ b/data/json/recipes/food/offal_dishes.json
@@ -135,7 +135,7 @@
     "difficulty": 6,
     "charges": 1,
     "time": "30 m",
-    "book_learn": { "mag_glam": { "skill_level": 5 }, "cookbook_liverforkids": { "skill_level": 5, "recipe_name": "Buttery Duck Bites" } },
+    "book_learn": { "mag_glam": { "skill_level": 5 }, "cookbook_liverforkids": { "skill_level": 5 } },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
     "//": "strictly in terms of power usage this is only about 13u of power. bumping it to 15 assuming some heat is wasted by slow cooking it.",
@@ -159,7 +159,7 @@
     "book_learn": {
       "scots_cookbook": { "skill_level": 2 },
       "cookbook": { "skill_level": 0 },
-      "cookbook_liverforkids": { "skill_level": 1, "recipe_name": "Candied Onions and Giblets" }
+      "cookbook_liverforkids": { "skill_level": 1 }
     },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 36, "LIST" ] ] ],

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -106,10 +106,7 @@
     "difficulty": 4,
     "charges": 1,
     "time": "20 m",
-    "book_learn": {
-      "cookbook_italian": { "skill_level": 3 },
-      "cookbook_foodfashions": { "skill_level": 4, "recipe_name": "Spaghetti Luchetto" }
-    },
+    "book_learn": { "cookbook_italian": { "skill_level": 3 }, "cookbook_foodfashions": { "skill_level": 4 } },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "//": "There are ways to cook pasta that don't require boiling the water, and they are a lot more efficient, so this uses surface_heat",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -1248,10 +1248,7 @@
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
     "difficulty": 2,
-    "book_learn": {
-      "cookbook_sushi": { "skill_level": 2 },
-      "cookbook_daintydishes": { "skill_level": 3, "recipe_name": "Sticky Rice Hedgerows" }
-    },
+    "book_learn": { "cookbook_sushi": { "skill_level": 2 }, "cookbook_daintydishes": { "skill_level": 3 } },
     "time": "5 m",
     "charges": 3,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CONTAIN", "level": 1 } ],
@@ -1461,10 +1458,7 @@
     "subcategory": "CSC_FOOD_MEAT",
     "skill_used": "cooking",
     "difficulty": 4,
-    "book_learn": {
-      "cookbook_sushi": { "skill_level": 4 },
-      "cookbook_foodfashions": { "skill_level": 4, "recipe_name": "Low-Carb Sashimi Donburi" }
-    },
+    "book_learn": { "cookbook_sushi": { "skill_level": 4 }, "cookbook_foodfashions": { "skill_level": 4 } },
     "time": "9 m",
     "charges": 2,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CONTAIN", "level": 1 } ],
@@ -2031,7 +2025,7 @@
       "manual_survival": { "skill_level": 1 },
       "mag_survival": { "skill_level": 1 },
       "family_cookbook": { "skill_level": 1 },
-      "cookbook_daintydishes": { "skill_level": 2, "recipe_name": "Royal Penny Tea" }
+      "cookbook_daintydishes": { "skill_level": 2 }
     },
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
@@ -2072,7 +2066,7 @@
       "manual_survival": { "skill_level": 1 },
       "mag_survival": { "skill_level": 1 },
       "family_cookbook": { "skill_level": 1 },
-      "cookbook_daintydishes": { "skill_level": 2, "recipe_name": "Royal Penny Tea" }
+      "cookbook_daintydishes": { "skill_level": 2 }
     },
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ], [ [ "frying_oil", 1, "LIST" ] ] ],
@@ -2124,7 +2118,7 @@
       "manual_survival": { "skill_level": 1 },
       "mag_survival": { "skill_level": 1 },
       "family_cookbook": { "skill_level": 1 },
-      "cookbook_daintydishes": { "skill_level": 2, "recipe_name": "Royal Penny Tea" }
+      "cookbook_daintydishes": { "skill_level": 2 }
     },
     "//": "the cooking oil isn't supposed to be expended since you can recycle it after frying the burdocks",
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT", "level": 1 } ],
@@ -2635,7 +2629,7 @@
       "manual_survival": { "skill_level": 1 },
       "mag_survival": { "skill_level": 1 },
       "family_cookbook": { "skill_level": 1 },
-      "cookbook_daintydishes": { "skill_level": 2, "recipe_name": "Royal Penny Tea" }
+      "cookbook_daintydishes": { "skill_level": 2 }
     },
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "CUT", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 2, "LIST" ] ] ],
@@ -4044,10 +4038,7 @@
     "skill_used": "cooking",
     "difficulty": 5,
     "time": "45 m",
-    "book_learn": {
-      "family_cookbook": { "skill_level": 5 },
-      "cookbook_daintydishes": { "skill_level": 5, "recipe_name": "Sir Tenderloin the Toothsome" }
-    },
+    "book_learn": { "family_cookbook": { "skill_level": 5 }, "cookbook_daintydishes": { "skill_level": 5 } },
     "qualities": [ { "id": "BUTCHER", "level": 20 }, { "id": "COOK", "level": 3 }, { "id": "CUT", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "//": "vegetable = 2u, oil = 4u, 300g steak = 20u, sugar = 4u",
@@ -4069,10 +4060,7 @@
     "skill_used": "cooking",
     "difficulty": 5,
     "time": "45 m",
-    "book_learn": {
-      "family_cookbook": { "skill_level": 5 },
-      "cookbook_daintydishes": { "skill_level": 5, "recipe_name": "Lobsterman's Delight" }
-    },
+    "book_learn": { "family_cookbook": { "skill_level": 5 }, "cookbook_daintydishes": { "skill_level": 5 } },
     "qualities": [ { "id": "BUTCHER", "level": 20 }, { "id": "COOK", "level": 3 }, { "id": "CUT", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 17, "LIST" ] ] ],
     "//": "lobster = 10u, lemon = 1u, vegetable = 2u, oil = 4u",
@@ -4851,7 +4839,7 @@
       "family_cookbook": { "skill_level": 5 },
       "survival_book": { "skill_level": 3 },
       "textbook_survival": { "skill_level": 3 },
-      "cookbook_foodfashions": { "skill_level": 6, "recipe_name": "Shagbark Nut Ambrosia" }
+      "cookbook_foodfashions": { "skill_level": 6 }
     },
     "qualities": [ { "id": "COOK", "level": 3 }, { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 27, "LIST" ] ] ],
@@ -6136,7 +6124,7 @@
     "book_learn": {
       "adv_chemistry": { "skill_level": 6 },
       "textbook_chemistry": { "skill_level": 6 },
-      "cookbook_foodfashions": { "skill_level": 5, "recipe_name": "Natural Beet Sugar" }
+      "cookbook_foodfashions": { "skill_level": 5 }
     },
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" }, { "proficiency": "prof_inorganic_chemistry" } ],
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 1 } ],
@@ -8019,10 +8007,7 @@
     "difficulty": 3,
     "skills_required": [ "tailor", 1 ],
     "time": "30 m",
-    "book_learn": {
-      "scots_cookbook": { "skill_level": 3 },
-      "cookbook_liverforkids": { "skill_level": 4, "recipe_name": "Leprechaun Sausage" }
-    },
+    "book_learn": { "scots_cookbook": { "skill_level": 3 }, "cookbook_liverforkids": { "skill_level": 4 } },
     "batch_time_factors": [ 50, 4 ],
     "using": [ [ "sewing_standard", 2 ] ],
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "COOK", "level": 3 }, { "id": "CUT", "level": 2 } ],

--- a/data/mods/Generic_Guns/firearms/rifle.json
+++ b/data/mods/Generic_Guns/firearms/rifle.json
@@ -107,7 +107,7 @@
   {
     "id": "feral_rifle",
     "copy-from": "feral_militia_gun",
-        "type": "ITEM",
+    "type": "ITEM",
     "subtypes": [ "GUN" ],
     "name": { "str": "mad militias' rifle" },
     "description": "A fake semi-auto rifle for feral militiamen (because monster aiming is too lethal).",

--- a/data/mods/Generic_Guns/firearms/shot.json
+++ b/data/mods/Generic_Guns/firearms/shot.json
@@ -97,7 +97,7 @@
   {
     "id": "feral_shotgun",
     "copy-from": "feral_jackboot_gun",
-        "type": "ITEM",
+    "type": "ITEM",
     "subtypes": [ "GUN" ],
     "name": { "str": "feral bikers' shotgun" },
     "description": "A fake shotgun for feral bikers (because monster aiming is too lethal).",

--- a/data/mods/Generic_Guns/robots/active_bots.json
+++ b/data/mods/Generic_Guns/robots/active_bots.json
@@ -8,8 +8,8 @@
     "starting_ammo": { "pistol_ball": 30 },
     "special_attacks": [
       {
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "pistol_smg",
@@ -38,8 +38,8 @@
     "starting_ammo": { "rifle_huge_ball": 400 },
     "special_attacks": [
       {
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "rifle_huge_hmg",
@@ -68,8 +68,8 @@
     "starting_ammo": { "rifle_ball": 1000 },
     "special_attacks": [
       {
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "rifle_lmg",
@@ -103,8 +103,8 @@
     "starting_ammo": { "rifle_ball": 30 },
     "special_attacks": [
       {
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "rifle_assault",
@@ -133,8 +133,8 @@
     "starting_ammo": { "grenade_ammo_hedp": 6 },
     "special_attacks": [
       {
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "grenade_revolver",
@@ -164,8 +164,8 @@
     "special_attacks": [
       {
         "//": "For later: needs the ability to preferentially target legs and arms",
-            "type": "ITEM",
-    "subtypes": [ "GUN" ],
+        "type": "ITEM",
+        "subtypes": [ "GUN" ],
         "cooldown": 1,
         "move_cost": 150,
         "gun_type": "grenade_revolver",


### PR DESCRIPTION
#### Summary
Remove alternative recipe names and fix footrags

#### Purpose of change
- Some footrags needed sewing materials. They're just tied on, so that's no good.
- Some recipes had cutesy alternative names if you got them from certain books. That's just confusing.

#### Describe the solution
- All footrag types just need two sheets.
- No cutesy alternative names.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
