### PR TITLE
Backport 83090 - Molotovs aren't fire cubes

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -267,6 +267,7 @@ static const itype_id itype_fire( "fire" );
 static const itype_id itype_firecracker_act( "firecracker_act" );
 static const itype_id itype_firecracker_pack_act( "firecracker_pack_act" );
 static const itype_id itype_geiger_on( "geiger_on" );
+static const itype_id itype_glass_shard( "glass_shard" );
 static const itype_id itype_handrolled_cig( "handrolled_cig" );
 static const itype_id itype_heatpack_used( "heatpack_used" );
 static const itype_id itype_hygrometer( "hygrometer" );
@@ -3566,18 +3567,18 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
 {
 
     if( !p ) {
-        // It was thrown or dropped, so burst into flames
+        // It was thrown or dropped, so burst into flames.
         map &here = get_map();
         // Because fields decay with a half-life, we need to know how long it takes for the field to decay and set the age to slightly before that.
-        // the duration is also used for the effect's timer. It's hilariously lethal regardless.
+        // the duration is also used for the effect's timer.
         const time_duration target_duration = 1_minutes;
         const time_duration base_age = ( fd_fire->half_life / 2 ) - target_duration;
-        for( const tripoint_bub_ms &pt : here.points_in_radius( pos, 1, 0 ) ) {
+        for( const tripoint_bub_ms &pt : here.points_in_radius( pos, 2, 0 ) ) {
             Creature *critter = get_creature_tracker().creature_at( pt, true );
             if( critter && one_in( 2 ) ) {
                 critter->add_effect( effect_onfire, target_duration );
             } else if( !here.get_field( pt, fd_fire ) && one_in( 2 ) ) {
-                here.add_field( pt, fd_fire, 1, base_age );
+                here.add_field( pt, fd_fire, rng( 1, 2 ), base_age );
             }
         }
         avatar &player = get_avatar();
@@ -3586,6 +3587,7 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
             player.rem_morale( morale_pyromania_nofire );
             add_msg( m_good, _( "Fire…  Good…" ) );
         }
+        it->convert( itype_glass_shard ).active = false;
         return 1;
     }
 


### PR DESCRIPTION
#### Summary
Backport 83090 - Molotovs aren't fire cubes

#### Purpose of change
- Molotovs were creating perfect cubes of really intense fire. That's not how they work!

#### Describe the solution
- They splash in a wider area now, but only have a 50% chance to place a fire tile. The tile may be intensity 1 or 2. The age is manually set so the fire burns down in a more appropriate amount of time.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
