### PR TITLE
fix: flour spawns as a proper bag instead of a single unit

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1312,7 +1312,7 @@
       [ "maple_sap", 50 ],
       [ "syrup", 100 ],
       [ "maple_candy", 10 ],
-      [ "flour", 30 ],
+      { "prob": 30, "group": "flour_bag_paper_powder_1_70" },
       [ "milk_powder", 30 ],
       [ "powder_eggs", 10 ],
       { "group": "egg_bird_unfert_carton_egg_10" },

--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -238,7 +238,7 @@
     "id": "commercial_breakfast_mixes",
     "type": "item_group",
     "subtype": "distribution",
-    "items": [ [ "flour", 3 ], [ "chem_baking_soda", 1 ], [ "syrup", 1 ] ]
+    "items": [ { "prob": 3, "group": "flour_bag_plastic_full" }, [ "chem_baking_soda", 1 ], [ "syrup", 1 ] ]
   },
   {
     "id": "SUS_shelf_commercial_breakfast_mixes",


### PR DESCRIPTION
## Summary

Two item groups placed `flour` using shorthand `[ "flour", prob ]` notation. Since `flour` has a default `container` of `bag_paper_powder`, this produced a bag containing only 1 unit (12.5g) — the same class of bug fixed in #2251 for `fertilizer_commercial`.

Fixed using quantity-appropriate bag groups to avoid flooding the player with flour:

| Group | Location | Old | New | Quantity |
|---|---|---|---|---|
| `sugar_house_kitchen_items` | Sugar shack kitchen | 1 unit | `flour_bag_paper_powder_1_70` | 1–70 units (partially used home bag) |
| `commercial_breakfast_mixes` | Supermarket shelf | 1 unit | `flour_bag_plastic_full` | 20 units (small sealed store bag) |

## Test plan
- [ ] Visit a sugar shack — kitchen should contain a partially-used bag of flour (not a single-unit bag)
- [ ] Visit a supermarket — breakfast mixes shelf should occasionally have a small sealed flour bag