### PR TITLE
NPC temperature complaints respect allow_complain rule

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2624,11 +2624,11 @@ npc_action npc::address_needs( float danger )
             if( torso_temp <= BODYTEMP_COLD ) {
                 complain_about( "override_cold", 5_minutes,
                                 _( "I'd love to find somewhere warmer, but I'm following you instead." ),
-                                true, sounds::sound_t::order );
+                                false, sounds::sound_t::order );
             } else if( torso_temp >= BODYTEMP_HOT ) {
                 complain_about( "override_hot", 5_minutes,
                                 _( "I'd love to find somewhere cooler, but I'm following you instead." ),
-                                true, sounds::sound_t::order );
+                                false, sounds::sound_t::order );
             }
         }
     }
@@ -5512,14 +5512,14 @@ bool npc::complain()
         const bool severe = torso_temp <= BODYTEMP_VERY_COLD;
         const time_duration freq = severe ? 10_minutes : 30_minutes;
         if( complain_about( too_cold_string, freq, chat_snippets().snip_too_cold.translated(),
-                            severe, sounds::sound_t::order ) ) {
+                            false, sounds::sound_t::order ) ) {
             return true;
         }
     } else if( torso_temp >= BODYTEMP_HOT ) {
         const bool severe = torso_temp >= BODYTEMP_VERY_HOT;
         const time_duration freq = severe ? 10_minutes : 30_minutes;
         if( complain_about( too_hot_string, freq, chat_snippets().snip_too_hot.translated(),
-                            severe, sounds::sound_t::order ) ) {
+                            false, sounds::sound_t::order ) ) {
             return true;
         }
     }
@@ -5680,7 +5680,7 @@ bool npc::try_remove_warm_clothing()
                             string_format(
                                 _( "My %s is making me overheat!  You'll have to tell me to take it off." ),
                                 warmest_sturdy->tname() ),
-                            true, sounds::sound_t::order );
+                            false, sounds::sound_t::order );
         }
         return false;
     }
@@ -5721,7 +5721,7 @@ bool npc::seek_safe_temperature()
         if( !here.is_outside( pos_bub() ) ) {
             complain_about( "sheltering_cold", 5_minutes,
                             _( "I'll stay in here until it warms up.  Tell me to follow you when you need me." ),
-                            true, sounds::sound_t::order );
+                            false, sounds::sound_t::order );
             move_pause();
             return true;
         }
@@ -5747,7 +5747,7 @@ bool npc::seek_safe_temperature()
         if( best_fire_adj_dist <= seek_radius ) {
             complain_about( "seek_fire_warmth", 2_minutes,
                             _( "I'm freezing!  I'm heading for that fire." ),
-                            true, sounds::sound_t::order );
+                            false, sounds::sound_t::order );
             return try_move_to( best_fire_adj );
         }
         // No fire found; if outside, seek nearest enclosed shelter
@@ -5769,11 +5769,11 @@ bool npc::seek_safe_temperature()
                     complain_about( "seek_cold_shelter", 2_minutes,
                                     string_format( _( "I'm freezing!  I'm heading for that %s." ),
                                                    vp->vehicle().name ),
-                                    true, sounds::sound_t::order );
+                                    false, sounds::sound_t::order );
                 } else {
                     complain_about( "seek_cold_shelter", 2_minutes,
                                     _( "It's too cold out here, I need to find shelter." ),
-                                    true, sounds::sound_t::order );
+                                    false, sounds::sound_t::order );
                 }
                 return try_move_to( shelter );
             }
@@ -5807,7 +5807,7 @@ bool npc::seek_safe_temperature()
                 if( cool_dist <= seek_radius ) {
                     complain_about( "flee_fire_heat", 2_minutes,
                                     _( "The heat from that fire is unbearable!  I need to get away." ),
-                                    true, sounds::sound_t::order );
+                                    false, sounds::sound_t::order );
                     return try_move_to( cool_spot );
                 }
             }
@@ -5816,7 +5816,7 @@ bool npc::seek_safe_temperature()
         if( !here.is_outside( pos_bub() ) ) {
             complain_about( "sheltering_hot", 5_minutes,
                             _( "I'll stay in here until it cools down.  Tell me to follow you when you need me." ),
-                            true, sounds::sound_t::order );
+                            false, sounds::sound_t::order );
             move_pause();
             return true;
         }
@@ -5838,11 +5838,11 @@ bool npc::seek_safe_temperature()
                 complain_about( "seek_hot_shelter", 2_minutes,
                                 string_format( _( "It's too hot out here, I'm heading for that %s." ),
                                                vp->vehicle().name ),
-                                true, sounds::sound_t::order );
+                                false, sounds::sound_t::order );
             } else {
                 complain_about( "seek_hot_shelter", 2_minutes,
                                 _( "It's too hot out here, I need to find some shade." ),
-                                true, sounds::sound_t::order );
+                                false, sounds::sound_t::order );
             }
             return try_move_to( shelter );
         }


### PR DESCRIPTION
Temperature-related `complain_about` calls were using `force=true`, which bypasses the `allow_complain` ally rule. This meant NPCs would spam temperature complaints even when the player had selected "Tell me when you need something."

This PR changes all temperature complaint calls to `force=false` so they respect the rule. NPCs still physically respond to temperature (seek shelter, move toward fires, adjust clothing) — they just won't verbally announce it when the player has asked for silence.

Affected functions:
- `address_needs()` — override cold/hot while following
- `complain()` — regular and severe cold/hot complaints
- `try_remove_warm_clothing()` — overheating in sturdy armor
- `seek_safe_temperature()` — sheltering in place, seeking fire/shade