### PR TITLE
fix: prevent crash loading saves with NPCs reading books in nested containers

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4166,7 +4166,7 @@ int Character::calc_focus_equilibrium( bool ignore_pain ) const
 {
     int focus_equilibrium = 100;
 
-    if( activity.id() == ACT_READ ) {
+    if( activity.id() == ACT_READ && !activity.targets.empty() ) {
         const item_location book = activity.targets[0];
         if( book && book->is_book() ) {
             const cata::value_ptr<islot_book> &bt = book->type->book;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -681,6 +681,9 @@ class item_location::impl::item_in_container : public item_location::impl
             if( idx < 0 ) {
                 return nullptr;
             }
+            if( !container ) {
+                return nullptr;
+            }
             std::list<const item *> all_items = container->all_items_ptr();
             auto iter = all_items.begin();
             std::advance( iter, idx );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2262,8 +2262,12 @@ void npc::load( const JsonObject &data )
         complaints.emplace( member.name(), p );
     }
     data.read( "unique_id", unique_id );
+    // Temporarily clear activity so calc_focus_equilibrium() doesn't try to
+    // resolve item_locations before this NPC is in the critter tracker.
+    player_activity saved_activity = std::move( activity );
     clear_personality_traits();
     generate_personality_traits();
+    activity = std::move( saved_activity );
     data.read( "may_activity_occupancy_after_end_items_loc",
                may_activity_occupancy_after_end_items_loc );
 }


### PR DESCRIPTION
## Summary

- `item_in_container::unpack()` could dereference a null item pointer if its parent container failed to resolve (e.g. the owning character isn't in the critter tracker yet during load), crashing inside `item_contents::all_items_top`. Fixed by returning `nullptr` early when `!container`.
- `npc::load()` calls `clear_personality_traits()` → `unset_mutation()` → `reset_stats()` → `calc_focus_equilibrium()`, which tried to validate the NPC's `ACT_READ` book `item_location` before the NPC was registered in the critter tracker. Fixed by temporarily clearing the activity around the personality trait regeneration and restoring it afterward.
- `calc_focus_equilibrium()` accessed `activity.targets[0]` without checking if `targets` is non-empty, causing UB if an NPC had `ACT_READ` with no saved targets. Fixed with an `empty()` guard.

## Test plan

- [X] Load a save that has NPCs with `ACT_READ` activities (book in a bag in a backpack) — should load without crash or debug popups
- [X] Confirm affected NPCs continue their reading activity after load
