### PR TITLE
Fix staff sling damage type

### DIFF
--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -85,7 +85,6 @@
     "volume": "1375 ml",
     "longest_side": "150 cm",
     "price_postapoc": "1 USD 50 cent",
-    "//": "Not quite as long as a quarterstaff.",
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "good" },
     "ranged_damage": { "damage_type": "bash", "amount": 10 },
     "range": 5,


### PR DESCRIPTION
#### Summary
Fix staff sling damage type

#### Purpose of change
Staff slings were still adding bullet damage. It's supposed to be bash!

#### Describe the solution
It bash.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
