### PR TITLE
Don't always gib small animals

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2298,7 +2298,6 @@ void monster::apply_damage( Creature *source, bodypart_id /*bp*/, int dam,
 void monster::die_in_explosion( Creature *source )
 {
     map &here = get_map();
-
     hp = -9999; // huge to trigger explosion and prevent corpse item
     die( &here, source );
 }
@@ -3856,10 +3855,17 @@ item monster::to_item() const
     if( type->revert_to_itype.is_empty() ) {
         return item();
     }
-    // Birthday is wrong, but the item created here does not use it anyway (I hope).
     item result( type->revert_to_itype, calendar::turn );
-    const int damfac = std::max( 1, ( result.max_damage() + 1 ) * hp / type->hp );
-    result.set_damage( std::max( 0, ( result.max_damage() + 1 ) - damfac ) );
+    const int max_dmg = result.max_damage();
+
+    // Adjust corpse's damage based on degree of overkill.
+    const int damfac = std::max( 1, ( max_dmg + 1 ) * hp / type->hp );
+    int percent_damage = std::max( 0, ( max_dmg + 1 ) - damfac );
+
+    // Throwing a rock shouldn't gib a rabbit. Let's gate damage for sanity's sake.
+    int allowed_damage = std::clamp( -hp / 5, 0, 4 );
+    int final_damage = std::min( percent_damage, allowed_damage );
+    result.set_damage( final_damage );
     return result;
 }
 


### PR DESCRIPTION
#### Summary
Don't always gib small animals

#### Purpose of change
It was basically impossible to kill a rabbit without splattering it everywhere, even when using a very reasonable weapon like a knife.

#### Describe the solution
Add some gates for the damage level of the corpse spawned when a monster dies. These are:
Bruised: -5
Damaged: -10
Mangled: -15
Pulped: -20

If the monster's HP is above -5, the corpse will be pristine. If it is above -10, the corpse will be bruised, etc. These are simply run overtop of the exsting percentage-based calculation. They do not apply these damage levels, only limit when they can be applied.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
