### PR TITLE
Improve bathing

### DIFF
--- a/data/json/effects_on_condition/effects_eocs.json
+++ b/data/json/effects_on_condition/effects_eocs.json
@@ -144,22 +144,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "acid_bile_wash",
-    "condition": {
-      "and": [
-        { "or": [ { "u_has_effect": "bile" }, { "u_has_effect": "corroding" }, { "u_has_effect": "glowing" } ] },
-        { "and": [ "u_is_underwater" ] }
-      ]
-    },
-    "effect": [
-      { "u_lose_effect": "corroding" },
-      { "u_lose_effect": "bile" },
-      { "u_lose_effect": "glowing" },
-      { "u_message": "The harmful liquid is washed away." }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_dermatik_visible_INIT",
     "eoc_type": "EVENT",
     "required_event": "character_gains_effect",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1455,7 +1455,7 @@
     "concealment": 70,
     "required_str": 16,
     "max_volume": "1500 L",
-    "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "HIDE_PLACE", "NO_SIGHT", "FIRE_CONTAINER", "LIQUIDCONT" ],
+    "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "HIDE_PLACE", "NO_SIGHT", "FIRE_CONTAINER", "LIQUIDCONT", "SOAKING_TUB" ],
     "deconstruct": {
       "items": [
         { "item": "frame", "count": [ 2, 3 ] },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1741,8 +1741,8 @@ void read_activity_actor::start( player_activity &act, Character &who )
             }
             if( !plugged_in ) {
                 add_msg_if_player_sees( who,
-                    _( "%1$s can't find a nearby power grid to plug their %2$s into." ),
-                    who.disp_name(), ereader->tname() );
+                                        _( "%1$s can't find a nearby power grid to plug their %2$s into." ),
+                                        who.disp_name(), ereader->tname() );
             }
         }
     }
@@ -2196,15 +2196,15 @@ void read_activity_actor::finish( player_activity &act, Character &who )
         if( using_ereader ) {
             who.add_msg_player_or_npc( m_info,
                                        string_format( _( "You finish reading ebook %s." ),
-                                                      book->type_name() ),
+                                               book->type_name() ),
                                        string_format( _( "<npcname> finishes reading ebook %s." ),
-                                                      book->type_name() ) );
+                                               book->type_name() ) );
         } else {
             who.add_msg_player_or_npc( m_info,
                                        string_format( _( "You finish reading %s." ),
-                                                      book->type_name() ),
+                                               book->type_name() ),
                                        string_format( _( "<npcname> finishes reading %s." ),
-                                                      book->type_name() ) );
+                                               book->type_name() ) );
         }
     }
 
@@ -2218,15 +2218,15 @@ void read_activity_actor::canceled( player_activity &/*act*/, Character &who )
         if( using_ereader ) {
             who.add_msg_player_or_npc( m_info,
                                        string_format( _( "You stop reading ebook %s." ),
-                                                      book->type_name() ),
+                                               book->type_name() ),
                                        string_format( _( "<npcname> stops reading ebook %s." ),
-                                                      book->type_name() ) );
+                                               book->type_name() ) );
         } else {
             who.add_msg_player_or_npc( m_info,
                                        string_format( _( "You stop reading %s." ),
-                                                      book->type_name() ),
+                                               book->type_name() ),
                                        string_format( _( "<npcname> stops reading %s." ),
-                                                      book->type_name() ) );
+                                               book->type_name() ) );
         }
     }
     if( using_ereader && ereader && ereader->type->tool &&

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -215,6 +215,7 @@ static const efftype_id effect_airborne( "airborne" );
 static const efftype_id effect_alarm_clock( "alarm_clock" );
 static const efftype_id effect_bandaged( "bandaged" );
 static const efftype_id effect_beartrap( "beartrap" );
+static const efftype_id effect_bile( "bile" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
 static const efftype_id effect_blind( "blind" );
@@ -9531,7 +9532,8 @@ void Character::fall_asleep( const time_duration &duration )
     // Turn off any active e-file devices (tablets, laptops) when falling asleep
     std::vector<item *> active_edevices;
     visit_items( [&active_edevices]( item * it, item * ) -> VisitResponse {
-        if( it->type->can_use( "E_FILE_DEVICE" ) && it->type->transform_into ) {
+        if( it->type->can_use( "E_FILE_DEVICE" ) && it->type->transform_into )
+        {
             active_edevices.push_back( it );
         }
         return VisitResponse::NEXT;
@@ -13977,6 +13979,15 @@ void Character::water_immersion()
                 std::vector<bodypart_id> drenched_vec;
                 for( bodypart_id bp : drenched_parts ) {
                     drenched_vec.push_back( bp );
+                    if( has_effect( effect_corroding, bp ) ) {
+                        remove_effect( effect_corroding, bp );
+                    }
+                    if( has_effect( effect_bile, bp ) ) {
+                        remove_effect( effect_bile, bp );
+                    }
+                    if( has_effect( effect_glowing, bp ) ) {
+                        remove_effect( effect_glowing, bp );
+                    }
                 }
                 // Initialize exposure map
                 std::map<bodypart_id, float> exposure;
@@ -14001,9 +14012,36 @@ void Character::water_immersion()
             }
         }
     }
-    // Soaking in a liquid-filled tub (e.g. bathtub) drenches the character.
-    // Requires at least 15 L of liquid in the furniture tile.
+    if( in_bath() ) {
+        if( has_effect( effect_onfire ) ) {
+            add_msg( _( "The water puts out the flames!" ) );
+            remove_effect( effect_onfire );
+            // Motherfucker riding a horse in the bath.
+            if( is_mounted() ) {
+                monster *mon = mounted_creature.get();
+                if( mon->has_effect( effect_onfire ) ) {
+                    mon->remove_effect( effect_onfire );
+                }
+            }
+        }
+        if( has_effect( effect_corroding ) ) {
+            remove_effect( effect_corroding );
+        }
+        if( has_effect( effect_bile ) ) {
+            remove_effect( effect_bile );
+        }
+        if( has_effect( effect_glowing ) ) {
+            remove_effect( effect_glowing );
+        }
+        drench( 100, get_drenching_body_parts(), false );
+    }
+}
+
+bool Character::in_bath()
+{
+    map &here = get_map();
     if( !in_vehicle && here.has_flag( ter_furn_flag::TFLAG_SOAKING_TUB, pos_bub() ) ) {
+        // Requires at least 15 L of liquid in the furniture tile.
         units::volume water_vol = 0_ml;
         for( const item &it : here.i_at( pos_bub() ) ) {
             if( it.made_of( phase_id::LIQUID ) ) {
@@ -14012,18 +14050,13 @@ void Character::water_immersion()
         }
         // The bathtub spans two tiles but liquid is stored per-tile, so we only check the
         // tile the character is on.
+        // TODO: Water should spread to contiguous tiles, check for non-water fluids, hot water, etc.
         const units::volume min_vol = units::from_liter( 15 );
         if( water_vol >= min_vol ) {
-            drench( 100, get_drenching_body_parts( false ), false );
-            if( calendar::once_every( 1_minutes ) ) {
-                add_msg_if_player( m_good, _( "You soak in the water." ) );
-            }
-        } else {
-            if( calendar::once_every( 1_minutes ) ) {
-                add_msg_if_player( m_info, _( "The tub doesn't have enough water to soak in." ) );
-            }
+            return true;
         }
     }
+    return false;
 }
 
 void Character::pause()

--- a/src/character.h
+++ b/src/character.h
@@ -2803,6 +2803,8 @@ class Character : public Creature, public visitable
         /** Check if we're in a water tile and handle wetness effects.  Should be run when waiting or moving. */
         void water_immersion();
 
+        bool in_bath();
+
         /** Check player strong enough to lift an object unaided by equipment (jacks, levers etc) */
         bool can_lift( item &obj ) const;
         bool can_lift( vehicle &veh, map &here ) const;

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1650,7 +1650,8 @@ conditional_t::func f_is_on_liquid( bool is_npc )
 {
     return [is_npc]( const_dialogue const & d ) {
         map &here = get_map();
-        return !get_map().is_dry( d.const_actor( is_npc )->pos_bub( here ) );
+        return !get_map().is_dry( d.const_actor( is_npc )->pos_bub( here ) ) &&
+               !d.const_actor( is_npc )->in_bath();
     };
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14399,7 +14399,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
             if( carrier != nullptr ) {
                 if( carrier->is_npc() ) {
                     add_msg_if_player_sees( *carrier, m_bad, _( "%s's %s breaks loose!" ),
-                                           carrier->disp_name( true, true ), cable_name );
+                                            carrier->disp_name( true, true ), cable_name );
                 } else {
                     carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
                 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2877,7 +2877,8 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
 
     auto scan_cost = [&]() -> std::optional<int> {
         p->mod_moves( -100 );
-        if( one_in( 25 ) ) {
+        if( one_in( 25 ) )
+        {
             return 1;
         }
         return std::nullopt;
@@ -2895,9 +2896,9 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
             };
 
             const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                here, _( "Scan whom?" ),
-                _( "There is no one to scan nearby." ), f, false
-            );
+                        here, _( "Scan whom?" ),
+                        _( "There is no one to scan nearby." ), f, false
+                    );
 
             if( !pnt_ ) {
                 return std::nullopt;
@@ -2907,21 +2908,21 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
 
             if( pnt == p->pos_bub() ) {
                 p->add_msg_if_player( m_info,
-                    _( "Your radiation level: %d mSv (%d mSv from items)" ),
-                    p->get_rad(),
-                    static_cast<int>( p->get_leak_level() )
-                );
+                                      _( "Your radiation level: %d mSv (%d mSv from items)" ),
+                                      p->get_rad(),
+                                      static_cast<int>( p->get_leak_level() )
+                                    );
                 return scan_cost();
             }
 
             if( npc *const person_ = creatures.creature_at<npc>( pnt ) ) {
                 npc &person = *person_;
                 p->add_msg_if_player( m_info,
-                    _( "%s's radiation level: %d mSv (%d mSv from items)" ),
-                    person.get_name(),
-                    person.get_rad(),
-                    static_cast<int>( person.get_leak_level() )
-                );
+                                      _( "%s's radiation level: %d mSv (%d mSv from items)" ),
+                                      person.get_name(),
+                                      person.get_rad(),
+                                      static_cast<int>( person.get_leak_level() )
+                                    );
                 return scan_cost();
             }
 
@@ -2930,9 +2931,9 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
 
         case 1:
             p->add_msg_if_player( m_info,
-                _( "The ground's radiation level: %d mSv/h" ),
-                here.get_radiation( p->pos_bub() )
-            );
+                                  _( "The ground's radiation level: %d mSv/h" ),
+                                  here.get_radiation( p->pos_bub() )
+                                );
             return scan_cost();
 
         case 2:

--- a/src/talker.h
+++ b/src/talker.h
@@ -395,6 +395,9 @@ class const_talker
                                    const itype_id & = itype_id::NULL_ID() ) const {
             return false;
         }
+        virtual bool in_bath() const {
+            return false;
+        }
 
         // missions
         virtual std::vector<mission *> available_missions() const {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8404,8 +8404,10 @@ void vehicle::update_time( map &here, const time_point &update_to )
 
         const double area_in_mm2 = std::pow( pt.info().bonus, 2 ) * M_PI;
         const double elapsed_turns = to_turns<double>( elapsed );
-        const double avg_mm_per_hour = elapsed_turns > 0.0 ? accum_weather.rain_amount / elapsed_turns : 0.0;
-        const int qty = roll_remainder( funnel_charges_per_turn( area_in_mm2, avg_mm_per_hour ) * elapsed_turns );
+        const double avg_mm_per_hour = elapsed_turns > 0.0 ? accum_weather.rain_amount / elapsed_turns :
+                                       0.0;
+        const int qty = roll_remainder( funnel_charges_per_turn( area_in_mm2,
+                                        avg_mm_per_hour ) * elapsed_turns );
         int c_qty = qty + ( tank->can_reload( water_clean ) ?  tank->ammo_remaining( ) : 0 );
         int cost_to_purify = c_qty * itype_water_purifier->charges_to_use();
 


### PR DESCRIPTION
#### Summary
Improve bathing

#### Purpose of change
Improve bathing somewhat

#### Describe the solution
- Dumpsters can now also be used as soaking tubs.
- Moved in_bath() to its own bool so we can call it in other places if need be.
- water_immersion() now removes acid, bile, and glowing. Bathing removes onfire (onfire is handled in swim() for normal tiles).
- Removed messaging. It's really not necessary here.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
