### PR TITLE
Possibly fix invalid talker bug.

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -304,43 +304,59 @@ bool mon_spellcasting_actor::call( monster &mon ) const
         return false;
     }
 
-    if( !mon.attack_target() && !allow_no_target ) {
+    Creature *target = mon.attack_target();
+
+    if( !target && !allow_no_target ) {
         // this is an attack. there is no reason to attack if there isn't a real target.
         // Unless we don't need one
         return false;
     }
 
     if( has_condition ) {
-        dialogue d( get_talker_for( &mon ),
-                    allow_no_target ? nullptr : get_talker_for( mon.attack_target() ) );
+        dialogue d(
+            get_talker_for( &mon ),
+            ( allow_no_target || !target ) ? nullptr : get_talker_for( target )
+        );
+
         if( !condition( d ) ) {
             add_msg_debug( debugmode::DF_MATTACK, "Attack conditionals failed" );
             return false;
         }
     }
 
-    const tripoint_bub_ms target = ( spell_data.self ||
-                                     allow_no_target ) ? mon.pos_bub() : mon.attack_target()->pos_bub();
+    const tripoint_bub_ms target_pos =
+        ( spell_data.self || allow_no_target || !target )
+        ? mon.pos_bub()
+        : target->pos_bub();
+
     spell spell_instance = spell_data.get_spell( mon );
     spell_instance.set_message( spell_data.trigger_message );
 
     // Bail out if the target is out of range.
-    if( !spell_data.self &&
-        trig_dist( mon.pos_bub(), target ) > spell_instance.range( mon ) ) {
+    if( !spell_data.self && target &&
+        trig_dist( mon.pos_bub(), target_pos ) > spell_instance.range( mon ) ) {
         return false;
     }
 
     std::string target_name;
-    if( const Creature *target_monster = get_creature_tracker().creature_at( target ) ) {
-        target_name = target_monster->disp_name();
+    if( target ) {
+        if( const Creature *target_monster = get_creature_tracker().creature_at( target_pos ) ) {
+            target_name = target_monster->disp_name();
+        }
     }
 
-    add_msg_if_player_sees( target, spell_instance.message(), mon.disp_name(),
-                            spell_instance.name(), target_name );
+    add_msg_if_player_sees(
+        target_pos,
+        spell_instance.message(),
+        mon.disp_name(),
+        spell_instance.name(),
+        target_name
+    );
 
     avatar fake_player;
     mon.mod_moves( -spell_instance.casting_time( fake_player, true ) );
-    spell_instance.cast_all_effects( mon, target );
+
+    spell_instance.cast_all_effects( mon, target_pos );
 
     return true;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1295,7 +1295,7 @@ std::vector<options_manager::id_and_option> options_manager::build_tilesets_list
     search_resource( TILESETS, result, { PATH_INFO::user_gfx(), PATH_INFO::gfxdir() },
                      "tileset",
                      PATH_INFO::tileset_conf() );
- 
+
     auto iter = result.begin();
 
     // Block nonfunctional out-of-repo tilesets.


### PR DESCRIPTION
#### Summary
Possibly fix invalid talker bug.

#### Purpose of change
#2353 indicated that a monster spell with an invalid target (possibly one which died or something?) was causing a crash. This may be the cause of the ancient #2141 bug, but I'm not really sure. Our mon_spellcasting_actor::call() was identical to DDA's and their Amigara Horrors are not causing a crash, I don't think.

#### Describe the solution
Add a null guard and avoid calling mon.attack_target() afterwards, instead using a variable that we can preemptively rule out if it's null.

#### Describe alternatives you've considered

#### Testing
- Loaded the attached save in the linked issue. Before the fix, I could mill around on the roof for a couple hours and I'd get the crash. Afterwards, all seems fine.

- Tested a bunch of different monster spells to make sure they all worked.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
