### PR TITLE
Fishing fixes

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3623,7 +3623,9 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
                                                  3_hours ) );
         corpse.set_var( "activity_var", who.name );
         item_location loc = here.add_item_or_charges_ret_loc( who.pos_bub(), corpse );
-        who.add_msg_if_player( m_good, _( "You caught a %s." ), corpse_type.nname() );
+        if( who.is_avatar() ) {
+            popup( _( "You caught a %s." ), corpse_type.nname() );
+        }
         if( loc ) {
             who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
@@ -3684,7 +3686,7 @@ void fish_activity_actor::do_turn( player_activity &, Character &who )
     }
     // no matter the population of fish, your skill and tool limits the ease of catching.
     fish_chance = std::min( survival_skill * 10, fish_chance );
-    if( x_in_y( fish_chance, 600000 ) ) {
+    if( x_in_y( fish_chance, 500000 ) ) {
         who.add_msg_if_player( m_good, _( "You feel a tug on your line!" ) );
         rod_fish( who, fishables );
     }


### PR DESCRIPTION
#### Summary
Fishing fixes

#### Purpose of change
Fishing was a little too unrewarding, and the fact that it didn't prompt you when you caught things was making it too easy to let your catches rot.

#### Describe the solution
- You now get a popup every time you catch a fish.
- Reduce average time to catch by about 17%.

You should still be catching only around 1 fish every 2 to 3 hours if your skill is at all decent. Fishing is a light activity though so it's probably a good idea to make sure it's not always gonna be a waste of kcals.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
