### PR TITLE
fix: gracefully handle save game exceptions caused by removed content

### DIFF
--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -954,5 +954,15 @@
     "min": 0,
     "max": 1600,
     "rate": "1 m"
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "seer_mark",
+    "remove": true
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "BOSS_Brigitte_LaCroix_01",
+    "remove": true
   }
 ]

--- a/data/json/obsoletion_and_migration/obsoletion_missions.json
+++ b/data/json/obsoletion_and_migration/obsoletion_missions.json
@@ -37,5 +37,22 @@
   {
     "id": "EOC_vitrified_farm_entry",
     "type": "effect_on_condition"
+  },
+  {
+    "id": "MISSION_SEER_GATHER_BONE",
+    "type": "mission_definition",
+    "name": { "str": "Find scrap for the bone seer" },
+    "description": "Obsolete mission from removed Kindred faction content.",
+    "goal": "MGOAL_GO_TO",
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MISSION_SEER_GATHER_BONE_CLEANUP",
+    "global": true,
+    "condition": { "u_has_mission": "MISSION_SEER_GATHER_BONE" },
+    "effect": [ { "remove_active_mission": "MISSION_SEER_GATHER_BONE" } ]
   }
 ]

--- a/data/json/obsoletion_and_migration/obsoletion_npc_classes.json
+++ b/data/json/obsoletion_and_migration/obsoletion_npc_classes.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "npc_class",
+    "id": "NC_BONE_SEER",
+    "name": { "str": "Bone Seer" },
+    "job_description": "Obsolete class from removed Kindred faction content.",
+    "common": false
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_KINDRED_COOPER",
+    "name": { "str": "Rogue Kindred" },
+    "job_description": "Obsolete class from removed Kindred faction content.",
+    "common": false
+  }
+]


### PR DESCRIPTION
Add obsoletion entries for content removed with the Kindred faction to prevent debug popups and crashes when loading existing saves.

## Changes

- **`MISSION_SEER_GATHER_BONE`**: Stub mission definition + EOC to clean it from active quest logs
- **`seer_mark`, `BOSS_Brigitte_LaCroix_01`**: `TRAIT_MIGRATION` entries to silently drop these mutations on load
- **`NC_BONE_SEER`, `NC_KINDRED_COOPER`**: Minimal stub `npc_class` definitions to satisfy ID lookups on already-spawned NPCs in existing saves

All fixes use the JSON obsoletion mechanic — no C++ changes.