### PR TITLE
Improve electric lantern and reading light recipes

### DIFF
--- a/data/json/recipes/tools/lights.json
+++ b/data/json/recipes/tools/lights.json
@@ -27,7 +27,7 @@
     "book_learn": [ [ "manual_electronics", 3 ], [ "advanced_electronics", 3 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "using": [ [ "glue_any", 1 ] ],
-    "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 1 ] ], [ [ "light_bulb", 1 ], [ "e_scrap", 1 ] ] ]
+    "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 1 ] ], [ [ "light_bulb", 1 ], [ "lightstrip_inactive", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -43,7 +43,7 @@
     "proficiencies": [ { "proficiency": "prof_plasticworking", "time_multiplier": 1.5 }, { "proficiency": "prof_elec_soldering" } ],
     "using": [ [ "soldering_standard", 7 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "cable", 8 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "circuit", 2 ] ], [ [ "e_scrap", 2 ] ], [ [ "amplifier", 1 ] ] ]
+    "components": [ [ [ "cable", 8 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "circuit", 2 ] ], [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ], [ [ "amplifier", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Improve electric lantern and reading light recipes

#### Purpose of change
fixes 2037

#### Describe the solution
Two recipes used electronic scrap instead of LEDs/bulbs.

#### Describe alternatives you've considered
now they use LEDs/bulbs

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
