### PR TITLE
fix: complete Kindred obsoletion - add missing npc_template stubs

### DIFF
--- a/data/json/obsoletion_and_migration/obsoletion_npc_templates.json
+++ b/data/json/obsoletion_and_migration/obsoletion_npc_templates.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "npc",
+    "id": "SEER_Brigitte_LaCroix",
+    "//": "Obsolete template from removed Kindred faction content.",
+    "class": "NC_BONE_SEER",
+    "attitude": 7,
+    "mission": 3,
+    "chat": "TALK_DONE",
+    "faction": "no_faction"
+  },
+  {
+    "type": "npc",
+    "id": "KINDRED_Darren_Cooper",
+    "//": "Obsolete template from removed Kindred faction content.",
+    "class": "NC_KINDRED_COOPER",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_DONE",
+    "faction": "no_faction"
+  }
+]


### PR DESCRIPTION
## Summary

- PR #2241 added `npc_class` stubs for `NC_BONE_SEER` and `NC_KINDRED_COOPER` but missed the corresponding `npc_template` stubs
- Existing saves with `SEER_Brigitte_LaCroix` or `KINDRED_Darren_Cooper` spawned in them would trigger a debug error on load: `Tried to get invalid npc: SEER_Brigitte_LaCroix`
- Adds `obsoletion_npc_templates.json` with minimal stubs for both Kindred NPCs, satisfying ID lookups without restoring any removed content

## Test plan

- [x] Load a save with a Brigitte LaCroix or Darren Cooper NPC — no debug popup on load