### PR TITLE
Fix improper merge of wield check and null guard

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1463,8 +1463,14 @@ void npc::do_npc_read( bool ebook )
     if( ebook ) {
         if( !ereader->has_flag( flag_ALLOWS_REMOTE_USE ) ) {
             item the_book = *book.get_item();
-            npc_character->wield( *ereader );
-            ereader = npc_character->get_wielded_item();
+            if( !npc_character->is_wielding( *ereader ) ) {
+                npc_character->wield( *ereader );
+                ereader = npc_character->get_wielded_item();
+            }
+            if( !ereader ) {
+                deactivate();
+                return;
+            }
             item *newit = ereader->get_item_with( [&]( const item & it ) {
                 return it.typeId() == the_book.typeId();
             } );


### PR DESCRIPTION
#### Summary
Fix improper merge of wield check and null guard

#### Purpose of change
#2250 and #2249 were merged incorrectly, this fixes them.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
