### PR TITLE
Ballistas are launchers

### DIFF
--- a/data/json/items/ranged/ballista.json
+++ b/data/json/items/ranged/ballista.json
@@ -14,7 +14,7 @@
     "price_postapoc": "25 USD",
     "material": [ "wood", "steel" ],
     "flags": [ "PRIMITIVE_RANGED_WEAPON", "RELOAD_ONE", "MOUNTED_GUN", "DURABLE_MELEE" ],
-    "skill": "rifle",
+    "skill": "launcher",
     "min_strength": 8,
     "ammo": [ "bolt_ballista" ],
     "loudness": 20,


### PR DESCRIPTION
#### Summary
Ballistas are launchers

#### Purpose of change
Ballistas were using the rifle skill. That makes no sense. Neither does archery.

#### Describe the solution
They're big guns, so they use launchers.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
