### PR TITLE
fix: skip wield in do_npc_read if ereader already wielded

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1461,8 +1461,10 @@ void npc::do_npc_read( bool ebook )
     if( ebook ) {
         if( !ereader->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
             item the_book = *book.get_item();
-            npc_character->wield( *ereader );
-            ereader = npc_character->get_wielded_item();
+            if( !npc_character->is_wielding( *ereader ) ) {
+                npc_character->wield( *ereader );
+                ereader = npc_character->get_wielded_item();
+            }
             item *newit = ereader->get_item_with( [&]( const item & it ) {
                 return it.typeId() == the_book.typeId();
             } );


### PR DESCRIPTION
## Summary

- `read_activity_actor::finish()` deactivates the ereader screen but leaves it wielded after reading completes
- On the next dialogue-triggered read, `do_npc_read` calls `Character::wield(*ereader)` while the ereader is already in the weapon slot
- `Character::wield` detects `is_wielding(ereader) = true`, treats it as an unwield, stows the ereader ("NPC puts away the tablet"), and returns without re-wielding — the read silently fails
- A second attempt always worked because the ereader was then in inventory (not wielded)
- Fix: skip the `wield()` call entirely when the ereader is already wielded

## Test plan

- [x] Ask an NPC companion to read an ebook — they start reading first time without putting the tablet away
- [x] Ask again after the reading session finishes — still works without a double-ask