### PR TITLE
Remove human autopsy proficiency from combat medic

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5579,7 +5579,6 @@
       "prof_intro_biology",
       "prof_physiology",
       "prof_burn_care",
-      "prof_dissect_humans",
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",


### PR DESCRIPTION
#### Summary
Remove human autopsy proficiency from combat medic

#### Purpose of change
Combat medics had this proficiency despite the fact that the military does not train these guys to do autopsies.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
