### PR TITLE
Frozen corpses are harder to pulp, cars don't stop revival

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8771,6 +8771,10 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
             } else if( corpse.volume() <= 483750_ml ) {
                 divisor = 125_ml;
             }
+            // Frozen corpses take twice as long to pulp.
+            if( corpse.has_flag( flag_FROZEN ) ) {
+                divisor /= 2;
+            }
             double corpse_volume_factor = corpse.volume() / divisor;
             while( corpse.damage() < corpse.max_damage() ) {
                 // Increase damage as we keep smashing ensuring we do eventually smash the target.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8622,7 +8622,7 @@ bool item::ready_to_revive( map &here, const tripoint_bub_ms &pos )
     if( !can_revive() ) {
         return false;
     }
-    if( here.veh_at( pos ) ) {
+    if( here.veh_at( pos ) && !here.passable( pos ) ) {
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Frozen corpses are harder to pulp, cars don't stop revival

#### Purpose of change
Cars were totally blocking corpse revival. Now they only do it if the tile is impassable.

#### Describe the solution
- Corpses revive in cars.
- Frozen corpses take twice as long to pulp.

#### Describe alternatives you've considered
The corpse could check whether it's inside the car or simply under it. This was an easy fix for now though.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
