### PR TITLE
Nerf fertilizer

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2740,9 +2740,9 @@ void iexamine::fertilize_plant( Character &you, const tripoint_bub_ms &tile,
         planted = you.use_amount( fertilizer, 1 );
     }
 
-    // Reduce the amount of time it takes until the next stage of the plant by
-    // 20% of a seasons length. (default 2.8 days).
-    const time_duration fertilizerEpoch = calendar::season_length() * 0.2;
+    // Fertilizer advances the plant's growth by 10% of the season length
+    // (defined in external settings). The default is 9.1 days.
+    const time_duration fertilizerEpoch = calendar::season_length() * 0.1;
 
     map &here = get_map();
     // Can't use item_stack::only_item() since there might be fertilizer
@@ -2757,7 +2757,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint_bub_ms &tile,
         return;
     }
 
-    // TODO: item should probably clamp the value on its own
+    // TODO: Fertilizer should probably boost yields.
     seed->set_birthday( seed->birthday() - fertilizerEpoch );
     // The plant furniture has the NOITEM token which prevents adding items on that square,
     // spawned items are moved to an adjacent field instead, but the fertilizer token


### PR DESCRIPTION
#### Summary
Nerf fertilizer

#### Purpose of change
The notes in the fertilizer code did not line up with what it was actually doing. They claimed that it was reducing the time it took for the crop to reach its next growth phase by "20% of a season length (default 2.8 days)." This is not what was happening and apparently reflects a time when seasons were MUCH shorter.

Seasons in Cataclysm are 91 days long, and 20% of 91 is roughly 18. The code was not "making the next growth stage come sooner", it was simply artificially advancing the growth time by 18 days irrespective of growth stages., with no regard for when the fertilizer was applied.

#### Describe the solution
For now, we bring it down from 20% of a season length to 10%, advancing the growth timer by 9 days instead of 18. This is still a solid bonus.

#### Describe alternatives you've considered
Fertilizer shouldn't advance growth time at all. The simplest way to handle it would be to make it increase yields. Eventually, once plants track more about their overall wellbeing, fertilizer should be something that corrects and prevents deficiencies rather than conferring a bonus to an otherwise healthy plant.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
