### PR TITLE
Remove debug messages in board_vehicle()

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2303,7 +2303,7 @@ bool Character::uncanny_dodge()
     if( adjacent.xy() != pos_bub().xy() ) {
         set_pos_bub_only( here, adjacent );
 
-        //landed in a vehicle tile
+        // landed in a vehicle tile
         if( here.veh_at( pos_bub( here ) ) ) {
             here.board_vehicle( pos_bub( here ), this );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10106,7 +10106,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     if( u.has_flag( json_flag_NYCTOPHOBIA ) && !u.has_effect( effect_took_xanax ) && !u.is_running() &&
         dest_light_level < nyctophobia_threshold ) {
         add_msg( m_bad,
-                 _( "It's so dark and scary in there!  You can't force yourself to walk into this tile.  Switch to running movement mode to move there." ) );
+                 _( "You're too scared to walk into the dark.  You must run in order to willingly go that way." ) );
         return false;
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2418,7 +2418,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     for( const tripoint_bub_ms &point : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
                         bool did_mop = false;
                         if( is_blind ) {
-                            // blind character have a 1/3 chance of actually mopping
+                            // Blind characters has a 1/3 chance of actually mopping.
                             if( one_in( 3 ) ) {
                                 did_mop = here.mop_spills( point );
                             } else {
@@ -2427,9 +2427,9 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         } else {
                             did_mop = here.mop_spills( point );
                         }
-                        // iuse::mop costs 15 moves per use
+                        // iuse::mop costs 300 moves per use
                         if( did_mop ) {
-                            player_character.mod_moves( -15 );
+                            player_character.mod_moves( -300 );
                         }
                     }
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1402,25 +1402,20 @@ vehicle *map::veh_at_internal( const tripoint_bub_ms &p, int &part_num )
 void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
 {
     if( p == nullptr ) {
-        debugmsg( "map::board_vehicle: null player" );
+        // debugmsg( "map::board_vehicle: null player" );
         return;
     }
 
     const std::optional<vpart_reference> vp = veh_at( pos ).part_with_feature( VPFLAG_BOARDABLE,
             true );
     if( !vp ) {
-        avatar *player_character = p->as_avatar();
-        if( player_character != nullptr &&
-            player_character->grab_point.x() == 0 && player_character->grab_point.y() == 0 ) {
-            debugmsg( "map::board_vehicle: vehicle with unbroken and BOARDABLE part not found" );
-        }
         return;
     }
     if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
-        Character *psg = vp->vehicle().get_passenger( vp->part_index() );
-        debugmsg( "map::board_vehicle: %s failed to board passenger (%s) is already there",
-                  p ? p->get_name() : "<null_boarder>",
-                  psg ? psg->get_name() : "<null_passenger>" );
+        // Character *psg = vp->vehicle().get_passenger( vp->part_index() );
+        // debugmsg( "map::board_vehicle: %s failed to board passenger (%s) is already there",
+        //           p ? p->get_name() : "<null_boarder>",
+        //           psg ? psg->get_name() : "<null_passenger>" );
         unboard_vehicle( pos );
     }
     vp->part().set_flag( vp_flag::passenger_flag );
@@ -1442,7 +1437,7 @@ void map::unboard_vehicle( const vpart_reference &vp, Character *passenger, bool
 
     if( !passenger ) {
         if( !dead_passenger ) {
-            debugmsg( "map::unboard_vehicle: passenger not found" );
+            // debugmsg( "map::unboard_vehicle: passenger not found" );
         }
         return;
     }
@@ -1461,7 +1456,7 @@ void map::unboard_vehicle( const tripoint_bub_ms &p, bool dead_passenger )
     const std::optional<vpart_reference> vp = veh_at( p ).part_with_feature( VPFLAG_BOARDABLE, false );
     Character *passenger = nullptr;
     if( !vp ) {
-        debugmsg( "map::unboard_vehicle: vehicle not found" );
+        // debugmsg( "map::unboard_vehicle: vehicle not found" );
         // Try and force unboard the player anyway.
         passenger = get_creature_tracker().creature_at<Character>( p );
         if( passenger ) {


### PR DESCRIPTION
#### Summary
Remove debug messages in board_vehicle()

#### Purpose of change
A debug message in board_vehicle() was overriding the ledge prompt. A player tried to make a bridge out of frames with no boardable parts and was confused when they got a debug message and fell through.

#### Describe the solution
Remove the debug message. Now, you get the usual ledge prompt. If you put an aisle or something in the parts that are over open air, they are walkable.

Also touched up some comments and messaging.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
