### PR TITLE
Adjust butchery times

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -803,18 +803,18 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
 
     int time_to_cut;
     switch( corpse.size ) {
-        // Time (roughly) in turns to cut up the corpse
+        // Time (roughly) in turns to cut up the corpse.
         case creature_size::tiny:
-            time_to_cut = 600; // 10 minutes
+            time_to_cut = 300; // 5 minutes
             break;
         case creature_size::small:
-            time_to_cut = 1200; // 20 minutes
+            time_to_cut = 900; // 15 minutes
             break;
         case creature_size::medium:
             time_to_cut = 1800; // 30 minutes
             break;
         case creature_size::large:
-            time_to_cut = 2400; // 40 minutes
+            time_to_cut = 2700; // 45 minutes
             break;
         case creature_size::huge:
             time_to_cut = 8400; // 140 minutes


### PR DESCRIPTION
#### Summary
Adjust butchery times

#### Purpose of change
It was pointed out that it was taking a very long time to butcher small and tiny creatures, and given that butchery is an Active activity, that was making it a pretty bad way to get kcal.

#### Describe the solution
Change the base times from 10 and 20 minutes to 5 and 15 minutes. Full butchery on a tiny fish now takes a base time of 30 minutes, while a small fish now takes an hour and 15 minutes to fully process. Using surfaces, field dressing, and getting help from companions makes this faster as always.

#### Testing
Did a full butchery on an atlantic salmon. Took about 2 hours because my tools sucked, but gave me over 1100 kcal in meat alone.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
