### PR TITLE
Reduce severity of radiation damage

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4252,6 +4252,7 @@
       "int_mod": [ -0.1 ],
       "per_mod": [ -0.083 ],
       "hurt_min": [ 1 ],
+      "hurt_max": [ 1 ],
       "hurt_chance": [ 8000 ]
     },
     "blood_analysis_description": "Irradiated"


### PR DESCRIPTION
#### Summary
Reduce severity of radiation damage

#### Purpose of change
Rad damage was too high!

#### Describe the solution
Less of it

#### Testing
Set rads to 1000 and stood there all day without bandages or meds or anything. HP dropped to 50% by the time rads were down to 700. 1000 rads is a lot so that seems fine.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
