### PR TITLE
Fix harvesting for fruit

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -25,6 +25,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "dandelion_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -40,6 +41,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [
       { "seasons": [ "spring", "autumn" ], "id": "burdock_harv" },
       { "seasons": [ "summer" ], "id": "burdock_summer_harv" }
@@ -73,6 +75,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer" ], "id": "wild_carrot_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -88,6 +91,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "autumn", "winter" ], "id": "m_stellatum_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -103,6 +107,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "//": "Root can always be harvested, but there is no flower to harvest seeds from in winter.",
     "harvest_by_season": [
       { "seasons": [ "summer", "autumn" ], "id": "salsify_seed_harv" },
@@ -138,6 +143,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -153,6 +159,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "spurge_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -187,6 +194,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "//": "Add flower and bud spawns once useful.",
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
@@ -203,6 +211,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "//": "Add flower and bud spawns once useful.",
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
@@ -219,6 +228,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [
       { "seasons": [ "spring", "summer", "autumn" ], "id": "lotus_harv" },
       { "seasons": [ "summer" ], "id": "lotus_summer_harv" },
@@ -239,6 +249,7 @@
     "required_str": -1,
     "coverage": 5,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "sunflower_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -254,6 +265,7 @@
     "required_str": -1,
     "coverage": 5,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "autumn", "winter" ], "id": "jerusalem_artichoke_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -284,6 +296,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "bluebell_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -314,6 +327,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "chicory_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -329,6 +343,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC", "GRAZER_INEDIBLE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "datura_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -385,6 +400,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "wild_sarsaparilla_harv" } ],
     "bash": {
       "str_min": 2,
@@ -407,6 +423,7 @@
     "required_str": -1,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "autumn", "winter" ], "id": "wintergreen_harv" } ],
     "bash": {
       "str_min": 2,
@@ -429,6 +446,7 @@
     "concealment": 50,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "SHORT", "SHRUB", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring" ], "id": "japanese_knotweed_harv" } ],
     "bash": {
       "str_min": 2,
@@ -450,6 +468,7 @@
     "color": [ "brown_green", "magenta", "magenta", "brown" ],
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [
       { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" },
       { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" }
@@ -474,6 +493,7 @@
     "move_cost_mod": 0,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [
       { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" },
       { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" }
@@ -520,6 +540,7 @@
     "move_cost_mod": 0,
     "coverage": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "thistle_harv" } ],
     "bash": {
       "str_min": 2,
@@ -562,6 +583,7 @@
     "concealment": 45,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "FLAT", "THIN_OBSTACLE", "SHRUB", "SMALL_HIDE" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "wild_rice_harv" } ],
     "bash": {
       "str_min": 2,

--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -418,6 +418,7 @@
     "move_cost": 0,
     "roof": "t_treetop",
     "transforms_into": "t_tree_basswood_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "spring" ], "id": "young_leaves_harv" } ],
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "bash": {
@@ -651,6 +652,7 @@
     "move_cost": 0,
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_apple_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "apple_harv" } ],
     "bash": {
       "str_min": 80,
@@ -705,6 +707,7 @@
     "move_cost": 0,
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_crabapple_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "crabapple_harv" } ],
     "bash": {
       "str_min": 80,
@@ -759,6 +762,7 @@
     "move_cost": 0,
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_pear_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "pear_harv" } ],
     "bash": {
       "str_min": 80,
@@ -813,6 +817,7 @@
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_coffee_harvested",
     "looks_like": "t_tree_plum",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "coffee_harv" } ],
     "bash": {
       "str_min": 80,
@@ -867,6 +872,7 @@
     "roof": "t_treetop_fruit",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_cherry_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "cherry_harv" } ],
     "bash": {
       "str_min": 80,
@@ -921,6 +927,7 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_juniper_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "juniper_harv" } ],
     "bash": {
       "str_min": 80,
@@ -967,6 +974,7 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_peach_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "peach_harv" } ],
     "bash": {
       "str_min": 80,
@@ -1021,6 +1029,7 @@
     "roof": "t_treetop_fruit",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_apricot_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "apricot_harv" } ],
     "bash": {
       "str_min": 80,
@@ -1075,6 +1084,7 @@
     "roof": "t_treetop_fruit",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_plum_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "plum_harv" } ],
     "bash": {
       "str_min": 80,
@@ -1128,6 +1138,7 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_mulberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_tree_apple",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "mulberry_harv" } ],
     "bash": {
@@ -1182,6 +1193,7 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "REDUCE_SCENT", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_tupelo_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_tree_plum",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "tupelo_harv" } ],
     "bash": {
@@ -1235,6 +1247,7 @@
     "coverage": 70,
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "TREE", "REDUCE_SCENT", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_nannyberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_tree_plum",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "nannyberry_harv" } ],
     "bash": {
@@ -1288,6 +1301,7 @@
     "roof": "t_treetop",
     "flags": [ "FLAMMABLE", "NOITEM", "SUPPORTS_ROOF", "TREE", "BROWSABLE", "CLIMB_ADJACENT" ],
     "transforms_into": "t_tree_elderberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_tree_plum",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "elderberry_harv" } ],
     "bash": {
@@ -2286,6 +2300,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_peanut_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_peanut_harv" } ],
     "bash": {
       "str_min": 4,
@@ -2339,6 +2354,7 @@
     "coverage": 60,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_autumn_olive_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_autumn_olive_harv" } ],
     "bash": {
       "str_min": 4,
@@ -2391,6 +2407,7 @@
     "coverage": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_hobblebush_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_hobblebush_harv" } ],
     "bash": {
       "str_min": 4,
@@ -2444,6 +2461,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_blueberry_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_blueberry_harv" } ],
     "bash": {
       "str_min": 4,
@@ -2497,6 +2515,7 @@
     "coverage": 5,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "BROWSABLE" ],
     "transforms_into": "t_shrub_strawberry_harvested",
+    "examine_action": "harvest_ter",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_strawberry_harv" } ],
     "bash": {
       "str_min": 4,
@@ -2549,6 +2568,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SHARP", "BROWSABLE" ],
     "transforms_into": "t_shrub_blackberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_blueberry",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_blackberry_harv" } ],
     "bash": {
@@ -2603,6 +2623,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_huckleberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_blueberry",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_huckleberry_harv" } ],
     "bash": {
@@ -2657,6 +2678,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SHARP", "BROWSABLE" ],
     "transforms_into": "t_shrub_raspberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_strawberry",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_raspberry_harv" } ],
     "bash": {
@@ -2711,6 +2733,7 @@
     "concealment": 20,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_grape_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_blueberry",
     "harvest_by_season": [ { "seasons": [ "summer" ], "id": "shrub_grape_harv" } ],
     "bash": {
@@ -2764,6 +2787,7 @@
     "coverage": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_spicebush_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_blueberry",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_spicebush_harv" } ],
     "bash": {
@@ -2816,6 +2840,7 @@
     "coverage": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE", "BROWSABLE" ],
     "transforms_into": "t_shrub_chokeberry_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_blueberry",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_chokeberry_harv" } ],
     "bash": {
@@ -2869,6 +2894,7 @@
     "concealment": 10,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SHARP", "BROWSABLE" ],
     "transforms_into": "t_shrub_rose_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub_strawberry",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "shrub_rose_harv" } ],
     "//": "Insert rose (flower) harvest in summer once flowers have a use (same for other generic flowers).",
@@ -2924,6 +2950,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE" ],
     "transforms_into": "t_shrub_hydrangea_harvested",
+    "examine_action": "harvest_ter",
     "fall_damage_reduction": 5,
     "looks_like": "t_shrub",
     "bash": {
@@ -2980,6 +3007,7 @@
     "concealment": 40,
     "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "THIN_OBSTACLE", "SHRUB", "SHORT", "SMALL_HIDE" ],
     "transforms_into": "t_shrub_lilac_harvested",
+    "examine_action": "harvest_ter",
     "looks_like": "t_shrub",
     "bash": {
       "str_min": 4,


### PR DESCRIPTION
#### Summary
Fix harvesting for fruit

#### Purpose of change
Fruit harvesting was broken for some plants after the nectar removal thing.

#### Describe the solution
fix

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
