### PR TITLE
Cheaper tampons

### DIFF
--- a/data/json/items/generic/bathroom_house.json
+++ b/data/json/items/generic/bathroom_house.json
@@ -80,75 +80,31 @@
     "id": "tampon",
     "name": { "str": "tampon" },
     "type": "ITEM",
-    "description": "A small cotton tampon with a plastic applicator.",
+    "description": "A cylindrical wad of fabric with a plastic applicator.  These are intended for menstrual hygiene, but could be taken apart for some cotton and string.",
     "symbol": "+",
     "color": "white",
     "looks_like": "cotton_ball",
     "container": "bag_plastic_small",
     "price": "25 cent",
-    "price_postapoc": "2 USD",
-    "//": "Makes a decent trade commodity but can be acquired in bulk.",
+    "price_postapoc": "10 cent",
     "weight": "10 g",
     "volume": "50 ml",
-    "material": [ "plastic", "cotton" ],
-    "snippet_category": [
-      {
-        "id": "tampon1",
-        "text": "A small cotton tampon with a plastic applicator.  Useless for some, an invaluable commodity for others."
-      },
-      { "id": "tampon2", "text": "A 'light' cotton tampon with a plastic applicator rated for light flows." },
-      { "id": "tampon3", "text": "A 'super' cotton tampon with a plastic applicator rated for heavy flows." },
-      { "id": "tampon4", "text": "A small, lavender-scented cotton tampon with a plastic applicator." },
-      {
-        "id": "tampon5",
-        "text": "A small cotton tampon with a plastic applicator proudly claiming to be anti-microbial.  Ultra-fine print indicates that this tampon has no noticeable health benefits compared to others."
-      },
-      {
-        "id": "tampon6",
-        "text": "An expensive-looking tampon with a fancy, smooth plastic applicator.  The ultra-soft cotton has the appearance of a fluffy cloud."
-      },
-      {
-        "id": "tampon7",
-        "text": "A cheap-looking tampon.  The cotton looks rough, the plastic applicator has a few sharp edges, and the string is somehow already knotted."
-      }
-    ]
+    "material": [ "plastic", "cotton" ]
   },
   {
     "id": "menstrual_pad",
     "name": { "str": "menstrual pad" },
     "type": "ITEM",
-    "description": "An absorbent pad.",
+    "description": "An absorbent sanitary napkin.",
     "symbol": "=",
     "color": "white",
     "looks_like": "bandages",
     "container": "bag_plastic_small",
     "price": "25 cent",
-    "price_postapoc": "2 USD",
-    "//": "Makes a decent trade commodity but can be acquired in bulk.",
+    "price_postapoc": "10 cent",
     "weight": "10 g",
     "volume": "50 ml",
-    "material": [ "plastic", "cotton" ],
-    "snippet_category": [
-      {
-        "id": "menstrual_pad1",
-        "text": "An absorbent menstrual pad.  Unfortunately, not as useful as a bandage as you'd think.  The adhesive is on the side opposite of the absorbent part."
-      },
-      { "id": "menstrual_pad2", "text": "A small panty-liner only meant for the lightest flows." },
-      { "id": "menstrual_pad3", "text": "A large menstrual pad meant for use overnight." },
-      {
-        "id": "menstrual_pad4",
-        "text": "An absorbent menstrual pad with racing stripes, for the fastest flows.  Probably."
-      },
-      { "id": "menstrual_pad5", "text": "An absorbent menstrual pad that smells strongly of essential oils." },
-      {
-        "id": "menstrual_pad6",
-        "text": "A pride-themed menstrual pad in trans flag coloring.  'Men can bleed too!' is proudly written on the packaging."
-      },
-      {
-        "id": "menstrual_pad7",
-        "text": "A cheap menstrual pad.  The cotton somehow looks like sandpaper and is almost see-through thin."
-      }
-    ]
+    "material": [ "paper", "cotton" ]
   },
   {
     "id": "menstrual_cup",
@@ -160,8 +116,7 @@
     "looks_like": "bottle_plastic_small",
     "container": "bag_plastic_small",
     "price": "10 USD",
-    "price_postapoc": "5 USD",
-    "//": "Makes a decent trade commodity.",
+    "price_postapoc": "1 USD",
     "weight": "10 g",
     "volume": "50 ml",
     "material": [ "plastic" ]


### PR DESCRIPTION
#### Summary
Cheaper tampons

#### Purpose of change
Tampons were $2.50 a pop, which is insane. Yes people would be glad to have these, but that's really excessive, especially considering that they're everywhere and you can carry a million of them.

#### Describe the solution
- Remove the variant text from tampons.
- Tampons and pads are now $0.10 each.
- Adjust the descriptions for both items.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
