### PR TITLE
fix: use Chebyshev distance for cable length, show stretch warning for NPCs

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14408,8 +14408,13 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
             }
             return true;
         } else if( link().length + M_SQRT2 >= link().max_length + 1 && carrier != nullptr ) {
-            carrier->add_msg_if_player( m_warning, _( "Your %s is stretched to its limit!" ),
-                                        link_name() );
+            if( carrier->is_npc() ) {
+                add_msg_if_player_sees( *carrier, m_warning, _( "%s's %s is stretched to its limit!" ),
+                                        carrier->disp_name( true, true ), link_name() );
+            } else {
+                carrier->add_msg_if_player( m_warning, _( "Your %s is stretched to its limit!" ),
+                                            link_name() );
+            }
         }
         return false;
     };
@@ -14503,8 +14508,10 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     }
 
     // If either of the link's connected sides moved, check the cable's length.
+    // Use Chebyshev (square) distance so that diagonal movement costs the same as cardinal,
+    // matching player intuition that "N tiles" means N moves in any direction.
     if( length_check_needed ) {
-        link().length = rl_dist( pos, t_veh_bub_pos + t_veh->part( link_vp_index ).precalc[0].raw() );
+        link().length = square_dist( pos, t_veh_bub_pos + t_veh->part( link_vp_index ).precalc[0].raw() );
         if( check_length() ) {
             return reset_link( true, carrier, link_vp_index );
         }


### PR DESCRIPTION
## Summary

- Cable length was measured with Euclidean distance, so an NPC standing diagonally (e.g. 3 tiles right, 4 tiles up) from the vehicle port measured as distance 5 and silently disconnected — even though the player counts that as 4 tiles away. This caused NPC tablets to lose their vehicle connection and drain dead while appearing plugged in.
- Switch the cable-length check from `rl_dist` (Euclidean) to `square_dist` (Chebyshev) so that `cable_length: N` means N tile-moves in any direction, consistent with how every other range check in the game works.
- Fix the "stretched to its limit" pre-disconnect warning: it used `add_msg_if_player`, which is silent when an NPC is the cable carrier. Change it to `add_msg_if_player_sees` so nearby players see the warning before the cable breaks loose.

## Test plan

- [x] Plug an NPC's e-ink tablet into a vehicle battery port
- [x] Position the NPC diagonally from the port at 3 tiles right + 4 tiles up (previously Euclidean 5, now Chebyshev 4) — confirm cable stays connected and tablet charges
- [x] Move the NPC 5 Chebyshev tiles from the port — confirm cable disconnects with the "breaks loose" message
- [x] While NPC is at max cable length, observe nearby — confirm "stretched to its limit" warning is now visible to the player