### PR TITLE
Fix efile copy menu showing duplicates across devices and against destination

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1800,8 +1800,51 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
     bool copying = action == EF_COPY_FROM_THIS || action == EF_COPY_ONTO_THIS;
     bool wiping = action == EF_WIPE;
 
-    const inventory_filter_preset preset( [&copying]( const item_location & loc ) {
-        return loc.is_efile() && ( !copying || loc->is_ecopiable() );
+    // For copy actions, pre-compute the canonical source item for each typeId:
+    // - exclude files already on the destination device
+    // - when multiple source devices have the same file, use only the first occurrence
+    // E_FILE_COLLECTION items (recipe catalogs, photo collections) are exempt: add_efile
+    // merges their contents into an existing collection rather than creating a duplicate,
+    // so they must always be shown regardless of what is already on the destination.
+    std::map<itype_id, const item *> canonical_copy_sources;
+    if( copying ) {
+        std::set<itype_id> dest_typeids;
+        for( const item *f : to_edevice->efiles() ) {
+            if( !f->has_flag( flag_E_FILE_COLLECTION ) ) {
+                dest_typeids.insert( f->typeId() );
+            }
+        }
+        for( const item_location &src_dev : from_edevices ) {
+            if( !src_dev ) {
+                continue;
+            }
+            for( const item *f : src_dev->efiles() ) {
+                if( f->has_flag( flag_E_FILE_COLLECTION ) ) {
+                    continue; // not deduplicated; merged into existing collection by add_efile
+                }
+                const itype_id &tid = f->typeId();
+                if( !dest_typeids.count( tid ) && !canonical_copy_sources.count( tid ) ) {
+                    canonical_copy_sources[tid] = f;
+                }
+            }
+        }
+    }
+
+    const inventory_filter_preset preset( [&]( const item_location & loc ) {
+        if( !loc.is_efile() || ( copying && !loc->is_ecopiable() ) ) {
+            return false;
+        }
+        if( copying ) {
+            if( loc->has_flag( flag_E_FILE_COLLECTION ) ) {
+                // Always show: add_efile merges these rather than creating duplicates
+                return true;
+            }
+            // Only show the canonical item for each typeId (deduplicates across devices
+            // and hides files already present on the destination device)
+            auto it = canonical_copy_sources.find( loc->typeId() );
+            return it != canonical_copy_sources.end() && it->second == loc.get_item();
+        }
+        return true;
     } );
 
     const int available_charges = to_edevice->ammo_remaining( );


### PR DESCRIPTION
## Summary

When using "Copy files onto this device" or "Copy files off of this device" and selecting multiple source devices, the file selection menu showed duplicate entries — the same ebook appearing once per source device that contained it. Files already present on the destination device were also shown unnecessarily.

### Fix

Pre-compute a canonical source item per `typeId` before building the selector. For each unique file type, only the first encountered source device's copy is shown. Files whose `typeId` already exists on the destination are excluded entirely.

`E_FILE_COLLECTION` items (recipe catalogs, photo collections) are **exempt** from this deduplication. `add_efile` merges their contents into an existing collection rather than inserting a duplicate item, so they must always appear in the menu — including when the destination already has a catalog of the same type. Filtering them out would silently block recipe merging.

Applies to both `EF_COPY_ONTO_THIS` and `EF_COPY_FROM_THIS`.

## Test plan

- [x] Same ebook on two source devices → appears exactly once in file list
- [x] Each source has a unique ebook → both appear
- [x] File already on destination → not shown in file list
- [x] All source files already on destination → empty list / "no files" popup
- [x] Mix of overlapping and unique files across sources + destination → only unowned unique files shown
- [x] Recipe catalog: destination has no catalog → catalog shown, copy inserts with all recipes intact
- [x] Recipe catalog: destination already has a catalog → source catalogs still shown; recipes merged correctly after copy
- [x] Recipe catalog: multiple source devices each with catalogs → all shown; all recipes merged
- [x] Move and wipe operations unaffected (no deduplication applied)