### PR TITLE
Fix funnel rain overcollection during light precipitation

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8403,7 +8403,9 @@ void vehicle::update_time( map &here, const time_point &update_to )
         }
 
         const double area_in_mm2 = std::pow( pt.info().bonus, 2 ) * M_PI;
-        const int qty = roll_remainder( funnel_charges_per_turn( area_in_mm2, accum_weather.rain_amount ) );
+        const double elapsed_turns = to_turns<double>( elapsed );
+        const double avg_mm_per_hour = elapsed_turns > 0.0 ? accum_weather.rain_amount / elapsed_turns : 0.0;
+        const int qty = roll_remainder( funnel_charges_per_turn( area_in_mm2, avg_mm_per_hour ) * elapsed_turns );
         int c_qty = qty + ( tank->can_reload( water_clean ) ?  tank->ammo_remaining( ) : 0 );
         int cost_to_purify = c_qty * itype_water_purifier->charges_to_use();
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -157,23 +157,9 @@ float incident_sun_irradiance( const weather_type_id &wtype, const time_point &t
 static void proc_weather_sum( const weather_type_id &wtype, weather_sum &data,
                               const time_point &t, const time_duration &tick_size )
 {
-    int amount = 0;
-    if( wtype->rains ) {
-        switch( wtype->precip ) {
-            case precip_class::very_light:
-                amount = 1 * to_turns<int>( tick_size );
-                break;
-            case precip_class::light:
-                amount = 4 * to_turns<int>( tick_size );
-                break;
-            case precip_class::heavy:
-                amount = 8 * to_turns<int>( tick_size );
-                break;
-            default:
-                break;
-        }
+    if( wtype->rains && wtype->precip != precip_class::none ) {
+        data.rain_amount += precip_mm_per_hour( wtype->precip ) * to_turns<double>( tick_size );
     }
-    data.rain_amount += amount;
 
     // TODO: Change this sunlight "sampling" here into a proper interpolation
     const float tick_sunlight = incident_sunlight( wtype, t );
@@ -237,7 +223,9 @@ void retroactively_fill_from_funnel( item &it, const trap &tr, const time_point 
     // Technically 0.0 division is OK, but it will be cleaner without it
     if( data.rain_amount > 0 ) {
         const double turns = to_turns<double>( end - start );
-        const double charges_per_turn = 1.0 / tr.funnel_turns_per_charge( data.rain_amount );
+        // rain_amount is sum of (mm/hour * turns), so dividing by turns gives average mm/hour
+        const double avg_mm_per_hour = data.rain_amount / turns;
+        const double charges_per_turn = 1.0 / tr.funnel_turns_per_charge( avg_mm_per_hour );
         const int rain = roll_remainder( charges_per_turn * turns );
         it.add_rain_to_container( rain );
         // add_msg_debug( "Retroactively adding %d water from turn %d to %d", rain, startturn, endturn);

--- a/src/weather.h
+++ b/src/weather.h
@@ -112,7 +112,7 @@ struct weather_printable {
 };
 
 struct weather_sum {
-    int rain_amount = 0;
+    double rain_amount = 0.0;
     float sunlight = 0.0f;
     float radiant_exposure = 0.0f; // J/m2
     int wind_amount = 0;


### PR DESCRIPTION
Fixes #2168

## Root cause

`weather_sum::rain_amount` (accumulated by `proc_weather_sum`) stored arbitrary integer units — 1/4/8 per turn for very_light/light/heavy precipitation respectively. However, both the retroactive funnel fill path (`retroactively_fill_from_funnel`) and the vehicle funnel path (`vehicle::update_time`) passed this value directly to `funnel_charges_per_turn()`, which expects rainfall in **mm/hour**.

After 15 minutes (900 turns) of light drizzle:
- `rain_amount` = 900 (1 unit × 900 turns)
- Correct rate = 0.5 mm/hour
- Bug: treated as **900 mm/hour** → ~1800× overcounting
- Result: a standard funnel would collect **254 charges** from light drizzle instead of **~0.14 expected** (probabilistically 0 or 1)

The real-time `fill_funnels` path (called every turn while the player is in the simulation) was already correct — it uses `precip_mm_per_hour()` directly and applies `one_in(whole)` probability for sub-1-charge-per-turn rates.

## What changed

**`src/weather.h`** — `weather_sum::rain_amount` changed from `int` to `double`.

**`src/weather.cpp` — `proc_weather_sum`** — Instead of accumulating arbitrary integer units, now accumulates `precip_mm_per_hour(precip) * elapsed_turns`. This makes `rain_amount` store the sum of `mm/hour × turns` over the sampled period.

**`src/weather.cpp` — `retroactively_fill_from_funnel`** — Divides `rain_amount` by total elapsed turns to recover the time-averaged mm/hour rate, then passes that to the existing physics formula. Mixed weather (e.g. drizzle then heavy rain) is correctly averaged.

**`src/vehicle.cpp` — `vehicle::update_time`** — Same fix: computes `avg_mm_per_hour = rain_amount / elapsed_turns`, then multiplies `funnel_charges_per_turn` by `elapsed_turns` to get total charges for the batched period.

## Behaviour after fix

- Drizzle (0.5 mm/hour): standard funnel collects ~1 charge per ~1.77 hours on average, via `roll_remainder` probabilistic rounding — so light rain correctly results in 0 or occasionally 1 charge over short periods rather than hundreds
- Light rain (1.5 mm/hour): ~1 charge per ~35 minutes
- Heavy rain (3.0 mm/hour): ~1 charge per ~18 minutes
- These rates apply consistently whether the funnel fill is calculated in real-time or retroactively after loading/fast-travel