### PR TITLE
Fix wooden shed stick recipe

### DIFF
--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -138,7 +138,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carving" } ],
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ], [ "splinter", 1 ] ] ]
+    "components": [ [ [ "2x4", 1 ], [ "stick", 1 ]] ]
   },
   {
     "result": "butchering_kit",


### PR DESCRIPTION
#### Summary
Fix wooden shed stick recipe

#### Purpose of change
Wooden shed stick was craftable for 1 splinter and would deconstruct into 3

#### Describe the solution
It is no longer craftable with splintered wood

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
