### PR TITLE
fix: dry dog food spawns as a proper bag instead of a single unit

### DIFF
--- a/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_security.json
+++ b/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_security.json
@@ -395,7 +395,7 @@
         "U|      H|"
       ],
       "palettes": [ "lab_common_palette", "lab_security_palette" ],
-      "place_loot": [ { "item": "dogfood_dry", "x": 0, "y": 3, "chance": 100 }, { "item": "dogfood", "x": 0, "y": 3, "chance": 100 } ],
+      "place_loot": [ { "group": "dogfood_dry_bag_plastic_6", "x": 0, "y": 3, "chance": 100 }, { "item": "dogfood", "x": 0, "y": 3, "chance": 100 } ],
       "place_nested": [
         { "chunks": [ [ "1x6_bash", 50 ], [ "null", 50 ] ], "x": [ 2, 4 ], "y": 2 },
         { "chunks": [ [ "1x6_bash", 50 ], [ "null", 50 ] ], "x": [ 2, 3 ], "y": 4 }
@@ -427,7 +427,7 @@
         "   ն   | |"
       ],
       "palettes": [ "lab_common_palette", "lab_security_palette" ],
-      "place_loot": [ { "item": "dogfood_dry", "x": 0, "y": 6, "chance": 100 }, { "item": "dogfood", "x": 0, "y": 6, "chance": 100 } ],
+      "place_loot": [ { "group": "dogfood_dry_bag_plastic_6", "x": 0, "y": 6, "chance": 100 }, { "item": "dogfood", "x": 0, "y": 6, "chance": 100 } ],
       "place_nested": [
         { "chunks": [ [ "1x6_bash", 50 ], [ "null", 50 ] ], "x": [ 2, 3 ], "y": 5 },
         { "chunks": [ [ "1x6_bash", 50 ], [ "null", 50 ] ], "x": [ 2, 4 ], "y": 7 }


### PR DESCRIPTION
## Summary

Lab security kennel nests placed `dogfood_dry` directly via `place_loot`, producing a bag with only 1 unit due to `dogfood_dry`'s default `container` field (`bag_plastic`). Same class of bug as #2251.

Fixed by using `dogfood_dry_bag_plastic_6` (6 units — the smallest available bag group), appropriate for a lab kennel that's been stocked but not overstocked.

Only the two lab security kennel nests had this bug. Other `dogfood_dry` appearances (NPC inventory, profession starting gear, the domestic dog-accessories collection) are intentionally single-unit.

## Test plan
- [ ] Find a lab security kennel — dog food bowl area should have a bag of 6 dry kibble rather than a single-unit bag