### PR TITLE
Fix faction camp harvest results

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3564,11 +3564,6 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             const bool nv = !overridden;
             draw_options opts{};
             opts.category = TILE_CATEGORY::FURNITURE;
-
-
-
-
-
             return memorize_only
                    ? false
                    : draw_from_id_string(
@@ -3586,14 +3581,8 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
         // Try drawing memory if invisible and not overridden.
         const memorized_tile &mt = get_furniture_memory_at( here.get_abs( p ) );
         if( !mt.get_dec_id().empty() ) {
-
             draw_options opts{};
             opts.category = TILE_CATEGORY::FURNITURE;
-
-
-
-
-
             return memorize_only
                    ? false
                    : draw_from_id_string(
@@ -3722,10 +3711,6 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             } else {
                 draw_options opts{};
                 opts.category = TILE_CATEGORY::TRAP;
-
-
-
-
                 return draw_from_id_string(
                            mt.get_dec_id(),
                            p,
@@ -4299,15 +4284,9 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             } else {
                 draw_options opts{};
                 opts.category = TILE_CATEGORY::VEHICLE_PART;
-
-
-
                 if( !variant_storage.empty() ) {
                     opts.variant = variant_storage;
                 }
-
-
-
                 return draw_from_id_string(
                            tid_storage,
                            p,

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2994,6 +2994,7 @@ point_rel_omt connection_direction_of( const point_rel_omt &dir, const recipe &m
     }
 
     return connection_dir;
+    \
 }
 
 static void salt_water_pipe_orientation_adjustment( const point_rel_omt &dir, bool &orthogonal,
@@ -3602,12 +3603,21 @@ std::pair<size_t, std::string> basecamp::farm_action( const point_rel_omt &dir, 
                     if( seed != items.end() && farm_valid_seed( *seed ) ) {
                         plots_cnt += 1;
                         if( comp ) {
-                            int skillLevel = round( comp->get_skill_level( skill_survival ) );
-                            ///\EFFECT_SURVIVAL increases number of plants harvested from a seed
-                            int plant_count = rng( skillLevel / 2, skillLevel );
-                            plant_count *= farm_map.furn( pos )->plant->harvest_multiplier;
-                            plant_count = std::min( std::max( plant_count, 1 ), 12 );
-                            int seed_cnt = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
+
+
+                            float skillLevel = comp->get_skill_level( skill_survival );
+                            ///\EFFECT_SURVIVAL increases number of plants harvested from a seed.
+                            float skill_divisor = 4.f;
+                            // Fertilizer reduces the odds of a bad harvest.
+                            if( farm_map.i_at( pos ).size() > 1 ) {
+                                skill_divisor = 2.f;
+                            }
+                            float plant_count = rng_float( skillLevel / skill_divisor, skillLevel );
+                            const auto &fp = farm_map.furn( pos )->plant;
+                            plant_count *= fp->harvest_multiplier;
+                            int plant_count_int = static_cast<int>( std::round( plant_count ) );
+                            plant_count = std::min( std::max( plant_count_int, 1 ), 10 );
+                            int seed_cnt = rng( plant_count_int / 4, plant_count_int / 2 );
                             for( item &i : iexamine::get_harvest_items( *seed->type, plant_count,
                                     seed_cnt, true ) ) {
                                 here.add_item_or_charges( player_character.pos_bub(), i );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2687,7 +2687,6 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
             float plant_count = rng_float( skillLevel / skill_divisor, skillLevel );
             const auto &fp = here.furn( examp )->plant;
             plant_count *= fp->harvest_multiplier;
-            \
             int plant_count_int = static_cast<int>( std::round( plant_count ) );
             plant_count = std::min( std::max( plant_count_int, 1 ), 10 );
             int seedCount = rng( plant_count_int / 4, plant_count_int / 2 );


### PR DESCRIPTION
#### Summary
Fix faction camp harvest results

#### Purpose of change
Faction camp harvests were using the old system, which didnt benefit from fertilizer.

#### Describe the solution
now it do

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
