### PR TITLE
Fix gun cleaning

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_gradual_eocs.json
@@ -286,28 +286,36 @@
     "type": "effect_on_condition",
     "id": "EOC_CROSSED_THRESHOLD_CLEANUP",
     "//": "Fallback in case we somehow didn't lose gradual mutation when we crossed the threshold.",
-    "condition": { "and": [ { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] }, { "u_has_flag": "MUTATION_THRESHOLD" }, { "or": [ 
-      { "u_has_trait": "MUTATING_GRADUAL_BATRACHIAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_AVIAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_BOVOID" },
-      { "u_has_trait": "MUTATING_GRADUAL_CEPHALOPOD" },
-      { "u_has_trait": "MUTATING_GRADUAL_CHIROPTERAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_CRUSTACEAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_FELINE" },
-      { "u_has_trait": "MUTATING_GRADUAL_PISCINE" },
-      { "u_has_trait": "MUTATING_GRADUAL_GASTROPOD" },
-      { "u_has_trait": "MUTATING_GRADUAL_INSECT" },
-      { "u_has_trait": "MUTATING_GRADUAL_LAGOMORPH" },
-      { "u_has_trait": "MUTATING_GRADUAL_REPTILIAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_CANINE" },
-      { "u_has_trait": "MUTATING_GRADUAL_MURINE" },
-      { "u_has_trait": "MUTATING_GRADUAL_PLANT" },
-      { "u_has_trait": "MUTATING_GRADUAL_RATTINE" },
-      { "u_has_trait": "MUTATING_GRADUAL_SLIME" },
-      { "u_has_trait": "MUTATING_GRADUAL_ARANEAN" },
-      { "u_has_trait": "MUTATING_GRADUAL_TROGLOBITE" },
-      { "u_has_trait": "MUTATING_GRADUAL_URSINE" }
-    ] } ] },
+    "condition": {
+      "and": [
+        { "math": [ "has_var(u_MUTATING_GRADUAL_vitamin)" ] },
+        { "u_has_flag": "MUTATION_THRESHOLD" },
+        {
+          "or": [
+            { "u_has_trait": "MUTATING_GRADUAL_BATRACHIAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_AVIAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_BOVOID" },
+            { "u_has_trait": "MUTATING_GRADUAL_CEPHALOPOD" },
+            { "u_has_trait": "MUTATING_GRADUAL_CHIROPTERAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_CRUSTACEAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_FELINE" },
+            { "u_has_trait": "MUTATING_GRADUAL_PISCINE" },
+            { "u_has_trait": "MUTATING_GRADUAL_GASTROPOD" },
+            { "u_has_trait": "MUTATING_GRADUAL_INSECT" },
+            { "u_has_trait": "MUTATING_GRADUAL_LAGOMORPH" },
+            { "u_has_trait": "MUTATING_GRADUAL_REPTILIAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_CANINE" },
+            { "u_has_trait": "MUTATING_GRADUAL_MURINE" },
+            { "u_has_trait": "MUTATING_GRADUAL_PLANT" },
+            { "u_has_trait": "MUTATING_GRADUAL_RATTINE" },
+            { "u_has_trait": "MUTATING_GRADUAL_SLIME" },
+            { "u_has_trait": "MUTATING_GRADUAL_ARANEAN" },
+            { "u_has_trait": "MUTATING_GRADUAL_TROGLOBITE" },
+            { "u_has_trait": "MUTATING_GRADUAL_URSINE" }
+          ]
+        }
+      ]
+    },
     "recurrence": [ "4 hours", "8 hours" ],
     "effect": [ { "run_eocs": "EOC_LOSE_MUTATING_GRADUAL" } ]
   },

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -140,7 +140,10 @@
   {
     "id": "datura_harv",
     "type": "harvest",
-    "entries": [ { "drop": "datura_seed", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] }, { "drop": "withered", "base_num": [ 1, 2 ] } ]
+    "entries": [
+      { "drop": "datura_seed", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.5 ] },
+      { "drop": "withered", "base_num": [ 1, 2 ] }
+    ]
   },
   {
     "id": "mustard_harv",
@@ -425,7 +428,10 @@
   {
     "id": "wintergreen_harv",
     "type": "harvest",
-    "entries": [ { "drop": "wintergreen_berry", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] }, { "drop": "wintergreen_leaves", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [
+      { "drop": "wintergreen_berry", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] },
+      { "drop": "wintergreen_leaves", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] }
+    ]
   },
   {
     "id": "seaweed_harv",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -963,7 +963,7 @@
     "description": "A makeshift antiseptic made from bleach and water.  The volatile chlorine compounds break down quickly, so it won't stay good for long.",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "DECAYS" ],
     "//": "Gentler but less effective than ethanol.",
-    "use_action": { "type": "heal", "disinfectant_power": 2, "bite": 0.80, "move_cost": 3000 },
+    "use_action": { "type": "heal", "disinfectant_power": 2, "bite": 0.8, "move_cost": 3000 },
     "properties": { "decay_hours": "16" },
     "revert_to": "salt_water"
   },

--- a/data/json/mutations/mutation_gradual.json
+++ b/data/json/mutations/mutation_gradual.json
@@ -38,7 +38,6 @@
     "id": "MUTATING_GRADUAL_ARANEAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Aranean Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more aranean traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_ARANEAN" ] }
   },
@@ -47,7 +46,6 @@
     "id": "MUTATING_GRADUAL_AVIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Avian Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more avian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_AVIAN" ] }
   },
@@ -56,7 +54,6 @@
     "id": "MUTATING_GRADUAL_BATRACHIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Batrachian Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more batrachian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_BATRACHIAN" ] }
   },
@@ -65,7 +62,6 @@
     "id": "MUTATING_GRADUAL_BOVOID",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Bovoid Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more bovoid traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_BOVOID" ] }
   },
@@ -74,7 +70,6 @@
     "id": "MUTATING_GRADUAL_CANINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Canine Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more canine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CANINE" ] }
   },
@@ -83,7 +78,6 @@
     "id": "MUTATING_GRADUAL_CEPHALOPOD",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Cephalopod Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more cephalopod traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CEPHALOPOD" ] }
   },
@@ -92,7 +86,6 @@
     "id": "MUTATING_GRADUAL_CHIROPTERAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Chiropteran Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more chiropteran traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CHIROPTERAN" ] }
   },
@@ -101,7 +94,6 @@
     "id": "MUTATING_GRADUAL_CRUSTACEAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Crustacean Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more crustacean traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_CRUSTACEAN" ] }
   },
@@ -110,7 +102,6 @@
     "id": "MUTATING_GRADUAL_FELINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Feline Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more feline traits.",
     "delete": { "cancels": [ "MUTAGEN" ] }
   },
@@ -119,7 +110,6 @@
     "id": "MUTATING_GRADUAL_GASTROPOD",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Gastropod Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more gastropod traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_GASTROPOD" ] }
   },
@@ -128,7 +118,6 @@
     "id": "MUTATING_GRADUAL_LAGOMORPH",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Lagomorph Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more lagomorph traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_LAGOMORPH" ] }
   },
@@ -137,7 +126,6 @@
     "id": "MUTATING_GRADUAL_PISCINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Piscine Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more piscine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_PISCINE" ] }
   },
@@ -146,7 +134,6 @@
     "id": "MUTATING_GRADUAL_INSECT",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Insect Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more insect traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_INSECT" ] }
   },
@@ -155,7 +142,6 @@
     "id": "MUTATING_GRADUAL_REPTILIAN",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Reptilian Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more reptilian traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_REPTILIAN" ] }
   },
@@ -164,7 +150,6 @@
     "id": "MUTATING_GRADUAL_MURINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Murine Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more murine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_MURINE" ] }
   },
@@ -173,7 +158,6 @@
     "id": "MUTATING_GRADUAL_PLANT",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Plant Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more plant traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_PLANT" ] }
   },
@@ -182,7 +166,6 @@
     "id": "MUTATING_GRADUAL_RATTINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Rattine Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more rattine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_RATTINE" ] }
   },
@@ -191,7 +174,6 @@
     "id": "MUTATING_GRADUAL_TROGLOBITE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Troglobite Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more troglobite traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_TROGLOBITE" ] }
   },
@@ -200,7 +182,6 @@
     "id": "MUTATING_GRADUAL_URSINE",
     "copy-from": "MUTATING_GRADUAL_ABSTRACT",
     "name": { "str": "Ursine Evolution" },
-     
     "description": "Not long ago, you began to change.  As time passes, you will gradually mutate more and more ursine traits.",
     "delete": { "cancels": [ "MUTATING_GRADUAL_URSINE" ] }
   },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3818,7 +3818,7 @@
     "id": "atomic_lamp_off",
     "replace": "atomic_light_off"
   },
-    {
+  {
     "type": "MIGRATION",
     "id": "dynamite_bomb",
     "replace": "dynamite_bundle"

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -57,7 +57,9 @@
     "id": "gun_cleaning_bp",
     "type": "requirement",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "tools": [ [ [ "pipe_cleaner", -1 ] ], [ [ "water_boiling_heat", 2, "LIST" ] ] ],
+    "tools": [
+      [ [ "pipe_cleaner", -1 ] ]
+      ],
     "components": [
       [ [ "soap", 1 ], [ "liquid_soap", 1 ] ],
       [ [ "water", 3 ] ],


### PR DESCRIPTION
#### Summary
Fix gun cleaning

#### Purpose of change
The gun cleaning "recipe" used a toolset which tried to call boiling_water_heat as a tool. For some reason this was coming up as undefined even though it's used all over the place.

#### Describe the solution
Just remove the heat requirement. Hot water is nice to have when cleaning but I doubt it's COMPLETELY NECESSARY when elbow grease is available.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
