### PR TITLE
Bleach recipe -> Dakin's solution

### DIFF
--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -671,6 +671,29 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "dakins_solution",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "chemistry",
+    "skills_required":[ [ "electronics", 3 ], [ "firstaid", 3 ] ],
+    "difficulty": 4,
+    "time": "25 m",
+    "batch_time_factors": [ 90, 4 ],
+    "//1": "This method produces 1% concentrated bleach. Our bleach item is 5%.",
+    "//2": "So it's useless unless you know about Dakin's, thus the high requirements.",
+    "book_learn": [ [ "adv_chemistry", 5 ], [ "recipe_labchem", 5 ], [ "atomic_survival", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "electrolysis_kit", 250 ] ] ],
+    "components": [ [ [ "salt_water", 5 ], [ "saline", 5 ] ], [ [ "water_clean", 5 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "oxy_powder",
     "byproducts": [ [ "salt_water", 2 ] ],
     "category": "CC_CHEM",


### PR DESCRIPTION
#### Summary
Remove bleach recipe

#### Purpose of change
Someone pointed out an exploit to get infinite Dakin's solution by crafting bleach from the salt water it breaks down into. Looking into this, I discovered that the chloralkali process the game is attempting to depict makes a 1% bleach solution, while household bleach is typically 5-6%. There's no easy way to get from 1% to 5%, so the process is not really going to get you usable bleach.

However, Dakin's solution is only 0.5% bleach, so this process is ideal for making it from salt water.

#### Describe the solution
Change the result from bleach to Dakin's solution. Up the skill requirements as this is a simple process, but knowing what to do with it is not something you'd just be able to put together easily.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
