### PR TITLE
Fix trig dist truncation and spruce up throwing

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5024,7 +5024,8 @@ bool disable_activity_actor::can_disable_or_reprogram( const monster &monster )
         return false;
     }
 
-    return ( ( monster.friendly != 0 || ( monster.has_effect( effect_sensor_stun ) && !monster.in_species( species_ZOMBIE ) ) ) &&
+    return ( ( monster.friendly != 0 || ( monster.has_effect( effect_sensor_stun ) &&
+                                          !monster.in_species( species_ZOMBIE ) ) ) &&
              !monster.has_flag( mon_flag_RIDEABLE_MECH ) &&
              !( monster.has_flag( mon_flag_PAY_BOT ) && monster.has_effect( effect_paid ) ) ) &&
            ( !monster.type->revert_to_itype.is_empty() || monster.type->id == mon_manhack );

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -240,7 +240,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
     const bool do_animation = get_option<bool>( "ANIMATION_PROJECTILES" );
     bool skip_hit = false;
 
-    double range = std::round( trig_dist_z_adjust( source, target_arg ) );
+    double range = trig_dist( source, target_arg );
 
     creature_tracker &creatures = get_creature_tracker();
     Creature *target_critter = creatures.creature_at( target_arg );
@@ -625,7 +625,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 return false;
             }
             // Search for creatures in radius 4 around impact site.
-            if( static_cast<int>( std::round( trig_dist_z_adjust( z.pos_bub( *here ), tp ) ) ) <= 4 &&
+            if( trig_dist( z.pos_bub( *here ), tp ) <= 4 &&
                 here->clear_path( z.pos_bub( *here ), tp, 4, 1, 100 ) && ( z.pos_bub( *here ) != tp ) ) {
                 // Don't hit targets that have already been hit
                 for( const auto &it : attack.targets_hit ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11004,7 +11004,7 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
                 }
             }
         }
-        bool in_range = ( is_adjacent( &critter, true ) ) || ( ( posz() == critter.posz() ) && ( static_cast<int>( std::round( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) ) <= range ) ) || ( std::ceil( trig_dist_z_adjust( pos_bub(), critter.pos_bub() ) ) <= range );
+        bool in_range = is_adjacent( &critter, true ) || ( ( posz() == critter.posz() ) && trig_dist( pos_bub(), critter.pos_bub() ) <= range ) || static_cast<int>( std::ceil( trig_dist_precise( pos_bub(), critter.pos_bub() ) ) ) <= range;
         // TODO: get rid of fake npcs (pos() check)
         bool valid_target = this != &critter && pos_bub() != critter.pos_bub() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -99,5 +99,5 @@ city::city( const point_om_omt &P, int const S )
 
 int city::get_distance_from( const tripoint_om_omt &p ) const
 {
-    return std::max( static_cast<int>( trig_dist( p, tripoint_om_omt{ pos, 0 } ) ) - size, 0 );
+    return std::max( trig_dist( p, tripoint_om_omt{ pos, 0 } ) - size, 0 );
 }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -580,8 +580,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
                                "Shrapnel hit %s at %d m/s at a distance of %d",
                                critter->disp_name(),
                                frag.proj.speed,
-                               static_cast<int>( std::round(
-                                                     trig_dist_z_adjust( src, target ) ) ) );
+                               trig_dist( src, target ) );
                 add_msg_debug( debugmode::DF_EXPLOSION,
                                "Shrapnel dealt %d damage", frag.dealt_dam.total_damage() );
 
@@ -713,7 +712,7 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune )
 {
     draw_explosion( p, 8, c_white );
     Character &player_character = get_player_character();
-    int dist = static_cast<int>( std::round( trig_dist_z_adjust( player_character.pos_bub(), p ) ) );
+    int dist = trig_dist( player_character.pos_bub(), p );
     map &here = get_map();
     if( dist <= 8 && !player_immune ) {
         if( !player_character.has_flag( STATIC( json_character_flag( "IMMUNE_HEARING_DAMAGE" ) ) ) ) {
@@ -742,7 +741,7 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune )
             continue;
         }
         // TODO: can the following code be called for all types of creatures
-        dist = static_cast<int>( std::round( trig_dist_z_adjust( critter.pos_bub(), p ) ) );
+        dist = trig_dist( critter.pos_bub(), p );
         if( dist <= 8 ) {
             if( dist <= 4 ) {
                 critter.add_effect( effect_stunned, time_duration::from_turns( 10 - dist ) );
@@ -771,7 +770,7 @@ void shockwave( const tripoint_bub_ms &p, int radius, int force, int stun, int d
         if( critter.posz() != p.z() ) {
             continue;
         }
-        if( static_cast<int>( std::round( trig_dist_z_adjust( critter.pos_bub(), p ) <= radius ) ) ) {
+        if( trig_dist( critter.pos_bub(), p ) <= radius ) {
             add_msg( _( "%s is caught in the shockwave!" ), critter.name() );
             g->knockback( p, critter.pos_bub(), force, stun, dam_mult );
         }
@@ -781,14 +780,14 @@ void shockwave( const tripoint_bub_ms &p, int radius, int force, int stun, int d
         if( guy.posz() != p.z() ) {
             continue;
         }
-        if( static_cast<int>( std::round( trig_dist_z_adjust( guy.pos_bub(), p ) ) ) <= radius ) {
+        if( trig_dist( guy.pos_bub(), p ) <= radius ) {
             add_msg( _( "%s is caught in the shockwave!" ), guy.get_name() );
             g->knockback( p, guy.pos_bub(), force, stun, dam_mult );
         }
     }
     Character &player_character = get_player_character();
-    if( static_cast<int>( std::round( trig_dist_z_adjust( player_character.pos_bub(),
-                                      p ) ) ) <= radius && !ignore_player &&
+    if( trig_dist( player_character.pos_bub(),
+                   p ) <= radius && !ignore_player &&
         ( !player_character.has_trait( trait_LEG_TENT_BRACE ) ||
           !player_character.is_barefoot() ) ) {
         add_msg( m_bad, _( "You're caught in the shockwave!" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7564,7 +7564,7 @@ void game::zones_manager()
                         colorLine = zone.get_enabled() ? c_light_green : c_green;
                     }
 
-                    //Draw Zone name
+                    // Draw Zone name.
                     mvwprintz( w_zones, point( 3, iNum - start_index ), colorLine,
                                //~ "P: <Zone Name>" represents a personal zone
                                trim_by_length( ( zone.get_is_personal() ? _( "P: " ) : "" ) + zone.get_name(),
@@ -7572,13 +7572,13 @@ void game::zones_manager()
 
                     tripoint_abs_ms center = zone.get_center_point();
 
-                    //Draw direction + distance
+                    // Draw direction + distance.
                     mvwprintz( w_zones, point( zone_ui_width - 13, iNum - start_index ), colorLine, "%*d %s",
-                               5, static_cast<int>( trig_dist( player_absolute_pos, center ) ),
+                               5, trig_dist( player_absolute_pos, center ),
                                direction_name_short( direction_from( player_absolute_pos,
                                                      center ) ) );
 
-                    //Draw Vehicle Indicator
+                    // Draw Vehicle Indicator.
                     mvwprintz( w_zones, point( zone_ui_width - 4, iNum - start_index ), colorLine,
                                zone.get_is_vehicle() ? "*" : "" );
                 }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2223,8 +2223,9 @@ void inventory_selector::add_nearby_items( int radius, bool add_efiles )
                 add_vehicle_items( tripoint_bub_ms( pos ) );
                 continue;
             }
-            // Round up here to guard against bad range comparisons. clear_path() is stricter so it works out fine.
-            int dist = static_cast<int>( std::ceil( trig_dist_z_adjust( center, pos ) ) );
+            /* Ensure we round up here to guard against bad range comparisons.
+               clear_path() is stricter afterwards, so it works out fine. */
+            int dist = static_cast<int>( std::ceil( trig_dist_precise( center, pos ) ) );
             if( !here.clear_path( center, pos, dist, 1, 100 ) ) {
                 continue;
             }

--- a/src/item.h
+++ b/src/item.h
@@ -2078,7 +2078,7 @@ class item : public visitable
 
         /**How much of the specified vitamin is there?*/
         int get_vitamin_amount( const vitamin_id &vitamin ) const;
-        
+
         std::string get_fault_description( const fault_id &f_id ) const;
 
         /** Does this item have the specified fault? */

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -255,7 +255,7 @@ std::vector <tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int 
 
 float rl_dist_exact( const tripoint &loc1, const tripoint &loc2 )
 {
-    return trig_dist( loc1, loc2 );
+    return trig_dist_precise( loc1, loc2 );
 }
 
 int manhattan_dist( const point &loc1, const point &loc2 )
@@ -337,7 +337,7 @@ unsigned make_xyz( const tripoint &p )
 static std::tuple<double, double, double> slope_of( const std::vector<tripoint> &line )
 {
     cata_assert( !line.empty() && line.front() != line.back() );
-    const double len = trig_dist( line.front(), line.back() );
+    const double len = trig_dist_precise( line.front(), line.back() );
     double normDx = ( line.back().x - line.front().x ) / len;
     double normDy = ( line.back().y - line.front().y ) / len;
     double normDz = ( line.back().z - line.front().z ) / len;
@@ -350,7 +350,7 @@ static std::tuple<double, double, double> slope_of( const std::vector<tripoint> 
 static std::tuple<double, double, double> slope_of( const std::vector<tripoint_bub_ms> &line )
 {
     cata_assert( !line.empty() && line.front() != line.back() );
-    const double len = trig_dist( line.front(), line.back() );
+    const double len = trig_dist_precise( line.front(), line.back() );
     double normDx = ( line.back().x() - line.front().x() ) / len;
     double normDy = ( line.back().y() - line.front().y() ) / len;
     double normDz = ( line.back().z() - line.front().z() ) / len;
@@ -998,27 +998,27 @@ FastDistanceApproximation rl_dist_fast( const point_bub_ms &a, const point_bub_m
     return rl_dist_fast( tripoint_bub_ms( a, 0 ), tripoint_bub_ms( b, 0 ) );
 }
 
-float trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
+int trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
 {
-    return std::sqrt( static_cast<double>( ( loc1.x() - loc2.x() ) * ( loc1.x() - loc2.x() ) ) +
-                      ( ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) ) +
-                      ( ( loc1.z() - loc2.z() ) * ( loc1.z() - loc2.z() ) ) );
+    return static_cast<int>( std::round( std::sqrt( static_cast<double>( ( loc1.x() - loc2.x() ) *
+                                         ( loc1.x() - loc2.x() ) ) +
+                                         ( ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) ) +
+                                         ( ( 2 * ( loc1.z() - loc2.z() ) ) * ( 2 * ( loc1.z() - loc2.z() ) ) ) ) ) );
 }
 
-float trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 )
+int trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 )
 {
     return trig_dist( tripoint_bub_ms( loc1, 0 ), tripoint_bub_ms( loc2, 0 ) );
 }
 
-float trig_dist_z_adjust( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
+float trig_dist_precise( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 )
 {
     return std::sqrt( static_cast<double>( ( loc1.x() - loc2.x() ) * ( loc1.x() - loc2.x() ) ) +
                       ( ( loc1.y() - loc2.y() ) * ( loc1.y() - loc2.y() ) ) +
                       ( ( 2 * ( loc1.z() - loc2.z() ) ) * ( 2 * ( loc1.z() - loc2.z() ) ) ) );
 }
 
-float trig_dist_z_adjust( const point_bub_ms &loc1, const point_bub_ms &loc2 )
+float trig_dist_precise( const point_bub_ms &loc1, const point_bub_ms &loc2 )
 {
-    return trig_dist_z_adjust( tripoint_bub_ms( loc1, 0 ), tripoint_bub_ms( loc2, 0 ) );
+    return trig_dist_precise( tripoint_bub_ms( loc1, 0 ), tripoint_bub_ms( loc2, 0 ) );
 }
-

--- a/src/line.h
+++ b/src/line.h
@@ -161,38 +161,45 @@ std::vector<point> line_to( const point &p1, const point &p2, int t = 0 );
 std::vector<tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int t = 0, int t2 = 0 );
 // sqrt(dX^2 + dY^2)
 
-inline float trig_dist( const tripoint &loc1, const tripoint &loc2 )
+inline int trig_dist( const tripoint &loc1, const tripoint &loc2 )
 {
-    return std::sqrt( static_cast<double>( ( loc1.x - loc2.x ) * ( loc1.x - loc2.x ) ) +
-                      ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
-                      ( ( loc1.z - loc2.z ) * ( loc1.z - loc2.z ) ) );
+    return static_cast<int>( std::round( std::sqrt( static_cast<double>( ( loc1.x - loc2.x ) *
+                                         ( loc1.x - loc2.x ) ) +
+                                         ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
+                                         ( ( loc1.z - loc2.z ) * ( loc1.z - loc2.z ) ) ) ) );
 }
-float trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
-inline float trig_dist( const point &loc1, const point &loc2 )
+int trig_dist( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
+inline int trig_dist( const point &loc1, const point &loc2 )
 {
     return trig_dist( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
 }
-float trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 );
+int trig_dist( const point_bub_ms &loc1, const point_bub_ms &loc2 );
 
-inline float trig_dist_z_adjust( const tripoint &loc1, const tripoint &loc2 )
+
+/* Used when we actually want the float, like when calculating diagonal movecost
+   or similar */
+inline float trig_dist_precise( const tripoint &loc1, const tripoint &loc2 )
 {
     return std::sqrt( static_cast<double>( ( loc1.x - loc2.x ) * ( loc1.x - loc2.x ) ) +
                       ( ( loc1.y - loc2.y ) * ( loc1.y - loc2.y ) ) +
                       ( ( 2 * ( loc1.z - loc2.z ) ) * ( 2 * ( loc1.z - loc2.z ) ) ) );
 }
-float trig_dist_z_adjust( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
-inline float trig_dist_z_adjust( const point &loc1, const point &loc2 )
+float trig_dist_precise( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2 );
+inline float trig_dist_precise( const point &loc1, const point &loc2 )
 {
-    return trig_dist_z_adjust( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
+    return trig_dist_precise( tripoint( loc1, 0 ), tripoint( loc2, 0 ) );
 }
-float trig_dist_z_adjust( const point_bub_ms &loc1, const point_bub_ms &loc2 );
+float trig_dist_precise( const point_bub_ms &loc1, const point_bub_ms &loc2 );
 
-// Roguelike distance; maximum of dX and dY
+
+
+// Maximum of dX and dY
 inline int square_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     const tripoint d = ( loc1 - loc2 ).abs();
     return std::max( { d.x, d.y, d.z } );
 }
+
 inline int square_dist( const point &loc1, const point &loc2 )
 {
     const point d = ( loc1 - loc2 ).abs();
@@ -202,11 +209,9 @@ inline int square_dist( const point &loc1, const point &loc2 )
 // Choose between the above two according to the "circular distances" option
 inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
 {
-    if( trigdist ) {
-        return trig_dist( loc1, loc2 );
-    }
-    return square_dist( loc1, loc2 );
+    return trig_dist( loc1, loc2 );
 }
+
 inline int rl_dist( const point &a, const point &b )
 {
     return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
@@ -271,10 +276,7 @@ FastDistanceApproximation square_dist_fast( const tripoint_bub_ms &loc1,
 inline FastDistanceApproximation rl_dist_fast( const tripoint_bub_ms &loc1,
         const tripoint_bub_ms &loc2 )
 {
-    if( trigdist ) {
-        return trig_dist_fast( loc1, loc2 );
-    }
-    return square_dist_fast( loc1, loc2 );
+    return trig_dist_fast( loc1, loc2 );
 }
 FastDistanceApproximation rl_dist_fast( const point_bub_ms &a, const point_bub_ms &b );
 

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -226,7 +226,7 @@ void spell_effect::pain_split( const spell &sp, Creature &caster, const tripoint
 static bool in_spell_aoe( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
                           const int &radius, const bool ignore_walls )
 {
-    if( static_cast<int>( std::round( trig_dist_z_adjust( start, end ) ) ) > radius ) {
+    if( trig_dist( start, end ) > radius ) {
         return false;
     }
     if( ignore_walls ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4880,7 +4880,7 @@ void map::shoot( tripoint_bub_ms &p, const tripoint_bub_ms &source, projectile &
     const bool ignite = ammo_effects.count( ammo_effect_IGNITE );
     const bool laser = ammo_effects.count( ammo_effect_LASER );
 
-    int dist = static_cast<int>( std::round( trig_dist_z_adjust( source, p ) ) );
+    int dist = trig_dist( source, p );
     // Manually check coverage sources as coverage() isn't smart enough.
     int furn_coverage = 0;
     if( furn( p ) != f_null ) {
@@ -5308,7 +5308,7 @@ void map::translate_radius( const ter_id &from, const ter_id &to, float radi,
         const tripoint_abs_omt abs_omt_t = coords::project_to<coords::omt>( get_abs( t ) );
         const float radiX = trig_dist( p, t );
         if( ter( t ) == from ) {
-            // within distance, and either no submap limitation or same overmap coords.
+            // Within distance, and either no submap limitation or same overmap coords.
             if( radiX <= radi && ( !same_submap || abs_omt_t == abs_omt_p ) ) {
                 ter_set( t, to );
             }
@@ -8205,11 +8205,12 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
         return true;
     } );
 
-    float dist_to_ledge_base = trig_dist( viewer_p, tripoint_bub_ms( ledge_p.x(), ledge_p.y(),
-                                          viewer_p.z() ) );
+    float dist_to_ledge_base = trig_dist_precise( viewer_p, tripoint_bub_ms( ledge_p.x(), ledge_p.y(),
+                               viewer_p.z() ) );
     // Adjustment to ledge distance because ledge is assumed to be between two grids
     dist_to_ledge_base *= ( viewer_p.z() < target_p.z() ) ? -2.0f : 2.0f;
-    const float flat_dist = trig_dist( viewer_p, tripoint_bub_ms( target_p.xy(), viewer_p.z() ) );
+    const float flat_dist = trig_dist_precise( viewer_p, tripoint_bub_ms( target_p.xy(),
+                            viewer_p.z() ) );
     // Similarly adjust relative Z comparisons.
     const float adjusted_viewer_z = viewer_p.z() * 2;
     // "Opposite" of the angle between the viewer level and ledge
@@ -8218,7 +8219,8 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
     // Absolute level concealed by ledge, anything below this point is invisible
     const float covered_z = adjusted_viewer_z + ( tangent * flat_dist );
     // Compare adjusted target Z to covered area. Multiply by 100 to compare to eye_level().
-    int ledge_concealment = 100 * ( covered_z - ( target_p.z() * 2 ) );
+    int ledge_concealment = static_cast<int>( std::round( 100 * ( covered_z -
+                            ( target_p.z() * 2 ) ) ) );
     return std::max( ledge_concealment, 0 );
 }
 
@@ -8322,8 +8324,7 @@ std::vector<tripoint_bub_ms> map::find_clear_path( const tripoint_bub_ms &source
     const int max_start_offset = std::abs( ideal_start_offset ) * 2 + 1;
     for( int horizontal_offset = -1; horizontal_offset <= max_start_offset; ++horizontal_offset ) {
         int candidate_offset = horizontal_offset * ( start_sign == 0 ? 1 : start_sign );
-        if( sees( source, destination, static_cast<int>( std::round( trig_dist_z_adjust( source,
-                  destination ) ) ),
+        if( sees( source, destination, trig_dist( source, destination ),
                   candidate_offset, /*with_fields=*/true, /*allow_cached=*/false ) ) {
             return line_to( source, destination, candidate_offset, 0 );
         }
@@ -8533,8 +8534,7 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
     // Ugly `if` for now
     // TODO: Why is it even like this?
     if( f.z() == t.z() ) {
-        if( ( range < static_cast<int>( std::round( trig_dist_z_adjust( f, t ) ) ) ) ||
-            !inbounds( t ) ) {
+        if( !inbounds( t ) || ( range < trig_dist( f, t ) ) ) {
             return false; // Out of range!
         }
         bool is_clear = true;
@@ -8559,8 +8559,8 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
         return is_clear;
     }
 
-    // Handle direct vertical neighbor (1 tile away, different Z)
-    if( static_cast<int>( trig_dist( f.raw(), t.raw() ) ) < 2 && f.z() != t.z() ) {
+    /* Handle direct vertical neighbor (1 tile away, different Z) */
+    if( trig_dist( f.raw(), t.raw() ) < 2 && f.z() != t.z() ) {
         const bool going_up = t.z() > f.z();
         const tripoint_bub_ms &lower = going_up ? f : t;
         const tripoint_bub_ms &upper = going_up ? t : f;
@@ -8580,9 +8580,8 @@ bool map::clear_path( const tripoint_bub_ms &f, const tripoint_bub_ms &t, const 
         return false;
     }
 
-    // 3D path check
-    if( ( range < static_cast<int>( std::round( trig_dist_z_adjust( f, t ) ) ) ) ||
-        !inbounds( t ) ) {
+    // 3D path check.
+    if( !inbounds( t ) || ( range < trig_dist( f, t ) ) ) {
         return false;
     }
 

--- a/src/map_iterator.h
+++ b/src/map_iterator.h
@@ -179,7 +179,7 @@ inline tripoint_range<Tripoint> points_on_radius_circ( const Tripoint &center, c
     const tripoint offset( radius, radius, radiusz );
     return tripoint_range<Tripoint>( center - offset,
     center + offset, [center, radius]( const Tripoint & pt ) {
-        float r = trig_dist( center, pt );
+        int r = trig_dist( center, pt );
         return radius - 0.5f < r && r < radius + 0.5f;
     } );
 }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -167,7 +167,7 @@ bool leap_actor::call( monster &z ) const
                            candidate.to_string_writable() );
             continue;
         }
-        float leap_dist = trig_dist( z.pos_bub(), candidate );
+        int leap_dist = trig_dist( z.pos_bub(), candidate );
         add_msg_debug( debugmode::DF_MATTACK,
                        "Candidate coordinates %s, distance %.1f, min range %.1f, max range %.1f",
                        candidate.to_string_writable(), leap_dist, min_range, max_range );
@@ -313,8 +313,7 @@ bool mon_spellcasting_actor::call( monster &mon ) const
 
     // Bail out if the target is out of range.
     if( !spell_data.self &&
-        static_cast<int>( std::round( trig_dist_z_adjust( mon.pos_bub(),
-                                      target ) > spell_instance.range( mon ) ) ) ) {
+        trig_dist( mon.pos_bub(), target ) > spell_instance.range( mon ) ) {
         return false;
     }
 
@@ -1231,7 +1230,7 @@ bool gun_actor::call( monster &z ) const
         }
     }
 
-    const int dist = static_cast<int>( std::round( trig_dist_z_adjust( z.pos_bub(), aim_at ) ) );
+    const int dist = trig_dist( z.pos_bub(), aim_at );
     if( target ) {
         add_msg_debug( debugmode::DF_MATTACK, "Target %s at range %d", target->disp_name(), dist );
     } else {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -153,6 +153,7 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_CLUMSY( "CLUMSY" );
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEFT( "DEFT" );
+static const trait_id trait_ECHOLOCATION( "ECHOLOCATION" );
 static const trait_id trait_POISONOUS( "POISONOUS" );
 static const trait_id trait_POISONOUS2( "POISONOUS2" );
 static const trait_id trait_VINES2( "VINES2" );
@@ -385,7 +386,9 @@ float Character::hit_roll() const
     }
 
     // Fighting in the dark is hard.
-    if( !sight_impaired() && fine_detail_vision_mod() >= 7.0f ) {
+    // TODO: sees_with_specials should help, but we'd need to pass the target to this function.
+    if( ( sight_impaired() || fine_detail_vision_mod() >= 7.0f ) &&
+        !( has_trait( trait_ECHOLOCATION ) && !is_deaf() && !is_underwater() ) ) {
         hit -= 1.0f;
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -255,7 +255,7 @@ static bool within_target_range( const monster *const z, const Creature *const t
 
     return target != nullptr &&
            ( z->is_adjacent( target, true ) ||
-             static_cast<int>( ( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) ) <= range ) ) &&
+             trig_dist( z->pos_bub(), target->pos_bub() ) <= range ) &&
            z->sees( here, *target );
 }
 
@@ -689,7 +689,7 @@ bool mattack::shriek_stun( monster *z )
         return false;
     }
 
-    int dist = static_cast<int>( std::round( trig_dist_z_adjust( z->pos_bub(), target->pos_bub() ) ) );
+    int dist = trig_dist( z->pos_bub(), target->pos_bub() );
     // Currently the cone is 2D, so don't use it for 3D attacks
     if( dist > 7 ||
         z->posz() != target->posz() ||
@@ -1002,7 +1002,7 @@ bool mattack::pull_metal_aoe( monster *z )
         // FIXME: Hardcoded damage type
         proj.impact.add_damage( STATIC( damage_type_id( "bash" ) ), pr.first.weight() / 250_gram );
         // make the projectile stop one tile short to prevent hitting the user
-        proj.range = static_cast<int>( std::round( trig_dist_z_adjust( pr.second, z->pos_bub() ) ) ) - 1;
+        proj.range = trig_dist( pr.second, z->pos_bub() ) - 1;
         proj.proj_effects = {{ ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET }};
 
         dealt_projectile_attack dealt;
@@ -3868,8 +3868,8 @@ bool mattack::flesh_tendril( monster *z )
         return false;
     }
 
-    const int distance_to_target = static_cast<int>( std::round( trig_dist_z_adjust( z->pos_bub(),
-                                   target->pos_bub() ) ) );
+    const int distance_to_target = trig_dist( z->pos_bub(),
+                                   target->pos_bub() );
 
     // the monster summons stuff to fight you
     if( distance_to_target > 3 && one_in( 12 ) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -765,20 +765,16 @@ void monster::plan()
 
 /**
  * Method to make monster movement speed consistent in the face of staggering behavior and
- * differing distance metrics.
- * It works by scaling the cost to take a step by
- * how much that step reduces the distance to your goal.
- * Since it incorporates the current distance metric,
- * it also scales for diagonal vs orthogonal movement.
+ * differing distance metrics. It works by scaling the cost to take a step by
+ * how much that step reduces the distance to your goal, scaled correctly for diagonals.
  **/
 static float get_stagger_adjust( const tripoint_bub_ms &source, const tripoint_bub_ms &destination,
                                  const tripoint_bub_ms &next_step )
 {
-    // TODO: push this down into rl_dist
     const float initial_dist =
-        trig_dist_z_adjust( source, destination );
+        trig_dist( source, destination );
     const float new_dist =
-        trig_dist_z_adjust( next_step, destination );
+        trig_dist_precise( next_step, destination );
     // If we return 0, it wil cancel the action.
     return std::max( 0.01f, initial_dist - new_dist );
 }
@@ -1441,8 +1437,8 @@ void monster::footsteps( const tripoint_bub_ms &p )
     if( volume == 0 ) {
         return;
     }
-    int dist = static_cast<int>( std::round( trig_dist_z_adjust( p,
-                                 get_player_character().pos_bub() ) ) );
+    int dist = trig_dist( p,
+                          get_player_character().pos_bub() );
     sounds::add_footstep( p, volume, dist, this, type->get_footsteps() );
 }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3245,10 +3245,8 @@ void npc::avoid_friendly_fire()
     candidates.erase( candidates.begin() );
     std::sort( candidates.begin(), candidates.end(),
     [&tar, &center]( const tripoint_bub_ms & l, const tripoint_bub_ms & r ) {
-        return ( static_cast<int>( std::round( trig_dist_z_adjust( l,
-                                               tar ) ) ) - static_cast<int>( std::round( trig_dist_z_adjust( l, center ) ) ) ) <
-               ( static_cast<int>( std::round( trig_dist_z_adjust( r,
-                                               tar ) ) ) - static_cast<int>( std::round( trig_dist_z_adjust( r, center ) ) ) );
+        return ( trig_dist( l, tar ) - trig_dist( l, center ) ) <
+               ( trig_dist( r, tar ) - trig_dist( r, center ) );
     } );
 
     for( const tripoint_bub_ms &pt : candidates ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -146,8 +146,9 @@ static const flag_id json_flag_CROSSBOW( "CROSSBOW" );
 static const flag_id json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const flag_id json_flag_FILTHY( "FILTHY" );
 
-static const limb_score_id limb_score_vision( "vision" );
 static const limb_score_id limb_score_manip( "manip" );
+static const limb_score_id limb_score_night_vis( "night_vis" );
+static const limb_score_id limb_score_vision( "vision" );
 
 static const material_id material_budget_steel( "budget_steel" );
 static const material_id material_case_hardened_steel( "case_hardened_steel" );
@@ -175,6 +176,7 @@ static const skill_id skill_swimming( "swimming" );
 static const skill_id skill_throw( "throw" );
 
 static const trait_id trait_BRAWLER( "BRAWLER" );
+static const trait_id trait_ECHOLOCATION( "ECHOLOCATION" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
 
 static const trap_str_id tr_practice_target( "tr_practice_target" );
@@ -563,27 +565,25 @@ target_handler::trajectory target_handler::mode_turrets( avatar &you, vehicle &v
         const std::vector<vehicle_part *> &turrets )
 {
     map &here = get_map();
-    // Find radius of a circle centered at u encompassing all points turrets can aim at
-    // FIXME: this calculation is fine for square distances, but results in an underestimation
-    //        when used with real circles
+    // Find radius of a circle centered at you encompassing all points turrets can aim at.
     int range_total = 0;
     for( vehicle_part *t : turrets ) {
         int range = veh.turret_query( *t ).range();
         tripoint_bub_ms pos = veh.bub_part_pos( here, *t );
 
         int res = 0;
-        res = std::max( res, static_cast<int>( std::round( trig_dist_z_adjust( you.pos_bub(),
-                                               pos + point( range,
-                                                       0 ) ) ) ) );
-        res = std::max( res, static_cast<int>( std::round( trig_dist_z_adjust( you.pos_bub(),
-                                               pos + point( -range,
-                                                       0 ) ) ) ) );
-        res = std::max( res, static_cast<int>( std::round( trig_dist_z_adjust( you.pos_bub(),
-                                               pos + point( 0,
-                                                       range ) ) ) ) );
-        res = std::max( res, static_cast<int>( std::round( trig_dist_z_adjust( you.pos_bub(),
-                                               pos + point( 0,
-                                                       -range ) ) ) ) );
+        res = std::max( res, trig_dist( you.pos_bub(),
+                                        pos + point( range,
+                                                0 ) ) );
+        res = std::max( res, trig_dist( you.pos_bub(),
+                                        pos + point( -range,
+                                                0 ) ) );
+        res = std::max( res, trig_dist( you.pos_bub(),
+                                        pos + point( 0,
+                                                range ) ) );
+        res = std::max( res, trig_dist( you.pos_bub(),
+                                        pos + point( 0,
+                                                -range ) ) );
         range_total = std::max( range_total, res );
     }
 
@@ -1288,7 +1288,7 @@ int throw_cost( const Character &c, const item &to_throw )
 static double calculate_aim_cap_without_target( const Character &you,
         const tripoint_bub_ms &target )
 {
-    const int range = static_cast<int>( std::round( trig_dist_z_adjust( you.pos_bub(), target ) ) );
+    const int range = trig_dist( you.pos_bub(), target );
     // Get angle of triangle that spans the target square.
     const double angle = 2 * atan2( 0.5, range );
     // Convert from radians to arcmin.
@@ -1375,21 +1375,36 @@ int Character::throwing_dispersion( const item &to_throw, Creature *critter,
     const float throw_skill = std::min( static_cast<float>( MAX_SKILL ),
                                         get_skill_level( skill_throw ) );
     int dispersion = 10 * throw_difficulty / ( 8 * throw_skill + 4 );
-    // If the target is a creature, it moves around and ruins aim
+    // If the target is a creature, it moves around and ruins aim.
     // TODO: Inform projectile functions if the attacker actually aims for the critter or just the tile
     if( critter != nullptr ) {
         // It's easier to dodge at close range (thrower needs to adjust more)
         // Dodge x10 at point blank, x5 at 1 dist, then flat
         float effective_dodge = critter->get_dodge() * std::max( 1,
-                                10 - 5 * static_cast<int>( std::round( trig_dist_z_adjust( pos_bub(),
-                                        critter->pos_bub() ) ) ) );
+                                10 - 5 * trig_dist( pos_bub(),
+                                        critter->pos_bub() ) );
         dispersion += throw_dispersion_per_dodge( true ) * effective_dodge;
     }
-    // 1 perception per 1 eye encumbrance
-    ///\EFFECT_PER decreases throwing accuracy penalty from eye encumbrance
-    dispersion += std::max( 0, ( encumb( bodypart_id( "eyes" ) ) - get_per() ) * 10 );
-
-    // Blind throws are less accurate
+    float vision_mod = get_limb_score( limb_score_vision );
+    // If it's dark, cap our vision at night vision, unless we have IR or something.
+    if( fine_detail_vision_mod( critter->pos_bub() ) >= 4.f && !sees_with_specials( *critter ) ) {
+        vision_mod = std::min( vision_mod, get_limb_score( limb_score_night_vis ) );
+    }
+    // Echolocation lets hearing sub in for vision here.
+    bool echolocation = has_trait( trait_ECHOLOCATION ) && !is_deaf() && !is_underwater() &&
+                        !critter->is_underwater();
+    if( echolocation ) {
+        // todo: hearing_ability() could probably stand in here but idk how it scales.
+        vision_mod = 1.0f;
+    }
+    int perception_mod = std::max( 0, get_per() - 10 );
+    dispersion += std::max( 0, static_cast<int>( std::round( ( ( 1.f - vision_mod ) * 2000 -
+                            ( perception_mod * 100 ) ) ) ) );
+    // The inverse of the below doesn't necessarily mean false, as we could be peek-throwing or something.
+    if( !sees( get_map(), *critter ) && !sees_with_specials( *critter ) && !echolocation ) {
+        is_blind_throw = true;
+    }
+    // Blind throws are less accurate.
     if( is_blind_throw ) {
         dispersion *= 4;
     }
@@ -1588,7 +1603,7 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
     // Throw from the player's position, unless we're blind throwing.
     const tripoint_bub_ms throw_from = blind_throw_from_pos ? *blind_throw_from_pos : pos_bub();
 
-    float range = static_cast<int>( std::round( trig_dist_z_adjust( throw_from, target ) ) );
+    int range = trig_dist( throw_from, target );
     proj.range = range;
     float skill_lvl = get_skill_level( skill_throw );
 
@@ -1804,11 +1819,11 @@ Target_attributes::Target_attributes( tripoint_bub_ms src, tripoint_bub_ms targe
 
     Creature *target_critter = get_creature_tracker().creature_at( target );
     Creature *shooter = get_creature_tracker().creature_at( src );
-    range = static_cast<int>( std::round( trig_dist_z_adjust( src, target ) ) );
+    range = trig_dist( src, target );
     size = target_critter != nullptr ?
            target_critter->ranged_target_size() :
            here.ranged_target_size( target );
-    size_in_moa = target_size_in_moa( range, size ) ;
+    size_in_moa = target_size_in_moa( range, size );
     light = here.ambient_light_at( target );
     visible = shooter->sees( here, target );
 
@@ -2241,8 +2256,8 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
     }
 
     const dispersion_sources dispersion( you.throwing_dispersion( weapon, target, is_blind_throw ) );
-    const double range = static_cast<double>( std::round( trig_dist_z_adjust( you.pos_bub(),
-                         target_pos ) ) );
+    const double range = trig_dist( you.pos_bub(),
+                                    target_pos );
 
     const double target_size = target != nullptr ? target->ranged_target_size() : 1.0f;
 
@@ -2284,15 +2299,15 @@ static void draw_throwcreature_aim( const target_ui &ui, const Character &you,
     }
     item weapon = null_item_reference();
     const dispersion_sources dispersion( you.throwing_dispersion( weapon, target, false ) );
-    double range = static_cast<double>( std::round( trig_dist_z_adjust( you.grab_1.victim->pos_bub(),
-                                        target_pos ) ) );
+    double range = trig_dist_precise( you.grab_1.victim->pos_bub(),
+                                      target_pos );
     const double target_size = target != nullptr ? target->ranged_target_size() : 1.0f;
     float throwforce = 0.0f;
     if( you.grab_1.victim ) {
         throwforce = you.throwforce( *you.grab_1.victim );
     }
-    range = throwforce / 10;
-    float distance = trig_dist_z_adjust( you.grab_1.victim->pos_bub(), target_pos );
+    range = throwforce / 10.f;
+    float distance = trig_dist_precise( you.grab_1.victim->pos_bub(), target_pos );
     distance /= range;
     throwforce *= distance;
     static const std::vector<confidence_rating> throwforce_config_critter = {{
@@ -3239,7 +3254,7 @@ bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
             }
             if( dist_fn( valid_pos ) > range ) {
                 auto dist_fn_unrounded = [this]( const tripoint_bub_ms & p ) {
-                    return static_cast<int>( std::round( trig_dist_z_adjust( src, p ) ) );
+                    return trig_dist( src, p );
                 };
 
                 bool found = false;
@@ -3402,9 +3417,9 @@ void target_ui::update_target_list()
     }
     std::sort( targets.begin(), targets.end(), [&]( const tripoint_bub_ms lhs,
     const tripoint_bub_ms rhs ) {
-        return static_cast<int>( std::round( trig_dist_z_adjust( lhs,
-                                             you->pos_bub( here ) ) ) ) < static_cast<int>( std::round( trig_dist_z_adjust( rhs,
-                                                     you->pos_bub( here ) ) ) );
+        return trig_dist( lhs,
+                          you->pos_bub( here ) ) < trig_dist( rhs,
+                                  you->pos_bub( here ) );
     } );
 }
 
@@ -3505,11 +3520,10 @@ int target_ui::dist_fn( const tripoint_bub_ms &p )
         }
     }
     if( src.z() == p.z() ) {
-        return static_cast<int>( z_adjust + static_cast<int>( std::round( trig_dist_z_adjust( src,
-                                 p ) ) ) );
+        return z_adjust + trig_dist( src, p );
     } else {
-        // Always round up so that the Z adjustment actually matters.
-        return static_cast<int>( z_adjust + std::ceil( trig_dist_z_adjust( src, p ) ) );
+        // Rounds up so we make sure the Z levels matter.
+        return z_adjust + static_cast<int>( std::ceil( trig_dist_precise( src, p ) ) );
     }
 }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -266,8 +266,8 @@ static int sound_distance( const tripoint_bub_ms &source, const tripoint_bub_ms 
     }
     // Regardless of underground effects, scale the vertical distance by 5x.
     vertical_attenuation *= 5;
-    return static_cast<int>( std::round( trig_dist_z_adjust( source.xy(),
-                                         sink.xy() ) ) ) + vertical_attenuation;
+    return trig_dist( source.xy(),
+                      sink.xy() ) + vertical_attenuation;
 }
 
 static std::string season_str( const season_type &season )


### PR DESCRIPTION
#### Summary
Fix trig dist truncation and spruce up throwing

#### Purpose of change
- The trig_dist() code was very messy, and in a lot of places it had some suspicious truncation going on.

#### Describe the solution
- trig_dist now returns a properly rounded int. 
- trig_dist_precise now returns a float.
- For absolutely no reason, I also added some fixes to throwing here, making it much harder in the dark but using limb scores and potentially echolocation or special vision to possibly make up for it.
- Echolocation was also added to the melee accuracy penalty check in darkness.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
