### PR TITLE
No claws for kalaripayattu

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -757,7 +757,6 @@
         "id": "buff_kalaripayattu_chuvadu",
         "name": "Chuvadu",
         "description": "The steps for attack keep you mobile and centered as you seek an opening.\n\n+1 Dodge ability,\n+1 Dodge attempt.",
-        "unarmed_allowed": true,
         "melee_allowed": true,
         "bonus_dodges": 1,
         "forbidden_buffs_all": [ "buff_kalaripayattu_simha_vadivu" ],
@@ -780,7 +779,7 @@
       "tec_kalaripayattu_marma_sastram",
       "tec_kalaripayattu_focused_strike"
     ],
-    "weapon_category": [ "BATONS", "CLAWS", "KNIVES", "MEDIUM_SWORDS", "SHORT_SWORDS", "WHIPS" ]
+    "weapon_category": [ "BATONS", "KNIVES", "MEDIUM_SWORDS", "SHORT_SWORDS", "WHIPS" ]
   },
   {
     "type": "martial_art",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1760,7 +1760,7 @@
       { "stat": "damage", "type": "stab", "scale": 0.66 }
     ],
     "description": "50% moves, 66% damage, min 2 melee",
-    "attack_vectors": [ "vector_null", "vector_claw", "vector_claw_right" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -1779,7 +1779,7 @@
       { "stat": "damage", "type": "stab", "scaling-stat": "per", "scale": 0.5 }
     ],
     "description": "50% of perception added to damage, grants Simha Vadivu.",
-    "attack_vectors": [ "vector_null", "vector_claw", "vector_claw_right" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",
@@ -1815,7 +1815,7 @@
       { "stat": "damage", "type": "cut", "scaling-stat": "per", "scale": 0.5 },
       { "stat": "damage", "type": "stab", "scaling-stat": "per", "scale": 0.5 }
     ],
-    "attack_vectors": [ "vector_null", "vector_claw", "vector_claw_right" ]
+    "attack_vectors": [ "vector_null" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
#### Summary
No claws for kalaripayattu

#### Purpose of change
A player was confused about how unarmed weapons worked, and this led to me realizing that including them the way I did in Kalaripayattu wasn't foolproof.

#### Describe the solution
Remove them, make the Chuvadu buff require a wielded weapon.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
