### PR TITLE
Fix melee AOEs

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -143,6 +143,21 @@
   },
   {
     "type": "technique",
+    "id": "tec_aoe_secondary",
+    "name": "Area Attack (secondary)",
+    "//": "Weakened generic hit that serves as the second part of all aoe attacks.",
+    "messages": [ "You catch %s with your attack", "<npcname> catches %s with their attack" ],
+    "melee_allowed": true,
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 0.5 },
+      { "stat": "damage", "type": "cut", "scale": 0.5 },
+      { "stat": "damage", "type": "stab", "scale": 0.5 },
+      { "stat": "movecost", "scale": 0.0 }
+    ],
+    "attack_vectors": [ "vector_null" ]
+  },
+  {
+    "type": "technique",
     "id": "BRUTAL",
     "name": "Brutal Strike",
     "melee_allowed": true,

--- a/src/character.h
+++ b/src/character.h
@@ -124,6 +124,8 @@ using drop_locations = std::list<drop_location>;
 
 using bionic_uid = unsigned int;
 
+static const matec_id no_technique_id( "" );
+
 constexpr int MAX_CLAIRVOYANCE = 40;
 // kcal in a kilogram of fat, used to convert stored kcal into body weight. 3500kcal/lb * 2.20462lb/kg = 7716.17
 constexpr float KCAL_PER_KG = 3500 * 2.20462;
@@ -1213,7 +1215,8 @@ class Character : public Creature, public visitable
                                     bool allow_unarmed = true, int forced_movecost = -1 );
 
         /** Handles reach melee attacks */
-        void reach_attack( const tripoint_bub_ms &p, int forced_movecost = -1 );
+        void reach_attack( const tripoint_bub_ms &p, int forced_movecost = -1,
+                           matec_id force_technique = no_technique_id );
 
         /**
          * Calls the to other melee_attack function with an empty technique id (meaning no specific

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3209,18 +3209,19 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
             info.back().bNewLine = true;
             int awkward_percent = gun_awkwardness( get_player_character() );
             if( awkward_percent < 75 ) {
-            info.emplace_back(
-                "GUN",
-                _( "Height penalty: " ),
-                string_format( "<neutral>%d%%</neutral>", awkward_percent ),
-                iteminfo::lower_is_better
-            ); } else {
-            info.emplace_back(
-                "GUN",
-                _( "Height penalty: " ),
-                string_format( "<bad>%d%%</bad>", awkward_percent ),
-                iteminfo::lower_is_better
-            );
+                info.emplace_back(
+                    "GUN",
+                    _( "Height penalty: " ),
+                    string_format( "<neutral>%d%%</neutral>", awkward_percent ),
+                    iteminfo::lower_is_better
+                );
+            } else {
+                info.emplace_back(
+                    "GUN",
+                    _( "Height penalty: " ),
+                    string_format( "<bad>%d%%</bad>", awkward_percent ),
+                    iteminfo::lower_is_better
+                );
             }
         }
         if( parts->test( iteminfo_parts::GUN_RECOIL_THEORETICAL_MINIMUM ) ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -255,7 +255,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
             return std::nullopt;
         }
         p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
-                                        "You set the timer to %d seconds.", timer_time ), timer_time );
+                                         "You set the timer to %d seconds.", timer_time ), timer_time );
     }
 
     if( !msg_transform.empty() ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4567,7 +4567,7 @@ bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> 
         if( gmode->has_flag( flag_BIPOD ) ) {
             map &here = get_map();
             bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, you.pos_bub( here ) ) ||
-                 you.is_prone();
+                    you.is_prone();
             if( !bipod ) {
                 if( const optional_vpart_position vp = here.veh_at( you.pos_abs( ) ) ) {
                     bipod = vp->vehicle().has_part( you.pos_abs( ), "MOUNTABLE" );
@@ -4576,8 +4576,8 @@ bool gunmode_checks_weapon( avatar &you, const map &m, std::vector<std::string> 
         }
         if( !bipod ) {
             messages.push_back( string_format(
-                        _( "You are too small to use the %s." ),
-                        gmode->tname() ) );
+                                    _( "You are too small to use the %s." ),
+                                    gmode->tname() ) );
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Fix melee AOEs

#### Purpose of change
Someone pointed out that impale wasn't working. I don't think it's worked for a very long time. After I fixed it, I realized melee AOEs in general were pretty screwy, doing full damage to every creature struck, often for not much more than the base movecost of the attack, which itself often has favorable properties.

#### Describe the solution
- Fix impale. It now only hits the creature on the far side of whatever you're attacking, and only orthogonally.
- All AOEs now do half damage with their bonus hits.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
