### PR TITLE
No disassembling worn items

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6008,6 +6008,11 @@ static bool check_if_disassemble_okay( item_location target, Character &who )
 {
     item *disassembly = target.get_item();
 
+    if( who.is_worn( *disassembly ) ) {
+        who.add_msg_if_player(
+            _( "You can't disassemble an item while you're wearing it." ) );
+        return false;
+    }
     // item_location::get_item() will return nullptr if the item is lost
     if( !disassembly ) {
         who.add_msg_player_or_npc(


### PR DESCRIPTION
#### Summary
No disassembling worn items

#### Purpose of change
Someone reported that encumbrance wasn't being recalculated when the player disassembled an item that they were wearing. Why the _fuck_ is that even possible?

#### Describe the solution
You can't disassemble things that you're wearing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
