### PR TITLE
Allow lockpicking practice with vehicle cargo and door locks

### DIFF
--- a/data/json/recipes/practice/devices.json
+++ b/data/json/recipes/practice/devices.json
@@ -11,7 +11,7 @@
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
     "proficiencies": [ { "proficiency": "prof_lockpicking", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
-    "tools": [ [ "lock" ] ],
+    "tools": [ [ "lock", "door_lock", "cargo_lock" ] ],
     "//": "Crude picks will eventually lose their shape",
     "components": [ [ [ "crude_picklock", 1 ] ] ],
     "autolearn": [ [ "traps", 3 ] ],
@@ -32,7 +32,7 @@
     "proficiencies": [ { "proficiency": "prof_lockpicking", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
     "qualities": [ { "id": "LOCKPICK", "level": 5 } ],
-    "tools": [ [ "lock" ] ],
+    "tools": [ [ "lock", "door_lock", "cargo_lock" ] ],
     "autolearn": [ [ "traps", 3 ] ],
     "book_learn": [ [ "book_lockpick", 1 ] ],
     "flags": [ "BLIND_EASY" ]


### PR DESCRIPTION
#### Purpose of change

Currently you can only practice lockpicking with one type of lock

#### Describe the solution

Now you can take locks off of cars and practice with those.

From the description, it sounds like these are not normal car door locks, but more like a padlock you bolt onto the car. (It might be a non-tumbler lock, but it doesn't look like the game models that; otherwise lockers would need tubular lock picks.)

#### Describe alternatives you've considered

Cope

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
