### PR TITLE
Ensure safe teleportation when using teleporter

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3308,7 +3308,7 @@ std::optional<int> iuse::teleport( Character *p, item *it, const tripoint_bub_ms
         return std::nullopt;
     }
     p->mod_moves( -to_moves<int>( 1_seconds ) );
-    teleport::teleport_creature( *p );
+    teleport::teleport_creature( *p, 2, 12, true );
     return 1;
 }
 

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -212,13 +212,11 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         }
         dest_target = dest->get_bub( abs_ms );
     }
-    //handles teleporting into solids.
+    // Handles teleporting into solids.
     if( dest->impassable( dest_target ) ) {
         if( force || force_safe ) {
-            std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 5 );
+            std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 1, 5 );
             nearest_points.erase( nearest_points.begin() );
-            //TODO: Swap for this once #75961 merges
-            //std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 1, 5 );
             for( tripoint_bub_ms p : nearest_points ) {
                 if( dest->passable_through( p ) ) {
                     dest_target = p;
@@ -229,7 +227,8 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         } else {
             if( safe ) {
                 if( c_is_u && display_message ) {
-                    add_msg( m_bad, _( "You cannot teleport safely." ) );
+                    // Failed to pick a safe spot to teleport.
+                    add_msg( m_bad, _( "You feel strange for a moment, but nothing happens." ) );
                 }
                 return false;
             }


### PR DESCRIPTION
#### Summary
Ensure safe teleportation when using teleporter

#### Purpose of change
The handheld teleporter is cool but it wasn't ensuring a safe teleportation. There are already drawbacks to using it, so we don't need another.

#### Describe the solution
safe = true

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
