### PR TITLE
Fix dragging immobile creatures

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1688,6 +1688,11 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
     }
 
     // Pull creature
+
+    if( c->has_effect( effect_tied ) || c->has_flag( mon_flag_IMMOBILE ) || c->has_effect_with_flag( json_flag_CANNOT_MOVE ) ) {
+        add_msg_if_player( _( "%s is immobile and cannot be moved." ), c->disp_name( false, true ) );
+        return;
+    }
     const Character *ch = as_character();
     const monster *mon = as_monster();
     const int str = ch != nullptr ? ch->get_str() : mon != nullptr ? mon->get_grab_strength() : 10;
@@ -1714,6 +1719,10 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 bool Creature::grapple_drag( Creature *c )
 {
     if( !has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
+        return false;
+    }
+    if( c->has_effect( effect_tied ) || c->has_flag( mon_flag_IMMOBILE ) || c->has_effect_with_flag( json_flag_CANNOT_MOVE ) ) {
+        add_msg_if_player( _( "%s is immobile and cannot be moved." ), c->disp_name( false, true ) );
         return false;
     }
     const Character *ch = as_character();


### PR DESCRIPTION
#### Summary
Fix dragging immobile creatures

#### Purpose of change
I discovered that people were dragging milspec searchlights into their homes for free light. Sigh.

#### Describe the solution
You can no longer drag or pull (e.g. with frog tongue) anything that is tied, immobile, or has the CANNOT_MOVE flag.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
