### PR TITLE
Protective bark grants tough feet

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3169,7 +3169,7 @@
   {
     "type": "mutation",
     "id": "BARK",
-    "flags": [ "BARKY" ],
+    "flags": [ "BARKY", "TOUGH_FEET" ],
     "name": { "str": "Protective Bark" },
     "points": 5,
     "visibility": 10,


### PR DESCRIPTION
#### Summary
Protective bark grants tough feet

#### Purpose of change
Protective bark was preventing the use of most shoes but not granting tough feet.

#### Describe the solution
Make it give tough feet for now, IDK the whole shoe thing is annoying right now.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
