### PR TITLE
Fix mut_tough

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -839,7 +839,7 @@
     "description": "It takes a lot to bring you down.  You get a 10% bonus to all hit points.",
     "starting_trait": true,
     "types": [ "DURABILITY" ],
-    "changes_to": [ "TOUGH2", "MUT_TOUGH2" ],
+    "changes_to": [ "TOUGH2", "MUT_TOUGH" ],
     "category": [ "URSINE", "CATTLE", "CHIMERA", "BEAST", "LIZARD", "CRUSTACEAN", "MEDICAL" ],
     "cancels": [ "FLIMSY", "FLIMSY2", "FLIMSY3" ],
     "social_modifiers": { "intimidate": 2 },
@@ -4843,13 +4843,14 @@
   {
     "type": "mutation",
     "id": "MUT_TOUGH",
-    "name": { "str": "Resilient" },
+    "name": { "str": "Durable" },
     "points": 2,
     "description": "You can survive injuries that would incapacitate humans: you get a 20% bonus to all hit points.",
     "social_modifiers": { "intimidate": 2 },
     "types": [ "DURABILITY" ],
     "prereqs": [ "LARGE", "LARGE_OK", "HUGE", "HUGE_OK", "STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4" ],
     "changes_to": [ "MUT_TOUGH2" ],
+    "cancels": [ "FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW" ],
     "category": [ "URSINE", "CATTLE", "CHIMERA", "BEAST", "LIZARD", "CRUSTACEAN" ],
     "enchantments": [ { "values": [ { "value": "MAX_HP", "multiply": 0.2 } ] } ]
   },
@@ -4863,6 +4864,7 @@
     "prereqs": [ "MUT_TOUGH" ],
     "threshreq": [ "THRESH_URSINE", "THRESH_CATTLE", "THRESH_CHIMERA", "THRESH_CRUSTACEAN" ],
     "changes_to": [ "MUT_TOUGH3" ],
+    "cancels": [ "FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW" ],
     "category": [ "URSINE", "CATTLE", "CHIMERA", "CRUSTACEAN" ],
     "enchantments": [ { "values": [ { "value": "MAX_HP", "multiply": 0.3 } ] } ]
   },


### PR DESCRIPTION
#### Summary
Fix mut_tough

#### Purpose of change
Tough wasn't falling off and there was an infinite loop with it and Durable (formerly Resilient).

#### Describe the solution
Add a prereq, fix the changes_to. Rename mut_tough.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
