### PR TITLE
Backport DDA 81779 - Fix highway segments generating over highway specials

### DIFF
--- a/data/json/mapgen/highway/highway.json
+++ b/data/json/mapgen/highway/highway.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-    "om_terrain": [ "hw_reserved", "hw_reserved_water", "hw_reserved_ramp" ],
+    "om_terrain": [ "hw_reserved", "hw_reserved_water" ],
     "object": { "fallback_predecessor_mapgen": "open_air" }
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_special.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_special.json
@@ -188,12 +188,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "hw_reserved_ramp",
-    "//": "for placing adjacent to bridgeheads for z = 1 ramp detection",
-    "copy-from": "hw_reserved"
-  },
-  {
-    "type": "overmap_terrain",
     "abstract": "generic_road",
     "copy-from": "road_abstract"
   },

--- a/data/json/overmap/special_locations.json
+++ b/data/json/overmap/special_locations.json
@@ -112,11 +112,6 @@
   },
   {
     "type": "overmap_location",
-    "id": "highway_ramp",
-    "terrains": [ "hw_reserved_ramp" ]
-  },
-  {
-    "type": "overmap_location",
     "id": "forest_trail",
     "terrains": [ "forest_trail" ]
   },


### PR DESCRIPTION
#### Summary
Backport DDA 81779 - Fix highway segments generating over highway specials

#### Purpose of change
There were some minor mapping errors with highways.

#### Describe the solution
Fix the errors.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
