### PR TITLE
NPCs don't try to use in-progress crafts

### DIFF
--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -15,8 +15,6 @@
 23-24 Monstrous:  Frightening to behold.  (Capabilities that even the most gullible person could not mistake for human.)<br><br>
 25-26 Impossible:  Tremendously capable.  (At this point you are flipping over small cars and doing calculus without scratch paper.)<br><br>
 27-28 Unbelievable:  Out of this world.  (You get the idea.)<br><br>
-29-30 Transcendant:  Phenomenal.<br><br>
-31+ Post-human:  Beyond what was.
 
 
 # Skill System Scaling:<br><br>

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2753,11 +2753,6 @@ int npc::confident_throw_range( const item &thrown, Creature *target ) const
 bool npc::wont_hit_friend( const tripoint_bub_ms &tar, const item &it, bool throwing ) const
 {
     map &here = get_map();
-    const Creature &ally = *ally_p;
-    const tripoint_bub_ms ally_pos = ally.pos_bub();
-    if( !here.inbounds( ally_pos ) ) {
-        continue;
-    }
     if( !here.inbounds( pos_bub() ) ) {
         return true;
     }


### PR DESCRIPTION
#### Summary
NPCs don't try to use in-progress crafts

#### Purpose of change
Telling an NPC to use an in-progress craft would result in them trying to use it as though it were completed.

#### Describe the solution
Disallow this. I'd like to try to get them to craft it if they know how, but the code is a bit complicated and a quick fix is fine for now.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
