### PR TITLE
Hungry NPCs no longer forage for food

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2805,15 +2805,6 @@ npc_action npc::address_needs( float danger )
                 }
             }
         }
-        // Last resort: harvest scavenging (forage underbrush, harvest plants).
-        for( const scored_water_source &h : find_nearby_harvestable() ) {
-            if( square_dist( pos_bub(), h.pos ) <= 1 ) {
-                here.examine( *this, h.pos );
-                return npc_noop;
-            } else if( move_to_and_verify( h.pos ) ) {
-                return npc_noop;
-            }
-        }
     }
 
     // Normal food/drink: camp -> inventory -> ground food -> terrain water.
@@ -2846,15 +2837,6 @@ npc_action npc::address_needs( float danger )
                 if( move_to_and_verify( ws.pos ) ) {
                     return npc_noop;
                 }
-            }
-        }
-        // Last resort: harvest scavenging (same as extreme path).
-        for( const scored_water_source &h : find_nearby_harvestable() ) {
-            if( square_dist( pos_bub(), h.pos ) <= 1 ) {
-                here.examine( *this, h.pos );
-                return npc_noop;
-            } else if( move_to_and_verify( h.pos ) ) {
-                return npc_noop;
             }
         }
     }


### PR DESCRIPTION
#### Summary
Hungry NPCs no longer forage for food

#### Purpose of change
Some code was backported from DDA that allowed hungry NPCs to forage for food. This made a degree of sense in principle, since a starving person would not just stand there and wait to die, but in practice they were doing it constantly and usually wasting a ton of kcal without getting much in return.

fixes #2344 

#### Describe the solution
Simply remove the foraging behavior. Leave the function in in case I ever want to use it.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
