### PR TITLE
fix: flour spawns as a proper bag instead of a single unit

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1312,7 +1312,7 @@
       [ "maple_sap", 50 ],
       [ "syrup", 100 ],
       [ "maple_candy", 10 ],
-      [ "flour", 30 ],
+      { "prob": 30, "group": "flour_bag_paper" },
       [ "milk_powder", 30 ],
       [ "powder_eggs", 10 ],
       { "group": "egg_bird_unfert_carton_egg_10" },

--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -238,7 +238,7 @@
     "id": "commercial_breakfast_mixes",
     "type": "item_group",
     "subtype": "distribution",
-    "items": [ [ "flour", 3 ], [ "chem_baking_soda", 1 ], [ "syrup", 1 ] ]
+    "items": [ { "prob": 3, "group": "flour_bag_paper" }, [ "chem_baking_soda", 1 ], [ "syrup", 1 ] ]
   },
   {
     "id": "SUS_shelf_commercial_breakfast_mixes",


### PR DESCRIPTION
## Summary

Two item groups were placing `flour` using shorthand notation (`[ "flour", prob ]`), which spawns the item with its default container (`bag_paper_powder`) but only 1 unit — giving a bag containing 12.5g of flour instead of a useful quantity.

Fixed by using the `flour_bag_paper` group (10–100 units per bag), the same pattern as #2251.

**Affected groups:**
- `sugar_house_kitchen_items` (`locations_commercial.json`) — sugar shack kitchen loot
- `commercial_breakfast_mixes` (`supermarket.json`) — supermarket shelf loot

Note: bakeries and pizza parlors already correctly use `flour_various_full` / `flour_bulk` which give proper quantities.

## Test plan
- [ ] Visit a sugar shack / maple sugar house — flour in the kitchen should be a bag with 10–100 units
- [ ] Check supermarket breakfast aisle — flour should be a full bag, not a single-unit bag