### PR TITLE
Feral humans sometimes drop rocks

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -14,6 +14,7 @@
           { "item": "crash_axe", "prob": 5, "damage": [ 1, 3 ] }
         ]
       },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
       { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
@@ -23,6 +24,7 @@
     "id": "feral_humans_death_drops_pipe",
     "entries": [
       { "item": "pipe", "prob": 100, "damage": [ 0, 2 ] },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
       { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
@@ -32,6 +34,7 @@
     "id": "feral_humans_death_drops_knife",
     "entries": [
       { "group": "kitchen_knives", "prob": 100, "damage": [ 0, 3 ] },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
       { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
@@ -47,6 +50,7 @@
           { "item": "claw_bar", "prob": 10, "damage": [ 0, 1 ] }
         ]
       },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
       { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
@@ -54,7 +58,11 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "feral_humans_death_drops_tool",
-    "entries": [ { "item": "hammer", "prob": 100, "damage": [ 1, 3 ] }, { "group": "mon_zombie_technician_death_drops", "prob": 100 } ]
+    "entries": [
+      { "item": "hammer", "prob": 100, "damage": [ 1, 3 ] },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
+      { "group": "mon_zombie_technician_death_drops", "prob": 100 }
+    ]
   },
   {
     "type": "item_group",
@@ -152,6 +160,7 @@
     "entries": [
       { "group": "survivor_stabbing", "prob": 100, "damage": [ 0, 3 ] },
       { "group": "underwear", "damage": [ 0, 3 ] },
+      { "item": "rock", "prob": 20, "count": [ 1, 2 ] },
       { "group": "survivor_basic_pants", "damage": [ 0, 3 ] },
       { "group": "survivor_basic_shirt", "damage": [ 0, 3 ] },
       { "group": "survivor_basic_hands", "damage": [ 0, 3 ], "prob": 95 },


### PR DESCRIPTION
#### Summary
Feral humans sometimes drop rocks

#### Purpose of change
- Feral humans never dropped their rocks, because they were stored in their monstergun, which isn't dropped on death.

#### Describe the solution
- Now they have a 20% chance to drop 1 or 2 rocks. They aren't supposed to literally each be carrying 6 perfect rocks, they're just meant to be picking shit up and throwing it opportunistically. 

#### Describe alternatives you've considered
variable ammo count

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
