### PR TITLE
Mutation fixes

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -132,6 +132,7 @@
       "NAILS",
       "CLAWS",
       "CLAWS_RETRACT",
+      "CLAWS_RETRACT_active",
       "WEBBED",
       "PATCHSKIN1",
       "PATCHSKIN2",
@@ -1162,7 +1163,16 @@
     "occupied_bodyparts": [ [ "hand_l", 1 ], [ "hand_r", 1 ] ],
     "toggled_pseudo_items": [ "integrated_fingertip_razors" ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_TOGGLED" ],
-    "mutation_conflicts": [ "BENDY3", "ARM_TENTACLES", "ARM_TENTACLES_4", "CLAWS_TENTACLE", "NAILS", "CLAWS", "CLAWS_RETRACT" ]
+    "mutation_conflicts": [
+      "BENDY3",
+      "ARM_TENTACLES",
+      "ARM_TENTACLES_4",
+      "CLAWS_TENTACLE",
+      "NAILS",
+      "CLAWS",
+      "CLAWS_RETRACT",
+      "CLAWS_RETRACT_active"
+    ]
   },
   {
     "id": "bio_recycler",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -536,13 +536,19 @@
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_ankle_r", "foot_ankle_l" ],
-        "material": [ { "type": "leather", "covered_by_mat": 80, "thickness": 2.0 }, { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 } ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 80, "thickness": 2.0 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "coverage": 98
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_heel_r", "foot_heel_l", "foot_arch_r", "foot_arch_l" ],
-        "material": [ { "type": "leather", "covered_by_mat": 40, "thickness": 2.0 }, { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 } ],
+        "material": [
+          { "type": "leather", "covered_by_mat": 40, "thickness": 2.0 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 }
+        ],
         "encumbrance": 20,
         "coverage": 100
       },

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -222,7 +222,7 @@
     "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ], [ "mutant_toxin", 24 ] ],
     "extend": { "flags": [ "BAD_TASTE" ] }
   },
-    {
+  {
     "id": "mutant_stomach_large",
     "copy-from": "hstomach",
     "type": "ITEM",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1484,7 +1484,7 @@
     "starting_trait": true,
     "vitamins_absorb_multi": [ [ "flesh", [ [ "vitC", 0 ], [ "calcium", 0 ], [ "iron", 0 ] ] ] ],
     "types": [ "DIET" ],
-    "cancels": [ "CANNIBAL", "VEGAN" ],
+    "cancels": [ "CANNIBAL", "CARNIVORE" ],
     "changes_to": [ "HERBIVORE" ],
     "category": [ "CATTLE", "RABBIT" ]
   },
@@ -1793,9 +1793,8 @@
     "points": -4,
     "description": "You're very strictly vegan, eating animal products is out of the question, even if it means death.  You also can't bear to wear clothing made of animal products, such as leather or fur.",
     "starting_trait": true,
-    "valid": false,
     "types": [ "DIET" ],
-    "cancels": [ "CANNIBAL", "VEGETARIAN" ]
+    "cancels": [ "CANNIBAL", "CARNIVORE" ]
   },
   {
     "type": "mutation",
@@ -4300,7 +4299,7 @@
     "name": { "str": "Alcohol Metabolism" },
     "points": 2,
     "description": "Your body produces enzymes that process alcohol more quickly.  Sobering up faster makes it less addictive, and you won't suffer as many negative health effects.",
-    "category": [ "TROGLOBITE", "MEDICAL", "SLIME", "ELFA", "PLANT" ]
+    "category": [ "TROGLOBITE", "MEDICAL", "SLIME", "ELFA" ]
   },
   {
     "type": "mutation",
@@ -7300,7 +7299,7 @@
     "points": -3,
     "description": "Your body's ability to digest meat is severely hampered.  Eating meat has a good chance of making you vomit it back up; even if you manage to keep it down, its nutritional value is greatly reduced.",
     "types": [ "DIET" ],
-    "prereqs": [ "VEGETARIAN", "VEGAN" ],
+    "prereqs": [ "VEGETARIAN" ],
     "leads_to": [ "RUMINANT" ],
     "category": [ "CATTLE", "RABBIT" ]
   },

--- a/data/json/recipes/tools/lights.json
+++ b/data/json/recipes/tools/lights.json
@@ -27,7 +27,12 @@
     "book_learn": [ [ "manual_electronics", 3 ], [ "advanced_electronics", 3 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "using": [ [ "glue_any", 1 ] ],
-    "components": [ [ [ "plastic_chunk", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 1 ] ], [ [ "light_bulb", 1 ], [ "lightstrip_inactive", 1 ] ] ]
+    "components": [
+      [ [ "plastic_chunk", 1 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "cable", 1 ] ],
+      [ [ "light_bulb", 1 ], [ "lightstrip_inactive", 1 ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -43,7 +48,13 @@
     "proficiencies": [ { "proficiency": "prof_plasticworking", "time_multiplier": 1.5 }, { "proficiency": "prof_elec_soldering" } ],
     "using": [ [ "soldering_standard", 7 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "cable", 8 ] ], [ [ "plastic_chunk", 2 ] ], [ [ "circuit", 2 ] ], [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ], [ [ "amplifier", 1 ] ] ]
+    "components": [
+      [ [ "cable", 8 ] ],
+      [ [ "plastic_chunk", 2 ] ],
+      [ [ "circuit", 2 ] ],
+      [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ],
+      [ [ "amplifier", 1 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1606,7 +1606,7 @@
     "name": "Change start date of the Cataclysm",
     "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
   },
-    {
+  {
     "type": "keybinding",
     "id": "CHANGE_FALL_OF_CIVILIZATION",
     "category": "NEW_CHAR_DESCRIPTION",

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -364,7 +364,8 @@ float Character::hit_roll() const
         hit -= 2.0f;
     }
     // Farsightedness makes us hit worse
-    if( !sees_with_echolocation() && has_flag( json_flag_HYPEROPIC ) && !worn_with_flag( flag_FIX_FARSIGHT ) &&
+    if( !sees_with_echolocation() && has_flag( json_flag_HYPEROPIC ) &&
+        !worn_with_flag( flag_FIX_FARSIGHT ) &&
         !has_effect( effect_contacts ) &&
         !has_effect( effect_transition_contacts ) ) {
         hit -= 2.0f;
@@ -436,7 +437,7 @@ std::string Character::get_miss_reason()
     const int enc = avg_encumb_of_limb_type( body_part_type::type::torso );
     float lowest_ratio = 1.0f;
     for( const bodypart_id &bp : get_all_body_parts( get_body_part_flags::only_main ) ) {
-    float r = get_part_hp_max( bp ) > 0 ? float( get_part_hp_cur( bp ) ) / get_part_hp_max( bp ) : 1.0f;
+        float r = get_part_hp_max( bp ) > 0 ? float( get_part_hp_cur( bp ) ) / get_part_hp_max( bp ) : 1.0f;
         if( r < lowest_ratio ) {
             lowest_ratio = r;
         }
@@ -450,7 +451,8 @@ std::string Character::get_miss_reason()
         add_miss_reason( _( "Your injuries make it hard to keep fighting." ), wound_factor );
     }
     if( enc > 10 ) {
-        const float scaled = enc < 25 ? static_cast<float>( enc ) / 25.0f : static_cast<float>( enc ) / 10.0f;
+        const float scaled = enc < 25 ? static_cast<float>( enc ) / 25.0f : static_cast<float>
+                             ( enc ) / 10.0f;
         add_miss_reason( _( "Your torso encumbrance throws you off-balance." ), roll_remainder( scaled ) );
     }
     const int farsightedness = 2 * ( has_flag( json_flag_HYPEROPIC ) &&

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3919,7 +3919,8 @@ static std::string assemble_description_help( const input_context &ctxt, const b
                         "<color_light_green>%2$s</color> to change the day civilization fell, "
                         "<color_light_green>%3$s</color> to change game start date, "
                         "<color_light_green>%4$s</color> to reset calendar." ),
-                     ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), ctxt.get_desc( "CHANGE_FALL_OF_CIVILIZATION" ), ctxt.get_desc( "CHANGE_START_OF_GAME" ),
+                     ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), ctxt.get_desc( "CHANGE_FALL_OF_CIVILIZATION" ),
+                     ctxt.get_desc( "CHANGE_START_OF_GAME" ),
                      ctxt.get_desc( "RESET_CALENDAR" ) );
     if( !get_option<bool>( "SELECT_STARTING_CITY" ) ) {
         help_text += string_format(


### PR DESCRIPTION
#### Summary
Mutation fixes

#### Purpose of change
- Radiogenic was way too good.
- A few minor mutation conflicts were creating some issues.

#### Describe the solution
- Extended Claws now blocks the same bionics as Retractable Claws.
- Vegan is no longer a prereq for Herbivore. This made a degree of sense but it was causing some issues with mutation progression.
- Radiogenic now heals half as quickly, up to a max of 48 points per day. That's on top of your regular healing, if you have any.
- Radiogenic no longer completely prevents Lifestyle penalties from radiation exposure, though it does half them.
- Radiogenic now purges 4 points of irradiation per hour instead of 10.

The idea with Radiogenic is that you're getting a great benefit at a cost, and there are times you'd want to do it and times when you wouldn't.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
