### PR TITLE
backport 84031

### DIFF
--- a/data/json/items/magazine/40mm.json
+++ b/data/json/items/magazine/40mm.json
@@ -19,6 +19,6 @@
     "count": 25,
     "linkage": "ammolink40mm",
     "flags": [ "MAG_BELT", "MAG_DESTROY" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40x53mm": 50 } } ]
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x53mm": 50 } } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Backport 84031 - 40mm ammo belt volume

#### Purpose of change
The 40mm ammo belt scales its volume according to the grenades inside of it

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
