### PR TITLE
Improve crowd crush checks

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -345,12 +345,16 @@ void suffer::while_grabbed( Character &you )
     // TODO: expand the search area - use the same logic as GROUP_BASH?
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
+    // This wouldn't work the same underwater and drowning already exists, so.
+    if( you.is_underwater() ) {
+        return;
+    }
     int crowd = 0;
     int impassable_ter = 0;
     // Medium size == 3.
     int your_size = static_cast<std::underlying_type_t<creature_size>>( you.get_size() );
-    int crush_grabs_req = your_size - 1;
-    // Minimum of 2 grabbers required.
+    int crush_grabs_req = your_size + 1;
+    // Minimum of 2 grabbers required, though for prone tiny characters this can technically be 1.
     crush_grabs_req = std::max( 2, crush_grabs_req );
 
     int crush_resist = 5;
@@ -370,9 +374,11 @@ void suffer::while_grabbed( Character &you )
         }
     }
 
-    add_msg_debug( debugmode::DF_CHARACTER,
-                   "Crowd pressure sum: character size requires %d grabbers, found %d ", crush_grabs_req, crowd );
-    // if we aren't near enough monsters with GROUP_BASH we won't suffocate
+    if( !you.is_on_ground() ) {
+        crowd = std::max( 0, crowd - 1 );
+    }
+
+    // If we aren't near enough monsters with GROUP_BASH we won't suffocate
     if( crowd < crush_grabs_req ) {
         return;
     }
@@ -391,7 +397,7 @@ void suffer::while_grabbed( Character &you )
         !you.has_trait( trait_SLIMESPAWNER ) ) {
         crush_resist -= 4;
     }
-    if( 100 * ( you.weight_carried() / you.weight_capacity() ) > 75 ) {
+    if( ( you.weight_capacity() > 0_gram ) && 100 * ( you.weight_carried() / you.weight_capacity() ) > 75 ) {
         crush_resist -= 4;
     }
     if( you.has_trait( trait_TRANSPIRATION ) || you.has_trait( trait_SLIMESPAWNER ) ) {
@@ -402,17 +408,19 @@ void suffer::while_grabbed( Character &you )
     }
     if( crowd == crush_grabs_req &&
         rng( 1, ( 100 + ( 100 - you.get_limb_score( limb_score_breathing ) ) ) ) <= crush_resist ) {
-        // only a chance to lose breath at minimum grabs
+        // Only a chance to lose breath at minimum grabs.
         you.oxygen -= rng( 0, 1 );
-    } else if( crowd <= crush_grabs_req * 2 ) {
+    } else if( crowd > crush_grabs_req ) {
+        if( crowd <= crush_grabs_req * 2 ) {
         you.oxygen -= 1;
-    } else if( crowd <= crush_grabs_req * 3 ) {
-        you.oxygen -= rng( 1, 2 );
-    } else if( crowd <= crush_grabs_req * 4 ) {
-        you.oxygen -= 2;
+        } else if( crowd <= crush_grabs_req * 3 ) {
+            you.oxygen -= rng( 1, 2 );
+        } else if( crowd <= crush_grabs_req * 4 ) {
+            you.oxygen -= 2;
+        }
     }
 
-    // a few warnings before starting to take damage
+    // A few warnings before starting to take damage.
     if( you.oxygen <= 5 ) {
         you.add_msg_if_player( m_bad, _( "You're being suffocated!" ) );
         if( uistate.distraction_oxygen && you.is_avatar() ) {


### PR DESCRIPTION
#### Summary
Improve crowd crush checks

#### Purpose of change
Crowd crush was greatly improved but it was still technically possible when being grabbed by 2 zombies in the open. That is dumb.

#### Describe the solution
Crowd crush now requires enum_size()+1 grabbers to trigger. For a medium character, that is 4. It requires 1 less grabber when you're prone.

Also fixed an overlap error in how suffocation could be applied if you were grabbed by a lot of guys.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
