### PR TITLE
Add missing null guard to consume menu

### DIFF
--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -103,20 +103,20 @@ static bool alcohol_add( Character &u, int in )
         const std::string msg_1 =
             ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
         u.add_msg_if_player( m_warning,
-            SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
+                             SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
         u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
         if( u.in_sleep_state() ) {
             last_alc_dream = calendar::turn;
         }
 
-    // If you're in active withdrawal, you feel horrible!
+        // If you're in active withdrawal, you feel horrible!
     } else if( u.has_effect( effect_withdrawal_alcohol ) && in > 7 && rng( 0, 80 ) < in &&
                ( !u.in_sleep_state() || !recent_dream ) ) {
         const std::string msg_2 =
             ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );
         u.add_msg_if_player( m_bad,
-            SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
+                             SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
         u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
         if( u.in_sleep_state() ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -192,8 +192,7 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
 
     item_location location = inv_s.execute();
 
-    //output to global consume menu UI state
-    if( using_consume_menu ) {
+    if( using_consume_menu && location != item_location::nowhere ) {
 
         inventory_entry const &e = inv_s.get_highlighted();
         bool const collated = e.is_collation_entry();


### PR DESCRIPTION
#### Summary
Add missing null guard to consume menu

#### Purpose of change
A null guard was missing from the consume menu. Presumably, this was missed in a backport.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
