### PR TITLE
Improve autodrive crater avoidance

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -844,6 +844,7 @@ void vehicle::autodrive_controller::enqueue_if_ramp( point_queue &ramp_points,
     }
     // Please don't drive into craters.
     if( !here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ) {
+        ramp_points.visited.emplace( p );
         return;
     }
     ramp_points.visited.emplace( p );


### PR DESCRIPTION
#### Summary
Improve autodrive crater avoidance

#### Purpose of change
Autodrive was supposed to be avoiding non-ROAD ramps (e.g. craters) but the old solution wasn't actually marking them for no-go, just silently returning when it hit one, which meant it would still go that way if it didn't find a more optimal route.

#### Describe the solution
Properly mark such tiles as visited during the ramp emplacement. This is not a full fix as cars can still bug out when you manually drive them into a crater, but it's an easy place to start.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
