### PR TITLE
Fix up supermarkets a bit

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -265,8 +265,18 @@
     "items": [
       { "group": "drugs_analgesic", "prob": 100 },
       { "group": "drugs_heal_simple", "prob": 100 },
-      { "group": "drugs_misc", "prob": 100 },
+      { "group": "drugs_misc", "prob": 30 },
       { "group": "drugs_rare", "prob": 100 }
+    ]
+  },
+    {
+    "id": "drugs_otc",
+    "type": "item_group",
+    "//": "Drugs stocked by a pharmacy, not including prescription medications",
+    "items": [
+      { "group": "drugs_analgesic", "prob": 100 },
+      { "group": "drugs_heal_simple", "prob": 100 },
+      { "group": "drugs_misc", "prob": 30 }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -20,7 +20,7 @@
     "id": "SUS_shelf_commercial_sauces_dressings",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sauces_dressings", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_sauces_dressings", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_spices_seasoning",
@@ -43,7 +43,7 @@
     "id": "SUS_shelf_commercial_spices_seasoning",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_spices_seasoning", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_spices_seasoning", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_oil_vinegar",
@@ -55,7 +55,7 @@
     "id": "SUS_shelf_commercial_oil_vinegar",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_oil_vinegar", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_oil_vinegar", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_exotic_food",
@@ -67,7 +67,7 @@
     "id": "SUS_shelf_commercial_exotic_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_exotic_food", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_exotic_food", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_grains",
@@ -79,7 +79,7 @@
     "id": "SUS_shelf_commercial_grains",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_grains", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_grains", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_baking",
@@ -100,7 +100,7 @@
     "id": "SUS_shelf_commercial_baking",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baking", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_baking", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_pasta",
@@ -112,7 +112,7 @@
     "id": "SUS_shelf_commercial_pasta",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_pasta", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_pasta", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_canned_vegetables",
@@ -124,7 +124,7 @@
     "id": "SUS_shelf_commercial_canned_vegetables",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_vegetables", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_canned_vegetables", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_canned_fruits",
@@ -136,7 +136,7 @@
     "id": "SUS_shelf_commercial_canned_fruits",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_fruits", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_canned_fruits", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_canned_meat",
@@ -160,7 +160,7 @@
     "id": "SUS_shelf_commercial_canned_meat",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_meat", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_canned_meat", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_canned_meals",
@@ -185,7 +185,7 @@
     "id": "SUS_shelf_commercial_canned_meals",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_meals", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_canned_meals", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_coffee",
@@ -197,7 +197,7 @@
     "id": "SUS_shelf_commercial_coffee",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_coffee", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_coffee", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_tea",
@@ -216,7 +216,7 @@
     "id": "SUS_shelf_commercial_tea",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_tea", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_tea", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_breakfast_cereal",
@@ -232,7 +232,7 @@
     "id": "SUS_shelf_commercial_breakfast_cereal",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_breakfast_cereal", "count": [ 1, 5 ] } ]
+    "entries": [ { "group": "commercial_breakfast_cereal", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_breakfast_mixes",
@@ -244,7 +244,7 @@
     "id": "SUS_shelf_commercial_breakfast_mixes",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_breakfast_mixes", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_breakfast_mixes", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_spreads",
@@ -268,7 +268,7 @@
     "id": "SUS_shelf_commercial_sweet_snacks",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sweet_snacks", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_sweet_snacks", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_butter_cream",
@@ -329,13 +329,13 @@
     "id": "SUS_shelf_commercial_cheese",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_cheese", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_cheese", "count": [ 1, 4 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_milk",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "any_milk", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "any_milk", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_eggs",
@@ -347,7 +347,7 @@
     "id": "SUS_shelf_commercial_eggs",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_eggs", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_eggs", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_deli",
@@ -360,7 +360,7 @@
     "id": "SUS_shelf_commercial_deli",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_deli", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_deli", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_meat",
@@ -372,7 +372,7 @@
     "id": "SUS_shelf_commercial_meat",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_meat", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_meat", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_seafood",
@@ -384,7 +384,7 @@
     "id": "SUS_shelf_commercial_seafood",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_seafood", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_seafood", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_icecream",
@@ -405,7 +405,7 @@
     "id": "SUS_shelf_commercial_icecream",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_icecream", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_icecream", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_frozen_dessert",
@@ -417,7 +417,7 @@
     "id": "SUS_shelf_commercial_frozen_dessert",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_dessert", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_frozen_dessert", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_water",
@@ -429,29 +429,29 @@
     "id": "SUS_shelf_commercial_water",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_water", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_water", "count": [ 1, 4 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_soda",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "soda_in_container_full", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "soda_in_container_full", "count": [ 1, 4 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_soda",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "cola", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "rootbeer", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "lemonlime", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "orangesoda", "prob": 15, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "colamdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "zerocola", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "zeroorange", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "zerotropical", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "zeromdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
-      { "item": "tonic_water", "prob": 5, "container-item": "can_drink", "sealed": true, "count": [ 1, 6 ] },
+      { "item": "cola", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "rootbeer", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "lemonlime", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "orangesoda", "prob": 15, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "colamdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "zerocola", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "zeroorange", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "zerotropical", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "zeromdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "tonic_water", "prob": 5, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
       { "item": "cola", "prob": 20, "container-item": "bottle_twoliter", "sealed": true },
       { "item": "rootbeer", "prob": 20, "container-item": "bottle_twoliter", "sealed": true },
       { "item": "lemonlime", "prob": 10, "container-item": "bottle_twoliter", "sealed": true },
@@ -474,7 +474,7 @@
     "id": "SUS_shelf_commercial_juices",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_juices", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_juices", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_sports_drink",
@@ -486,7 +486,7 @@
     "id": "SUS_shelf_commercial_sports_drink",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sports_drink", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_sports_drink", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_snacks_chips",
@@ -498,7 +498,7 @@
     "id": "SUS_shelf_commercial_chips",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_snacks_chips", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_snacks_chips", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_snacks_nuts_crackers",
@@ -522,7 +522,7 @@
     "id": "SUS_shelf_commercial_nuts_crackers",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_snacks_nuts_crackers", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_snacks_nuts_crackers", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_chocolate",
@@ -534,7 +534,7 @@
     "id": "SUS_shelf_commercial_chocolate",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_chocolate", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_chocolate", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_candy",
@@ -556,7 +556,7 @@
     "id": "SUS_shelf_commercial_candy",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_candy", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_candy", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_pet_food",
@@ -568,7 +568,7 @@
     "id": "SUS_shelf_commercial_pet_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_pet_food", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_pet_food", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_pet_accessories",
@@ -599,7 +599,7 @@
     "id": "SUS_shelf_commercial_baby_accessories_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baby_accessories_food", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_baby_accessories_food", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_baby_hygiene",
@@ -611,7 +611,7 @@
     "id": "SUS_shelf_commercial_baby_hygiene",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baby_hygiene", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_baby_hygiene", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_office_supplies",
@@ -631,7 +631,7 @@
     "id": "SUS_shelf_commercial_office_supplies",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_office_supplies", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_office_supplies", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_electronics_accessories",
@@ -679,7 +679,7 @@
     "id": "SUS_shelf_commercial_laundry",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_household_laundry", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_household_laundry", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_household_dish_cleaning",
@@ -691,7 +691,7 @@
     "id": "SUS_shelf_commercial_dish_cleaning",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_household_dish_cleaning", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_household_dish_cleaning", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_cleaning_supplies",
@@ -703,7 +703,7 @@
     "id": "SUS_shelf_commercial_cleaning_supplies",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_cleaning_supplies", "count": [ 1, 5 ] } ]
+    "entries": [ { "group": "commercial_cleaning_supplies", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_toilet_paper",
@@ -715,7 +715,7 @@
     "id": "SUS_shelf_commercial_toilet_paper",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_toilet_paper", "count": [ 1, 5 ] } ]
+    "entries": [ { "group": "commercial_toilet_paper", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_dental_care",
@@ -727,13 +727,13 @@
     "id": "SUS_shelf_commercial_dental_care",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_dental_care", "count": [ 1, 5 ] } ]
+    "entries": [ { "group": "commercial_dental_care", "count": [ 1, 3 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_drugs",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "drugs_pharmacy", "count": [ 1, 5 ] } ]
+    "entries": [ { "group": "drugs_heal_simple", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_shower_supplies",
@@ -753,7 +753,7 @@
     "id": "SUS_shelf_commercial_shower_supplies",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_shower_supplies", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_shower_supplies", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_personal_care",
@@ -901,7 +901,7 @@
     "id": "SUS_shelf_commercial_frozen_meals",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_meals", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_frozen_meals", "count": [ 1, 4 ] } ]
   },
   {
     "id": "commercial_frozen_vegetables",
@@ -921,7 +921,7 @@
     "id": "SUS_shelf_commercial_frozen_vegetables",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_vegetables", "count": [ 1, 6 ] } ]
+    "entries": [ { "group": "commercial_frozen_vegetables", "count": [ 1, 4 ] } ]
   },
   {
     "id": "any_supermarket_SUS",

--- a/data/json/mapgen/supermarket.json
+++ b/data/json/mapgen/supermarket.json
@@ -247,24 +247,24 @@
       "toilets": { "t": {  } },
       "items": {
         "W": { "item": "SUS_janitors_closet" },
-        "H": { "item": "SUS_shelf_any", "chance": 20 },
+        "H": { "item": "SUS_shelf_any", "chance": 18 },
         "E": { "item": "SUS_commercial_chewing_gum", "chance": 50 },
         "N": { "item": "SUS_shelf_commercial_vegetables", "chance": 50 },
-        "z": { "item": "any_supermarket_SUS_freezer", "chance": 20 },
-        "Z": { "item": "any_supermarket_SUS_fridge", "chance": 20 },
-        "X": [ { "item": "SUS_shelf_commercial_meat", "chance": 20 } ],
-        "b": [ { "item": "SUS_shelf_commercial_meat", "chance": 20 } ],
+        "z": { "item": "any_supermarket_SUS_freezer", "chance": 18 },
+        "Z": { "item": "any_supermarket_SUS_fridge", "chance": 18 },
+        "X": [ { "item": "SUS_shelf_commercial_meat", "chance": 18 } ],
+        "b": [ { "item": "SUS_shelf_commercial_meat", "chance": 18 } ],
         "t": { "item": "SUS_toilet" },
         "p": { "item": "SUS_business_bookcase" },
         "f": { "item": "SUS_fridge" },
         "e": { "item": "public_sink" },
         "a": [
-          { "item": "SUS_dishes", "chance": 20 },
-          { "item": "SUS_cookware", "chance": 20 },
-          { "item": "SUS_appliances_cupboard", "chance": 20 },
-          { "item": "SUS_coffee_cupboard", "chance": 20 },
-          { "item": "SUS_breakfast_cupboard", "chance": 20 },
-          { "item": "SUS_spice_collection", "chance": 20 }
+          { "item": "SUS_dishes", "chance": 18 },
+          { "item": "SUS_cookware", "chance": 18 },
+          { "item": "SUS_appliances_cupboard", "chance": 18 },
+          { "item": "SUS_coffee_cupboard", "chance": 18 },
+          { "item": "SUS_breakfast_cupboard", "chance": 18 },
+          { "item": "SUS_spice_collection", "chance": 18 }
         ],
         "L": { "item": "fast_locker" },
         "d": { "item": "SUS_office_desk" },
@@ -297,7 +297,7 @@
         "Ù": { "chance": 13, "vehicle": "parking_garage", "rotation": 270 },
         "Ẃ": { "chance": 13, "vehicle": "truck_trailer" },
         "Ẅ": { "chance": 13, "vehicle": "semi_truck" },
-        "M": { "chance": 20, "vehicle": "forklift", "rotation": 90 },
+        "M": { "chance": 18, "vehicle": "forklift", "rotation": 90 },
         "$": { "vehicle": "shopping_cart" },
         "£": { "vehicle": "shopping_cart" },
         "¢": { "vehicle": "shopping_cart", "rotation": 90 }
@@ -317,8 +317,10 @@
         { "point": "bash", "x": [ 24, 46 ], "y": [ 46, 48 ], "repeat": [ 20, 60 ] }
       ],
       "place_monster": [
-        { "group": "GROUP_FERAL", "x": [ 10, 16 ], "y": [ 15, 16 ], "repeat": [ 6, 25 ] },
-        { "group": "GROUP_FERAL", "x": [ 10, 16 ], "y": [ 40, 42 ], "repeat": [ 2, 10 ] },
+        { "group": "GROUP_FERAL", "x": [ 10, 16 ], "y": [ 15, 16 ], "repeat": [ 4, 20 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 10, 16 ], "y": [ 15, 16 ], "repeat": [ 1, 10 ] },
+        { "group": "GROUP_FERAL", "x": [ 10, 16 ], "y": [ 40, 42 ], "repeat": [ 1, 6 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 10, 16 ], "y": [ 15, 16 ], "repeat": [ 1, 5 ] },
         { "group": "GROUP_GROCERY", "x": [ 50, 56 ], "y": [ 12, 18 ], "repeat": [ 1, 10 ], "chance": 85 },
         {
           "monster": [ "mon_grocerybot", "mon_grocerybot_busted" ],
@@ -436,7 +438,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_exotic_food", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_exotic_food", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -454,7 +456,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -472,7 +474,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_baking", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_baking", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -490,7 +492,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_vegetables", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_vegetables", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -499,7 +501,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_fruits", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_fruits", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -517,7 +519,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_meals", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_meals", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -526,7 +528,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_coffee", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_coffee", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -535,7 +537,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_tea", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_tea", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -544,7 +546,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_cereal", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_cereal", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -553,7 +555,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_mixes", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_mixes", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -562,7 +564,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_spreads", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_spreads", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -571,7 +573,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_sweet_snacks", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_sweet_snacks", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -580,7 +582,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_butter_cream", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_butter_cream", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -589,7 +591,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_yogurt", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_yogurt", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -598,7 +600,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_cheese", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_cheese", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -607,7 +609,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_milk", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_milk", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -616,7 +618,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_eggs", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_eggs", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -625,7 +627,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_deli", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_deli", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -634,7 +636,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_meat", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_meat", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -688,7 +690,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_juices", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_juices", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -697,7 +699,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_sports_drink", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_sports_drink", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -706,7 +708,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_chips", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_chips", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -715,7 +717,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_nuts_crackers", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_nuts_crackers", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -724,7 +726,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_chocolate", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_chocolate", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -733,7 +735,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_candy", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_candy", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -751,7 +753,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_pet_accessories", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_pet_accessories", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -760,7 +762,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_baby_accessories_food", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_baby_accessories_food", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -769,7 +771,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_baby_hygiene", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_baby_hygiene", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -778,7 +780,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_office_supplies", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_office_supplies", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -787,7 +789,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_electronics_accessories", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_electronics_accessories", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -796,7 +798,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_books", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_books", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -805,7 +807,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_magazines", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_magazines", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -814,7 +816,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_laundry", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_laundry", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -823,7 +825,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_dish_cleaning", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_dish_cleaning", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -832,7 +834,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_cleaning_supplies", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_cleaning_supplies", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -841,7 +843,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_toilet_paper", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_toilet_paper", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -850,7 +852,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_dental_care", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_dental_care", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -859,7 +861,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_drugs", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_drugs", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -868,7 +870,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_shower_supplies", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_shower_supplies", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -877,7 +879,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_personal_care", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_personal_care", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -886,7 +888,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_vegetables", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_vegetables", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -895,7 +897,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_fruits", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_fruits", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -904,7 +906,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_bread_specialty", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_bread_specialty", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -913,7 +915,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_bread_sweet", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_bread_sweet", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -922,7 +924,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_bread", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_bread", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -931,7 +933,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_frozen_vegetables", "x": 0, "y": 0, "chance": 20 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_frozen_vegetables", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Fix up supermarkets a bit

#### Purpose of change
Supermarkets did a lot of things in funky ways. I fixed many of them, but there are still some issues.

#### Describe the solution
- Reduce the number of ferals and add some zombies.
- Removed prescription drugs from the shelves.
- Reduced the amount of stuff on shelves by 5% across the board

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
