### PR TITLE
Fix neoprene salvage and rubber/bolts bash results

### DIFF
--- a/data/json/construction/floors_outdoors.json
+++ b/data/json/construction/floors_outdoors.json
@@ -101,7 +101,7 @@
     "required_skills": [ [ "survival", 0 ] ],
     "time": "60 m",
     "qualities": [ [ { "id": "DIG", "level": 1 } ] ],
-    "byproducts": [ { "item": "shredded_rubber", "count": [ 150, 200 ] } ],
+    "byproducts": [ { "item": "shredded_rubber", "charges": [ 150, 200 ] } ],
     "pre_terrain": "t_rubber_mulch",
     "post_terrain": "t_dirt"
   },

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -526,7 +526,7 @@
     "price": "12 USD",
     "price_postapoc": "5 USD",
     "to_hit": 1,
-    "material": [ "neoprene", "cotton" ],
+    "material": [ "neoprene", "spandex" ],
     "symbol": "[",
     "looks_like": "arm_warmers",
     "color": "light_red",
@@ -536,6 +536,10 @@
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
+        "material": [
+          { "type": "neoprene", "covered_by_mat": 95, "thickness": 2 },
+          { "type": "spandex", "covered_by_mat": 100, "thickness": 0.3 }
+        ],
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 5,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
@@ -872,13 +876,13 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "elbow pads", "str_pl": "pairs of elbow pads" },
-    "description": "A pair of elbow pads made of stout plastic and cloth.",
+    "description": "A pair of elbow pads made of stout plastic and spandex.",
     "weight": "110 g",
     "volume": "750 ml",
     "price": "35 USD",
     "price_postapoc": "2 USD 50 cent",
     "to_hit": 1,
-    "material": [ "plastic", "nylon" ],
+    "material": [ "plastic", "spandex" ],
     "symbol": "[",
     "looks_like": "armguard_hard",
     "color": "dark_gray",
@@ -888,7 +892,7 @@
       {
         "material": [
           { "type": "plastic", "covered_by_mat": 60, "thickness": 4 },
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 1 }
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.3 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "specifically_covers": [ "arm_elbow_l", "arm_elbow_r" ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -592,13 +592,13 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "knee pads", "str_pl": "pairs of knee pads" },
-    "description": "A pair of knee pads made of stout plastic and cloth.",
+    "description": "A pair of knee pads made of stout plastic and spandex.",
     "weight": "210 g",
     "volume": "1500 ml",
     "price": "25 USD",
     "price_postapoc": "50 cent",
     "to_hit": 1,
-    "material": [ "plastic", "nylon" ],
+    "material": [ "plastic", "spandex" ],
     "symbol": "[",
     "looks_like": "legguard_hard",
     "color": "dark_gray",
@@ -608,7 +608,7 @@
       {
         "material": [
           { "type": "plastic", "covered_by_mat": 60, "thickness": 4 },
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 1 }
+          { "type": "spandex", "covered_by_mat": 100, "thickness": 0.3 }
         ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -158,7 +158,7 @@
     "subtype": "collection",
     "items": [
       { "item": "scrap", "count": [ 125, 250 ] },
-      { "item": "nuts_bolts", "count": [ 10, 25 ] },
+      { "item": "nuts_bolts", "charges": [ 10, 25 ] },
       { "item": "sheet_metal_small", "count": [ 50, 100 ] },
       { "item": "steel_fragment", "count": [ 100, 200 ] },
       { "item": "steel_chunk", "count": [ 50, 100 ] },

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -287,7 +287,7 @@
     "difficulty": 3,
     "time": "280 m",
     "book_learn": [ [ "textbook_tailor", 3 ], [ "manual_tailor", 4 ], [ "tailor_portfolio", 3 ] ],
-    "using": [ [ "tailoring_cotton_sheet", 4 ], [ "tailoring_neoprene_sheet", 3 ] ],
+    "using": [ [ "tailoring_spandex_sheet", 4 ], [ "tailoring_neoprene_sheet", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_polymerworking" } ]
   },
   {
@@ -295,15 +295,15 @@
     "type": "recipe",
     "copy-from": "armguard_soft",
     "time": "280 m",
-    "using": [ [ "tailoring_cotton_sheet", 3 ], [ "tailoring_neoprene_sheet", 3 ] ]
+    "using": [ [ "tailoring_spandex_sheet", 3 ], [ "tailoring_neoprene_sheet", 3 ] ]
   },
   {
     "result": "xl_armguard_soft",
     "type": "recipe",
     "copy-from": "armguard_soft",
     "time": "315 m",
-    "byproducts": [ [ "nomex_patch", 2 ] ],
-    "using": [ [ "tailoring_cotton_sheet", 5 ], [ "tailoring_neoprene_sheet", 4 ] ]
+    "byproducts": [ [ "neoprene_patch", 2 ] ],
+    "using": [ [ "tailoring_spandex_sheet", 5 ], [ "tailoring_neoprene_sheet", 4 ] ]
   },
   {
     "result": "elbow_pads",
@@ -316,8 +316,8 @@
     "skills_required": [ [ "tailor", 1 ] ],
     "time": "120 m",
     "autolearn": true,
-    "byproducts": [ [ "cotton_patch", 2 ] ],
-    "using": [ [ "plastic_molding", 1 ], [ "tailoring_cotton_sheet", 2 ] ],
+    "byproducts": [ [ "spandex_patch", 2 ] ],
+    "using": [ [ "plastic_molding", 1 ], [ "tailoring_spandex_sheet", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ]
   },
   {

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -507,7 +507,7 @@
     "time": "1 m",
     "activity_level": "NO_EXERCISE",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "spandex_sheet", 1 ] ], [ [ "thread_nomex", 5 ] ] ]
+    "components": [ [ [ "spandex_sheet", 1 ] ], [ [ "thread", 5 ] ] ]
   },
   {
     "result": "bikini_top",
@@ -515,7 +515,7 @@
     "time": "2 m",
     "activity_level": "NO_EXERCISE",
     "qualities": [ { "id": "CUT_FINE", "level": 1 } ],
-    "components": [ [ [ "spandex_sheet", 1 ] ], [ [ "thread_nomex", 5 ] ], [ [ "thread", 10 ] ] ]
+    "components": [ [ [ "spandex_sheet", 1 ] ], [ [ "thread", 10 ] ] ]
   },
   {
     "result": "bikini_top_fur",
@@ -4822,7 +4822,7 @@
     "activity_level": "NO_EXERCISE",
     "time": "30 s",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "nomex_patch", 8 ] ] ]
+    "components": [ [ [ "neoprene_patch", 8 ] ] ]
   },
   {
     "result": "nomex_sheet",
@@ -5818,7 +5818,7 @@
     "skill_used": "tailor",
     "time": "15 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "kevlar_sheet", 20 ] ], [ [ "thread_kevlar", 80 ] ] ],
+    "components": [ [ [ "kevlar_sheet", 26 ] ], [ [ "thread_kevlar", 80 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -5828,7 +5828,7 @@
     "skill_used": "tailor",
     "time": "10 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "kevlar_sheet", 15 ] ], [ [ "thread_kevlar", 50 ] ] ],
+    "components": [ [ [ "kevlar_sheet", 12 ] ], [ [ "thread_kevlar", 50 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -5838,7 +5838,7 @@
     "skill_used": "tailor",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "kevlar_sheet", 50 ] ], [ [ "thread_kevlar", 150 ] ] ],
+    "components": [ [ [ "kevlar_sheet", 24 ] ], [ [ "thread_kevlar", 150 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -2570,7 +2570,7 @@
       { "item": "e_scrap", "count": [ 2, 6 ] },
       { "item": "cable", "charges": [ 300, 600 ] },
       { "item": "plastic_chunk", "count": [ 1, 2 ] },
-      { "item": "nuts_bolts", "count": [ 2, 5 ] }
+      { "item": "nuts_bolts", "charges": [ 2, 5 ] }
     ],
     "damage_reduction": { "all": 24 },
     "variants": [ { "symbols": "R", "symbols_broken": ";" } ]
@@ -2637,11 +2637,11 @@
       { "item": "steel_chunk", "count": [ 4, 7 ] },
       { "item": "steel_fragment", "count": [ 21, 40 ] },
       { "item": "scrap", "count": [ 108, 215 ] },
-      { "item": "nuts_bolts", "count": [ 7, 15 ] },
+      { "item": "nuts_bolts", "charges": [ 7, 15 ] },
       { "item": "pipe_fittings", "prob": 30 },
       { "item": "rubber_tire_chunk", "prob": 35 },
       { "item": "chunk_rubber", "count": [ 8, 19 ] },
-      { "item": "shredded_rubber", "count": [ 8, 20 ] }
+      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
     ],
     "damage_reduction": { "all": 46 },
     "variants": [ { "symbols": "&", "symbols_broken": "*" } ]
@@ -2679,10 +2679,10 @@
     "breaks_into": [
       { "item": "sheet_metal_small", "count": [ 3, 6 ] },
       { "item": "scrap", "count": [ 10, 21 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] },
       { "item": "rubber_tire_chunk", "prob": 80 },
       { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "shredded_rubber", "charges": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
@@ -2723,10 +2723,10 @@
       { "item": "plastic_chunk", "count": [ 1, 2 ] },
       { "item": "sheet_metal_small", "count": [ 3, 6 ] },
       { "item": "scrap", "count": [ 10, 21 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] },
       { "item": "rubber_tire_chunk", "prob": 80 },
       { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "shredded_rubber", "charges": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 18 },
     "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
@@ -2765,10 +2765,10 @@
       { "item": "steel_fragment", "count": [ 4, 8 ] },
       { "item": "sheet_metal_small", "count": [ 3, 6 ] },
       { "item": "scrap", "count": [ 15, 30 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] },
       { "item": "rubber_tire_chunk", "prob": 80 },
       { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "shredded_rubber", "charges": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 10 },
     "variants": [ { "symbols": "/", "symbols_broken": "*" } ]
@@ -2812,10 +2812,10 @@
       { "item": "steel_fragment", "count": [ 4, 8 ] },
       { "item": "sheet_metal_small", "count": [ 3, 6 ] },
       { "item": "scrap", "count": [ 15, 30 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] },
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] },
       { "item": "rubber_tire_chunk", "prob": 80 },
       { "item": "chunk_rubber", "count": [ 16, 38 ] },
-      { "item": "shredded_rubber", "count": [ 16, 40 ] }
+      { "item": "shredded_rubber", "charges": [ 16, 40 ] }
     ],
     "damage_reduction": { "all": 12 },
     "variants": [ { "symbols": "=", "symbols_broken": "*" } ]
@@ -2869,7 +2869,7 @@
       { "item": "bearing", "count": [ 1, 3 ] },
       { "item": "steel_fragment", "count": [ 2, 4 ] },
       { "item": "scrap", "count": [ 6, 12 ] },
-      { "item": "nuts_bolts", "count": [ 3, 6 ] }
+      { "item": "nuts_bolts", "charges": [ 3, 6 ] }
     ],
     "damage_reduction": { "all": 54 },
     "variants": [ { "symbols": "X", "symbols_broken": "X" } ]


### PR DESCRIPTION
#### Summary
Fix neoprene salvage and rubber/bolts bash results

#### Purpose of change
- Neoprene stuff was salvaging into Nomex because of some json errors.
- Many items which were dropping shredded rubber or nuts and bolts were dropping counts, not charges, which was resulting in hundreds of times more items than was intended.

#### Describe the solution
fix,

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
