### PR TITLE
Prevent placing traps in midair

### DIFF
--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -830,7 +830,7 @@
     "symbol": "[",
     "color": "dark_gray",
     "warmth": 15,
-    "material_thickness": 0.1,
+    "material_thickness": 0.08,
     "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
     "armor": [
       {

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -12,6 +12,7 @@
     "difficulty": 0,
     "action": "bubble",
     "drops": [ "bubblewrap" ],
+    "benign": true,
     "vehicle_data": { "sound_volume": 18, "sound": "Pop!" }
   },
   {
@@ -27,6 +28,7 @@
     "difficulty": 0,
     "action": "glass",
     "drops": [ "glass_shard" ],
+    "benign": true,
     "vehicle_data": { "sound_volume": 10, "sound": "Crunch!" }
   },
   {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4121,12 +4121,13 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
                                    const std::string &name ) const
 {
     if( !allow_under_player && pos == p.pos_bub() ) {
-        p.add_msg_if_player( m_info, _( "Yeah.  Place the %s at your feet.  Real damn smart move." ),
+        p.add_msg_if_player( m_info, _( "You should move before you place the %s there." ),
                              name );
         return false;
     }
     map &here = get_map();
-    if( here.move_cost( pos ) != 2 ) {
+    // !needs_solid_neighbor probably doesn't matter here, but let's assume we can put tripwires in midair.
+    if( here.move_cost( pos ) != 2 || ( here.ter( pos )->has_flag( "EMPTY_SPACE" ) && !needs_solid_neighbor ) ) {
         p.add_msg_if_player( m_info, _( "You can't place a %s there." ), name );
         return false;
     }


### PR DESCRIPTION
#### Summary
Prevent placing traps in midair

#### Purpose of change
It was possible to place traps in midair, and they'd just hover.

#### Describe the solution
- Traps can no longer be placed in midair.
- Bubble wrap and glass shards are now flagged as benign, so they will not block monster pathing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
