### PR TITLE
Fix stealing warning blocking loot from hostile faction NPCs

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6863,6 +6863,11 @@ std::unique_ptr<activity_actor> haircut_activity_actor::deserialize( JsonValue &
 static bool check_stealing( Character &who, item &it )
 {
     if( !it.is_owned_by( who, true ) ) {
+        // Don't flag taking items from hostile factions as stealing.
+        const faction *owner_fac = g->faction_manager_ptr->get( it.get_owner(), false );
+        if( owner_fac && owner_fac->likes_u < -10 ) {
+            return true;
+        }
         // Has the player given input on if stealing is ok?
         if( who.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
             Pickup::query_thief();

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -14,6 +14,7 @@
 #include "colony.h"
 #include "debug.h"
 #include "enums.h"
+#include "faction.h"
 #include "game.h"
 #include "input.h"
 #include "input_context.h"
@@ -197,12 +198,16 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
     }
 
     if( !newit.is_owned_by( player_character, true ) ) {
-        // Has the player given input on if stealing is ok?
-        if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            Pickup::query_thief();
-        }
-        if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
-            return true; // Since we are honest, return no problem before picking up
+        // Don't flag taking items from hostile factions as stealing.
+        const faction *owner_fac = g->faction_manager_ptr->get( newit.get_owner(), false );
+        if( !owner_fac || owner_fac->likes_u >= -10 ) {
+            // Has the player given input on if stealing is ok?
+            if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
+                Pickup::query_thief();
+            }
+            if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
+                return true; // Since we are honest, return no problem before picking up
+            }
         }
     }
     if( newit.invlet != '\0' &&


### PR DESCRIPTION
## Summary

- Items on NPCs are assigned to their faction at spawn via `set_owner`. After the NPC dies, items retain faction ownership.
- When `THIEF_MODE` is set to never steal, the stealing check blocked pickup of any faction-owned item, including loot from dead enemies.
- Fixed by skipping the stealing check in both pickup code paths when the item's owner faction has `likes_u < -10` (the existing `guaranteed_hostile` threshold). Looting dead enemies is now always permitted regardless of `THIEF_MODE`.

## Test plan

- [ ] Kill a hostile faction NPC (e.g. raiders from Missing Caravan quest)
- [ ] Verify items can be looted with `THIEF_MODE` set to never steal
- [ ] Verify stealing warning still triggers when taking items from neutral/friendly faction NPCs