### PR TITLE
make acid bombs easier to make

### DIFF
--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -10,7 +10,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "components": [
-      [ [ "jar_glass_sealed", 1 ], [ "clay_canister", 2 ], [ "flask_glass", 2 ] ],
+      [ [ "bottle_glass", 1 ], [ "jar_glass_sealed", 1 ], [ "bottle_glass_seasoning", 2 ], [ "clay_canister", 2 ], [ "flask_glass", 2 ] ],
       [ [ "any_strong_acid", 2, "LIST" ] ],
       [ [ "cordage_short", 1, "LIST" ], [ "duct_tape", 5 ] ]
     ]

--- a/data/json/recipes/weapon/explosive.json
+++ b/data/json/recipes/weapon/explosive.json
@@ -10,7 +10,13 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "components": [
-      [ [ "bottle_glass", 1 ], [ "jar_glass_sealed", 1 ], [ "bottle_glass_seasoning", 2 ], [ "clay_canister", 2 ], [ "flask_glass", 2 ] ],
+      [
+        [ "bottle_glass", 1 ],
+        [ "jar_glass_sealed", 1 ],
+        [ "bottle_glass_seasoning", 2 ],
+        [ "clay_canister", 2 ],
+        [ "flask_glass", 2 ]
+      ],
       [ [ "any_strong_acid", 2, "LIST" ] ],
       [ [ "cordage_short", 1, "LIST" ], [ "duct_tape", 5 ] ]
     ]


### PR DESCRIPTION
added items which could be realistically used to acid bomb recipe

#### Summary
add a bunch of stuff to acid bomb recipe

#### Purpose of change
not stare at my 20 glass bottles and 4 0.5l jars

#### Describe the solution
add glass bottles & other useable items to acid bomb recipe

#### Describe alternatives you've considered

stare at all these glass bottles I stole from a bar that I can't use to make acid bombs, maybe make molotovs instead?

#### Testing

made debug test char, made acid bomb succesfully

#### Additional context

(i've never done this github stuff before hopefully it works)
