### PR TITLE
Hallucinations don't drop items

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8652,7 +8652,7 @@ void Character::apply_damage( Creature *source, bodypart_id hurt, int dam,
         }
     }
 
-    if( !weapon.is_null() && !can_wield( weapon ).success() &&
+    if( !weapon.is_null() && !is_hallucination() && !can_wield( weapon ).success() &&
         can_drop( weapon ).success() ) {
         if( is_avatar() ) {
             popup( _( "You are no longer able to wield your %s and drop it!" ),


### PR DESCRIPTION
#### Summary
Hallucinations don't drop items

#### Purpose of change
Hallucinations could drop items under certain circumstances.

#### Describe the solution
Add !is_hallucination()

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
