### PR TITLE
Backport 83368 - Fix assignment of un-alert monsters to immobile horde map

### DIFF
--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -156,9 +156,9 @@ std::unordered_map<tripoint_abs_ms, horde_entity>::iterator horde_map::spawn_ent
 {
     std::unordered_map <tripoint_om_sm, std::unordered_map<tripoint_abs_ms, horde_entity>> &target_map =
                 mon.type->has_flag( mon_flag_DORMANT ) ? dormant_monster_map :
+                !is_alert( *mon.type ) ? immobile_monster_map :
                 ( mon.has_dest() || mon.wandf > 0 ) ? active_monster_map :
-                is_alert( *mon.type ) ? idle_monster_map :
-                immobile_monster_map;
+                idle_monster_map;
     std::unordered_map<tripoint_abs_ms, horde_entity>::iterator result;
     point_abs_om omp;
     tripoint_om_sm sm;


### PR DESCRIPTION
#### Summary
Backport 83368 - Fix assignment of un-alert monsters to immobile horde map

#### Describe the solution
Stops turrets and searchlights from moving around like Toy Story when you aren't looking. Should also stop tied-down animals from wandering off.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
