### PR TITLE
Fix NPCs not eating from camp food stockpile

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4708,7 +4708,7 @@ bool npc::consume_food_from_camp()
 
         if( kcal_to_eat > 0 ) {
             nutrients meal = bcp->camp_food_supply( -kcal_to_eat );
-            bcp->feed_workers( *this, -meal );
+            bcp->feed_workers( *this, -meal, true );
 
             return true;
         } else {


### PR DESCRIPTION
consume_food_from_camp() called feed_workers() without is_player_meal=true, causing it to return immediately without feeding the NPC. 

Food was deducted from the stockpile but never added to the NPC's stomach.

Test: have hungry npc in camp 
Before:  stays hungry despite doing "distribute food"
After: calories go into npc stomach

Verified by using camp debug logs