### PR TITLE
Fix NPC ebook reading: menu filter, activation, powergrid, cable, read-in-order

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1707,6 +1707,44 @@ void read_activity_actor::start( player_activity &act, Character &who )
     // starting the activity should cost a charge to boot up the ebook app
     if( using_ereader ) {
         ereader->ammo_consume( ereader->ammo_required(), who.pos_bub(), &who );
+        // Try to plug the ereader into a nearby appliance/powergrid to charge while reading.
+        // Search within cable length — any appliance tile in the network works.
+        if( ereader->can_link_up() && ereader->has_no_links() ) {
+            map &here = get_map();
+            const link_up_actor *link_actor = static_cast<const link_up_actor *>(
+                                                  ereader->get_use( "link_up" )->get_actor_ptr() );
+            const int cable_len = link_actor->cable_length == -1 ?
+                                  ereader->type->maximum_charges() : link_actor->cable_length;
+            bool plugged_in = false;
+            for( const tripoint_bub_ms &pt : here.points_in_radius( who.pos_bub(), cable_len ) ) {
+                // points_in_radius uses Chebyshev (square), but process_link uses rl_dist (Euclidean).
+                // Skip tiles that would immediately exceed max_length after plugging in.
+                if( rl_dist( who.pos_bub(), pt ) > cable_len ) {
+                    continue;
+                }
+                const optional_vpart_position ovp = here.veh_at( pt );
+                if( !ovp ) {
+                    continue;
+                }
+                if( ovp->vehicle().avail_linkable_part( ovp->mount_pos(), true ) == -1 ) {
+                    continue;
+                }
+                if( ereader->link_to( ovp, link_state::vehicle_port ).success() ) {
+                    who.add_msg_player_or_npc(
+                        string_format( _( "You plug your %s into the %s." ),
+                                       ereader->tname(), ovp->vehicle().name ),
+                        string_format( _( "<npcname> plugs their %s into the %s." ),
+                                       ereader->tname(), ovp->vehicle().name ) );
+                    plugged_in = true;
+                    break;
+                }
+            }
+            if( !plugged_in ) {
+                add_msg_if_player_sees( who,
+                    _( "%1$s can't find a nearby power grid to plug their %2$s into." ),
+                    who.disp_name(), ereader->tname() );
+            }
+        }
     }
 
     act.moves_total = moves_total;
@@ -2059,9 +2097,11 @@ bool read_activity_actor::npc_read( npc &learner )
                      book->type_name() );
         }
 
-    } else if( display_messages && skill ) {
-        add_msg( m_info, _( "%s can no longer learn from %s." ), learner.disp_name(),
-                 book->type_name() );
+    } else if( skill ) {
+        if( display_messages ) {
+            add_msg( m_info, _( "%s can no longer learn from %s." ), learner.disp_name(),
+                     book->type_name() );
+        }
         continuous = false;
         // read non-skill books only once
     } else if( !skill ) {
@@ -2073,7 +2113,20 @@ bool read_activity_actor::npc_read( npc &learner )
 
 void read_activity_actor::finish( player_activity &act, Character &who )
 {
+    // Deactivate ereader screen (turn off) if it was activated when reading started
+    auto deactivate_ereader = [&]() {
+        if( using_ereader && ereader && ereader->type->tool &&
+            ereader->type->tool->power_draw > 0_W ) {
+            // Disconnect from powergrid before turning off
+            if( ereader->can_link_up() && !ereader->has_no_links() ) {
+                ereader->reset_link( false );
+            }
+            who.invoke_item( &*ereader, "transform", who.pos_bub() );
+        }
+    };
+
     if( cancel_if_book_invalid( act, book, who ) ) {
+        deactivate_ereader();
         return;
     }
 
@@ -2085,6 +2138,7 @@ void read_activity_actor::finish( player_activity &act, Character &who )
                                  player_readma( *who.as_avatar() ) : player_read( *who.as_avatar() );
 
         if( should_null ) {
+            deactivate_ereader();
             act.set_to_null();
             return;
         }
@@ -2092,11 +2146,13 @@ void read_activity_actor::finish( player_activity &act, Character &who )
 
         // npcs can't read martial arts books yet
         if( is_mabook ) {
+            deactivate_ereader();
             act.set_to_null();
             return;
         }
 
         if( npc_read( static_cast<npc &>( who ) ) ) {
+            deactivate_ereader();
             act.set_to_null();
             return;
         }
@@ -2121,6 +2177,7 @@ void read_activity_actor::finish( player_activity &act, Character &who )
                 for( const std::string &reason : fail_messages ) {
                     add_msg( m_bad, reason );
                 }
+                deactivate_ereader();
                 act.set_to_null();
                 return;
             }
@@ -2130,16 +2187,55 @@ void read_activity_actor::finish( player_activity &act, Character &who )
                            to_string_writable( time_taken ) );
         }
 
-        // restart the activity
+        // restart the activity without deactivating — ereader stays on while reading
         moves_total = to_moves<int>( time_taken );
         act.moves_total = to_moves<int>( time_taken );
         act.moves_left = to_moves<int>( time_taken );
         return;
     } else  {
-        who.add_msg_if_player( m_info, _( "You finish reading." ) );
+        if( using_ereader ) {
+            who.add_msg_player_or_npc( m_info,
+                                       string_format( _( "You finish reading ebook %s." ),
+                                                      book->type_name() ),
+                                       string_format( _( "<npcname> finishes reading ebook %s." ),
+                                                      book->type_name() ) );
+        } else {
+            who.add_msg_player_or_npc( m_info,
+                                       string_format( _( "You finish reading %s." ),
+                                                      book->type_name() ),
+                                       string_format( _( "<npcname> finishes reading %s." ),
+                                                      book->type_name() ) );
+        }
     }
 
+    deactivate_ereader();
     act.set_to_null();
+}
+
+void read_activity_actor::canceled( player_activity &/*act*/, Character &who )
+{
+    if( is_valid_book( book ) ) {
+        if( using_ereader ) {
+            who.add_msg_player_or_npc( m_info,
+                                       string_format( _( "You stop reading ebook %s." ),
+                                                      book->type_name() ),
+                                       string_format( _( "<npcname> stops reading ebook %s." ),
+                                                      book->type_name() ) );
+        } else {
+            who.add_msg_player_or_npc( m_info,
+                                       string_format( _( "You stop reading %s." ),
+                                                      book->type_name() ),
+                                       string_format( _( "<npcname> stops reading %s." ),
+                                                      book->type_name() ) );
+        }
+    }
+    if( using_ereader && ereader && ereader->type->tool &&
+        ereader->type->tool->power_draw > 0_W ) {
+        if( ereader->can_link_up() && !ereader->has_no_links() ) {
+            ereader->reset_link( false );
+        }
+        who.invoke_item( &*ereader, "transform", who.pos_bub() );
+    }
 }
 
 bool read_activity_actor::can_resume_with_internal( const activity_actor &other,

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -460,6 +460,7 @@ class read_activity_actor : public activity_actor
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &act, Character &who ) override;
         void finish( player_activity &act, Character &who ) override;
+        void canceled( player_activity &act, Character &who ) override;
 
         std::string get_progress_message( const player_activity & ) const override;
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1293,6 +1293,25 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         if( !you.items_with( filter ).empty() ) {
             return activity_reason_info::ok( do_activity_reason::NEEDS_BOOK_TO_LEARN );
         }
+        // items_with/visit_items skips E_FILE_STORAGE pockets, so check ereaders explicitly
+        bool has_readable_ebook = false;
+        you.visit_items( [&]( item * it, item * ) {
+            if( has_readable_ebook || !it->is_estorage() ) {
+                return has_readable_ebook ? VisitResponse::ABORT : VisitResponse::NEXT;
+            }
+            for( const item *ebook : it->ebooks() ) {
+                read_condition_result condition = you.check_read_condition( *ebook );
+                if( condition == read_condition_result::SUCCESS ||
+                    condition == read_condition_result::TOO_DARK ) {
+                    has_readable_ebook = true;
+                    return VisitResponse::ABORT;
+                }
+            }
+            return VisitResponse::NEXT;
+        } );
+        if( has_readable_ebook ) {
+            return activity_reason_info::ok( do_activity_reason::NEEDS_BOOK_TO_LEARN );
+        }
         // TODO: find books from zone?
         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
     }
@@ -3295,17 +3314,64 @@ static bool generic_multi_activity_do(
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_BOOK_TO_LEARN ) {
-        const item_filter filter = [ &you ]( const item & i ) {
-            read_condition_result condition = you.check_read_condition( i );
-            return condition == read_condition_result::SUCCESS;
-        };
-        std::vector<item *> books = you.items_with( filter );
-        if( !books.empty() && books[0] ) {
-            const time_duration time_taken = you.time_to_read( *books[0], you );
-            item_location book = item_location( you, books[0] );
-            item_location ereader;
+        // Find the first readable book, tracking whether it lives inside an ereader
+        item *book_ptr = nullptr;
+        item *ereader_ptr = nullptr;
+        you.visit_items( [&]( item * it, item * parent ) {
+            if( book_ptr != nullptr ) {
+                return VisitResponse::ABORT;
+            }
+            if( you.check_read_condition( *it ) == read_condition_result::SUCCESS ) {
+                book_ptr = it;
+                ereader_ptr = ( parent && parent->is_estorage() ) ? parent : nullptr;
+                return VisitResponse::ABORT;
+            }
+            // E_FILE_STORAGE contents are not visited by visit_contents, check ereaders explicitly
+            if( it->is_estorage() ) {
+                for( const item *ebook : it->ebooks() ) {
+                    if( you.check_read_condition( *ebook ) == read_condition_result::SUCCESS ) {
+                        book_ptr = const_cast<item *>( ebook );
+                        ereader_ptr = it;
+                        return VisitResponse::ABORT;
+                    }
+                }
+            }
+            return VisitResponse::NEXT;
+        } );
+        if( book_ptr ) {
+            item_location book;
+            item_location ereader_loc;
+            if( ereader_ptr ) {
+                ereader_loc = item_location( you, ereader_ptr );
+                // Activate the ereader screen if it's currently off
+                if( ereader_ptr->type->tool && ereader_ptr->type->tool->power_draw == 0_W ) {
+                    you.invoke_item( ereader_ptr, "transform", you.pos_bub() );
+                }
+                // After possible transform, find the first readable ebook with fresh pointers
+                for( const item *ebook : ereader_ptr->ebooks() ) {
+                    if( you.check_read_condition( *ebook ) == read_condition_result::SUCCESS ) {
+                        book = item_location( ereader_loc, const_cast<item *>( ebook ) );
+                        break;
+                    }
+                }
+                if( !book ) {
+                    return true;
+                }
+            } else {
+                book = item_location( you, book_ptr );
+            }
+            const time_duration time_taken = you.time_to_read( *book, you );
             you.backlog.emplace_front( act_id );
-            you.assign_activity( read_activity_actor( time_taken, book, ereader, true ) );
+            you.assign_activity( read_activity_actor( time_taken, book, ereader_loc, true ) );
+            if( ereader_ptr ) {
+                you.add_msg_player_or_npc(
+                    string_format( _( "You start reading ebook %s." ), book->type_name() ),
+                    string_format( _( "<npcname> starts reading ebook %s." ), book->type_name() ) );
+            } else {
+                you.add_msg_player_or_npc(
+                    string_format( _( "You start reading %s." ), book->type_name() ),
+                    string_format( _( "<npcname> starts reading %s." ), book->type_name() ) );
+            }
             return false;
         }
     } else if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1608,12 +1608,12 @@ class ebookread_inventory_preset : public read_inventory_preset
         }
 };
 
-item_location game_menus::inv::read( Character &you )
+item_location game_menus::inv::read( Character &you, bool include_ebooks )
 {
     const std::string msg = you.is_avatar() ? _( "You have nothing to read." ) :
                             string_format( _( "%s has nothing to read." ), you.disp_name() );
     return inv_internal( you, read_inventory_preset( you ), _( "Read" ), 1, msg, "", item_location(),
-                         true );
+                         include_ebooks );
 }
 
 item_location game_menus::inv::ebookread( Character &you, item_location &ereader )

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -121,8 +121,8 @@ item_location disassemble( Character &you );
 item_location gun_to_modify( Character &you, const item &gunmod );
 /** Gunmod removal menu. */
 item_location gunmod_to_remove( Character &you, item &gun );
-/** Book reading menu. */
-item_location read( Character &you );
+/** Book reading menu. @param include_ebooks if true, ebook files from ereaders appear in menu. */
+item_location read( Character &you, bool include_ebooks = true );
 /** E-Book reading menu. */
 item_location ereader_to_use( Character &you );
 /** eBook reading menu. */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14397,13 +14397,19 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
             std::string cable_name = is_cable_item ? string_format( _( "over-extended %s" ), label( 1 ) ) :
                                      string_format( _( "%s's over-extended cable" ), label( 1 ) );
             if( carrier != nullptr ) {
-                carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
+                if( carrier->is_npc() ) {
+                    add_msg_if_player_sees( *carrier, m_bad, _( "%s's %s breaks loose!" ),
+                                           carrier->disp_name( true, true ), cable_name );
+                } else {
+                    carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
+                }
             } else {
-                add_msg_if_player_sees( pos, m_bad, _( "Your %s breaks loose!" ), cable_name );
+                add_msg_if_player_sees( pos, m_bad, _( "The %s breaks loose!" ), cable_name );
             }
             return true;
         } else if( link().length + M_SQRT2 >= link().max_length + 1 && carrier != nullptr ) {
-            carrier->add_msg_if_player( m_warning, _( "Your %s is stretched to its limit!" ), link_name() );
+            carrier->add_msg_if_player( m_warning, _( "Your %s is stretched to its limit!" ),
+                                        link_name() );
         }
         return false;
     };

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1125,6 +1125,7 @@ void npc::revert_after_activity()
 {
     mission = previous_mission;
     attitude = previous_attitude;
+    activity.canceled( *this );
     activity = player_activity();
     current_activity_id = activity_id::NULL_ID();
     clear_destination();
@@ -1423,30 +1424,44 @@ void npc::do_npc_read( bool ebook )
     item_location ereader;
 
     if( !ebook ) {
-        book = game_menus::inv::read( *npc_player );
+        book = game_menus::inv::read( *npc_player, false );
     } else {
         ereader = game_menus::inv::ereader_to_use( *npc_player );
         if( !ereader ) {
             add_msg( _( "Nevermind." ) );
             return;
         }
+        // Activate the ereader screen before selecting the book so that the
+        // book item_location is created against the already-on ereader and
+        // remains valid across save/load cycles.
+        if( ereader->type->tool && ereader->type->tool->power_draw == 0_W ) {
+            npc_player->invoke_item( &*ereader, "transform", npc_player->pos_bub() );
+        }
         book = game_menus::inv::ebookread( *npc_player, ereader );
     }
 
+    const auto deactivate = [&]() {
+        if( ereader && ereader->type->tool && ereader->type->tool->power_draw > 0_W ) {
+            npc_player->invoke_item( &*ereader, "transform", npc_player->pos_bub() );
+        }
+    };
+
     if( !book ) {
-        add_msg( _( "Nevermind." ) );
+        deactivate();
         return;
     }
 
     std::vector<std::string> fail_reasons;
     Character *npc_character = as_character();
     if( !npc_character ) {
+        deactivate();
         return;
     }
 
     book = book.obtain( *npc_character );
     if( can_read( *book, fail_reasons ) ) {
-        add_msg_if_player_sees( pos_bub(), _( "%s starts reading." ), disp_name() );
+        add_msg_if_player_sees( pos_bub(), ebook ? _( "%s starts reading ebook %s." ) :
+                                _( "%s starts reading %s." ), disp_name(), book->type_name() );
 
         // NPCs can't read to other NPCs yet
         const time_duration time_taken = time_to_read( *book, *this );
@@ -1456,6 +1471,7 @@ void npc::do_npc_read( bool ebook )
         assign_activity( actor );
 
     } else {
+        deactivate();
         for( const std::string &reason : fail_reasons ) {
             say( reason );
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -94,6 +94,7 @@ static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
+static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 
 static const bionic_id bio_ads( "bio_ads" );
 static const bionic_id bio_blade( "bio_blade" );
@@ -4097,6 +4098,11 @@ bool npc::do_player_activity()
         // instead; just scan the map ONCE for a task to do, and if it returns false
         // then stop scanning, abandon the activity, and kill the backlog of moves.
         if( !generic_multi_activity_handler( activity, *this->as_character(), true ) ) {
+            if( activity.id() == ACT_MULTIPLE_READ ) {
+                add_msg_if_player_sees( *this,
+                                        _( "%s has nothing left to study from their books." ),
+                                        disp_name() );
+            }
             revert_after_activity();
             set_moves( 0 );
             return true;


### PR DESCRIPTION
## Summary

NPCs assigned to read books had many bugs and "quality of life" issues that made ebook/tablet reading tedious.

### Fixes

**Menu filtering** — The "assign NPC to read" menu was showing unreadable books (too dark, wrong skill level, already mastered). The filter now uses `check_read_condition()` to show only books that are actually readable right now.

**Device activation** — When an NPC picks up an e-ink tablet or laptop to read from, the device is now turned on at activity start and turned off when the activity ends or is cancelled.

**Power consumption** — The reading activity now calls `ammo_consume()` at activity start to pay the device's power cost, matching how player reading works.

**Powergrid charging** — At activity start, if the device has a cable (`link_up` flagged), the actor now searches nearby tiles for a vehicle power port or powergrid  and plugs in, so the device charges while reading. Previously NPCs never plugged in at all.

**Cable disconnect / read-in-order loop** — The powergrid search used `map::points_in_radius` (Chebyshev/square distance) but `process_link` validates cable length with `rl_dist` (rounded Euclidean). Diagonal tiles that are within the Chebyshev square but beyond Euclidean range caused the cable to break loose immediately after plugging in. Fixed by adding an `rl_dist` guard to skip those tiles.

**Activity lifecycle** — Added a `canceled()` override so that turning off the device and unplugging the cable happen correctly on cancellation (e.g. interrupted by combat). Also fixed `revert_after_activity()` to call `activity.canceled()` for consistent cleanup.

**Activation order** — `do_npc_read()` now turns the device on *before* showing the book-selection menu, so `check_read_condition()` sees the device as active and doesn't filter it out.

**Read in order (ebooks)** — "Read books in order" was completing instantly when the NPC only had a tablet. Root cause: `item_contents::visit_contents` only recurses into `CONTAINER` pockets — `E_FILE_STORAGE` pockets (ereaders/laptops) are explicitly skipped. Both the reason-check in `can_do_activity_there` and the book-selection handler in the `NEEDS_BOOK_TO_LEARN` path now explicitly check `is_estorage()` + `ebooks()`.

**NPC-visible cable break message** — When a cable breaks loose the message was always sent as a player-only message. Now if the carrier is an NPC, nearby players see `Lara's e-ink tablet PC (on)'s over-extended cable breaks loose!`

These fixes apply to both e-ink tablets and laptops (any item with `E_FILE_STORAGE` and `link_up`).

## Test plan

- [x] NPC assigned to read a physical book → reads normally, no regression
- [x] NPC assigned to read a tablet (ebook) → device turns on, NPC reads, device turns off when done
- [x] NPC with discharged tablet near a vehicle or powergrid→ plugs in, charges while reading
- [x] NPC plugged in diagonally (1 tile diagonal) → cable stays connected, no immediate break
- [x] NPC plugged in, then moves out of cable range → player sees cable break message
  > `Lara's e-ink tablet PC (on)'s over-extended cable breaks loose!`
- [x] "Read books in order" with NPC that only has a tablet → picks up ebook correctly, does not complete instantly
- [x] Save and reload mid-read → device still on, activity continues correctly
- [x] NPC interrupted mid-read (combat) → device turns off, cable unplugs cleanly