### PR TITLE
Raise base NPC stats by 2

### DIFF
--- a/data/json/effects_on_condition/bionic_eocs.json
+++ b/data/json/effects_on_condition/bionic_eocs.json
@@ -95,7 +95,7 @@
     "deactivate_condition": { "not": { "u_has_bionics": "bio_faulty_grossfood" } },
     "effect": [
       { "u_message": "Your stomach churns and a foul taste crawls up your throat.", "type": "bad" },
-      { "u_add_effect": "nausea", "duration": "rng(1, 10) minutes" }
+      { "u_add_effect": "nausea", "duration": "5 minutes" }
     ]
   },
   {

--- a/src/npc.h
+++ b/src/npc.h
@@ -1472,7 +1472,7 @@ class standard_npc : public npc
         explicit standard_npc( const std::string &name = "",
                                const tripoint_bub_ms &pos = tripoint_bub_ms( HALF_MAPSIZE_X, HALF_MAPSIZE_Y, 0 ),
                                const std::vector<std::string> &clothing = {},
-                               int sk_lvl = 4, int s_str = 8, int s_dex = 8, int s_int = 8, int s_per = 8 );
+                               int sk_lvl = 4, int s_str = 10, int s_dex = 10, int s_int = 10, int s_per = 10 );
 };
 
 // instances of this can be accessed via string_id<npc_template>.


### PR DESCRIPTION
#### Summary
Raise base NPC stats by 2

#### Purpose of change
NPCs were always genning extremely weak. This was exacerbated when all the random ones were moved to the class NC_NONE, which confers no bonuses.

#### Describe the solution
Start them at 10. They can get + and - from there.

#### Describe alternatives you've considered
I haven't figured out how their random rolls actually work, they could probably stand to have a bit more range.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
