### PR TITLE
make cargo shorts and pants pockets equal

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1315,20 +1315,6 @@
         "max_contains_weight": "3 kg",
         "max_item_length": "165 mm",
         "moves": 100
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "400 ml",
-        "max_contains_weight": "3 kg",
-        "max_item_length": "165 mm",
-        "moves": 100
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "400 ml",
-        "max_contains_weight": "3 kg",
-        "max_item_length": "165 mm",
-        "moves": 100
       }
     ],
     "warmth": 5,


### PR DESCRIPTION
#### Summary
Cargo shorts had more pockets than cargo pants despite being smaller

#### Purpose of change
Give them equal pockets so i don't feel like i'm losing out by wearing cargo pants instead of shorts

#### Describe the solution
Copy pasted cargo pants "pocket_data" to cargo shorts
https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/b3e0bba873c6c0420301824538e999069f5b4e05/data/json/items/armor/legs_clothes.json#L875

#### Describe alternatives you've considered
None as i asked worm girl about which would be the best option beforehand

#### Testing
Opened item spawn menu, see cargo shorts now have the same pockets as cargo pants

#### Additional context
<img width="736" height="1024" alt="image" src="https://github.com/user-attachments/assets/24116e62-cdb0-4627-83f9-5352dcf7b5ec" />
<img width="825" height="1006" alt="image" src="https://github.com/user-attachments/assets/0b9f6c05-dbdc-45ea-83eb-63b40b804c64" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
