### PR TITLE
Start removing isherwoods

### DIFF
--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -150,7 +150,7 @@
   {
     "type": "forest_biome_mapgen",
     "id": "biome_forest_default",
-    "terrains": [ "forest", "special_forest", "special_forest_isherwood" ],
+    "terrains": [ "forest", "special_forest" ],
     "sparseness_adjacency_factor": 3,
     "item_group": "forest",
     "item_group_chance": 60,
@@ -198,7 +198,6 @@
       "river_sw",
       "slimepit_z0",
       "special_forest_thick",
-      "special_forest_thick_isherwood",
       "spider_pit",
       "standing_stones",
       "stream",


### PR DESCRIPTION
#### Summary
Start removing Isherwoods

#### Purpose of change
The Isherwoods are slated for removal. For the curious, they were originally supposed to be a backwoods family with a homestead who could conceivably have avoided the worst of the cataclysm by having never been the type to rely on the cities. Isolated and self-sufficient, they were in a position to simply go on with their lives despite the apocalypse that befell everyone else. This is the source of their mistrust of the federal government. They're "hillbilly" types, for lack of a better word, and back when this was just a zombie game, it made sense that they almost hadn't realized there had even been a Cataclysm.

That lore no longer holds. The Cataclysm did not spare people in rural areas. Portal storms and feralization were equal opportunity offenders. It is conceivable that a rural family could have survived, but not with any degree of ignorance as to what happened, and certainly not without enduring loss and privation, which are never elements that the Isherwoods have been good at exhibiting.

Furthermore, some time ago in DDA, mutable farm maps were added. These are massive corporate farms that would be impossible for a single family, even a large one, to manage. The Isherwoods were moved to one of these, and lost their image as salt-of-the-earth survivalists and instead became sort of a bourgeois landowning family that had inexplicably been spared any hardship except for a few monsters at the edge of their property and one of their own, who hadn't been at home, getting abducted by mi-go.

Their farms are full of randomly generated monsters and other problems, and they don't address this. Furthermore, they're a massive source of free loot for the player, and even if you don't rob or kill them, they have a bunch of really boring fetch quests that give you access to things you should be finding by more interesting means.

The final verdict is that they add little and detract a lot, so away they go.

#### Describe the solution
Remove their stuff from region settings, preventing it from spawning in new worlds.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
