### PR TITLE
Fix soaking long pole

### DIFF
--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -90,7 +90,7 @@
     "price": "40 USD",
     "price_postapoc": "50 cent",
     "countdown_interval": "4 hours",
-    "revert_to": "spear_shaft",
+    "revert_to": "long_pole",
     "qualities": [ [ "HAMMER", 1 ] ],
     "melee_damage": { "bash": 18 }
   },


### PR DESCRIPTION
#### Summary
Fix soaking long pole

#### Purpose of change
The soaking long pole was transforming into a spear shaft. That was unintended.

#### Describe the solution
It now transforms into a long pole.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
