### PR TITLE
Fix sky island

### DIFF
--- a/data/mods/Sky_Island/island_upgrades.json
+++ b/data/mods/Sky_Island/island_upgrades.json
@@ -114,18 +114,17 @@
       { "u_message": "Mapping island for future construction…" },
       {
         "u_location_variable": { "global_val": "OM_island_center" },
-        "target_params": { "om_terrain": "sky_island_core", "om_terrain_match_type": "CONTAINS", "search_range": 4 }
+        "target_params": { "om_terrain": "sky_island_core", "om_terrain_match_type": "CONTAINS" }
       },
       {
         "u_location_variable": { "global_val": "OM_island_subcenter" },
-        "target_params": { "om_terrain": "sky_island_core", "om_terrain_match_type": "CONTAINS", "search_range": 4, "offset_z": -1 }
+        "target_params": { "om_terrain": "sky_island_core", "om_terrain_match_type": "CONTAINS", "offset_z": -1 }
       },
       {
         "u_location_variable": { "global_val": "OM_island_subnw" },
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": -1,
           "offset_y": -1
@@ -136,7 +135,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_y": -1
         }
@@ -146,7 +144,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": 1,
           "offset_y": -1
@@ -157,7 +154,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": -1
         }
@@ -167,7 +163,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": 1
         }
@@ -177,7 +172,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": -1,
           "offset_y": 1
@@ -188,7 +182,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_y": 1
         }
@@ -198,7 +191,6 @@
         "target_params": {
           "om_terrain": "sky_island_core",
           "om_terrain_match_type": "CONTAINS",
-          "search_range": 4,
           "offset_z": -1,
           "offset_x": 1,
           "offset_y": 1

--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -218,7 +218,7 @@
     "item": "etched_skull",
     "start": {
       "update_mapgen": { "place_item": [ { "item": "etched_skull", "x": [ 3, 21 ], "y": [ 6, 21 ], "amount": 1 } ] },
-      "assign_mission_target": { "om_terrain": "cave_rat", "om_special": "Rat Cave", "reveal_radius": 3, "search_range": 120 }
+      "assign_mission_target": { "om_terrain": "cave_rat", "om_special": "Rat Cave", "reveal_radius": 3 }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "followup": "MISSION_INVESTIGATE_PRISON_VISIONARY",
@@ -243,7 +243,7 @@
     "value": 150000,
     "item": "visions_solitude",
     "start": {
-      "assign_mission_target": { "om_terrain": "island_forest_thick", "om_special": "Island", "reveal_radius": 3, "search_range": 180 },
+      "assign_mission_target": { "om_terrain": "island_forest_thick", "om_special": "Island", "reveal_radius": 3 },
       "update_mapgen": { "om_terrain": "prison_1_4", "place_item": [ { "item": "visions_solitude", "x": 15, "y": 22 } ] }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
@@ -289,7 +289,7 @@
     "value": 250000,
     "item": "vegetable_tainted",
     "start": {
-      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 3, "search_range": 120 },
+      "assign_mission_target": { "om_terrain": "forest", "reveal_radius": 3 },
       "update_mapgen": { "place_item": [ { "item": "vegetable_tainted", "x": 14, "y": 15, "amount": [ 10, 20 ], "repeat": [ 1, 3 ] } ] }
     },
     "origins": [ "ORIGIN_SECONDARY" ],


### PR DESCRIPTION
#### Summary
Fix sky island

#### Purpose of change
Sky island had max search radii defined for non-random mission defs.

#### Describe the solution
Remove they.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
