### PR TITLE
Pool water is no good, fix minor issues

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -103,8 +103,7 @@
       "str_max": 30,
       "sound": "porcelain breaking!",
       "sound_fail": "whunk!",
-      "items": [ { "item": "ceramic_shard", "count": [ 2, 8 ] }, { "item": "wax_paraffin", "count": 1 } ],
-      "destroyed_field": [ "fd_dirty_water", 4 ]
+      "items": [ { "item": "ceramic_shard", "count": [ 2, 8 ] }, { "item": "wax_paraffin", "count": 1 } ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -241,7 +241,7 @@
     "type": "terrain",
     "id": "t_water_pool",
     "name": "pool water",
-    "description": "A deep pool full of water.  Never swim without a lifeguard present.  Even though monsters probably ate them.",
+    "description": "A deep pool full of water, stagnant now that nobody's around to tend to it.",
     "symbol": "~",
     "looks_like": "t_water_dp",
     "color": "light_blue",
@@ -249,14 +249,14 @@
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "INDOORS", "DEEP_WATER", "EMPTY_SPACE" ],
     "connect_groups": [ "INDOORFLOOR", "POOLWATER" ],
     "connects_to": "POOLWATER",
-    "liquid_source": { "id": "water" },
+    "liquid_source": { "id": "water_murky" },
     "examine_action": "water_source"
   },
   {
     "type": "terrain",
     "id": "t_water_pool_shallow",
     "name": "shallow pool water",
-    "description": "A shallow pool of water.",
+    "description": "A shallow pool of water, stagnant now that nobody's around to tend to it.",
     "symbol": "~",
     "looks_like": "t_water_pool",
     "color": "light_blue",
@@ -264,14 +264,14 @@
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "INDOORS", "SHALLOW_WATER" ],
     "connect_groups": [ "INDOORFLOOR", "POOLWATER" ],
     "connects_to": "POOLWATER",
-    "liquid_source": { "id": "water" },
+    "liquid_source": { "id": "water_murky" },
     "examine_action": "water_source"
   },
   {
     "type": "terrain",
     "id": "t_water_pool_outdoors",
     "name": "pool water",
-    "description": "A deep pool full of water.  Never swim without a lifeguard present.  Even though monsters probably ate them.",
+    "description": "A deep pool full of water, stagnant now that nobody's around to tend to it.",
     "symbol": "~",
     "looks_like": "t_water_pool",
     "color": "light_blue",
@@ -279,14 +279,14 @@
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "DEEP_WATER", "EMPTY_SPACE" ],
     "connect_groups": "POOLWATER",
     "connects_to": "POOLWATER",
-    "liquid_source": { "id": "water" },
+    "liquid_source": { "id": "water_murky" },
     "examine_action": "water_source"
   },
   {
     "type": "terrain",
     "id": "t_water_pool_shallow_outdoors",
     "name": "shallow pool water",
-    "description": "A shallow pool of water.",
+    "description": "A shallow pool of water, stagnant now that nobody's around to tend to it.",
     "symbol": "~",
     "looks_like": "t_water_pool",
     "color": "light_blue",
@@ -294,7 +294,7 @@
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER" ],
     "connect_groups": "POOLWATER",
     "connects_to": "POOLWATER",
-    "liquid_source": { "id": "water" },
+    "liquid_source": { "id": "water_murky" },
     "examine_action": "water_source"
   },
   {

--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -182,7 +182,7 @@
     "subtypes": [ "TOOL" ],
     "id": "betavoltaic",
     "category": "spare_parts",
-    "price": "407 USD 11 cents",
+    "price": "400 USD",
     "price_postapoc": "2 USD",
     "name": { "str": "betavoltaic cell" },
     "symbol": "=",

--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -208,7 +208,7 @@
         "time": "40 m",
         "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
       },
-      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
     "size": "125000 ml",
     "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED" ] },


### PR DESCRIPTION
#### Summary
Pool water is no good, fix minor issues

#### Purpose of change
Pool water was fairly drinkable despite being stagnant untreated water sitting untended in (probably) spring in the middle of the apocalypse.

#### Describe the solution
- Pool water is now murky.
- Fix a few json errors that were causing load failures.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
