### PR TITLE
Fix soaking long pole reverting to spear shaft instead of long pole

### DIFF
--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -90,7 +90,7 @@
     "price": "40 USD",
     "price_postapoc": "50 cent",
     "countdown_interval": "4 hours",
-    "revert_to": "spear_shaft",
+    "revert_to": "long_pole",
     "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 18 }
   },


### PR DESCRIPTION
Closes #2181

## Summary

- `soaking_long_pole_active` was incorrectly set to `revert_to: spear_shaft`, meaning the crafting process (wood beam + oil) skipped `long_pole` entirely and produced a spear shaft directly
- This made `long_pole` effectively unobtainable through crafting — the only world source was deconstructing `f_showjump` furniture at equestrian/ranch locations
- Fix: change `revert_to` to `long_pole`, so the soaking process correctly produces what it says on the tin; players can then use existing recipes to craft it into a spear shaft or pike as desired

## Test plan

- [x] Craft `soaking_long_pole_active` (wood beam + oil, fab 3, SAW_W + CUT_FINE + FILE)
- [x] Wait 4 hours for it to cure
- [x] Confirmed it produces a `long_pole`, not a `spear_shaft`
- [x] Confirmed `long_pole` can be used in downstream recipes (spear shaft, wooden pike, etc.)