### PR TITLE
Create new weight class for underweight/skinny

### DIFF
--- a/data/json/ui/weight.json
+++ b/data/json/ui/weight.json
@@ -20,11 +20,18 @@
         "condition": { "and": [ { "math": [ "u_val('bmi_permil')", ">", "1000" ] }, { "math": [ "u_val('bmi_permil')", "<=", "2000" ] } ] }
       },
       {
+        "id": "skinny",
+        "text": "Skinny",
+        "color": "yellow",
+        "//": "between 2 and 3 points of BMI from bodyfat (8-10% of normal healthy weight is fat)",
+        "condition": { "and": [ { "math": [ "u_val('bmi_permil')", ">", "2000" ] }, { "math": [ "u_val('bmi_permil')", "<=", "2500" ] } ] }
+      },
+      {
         "id": "underweight",
         "text": "Underweight",
-        "color": "yellow",
-        "//": "between 2 and 3 points of BMI from bodyfat (8-12% of normal healthy weight is fat)",
-        "condition": { "and": [ { "math": [ "u_val('bmi_permil')", ">", "2000" ] }, { "math": [ "u_val('bmi_permil')", "<=", "3000" ] } ] }
+        "color": "c_light_gray",
+        "//": "between 2 and 3 points of BMI from bodyfat (10-12% of normal healthy weight is fat)",
+        "condition": { "and": [ { "math": [ "u_val('bmi_permil')", ">", "2500" ] }, { "math": [ "u_val('bmi_permil')", "<=", "3000" ] } ] }
       },
       {
         "id": "normal",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4891,7 +4891,7 @@ int Character::kcal_speed_penalty() const
     static const std::vector<std::pair<float, float>> starv_thresholds = { {
             std::make_pair( 0.0f, -90.0f ),
             std::make_pair( character_weight_category::emaciated, -50.f ),
-            std::make_pair( character_weight_category::underweight, -25.0f ),
+            std::make_pair( character_weight_category::skinny, -25.0f ),
             std::make_pair( character_weight_category::normal, 0.0f )
         }
     };

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1182,7 +1182,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
             hunger_effect = effect_hunger_hungry;
         } else if( recently_ate ) {
             hunger_effect = effect_hunger_very_hungry;
-        } else if( get_bmi_fat() < character_weight_category::underweight ) {
+        } else if( get_bmi_fat() < character_weight_category::skinny ) {
             hunger_effect = effect_hunger_near_starving;
         } else if( get_bmi_fat() < character_weight_category::emaciated ) {
             hunger_effect = effect_hunger_starving;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -640,6 +640,9 @@ std::pair<std::string, nc_color> display::weight_text_color( const Character &u 
         weight_color = c_light_gray;
     } else if( bmi > character_weight_category::underweight ) {
         weight_string = translate_marker( "Underweight" );
+        weight_color = c_light_gray;
+    } else if( bmi > character_weight_category::skinny ) {
+        weight_string = translate_marker( "Skinny" );
         weight_color = c_yellow;
     } else if( bmi > character_weight_category::emaciated ) {
         weight_string = translate_marker( "Emaciated" );
@@ -696,7 +699,9 @@ std::string display::weight_long_description( const Character &u )
     } else if( bmi > character_weight_category::normal ) {
         return _( "You look to be a pretty healthy weight, with some fat to last you through the winter, but nothing excessive." );
     } else if( bmi > character_weight_category::underweight ) {
-        return _( "You are thin, thinner than is healthy.  You are less resilient to going without food." );
+        return _( "You are a little on the slim side.  It's nothing to worry about yet, but it might be a good idea to put on some weight." );
+    } else if( bmi > character_weight_category::skinny ) {
+        return _( "You are thinner than is healthy.  You're weak from lack of energy and it's getting bad enough to lead to health problems." );
     } else if( bmi > character_weight_category::emaciated ) {
         return _( "You are very unhealthily underweight, nearing starvation." );
     } else {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -699,7 +699,7 @@ std::string display::weight_long_description( const Character &u )
     } else if( bmi > character_weight_category::normal ) {
         return _( "You look to be a pretty healthy weight, with some fat to last you through the winter, but nothing excessive." );
     } else if( bmi > character_weight_category::underweight ) {
-        return _( "You are a little on the slim side.  It's nothing to worry about yet, but it might be a good idea to put on some weight." );
+        return _( "You are a little on the slim side.  It might be a good idea to put on some weight before it gets too bad." );
     } else if( bmi > character_weight_category::skinny ) {
         return _( "You are thinner than is healthy.  You're weak from lack of energy and it's getting bad enough to lead to health problems." );
     } else if( bmi > character_weight_category::emaciated ) {

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -181,7 +181,8 @@ const std::map<float, std::string> activity_levels_str_map = {
 namespace character_weight_category
 {
 constexpr float emaciated = 1.0f;
-constexpr float underweight = 2.0f;
+constexpr float skinny = 2.0f;
+constexpr float underweight = 2.5f;
 constexpr float normal = 3.0f;
 constexpr float overweight = 5.0f;
 constexpr float obese = 10.0f;

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -512,7 +512,7 @@ static medical_column draw_effects_summary( const int column_count, Character &y
 
     const float bmi = you.get_bmi_fat();
 
-    if( bmi < character_weight_category::underweight ) {
+    if( bmi < character_weight_category::skinny ) {
         std::string starvation_name;
         std::string starvation_text;
 
@@ -526,7 +526,7 @@ static medical_column draw_effects_summary( const int column_count, Character &y
                 _( "Your body is weakened by starvation.  Only time and regular meals will help you recover.\n\n" );
         }
 
-        if( bmi < character_weight_category::underweight ) {
+        if( bmi < character_weight_category::skinny ) {
             const float str_penalty = 1.0f - ( ( bmi - 13.0f ) / 3.0f );
             starvation_text += std::string( _( "Strength" ) ) + " -" + string_format( "%2.0f%%\n",
                                str_penalty * 100.0f );
@@ -624,7 +624,7 @@ static medical_column draw_stats_summary( const int column_count, Character &you
     }
     if( you.kcal_speed_penalty() < 0 ) {
         pen = std::abs( you.kcal_speed_penalty() );
-        pge_str = pgettext( "speed penalty", you.get_bmi() < character_weight_category::underweight ?
+        pge_str = pgettext( "speed penalty", you.get_bmi() < character_weight_category::skinny ?
                             "Starving" : "Underfed" );
         speed_detail_str += colorize( string_format( _( "%s    -%2d%%\n" ), pge_str, pen ), c_red );
     }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1527,7 +1527,7 @@ void Character::disp_info( bool customize_character )
 
     const float bmi = get_bmi_fat();
 
-    if( bmi < character_weight_category::underweight ) {
+    if( bmi < character_weight_category::skinny ) {
         std::string starvation_name;
         std::string starvation_text;
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -267,7 +267,7 @@ void suffer::mutation_power( Character &you, const trait_id &mut_id )
             you.set_cost_timer( mut_id, mut_id->cooldown - 1_turns );
         }
         if( mut_id->hunger ) {
-            if( you.get_bmi_fat() < character_weight_category::underweight ) {
+            if( you.get_bmi_fat() < character_weight_category::skinny ) {
                 you.add_msg_if_player( m_warning,
                                        _( "You're too malnourished to keep your %s going." ),
                                        you.mutation_name( mut_id ) );


### PR DESCRIPTION
#### Summary
Create new weight class for underweight/skinny

#### Purpose of change
"Underweight" was too far below normal. It was possible to start getting malnutrition messages and even experiencing penalties while your weight still said Normal.

#### Describe the solution
Previously:
Morbidly Obese
Obese
Overweight
Normal
Underweight
Emaciated
Skeletal

Now:
Morbidly Obese
Obese
Overweight
Normal
**Underweight**
Skinny
Emaciated
Skeletal

Underweight is now the lower range of normal, where you start getting messages about being hungry all the time and stuff. Skinny is what Underweight used to be.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
