### PR TITLE
Fix Gradual Mutation More Better

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
@@ -22,6 +22,7 @@
         "MUTATING_GRADUAL_PLANT",
         "MUTATING_GRADUAL_RATTINE",
         "MUTATING_GRADUAL_REPTILIAN",
+        "MUTATING_GRADUAL_SLIME",
         "MUTATING_GRADUAL_TROGLOBITE",
         "MUTATING_GRADUAL_URSINE"
       ]
@@ -32,7 +33,6 @@
     "id": "EOC_LOSE_MUTATING_GRADUAL",
     "effect": [
       { "u_message": "The everpresent churning in your tortured flesh finally ceases.  Is it over?" },
-      { "u_lose_trait": "MUTATING_GRADUAL_ABSTRACT" },
       { "u_lose_trait": "MUTATING_GRADUAL_BATRACHIAN" },
       { "u_lose_trait": "MUTATING_GRADUAL_BIRD" },
       { "u_lose_trait": "MUTATING_GRADUAL_CATTLE" },
@@ -43,6 +43,7 @@
       { "u_lose_trait": "MUTATING_GRADUAL_PISCINE" },
       { "u_lose_trait": "MUTATING_GRADUAL_GASTROPOD" },
       { "u_lose_trait": "MUTATING_GRADUAL_INSECT" },
+      { "u_lose_trait": "MUTATING_GRADUAL_LAGOMORPH" },
       { "u_lose_trait": "MUTATING_GRADUAL_REPTILIAN" },
       { "u_lose_trait": "MUTATING_GRADUAL_CANINE" },
       { "u_lose_trait": "MUTATING_GRADUAL_MURINE" },
@@ -51,7 +52,9 @@
       { "u_lose_trait": "MUTATING_GRADUAL_SLIME" },
       { "u_lose_trait": "MUTATING_GRADUAL_ARANEAN" },
       { "u_lose_trait": "MUTATING_GRADUAL_TROGLOBITE" },
-      { "u_lose_trait": "MUTATING_GRADUAL_URSINE" }
+      { "u_lose_trait": "MUTATING_GRADUAL_URSINE" },
+      { "u_lose_var": "u_MUTATING_GRADUAL_threshold)" },
+      { "u_lose_var": "u_MUTATING_GRADUAL_vitamin)" }
     ]
   },
   {
@@ -82,14 +85,9 @@
     "eoc_type": "EVENT",
     "required_event": "crosses_mutation_threshold",
     "condition": {
-      "and": [ { "not": { "test_eoc": "EOC_TRAIT_IS_MUTATING_GRADUAL" } }, { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] } ]
+      "and": [ { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] } ]
     },
-    "effect": [
-      {
-        "if": { "math": [ "u_has_trait(u_MUTATING_GRADUAL_threshold)" ] },
-        "then": [ { "u_message": "You are new born, complete." }, { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
-      }
-    ]
+    "effect": [ { "u_message": "You are new born, complete." }, { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
   },
   {
     "type": "effect_on_condition",
@@ -159,7 +157,7 @@
         "if": { "compare_string": [ { "context_val": "trait" }, "MUTATING_GRADUAL_LAGOMORPH" ] },
         "then": [
           { "u_add_var": "MUTATING_GRADUAL_vitamin", "value": "mutagen_rabbit" },
-          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_FELINE" }
+          { "u_add_var": "MUTATING_GRADUAL_threshold", "value": "THRESH_LAGOMORPH" }
         ]
       },
       {
@@ -285,6 +283,16 @@
         "else": { "math": [ "u_recently_mutated_cooldown -= 1" ] }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CROSSED_THRESHOLD_CLEANUP",
+    "//": "Fallback in case we somehow didn't lose gradual mutation when we crossed the threshold.",
+    "condition": {
+      "and": [ { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] }, { "u_has_flag": "MUTATION_THRESHOLD" } ]
+    },
+    "recurrence": [ "4 hours", "8 hours" ],
+    "effect": [ { "u_message": "You are new born, complete." }, { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/mutations/mutation_gradual.json
+++ b/data/json/mutations/mutation_gradual.json
@@ -38,6 +38,7 @@
     "id": "MUTATING_GRADUAL_ARANEAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Aranean Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more aranean traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_ARANEAN" ] }
   },
@@ -46,6 +47,7 @@
     "id": "MUTATING_GRADUAL_AVIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Avian Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more avian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_AVIAN" ] }
   },
@@ -54,6 +56,7 @@
     "id": "MUTATING_GRADUAL_BATRACHIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Batrachian Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more batrachian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_BATRACHIAN" ] }
   },
@@ -62,6 +65,7 @@
     "id": "MUTATING_GRADUAL_BOVOID",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Bovoid Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more bovoid traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_BOVOID" ] }
   },
@@ -70,6 +74,7 @@
     "id": "MUTATING_GRADUAL_CANINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Canine Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more canine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CANINE" ] }
   },
@@ -78,6 +83,7 @@
     "id": "MUTATING_GRADUAL_CEPHALOPOD",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Cephalopod Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more cephalopod traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CEPHALOPOD" ] }
   },
@@ -86,6 +92,7 @@
     "id": "MUTATING_GRADUAL_CHIROPTERAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Chiropteran Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more chiropteran traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CHIROPTERAN" ] }
   },
@@ -94,6 +101,7 @@
     "id": "MUTATING_GRADUAL_CRUSTACEAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Crustacean Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more crustacean traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CRUSTACEAN" ] }
   },
@@ -102,6 +110,7 @@
     "id": "MUTATING_GRADUAL_FELINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Feline Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more feline traits.",
     "delete": { "cancels": [ "MUTAGEN" ] }
   },
@@ -110,6 +119,7 @@
     "id": "MUTATING_GRADUAL_GASTROPOD",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Gastropod Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more gastropod traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_GASTROPOD" ] }
   },
@@ -118,14 +128,16 @@
     "id": "MUTATING_GRADUAL_LAGOMORPH",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Lagomorph Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more lagomorph traits.",
-    "delete": { "cancels": [ "MUTATING_GRADUAL_PISCINE" ] }
+    "delete": { "cancels": [ "MUTATING_GRADUAL_LAGOMORPH" ] }
   },
   {
     "type": "mutation",
     "id": "MUTATING_GRADUAL_PISCINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Piscine Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more piscine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_PISCINE" ] }
   },
@@ -134,6 +146,7 @@
     "id": "MUTATING_GRADUAL_INSECT",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Insect Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more insect traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_INSECT" ] }
   },
@@ -142,6 +155,7 @@
     "id": "MUTATING_GRADUAL_REPTILIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Reptilian Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more reptilian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_REPTILIAN" ] }
   },
@@ -150,6 +164,7 @@
     "id": "MUTATING_GRADUAL_MURINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Murine Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more murine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_MURINE" ] }
   },
@@ -158,6 +173,7 @@
     "id": "MUTATING_GRADUAL_PLANT",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Plant Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more plant traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_PLANT" ] }
   },
@@ -166,6 +182,7 @@
     "id": "MUTATING_GRADUAL_RATTINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Rattine Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more rattine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_RATTINE" ] }
   },
@@ -174,6 +191,7 @@
     "id": "MUTATING_GRADUAL_TROGLOBITE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Troglobite Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more troglobite traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_TROGLOBITE" ] }
   },
@@ -182,6 +200,7 @@
     "id": "MUTATING_GRADUAL_URSINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Ursine Evolution" },
+     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more ursine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_URSINE" ] }
   },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3462,9 +3462,12 @@ talk_effect_fun_t::func f_remove_trait( const JsonObject &jo, std::string_view m
 {
     str_or_var old_trait = get_str_or_var( jo.get_member( member ), member, true );
     return [is_npc, old_trait]( dialogue const & d ) {
-        d.actor( is_npc )->unset_mutation( trait_id( old_trait.evaluate( d ) ) );
-        get_event_bus().send<event_type::loses_mutation>( d.actor( is_npc )->get_character()->getID(),
-                trait_id( old_trait.evaluate( d ) ) );
+        const trait_id tid( old_trait.evaluate( d ) );
+        if( d.actor( is_npc )->has_trait( tid ) ) {
+            d.actor( is_npc )->unset_mutation( tid );
+            get_event_bus().send<event_type::loses_mutation>( d.actor( is_npc )->get_character()->getID(),
+                    tid );
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
Fix Gradual Mutation More Better

#### Purpose of change
The way Gradual Mutation was deleting itself post-threshold was squirrely in a number of ways, and the one-time check could be missed due to EoCs being the way they are.

#### Describe the solution
- Change the remove EOC to just blanket-remove all of the possible gradual mutation traits.
- Add Lagomorph to the list as it was missing.
- Change a couple of mismatched IDs.
- f_remove_trait now checks for the trait before trying to remove it, to avoid whiny debugmsgs from generic_factory.
- Added a backup EoC that runs every couple of hours that checks if you have the Threshold trait and gradual mutation, and clears gradual mutation if you do.
- Ensured clearing gradual mutation also clears the associated vars.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
