### PR TITLE
Cell phones with their lights on have yellow (active) names

### DIFF
--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -193,7 +193,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "light": 8,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ]
   },
   {
     "id": "directional_antenna",
@@ -891,7 +891,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "light": 20,
-    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID" ] }
+    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "smart_phone_locked",
@@ -952,7 +952,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "light": 20,
-    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID" ] }
+    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "UPS_off",


### PR DESCRIPTION
#### Summary
Cell phones with their lights on have yellow (active) names

#### Purpose of change
This was not the case

#### Describe the solution
now it's

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
