### PR TITLE
Fix crash when ammo_set called with null on recurbow_folded

### DIFF
--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -328,6 +328,7 @@
     "//2": "When taken down.",
     "price_postapoc": "20 USD",
     "flags": [ "NO_TURRET" ],
+    "ammo": [ "arrow" ],
     "modes": [ [ "DEFAULT", "disassembled", 0, [ "MELEE" ] ] ],
     "valid_mod_locations": [ [ "underbarrel", 1 ], [ "sights", 1 ], [ "stabilizer", 1 ], [ "dampening", 1 ], [ "arrow rest", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "arrow": 1 }, "open_container": true } ],

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -609,7 +609,7 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
                         mag.ammo_set( mag.ammo_default(), ch );
                     }
                     new_item.put_in( mag, pocket_type::MAGAZINE_WELL );
-                } else if( new_item.is_magazine() ) {
+                } else if( new_item.is_magazine() && !new_item.ammo_default().is_null() ) {
                     new_item.ammo_set( new_item.ammo_default(), ch );
                 } else if( new_item.magazine_current() ) {
                     new_item.ammo_set( new_item.magazine_current()->ammo_default(), ch );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -932,7 +932,7 @@ void item_pocket::set_item_defaults()
 {
     for( item &contained_item : contents ) {
         /* for guns and other items defined to have a magazine but don't use "ammo" */
-        if( contained_item.is_magazine() ) {
+        if( contained_item.is_magazine() && !contained_item.ammo_default().is_null() ) {
             contained_item.ammo_set(
                 contained_item.ammo_default(),
                 contained_item.ammo_capacity( item_controller->find_template(


### PR DESCRIPTION
## Summary

- `recurbow_folded` has a `MAGAZINE` pocket (to hold an arrow while stowed) which causes `is_magazine()` to return true, but had no `ammo` field so `ammo_default()` returned null
- `item_pocket::set_item_defaults()` passed this null return to `find_template()->ammo->type`, causing a null pointer dereference
- `item_group.cpp` had the same unguarded call when spawning magazine items

## Fix

- Add `"ammo": ["arrow"]` to `recurbow_folded` so `ammo_default()` returns a valid type
- Guard both call sites against null `ammo_default()` to prevent the same crash with other items in future

## Test plan

- [X ] Start a new game with the Hunter profession (starts with `recurbow_folded`)
- [X] Verify no crash/exception on load or spawn
