### PR TITLE
fix kettle helm nested category

### DIFF
--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -758,7 +758,7 @@
     "type": "nested_category",
     "activity_level": "MODERATE_EXERCISE",
     "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_LEGS",
+    "subcategory": "CSC_ARMOR_HEAD",
     "name": "platemail head protection",
     "description": "Recipes related to constructing steel plate armor for the head.",
     "skill_used": "fabrication",

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -363,7 +363,7 @@ struct mtype {
 
         // Amount of ammo the monster spawns with.
         std::map<itype_id, int> starting_ammo;
-        /** 
+        /**
          * Monster will spawn with a random ammo count between this and starting_ammo.
          * If starting_ammo_min > starting_ammo, ammo will not be randomized.
         */


### PR DESCRIPTION
#### Summary
fix kettle helm nested category

#### Purpose of change
Kettle helms were nested in the legs category.

#### Describe the solution
head

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
