### PR TITLE
Properly round volume and block sound spam

### DIFF
--- a/data/json/ui/ma_style.json
+++ b/data/json/ui/ma_style.json
@@ -58,12 +58,12 @@
       {
         "//": "Ninjutsu   ------------------------------------------",
         "condition": { "u_has_effect": "mabuff:buff_ninjutsu_static1" },
-        "id": "buff_sojutsu_static",
+        "id": "buff_ninjutsu_static1",
         "text": "Ninjutsu Stance"
       },
       {
         "condition": { "u_has_effect": "mabuff:buff_ninjutsu_static2" },
-        "id": "buff_sojutsu_static",
+        "id": "buff_ninjutsu_static2",
         "text": "Sneak Attack"
       },
       {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2524,7 +2524,7 @@ int Character::footstep_sound() const
             volume = calculate_by_enchantment( volume, enchant_vals::mod::FOOTSTEP_NOISE );
         }
     }
-    return std::round( volume );
+    return static_cast<int>( std::round( volume ) );
 }
 
 int Character::clatter_sound() const
@@ -2539,7 +2539,7 @@ void Character::make_footstep_noise() const
     }
 
     const int volume = footstep_sound();
-    if( volume <= 0 ) {
+    if( volume < 1 ) {
         return;
     }
     if( is_mounted() ) {
@@ -2557,7 +2557,7 @@ void Character::make_clatter_sound() const
 {
 
     const int volume = clatter_sound();
-    if( volume <= 0 ) {
+    if( volume < 1 ) {
         return;
     }
     sounds::sound( pos_bub(), volume, sounds::sound_t::movement, _( "clattering equipment" ), true,

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2716,7 +2716,7 @@ int outfit::clatter_sound() const
             }
         }
     }
-    return std::round( max_volume );
+    return static_cast<int>( std::round( max_volume ) );
 }
 
 float outfit::clothing_wetness_mult( const bodypart_id &bp ) const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3980,9 +3980,9 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
     }
 
     const bool goodhearing = has_flag( mon_flag_GOODHEARING );
-    const int volume = goodhearing ? 2 * vol - dist : vol - dist;
+    const int volume = static_cast<int>( std::round( goodhearing ? 2 * vol - dist : vol - dist ) );
     // Error is based on volume, louder sound = less error
-    if( volume <= 0 ) {
+    if( volume < 1 ) {
         return;
     }
 
@@ -4007,7 +4007,7 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
                              rng( -max_error, max_error ) );
     // target_z will require some special check due to soil muffling sounds
 
-    const int wander_turns = volume * ( goodhearing ? 6 : 1 );
+    const int wander_turns = static_cast<int>( std::round( volume * ( goodhearing ? 6 : 1 ) ) );
     // again, already following a more interesting sound
     if( wander_turns < wandf ) {
         return;


### PR DESCRIPTION
#### Summary
Properly round volume and block sound spam

#### Purpose of change
- A lot of legacy code has integer truncation in it, leading to some incongruous behavior.
- It is possible for some types of sounds to spam when the player does an extended action. A common offender is when you're trying to hotwire a car and hit ignore on a zombie which then bashes the car 100 times in one millisecond, deafening you irl.

#### Describe the solution
- Add a 400ms gate on more types of sounds.
- Add early exits on sounds < 1 volume.
- Ensure we skip drawing sound markers for <1 volume.
- Properly round footstep volume via static_cast<int>( std::round () )
- Properly round monster reaction to volume as above.
- Properly round adjusted volume as above.

#### Describe alternatives you've considered
It would be nice to get different tiles for different kinds of audio markers, and maybe colors to represent volume.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
