### PR TITLE
fix: bulk goods spawn as bags instead of individual units

### DIFF
--- a/data/json/mapgen/landscaping_supply.json
+++ b/data/json/mapgen/landscaping_supply.json
@@ -34,7 +34,6 @@
       "place_item": [
         { "item": "log", "repeat": [ 12, 120 ], "x": [ 19, 22 ], "y": [ 3, 5 ] },
         { "item": "stick", "repeat": [ 12, 192 ], "x": [ 24, 27 ], "y": [ 3, 5 ] },
-        { "item": "fertilizer_commercial", "repeat": [ 10, 60 ], "x": [ 33, 35 ], "y": [ 3, 5 ] },
         { "item": "stepladder", "x": 33, "y": 17, "chance": 100 }
       ],
       "terrain": {
@@ -83,6 +82,7 @@
         "&": "f_trashcan"
       },
       "place_items": [
+        { "item": "fertilizer_commercial_bag_canvas_60", "x": [ 33, 35 ], "y": [ 3, 5 ], "chance": 100, "repeat": [ 1, 2 ] },
         { "item": "clothing_work_gloves", "x": [ 38, 39 ], "y": [ 15, 16 ], "chance": 75, "repeat": [ 1, 8 ] },
         { "item": "tools_earthworking", "x": [ 38, 42 ], "y": 18, "chance": 70, "repeat": [ 1, 3 ] },
         { "item": "supplies_farming", "x": [ 41, 42 ], "y": [ 15, 16 ], "chance": 75, "repeat": [ 1, 4 ] },

--- a/data/json/mapgen/necc/church_retreat.json
+++ b/data/json/mapgen/necc/church_retreat.json
@@ -146,7 +146,7 @@
         { "item": "story_book", "x": 8, "y": 37 },
         { "item": "classic_literature", "x": 8, "y": 37 },
         { "item": "deck_of_cards", "x": 7, "y": 56 },
-        { "item": "fertilizer_commercial", "repeat": [ 1, 3 ], "x": [ 39, 40 ], "y": [ 48, 49 ] },
+        { "group": "fertilizer_commercial_bag_canvas_60", "repeat": [ 1, 2 ], "x": [ 39, 40 ], "y": [ 48, 49 ], "chance": 100 },
         { "item": "stick_long", "x": 50, "y": 18, "repeat": [ 5, 20 ] },
         { "item": "log", "x": 50, "y": 18, "repeat": [ 4, 8 ] },
         { "item": "stick_long", "x": 33, "y": 47, "repeat": [ 1, 5 ] }


### PR DESCRIPTION
## Summary

The landscaping supply center and NECC church retreat were placing \`fertilizer_commercial\` as individual items (1 charge each). This meant you would find many bags each containing only 1 unit, instead of a small number of bags each containing 60 units.

Fixed by using the existing \`fertilizer_commercial_bag_canvas_60\` item group, which produces a canvas bag with the correct 60-unit quantity. Spawn counts adjusted to 1–2 bags so total loot is comparable to the original intent.

## Note

The same spawning bug exists in other locations that use bulk goods directly via \`place_item\` or \`place_loot\` — including cattle fodder (\`cattlefodder\`), bird food (\`birdfood\`), and dry dog food (\`dogfood_dry\`) on farms, ranches, the zoo, and lab nests. Those all have corresponding bag item groups and should be addressed in a separate pass, with care taken to keep total loot quantities reasonable.

## Test plan
- [x] Visit a landscaping supply center — should find 1–2 canvas bags of commercial fertilizer (60 units each) rather than dozens of single-unit bags