### PR TITLE
Work smarter

### DIFF
--- a/data/mods/innawood/recipes/weapon/piercing.json
+++ b/data/mods/innawood/recipes/weapon/piercing.json
@@ -4,7 +4,7 @@
     "activity_level": "BRISK_EXERCISE",
     "result": "pike",
     "category": "CC_WEAPON",
-    "subcategory": "CSC_WEAPON_PIERCING",
+    "subcategory": "CSC_WEAPON_STABBING",
     "skill_used": "fabrication",
     "difficulty": 7,
     "time": "6 h",

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2815,17 +2815,17 @@ bool cata_tiles::draw_from_id_string_internal(
 
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string_internal(
-                    generic_id, pos, subtile, rota,
-                    ll, retract, nv_color_active,
-                    height_3d, opts );
+                           generic_id, pos, subtile, rota,
+                           ll, retract, nv_color_active,
+                           height_3d, opts );
             }
 
             generic_id = get_ascii_tile_id( sym, -1, -1 );
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string_internal(
-                    generic_id, pos, subtile, rota,
-                    ll, retract, nv_color_active,
-                    height_3d, opts );
+                           generic_id, pos, subtile, rota,
+                           ll, retract, nv_color_active,
+                           height_3d, opts );
             }
         }
     }
@@ -3863,7 +3863,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                     opts.offset = layer_var.offset;
 
                     ret_draw_field = draw_from_id_string(
-                                         sprite_to_draw, 
+                                         sprite_to_draw,
                                          p,
                                          subtile,
                                          rotation,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -322,7 +322,8 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
     }
     const float result = enchantment_cache->modify_value( enchant_vals::mod::CRAFTING_SPEED_MULTIPLIER,
                          crafting_speed );
-    add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %1f, int adjustment %2f, crafting speed multiplier %3f",
+    add_msg_debug( debugmode::DF_CHARACTER,
+                   "Limb score multiplier %1f, int adjustment %2f, crafting speed multiplier %3f",
                    get_limb_score( limb_score_manip ), int_adjustment, result );
 
     return std::max( result, 0.0f );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -315,12 +315,15 @@ float Character::crafting_speed_multiplier( const recipe &rec ) const
     float crafting_speed = morale_crafting_speed_multiplier( rec ) *
                            lighting_craft_speed_multiplier( rec ) *
                            limb_score * pain_multi;
-
+    float int_adjustment = get_int() / 100.f;
+    // Int makes up for speed penalties, but doesn't add speed on its own.
+    if( crafting_speed < 1.0f ) {
+        crafting_speed = std::min( 1.f, crafting_speed + int_adjustment );
+    }
     const float result = enchantment_cache->modify_value( enchant_vals::mod::CRAFTING_SPEED_MULTIPLIER,
                          crafting_speed );
-
-    add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %.1f, crafting speed multiplier %1f",
-                   get_limb_score( limb_score_manip ), result );
+    add_msg_debug( debugmode::DF_CHARACTER, "Limb score multiplier %1f, int adjustment %2f, crafting speed multiplier %3f",
+                   get_limb_score( limb_score_manip ), int_adjustment, result );
 
     return std::max( result, 0.0f );
 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2385,11 +2385,7 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
 
     std::stringstream modifiers_list;
     if( limb_modifier != 100 ) {
-        if( limb_modifier < 100 ) {
-            modifiers_list << _( "hands encumbrance/wounds" ) << " " << limb_modifier << "%";
-        } else {
-            modifiers_list << _( "extra manipulators" ) << " " << limb_modifier << "%";
-        }
+        modifiers_list << _( "manipulation score" ) << " " << limb_modifier << "%";
     }
     if( mut_multi != 100 ) {
         if( !modifiers_list.str().empty() ) {
@@ -2426,7 +2422,10 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
             }
             modifiers_list << _( "pain" ) << " " << pain_multi << "%";
         }
-
+        if( limb_modifier + morale_modifier + lighting_modifier + pain_multi < 400 ) {
+            float int_bonus = crafter.get_int();
+            modifiers_list << _( "intelligence bonus" ) << " " << int_bonus << "%";
+        }
         right_print( w, 0, 1, i_yellow,
                      string_format( craft_speed_reason_strings.at( SLOW_BUT_CRAFTABLE ).translated(),
                                     static_cast<int>( crafter.crafting_speed_multiplier( rec ) * 100 ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -986,7 +986,7 @@ std::optional<int> iuse::poison_tainted( Character *p, item *it, const tripoint_
         p->add_effect( effect_poison, 1_hours );
         return 1;
     }
-    p->add_effect( effect_poison_tainted, 1_hours * (rng( 1, 2 ) ) );
+    p->add_effect( effect_poison_tainted, 1_hours * ( rng( 1, 2 ) ) );
     p->add_effect( effect_foodpoison, 3_hours );
     return 1;
 }


### PR DESCRIPTION
#### Summary
Work smarter

#### Purpose of change
Intelligence doesn't do enough and people are always complaining about crafting speed penalties.

#### Describe the solution
If your crafting speed is below 100% due to limb score, pain, lighting, or morale, add intelligence% back to it, to a maximum of 100%

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
