### PR TITLE
Make the military bunker slightly less stupid.

### DIFF
--- a/data/json/mapgen/bunker.json
+++ b/data/json/mapgen/bunker.json
@@ -156,21 +156,21 @@
         "6": "f_console_broken"
       },
       "items": {
-        "R": { "item": "bunker_basement_books", "chance": 70 },
+        "R": { "item": "bunker_basement_books", "chance": 40 },
         "Y": { "item": "trash_cart", "chance": 50 },
-        "!": { "item": "bunker_basement_clothing", "chance": 50 },
+        "!": { "item": "bunker_basement_clothing", "chance": 40 },
         "s": { "item": "dining", "chance": 45 },
         "q": [
-          { "item": "milspec_arsenal_group_only_guns", "chance": 100 },
-          { "item": "arsenal_mics_group", "chance": 70 },
+          { "item": "milspec_arsenal_group_only_guns", "chance": 30 },
+          { "item": "arsenal_mics_group", "chance": 10 },
           { "item": "c4_box_part", "chance": 10 },
           { "item": "bionics_mil", "chance": 10 },
           { "item": "grenade_can_pa120_grenades_full", "chance": 10 }
         ],
         "U": { "item": "SUS_janitors_closet", "chance": 100 },
-        "L": { "item": "milspec_arsenal_group_only_ammo", "chance": 100 },
-        "G": { "item": "arsenal_armor_collection", "chance": 100 },
-        "E": { "item": "guns_rifle_milspec", "chance": 100 }
+        "L": [ { "item": "milspec_arsenal_group_only_ammo", "chance": 10 } ],
+        "G": { "item": "arsenal_armor_collection", "chance": 40 },
+        "E": { "item": "guns_rifle_milspec", "chance": 30 }
       },
       "place_fields": [ { "field": "fd_blood", "x": 2, "y": 3 }, { "field": "fd_blood", "x": 3, "y": 3 } ],
       "place_loot": [

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -933,9 +933,9 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
-    "city_distance": [ 20, -1 ],
-    "occurrences": [ 5, 100 ],
-    "flags": [ "MILITARY", "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "city_distance": [ 25, -1 ],
+    "occurrences": [ 1, 100 ],
+    "flags": [ "MILITARY", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
Make the military bunker slightly less stupid.

#### Purpose of change
The milspec_arsenal itemgroups are an abomination and must be destroyed. I don't have time to do that right now, but this location could at least get the barest whisper of a sanity pass.

#### Describe the solution
- Globally unique
- More remote
- Less stuff

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
