### PR TITLE
Ditch clunky skill names

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -20,7 +20,7 @@
   {
     "type": "skill",
     "id": "firstaid",
-    "name": { "str": "health care" },
+    "name": { "str": "medicine" },
     "description": "Your skill in effecting medical treatment.  Higher levels allow better use of medicines and items like bandages and first aid kits, and reduce the failure and complication rates of medical procedures.",
     "companion_survival_rank_factor": 1,
     "companion_industry_rank_factor": 1,
@@ -84,7 +84,7 @@
   {
     "type": "skill",
     "id": "cooking",
-    "name": { "str": "food handling" },
+    "name": { "str": "cooking" },
     "description": "Your skill in combining food ingredients to make other, tastier food items.  Also includes food preservation and safety, brewing, butchery, and more.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
@@ -299,8 +299,8 @@
   {
     "type": "skill",
     "id": "chemistry",
-    "name": { "str": "applied science" },
-    "description": "Your skill in general 'bench science', applying any of a wide range of precision techniques based on your overall understanding of scientific principles.  This is not a research skill, but about using the results of others' research.",
+    "name": { "str": "science" },
+    "description": "Your ability to safely and methodically handle the practical side of laboratory work, as well as your general understanding of the principles of the physical sciences, particularly chemistry.",
     "companion_industry_rank_factor": 1,
     "display_category": "display_crafting",
     "sort_rank": 19000,


### PR DESCRIPTION
#### Summary
Ditch clunky skill names

#### Purpose of change
Skills used to have simple, descriptive names, but at some point people talked themselves into giving some of them really obtuse ones in the name of hyperspecificity that isn't even accurate.

Additionally, the applied science skill's description seemed desperate to tell the player that their character isn't a real scientist, even though you can start as someone who is a scientist by trade and you can do a ton of science things.

#### Describe the solution
- Food Handling -> Cooking
- Health Care -> Medicine
- Applied Science -> Science

Change science's description to explain that it is in fact science and not somehow a different set of skills that aren't real science.

#### Describe alternatives you've considered
BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL BILL 

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
