### PR TITLE
Further limb improvements

### DIFF
--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -638,6 +638,7 @@
     "max_coverage": 45,
     "parent": "gastropod_foot",
     "side": 0,
+    "opposite": "gastropod_foot_lower",
     "name_multiple": "foot",
     "name": "upper foot"
   },
@@ -647,6 +648,7 @@
     "max_coverage": 45,
     "parent": "gastropod_foot",
     "side": 0,
+    "opposite": "gastropod_foot_upper",
     "name_multiple": "foot",
     "name": "lower foot"
   },
@@ -656,6 +658,7 @@
     "max_coverage": 10,
     "parent": "gastropod_foot",
     "side": 0,
+    "opposite": "sub_limb_debug",
     "name_multiple": "foot",
     "name": "pedal sole"
   },
@@ -668,6 +671,7 @@
     "secondary": true,
     "name_multiple": "foot (draped)",
     "name": "foot (draped)",
+    "opposite": "sub_limb_debug",
     "locations_under": [ "gastropod_foot_upper" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Further limb improvements

#### Purpose of change
Last minute fix following #2275 

#### Describe the solution
Fix the error message by adding opposites to all the sublimbs. It's a necessary field, I guess!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
