### PR TITLE
Dissection isn't butchery

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1177,13 +1177,13 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         // Mostly you're just left with organs and bones, the meat and skin are ruined.
         if( action == butcher_type::DISSECT ) {
             if( entry.type == harvest_drop_flesh ) {
-                roll /= 8;
+                roll /= 10;
             } else if( entry.type == harvest_drop_bone ) {
-                roll /= 2;
+                roll /= 3;
             } else if( entry.type == harvest_drop_skin ) {
                 roll = 0;
             } else if( entry.type == harvest_drop_offal ) {
-                roll /= 2;
+                roll /= 3;
             }
         }
 


### PR DESCRIPTION
#### Summary
Dissection isn't butchery

#### Purpose of change
Dissection was yielding the same results as full butchery. This was not intended.

#### Describe the solution
- You get no skin, 1/10th the meat, 1/3 the organs, and 1/3 the bones. Dissection is meant to be a very destructive process as you're thoroughly testing the corpse for weak points and other oddities.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
