### PR TITLE
Call update_bodytemp and update_body_wetness for NPCs each tick

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3387,6 +3387,8 @@ void npc::npc_update_body()
     if( calendar::once_every( 10_seconds ) ) {
         update_body( last_updated, calendar::turn );
         last_updated = calendar::turn;
+        update_body_wetness( *get_weather().weather_precise );
+        update_bodytemp();
     }
 }
 


### PR DESCRIPTION
## Problem

`update_bodytemp()` was only ever called for the player (`u.update_bodytemp()` in `do_turn.cpp`). NPCs had no equivalent call — `npc_update_body()` called `update_body()` but not `update_bodytemp()` or `update_body_wetness()`. As a result, NPCs were completely unaffected by temperature regardless of weather conditions.

## Fix

Add `update_body_wetness()` and `update_bodytemp()` to `npc::npc_update_body()`, which already throttles NPC body updates to every 10 seconds — a reasonable cadence for NPCs.

## Test

Confirmed NPCs now show overheating effects at 32°C where they previously showed none.