### PR TITLE
Add Kevlar leggings

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -1176,6 +1176,7 @@
       [ "tacjacket", 30 ],
       [ "leather_police_jacket", 5 ],
       [ "motorbike_armor", 5 ],
+      [ "leggings_cut_resistant", 5 ],
       [ "poncho", 15 ],
       [ "folding_poncho", 5 ],
       [ "sleeveless_longcoat", 2 ],

--- a/data/json/itemgroups/Clothing_Gear/gear_civilian.json
+++ b/data/json/itemgroups/Clothing_Gear/gear_civilian.json
@@ -389,6 +389,7 @@
       { "distribution": [ { "group": "full_survival_kit" }, { "group": "used_survival_kit" } ], "prob": 3 },
       [ "touring_suit", 20 ],
       [ "helmet_motor", 14 ],
+      [ "leggings_cut_resistant", 10 ],
       [ "motorbike_armor", 10 ],
       [ "motorbike_pants", 10 ],
       [ "motorbike_boots", 10 ],

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
@@ -9,19 +9,13 @@
     "type": "item_group",
     "id": "milspec_arsenal_223_pouch_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_223_gun&mags" },
-      { "group": "ammo_can_223_any", "prob": 75, "count": [ 1, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_223_gun&mags" }, { "group": "ammo_can_223_any", "prob": 75, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",
     "id": "milspec_arsenal_223_gun&mags",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_223" },
-      { "group": "milspec_arsenal_223", "prob": 50 }
-    ]
+    "items": [ { "group": "milspec_arsenal_223" }, { "group": "milspec_arsenal_223", "prob": 50 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223_mg.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223_mg.json
@@ -9,10 +9,7 @@
     "type": "item_group",
     "id": "milspec_arsenal_223_mg_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_223_mg_gun&mags" },
-      { "group": "ammo_can_223_any", "prob": 75, "count": [ 1, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_223_mg_gun&mags" }, { "group": "ammo_can_223_any", "prob": 75, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/308_mg.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/308_mg.json
@@ -9,10 +9,7 @@
     "type": "item_group",
     "id": "milspec_arsenal_308_mg_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_308_mg_gun&mags" },
-      { "group": "ammo_can_308_mg_any", "prob": 75, "count": [ 1, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_308_mg_gun&mags" }, { "group": "ammo_can_308_mg_any", "prob": 75, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/308_sniper.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/308_sniper.json
@@ -9,19 +9,13 @@
     "type": "item_group",
     "id": "milspec_arsenal_308_sniper_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_308_sniper_gun&mags" },
-      { "group": "ammo_can_308_any", "prob": 80, "count": [ 0, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_308_sniper_gun&mags" }, { "group": "ammo_can_308_any", "prob": 80, "count": [ 0, 2 ] } ]
   },
   {
     "type": "item_group",
     "id": "milspec_arsenal_308_sniper_gun&mags",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_308_sniper" },
-      { "group": "milspec_arsenal_308_sniper", "count": [ 1, 2 ], "prob": 30 }
-    ]
+    "items": [ { "group": "milspec_arsenal_308_sniper" }, { "group": "milspec_arsenal_308_sniper", "count": [ 1, 2 ], "prob": 30 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/9mm.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/9mm.json
@@ -9,10 +9,7 @@
     "type": "item_group",
     "id": "milspec_arsenal_9mm_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_9mm_gun&mags" },
-      { "group": "ammo_can_9mm_any", "prob": 75, "count": [ 1, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_9mm_gun&mags" }, { "group": "ammo_can_9mm_any", "prob": 75, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/9mm_submachine_gun.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/9mm_submachine_gun.json
@@ -1,5 +1,5 @@
 [
-   {
+  {
     "type": "item_group",
     "id": "milspec_arsenal_9mm_sub_gun&mags&cans",
     "subtype": "collection",
@@ -9,10 +9,7 @@
     "type": "item_group",
     "id": "milspec_arsenal_9mm_sub_gun&ammo",
     "subtype": "collection",
-    "items": [
-      { "group": "milspec_arsenal_9mm_sub_gun&mags" },
-      { "group": "ammo_can_9mm_any", "prob": 75, "count": [ 1, 2 ] }
-    ]
+    "items": [ { "group": "milspec_arsenal_9mm_sub_gun&mags" }, { "group": "ammo_can_9mm_any", "prob": 75, "count": [ 1, 2 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
@@ -2,7 +2,11 @@
   {
     "id": "ammo_can_9mm_any",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mmP", "prob": 100 }, { "group": "ammo_can_9mmfmj", "prob": 100 }, { "group": "ammo_can_9mm", "prob": 100 } ]
+    "items": [
+      { "group": "ammo_can_9mmP", "prob": 100 },
+      { "group": "ammo_can_9mmfmj", "prob": 100 },
+      { "group": "ammo_can_9mm", "prob": 100 }
+    ]
   },
   {
     "type": "item_group",
@@ -30,7 +34,7 @@
     "on_overflow": "discard",
     "items": [ { "item": "9mmP", "count": 1, "charges": 30 } ]
   },
-    {
+  {
     "type": "item_group",
     "id": "ammo_can_9mm",
     "container-item": "ammunition_can_30",

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -563,6 +563,7 @@
       { "item": "helmet_bike", "prob": 35 },
       { "item": "helmet_motor", "prob": 40 },
       { "item": "touring_suit", "prob": 15 },
+      { "item": "leggings_cut_resistant", "prob": 10 },
       { "item": "motorbike_armor", "prob": 10 },
       { "item": "motorbike_pants", "prob": 10 },
       { "item": "motorbike_boots", "prob": 10 },

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -532,7 +532,7 @@
     "warmth": 20,
     "material_thickness": 2,
     "environmental_protection": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {
         "material": [
@@ -1003,12 +1003,61 @@
     "id": "armguard_cut_resistant",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "cut-resistant arm sleeves", "str_pl": "pairs of cut-resistant arm sleeves" },
-    "description": "A long pair of cut-resistant Kevlar sleeves with thumbholes.  These were often used by loggers and landscapers for protection from thorns and chainsaw accidents.",
-    "weight": "450 g",
-    "copy-from": "armguard_soft",
+    "category": "armor",
+    "name": { "str": "cut-resistant sleeves", "str_pl": "pairs of cut-resistant sleeves" },
+    "description": "A long, stretchy pair of Kevlar sleeves with thumbholes.  These were often used by loggers and landscapers for protection from thorns and chainsaw accidents.",
+    "weight": "220 g",
+    "volume": "410 ml",
     "price": "12 USD",
-    "material": [ "kevlar" ]
+    "price_postapoc": "2 USD",
+    "to_hit": 1,
+    "material": [ "kevlar" ],
+    "symbol": "[",
+    "looks_like": "arm_warmers",
+    "color": "yellow",
+    "warmth": 10,
+    "flags": [ "SKINTIGHT" ],
+    "armor": [
+      {
+        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 1 } ],
+        "covers": [ "arm_l", "arm_r" ],
+        "encumbrance": 4,
+        "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
+        "coverage": 95
+      },
+      {
+        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 1 } ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_elbow_r", "arm_elbow_l" ],
+        "coverage": 100
+      },
+      {
+        "material": [ { "type": "kevlar", "covered_by_mat": 100, "thickness": 1 } ],
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_upper_l", "arm_upper_r" ],
+        "coverage": 10
+      }
+    ]
+  },
+  {
+    "id": "armguard_cut_resistant_xl",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "cut-resistant sleeves", "str_pl": "pairs of cut-resistant sleeves" },
+    "copy-from": "armguard_cut_resistant",
+    "weight": "330 g",
+    "volume": "615 ml",
+    "extend": { "flags": [ "PREFIX_XL", "OVERSIZE" ] }
+  },
+  {
+    "id": "armguard_cut_resistant_xs",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "cut-resistant sleeves", "str_pl": "pairs of cut-resistant sleeves" },
+    "copy-from": "armguard_cut_resistant",
+    "weight": "110 g",
+    "volume": "205 ml",
+    "extend": { "flags": [ "PREFIX_XS", "UNDERSIZE" ] }
   },
   {
     "id": "platemail_arm_guards",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1380,5 +1380,55 @@
     "name": { "str": "leather leg guards", "str_pl": "pairs of leather leg guards" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
+  },
+  {
+    "id": "leggings_kevlar",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str": "Kevlar leggings", "str_pl": "pairs of Kevlar leggings" },
+    "description": "A pair of Kevlar leggings designed to protect the legs from abrasion when riding a motorcycle.",
+    "weight": "310 g",
+    "volume": "500 ml",
+    "price": "12 USD",
+    "price_postapoc": "2 USD",
+    "to_hit": 1,
+    "material": [ "kevlar" ],
+    "symbol": "[",
+    "looks_like": "leggings",
+    "color": "yellow",
+    "warmth": 14,
+    "flags": [ "SKINTIGHT" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "kevlar", "covered_by_mat": 100, "thickness": 1 },
+          { "type": "spandex", "covered_by_mat": 100, "thickness": 0.1 }
+        ],
+        "covers": [ "leg_l", "leg_r" ],
+        "encumbrance": 6,
+        "coverage": 95
+      }
+    ]
+  },
+  {
+    "id": "leggings_kevlar_xl",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "Kevlar leggings", "str_pl": "pairs of Kevlar leggings" },
+    "copy-from": "leggings_kevlar",
+    "weight": "620 g",
+    "volume": "800 ml",
+    "extend": { "flags": [ "PREFIX_XL", "OVERSIZE" ] }
+  },
+  {
+    "id": "leggings_kevlar_xs",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "Kevlar leggings", "str_pl": "pairs of Kevlar leggings" },
+    "copy-from": "leggings_kevlar",
+    "weight": "155 g",
+    "volume": "250 ml",
+    "extend": { "flags": [ "PREFIX_XS", "UNDERSIZE" ] }
   }
 ]

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -67,10 +67,7 @@
     "clip_size": 1,
     "reload": 2000,
     "use_action": [ "GUN_REPAIR" ],
-    "faults": [
-      { "fault": "fault_gun_blackpowder" },
-      { "fault": "fault_gun_dirt" }
-    ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "valid_mod_locations": [ [ "grip mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
     "flags": [ "ALLOWS_BODY_BLOCK", "NEVER_JAMS", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 1 } } ],
@@ -112,10 +109,7 @@
       [ "sights mount", 1 ],
       [ "stock mount", 1 ]
     ],
-    "faults": [
-      { "fault": "fault_gun_blackpowder" },
-      { "fault": "fault_gun_dirt" }
-    ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "flags": [ "FIRE_TWOHAND", "NEVER_JAMS", "DURABLE_MELEE", "EASY_CLEAN" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 1 } } ],
     "melee_damage": { "bash": 15 }

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -451,6 +451,7 @@
       [ "chainmail_junk_chausses", 1 ],
       [ "armor_riot_torso", 10 ],
       [ "carpet_legguards", 8 ],
+      [ "leggings_cut_resistant", 4 ],
       [ "paper_greaves", 7 ],
       [ "chaps_leather", 15 ],
       [ "chaps_cut_resistant", 10 ],

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -22,23 +22,23 @@
     "subcategory": "CSC_ARMOR_ARMS",
     "skill_used": "tailor",
     "difficulty": 1,
-    "time": "60 m",
+    "time": "30 m",
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_sheet", 1 ] ]
+    "using": [ [ "tailoring_cotton_sheet", 4 ] ]
   },
   {
     "result": "xs_arm_warmers",
     "type": "recipe",
     "copy-from": "arm_warmers",
-    "time": "50 m",
-    "using": [ [ "tailoring_cotton_sheet", 1 ] ]
+    "time": "20 m",
+    "using": [ [ "tailoring_cotton_sheet", 2 ] ]
   },
   {
     "result": "xl_arm_warmers",
     "type": "recipe",
     "copy-from": "arm_warmers",
-    "time": "70 m",
-    "using": [ [ "tailoring_cotton_sheet", 2 ] ]
+    "time": "50 m",
+    "using": [ [ "tailoring_cotton_sheet", 6 ] ]
   },
   {
     "result": "armguard_chitin",
@@ -630,5 +630,47 @@
     ],
     "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "DRILL", "level": 3 } ],
     "tools": [ [ [ "swage", -1 ] ], [ [ "hotcut_any", 1, "LIST" ] ] ]
+  },
+  {
+    "result": "armguard_cut_resistant",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "30 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_kevlar_sheet", 12 ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "armguard_cut_resistant_xs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "45 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_kevlar_sheet", 6 ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "armguard_cut_resistant_xl",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "60 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_kevlar_sheet", 20 ] ],
+    "flags": [ "BLIND_HARD" ]
   }
 ]

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -1086,5 +1086,47 @@
     ],
     "qualities": [ { "id": "CHISEL", "level": 3 }, { "id": "DRILL", "level": 3 } ],
     "tools": [ [ [ "swage", -1 ] ], [ [ "hotcut_any", 1, "LIST" ] ] ]
+  },
+    {
+    "result": "leggings_kevlar",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "45 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_spandex_sheet", 8 ], [ "tailoring_kevlar_sheet", 18 ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+    {
+    "result": "leggings_kevlar_xs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "time": "60 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_spandex_sheet", 8 ], [ "tailoring_kevlar_sheet", 8 ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+    {
+    "result": "leggings_kevlar_xl",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "80 m",
+    "autolearn": true,
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SEW", "level": 1 } ],
+    "using": [ [ "tailoring_spandex_sheet", 24 ], [ "tailoring_kevlar_sheet", 24 ] ],
+    "flags": [ "BLIND_HARD" ]
   }
 ]

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -5826,9 +5826,29 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "10 m",
+    "time": "30 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "kevlar_sheet", 12 ] ], [ [ "thread_kevlar", 50 ] ] ],
+    "components": [ [ [ "kevlar_sheet", 10 ] ], [ [ "thread_kevlar", 25 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+    {
+    "result": "armguard_cut_resistant_xs",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "45 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "kevlar_sheet", 4 ] ], [ [ "thread_kevlar", 10 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+    {
+    "result": "armguard_cut_resistant_xl",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "20 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "kevlar_sheet", 20 ] ], [ [ "thread_kevlar", 50 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {


### PR DESCRIPTION
#### Summary
Add Kevlar leggings

#### Purpose of change
Motorcycle leggings made of Kevlar and spandex exist IRL, we don't have much skintight armor for the legs.

#### Describe the solution
Add 'em. Also give cut-resistant sleeves their own data instead of copy-from the soft arm guards.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
