### PR TITLE
Fix discomfort on parts you don't have

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2116,7 +2116,7 @@ std::unordered_set<bodypart_id> outfit::where_discomfort( const Character &guy )
 
     for( const item &i : worn ) {
         // check each sublimb individually
-        for( const sub_bodypart_id &sbp : i.get_covered_sub_body_parts() ) {
+        for( const sub_bodypart_id &sbp : i.get_covered_sub_body_parts( &guy ) ) {
             if( i.is_bp_comfortable( sbp ) ) {
                 covered_sbps.insert( sbp );
             }


### PR DESCRIPTION
#### Summary
Fix discomfort on parts you don't have

#### Purpose of change
It was possible for items to cause discomfort on parts the wearer didn't have because the check to apply discomfort was never designed to account for variable parts.

#### Describe the solution
Pass Character to covered_sub_body_parts()


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
