### PR TITLE
Slightly move the Teamster

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -157,7 +157,7 @@
         { "class": "refugee_GarryVilleneuve", "x": 45, "y": 13 },
         { "class": "guard", "x": 43, "y": 21 },
         { "class": "evac_broker", "x": 50, "y": 20 },
-        { "class": "evac_teamster", "x": 54, "y": 4 },
+        { "class": "evac_teamster", "x": 51, "y": 4 },
         { "class": "guard", "x": 60, "y": 9 },
         { "class": "guard", "x": 54, "y": 20 },
         { "class": "guard", "x": 63, "y": 15 }


### PR DESCRIPTION
#### Summary
Slightly move the Teamster

#### Purpose of change
Dude was standing too close to the zombies in the back bay.

#### Describe the solution
Move the teamster 3 tiles toward the corner so he's less likely to get sucked into the melee and killed.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
