### PR TITLE
Fix a seat in the budget town car with the wrong shape

### DIFF
--- a/data/json/vehicles/cars.json
+++ b/data/json/vehicles/cars.json
@@ -1577,7 +1577,7 @@
       { "x": 0, "y": 2, "parts": [ "reclining_seat#windshield_front", "seatbelt" ] },
       { "x": -1, "y": 0, "parts": [ "seat_back#left", "seatbelt" ] },
       { "x": -1, "y": 1, "parts": [ "seat_back#rear", "seatbelt" ] },
-      { "x": -1, "y": 2, "parts": [ "seat_back#left", "seatbelt" ] }
+      { "x": -1, "y": 2, "parts": [ "seat_back#right", "seatbelt" ] }
     ]
   },
   {


### PR DESCRIPTION
#### Summary

The rightmost back seat in the budget town car is accidentally `left` shaped. This PR fixes it to be the right (heh) shape.

#### Purpose of change

It's a very minor cosmetic-only change, which is why I'm doing it as my first PR.

#### Describe the solution

Edit the typo in the json file

#### Describe alternatives you've considered

Live with the very tiny inconsistency

#### Testing

Not sure what to put here

#### Additional context

Hi Worm Girl
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
