### PR TITLE
Backport 83189 - Filter out vertical movements for hordes

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4600,7 +4600,8 @@ void overmap::move_hordes()
             // Call up to overmapbuffer in case it needs to dispatch to an adjacent overmap.
             for( const tripoint_abs_ms &candidate :
                  squares_closer_to( mon->first, mon->second.destination ) ) {
-                if( overmap_buffer.passable( candidate ) ) {
+                // Just filter out cross-level candidates for now.
+                if( candidate.z() == mon->first.z() && overmap_buffer.passable( candidate ) ) {
                     viable_candidates.push_back( candidate );
                 }
             }


### PR DESCRIPTION
#### Summary
Backport 83189 - Filter out vertical movements for hordes

#### Purpose of change
Prevent hordes from leaving underground labs etc

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
