### PR TITLE
Prevent reprogramming zombies

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5023,7 +5023,7 @@ bool disable_activity_actor::can_disable_or_reprogram( const monster &monster )
         return false;
     }
 
-    return ( ( monster.friendly != 0 || monster.has_effect( effect_sensor_stun ) ) &&
+    return ( ( monster.friendly != 0 || ( monster.has_effect( effect_sensor_stun ) && !monster.in_species( species_ZOMBIE ) ) ) &&
              !monster.has_flag( mon_flag_RIDEABLE_MECH ) &&
              !( monster.has_flag( mon_flag_PAY_BOT ) && monster.has_effect( effect_paid ) ) ) &&
            ( !monster.type->revert_to_itype.is_empty() || monster.type->id == mon_manhack );


### PR DESCRIPTION
#### Summary
Prevent reprogramming zombies

#### Purpose of change
The recent dazzle rifle changes extended the stun to some zombie cyborgs, and I wanted to put a hard block on reprogramming them, as they're not controlled by their bionics like prototypes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
