### PR TITLE
Alcoholism fixes

### DIFF
--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -127,8 +127,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 1 },
-        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
@@ -140,9 +140,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
-        { "not":  { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } },
-        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "withdrawal_alcohol", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
@@ -154,8 +154,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 2 },
-        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
@@ -195,9 +195,9 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol_timer", "intensity": 3 },
-        { "not":  { "u_has_effect": "withdrawal_alcohol_detoxed" } },
-        { "not":  { "u_has_effect": "valium" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "withdrawal_alcohol_detoxed" } },
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol", "intensity": 3, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
@@ -209,8 +209,8 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
-        { "not":  { "u_has_effect": "valium" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "shakes", "intensity": 3, "duration": { "math": [ "300 + rand(5) * 60" ] } }
@@ -222,23 +222,29 @@
     "condition": {
       "and": [
         { "u_has_effect": "withdrawal_alcohol", "intensity": 3 },
-        { "not":  { "u_has_effect": "valium" } },
-        { "not":  { "u_has_effect": "drunk" } }
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
-    "effect": { "u_add_effect": "hallu", "intensity": 3, "duration": { "math": [ "1800 + rand(8) * 3600" ] } }
+    "effect": { "u_add_effect": "hallu", "duration": { "math": [ "1800 + rand(6) * 3600" ] } }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_ALCOHOL_DETOX",
     "eoc_type": "EVENT",
     "required_event": "character_loses_effect",
-    "condition": { "and": [ { "compare_string": [ "withdrawal_alcohol_timer", { "context_val": "effect" } ] }, { "not": { "u_has_effect": "drunk" } } ] },
+    "condition": {
+      "and": [
+        { "compare_string": [ "withdrawal_alcohol_timer", { "context_val": "effect" } ] },
+        { "not": { "u_has_effect": "drunk" } }
+      ]
+    },
     "effect": { "u_add_effect": "withdrawal_alcohol_detoxed", "duration": "PERMANENT" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_ALCOHOL_RETOX",
+    "recurrence": [ "30 seconds", "5 minutes" ],
     "condition": {
       "and": [
         { "or": [ { "u_has_effect": "withdrawal_alcohol" }, { "u_has_effect": "withdrawal_alcohol_detoxed" } ] },

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -2,92 +2,83 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "boating_license",
-    "name": "Boating License",
-    "description": "You've trained in how to pilot marine craft, as well as general boating and swimming safety.",
-    "points": 0,
-    "proficiencies": [ "prof_boat_pilot" ]
+    "id": "alcoholic",
+    "name": "Alcohol Addiction",
+    "description": "One drink became two, two became too many, and before long you were only able to find solace at the bottom of a bottle.  God damn, you need a drink.",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "alcohol" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "heroin_addict",
-    "name": "Heroin Dependence",
-    "description": "The last thing you remember was meeting God behind the local restaurant.  Then people started eating each other.  This doesn't feel like a fever dream.",
-    "points": -3,
-    "addictions": [ { "intensity": 40, "type": "opioid" } ]
+    "id": "amphetamine_addict",
+    "name": "Amphetamine Addiction",
+    "description": "You're not entirely sure what happened last night, but you woke up on the floor and everything has completely gone to shit.  This is not the first time this has happened to you.  With any luck, it will not be the last.",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "amphetamine" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "benzo_addict",
+    "name": "Benzodiazepine Addiction",
+    "description": "Bars, V, xannies, whatever you called those magical sedatives, they're all gone now.  The Cataclysm would make anybody nervous, but you've heard benzo withdrawals can be lethal…",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "diazepam" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "caffiene_addict",
+    "name": "Caffeine Addict",
+    "description": "Caffeine gave you life and without it you are nothing.  You'd better find a steady supply, and fast.",
+    "points": -1,
+    "addictions": [ { "intensity": 15, "type": "caffeine" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "cocaine_addict",
+    "name": "Cocaine Addiction",
+    "description": "Cocaine is indeed a hell of a drug.  One minute you're skiing down mountains of powder, the next you're rolling zombies and digging through dumpsters for crack.",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "cocaine" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "opioid_addict",
+    "name": "Opioid Addiction",
+    "description": "Whether by pill, pipe, or needle, you wound up chasing the dragon.  Your dealer's long dead, so you're going to need to get your fix before withdrawals set in.",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "opioid" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "sleeping_pill_addict",
+    "name": "Sleeping Pill Addiction",
+    "description": "You'd been having trouble falling asleep, so you started taking prescription sleep meds.  Now you can hardly seem to fall asleep at all without them, and you'll need plenty of rest to face the days ahead.",
+    "points": -2,
+    "addictions": [ { "intensity": 15, "type": "sleeping pill" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "smoker",
-    "name": "Nicotine Dependence",
-    "description": "Your coworkers always muttered when you had to duck outside every hour for a smoke, but it ended up saving your life when things got bad.  You'll need to find a steady supply of nicotine if you want to keep the cravings at bay.",
+    "name": "Smoker",
+    "description": "Cigarettes make you feel good and look cool; unfortunately, they also destroy your body, and going without is torture.  Surely you can find a pack of smokes, a vape, some chaw…anything to fight off the coming nic fit.",
     "points": -1,
-    "addictions": [ { "intensity": 10, "type": "nicotine" } ]
+    "addictions": [ { "intensity": 15, "type": "nicotine" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "crackhead",
-    "name": "Crack Cocaine Dependence",
-    "description": "Cocaine.  It is, indeed, a helluva drug.  You blew your money on some rocks, and before you knew it you were turning tricks behind the local pharmacy just to score a little more.  Where are you going to get your fix now?",
-    "points": -2,
-    "addictions": [ { "intensity": 20, "type": "crack" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "benzos_addict",
-    "name": "Sedative Dependence",
-    "description": "You got hooked on dangerous sedative medication.  Or, maybe a prescription spiraled out of control.  Either way, it's time to face the music.  Maybe you can wean yourself off, assuming a zombie doesn't get you first…",
-    "points": -2,
-    "addictions": [ { "intensity": 30, "type": "diazepam" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "tweaker",
-    "name": "Amphetamine Dependence",
-    "description": "You're not entirely sure what happened last night, but you woke up on the floor and everything has completely gone to shit.  The only thing running through your head, though, is where you're gonna find your next hit.",
-    "points": -2,
-    "addictions": [ { "intensity": 30, "type": "amphetamine" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "pillhead",
-    "name": "Painkiller Dependence",
-    "description": "After a bad accident, you became hooked on the opioids prescribed to you for the pain.  With the pharmacies shut down and your dealers turned undead, satisfying those cravings just got a lot more difficult.",
-    "points": -2,
-    "addictions": [ { "intensity": 20, "type": "opioid" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "alcoholic",
-    "name": "Alcohol Dependence",
-    "description": "One drink became two, two became too many, and before long you were only able to find solace at the bottom of a bottle.  God-damn, you need a drink.",
-    "points": -2,
-    "addictions": [ { "intensity": 20, "type": "alcohol" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "sleepingpillhead",
-    "name": "Sleeping Pill Dependence",
-    "description": "You'd been having trouble falling asleep, so you started taking prescription sleep meds.  Now you can hardly seem to fall asleep at all without them, and you'll need plenty of rest to face the days ahead.",
-    "points": -2,
-    "addictions": [ { "intensity": 20, "type": "sleeping pill" } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
-    "id": "caffiend",
-    "name": "Caffeine Fiend",
-    "description": "Caffeine gave you life and without it you are nothing.  You'd better find a steady supply, and fast.",
-    "points": -1,
-    "addictions": [ { "intensity": 30, "type": "caffeine" } ]
+    "id": "boating_license",
+    "name": "Boating License",
+    "description": "You've trained in how to pilot marine craft, as well as general boating and swimming safety.",
+    "points": 0,
+    "proficiencies": [ "prof_boat_pilot" ]
   },
   {
     "type": "profession",


### PR DESCRIPTION
#### Summary
Alcoholism fixes

#### Purpose of change
- Ensure that withdrawals fall off within a minute or so of getting drunk
- Reduce initial addiction intensity from backgrounds to 15. Standardize naming and rewrite some descriptions to remove references to (squints) "turning tricks behind the local pharmacy."

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
