### PR TITLE
Remove defunct molerat faction

### DIFF
--- a/data/json/monster_factions.json
+++ b/data/json/monster_factions.json
@@ -290,11 +290,6 @@
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "molerat",
-    "base_faction": "mutant"
-  },
-  {
-    "type": "MONSTER_FACTION",
     "name": "amigara",
     "base_faction": "mutant",
     "neutral": [ "amigara" ]
@@ -382,7 +377,6 @@
       "frog",
       "slug",
       "mutant_piscivores",
-      "molerat",
       "amigara",
       "mutant_with_vortex",
       "corvid",


### PR DESCRIPTION
These have long been deleted at some point and I can find no other references to them outside `gfx/`.

#### Summary
Cleanup "Clean up faction entry for molerats"

#### Purpose of change
Cleanup.

#### Describe the solution
Delete the JSON.

#### Describe alternatives you've considered
N/A.

#### Testing
N/A.

#### Additional context

I noticed these when porting https://github.com/I-am-Erk/CDDA-Tilesets/pull/2616.

https://github.com/CleverRaven/Cataclysm-DDA/pull/75993 deletes them from CDDA.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
