### PR TITLE
Radiogenic lifestyle modifier fix

### DIFF
--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1393,12 +1393,12 @@ void suffer::from_radiation( Character &you )
     }
 
     if( calendar::once_every( 1_days ) ) {
-        if( you.get_rad() > 0 ) {
-            int health_modifier = you.get_rad();
+        int lifestyle_modifier = you.get_rad();
+        if( lifestyle_modifier > 0 ) {
             if( you.has_trait( trait_RADIOGENIC ) ) {
-                health_modifier /= 2;
+                lifestyle_modifier /= 2;
             }
-            you.mod_daily_health( -you.get_rad(), -200 );
+            you.mod_daily_health( -lifestyle_modifier, -200 );
         }
     }
 


### PR DESCRIPTION
#### Summary
Radiogenic lifestyle modifier fix

#### Purpose of change
I made an oopsie with the lifestyle modifier for radiogenic characters.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
