### PR TITLE
Fix minor revival oopsie

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5800,24 +5800,22 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it )
 
 bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
 {
-    if( !it.is_corpse() ) {
-        debugmsg( "Tried to revive a non-corpse." );
-        return false;
-    }
     // If this is not here, the game may attempt to spawn a monster before the map exists,
     // leading to it querying for furniture, and crashing.
     if( g->new_game ) {
         return false;
     }
+    if( !it.is_corpse() ) {
+        debugmsg( "Tried to revive a non-corpse." );
+        return false;
+    }
     if( !it.can_revive() ) {
         return false;
     }
-
     assing_revive_form( it, p );
-
     shared_ptr_fast<monster> newmon_ptr;
     if( it.has_var( "zombie_form" ) ) {
-        // the monster was not a zombie but turns into one when its corpse is revived
+        // The monster was not a zombie but turns into one when its corpse is revived.
         newmon_ptr = make_shared_fast<monster>( mtype_id( it.get_var( "zombie_form" ) ) );
     } else {
         newmon_ptr = make_shared_fast<monster>( it.get_mtype()->id );
@@ -5825,7 +5823,7 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
     monster &critter = *newmon_ptr;
     critter.init_from_item( it );
     if( critter.get_hp() < 1 ) {
-        // Failed reanimation due to corpse being too burned
+        // Failed reanimation due to corpse being too burned.
         return false;
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13776,22 +13776,24 @@ bool item::process_corpse( map &here, Character *carrier, const tripoint_bub_ms 
     if( !ready_to_revive( here, pos ) ) {
         return false;
     }
-    if( carrier == nullptr ) {
-        if( corpse->in_species( species_ROBOT ) ) {
-            add_msg_if_player_sees( pos, m_warning, _( "A nearby robot has repaired itself and stands up!" ) );
+    if( g->revive_corpse( pos, *this ) ) {
+        if( carrier == nullptr ) {
+            if( corpse->in_species( species_ROBOT ) ) {
+                add_msg_if_player_sees( pos, m_warning, _( "A nearby robot has repaired itself and stands up!" ) );
+            } else {
+                add_msg_if_player_sees( pos, m_warning, _( "A nearby corpse rises from the dead!" ) );
+            }
+            return true;
         } else {
-            add_msg_if_player_sees( pos, m_warning, _( "A nearby corpse rises from the dead!" ) );
+            if( corpse->in_species( species_ROBOT ) ) {
+                carrier->add_msg_if_player( m_warning,
+                                            _( "A robot you're carrying has started moving!" ) );
+            } else {
+                carrier->add_msg_if_player( m_warning,
+                                            _( "A corpse you're carrying has started moving!" ) );
+            }
+            return true;
         }
-        return true;
-    } else {
-        if( corpse->in_species( species_ROBOT ) ) {
-            carrier->add_msg_if_player( m_warning,
-                                        _( "A robot you're carrying has started moving!" ) );
-        } else {
-            carrier->add_msg_if_player( m_warning,
-                                        _( "A corpse you're carrying has started moving!" ) );
-        }
-        return true;
     }
     return false;
 }


### PR DESCRIPTION
#### Summary
Fix minor revival oopsie

#### Purpose of change
I had the flu when I fixed revival so I didn't notice that while removing the redundant/wasteful check for whether the corpse was burnt, I accidentally also removed the part of the function that actually revives it. This must have happened after the initial PR. Flu medicine is a hell of a drug.

#### Describe the solution
Re-add the bool.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
