### PR TITLE
Fix devices not charging when plugged into appliances/grids

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14567,63 +14567,56 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
 
     if( power_in ) {
-        int available_charges = linked_veh.battery_power_level( ).first;
-        int wanted_charges = ammo_capacity( itype_battery->ammo->type ) - ammo_remaining( );
-
-        // Nothing to charge or nothing to charge with
-        if( wanted_charges == 0 || available_charges == 0 ) {
-            return link().charge_rate;
-        }
-
         if( short_time_passed ) {
-            // Single charge - subtract one from source, roll against efficiency to add one to destination
-            linked_veh.discharge_battery( here, 1, true );
-            if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
+            // Single charge: discharge from vehicle (which searches all connected batteries),
+            // check it succeeded, then roll against efficiency to add one unit to device.
+            const int deficit = linked_veh.discharge_battery( here, 1, true );
+            if( deficit == 0 && rng_float( 0.0, 1.0 ) <= link().efficiency ) {
                 ammo_set( itype_battery, ammo_remaining( ) + 1 );
             }
         } else {
-            // Multiple charges - get minimum from available charges, possible transfer in given time and
-            // amount of charges destination needs to charge itself to full with given efficiency.
-            // Subtract that value from the source and after reduction by efficiency add it to the destination.
+            // Multiple charges (catching up after time outside reality bubble):
+            // use connected_battery_power_level so grids/appliances are included,
+            // then transfer the minimum of what's possible/available/needed.
+            int available_charges = linked_veh.connected_battery_power_level( here ).first;
+            int wanted_charges = ammo_capacity( ammo_battery ) - ammo_remaining( );
+            if( wanted_charges == 0 || available_charges == 0 ) {
+                return link().charge_rate;
+            }
             int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges
+            int received_charges = spent_charges >= required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
-
+                                   : static_cast<int>( spent_charges * link().efficiency );
             linked_veh.discharge_battery( here, spent_charges, true );
             ammo_set( itype_battery, ammo_remaining( ) + received_charges );
         }
     } else {
-        const auto [bat_remaining, bat_capacity] = linked_veh.battery_power_level( );
-        int available_charges = ammo_remaining( );
-        int wanted_charges = bat_capacity - bat_remaining;
-
-        // Nothing to charge or nothing to charge with
-        if( wanted_charges == 0 || available_charges == 0 ) {
-            return link().charge_rate;
-        }
-
         if( short_time_passed ) {
-            // Single charge - subtract one from source, roll against efficiency to add one to destination
-            ammo_set( itype_battery, ammo_remaining( ) - 1 );
+            // Single charge: roll efficiency first, then attempt to push one unit into vehicle.
             if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
-                linked_veh.charge_battery( here, 1, true );
+                const int surplus = linked_veh.charge_battery( here, 1, true );
+                if( surplus == 0 ) {
+                    ammo_set( itype_battery, ammo_remaining( ) - 1 );
+                }
             }
         } else {
-            // Multiple charges - get minimum from available charges, possible transfer in given time and
-            // amount of charges destination needs to charge itself to full with given efficiency.
-            // Subtract that value from the source and after reduction by efficiency add it to the destination.
+            // Multiple charges (catching up after time outside reality bubble).
+            const auto [bat_remaining, bat_capacity] = linked_veh.connected_battery_power_level( here );
+            int available_charges = ammo_remaining( );
+            int wanted_charges = bat_capacity - bat_remaining;
+            if( wanted_charges == 0 || available_charges == 0 ) {
+                return link().charge_rate;
+            }
             int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges
+            int received_charges = spent_charges >= required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
-
+                                   : static_cast<int>( spent_charges * link().efficiency );
             ammo_set( itype_battery, ammo_remaining( ) - spent_charges );
             linked_veh.charge_battery( here, received_charges, true );
         }


### PR DESCRIPTION
## Summary

`db5d95ac` replaced the per-turn charging path in `charge_linked_batteries()` with a pre-check using `battery_power_level()`, which only looks at the connected vehicle's **own** battery parts. When a device is plugged into an appliance or cable port with no local batteries (e.g. a recharging station wired into a grid), the check returns 0 and the function exits early — so the device never gains charge. Meanwhile `ammo_consume()` uses `discharge_battery()` which searches the full connected grid, so the device doesn't drain either. Result: charge frozen, never rising.

Changes:
- **`short_time_passed` + `power_in`**: restore the original logic — call `discharge_battery()` and only credit the device if `deficit == 0`. `discharge_battery()` uses `search_connected_batteries()` internally so it correctly finds power across appliances and grids.
- **`short_time_passed` + `!power_in`**: fix a secondary bug introduced by `db5d95ac` where the device was always drained even if the vehicle couldn't accept the charge (full battery). Now only deducts if `surplus == 0`.
- **`long_time_passed` paths**: replace `battery_power_level()` with `connected_battery_power_level()` for the same grid-visibility reason.

## Test plan

- [ ] Plug tablet/laptop into a vehicle with batteries — internal battery should charge over time
- [ ] Plug tablet/laptop into an appliance connected to a power grid — should also charge
- [ ] Drain device fully, plug in — should recover from 0
- [ ] Device discharging into a vehicle (`power_in = false`) — vehicle battery should gain charge, device should only lose charge if vehicle accepted it