### PR TITLE
Metalworking chisel needs anvil 2 and no fileset

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -199,7 +199,7 @@
       [ "textbook_weparabic", 5 ]
     ],
     "using": [ [ "forging_standard", 3 ], [ "steel_tiny", 3 ] ],
-    "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "GRIND", "level": 2 } ],
+    "qualities": [ { "id": "ANVIL", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
     "//": "Specifically avoids blacksmithing requirement groups so that it's craftable without the metal fileset - this process would still be possible, just realistically take slightly longer.",
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "proficiencies": [


### PR DESCRIPTION
#### Summary
Metalworking chisel needs anvil 2 and no fileset

#### Purpose of change
The metalworking chisel was a seemingly unintended bottleneck in the blacksmithing process. Its comments suggested it should be possible to make without a metalworking chisel, yet it needed Anvil 3 even though there's no explanation for why that should be so. A metalworking chisel needs to be hard, but its shape is simple, only being a rod of steel with a pointed end and a flat hammering surface opposite - no need for a pritchelor hardy hole, or horn, or anything else.

It also specified GRIND 3 in its tool requirements even though the comments said it shouldn't need that sort of thing.

fixes #2013 

#### Describe the solution
It now just needs Anvil 2 (so the railroad track section is fine, or you can use steel plating taken off of an armored vehicle)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
