### PR TITLE
Remove refugee center patrol EOC

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -126,62 +126,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_REFUGEE_CENTER_NPC_MOVEMENT",
-    "//": "Runs once an hour and moves refugee center npcs around based on what hour it is.",
-    "global": true,
-    "recurrence": "1 hours",
-    "effect": [
-      {
-        "switch": { "math": [ "time_since('midnight', 'unit': 'hour')" ] },
-        "cases": [
-          { "case": 0, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 2, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } },
-          { "case": 4, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 6, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } },
-          { "case": 8, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 10, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } },
-          { "case": 12, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 14, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } },
-          { "case": 16, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 18, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } },
-          { "case": 20, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION" } },
-          { "case": 22, "effect": { "run_eocs": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION" } }
-        ]
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_REFUGEE_CENTER_GUARD_FIRST_POSITION",
-    "effect": [
-      {
-        "u_run_npc_eocs": [
-          {
-            "id": "EOC_REFUGEE_CENTER_GUARD_FIRST_SHIFT",
-            "effect": { "u_set_guard_pos": { "global_val": "_First" }, "unique_id": true }
-          }
-        ],
-        "unique_ids": [ "GUARD1", "GUARD2", "GUARD3", "GUARD4", "GUARD5", "GUARD6", "GUARD7" ]
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_REFUGEE_CENTER_GUARD_SECOND_POSITION",
-    "effect": [
-      {
-        "u_run_npc_eocs": [
-          {
-            "id": "EOC_REFUGEE_CENTER_GUARD_SECOND_SHIFT",
-            "effect": { "u_set_guard_pos": { "global_val": "_Second" }, "unique_id": true }
-          }
-        ],
-        "unique_ids": [ "GUARD1", "GUARD2", "GUARD3", "GUARD4", "GUARD5", "GUARD6", "GUARD7" ]
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_DIVING_INTO_WATER_CHECK",
     "global": true,
     "run_for_npcs": true,

--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -102,6 +102,7 @@
   {
     "id": "BLOCK_WHILE_WORN",
     "type": "json_flag",
+    "//": "Unused in vanialla, left in place for mods.",
     "info": "This item can be used to block attacks when worn."
   },
   {

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -17,7 +17,6 @@
     "color": "brown",
     "warmth": 5,
     "material_thickness": 3,
-    "techniques": [ "WBLOCK_1" ],
     "flags": [ "OUTER", "WATER_FRIENDLY" ],
     "armor": [
       {

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -241,6 +241,10 @@
     "type": "effect_on_condition"
   },
   {
+    "id": "EOC_REFUGEE_CENTER_NPC_MOVEMENT",
+    "type": "effect_on_condition"
+  },
+  {
     "type": "mutation",
     "id": "NO_CBM_INSTALLATION",
     "name": { "str": "Oversensitive System" },


### PR DESCRIPTION
#### Summary
Remove refugee center patrol EOC

#### Purpose of change
The guards at the refugee center have long had an hourly rotation where they move around. This was cute, but if any guard is dead, it throws a huge error once per hour. Worse, it was possible for the EoC to get messed up somehow and slowly lead them out of the center.

#### Describe the solution
Remove it. There's no problem with them being stationary.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
