### PR TITLE
fix: reformat church_retreat.json to pass JSON style check

### DIFF
--- a/data/json/mapgen/necc/church_retreat.json
+++ b/data/json/mapgen/necc/church_retreat.json
@@ -146,7 +146,13 @@
         { "item": "story_book", "x": 8, "y": 37 },
         { "item": "classic_literature", "x": 8, "y": 37 },
         { "item": "deck_of_cards", "x": 7, "y": 56 },
-        { "group": "fertilizer_commercial_bag_canvas_60", "repeat": [ 1, 2 ], "x": [ 39, 40 ], "y": [ 48, 49 ], "chance": 100 },
+        {
+          "group": "fertilizer_commercial_bag_canvas_60",
+          "repeat": [ 1, 2 ],
+          "x": [ 39, 40 ],
+          "y": [ 48, 49 ],
+          "chance": 100
+        },
         { "item": "stick_long", "x": 50, "y": 18, "repeat": [ 5, 20 ] },
         { "item": "log", "x": 50, "y": 18, "repeat": [ 4, 8 ] },
         { "item": "stick_long", "x": 33, "y": 47, "repeat": [ 1, 5 ] }


### PR DESCRIPTION
The fertilizer bag spawn fix in #2251 introduced a single-line JSON object that fails the JSON style linter. Reformatted to multi-line per JSON_STYLE.md.