### PR TITLE
fix: NPC wields ereader before reading instead of leaving it in bag

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1458,7 +1458,21 @@ void npc::do_npc_read( bool ebook )
         return;
     }
 
-    book = book.obtain( *npc_character );
+    if( ebook ) {
+        if( !ereader->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
+            item the_book = *book.get_item();
+            npc_character->wield( *ereader );
+            ereader = npc_character->get_wielded_item();
+            item *newit = ereader->get_item_with( [&]( const item & it ) {
+                return it.typeId() == the_book.typeId();
+            } );
+            if( newit ) {
+                book = item_location( ereader, &*newit );
+            }
+        }
+    } else {
+        book = book.obtain( *npc_character );
+    }
     if( can_read( *book, fail_reasons ) ) {
         add_msg_if_player_sees( pos_bub(), ebook ? _( "%s starts reading ebook %s." ) :
                                 _( "%s starts reading %s." ), disp_name(), book->type_name() );


### PR DESCRIPTION
When an NPC starts reading an ebook, wield the ereader so they physically hold it during the activity.

Previously, the NPC would leave the ereader in their bag/purse and start the reading activity without ever taking it out, which looked wrong.

## Changes

- Call `wield()` on the ereader before assigning the read activity, which also automatically stows any currently equipped weapon (e.g. a spear)
- Re-resolve the book `item_location` against the newly wielded ereader so the location stays valid
- Ereaders with `ALLOWS_REMOTE_USE` are skipped (no need to physically hold them)