### PR TITLE
Revert monster-on-monster attack animations for now

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -13,9 +13,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "activity_actor_definitions.h"
-#include "activity_handlers.h"
-#include "activity_type.h"
 #include "behavior.h"
 #include "bionics.h"
 #include "cached_options.h"
@@ -57,8 +54,6 @@
 #include "vehicle.h"
 #include "viewer.h"
 #include "vpart_position.h"
-
-static const activity_id ACT_NULL( "ACT_NULL" );
 
 static const damage_type_id damage_cut( "cut" );
 
@@ -1795,13 +1790,9 @@ bool monster::attack_at( const tripoint_bub_ms &p )
 
         Creature::Attitude attitude = attitude_to( mon );
         // mon_flag_ATTACKMON == hulk behavior, whack everything in your way
+        // TODO: Draw monattack here using asynchronous animation if player_character.sees( here, p )
         if( attitude == Attitude::HOSTILE || has_flag( mon_flag_ATTACKMON ) ) {
-            const bool attacked = melee_attack( mon );
-            // TODO: Maybe make this not happen if both attacker and defender are invisible.
-            if( attacked && player_character.sees( here, p ) && !player_character.in_sleep_state() && player_character.has_activity( ACT_NULL ) ) {
-                g->draw_hit_mon( p, mon, mon.is_dead() );
-            }
-            return attacked;
+            return melee_attack( mon );
         }
 
         return false;


### PR DESCRIPTION
#### Summary
Revert monster-on-monster attack animations for now

#### Purpose of change
A bunch of weird slowdown was happening. It is probably because of these new animations, which are not asynchronous and have no check for if the player can even see them.

#### Describe the solution
Revert. Later I can figure out a better solution, but this fix is necessary ASAP

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
