### PR TITLE
UPS Phaseout: Cloaks

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -2134,14 +2134,19 @@
     "warmth": 10,
     "material_thickness": 0.5,
     "environmental_protection": 4,
-    "use_action": {
-      "type": "transform",
-      "msg": "Your optical cloak flickers as it becomes transparent.",
-      "target": "optical_cloak_on",
-      "need_charges": 20,
-      "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
-    },
-    "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF", "POCKETS", "COLLAR" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 200 } } ],
+    "charges_per_use": 1,
+    "use_action": [
+      {
+        "type": "transform",
+        "msg": "Your optical cloak flickers as it becomes transparent.",
+        "target": "optical_cloak_on",
+        "need_charges": 2,
+        "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
+      },
+      { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
+    ],
+    "flags": [ "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF", "POCKETS", "COLLAR" ],
     "armor": [
       { "encumbrance": 25, "coverage": 65, "covers": [ "torso", "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] },
       {
@@ -2163,7 +2168,6 @@
     "name": { "str": "FB51 optical cloak (on)", "str_pl": "FB51 optical cloaks (on)" },
     "description": "A plastic cloak embedded with cameras and LEDs that will render you fully invisible to normal vision when powered and worn.  It is turned on, and continually draining power from a UPS.  Use it to turn it off.",
     "flags": [
-      "USE_UPS",
       "OVERSIZE",
       "HOOD",
       "BELTED",
@@ -2176,15 +2180,58 @@
       "COLLAR",
       "SPAWN_ACTIVE"
     ],
-    "power_draw": "20 kW",
+    "power_draw": "1 kW",
     "revert_to": "optical_cloak",
-    "use_action": {
-      "ammo_scale": 0,
-      "type": "transform",
-      "menu_text": "Turn off",
-      "msg": "The %s flickers for a moment as it becomes opaque.",
-      "target": "optical_cloak"
-    }
+    "charges_per_use": 0,
+    "use_action": [
+      {
+        "ammo_scale": 0,
+        "type": "transform",
+        "menu_text": "Turn off",
+        "msg": "The %s flickers for a moment as it becomes opaque.",
+        "target": "optical_cloak"
+      },
+      { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
+    ]
+  },
+  {
+    "id": "holo_cloak",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "name": { "str": "hologram cloak" },
+    "description": "A cloak woven with metallic fibers and covered with hexagonal sheets of reflective carbide.  When activated, it will create a holographic decoy of its wearer.",
+    "weight": "1552 g",
+    "volume": "3500 ml",
+    "price": "55000 USD",
+    "price_postapoc": "100 USD",
+    "to_hit": -1,
+    "material": [ "superalloy" ],
+    "symbol": "[",
+    "color": "light_gray",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } } ],
+    "charges_per_use": 25,
+    "warmth": 10,
+    "material_thickness": 0.5,
+    "environmental_protection": 2,
+    "use_action": [ "DIRECTIONAL_HOLOGRAM", { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" } ],
+    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "BELTED", "SOFT" ],
+    "armor": [
+      { "encumbrance": 10, "coverage": 70, "covers": [ "torso", "arm_l", "arm_r" ] },
+      {
+        "covers": [ "head" ],
+        "encumbrance": [ 10, 10 ],
+        "coverage": 100,
+        "specifically_covers": [ "head_crown", "head_forehead", "head_nape" ]
+      },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "coverage": 70,
+        "encumbrance": [ 10, 10 ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "layers": [ "BELTED" ]
+      }
+    ],
+    "tool_ammo": "battery"
   },
   {
     "id": "poncho",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -574,45 +574,6 @@
     "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ]
   },
   {
-    "id": "holo_cloak",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR", "TOOL" ],
-    "name": { "str": "hologram cloak" },
-    "description": "A cloak woven with metallic fibers and covered with hexagonal sheets of reflective carbide.  When activated, it will create a holographic decoy of its wearer.",
-    "weight": "1552 g",
-    "volume": "3500 ml",
-    "price": "55000 USD",
-    "price_postapoc": "100 USD",
-    "to_hit": -1,
-    "material": [ "superalloy" ],
-    "symbol": "[",
-    "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "rigid": true, "item_restriction": [ "light_battery_cell" ] } ],
-    "charges_per_use": 25,
-    "warmth": 10,
-    "material_thickness": 0.5,
-    "environmental_protection": 2,
-    "use_action": [ "DIRECTIONAL_HOLOGRAM" ],
-    "flags": [ "OVERSIZE", "HOOD", "WATERPROOF", "BELTED", "SOFT" ],
-    "armor": [
-      { "encumbrance": 10, "coverage": 70, "covers": [ "torso", "arm_l", "arm_r" ] },
-      {
-        "covers": [ "head" ],
-        "encumbrance": [ 10, 10 ],
-        "coverage": 100,
-        "specifically_covers": [ "head_crown", "head_forehead", "head_nape" ]
-      },
-      {
-        "covers": [ "leg_l", "leg_r" ],
-        "coverage": 70,
-        "encumbrance": [ 10, 10 ],
-        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
-        "layers": [ "BELTED" ]
-      }
-    ],
-    "tool_ammo": "battery"
-  },
-  {
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
     "category": "clothing",


### PR DESCRIPTION
#### Summary
UPS Phaseout: Cloaks

#### Purpose of change
UPS is dum

#### Describe the solution
The hologram cloak and optical cloak now use integrated batteries and a link up action rather than UPS.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
