### PR TITLE
Backport DDA 84967 - Properly cache and reuse rottable materials set

### DIFF
--- a/src/material.cpp
+++ b/src/material.cpp
@@ -384,7 +384,7 @@ material_list materials::get_all()
     return material_data.get_all();
 }
 
-std::set<material_id> materials::get_rotting()
+const std::set<material_id> &materials::get_rotting()
 {
     static generic_factory<material_type>::Version version;
     static std::set<material_id> rotting;

--- a/src/material.h
+++ b/src/material.h
@@ -180,7 +180,7 @@ void check();
 void reset();
 
 material_list get_all();
-std::set<material_id> get_rotting();
+const std::set<material_id> &get_rotting();
 
 } // namespace materials
 


### PR DESCRIPTION
#### Summary
Backport DDA 84967 - Properly cache and reuse rottable materials set

#### Purpose of change
Large numbers of items could in some cases cause major slowdown or even crashes. This fixes the crash someone was seeing and probably improves performance.


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
