### PR TITLE
Never Mind -> Nevermind

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1167,7 +1167,7 @@ std::optional<tripoint_rel_ms> choose_direction( const std::string &message,
         }
     } while( !done );
 
-    add_msg( _( "Never mind." ) );
+    add_msg( _( "Nevermind." ) );
     return std::nullopt;
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2646,7 +2646,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
         item_location item_loc = game_menus::inv::repair( *you, actor, main_tool );
 
         if( item_loc == item_location::nowhere ) {
-            you->add_msg_if_player( m_info, _( "Never mind." ) );
+            you->add_msg_if_player( m_info, _( "Nevermind." ) );
             act->set_to_null();
             return;
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -446,7 +446,7 @@ diary *avatar::get_avatar_diary()
 bool avatar::read( item_location &book, item_location ereader )
 {
     if( !book ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return false;
     }
 
@@ -615,7 +615,7 @@ bool avatar::read( item_location &book, item_location ereader )
 
         menu.query( true );
         if( menu.ret == UILIST_CANCEL ) {
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             return false;
         } else if( menu.ret >= 2 ) {
             continuous = true;
@@ -637,7 +637,7 @@ bool avatar::read( item_location &book, item_location ereader )
         menu.addentry( 2, true, '0', _( "Train until tired or success" ) );
         menu.query( true );
         if( menu.ret == UILIST_CANCEL ) {
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             return false;
         } else if( menu.ret == 1 ) {
             continuous = false;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -932,7 +932,7 @@ void avatar_action::eat( avatar &you, item_location &loc,
 
     if( !loc ) {
         you.cancel_activity();
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
     loc.overflow( here );
@@ -1108,7 +1108,7 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     }
 
     if( !loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 
@@ -1223,7 +1223,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
         loc = game_menus::inv::use();
 
         if( !loc ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
     }
@@ -1314,7 +1314,7 @@ void avatar_action::unload( avatar &you )
 {
     std::pair<item_location, bool> ret = game_menus::inv::unload( you );
     if( !ret.first ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 
@@ -1328,7 +1328,7 @@ void avatar_action::unload( avatar &you )
         }, _( "Insert item" ), 1, _( "You have no container to insert items." ) );
 
         if( !new_container ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
         you.unload( ret.first, false, new_container );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6055,7 +6055,7 @@ void Character::toolmod_add( item_location tool, item_location mod )
         if( !query_yn( _( "Permanently install your %1$s in your %2$s?" ),
                        colorize( mod->tname(), mod->color_in_inventory() ),
                        colorize( tool->tname(), tool->color_in_inventory() ) ) ) {
-            add_msg_if_player( _( "Never mind." ) );
+            add_msg_if_player( _( "Nevermind." ) );
             return; // player canceled installation
         }
     }
@@ -7043,7 +7043,7 @@ void Character::mend_item( item_location &&obj, bool interactive )
         }
         menu.query();
         if( menu.ret < 0 ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
         sel = menu.ret;

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -215,7 +215,7 @@ void Character::gunmod_add( item &gun, item &mod )
         if( !query_yn( _( "Permanently install your %1$s in your %2$s?" ),
                        colorize( moved_mod.tname(), moved_mod.color_in_inventory() ),
                        colorize( wielded_gun->tname(), wielded_gun->color_in_inventory() ) ) ) {
-            add_msg_if_player( _( "Never mind." ) );
+            add_msg_if_player( _( "Nevermind." ) );
             return; // player canceled installation
         }
     }
@@ -234,7 +234,7 @@ void Character::gunmod_add( item &gun, item &mod )
 
         prompt.query();
         if( prompt.ret < 0 ) {
-            add_msg_if_player( _( "Never mind." ) );
+            add_msg_if_player( _( "Nevermind." ) );
             return; // player canceled installation
         }
         actions[prompt.ret]();

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2666,7 +2666,7 @@ bool Character::disassemble()
 bool Character::disassemble( item_location target, bool interactive, bool disassemble_all )
 {
     if( !target ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return false;
     }
 
@@ -2679,12 +2679,12 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
     }
 
     if( obj.is_favorite &&
-        !query_yn( _( "You're going to disassemble favorited item.\nAre you sure?" ) ) ) {
+        !query_yn( _( "This item is marked as a favorite.\nAre you sure?" ) ) ) {
         return false;
     }
 
-    if( obj.is_worn_by_player() &&
-        !query_yn( _( "You're going to disassemble worn item.\nAre you sure?" ) ) ) {
+    if( obj.is_worn_by_player() ) {
+        add_msg_if_player( _( "You must remove that before disassembling it." ) );
         return false;
     }
 
@@ -2732,7 +2732,7 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
                                           obj.type_name( 1 ), obj.charges );
                 popup_input.title( title ).edit( num_dis );
                 if( popup_input.canceled() || num_dis <= 0 ) {
-                    add_msg( _( "Never mind." ) );
+                    add_msg( _( "Nevermind." ) );
                     return false;
                 }
                 num_dis = std::min( num_dis, obj.charges );
@@ -2844,7 +2844,7 @@ void Character::complete_disassemble( item_location target )
                                       obj.type_name( 1 ), obj.charges );
             popup_input.title( title ).edit( num_dis );
             if( popup_input.canceled() || num_dis <= 0 ) {
-                add_msg( _( "Never mind." ) );
+                add_msg( _( "Nevermind." ) );
                 activity.set_to_null();
                 return;
             }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8816,7 +8816,7 @@ void game::insert_item( drop_locations &targets )
     }, title, 1, _( "You have no container to insert items." ) );
 
     if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 
@@ -8830,7 +8830,7 @@ void game::insert_item()
     }, _( "Insert item" ), 1, _( "You have no container to insert items." ) );
 
     if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 
@@ -9595,7 +9595,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
         }
         loc = loc.obtain( u );
         if( !loc ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
     }
@@ -9644,7 +9644,7 @@ void game::reload_item()
                              _( "Reload item" ), 1, _( "You have nothing to reload." ) );
 
     if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -624,7 +624,7 @@ static void grab()
 
     const std::optional<tripoint_bub_ms> grabp_ = choose_adjacent( _( "Grab where?" ) );
     if( !grabp_ ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
     tripoint_bub_ms grabp = *grabp_;
@@ -1632,7 +1632,7 @@ static void loot()
 
     switch( flags ) {
         case None:
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             break;
         case SortLoot:
             player_character.assign_activity( ACT_MOVE_LOOT );
@@ -1717,7 +1717,7 @@ static void wear()
     if( loc ) {
         player_character.wear( loc );
     } else {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
     }
 }
 
@@ -1729,7 +1729,7 @@ static void takeoff()
     if( loc ) {
         player_character.takeoff( loc.obtain( player_character ) );
     } else {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
     }
 }
 
@@ -1764,7 +1764,7 @@ static void read()
             }
         }
     } else {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
     }
 }
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -317,7 +317,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
         item *const cont = target.item_loc.get_item();
 
         if( cont == nullptr || cont->is_null() ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
         // Sometimes the cont parameter is omitted, but the liquid is still within a container that counts
@@ -418,7 +418,7 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
     while( target.dest_opt == LD_NULL ) {
         menu.query();
         if( menu.ret < 0 || static_cast<size_t>( menu.ret ) >= actions.size() ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             // Explicitly canceled all options (container, drink, pour).
             return false;
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2106,7 +2106,7 @@ void iexamine::door_peephole( Character &you, const tripoint_bub_ms &examp )
         here.open_door( you, examp, true, false );
         you.add_msg_if_player( _( "You open the door." ) );
     } else {
-        you.add_msg_if_player( _( "Never mind." ) );
+        you.add_msg_if_player( _( "Nevermind." ) );
     }
 }
 
@@ -3495,7 +3495,7 @@ void iexamine::fvat_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             default:
-                add_msg( _( "Never mind." ) );
+                add_msg( _( "Nevermind." ) );
                 return;
         }
     }
@@ -3724,7 +3724,7 @@ void iexamine::compost_empty( Character &you, const tripoint_bub_ms &examp )
                 break;
             }
             default:
-                add_msg( _( "Never mind." ) );
+                add_msg( _( "Nevermind." ) );
                 return;
         }
     }
@@ -4791,7 +4791,7 @@ void iexamine::curtains( Character &you, const tripoint_bub_ms &examp )
         you.mod_moves( -to_moves<int>( 10_seconds ) );
         you.add_msg_if_player( _( "You tear the curtains and curtain rod off the windowframe." ) );
     } else {
-        you.add_msg_if_player( _( "Never mind." ) );
+        you.add_msg_if_player( _( "Nevermind." ) );
     }
 }
 
@@ -6569,7 +6569,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
     smenu.query();
 
     if( smenu.ret < 0 || static_cast<size_t>( smenu.ret ) >= entries.size() ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return;
     }
     int count = 0;
@@ -6587,7 +6587,7 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
     int amount = max_count;
     if( !query_int( amount, true, _( "Insert how many %s into the mill?" ),
                     item::nname( what->typeId(), count ) ) || amount <= 0 ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return;
     } else if( amount > count ) {
         add_msg( m_info, _( "You don't have that many." ) );
@@ -6786,7 +6786,7 @@ void iexamine::quern_examine( Character &you, const tripoint_bub_ms &examp )
             }
             break;
         default:
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             break;
         case 4:
             const furn_id &f = here.furn( examp );
@@ -7019,7 +7019,7 @@ void iexamine::smoker_options( Character &you, const tripoint_bub_ms &examp )
         }
         break;
         default:
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             break;
         case 7:
             if( portable ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1768,7 +1768,7 @@ std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint_b
     _( "You don't have any modified tools." ) );
 
     if( !loc ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -3264,7 +3264,7 @@ std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms
     int time;
     bool got_value = query_int( time, false, _( "Set the timer to ___ turns (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
     p->add_msg_if_player( _( "You set the timer to %s." ),
@@ -4766,7 +4766,7 @@ static bool heat_item( Character &p )
 
     item *heat = loc.get_item();
     if( heat == nullptr ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return false;
     }
     // simulates heat capacity of food, more weight = longer heating time
@@ -5091,7 +5091,7 @@ std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint_b
         item_location loc = game_menus::inv::gun_to_modify( *p->as_character(), *it );
 
         if( !loc ) {
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             return std::nullopt;
         }
 
@@ -5158,7 +5158,7 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_
                                            _( "You don't have compatible tools." ) );
 
     if( !loc ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -6395,7 +6395,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
         const std::optional<tripoint_bub_ms> aim_point_ = g->look_around();
 
         if( !aim_point_ ) {
-            p->add_msg_if_player( _( "Never mind." ) );
+            p->add_msg_if_player( _( "Nevermind." ) );
             return std::nullopt;
         }
         tripoint_bub_ms aim_point{ *aim_point_ };
@@ -8040,7 +8040,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     p->inv->restack( *p );
     heater h = find_heater( p, it );
     if( h.available_heater == -1 ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return false;
     }
     //Hotplate can only use it self as heat source
@@ -8344,7 +8344,7 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
     units::volume total_volume = 0_ml;
     for( drop_location pair : to_clean ) {
         if( !pair.first ) {
-            p->add_msg_if_player( m_info, _( "Never mind." ) );
+            p->add_msg_if_player( m_info, _( "Nevermind." ) );
             return std::nullopt;
         }
         total_volume += pair.first->volume( false, true, pair.second );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -254,7 +254,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
         got_timer_value = query_int( timer_time, false,
                                      _( "Set the timer to how many seconds (0 to cancel)?" ) );
         if( !got_timer_value || timer_time <= 0 ) {
-            p->add_msg_if_player( _( "Never mind." ) );
+            p->add_msg_if_player( _( "Nevermind." ) );
             return std::nullopt;
         }
         p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
@@ -1624,7 +1624,7 @@ std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoin
 
     item_location item_loc = game_menus::inv::salvage( *p, this );
     if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -1654,7 +1654,7 @@ std::optional<int> salvage_actor::use( Character *p, item &cutter, map *,
 
     item_location item_loc = game_menus::inv::salvage( *p, this );
     if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -2129,7 +2129,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, map *here,
 
     item_location loc = game_menus::inv::titled_menu( get_avatar(), _( "Inscribe which item?" ) );
     if( !loc ) {
-        p->add_msg_if_player( m_info, _( "Never mind." ) );
+        p->add_msg_if_player( m_info, _( "Nevermind." ) );
         return std::nullopt;
     }
     item &cut = *loc;
@@ -2920,7 +2920,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, map *here,
     } else {
         int ret = uilist( string_format( _( "Use %s" ), it.tname() ), opts );
         if( ret < 0 ) {
-            you->add_msg_if_player( _( "Never mind." ) );
+            you->add_msg_if_player( _( "Nevermind." ) );
             return std::nullopt;
         }
         internal_item = *std::next( all_items.begin(), ret );
@@ -3980,7 +3980,7 @@ bodypart_id heal_actor::use_healing_item( Character &healer, Character &patient,
                                         get_stopbleed_level( healer ), bite, infect, force, get_bandaged_level( healer ),
                                         get_disinfected_level( healer ) );
             if( healed == bodypart_str_id::NULL_ID() ) {
-                add_msg( m_info, _( "Never mind." ) );
+                add_msg( m_info, _( "Nevermind." ) );
                 return bodypart_str_id::NULL_ID().id(); // canceled
             }
             return healed;
@@ -4339,7 +4339,7 @@ std::optional<int> saw_barrel_actor::use( Character *p, item &it, map *,
     item_location loc = game_menus::inv::saw_barrel( *p, it );
 
     if( !loc ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -4406,7 +4406,7 @@ std::optional<int> saw_stock_actor::use( Character *p, item &it, map *,
     item_location loc = game_menus::inv::saw_stock( *p, it );
 
     if( !loc ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -4488,7 +4488,7 @@ std::optional<int> molle_attach_actor::use( Character *p, item &it,
     item_location loc = game_menus::inv::molle_attach( *p, it );
 
     if( !loc ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -4534,7 +4534,7 @@ std::optional<int> molle_detach_actor::use( Character *p, item &it,
         return 0;
     }
 
-    p->add_msg_if_player( _( "Never mind." ) );
+    p->add_msg_if_player( _( "Nevermind." ) );
     return std::nullopt;
 }
 
@@ -4660,7 +4660,7 @@ std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
     item_location mod_loc = game_menus::inv::gunmod_to_remove( *p, it );
 
     if( !mod_loc ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -4687,7 +4687,7 @@ std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
         }
     }
 
-    p->add_msg_if_player( _( "Never mind." ) );
+    p->add_msg_if_player( _( "Nevermind." ) );
     return std::nullopt;
 }
 
@@ -4772,7 +4772,7 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
         return 0;
     }
 
-    p->add_msg_if_player( _( "Never mind." ) );
+    p->add_msg_if_player( _( "Nevermind." ) );
     return std::nullopt;
 }
 
@@ -5169,7 +5169,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
             loc = game_menus::inv::titled_filter_menu( ups_filter, *you, choose_ups, -1, dont_have_ups );
         }
         if( !loc ) {
-            p->add_msg_if_player( _( "Never mind." ) );
+            p->add_msg_if_player( _( "Nevermind." ) );
             return std::nullopt;
         }
 
@@ -5205,7 +5205,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
             loc = game_menus::inv::titled_filter_menu( solar_filter, *you, choose_solar, -1, dont_have_solar );
         }
         if( !loc ) {
-            p->add_msg_if_player( _( "Never mind." ) );
+            p->add_msg_if_player( _( "Nevermind." ) );
             return std::nullopt;
         }
 
@@ -5244,7 +5244,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
                 here, _( "Attach the cable where?" ),
                 "", can_link, false, false );
     if( !pnt_ ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
     const tripoint_bub_ms &selection = *pnt_;
@@ -5347,7 +5347,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
                 here, to_towing ? _( "Attach cable to the vehicle that will do the towing." ) :
                 _( "Attach cable to the vehicle that will be towed." ), "", can_link, false, false );
     if( !pnt_ ) {
-        p->add_msg_if_player( _( "Never mind." ) );
+        p->add_msg_if_player( _( "Nevermind." ) );
         return std::nullopt;
     }
     const tripoint_bub_ms &selection = *pnt_;
@@ -5402,7 +5402,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
 {
     avatar *you = p->as_avatar();
     if( !you ) {
-        p->add_msg_if_player( m_info, _( "Never mind." ) );
+        p->add_msg_if_player( m_info, _( "Nevermind." ) );
         return std::nullopt;
     }
 
@@ -5433,7 +5433,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
                    _( "You don't have a compatible cable." ) );
     }
     if( !selected ) {
-        p->add_msg_if_player( m_info, _( "Never mind." ) );
+        p->add_msg_if_player( m_info, _( "Nevermind." ) );
         return std::nullopt;
     }
 

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -89,7 +89,7 @@ void attach_saddle_to( monster &z )
     }
     item_location loc = tack_loc();
     if( !loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
     z.add_effect( effect_monster_saddled, 1_turns, true );
@@ -211,7 +211,7 @@ void attach_bag_to( monster &z )
                         _( "Bag item" ) );
 
     if( !loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 
@@ -307,7 +307,7 @@ bool give_items_to( monster &z )
     }
     // Quit if there is nothing to add
     if( to_move.empty() ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return true;
     }
     z.add_effect( effect_controlled, 5_turns );
@@ -343,7 +343,7 @@ bool add_armor( monster &z )
     item_location loc = pet_armor_loc( z );
 
     if( !loc ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return true;
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1427,14 +1427,14 @@ void npc::do_npc_read( bool ebook )
     } else {
         ereader = game_menus::inv::ereader_to_use( *npc_player );
         if( !ereader ) {
-            add_msg( _( "Never mind." ) );
+            add_msg( _( "Nevermind." ) );
             return;
         }
         book = game_menus::inv::ebookread( *npc_player, ereader );
     }
 
     if( !book ) {
-        add_msg( _( "Never mind." ) );
+        add_msg( _( "Nevermind." ) );
         return;
     }
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3013,7 +3013,7 @@ void act_vehicle_unload_fuel( map &here, vehicle *veh )
         }
         smenu.query();
         if( smenu.ret < 0 || static_cast<size_t>( smenu.ret ) >= fuels.size() ) {
-            add_msg( m_info, _( "Never mind." ) );
+            add_msg( m_info, _( "Nevermind." ) );
             return;
         }
         fuel = fuels[smenu.ret];

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1730,7 +1730,7 @@ void vehicle::use_harness( int part, map *here, const tripoint_bub_ms &pos )
                 *here, _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
                 false );
     if( !pnt_ ) {
-        add_msg( m_info, _( "Never mind." ) );
+        add_msg( m_info, _( "Nevermind." ) );
         return;
     }
 
@@ -2506,7 +2506,7 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
 
             if( !loc )
             {
-                you.add_msg_if_player( _( "Never mind." ) );
+                you.add_msg_if_player( _( "Nevermind." ) );
                 return;
             }
 


### PR DESCRIPTION
#### Summary
Never Mind -> Nevermind

#### Purpose of change
When an action is canceled, the game would print, "Never mind." This is incorrect. Never mind is an imperative meaning "pay no attenton to [it]," which makes no sense in this context as no direct object is indicated or implied. The correct word in this case would be "nevermind", which is a standalone performative interjection, different in use and meaning than "never mind." The meaning of "nevermind" in this case is "disregard what was being discussed," which certainly does make sense and is obviously what was intended.

#### Describe the solution
"Never mind." -> "Nevermind."


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
