### PR TITLE
Fix maggot hp and skull helmet

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1107,10 +1107,10 @@
     "subtypes": [ "ARMOR" ],
     "name": { "str": "skull helmet" },
     "description": "The top part of a large animal skull, equipped with leather straps to secure it on your head.",
-    "weight": "1 kg",
-    "volume": "4 L",
+    "weight": "600 g",
+    "volume": "5 L",
     "price": "14 USD",
-    "price_postapoc": "2 USD",
+    "price_postapoc": "1 USD",
     "material": [ "bone", "leather" ],
     "symbol": "[",
     "color": "dark_gray",
@@ -1118,6 +1118,10 @@
     "flags": [ "WATER_FRIENDLY", "OUTER", "BELTED" ],
     "armor": [
       {
+        "material": [
+          { "type": "bone", "covered_by_mat": 100, "thickness": 1.5 },
+          { "type": "leather", "covered_by_mat": 5, "thickness": 1.0 }
+        ],
         "encumbrance": 26,
         "coverage": 100,
         "covers": [ "head" ],
@@ -1125,8 +1129,12 @@
         "rigid_layer_only": true
       },
       {
+        "material": [
+          { "type": "bone", "covered_by_mat": 100, "thickness": 1.5 },
+          { "type": "leather", "covered_by_mat": 5, "thickness": 1.0 }
+        ],
         "encumbrance": 0,
-        "coverage": 60,
+        "coverage": 90,
         "covers": [ "head" ],
         "specifically_covers": [ "head_forehead" ],
         "rigid_layer_only": true

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -968,7 +968,7 @@
     "bodytype": "snake",
     "volume": "1 L",
     "weight": "700 g",
-    "hp": 5,
+    "hp": 8,
     "speed": 15,
     "stomach_size": 150,
     "color": "light_green",


### PR DESCRIPTION
#### Summary
Fix maggot hp and skull helmet

#### Purpose of change
- Maggot HP was set to 5, but that's the same as its copy-from origin, so that needs to change.
- The old bone helmet was still around. I almost removed it but decided to fix it instead,

#### Describe the solution
Bump it to 8, fix coverage and material portions for the helmet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
