### PR TITLE
Fix and improve dazzle rifle

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -614,9 +614,9 @@
   {
     "type": "effect_type",
     "id": "sensor_stun",
-    "name": [ "Sensor scrambling" ],
-    "desc": [ "Your artificial senses are scrambled and report false readings." ],
-    "apply_message": "You're stunned!",
+    "name": [ "EM Interference" ],
+    "desc": [ "Your artificial senses are overloaded." ],
+    "apply_message": "ERROR!",
     "rating": "bad",
     "show_in_info": true
   },

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -184,7 +184,7 @@
     "subtypes": [ "GUN" ],
     "copy-from": "laser_rifle",
     "name": { "str": "hm12 dazzle rifle" },
-    "description": "This bulky anti-drone gun molded from black polymer was once beloved on all sides of the Eastern European theatre.  It disrupts navigation and communcation systems by firing a powerful electromagnetic pulse and will temporarily stun robots, if you manage to hit their sensors with a clean shot.",
+    "description": "This bulky anti-drone gun molded from black polymer was once beloved on all sides of the Eastern European theater.  It disrupts navigation and communcation systems by firing a brief but powerful burst of microwave energy.  A direct hit may cause robots, drones, and even cyborgs to malfunction for a short time.",
     "price_postapoc": "150 USD",
     "ranged_damage": { "damage_type": "pure", "amount": 1 },
     "energy_drain": "20 kJ",


### PR DESCRIPTION
#### Summary
Fix and improve dazzle rifle

#### Purpose of change
The dazzle rifle wasn't working on cyborgs or even most robots.

#### Describe the solution
The dazzle rifle is now clearer about how to use it and what it does. Its description is more in line with what actual weapons of this type do, and the messaging when it works is clearer and more scientifically accurate.

The rifle's stun effects now last slightly longer unless the target is also a zombie, in which case the messaging is different and we only get half the duration. You can't reprogram zombie bio-operators, but you can stun one for 4 seconds if you really want.

If the beam scores a critical hit on a character, it checks if they have any powered bionics. There's a 50% chance for each one that it'll be turned off. If any bionics were deactivated this way, the character is stunned for 2 seconds.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
