### PR TITLE
Fix C-4 power and neoprene sleeve encumbrance

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -540,7 +540,7 @@
           { "type": "spandex", "covered_by_mat": 100, "thickness": 0.3 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 5,
+        "encumbrance": 6,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "coverage": 95
       },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -56,7 +56,7 @@
     "material": [ "rdx" ],
     "symbol": ";",
     "color": "light_gray",
-    "countdown_action": { "type": "explosion", "explosion": { "power": 2800 } },
+    "countdown_action": { "type": "explosion", "explosion": { "power": 1960 } },
     "countdown_interval": "6 seconds",
     "flags": [ "NPC_THROW_NOW", "SPAWN_ACTIVE" ]
   },


### PR DESCRIPTION
#### Summary
Fix C-4 power and neoprene sleeve encumbrance

#### Purpose of change
C-4 had the wrong power level set. Even assuming its entire mass is C-4 (and it's not, there's a detonator in there), it was much more powerful than it should be. C-4 is ~1.25g TNT equivalent, so that's an easy fix.

Neoprene sleeves had too little encumbrance as they cover the entire arm.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
