### PR TITLE
Foraging difficulty varies by item

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -41,7 +41,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -89,7 +90,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -116,7 +118,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -141,7 +144,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -168,7 +172,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -193,7 +198,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -220,7 +226,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -245,7 +252,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -272,7 +280,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -297,7 +306,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -324,7 +334,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -349,7 +360,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -376,7 +388,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -401,7 +414,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -428,7 +442,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -453,7 +468,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -481,7 +497,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -507,7 +524,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -531,7 +549,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -548,7 +567,6 @@
     "move_cost": 0,
     "roof": "t_treetop_dead",
     "examine_action": "harvest_ter",
-    "//": "gives a maximum of ~15L and ~8.5kg of wood between sticks and twigs",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn", "winter" ], "id": "tree_dead_harv" } ],
     "transforms_into": "t_tree_very_dead",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "TREE", "CLIMB_ADJACENT" ],
@@ -611,7 +629,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 0, 5 ] },
+        { "item": "stick_long", "count": [ 0, 3 ] },
+        { "item": "stick", "count": [ 0, 3 ] },
         { "item": "splinter", "count": [ 0, 4 ] },
         { "item": "twig", "count": [ 2, 7 ] },
         { "item": "leaves", "count": [ 5, 20 ] }
@@ -661,7 +680,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -688,7 +708,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -716,7 +737,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -743,7 +765,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -771,7 +794,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -798,7 +822,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -826,7 +851,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -853,7 +879,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -881,7 +908,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -908,7 +936,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -983,7 +1012,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1010,7 +1040,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1038,7 +1069,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1065,7 +1097,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1093,7 +1126,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1120,7 +1154,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1148,7 +1183,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1175,7 +1211,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1203,7 +1240,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1230,7 +1268,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1257,7 +1296,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1283,7 +1323,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1311,7 +1352,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1338,7 +1380,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1468,7 +1511,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1493,7 +1537,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1519,7 +1564,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1544,7 +1590,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1572,7 +1619,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1597,7 +1645,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1622,7 +1671,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1647,7 +1697,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1671,7 +1722,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1695,7 +1747,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1719,7 +1772,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1747,7 +1801,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1774,7 +1829,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1802,7 +1858,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1828,7 +1885,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1856,7 +1914,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1882,7 +1941,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1910,7 +1970,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1936,7 +1997,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -1984,7 +2046,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]
@@ -2011,7 +2074,8 @@
       "sound_fail": "whack!",
       "ter_set": "t_dirt",
       "items": [
-        { "item": "stick_long", "count": [ 3, 10 ] },
+        { "item": "stick_long", "count": [ 1, 4 ] },
+        { "item": "stick", "count": [ 1, 3 ] },
         { "item": "splinter", "count": [ 10, 25 ] },
         { "item": "leaves", "count": [ 50, 150 ] }
       ]

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -12,63 +12,72 @@
   {
     "id": "generic_flower_harv",
     "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 0, 2 ] } ]
+    "entries": [
+      { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 5 },
+      { "drop": "seed_flower", "base_num": [ 0, 2 ], "difficulty": 8 }
+    ]
   },
   {
     "id": "plant_dead_harv",
     "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] } ]
+    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 5 } ]
   },
   {
     "id": "dandelion_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raw_dandelion", "base_num": [ 1, 4 ] } ]
+    "entries": [ { "drop": "raw_dandelion", "base_num": [ 1, 4 ], "difficulty": 8 } ]
   },
   {
     "id": "burdock_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raw_burdock", "base_num": [ 1, 4 ] } ]
+    "entries": [ { "drop": "raw_burdock", "base_num": [ 1, 4 ], "difficulty": 8 } ]
   },
   {
     "id": "burdock_summer_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raw_burdock", "base_num": [ 1, 4 ] }, { "drop": "plant_stalk", "base_num": [ 1, 4 ] } ]
+    "entries": [
+      { "drop": "raw_burdock", "base_num": [ 1, 4 ], "difficulty": 8 },
+      { "drop": "plant_stalk", "base_num": [ 1, 4 ], "difficulty": 6 }
+    ]
   },
   {
     "id": "thistle_harv",
     "type": "harvest",
-    "entries": [ { "drop": "plant_stalk", "base_num": [ 1, 2 ] } ]
+    "entries": [ { "drop": "plant_stalk", "base_num": [ 1, 2 ], "difficulty": 8 } ]
   },
   {
     "id": "salsify_harv",
     "type": "harvest",
-    "entries": [ { "drop": "salsify_raw" } ]
+    "entries": [ { "drop": "salsify_raw", "difficulty": 8 } ]
   },
   {
     "id": "m_stellatum_harv",
     "type": "harvest",
-    "entries": [ { "drop": "m_stellatum_berries", "base_num": [ 1, 3 ] } ]
+    "entries": [ { "drop": "m_stellatum_berries", "base_num": [ 1, 3 ], "difficulty": 6 } ]
   },
   {
     "id": "wild_carrot_harv",
     "type": "harvest",
-    "entries": [ { "drop": "carrot_wild" } ]
+    "entries": [ { "drop": "carrot_wild", "difficulty": 6 } ]
   },
   {
     "id": "beehive_harv",
     "type": "harvest",
     "message": "You carefully crack open the hive structure and drain the liquid.",
-    "entries": [ { "drop": "honeycomb", "base_num": [ 10, 40 ] }, { "drop": "wax", "base_num": [ 4, 5 ] } ]
+    "entries": [
+      { "drop": "honeycomb", "base_num": [ 10, 40 ], "difficulty": 0 },
+      { "drop": "wax", "base_num": [ 4, 5 ], "difficulty": 0 }
+    ]
   },
   {
     "id": "jerusalem_artichoke_harv",
     "type": "harvest",
-    "entries": [ { "drop": "jerusalem_artichoke", "base_num": [ 1, 3 ] } ]
+    "entries": [ { "drop": "jerusalem_artichoke", "base_num": [ 1, 3 ], "difficulty": 8 } ]
   },
   {
     "id": "wild_sarsaparilla_harv",
     "type": "harvest",
-    "entries": [ { "drop": "wild_sarsaparilla_root" } ]
+    "entries": [ { "drop": "wild_sarsaparilla_root", "difficulty": 8 } ]
   },
   {
     "id": "salsify_seed_harv",
@@ -78,36 +87,43 @@
   {
     "id": "chamomille_harv",
     "type": "harvest",
-    "entries": [ { "drop": "chamomile", "base_num": [ 4, 8 ] } ]
+    "entries": [ { "drop": "chamomile", "base_num": [ 1, 8 ], "difficulty": 5 } ]
   },
   {
     "id": "spurge_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "withered", "base_num": [ 1, 2 ] },
+      { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 3 },
       { "drop": "seed_spurge", "base_num": [ 1, 2 ] },
-      { "drop": "spurge", "base_num": [ 1, 4 ] }
+      { "drop": "spurge", "base_num": [ 1, 4 ], "difficulty": 6 }
     ]
   },
   {
     "id": "sunflower_harv",
     "type": "harvest",
-    "entries": [ { "drop": "sunflower" } ]
+    "entries": [ { "drop": "sunflower", "difficulty": 8 } ]
   },
   {
     "id": "cattails_winter_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cattail_rhizome" } ]
+    "entries": [ { "drop": "cattail_rhizome" }, { "drop": "withered", "base_num": [ 1, 5 ], "difficulty": 3 } ]
   },
   {
     "id": "cattails_summer_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cattail_rhizome", "base_num": [ 0, 1 ] }, { "drop": "cattail_stalk", "base_num": [ 1, 4 ] } ]
+    "entries": [
+      { "drop": "cattail_rhizome", "base_num": [ 0, 1 ] },
+      { "drop": "cattail_stalk", "base_num": [ 1, 4 ], "difficulty": 6 },
+      { "drop": "withered", "base_num": [ 1, 3 ], "difficulty": 3 }
+    ]
   },
   {
     "id": "lotus_harv",
     "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "lotus", "base_num": [ 1, 2 ] } ]
+    "entries": [
+      { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 3 },
+      { "drop": "lotus", "base_num": [ 1, 2 ], "difficulty": 6 }
+    ]
   },
   {
     "id": "lotus_summer_harv",
@@ -122,15 +138,15 @@
     "id": "lotus_autumn_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "withered", "base_num": [ 1, 2 ] },
-      { "drop": "lotus", "base_num": [ 1, 2 ] },
+      { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 2 },
+      { "drop": "lotus", "base_num": [ 1, 2 ], "difficulty": 8 },
       { "drop": "lotus_rhizome", "base_num": [ 1, 2 ] }
     ]
   },
   {
     "id": "bluebell_harv",
     "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
+    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ], "difficulty": 4 }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
   },
   {
     "id": "chicory_harv",
@@ -154,12 +170,12 @@
     "id": "walnut_harv",
     "type": "harvest",
     "//": "Walnut trees can have insane harvests compared to other nuts.",
-    "entries": [ { "drop": "walnut", "base_num": [ 1, 8 ], "scale_num": [ 0, 0.5 ] } ]
+    "entries": [ { "drop": "walnut", "base_num": [ 1, 8 ], "scale_num": [ 0, 0.5 ], "difficulty": 8 } ]
   },
   {
     "id": "butternut_harv",
     "type": "harvest",
-    "entries": [ { "drop": "butternut", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "butternut", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "fern_harv",
@@ -169,22 +185,22 @@
   {
     "id": "bamboo_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raw_bamboo", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "raw_bamboo", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_rose_harv",
     "type": "harvest",
-    "entries": [ { "drop": "rose_hips", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "rose_hips", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_autumn_olive_harv",
     "type": "harvest",
-    "entries": [ { "drop": "autumn_olive", "base_num": [ 1, 7 ], "scale_num": [ 0, 0.5 ] } ]
+    "entries": [ { "drop": "autumn_olive", "base_num": [ 1, 7 ], "scale_num": [ 0, 0.5 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_chokeberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "chokeberries", "base_num": [ 1, 7 ], "scale_num": [ 0, 0.5 ] } ]
+    "entries": [ { "drop": "chokeberries", "base_num": [ 1, 7 ], "scale_num": [ 0, 0.5 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_spicebush_harv",
@@ -195,34 +211,34 @@
     "id": "shrub_grape_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "grapes", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] },
+      { "drop": "grapes", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 },
       { "drop": "grape_leaves", "base_num": [ 1, 4 ] }
     ]
   },
   {
     "id": "shrub_raspberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raspberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "raspberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_huckleberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "huckleberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "huckleberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_blackberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "blackberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "blackberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_strawberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "strawberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "strawberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_blueberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "blueberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "blueberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "shrub_hobblebush_harv",
@@ -238,220 +254,224 @@
     "id": "pecan_harv",
     "type": "harvest",
     "//": "We are at the edge of the plant's range, so yields are poor.",
-    "entries": [ { "drop": "pecan", "base_num": [ 0, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "pecan", "base_num": [ 0, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "almond_harv",
     "type": "harvest",
     "//": "We are outside this plant's range, so yields are very poor.",
-    "entries": [ { "drop": "almond", "base_num": [ 0, 1 ] } ]
+    "entries": [ { "drop": "almond", "base_num": [ 0, 1 ], "difficulty": 8 } ]
   },
   {
     "id": "pistachio_harv",
     "type": "harvest",
     "//": "We are outside this plant's range, so yields are very poor.",
-    "entries": [ { "drop": "pistachio", "base_num": [ 0, 1 ] } ]
+    "entries": [ { "drop": "pistachio", "base_num": [ 0, 1 ], "difficulty": 8 } ]
   },
   {
     "id": "hickory_harv",
     "type": "harvest",
-    "entries": [ { "drop": "hickory_nut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "hickory_nut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "willow_harv",
     "type": "harvest",
-    "entries": [ { "drop": "willowbark", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "willowbark", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 6 } ]
   },
   {
     "id": "birch_harv",
     "type": "harvest",
-    "entries": [ { "drop": "birchbark", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "birchbark", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "tree_dead_harv",
     "type": "harvest",
-    "entries": [ { "drop": "stick", "base_num": [ 2, 5 ] }, { "drop": "twig", "base_num": [ 6, 20 ] } ]
+    "entries": [
+      { "drop": "stick", "base_num": [ 1, 5 ], "difficulty": 2 },
+      { "drop": "twig", "base_num": [ 4, 10 ], "difficulty": 2 }
+    ]
   },
   {
     "id": "pine_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "pine_bough", "base_num": [ 2, 8 ] },
-      { "drop": "pinecone", "base_num": [ 1, 3 ] },
+      { "drop": "pine_bough", "base_num": [ 1, 6 ], "difficulty": 3 },
+      { "drop": "stick", "base_num": [ 0, 3 ], "difficulty": 2 },
+      { "drop": "pinecone", "base_num": [ 0, 3 ], "difficulty": 3 },
       { "drop": "pine_resin", "base_num": [ 1, 3 ] }
     ]
   },
   {
     "id": "elderberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "elderberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "elderberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "nannyberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "nannyberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "nannyberries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "tupelo_harv",
     "type": "harvest",
-    "entries": [ { "drop": "tupelo_fruit", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "tupelo_fruit", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "mulberry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "mulberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "mulberries", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "plum_harv",
     "type": "harvest",
-    "entries": [ { "drop": "plums", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "plums", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "apricot_harv",
     "type": "harvest",
-    "entries": [ { "drop": "apricot", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "apricot", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "peach_harv",
     "type": "harvest",
-    "entries": [ { "drop": "peach", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "peach", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "juniper_harv",
     "type": "harvest",
-    "entries": [ { "drop": "juniper", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "juniper", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "cherry_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cherries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "cherries", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "coffee_harv",
     "type": "harvest",
-    "entries": [ { "drop": "coffee_pod", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "coffee_pod", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "pear_harv",
     "type": "harvest",
-    "entries": [ { "drop": "pear", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "pear", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "apple_harv",
     "type": "harvest",
-    "entries": [ { "drop": "apple", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "apple", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "crabapple_harv",
     "type": "harvest",
-    "entries": [ { "drop": "crabapple", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "crabapple", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "sassafras_harv",
     "type": "harvest",
-    "entries": [ { "drop": "sassafras_root", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "sassafras_root", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "oak_harv",
     "type": "harvest",
     "//": "Acorn production varies wildly by year.",
-    "entries": [ { "drop": "acorns", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "acorns", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "cottonwood_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cottonwood_tree_boll", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.5 ] } ]
+    "entries": [ { "drop": "cottonwood_tree_boll", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.5 ], "difficulty": 8 } ]
   },
   {
     "id": "beech_harv",
     "type": "harvest",
-    "entries": [ { "drop": "beech_nuts", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "beech_nuts", "base_num": [ 1, 6 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "hazelnut_harv",
     "type": "harvest",
-    "entries": [ { "drop": "hazelnut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "hazelnut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "chestnut_harv",
     "type": "harvest",
-    "entries": [ { "drop": "chestnut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "chestnut", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "blackjack_harv",
     "type": "harvest",
-    "entries": [ { "drop": "tanbark", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "tanbark", "base_num": [ 1, 4 ], "scale_num": [ 0, 0.3 ], "difficulty": 6 } ]
   },
   {
     "id": "alder_harv",
     "type": "harvest",
-    "entries": [ { "drop": "alder_bark", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ] } ]
+    "entries": [ { "drop": "alder_bark", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ], "difficulty": 6 } ]
   },
   {
     "id": "young_leaves_harv",
     "type": "harvest",
-    "entries": [ { "drop": "young_leaves", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "young_leaves", "base_num": [ 1, 5 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "generic_edible_flower_spring_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "young_leaves", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ] },
-      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ] },
-      { "drop": "plant_stalk", "base_num": [ 0, 1 ] },
-      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ] }
+      { "drop": "young_leaves", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ], "difficulty": 8 },
+      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ], "difficulty": 3 },
+      { "drop": "plant_stalk", "base_num": [ 0, 1 ], "difficulty": 6 },
+      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ], "difficulty": 6 }
     ]
   },
   {
     "id": "generic_edible_flower_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ] },
-      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ] }
+      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ], "difficulty": 3 },
+      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ], "difficulty": 6 }
     ]
   },
   {
     "id": "dogbane_harv",
     "type": "harvest",
-    "entries": [ { "drop": "dogbane", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ] } ]
+    "entries": [ { "drop": "dogbane", "base_num": [ 1, 3 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 } ]
   },
   {
     "id": "japanese_knotweed_harv",
     "type": "harvest",
-    "entries": [ { "drop": "japanese_knotweed_stem", "base_num": [ 1, 2 ] } ]
+    "entries": [ { "drop": "japanese_knotweed_stem", "base_num": [ 1, 2 ], "difficulty": 8 } ]
   },
   {
     "id": "wild_rice_harv",
     "type": "harvest",
-    "entries": [ { "drop": "wild_rice", "base_num": [ 2, 4 ] } ]
+    "entries": [ { "drop": "wild_rice", "base_num": [ 2, 4 ], "difficulty": 8 } ]
   },
   {
     "id": "wintergreen_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "wintergreen_berry", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] },
-      { "drop": "wintergreen_leaves", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ] }
+      { "drop": "wintergreen_berry", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ], "difficulty": 8 },
+      { "drop": "wintergreen_leaves", "base_num": [ 1, 2 ], "scale_num": [ 0, 0.3 ], "difficulty": 3 }
     ]
   },
   {
     "id": "seaweed_harv",
     "type": "harvest",
-    "entries": [ { "drop": "seaweed" } ]
+    "entries": [ { "drop": "seaweed", "difficulty": 3 } ]
   },
   {
     "id": "kelp_sugar_harv",
     "type": "harvest",
-    "entries": [ { "drop": "kelp_sugar" } ]
+    "entries": [ { "drop": "kelp_sugar", "difficulty": 8 } ]
   },
   {
     "id": "bladderwrack_harv",
     "type": "harvest",
-    "entries": [ { "drop": "bladderwrack" } ]
+    "entries": [ { "drop": "bladderwrack", "difficulty": 8 } ]
   },
   {
     "id": "sea_lettuce_harv",
     "type": "harvest",
-    "entries": [ { "drop": "sea_lettuce" } ]
+    "entries": [ { "drop": "sea_lettuce", "difficulty": 8 } ]
   },
   {
     "id": "fish_tiny",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4938,15 +4938,18 @@ void harvest_activity_actor::finish( player_activity &act, Character &who )
     const float survival_skill = who.get_skill_level( skill_survival );
     bool got_anything = false;
     for( const harvest_entry &entry : here.get_harvest( target ).obj() ) {
-        int forage_roll = rng( 0, 49 );
+        /* Assuming perfect visibility and 10 perception, entry.difficulty is the
+           survival skill that would be required to reach the cap. 0 entry.difficulty
+           bypasses the hard cap. */
+        int difficulty = entry.difficulty * 3 + 13;
+        int forage_roll = rng( 0, difficulty );
         const float min_num = entry.scale_num.first * survival_skill + entry.base_num.first;
         const float max_num = entry.scale_num.second * survival_skill + entry.base_num.second;
         int vision_factor = std::clamp( 5 - static_cast<int>( std::floor( who.fine_detail_vision_mod() ) ),
                                         -4, 4 );
         const int roll = std::min<int>( entry.max, std::round( rng_float( min_num, max_num ) ) );
-        got_anything = ( std::min( ( survival_skill * 3 + ( who.per_cur + vision_factor ) ),
-                                   42.0f ) > forage_roll ) &&
-                       ( roll > 0 );
+        got_anything |= ( ( survival_skill * 3 + ( who.get_vision_per() + vision_factor ) ) > forage_roll )
+                        && roll > 0 && ( entry.difficulty == 0 || rng( 0, 49 ) < 40 );
         if( got_anything ) {
             for( int i = 0; i < roll; i++ ) {
                 iexamine_helper::handle_harvest( who, entry.drop, false );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4685,16 +4685,27 @@ int Character::get_arm_str() const
     return str_cur * get_modifier( character_modifier_limb_str_mod );
 }
 
-int Character::spot_check() const
+int Character::get_vision_per() const
 {
     float vision_score = get_limb_score( limb_score_vision );
+    // FIXME: We shouldn't use fine_detail_vision here as full night vis chars still need to be checking NV.
     if( fine_detail_vision_mod() > 4 ) {
         vision_score = std::min( get_limb_score( limb_score_vision ),
                                  get_limb_score( limb_score_night_vis ) );
     }
-    return ( Character::get_per() + int( Character::has_proficiency(
-            proficiency_prof_spotting ) ) *
-             Character::get_per_base() ) * vision_score ;
+    return Character::get_per() * vision_score;
+}
+
+int Character::spot_check() const
+{
+    float vision_score = get_limb_score( limb_score_vision );
+    if( fine_detail_vision_mod() > 4 ) {
+        // FIXME: We shouldn't use fine_detail_vision here as full night vis chars still need to be checking NV.
+        vision_score = std::min( get_limb_score( limb_score_vision ),
+                                 get_limb_score( limb_score_night_vis ) );
+    }
+    return ( get_per() + int( has_proficiency(
+                                  proficiency_prof_spotting ) ) * get_per_base() ) * vision_score;
 }
 
 int Character::ranged_dex_mod() const

--- a/src/character.h
+++ b/src/character.h
@@ -683,6 +683,8 @@ class Character : public Creature, public visitable
         int get_enchantment_speed_bonus() const;
         // Strength modified by limb lifting score
         int get_arm_str() const;
+        // Perception modified by vision score (or NV, if it's dark).
+        int get_vision_per() const;
         // Defines distance from which CAMOUFLAGE mobs are visible
         int spot_check() const override;
 

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -146,6 +146,7 @@ void harvest_entry::load( const JsonObject &jo )
     optional( jo, was_loaded, "type", type, harvest_drop_type_id::NULL_ID() );
     optional( jo, was_loaded, "base_num", base_num, { 1.0f, 1.0f } );
     optional( jo, was_loaded, "scale_num", scale_num, { 0.0f, 0.0f } );
+    optional( jo, was_loaded, "difficulty", difficulty, 10 );
     optional( jo, was_loaded, "max", max, 1000 );
     optional( jo, was_loaded, "mass_ratio", mass_ratio, 0.00f );
     optional( jo, was_loaded, "flags", flags );
@@ -173,6 +174,7 @@ class harvest_entry_reader : public generic_typed_reader<harvest_entry_reader>
             optional( jo, false, "type", ret.type, harvest_drop_type_id::NULL_ID() );
             optional( jo, false, "base_num", ret.base_num, { 1.0f, 1.0f } );
             optional( jo, false, "scale_num", ret.scale_num, { 0.0f, 0.0f } );
+            optional( jo, false, "difficulty", ret.difficulty, 10 );
             optional( jo, false, "max", ret.max, 1000 );
             optional( jo, false, "mass_ratio", ret.mass_ratio, 0.00f );
             optional( jo, false, "flags", ret.flags );

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -78,6 +78,10 @@ struct harvest_entry {
     // This is multiplied by survival and added to the above
     // TODO: Make it a map: skill->scaling
     std::pair<float, float> scale_num = { 0.0f, 0.0f };
+    /* Assuming perfect visibility and 10 perception, entry.difficulty is the
+       survival skill that would be required to reach the cap. We can and should
+       set it above 10 for hard-to-find items. 0 difficulty allows 100% harvest rates. */
+    int difficulty = 10;
 
     int max = 1000;
     harvest_drop_type_id type;


### PR DESCRIPTION
#### Summary
Foraging difficulty varies by item

#### Purpose of change
Foraging difficulty (picking wild plants, not underbrush, which is a separate thing) was a bit overtuned, and was being equally applied to all possible results, meaning twigs were as hard to find as fruits.

#### Describe the solution
- Individual drops in harvest.json can now have their own difficulty set. By default, this is set to 10, which is the same probability as before.
- Difficulty is an integer that represents the survival skill required to reach the success cap (it's like 80%) at 10 perception with full visibility and vision scores.
- Vision scores now impact your effective perception.
- Most forageables, including edibles, are now a bit easier to collect.
- Basic items like sticks, dead plants, etc. are now WAY easier to collect.
- Cattails now yield more dead plants in winter. Outside of winter, they can still yield some (before, they never would).
- Updated the bash results so trees drop regular sticks too instead of just long ones if they get somehow smashed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
