### PR TITLE
Enforce 7 day head start for monsters

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -23,7 +23,7 @@
 /** How much light moon provides per lit-up quarter (Full-moon light is four times this value) */
 static constexpr float moonlight_per_quarter = 1.5f;
 
-// Divided by 100 to prevent overflowing when converted to moves
+// Divided by 100 to prevent overflowing when converted to moves.
 const int calendar::INDEFINITELY_LONG( std::numeric_limits<int>::max() / 100 );
 static bool is_eternal_season = false;
 static bool is_eternal_night = false;
@@ -31,10 +31,12 @@ static bool is_eternal_day = false;
 static int cur_season_length = 1;
 static lat_long location = { 42.36_degrees, -71.06_degrees };
 
-time_point calendar::start_of_cataclysm = calendar::turn_zero;
-time_point calendar::fall_of_civilization = calendar::turn_zero + 20_days;
-time_point calendar::start_of_game = calendar::fall_of_civilization;
 time_point calendar::turn = calendar::turn_zero;
+// The oldest any perishable items can be.
+time_point calendar::start_of_cataclysm = calendar::turn_zero;
+// Locked to at least 1 week before start as monsters weren't actually born yesterday.
+time_point calendar::fall_of_civilization = calendar::turn_zero + 13_days;
+time_point calendar::start_of_game = calendar::fall_of_civilization + 7_days;
 season_type calendar::initial_season = SPRING;
 
 // The solar altitudes at which light changes in various ways

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -452,7 +452,7 @@ void monster::try_upgrade( bool pin_time )
     if( !can_upgrade() ) {
         return;
     }
-
+    
     const int current_day = to_days<int>( calendar::turn - calendar::fall_of_civilization );
     // This should only occur when a monster is created or upgraded to a new form.
     if( upgrade_time < 0 ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3710,7 +3710,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 scen = get_scenario();
             }
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),
-                                             _( "Select Cataclysm start date" ), calendar_ui::granularity::hour ) );
+                                             _( "Cataclysm start date (affects items)" ), calendar_ui::granularity::day ) );
             details_recalc = true;
         } else if( action == "CHANGE_FALL_OF_CIVILIZATION" ) {
             const scenario *scen = sorted_scens[cur_id];
@@ -3718,7 +3718,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 scen = get_scenario();
             }
             scen->change_fall_of_civilization( calendar_ui::select_time_point( scen->fall_of_civilization(),
-                                               _( "Select fall of civilization date" ), calendar_ui::granularity::hour ) );
+                                               _( "Fall of civilization date (affects monsters)" ), calendar_ui::granularity::day ) );
             details_recalc = true;
         } else if( action == "CHANGE_START_OF_GAME" ) {
             const scenario *scen = sorted_scens[cur_id];
@@ -4589,11 +4589,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),
-                                             _( "Select cataclysm start date" ), calendar_ui::granularity::hour ) );
+                                             _( "Cataclysm start date (affects items)" ), calendar_ui::granularity::day ) );
         } else if( action == "CHANGE_FALL_OF_CIVILIZATION" ) {
             const scenario *scen = get_scenario();
             scen->change_fall_of_civilization( calendar_ui::select_time_point( scen->fall_of_civilization(),
-                                               _( "Select fall of civilization date" ), calendar_ui::granularity::hour ) );
+                                               _( "Fall of civilization date (affects monsters)" ), calendar_ui::granularity::day ) );
         } else if( action == "CHANGE_START_OF_GAME" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_game( calendar_ui::select_time_point( scen->start_of_game(),


### PR DESCRIPTION
#### Summary
Enforce 7 day head-start for monsters

#### Purpose of change
I nixed the 20 day head start, but it turns out a lot of monster stuff was balanced around it, so healthy cows, horses, and deer became far too common, and overall the game got much easier than intended. 20 days is a bit harsh, but canonically things have been bad for a while, so let's fiddle with some dials.

In lore, zombies have actually been around in small numbers for at least six months, and mutants far longer than that. However, neither really started showing up in droves until the build-up to the nuclear war and the portal storms, which were one week before game start by default. At that time, all hell broke loose. While the riots had been the site of mass murder for weeks now, the majority of mankind was wiped and revived over the past week. This means that it should neither feel like all the zombies showed up this morning, nor that they've already been around for ages. Combining our half-life system with a modest head-start for the monsters should give the ideal result.

#### Describe the solution
- Fall of Civilization (monsters) and Start of Cataclysm (items) are now strictly bounded to a 0 to 20 day head start for items and a 7 day head start for monsters. You can raise it higher than that, but you cannot bring it below that.
- Added some text clarifying what the two constants mean.
- This does not affect ongoing saves.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
