### PR TITLE
Stinger, bugfix, tail club, weight

### DIFF
--- a/data/json/attack_vectors.json
+++ b/data/json/attack_vectors.json
@@ -23,6 +23,13 @@
   },
   {
     "type": "attack_vector",
+    "id": "vector_tail_tip",
+    "limbs": [ "long_tail" ],
+    "contact_area": [ "long_tail_tip" ],
+    "natural_attack": true
+  },
+  {
+    "type": "attack_vector",
     "id": "vector_bite",
     "limbs": [ "mouth" ],
     "contact_area": [ "mouth_lips" ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1044,6 +1044,74 @@
     "melee_damage": { "stab": 14 }
   },
   {
+    "id": "integrated_stinging_tail",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "stinger" },
+    "description": "A hypodermic barb of class-sharp chitin.",
+    "weight": "800 g",
+    "volume": "1200 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "sclerotin", "iflesh" ],
+    "symbol": ";",
+    "color": "black",
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "PERSONAL",
+      "WATER_FRIENDLY",
+      "PADDED",
+      "NO_SALVAGE",
+      "PROVIDES_TECHNIQUES",
+      "NATURAL_WEAPON"
+    ],
+    "techniques": [ "STINGER_STAB" ],
+    "armor": [
+      {
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 3 } ],
+        "covers": [ "long_tail" ],
+        "specifically_covers": [ "long_tail_tip" ],
+        "coverage": 8,
+        "encumbrance": 3
+      }
+    ],
+    "melee_damage": { "stab": 11 }
+  },
+  {
+    "id": "integrated_club_tail",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "tail club" },
+    "description": "A weighty knob of fused vertebrae and osteoderms weighing down the tip of the tail like a ball and chain.",
+    "weight": "2300 g",
+    "volume": "2200 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "bone", "scales", "flesh" ],
+    "symbol": ";",
+    "color": "brown",
+    "warmth": 8,
+    "material_thickness": 3,
+    "flags": [
+      "INTEGRATED",
+      "ALLOWS_NATURAL_ATTACKS",
+      "UNBREAKABLE",
+      "PERSONAL",
+      "WATER_FRIENDLY",
+      "PADDED",
+      "NO_SALVAGE",
+      "PROVIDES_TECHNIQUES",
+      "NATURAL_WEAPON"
+    ],
+    "techniques": [ "TAIL_CLUB" ],
+    "armor": [ { "covers": [ "long_tail" ], "specifically_covers": [ "long_tail_tip" ], "coverage": 8, "encumbrance": 3 } ],
+    "melee_damage": { "bash": 12 }
+  },
+  {
     "id": "integrated_chitin",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/json/mapgen/lab/lab_floorplans.json
+++ b/data/json/mapgen/lab/lab_floorplans.json
@@ -313,7 +313,8 @@
           "chance": 33,
           "pack_size": [ 1, 2 ]
         }
-      ]
+      ],
+      "flags": [ "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN", "ERASE_TRAP_BEFORE_PLACING_TERRAIN", "ALLOW_TERRAIN_UNDER_ITEMS" ]
     }
   },
   {

--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -796,6 +796,7 @@
     "limb_types": [ "tail" ],
     "limb_scores": [ [ "balance", 0.16 ] ],
     "similar_bodyparts": [ "fish_tail" ],
+    "techniques": [ "TAIL_WHIP" ],
     "hit_size": 10,
     "hit_difficulty": 0.85,
     "stylish_bonus": 1,

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -1687,5 +1687,102 @@
         "req_flag": "VENOM2"
       }
     ]
+  },
+  {
+    "type": "technique",
+    "id": "STINGER_STAB",
+    "name": "Sting",
+    "melee_allowed": true,
+    "messages": [ "You sting %s", "<npcname> stings %s" ],
+    "unarmed_allowed": true,
+    "basic": true,
+    "weighting": -3,
+    "reach_ok": false,
+    "crit_ok": true,
+    "attack_vectors": [ "vector_tail_tip" ],
+    "tech_effects": [
+      {
+        "id": "anticoagulant_draculin",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom is injected into the wound!",
+        "req_flag": "DRACULIN_VENOM"
+      },
+      {
+        "id": "venom_player1",
+        "chance": 90,
+        "duration": 600,
+        "on_damage": true,
+        "message": "Venom is injected into the wound!",
+        "req_flag": "VENOM1"
+      },
+      {
+        "id": "venom_player2",
+        "chance": 90,
+        "duration": 3000,
+        "on_damage": true,
+        "message": "Venom is injected into the wound!",
+        "req_flag": "VENOM2"
+      }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_CLUB",
+    "name": "Tail Club",
+    "melee_allowed": true,
+    "messages": [ "You club %s with your tail", "<npcname> clubs %s with their tail" ],
+    "unarmed_allowed": true,
+    "basic": true,
+    "weighting": -3,
+    "reach_ok": false,
+    "crit_ok": true,
+    "condition": { "not": { "u_has_flag": "GRAB" } },
+    "attack_vectors": [ "vector_tail_tip" ]
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_CLUB_KNOCKDOWN",
+    "name": "Tail Club",
+    "melee_allowed": true,
+    "messages": [ "You club %s with your tail", "<npcname> clubs %s with their tail" ],
+    "unarmed_allowed": true,
+    "basic": true,
+    "weighting": -3,
+    "reach_ok": false,
+    "crit_ok": true,
+    "attack_vectors": [ "vector_tail_tip" ],
+    "//": "Enemy must be of a similar size, logically downable, and not flying.",
+    "tech_effects": [ { "id": "downed", "duration": 150, "on_damage": true, "message": "The attack knocks %s down!" } ],
+    "condition": {
+      "and": [
+        {
+          "and": [
+            { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
+            { "not": { "npc_has_effect": "downed" } },
+            { "not": { "and": [ { "npc_bodytype": "blob" }, { "npc_bodytype": "snake" } ] } },
+            { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
+          ]
+        },
+        { "not": { "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_flag": "GRAB" } ] } },
+        { "not": { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] } }
+      ]
+    }
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_WHIP",
+    "name": "Tail Lash",
+    "melee_allowed": true,
+    "messages": [ "You lash %s with your tail", "<npcname> lashes %s with their tail" ],
+    "unarmed_allowed": true,
+    "basic": true,
+    "fallback": true,
+    "weighting": -8,
+    "reach_ok": false,
+    "crit_ok": true,
+    "condition": { "and": [ { "u_has_trait": "THICK_TAIL" }, { "not": { "u_has_flag": "GRAB" } } ] },
+    "attack_vectors": [ "vector_tail_tip" ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2589,7 +2589,8 @@
         "values": [
           { "value": "MOVE_COST", "multiply": -0.1 },
           { "value": "ATTACK_SPEED", "multiply": -0.05 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.1 }
+          { "value": "CARRY_WEIGHT", "multiply": -0.1 },
+          { "value": "WEIGHT", "multiply": -0.1 }
         ]
       }
     ]
@@ -3948,8 +3949,8 @@
     "description": "Your limbs seem to have a little more 'give' to them.  +1 Dexterity.",
     "changes_to": [ "BENDY2" ],
     "cancels": [ "HUMAN_ARMS", "HUMAN_LEGS" ],
-    "threshreq": [ "THRESH_SLIME", "THRESH_ELFA" ],
-    "category": [ "SLIME", "ELFA" ],
+    "threshreq": [ "THRESH_SLIME", "THRESH_ELFA", "THRESH_CEPHALOPOD" ],
+    "category": [ "SLIME", "ELFA", "CEPHALOPOD" ],
     "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": 1 } ] } ]
   },
   {
@@ -4731,12 +4732,6 @@
     "restricts_gear": [ "leg_hip_l", "leg_hip_r" ],
     "allowed_items": [ "ALLOWS_TAIL" ],
     "allow_soft_gear": true,
-    "attacks": {
-      "attack_text_u": "You whap %s with your tail!",
-      "attack_text_npc": "%1$s whaps %2$s with their tail!",
-      "chance": 20,
-      "base_damage": { "damage_type": "bash", "amount": 8 }
-    },
     "enchantments": [ "ench_long_tail", { "values": [ { "value": "DODGE_CHANCE", "add": 0.5 } ] } ],
     "flags": [ "TOUGH_TAIL" ]
   },
@@ -4803,13 +4798,8 @@
     "category": [ "INSECT" ],
     "threshreq": [ "THRESH_INSECT" ],
     "allow_soft_gear": true,
-    "attacks": {
-      "attack_text_u": "You sting %s with your tail!",
-      "attack_text_npc": "%1$s stings %2$s with their tail!",
-      "chance": 20,
-      "base_damage": { "damage_type": "stab", "amount": 20 }
-    },
-    "enchantments": [ "ench_long_tail" ]
+    "enchantments": [ "ench_long_tail" ],
+    "integrated_armor": [ "integrated_stinging_tail" ]
   },
   {
     "type": "mutation",
@@ -4825,12 +4815,6 @@
     "restricts_gear": [ "leg_hip_l", "leg_hip_r" ],
     "allowed_items": [ "ALLOWS_TAIL" ],
     "allow_soft_gear": true,
-    "attacks": {
-      "attack_text_u": "You club %s with your tail!",
-      "attack_text_npc": "%1$s clubs %2$s with their tail!",
-      "chance": 20,
-      "base_damage": { "damage_type": "bash", "amount": 18 }
-    },
     "enchantments": [ "ench_long_tail" ],
     "flags": [ "TOUGH_TAIL" ]
   },
@@ -5221,7 +5205,7 @@
       }
     ],
     "types": [ "ARMS", "HANDS" ],
-    "enchantments": [ "ench_wings_bird" ],
+    "enchantments": [ "ench_wings_bird", { "values": [ { "value": "WEIGHT", "multiply": -0.1 } ] } ],
     "prereqs": [ "ARM_FEATHERS" ],
     "prereqs2": [ "HOLLOW_BONES" ],
     "threshreq": [ "THRESH_BIRD" ],
@@ -5243,6 +5227,7 @@
     "restricts_gear": [ "torso" ],
     "flags": [ "WINGS_1" ],
     "active": true,
+    "enchantments": [ { "values": [ { "value": "WEIGHT", "multiply": 0.04 } ] } ],
     "transform": { "target": "WINGS_INSECT_active", "msg_transform": "You begin buzzing your wings.", "active": true, "moves": 20 }
   },
   {
@@ -5253,7 +5238,7 @@
     "copy-from": "WINGS_INSECT",
     "valid": false,
     "flags": [ "WINGS_1", "MUSCLE_VEH_BOOST" ],
-    "enchantments": [ "ench_wings_insect_active" ],
+    "enchantments": [ "ench_wings_insect_active", { "values": [ { "value": "WEIGHT", "multiply": 0.04 } ] } ],
     "transform": { "target": "WINGS_INSECT", "msg_transform": "Your wings go still.", "active": false, "moves": 0 }
   },
   {
@@ -5341,7 +5326,7 @@
     "visibility": 8,
     "ugliness": 9,
     "encumbrance_always": [ [ "leg_l", 10 ], [ "leg_r", 10 ], [ "foot_l", 10 ], [ "foot_r", 10 ] ],
-    "enchantments": [ "ench_gastropod_foot", "ench_gastropod_foot_bonuses" ],
+    "enchantments": [ "ench_gastropod_foot", "ench_gastropod_foot_bonuses", { "values": [ { "value": "WEIGHT", "multiply": 0.15 } ] } ],
     "destroys_gear": true
   },
   {
@@ -5629,7 +5614,15 @@
     "leads_to": [ "HIBERNATE" ],
     "category": [ "URSINE" ],
     "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "bash": 1 } ],
-    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": 0.05 }, { "value": "MOVECOST_SWIM_MOD", "multiply": -0.05 } ] } ]
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MOVE_COST", "multiply": 0.05 },
+          { "value": "MOVECOST_SWIM_MOD", "multiply": -0.05 },
+          { "value": "WEIGHT", "multiply": 0.1 }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -6403,7 +6396,7 @@
     "description": "Most of your fingers have grown to tremendous length, becoming a broad pair of leathery wings.  This allows you to arrest a fall or glide from a ledge if you aren't too weighed down, but naturally impedes your fine motor skills.  They even keep you warm when you sleep.",
     "types": [ "ARMS", "HANDS" ],
     "flags": [ "WING_GLIDE", "WINGS_2", "ARM_WINGS" ],
-    "enchantments": [ "ench_wings_bird" ],
+    "enchantments": [ "ench_wings_bird", { "values": [ { "value": "WEIGHT", "multiply": -0.1 } ] } ],
     "prereqs": [ "WEBBED" ],
     "category": [ "CHIROPTERAN" ],
     "restricts_gear": [ "arm_l", "arm_r", "hand_l", "hand_r" ],
@@ -6675,7 +6668,8 @@
           { "value": "MOVE_COST", "multiply": -0.15 },
           { "value": "ATTACK_SPEED", "multiply": -0.05 },
           { "value": "STAMINA_REGEN_MOD", "add": 0.1 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.125 }
+          { "value": "CARRY_WEIGHT", "multiply": -0.125 },
+          { "value": "WEIGHT", "multiply": -0.2 }
         ]
       }
     ]
@@ -6697,7 +6691,8 @@
           { "value": "MAX_HP", "multiply": 0.05 },
           { "value": "MOVECOST_SWIM_MOD", "multiply": 0.2 },
           { "value": "DODGE_CHANCE", "add": -1.0 },
-          { "value": "CARRY_WEIGHT", "multiply": 0.15 }
+          { "value": "CARRY_WEIGHT", "multiply": 0.15 },
+          { "value": "WEIGHT", "multiply": 0.15 }
         ]
       }
     ],
@@ -7830,7 +7825,7 @@
     "threshreq": [ "THRESH_INSECT", "THRESH_SPIDER" ],
     "category": [ "INSECT", "SPIDER" ],
     "restricts_gear": [ "torso" ],
-    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": -2 } ] } ]
+    "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": -2 }, { "value": "WEIGHT", "multiply": 0.08 } ] } ]
   },
   {
     "type": "mutation",
@@ -7844,7 +7839,8 @@
     "prereqs": [ "INSECT_ARMS" ],
     "prereqs2": [ "ANTENNAE" ],
     "threshreq": [ "THRESH_INSECT" ],
-    "category": [ "INSECT" ]
+    "category": [ "INSECT" ],
+    "enchantments": [ { "values": [ { "value": "WEIGHT", "multiply": 0.08 } ] } ]
   },
   {
     "type": "mutation",
@@ -7863,7 +7859,7 @@
     "threshreq": [ "THRESH_SPIDER" ],
     "category": [ "SPIDER" ],
     "restricts_gear": [ "torso" ],
-    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": 0.3 } ] } ]
+    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": 0.3 }, { "value": "WEIGHT", "multiply": 0.12 } ] } ]
   },
   {
     "type": "mutation",
@@ -7891,6 +7887,7 @@
       ]
     ],
     "enchantments": [
+      { "condition": "ALWAYS", "values": [ { "value": "WEIGHT", "multiply": 0.12 } ] },
       {
         "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.85 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.5 } ],

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -3075,9 +3075,9 @@
     "condition_desc": "* Only works on a target of <info>similar or smaller</info> size, requires <info>Cross Hands</info>",
     "knockback_dist": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.5 },
-      { "stat": "damage", "type": "cut", "scale": 1.5 },
-      { "stat": "damage", "type": "stab", "scale": 1.5 }
+      { "stat": "damage", "type": "bash", "scale": 1.25 },
+      { "stat": "damage", "type": "cut", "scale": 1.25 },
+      { "stat": "damage", "type": "stab", "scale": 1.25 }
     ],
     "attack_vectors": [ "vector_palm" ]
   },
@@ -3104,9 +3104,9 @@
     "down_dur": 1,
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.75 },
-      { "stat": "damage", "type": "bash", "scale": 1.2 },
-      { "stat": "damage", "type": "cut", "scale": 1.2 },
-      { "stat": "damage", "type": "stab", "scale": 1.2 }
+      { "stat": "damage", "type": "bash", "scale": 1.25 },
+      { "stat": "damage", "type": "cut", "scale": 1.25 },
+      { "stat": "damage", "type": "stab", "scale": 1.25 }
     ],
     "attack_vectors": [ "vector_grasp" ]
   },
@@ -3147,9 +3147,9 @@
     "tech_effects": [ { "id": "staggered", "chance": 80, "duration": 200, "on_damage": true, "message": "%s is knocked off-balance!" } ],
     "knockback_dist": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 2.0 },
-      { "stat": "damage", "type": "cut", "scale": 2.0 },
-      { "stat": "damage", "type": "stab", "scale": 2.0 }
+      { "stat": "damage", "type": "bash", "scale": 1.75 },
+      { "stat": "damage", "type": "cut", "scale": 1.75 },
+      { "stat": "damage", "type": "stab", "scale": 1.75 }
     ],
     "attack_vectors": [ "vector_palm" ]
   },


### PR DESCRIPTION
#### Summary
Stinger, bugfix, tail club, weight

#### Purpose of change
Let's do a bunch of things at once.

#### Describe the solution
- Fixed a bug with mapgen that was throwing an error.
- Removed the old-style extra attacks from stinger and tail club.
- Stinger and tail club now grant an integrated unarmed weapon which function about like you might imagine. Stinger delivers poison if you have it, tail club can do a knockdown.
- Thick tail gets a regular tail lash attack. This attack is nothing special and just functions as a fallback like the basic punch/kick and stuff.
- Several mutations now add or subtract a small amount to your overall body weight. These include the extra limb ones (except tentacles, which are probably lighter than arms, fat deposits, and dense bones for extra weight, and light/hollow bones and wings for less weight. This could be more comprehensive but it's a pretty minor thing. Credit to @anoobindisguise for reminding me (indirectly) that this needed doing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
