### PR TITLE
Backport 86116 - Add NPCs to new overmap when shifting dimensions

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12138,8 +12138,11 @@ bool game::travel_to_dimension( const std::string &new_prefix,
 {
     map &here = get_map();
     avatar &player = get_avatar();
+    std::vector<npc_ptr> moving_npcs;
+    moving_npcs.reserve( npc_travellers.size() );
     if( !npc_travellers.empty() ) {
         int traveller_count = npc_travellers.size();
+        overmap &old_om = overmap_buffer.get( project_to<coords::om>( player.pos_abs().xy() ) );
         for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
             // skip unloading a traveller
             bool skip = false;
@@ -12156,7 +12159,9 @@ bool game::travel_to_dimension( const std::string &new_prefix,
                 ( *it )->on_unload();
                 it = critter_tracker->active_npc.erase( it );
             } else {
-                it++;
+                if( const npc_ptr ptr = old_om.erase_npc( ( *it++ )->getID() ) ) {
+                    moving_npcs.push_back( ptr );
+                }
             }
         }
     } else {
@@ -12199,7 +12204,11 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     // Clear the overmap
     overmap_buffer.clear();
     // load/create new overmap
-    overmap_buffer.get( point_abs_om{} );
+    overmap &new_om = overmap_buffer.get( project_to<coords::om>( player.pos_abs().xy() ) );
+    // insert travelled NPCs
+    for( const npc_ptr &guy : moving_npcs ) {
+        new_om.insert_npc( guy );
+    }
     // clear map memory from the previous dimension
     player.clear_map_memory();
     // Load map memory in new dimension, if there is any


### PR DESCRIPTION
#### Summary
Backport 86116 - Add NPCs to new overmap when shifting dimensions


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
