### PR TITLE
Fix vehicle direction indicator

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1946,7 +1946,6 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         // check to see if player is located at ter
         draw_options opts{};
         opts.category = TILE_CATEGORY::NONE;
-
         int height_3d = 0;
         draw_from_id_string(
             "cursor",
@@ -1963,12 +1962,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         if( indicator_offset ) {
             draw_options opts{};
             opts.category = TILE_CATEGORY::NONE;
-
-
             int height_3d = 0;
             draw_from_id_string(
                 "cursor",
-                tripoint_bub_ms( g->ter_view_p.xy(), center.z() ),
+                tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
                 0, 0,
                 lit_level::LIT,
                 false,


### PR DESCRIPTION
#### Summary
Fix vehicle direction indicator

#### Purpose of change
The vehicle direction indicator was stuck to the player instead of displaying at its usual offset.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
