### PR TITLE
Fix LED strip

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -254,7 +254,7 @@
     "move_cost_mod": -1,
     "coverage": 38,
     "concealment": 38,
-    "deconstruct": { "items": [ { "item": "lightstrip_inactive" }, { "item": "aluminum_chunk", "count": 4 } ] },
+    "deconstruct": { "items": [ { "item": "aluminum_chunk", "count": 4 }, { "item": "e_scrap", "count": [ 1, 4 ] } ] },
     "bash": {
       "str_min": 18,
       "str_max": 80,

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -4,7 +4,7 @@
     "type": "ITEM",
     "category": "tools",
     "name": { "str": "atomic lamp" },
-    "description": "Powered by the magic of nuclear decay and low-energy LEDs, this expensive little light will provide just enough light to read by for at least a decade.  It is also available with a cute cartoon bear cover to turn it into a nightlight for a very wealthy child with a fear of the dark.  Use it to close the cover and hide the light.",
+    "description": "Powered by the magic of nuclear decay and low-energy LEDs, this device will provide just enough light to read by for at least a decade.  Use it to close the cover and hide the light.",
     "weight": "560 g",
     "volume": "750 ml",
     "price": "1250 USD",
@@ -481,11 +481,11 @@
     "power_draw": "5 W",
     "revert_to": "lightstrip_inactive",
     "revert_msg": "The LED strip fades away.",
-    "light": 200,
+    "light": 100,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK" ],
     "use_action": [
       { "target": "lightstrip_inactive", "msg": "You turn off the LED strip.", "need_charges": 1, "type": "transform" },
-      { "type": "link_up", "cable_length": 10, "charge_rate": "5 W" }
+      { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" }
     ]
   },
   {
@@ -493,18 +493,17 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "LED strip (inactive)", "str_pl": "LED strips (inactive)" },
-    "description": "25 feet of colorful LED strip, that are often used as house lights or on some holidays.",
-    "weight": "158 g",
+    "description": "A one meter strip of LED lights, usually used for decoration or accent lighting.",
+    "weight": "50 g",
     "volume": "70 ml",
     "price": "10 USD",
     "price_postapoc": "2 cent",
     "symbol": ";",
-    "material": [ { "type": "plastic", "portion": 1 }, { "type": "aluminum", "portion": 9 } ],
+    "material": [ { "type": "plastic", "portion": 1 }, { "type": "aluminum", "portion": 1 }, { "type": "vinyl", "portion": 9 } ],
     "color": "white",
-    "//": "25 feet (7.5 m) + 1.5 meters for plug",
     "use_action": [
       { "target": "lightstrip", "msg": "You turn on the LED strip.", "need_charges": 1, "type": "transform" },
-      { "type": "link_up", "cable_length": 9, "charge_rate": "5 W" }
+      { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" }
     ],
     "tool_ammo": [ "battery" ]
   },

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -114,13 +114,7 @@
     "proficiencies": [ { "proficiency": "prof_appliance_repair" } ],
     "using": [ [ "soldering_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [
-      [ [ "cable", 2 ] ],
-      [ [ "amplifier", 1 ] ],
-      [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ],
-      [ [ "steel_fragment", 1 ] ],
-      [ [ "scrap", 3 ] ]
-    ]
+    "components": [ [ [ "cable", 2 ] ], [ [ "amplifier", 1 ] ], [ [ "light_bulb", 1 ] ], [ [ "steel_fragment", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
     "result": "standing_lamp",
@@ -140,7 +134,7 @@
     "components": [
       [ [ "cable", 2 ] ],
       [ [ "amplifier", 1 ] ],
-      [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ],
+      [ [ "light_bulb", 1 ] ],
       [ [ "steel_chunk", 1 ] ],
       [ [ "pipe_fittings", 1 ] ],
       [ [ "pipe", 2 ] ]

--- a/data/json/recipes/recipes_holiday.json
+++ b/data/json/recipes/recipes_holiday.json
@@ -15,7 +15,7 @@
     "using": [ [ "plastic_molding", 2 ] ],
     "components": [
       [ [ "plastic_bottles_4l", 1, "LIST" ] ],
-      [ [ "lightstrip_inactive", 1 ] ],
+      [ [ "light_bulb", 1 ] ],
       [ [ "light_battery_cell", 1 ] ],
       [ [ "paint_yellow", 1 ] ]
     ]

--- a/data/json/recipes/tools/lights.json
+++ b/data/json/recipes/tools/lights.json
@@ -52,7 +52,7 @@
       [ [ "cable", 8 ] ],
       [ [ "plastic_chunk", 2 ] ],
       [ [ "circuit", 2 ] ],
-      [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ],
+      [ [ "light_bulb", 1 ] ],
       [ [ "amplifier", 1 ] ]
     ]
   },
@@ -78,7 +78,7 @@
         [ "bottle_glass", 1 ],
         [ "plastic_bottles_any", 1, "LIST" ]
       ],
-      [ [ "lightstrip_inactive", 1 ], [ "light_bulb", 1 ] ],
+      [ [ "light_bulb", 1 ] ],
       [ [ "cable", 10 ] ]
     ]
   },
@@ -95,12 +95,7 @@
     "reversible": true,
     "decomp_learn": 1,
     "book_learn": [ [ "manual_electronics", 1 ], [ "mag_electronics", 2 ] ],
-    "components": [
-      [ [ "amplifier", 4 ] ],
-      [ [ "steel_fragment", 2 ], [ "scrap", 6 ] ],
-      [ [ "lightstrip_inactive", 4 ], [ "light_bulb", 4 ] ],
-      [ [ "cable", 10 ] ]
-    ]
+    "components": [ [ [ "amplifier", 4 ] ], [ [ "steel_fragment", 2 ], [ "scrap", 6 ] ], [ [ "light_bulb", 4 ] ], [ [ "cable", 10 ] ] ]
   },
   {
     "type": "recipe",
@@ -115,12 +110,7 @@
     "reversible": true,
     "decomp_learn": 1,
     "book_learn": [ [ "manual_electronics", 1 ], [ "mag_electronics", 2 ] ],
-    "components": [
-      [ [ "amplifier", 4 ] ],
-      [ [ "steel_fragment", 2 ], [ "scrap", 6 ] ],
-      [ [ "lightstrip_inactive", 4 ], [ "light_bulb", 4 ] ],
-      [ [ "cable", 10 ] ]
-    ]
+    "components": [ [ [ "amplifier", 4 ] ], [ [ "steel_fragment", 2 ], [ "scrap", 6 ] ], [ [ "light_bulb", 4 ] ], [ [ "cable", 10 ] ] ]
   },
   {
     "type": "recipe",
@@ -139,7 +129,7 @@
     "components": [
       [ [ "amplifier", 2 ] ],
       [ [ "plastic_chunk", 2 ], [ "scrap", 3 ] ],
-      [ [ "lightstrip_inactive", 2 ], [ "light_bulb", 2 ] ],
+      [ [ "lightstrip_inactive", 3 ], [ "light_bulb", 2 ] ],
       [ [ "cable", 10 ] ]
     ]
   },
@@ -160,7 +150,7 @@
     "components": [
       [ [ "amplifier", 3 ] ],
       [ [ "plastic_chunk", 3 ], [ "scrap", 4 ] ],
-      [ [ "lightstrip_inactive", 3 ], [ "light_bulb", 3 ] ],
+      [ [ "lightstrip_inactive", 4 ], [ "light_bulb", 3 ] ],
       [ [ "cable", 12 ] ]
     ]
   },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2264,7 +2264,7 @@
     "difficulty": 1,
     "time": "6 m",
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
-    "components": [ [ [ "cable", 12 ] ], [ [ "amplifier", 2 ] ], [ [ "lightstrip_inactive", 1 ] ], [ [ "scrap_aluminum", 4 ] ] ]
+    "components": [ [ [ "cable", 12 ] ], [ [ "amplifier", 2 ] ], [ [ "scrap_aluminum", 4 ] ] ]
   },
   {
     "result": "holy_symbol",


### PR DESCRIPTION
#### Summary
Fix LED strip

#### Purpose of change
The LED strip had some problems with its battery/link up setup. It was also for some reason set to be 5 meters but its power draw was for only 1 meter. The game doesn't let you make very good use of huge strips anyway, so it's better to just shrink it.

#### Describe the solution
Port DDA's changes and rework them a bit.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
