### PR TITLE
Rewrite alcoholism

### DIFF
--- a/data/json/addictions.json
+++ b/data/json/addictions.json
@@ -4,7 +4,7 @@
     "id": "caffeine",
     "name": "Caffeine Withdrawal",
     "type_name": "caffeine",
-    "description": "Strength - 1;   Slight sluggishness;   Occasional cravings",
+    "description": "Not medically significant.",
     "craving_morale": "morale_craving_caffeine",
     "effect_on_condition": "EOC_CAFFEINE_ADDICTION"
   },
@@ -13,7 +13,7 @@
     "id": "nicotine",
     "name": "Nicotine Withdrawal",
     "type_name": "nicotine",
-    "description": "Intelligence - 1;   Occasional cravings",
+    "description": "Not medically significant.",
     "craving_morale": "morale_craving_nicotine",
     "builtin": "nicotine_effect"
   },
@@ -22,7 +22,7 @@
     "id": "alcohol",
     "name": "Alcohol Withdrawal",
     "type_name": "alcohol",
-    "description": "Perception - 1;   Intelligence - 1;   Occasional Cravings;\nRisk of delirium tremens",
+    "description": "Risk of delirium tremens.",
     "craving_morale": "morale_craving_alcohol",
     "builtin": "alcohol_effect"
   },
@@ -31,7 +31,7 @@
     "id": "sleeping pill",
     "name": "Sleeping Pill Dependence",
     "type_name": "sleeping pills",
-    "description": "You may find it difficult to sleep without medication.",
+    "description": "May cause insomnia.",
     "effect_on_condition": "EOC_SLEEP_ADDICTION"
   },
   {
@@ -39,7 +39,7 @@
     "id": "opioid",
     "name": "Opioid Withdrawal",
     "type_name": "opioids",
-    "description": "Strength - 1;   Perception - 1;   Dexterity - 1;\nDepression and physical pain to some degree.  Frequent cravings.  Vomiting.",
+    "description": "Nausea, pain, severe depression.",
     "craving_morale": "morale_craving_opioid",
     "builtin": "opioid_effect"
   },
@@ -48,7 +48,7 @@
     "id": "amphetamine",
     "name": "Amphetamine Withdrawal",
     "type_name": "amphetamine",
-    "description": "Strength - 1;   Intelligence - 1;\nMovement rate reduction.  Depression.  Weak immune system.  Frequent cravings.",
+    "description": "Slowdown and severe depression.",
     "craving_morale": "morale_craving_speed",
     "builtin": "amphetamine_effect"
   },

--- a/data/json/addictions.json
+++ b/data/json/addictions.json
@@ -20,9 +20,9 @@
   {
     "type": "addiction_type",
     "id": "alcohol",
-    "name": "Alcohol Withdrawal",
+    "name": "Craving Alcohol",
     "type_name": "alcohol",
-    "description": "Risk of delirium tremens.",
+    "description": "A drink would make everything better.",
     "craving_morale": "morale_craving_alcohol",
     "builtin": "alcohol_effect"
   },

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3545,6 +3545,56 @@
   },
   {
     "type": "effect_type",
+    "id": "withdrawal_Alcohol",
+    "name": [ "Mild Alcohol Withdrawal", "Moderate Alcohol Withdrawal", "Severe Alcohol Withdrawal" ],
+    "desc": [
+      "You could use a drink to settle your nerves.",
+      "You are in dire need of a drink.",
+      "You feel horrible, like you'll die if you can't have a drink!"
+    ],
+    "max_intensity": 3,
+    "apply_message": "You really need a drink!",
+    "int_dur_factor": "8 h",
+    "miss_messages": [ [ "You feel horrible.", 1 ] ],
+    "base_mods": {
+      "thirst_tick": [ 1800 ],
+      "thirst_min": [ 1 ],
+      "fatigue_tick": [ 300 ],
+      "fatigue_min": [ 1 ],
+      "pain_max_val": [ 15 ],
+      "pain_min": [ 1, 0 ],
+      "cough_chance": [ 300, 0 ],
+      "stamina_min": [ -100 ],
+      "stamina_max": [ -200 ],
+      "stamina_chance": [ 1200 ],
+      "h_mod_min": [ -1 ],
+      "h_mod_chance": [ 43200 ],
+      "vomit_chance": [ 100 ],
+      "vomit_tick": [ 1800 ]
+    },
+    "scaling_mods": {
+      "str_mod": [ -0.5 ],
+      "per_mod": [ -0.25 ],
+      "dex_mod": [ -0.66 ],
+      "int_mod": [ -0.75 ],
+      "stamina_max": [ -500 ],
+      "stamina_chance": [ -300 ],
+      "vomit_chance": [ -10 ]
+    },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.1 },
+      { "limb_score": "vision", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "balance", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "footing", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "swim", "modifier": 1.0, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
     "id": "fearparalyze",
     "name": [ "Frightened" ],
     "desc": [ "You are paralyzed by fear." ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3576,7 +3576,6 @@
       "fatigue_min": [ 1 ],
       "pain_max_val": [ 15 ],
       "pain_min": [ 1, 0 ],
-      "cough_chance": [ 300, 0 ],
       "stamina_min": [ -100 ],
       "stamina_max": [ -200 ],
       "stamina_chance": [ 1200 ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3546,7 +3546,15 @@
   {
     "type": "effect_type",
     "id": "withdrawal_alcohol_timer",
-    "max_intensity": 3
+    "max_intensity": 3,
+    "int_dur_factor": "24 h",
+    "max_duration": "72 h",
+    "//": "Helper effect to track progression of withdrawals."
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_alcohol_detoxed",
+    "//": "Safe from withdrawals until you drink again."
   },
   {
     "type": "effect_type",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3545,7 +3545,12 @@
   },
   {
     "type": "effect_type",
-    "id": "withdrawal_Alcohol",
+    "id": "withdrawal_alcohol_timer",
+    "max_intensity": 3
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_alcohol",
     "name": [ "Mild Alcohol Withdrawal", "Moderate Alcohol Withdrawal", "Severe Alcohol Withdrawal" ],
     "desc": [
       "You could use a drink to settle your nerves.",
@@ -3554,8 +3559,8 @@
     ],
     "max_intensity": 3,
     "apply_message": "You really need a drink!",
-    "int_dur_factor": "8 h",
     "miss_messages": [ [ "You feel horrible.", 1 ] ],
+    "rating": "bad",
     "base_mods": {
       "thirst_tick": [ 1800 ],
       "thirst_min": [ 1 ],

--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -127,8 +127,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 1 },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
@@ -140,9 +140,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
-        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } ] },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } },
+        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
@@ -154,8 +154,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
@@ -167,9 +167,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
-        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } ] },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not": { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
@@ -181,9 +181,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
-        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 3 } ] },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not": { "u_has_effect": "withdrawal_alcohol", "intensity": 3 } },
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
@@ -195,9 +195,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
-        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
-        { "not": [ "u_has_effect", "valium" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not":  { "u_has_effect": "valium" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 3, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
@@ -209,8 +209,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
-        { "not": [ "u_has_effect", "valium" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "valium" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "shakes", "intensity": 3, "duration": { "math": [ "300 + rand(5) * 60" ] } }
@@ -222,8 +222,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
-        { "not": [ "u_has_effect", "valium" ] },
-        { "not": [ { "u_has_effect": "drunk" } ] }
+        { "not":  { "u_has_effect": "valium" } },
+        { "not":  { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "hallu", "intensity": 3, "duration": { "math": [ "1800 + rand(8) * 3600" ] } }
@@ -231,8 +231,10 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_ALCOHOL_DETOX",
-    "condition": { "and": [ { "u_lose_effect": "withdrawal_alcohol_timer" }, { "not": [ { "u_has_effect": "drunk" } ] } ] },
-    "effect": { "u_add_effect": "withdrawal_alcohol_detoxed", "duration": "permanent" }
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": { "and": [ { "compare_string": [ "withdrawal_alcohol_timer", { "context_val": "effect" } ] }, { "not": { "u_has_effect": "drunk" } } ] },
+    "effect": { "u_add_effect": "withdrawal_alcohol_detoxed", "duration": "PERMANENT" }
   },
   {
     "type": "effect_on_condition",
@@ -243,6 +245,6 @@
         { "u_has_effect": "drunk" }
       ]
     },
-    "effect": { "and": [ { "u_lose_effect": "withdrawal_alcohol_detoxed" }, { "u_lose_effect": "withdrawal_alcohol" } ] }
+    "effect": [ { "u_lose_effect": "withdrawal_alcohol_detoxed" }, { "u_lose_effect": "withdrawal_alcohol" } ]
   }
 ]

--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -119,5 +119,130 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_1",
+    "recurrence": [ "10 minutes", "10 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 1 },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_2_1",
+    "recurrence": [ "10 minutes", "48 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
+        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } ] },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_2_2",
+    "recurrence": [ "12 hours", "48 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_3_1",
+    "recurrence": [ "10 minutes", "10 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
+        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } ] },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_3_2",
+    "recurrence": [ "12 hours", "72 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
+        { "not": [ { "u_has_effect": "withdrawal_alcohol", "intensity": 3 } ] },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_3_3",
+    "recurrence": [ "20 hours", "72 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
+        { "not": [ "u_has_effect", "withdrawal_alcohol_detoxed" ] },
+        { "not": [ "u_has_effect", "valium" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 3, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_3_SHAKES",
+    "recurrence": [ "18 minutes", "12 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
+        { "not": [ "u_has_effect", "valium" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "shakes", "intensity": 3, "duration": { "math": [ "300 + rand(5) * 60" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_WITHDRAWAL_3_HALLU",
+    "recurrence": [ "18 minutes", "12 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
+        { "not": [ "u_has_effect", "valium" ] },
+        { "not": [ { "u_has_effect": "drunk" } ] }
+      ]
+    },
+    "effect": { "u_add_effect": "hallu", "intensity": 3, "duration": { "math": [ "1800 + rand(8) * 3600" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_DETOX",
+    "condition": { "and": [ { "u_lose_effect": "withdrawal_alcohol_timer" }, { "not": [ { "u_has_effect": "drunk" } ] } ] },
+    "effect": { "u_add_effect": "withdrawal_alcohol_detoxed", "duration": "permanent" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ALCOHOL_RETOX",
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_effect": "withdrawal_alcohol" }, { "u_has_effect": "withdrawal_alcohol_detoxed" } ] },
+        { "u_has_effect": "drunk" }
+      ]
+    },
+    "effect": { "and": [ { "u_lose_effect": "withdrawal_alcohol_detoxed" }, { "u_lose_effect": "withdrawal_alcohol" } ] }
   }
 ]

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -25,6 +25,7 @@
 #include "talker.h"
 #include "text_snippets.h"
 
+static const efftype_id effect_withdrawal_alcohol_timer( "effect_withdrawal_alcohol_timer" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
 
@@ -75,6 +76,43 @@ void add_type::reset()
 const std::vector<add_type> &add_type::get_all()
 {
     return add_type_factory.get_all();
+}
+
+static bool alcohol_add( Character &u, int in)
+{
+    static time_point last_alc_dream = calendar::turn_zero;
+    const bool recent_dream = ( calendar::turn - last_alc_dream < 3_hours );
+    const morale_type morale_type = morale_craving_alcohol;
+
+    int timer_int = std::min( in / 3, 3 );
+
+    bool ret = false;
+    if( x_in_y( in, to_turns<int>( 2_hours ) ) ) {
+        if( !u.has_effect( effect_withdrawal_alcohol_timer ) || u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) {
+            u.add_effect( effect_withdrawal_alcohol_timer, 1_turns, true, timer_int );
+        }
+        ret = true;
+    }
+    if( one_in( 40 ) && rng( 0, 30 ) < in && ( !u.in_sleep_state() || !recent_dream ) ) {
+        const std::string msg_1 =  ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
+        u.add_msg_if_player( m_warning,
+                             SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
+        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
+        ret = true;
+        if( u.in_sleep_state() ) {
+            last_alc_dream = calendar::turn;
+        }
+    } else if( rng( 8, 600 ) < in && ( !u.in_sleep_state() || !recent_dream ) ) {
+        const std::string msg_2 = ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );
+        u.add_msg_if_player( m_bad,
+                             SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
+        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
+        ret = true;
+        if( u.in_sleep_state() ) {
+                last_alc_dream = calendar::turn;
+        }
+    }
+    return ret;
 }
 
 static bool alcohol_diazepam_add( Character &u, int in, bool is_alcohol )
@@ -207,7 +245,7 @@ static bool nicotine_effect( Character &u, addiction &add )
 static bool alcohol_effect( Character &u, addiction &add )
 {
     const int in = std::min( 20, add.intensity );
-    return alcohol_diazepam_add( u, in, true );
+    return alcohol_add( u, in );
 }
 
 static bool diazepam_effect( Character &u, addiction &add )

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -89,7 +89,7 @@ static bool alcohol_add( Character &u, int in)
     bool ret = false;
     if( x_in_y( in, to_turns<int>( 2_hours ) ) ) {
         if( !u.has_effect( effect_withdrawal_alcohol_timer ) || u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) {
-            u.add_effect( effect_withdrawal_alcohol_timer, 1_turns, true, timer_int );
+            u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
         }
         ret = true;
     }
@@ -115,7 +115,7 @@ static bool alcohol_add( Character &u, int in)
     return ret;
 }
 
-static bool alcohol_diazepam_add( Character &u, int in, bool is_alcohol )
+static bool benzodiazepine_add( Character &u, int in, bool is_alcohol )
 {
     static time_point last_alc_dream = calendar::turn_zero;
     static time_point last_dia_dream = calendar::turn_zero;
@@ -251,7 +251,7 @@ static bool alcohol_effect( Character &u, addiction &add )
 static bool diazepam_effect( Character &u, addiction &add )
 {
     const int in = std::min( 20, add.intensity );
-    return alcohol_diazepam_add( u, in, false );
+    return benzodiazepine_add( u, in, false );
 }
 
 static bool opioid_effect( Character &u, addiction &add )

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -27,6 +27,7 @@
 #include "text_snippets.h"
 
 static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
+static const efftype_id effect_withdrawal_alcohol( "withdrawal_alcohol" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
 
@@ -96,7 +97,8 @@ static bool alcohol_add( Character &u, int in )
         ret = true;
     }
 
-    if( rng( 0, 40 ) < in &&
+    // If you're not drunk, you want to be.
+    if( rng( 0, 100 ) < in &&
         ( !u.in_sleep_state() || !recent_dream ) ) {
         const std::string msg_1 =
             ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
@@ -108,7 +110,8 @@ static bool alcohol_add( Character &u, int in )
             last_alc_dream = calendar::turn;
         }
 
-    } else if( in > 7 && rng( 0, 40 ) < in &&
+    // If you're in active withdrawal, you feel horrible!
+    } else if( u.has_effect( effect_withdrawal_alcohol ) && in > 7 && rng( 0, 80 ) < in &&
                ( !u.in_sleep_state() || !recent_dream ) ) {
         const std::string msg_2 =
             ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -79,7 +79,7 @@ const std::vector<add_type> &add_type::get_all()
     return add_type_factory.get_all();
 }
 
-static bool alcohol_add( Character &u, int in)
+static bool alcohol_add( Character &u, int in )
 {
     static time_point last_alc_dream = calendar::turn_zero;
     const bool recent_dream = ( calendar::turn - last_alc_dream < 3_hours );
@@ -88,29 +88,36 @@ static bool alcohol_add( Character &u, int in)
     int timer_int = std::min( in / 3, 3 );
 
     bool ret = false;
-    if( x_in_y( in, to_turns<int>( 2_hours ) ) ) {
-        if( !u.has_effect( effect_withdrawal_alcohol_timer ) || u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) {
+    if( x_in_y( in, 24 ) ) {
+        if( !u.has_effect( effect_withdrawal_alcohol_timer ) ||
+            u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) {
             u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
         }
         ret = true;
     }
-    if( one_in( 40 ) && rng( 0, 30 ) < in && ( !u.in_sleep_state() || !recent_dream ) ) {
-        const std::string msg_1 =  ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
+
+    if( rng( 0, 40 ) < in &&
+        ( !u.in_sleep_state() || !recent_dream ) ) {
+        const std::string msg_1 =
+            ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
         u.add_msg_if_player( m_warning,
-                             SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
+            SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
         u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
         if( u.in_sleep_state() ) {
             last_alc_dream = calendar::turn;
         }
-    } else if( rng( 8, 600 ) < in && ( !u.in_sleep_state() || !recent_dream ) ) {
-        const std::string msg_2 = ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );
+
+    } else if( in > 7 && rng( 0, 40 ) < in &&
+               ( !u.in_sleep_state() || !recent_dream ) ) {
+        const std::string msg_2 =
+            ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );
         u.add_msg_if_player( m_bad,
-                             SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
+            SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
         u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
         if( u.in_sleep_state() ) {
-                last_alc_dream = calendar::turn;
+            last_alc_dream = calendar::turn;
         }
     }
     return ret;

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -14,6 +14,7 @@
 #include "creature.h"
 #include "debug.h"
 #include "dialogue.h"
+#include "effect.h"
 #include "effect_on_condition.h"
 #include "enums.h"
 #include "flexbuffer_json-inl.h"
@@ -25,7 +26,7 @@
 #include "talker.h"
 #include "text_snippets.h"
 
-static const efftype_id effect_withdrawal_alcohol_timer( "effect_withdrawal_alcohol_timer" );
+static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
 

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -61,7 +61,7 @@ class addiction
     public:
         addiction_id type;
         int intensity = 0;
-        time_duration sated = 1_hours;
+        time_duration sated = 5_hours;
 
         addiction() = default;
         explicit addiction( const addiction_id &t, const int i = 1 ) : type {t}, intensity {i} { }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -155,6 +155,7 @@ static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
 static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
 
+static const addiction_id addiction_alcohol( "alcohol" );
 static const addiction_id addiction_opioid( "opioid" );
 static const addiction_id addiction_sleeping_pill( "sleeping pill" );
 
@@ -285,6 +286,7 @@ static const efftype_id effect_tapeworm( "tapeworm" );
 static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 static const efftype_id effect_winded( "winded" );
+static const efftype_id effect_withdrawal_timer_alcohol( "withdrawal_timer_alcohol" );
 
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
@@ -11828,6 +11830,12 @@ bool Character::can_sleep()
     int sleepy = get_comfort_at( pos_bub() ).comfort;
     if( has_addiction( addiction_sleeping_pill ) ) {
         sleepy -= 4;
+    }
+    if( addiction_level( addiction_alcohol ) > 5 ) {
+        sleepy -= 1;
+    }
+    if( has_effect( effect_withdrawal_timer_alcohol ) ) {
+        sleepy -= get_effect_int( effect_withdrawal_timer_alcohol );
     }
     sleepy = enchantment_cache->modify_value( enchant_vals::mod::SLEEPY, sleepy );
     if( get_fatigue() < fatigue_levels::TIRED + 1 ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -5052,7 +5052,7 @@ bool npc::consume_food()
 
     if( inv_food.empty() ) {
         if( !needs_food() ) {
-            // When NO_NPC_FOOD is active and NPC has no food, silently reset hunger/thirst
+            // Silently reset hunger/thirst.
             set_hunger( 0 );
             set_thirst( 0 );
         }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -439,11 +439,11 @@ void suffer::while_grabbed( Character &you )
 
 void suffer::from_addictions( Character &you )
 {
-    time_duration timer = -6_hours;
+    time_duration timer = -9_hours;
     if( you.has_trait( trait_ADDICTIVE ) ) {
-        timer = -10_hours;
+        timer = -12_hours;
     } else if( you.has_trait( trait_NONADDICTIVE ) ) {
-        timer = -3_hours;
+        timer = -6_hours;
     }
     for( addiction &cur_addiction : you.addictions ) {
         if( cur_addiction.sated <= 0_turns &&

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -446,12 +446,7 @@ void suffer::from_addictions( Character &you )
         timer = -6_hours;
     }
     for( addiction &cur_addiction : you.addictions ) {
-        if( cur_addiction.sated <= 0_turns &&
-            cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
-            if( uistate.distraction_withdrawal && !you.is_npc() ) {
-                g->cancel_activity_or_ignore_query( distraction_type::withdrawal,
-                                                    _( "You start having withdrawals!" ) );
-            }
+        if( cur_addiction.sated <= 0_turns && cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
             cur_addiction.run_effect( you );
         }
         cur_addiction.sated -= 1_turns;
@@ -1877,7 +1872,9 @@ void Character::suffer()
         suffer::while_underwater( *this );
     }
 
-    suffer::from_addictions( *this );
+    if( calendar::once_every( 5_minutes ) ) {
+        suffer::from_addictions( *this );
+    }
 
     if( !in_sleep_state() ) {
         suffer::while_awake( *this, current_stim );


### PR DESCRIPTION
#### Summary
Rewrite alcoholism

#### Purpose of change
Addictions suck, drugs suck, all of the code is ancient and weird and sucks.

#### Describe the solution
- Addiction is still tracked in C++. It could feasably entirely be done in EOC, but I'll leave that to modders.
- Addiction is now checked every 5 minutes instead of every second (whaaaat the fuck lol)
- Hardcoded addiction applies insomnia, morale hits, periodic mild withdrawal.
- Move alcohol withdrawal to an actual effect instead of hardcoded bullshit.
- Alcohol timeline: Cravings, but no actual symptoms until ~8 hours without any alcohol in system. Mild symptoms for 12 hours. Moderate symptoms for 12 hours. Severe symptoms for up to 48 hours, then moderate 12 hours -> mild 12 hours -> detoxed.
- Severe symptoms include periodic shakes and hallucinations, and can be mitigated/prevented by benzos (xanax/valium).
- Once detoxed, cravings persist, but not withdrawals.
- Severe cravings are gated by being in active withdrawal.
- Withdrawals come in (currently) 3 intensities. They randomly come on according to how bad your addiction is and where you're at in the timeline.

#### Describe alternatives you've considered
I have to do this for all the other drugs aaah

#### Testing
oouggh

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
