### PR TITLE
Redo Nicotine Addiction

### DIFF
--- a/data/json/addictions.json
+++ b/data/json/addictions.json
@@ -2,18 +2,18 @@
   {
     "type": "addiction_type",
     "id": "caffeine",
-    "name": "Caffeine Withdrawal",
+    "name": "Craving Caffeine",
     "type_name": "caffeine",
-    "description": "Not medically significant.",
+    "description": "Life without caffeine is rough, but there are worse things to be hooked on.",
     "craving_morale": "morale_craving_caffeine",
     "effect_on_condition": "EOC_CAFFEINE_ADDICTION"
   },
   {
     "type": "addiction_type",
     "id": "nicotine",
-    "name": "Nicotine Withdrawal",
+    "name": "Craving Nicotine",
     "type_name": "nicotine",
-    "description": "Not medically significant.",
+    "description": "A cigarette, a vape, even the gum would be better than going without.",
     "craving_morale": "morale_craving_nicotine",
     "builtin": "nicotine_effect"
   },
@@ -29,35 +29,35 @@
   {
     "type": "addiction_type",
     "id": "sleeping pill",
-    "name": "Sleeping Pill Dependence",
+    "name": "Sleeping Pill Insomnia",
     "type_name": "sleeping pills",
-    "description": "May cause insomnia.",
+    "description": "You will have a hard time sleeping without help.",
     "effect_on_condition": "EOC_SLEEP_ADDICTION"
   },
   {
     "type": "addiction_type",
     "id": "opioid",
-    "name": "Opioid Withdrawal",
+    "name": "Craving Opioids",
     "type_name": "opioids",
-    "description": "Nausea, pain, severe depression.",
+    "description": "You really need some painkillers.",
     "craving_morale": "morale_craving_opioid",
     "builtin": "opioid_effect"
   },
   {
     "type": "addiction_type",
     "id": "amphetamine",
-    "name": "Amphetamine Withdrawal",
+    "name": "Craving Amphetamines",
     "type_name": "amphetamine",
-    "description": "Slowdown and severe depression.",
+    "description": "Everything is too much and too loud, and you can't keep up.",
     "craving_morale": "morale_craving_speed",
     "builtin": "amphetamine_effect"
   },
   {
     "type": "addiction_type",
     "id": "cocaine",
-    "name": "Cocaine Withdrawal",
+    "name": "Craving Cocaine",
     "type_name": "cocaine",
-    "description": "Perception - 1;   Intelligence - 1;   Frequent cravings.",
+    "description": "Just a bump would fix you.",
     "craving_morale": "morale_craving_cocaine",
     "builtin": "cocaine_effect"
   },

--- a/data/json/backgrounds.json
+++ b/data/json/backgrounds.json
@@ -30,7 +30,7 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "caffiene_addict",
-    "name": "Caffeine Addict",
+    "name": "Caffeine Addiction",
     "description": "Caffeine gave you life and without it you are nothing.  You'd better find a steady supply, and fast.",
     "points": -1,
     "addictions": [ { "intensity": 15, "type": "caffeine" } ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3561,8 +3561,8 @@
     "id": "withdrawal_alcohol",
     "name": [ "Mild Alcohol Withdrawal", "Moderate Alcohol Withdrawal", "Severe Alcohol Withdrawal" ],
     "desc": [
-      "You could use a drink to settle your nerves.",
-      "You are in dire need of a drink.",
+      "You're starting to feel sick.  You know a drink would fix this.",
+      "Your body aches and you have chills, like you've got the flu.",
       "You feel horrible, like you'll die if you can't have a drink!"
     ],
     "max_intensity": 3,
@@ -3576,6 +3576,7 @@
       "fatigue_min": [ 1 ],
       "pain_max_val": [ 15 ],
       "pain_min": [ 1, 0 ],
+      "pain_chance": [ 3600 ],
       "stamina_min": [ -100 ],
       "stamina_max": [ -200 ],
       "stamina_chance": [ 1200 ],
@@ -3585,10 +3586,11 @@
       "vomit_tick": [ 1800 ]
     },
     "scaling_mods": {
-      "str_mod": [ -0.5 ],
-      "per_mod": [ -0.25 ],
-      "dex_mod": [ -0.66 ],
-      "int_mod": [ -0.75 ],
+      "str_mod": [ -0.67 ],
+      "per_mod": [ -0.34 ],
+      "dex_mod": [ -0.67 ],
+      "int_mod": [ -1.0 ],
+      "pain_chance": [ -500 ],
       "stamina_max": [ -500 ],
       "stamina_chance": [ -300 ],
       "vomit_chance": [ -10 ]
@@ -3597,6 +3599,58 @@
       { "limb_score": "manip", "modifier": 0.9, "scaling": -0.1 },
       { "limb_score": "block", "modifier": 1.0, "scaling": -0.1 },
       { "limb_score": "vision", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "balance", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "footing", "modifier": 0.8, "scaling": -0.2 },
+      { "limb_score": "swim", "modifier": 1.0, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_nicotine_timer",
+    "max_intensity": 3,
+    "int_dur_factor": "32 h",
+    "max_duration": "96 h",
+    "//": "Helper effect to track progression of withdrawals."
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_nicotine_detoxed",
+    "//": "Safe from withdrawals until you smoke again."
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_nicotine",
+    "name": [ "Mild Nicotine Withdrawal", "Nicotine Withdrawal" ],
+    "desc": [
+      "You feel anxious, irritable, and distracted.",
+      "Your ears ring and your head is pounding."
+    ],
+    "max_intensity": 2,
+    "apply_message": "Going so long without nicotine feels awful.",
+    "miss_messages": [ [ "You feel horrible.", 1 ] ],
+    "rating": "bad",
+    "base_mods": {
+      "pain_max_val": [ 35 ],
+      "pain_min": [ 1, 0 ],
+      "pain_chance": [ 1800 ],
+      "stamina_min": [ -100 ],
+      "stamina_max": [ -200 ],
+      "stamina_chance": [ 2400 ]
+    },
+    "scaling_mods": {
+      "per_mod": [ -0.50 ],
+      "dex_mod": [ -0.50 ],
+      "int_mod": [ -1.0 ],
+      "stamina_max": [ -500 ],
+      "stamina_chance": [ -300 ],
+      "pain_chance": [ -600 ]
+    },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.1 },
       { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 },
       { "limb_score": "move_speed", "modifier": 1.0, "scaling": -0.05 },
       { "limb_score": "balance", "modifier": 0.9, "scaling": -0.2 },

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3624,10 +3624,7 @@
     "type": "effect_type",
     "id": "withdrawal_nicotine",
     "name": [ "Mild Nicotine Withdrawal", "Nicotine Withdrawal" ],
-    "desc": [
-      "You feel anxious, irritable, and distracted.",
-      "Your ears ring and your head is pounding."
-    ],
+    "desc": [ "You feel anxious, irritable, and distracted.", "Your ears ring and your head is pounding." ],
     "max_intensity": 2,
     "apply_message": "Going so long without nicotine feels awful.",
     "miss_messages": [ [ "You feel horrible.", 1 ] ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3586,10 +3586,10 @@
       "vomit_tick": [ 1800 ]
     },
     "scaling_mods": {
-      "str_mod": [ -0.67 ],
-      "per_mod": [ -0.34 ],
-      "dex_mod": [ -0.67 ],
-      "int_mod": [ -1.0 ],
+      "str_mod": [ -1.34 ],
+      "per_mod": [ -0.67 ],
+      "dex_mod": [ -1.0 ],
+      "int_mod": [ -1.67 ],
       "pain_chance": [ -500 ],
       "stamina_max": [ -500 ],
       "stamina_chance": [ -300 ],
@@ -3641,8 +3641,8 @@
       "stamina_chance": [ 2400 ]
     },
     "scaling_mods": {
-      "per_mod": [ -0.50 ],
-      "dex_mod": [ -0.50 ],
+      "per_mod": [ -0.5 ],
+      "dex_mod": [ -1.0 ],
       "int_mod": [ -1.0 ],
       "stamina_max": [ -500 ],
       "stamina_chance": [ -300 ],

--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -252,5 +252,97 @@
       ]
     },
     "effect": [ { "u_lose_effect": "withdrawal_alcohol_detoxed" }, { "u_lose_effect": "withdrawal_alcohol" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_WITHDRAWAL_1",
+    "recurrence": [ "10 minutes", "6 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_nicotine_timer", "intensity": 1 },
+        { "not": { "u_has_effect": "withdrawal_nicotine_detoxed" } },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine", "intensity": 1, "duration": { "math": [ "1800 + rand(2) * 1800" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_WITHDRAWAL_2_1",
+    "recurrence": [ "10 minutes", "6 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_nicotine_timer", "intensity": 2 },
+        { "not": { "u_has_effect": "withdrawal_nicotine", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_nicotine_detoxed" } },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine", "intensity": 1, "duration": { "math": [ "1800 + rand(2) * 1800" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_WITHDRAWAL_2_2",
+    "recurrence": [ "20 hours", "28 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_nicotine_timer", "intensity": 2 },
+        { "not": { "u_has_effect": "withdrawal_nicotine_detoxed" } },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine", "intensity": 2, "duration": { "math": [ "3600 + rand(2) * 3600" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_WITHDRAWAL_3_1",
+    "recurrence": [ "10 minutes", "10 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_nicotine_timer", "intensity": 3 },
+        { "not": { "u_has_effect": "withdrawal_nicotine", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_nicotine_detoxed" } },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine", "intensity": 1, "duration": { "math": [ "1800 + rand(2) * 1800" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_WITHDRAWAL_3_2",
+    "recurrence": [ "12 hours", "72 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_nicotine_timer", "intensity": 3 },
+        { "not": { "u_has_effect": "withdrawal_nicotine_detoxed" } },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine", "intensity": 2, "duration": { "math": [ "7200 + rand(2) * 3600" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_DETOX",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": {
+      "and": [
+        { "compare_string": [ "withdrawal_nicotine_timer", { "context_val": "effect" } ] },
+        { "not": { "u_has_effect": "cig" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_nicotine_detoxed", "duration": "PERMANENT" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NICOTINE_RETOX",
+    "recurrence": [ "30 seconds", "5 minutes" ],
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_effect": "withdrawal_nicotine" }, { "u_has_effect": "withdrawal_nicotine_detoxed" } ] },
+        { "u_has_effect": "cig" }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "withdrawal_nicotine_detoxed" }, { "u_lose_effect": "withdrawal_nicotine" } ]
   }
 ]

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -425,6 +425,7 @@ bool addiction::run_effect( Character &u )
 {
     bool ret = false;
     if( !type->get_effect().is_null() ) {
+        add_msg( _( "effect for type is not null" ) );
         dialogue d( get_talker_for( u ), nullptr );
         ret = type->get_effect()->activate( d );
     } else {

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -26,8 +26,12 @@
 #include "talker.h"
 #include "text_snippets.h"
 
-static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
 static const efftype_id effect_withdrawal_alcohol( "withdrawal_alcohol" );
+static const efftype_id effect_withdrawal_alcohol_detoxed( "withdrawal_alcohol_detoxed" );
+static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
+static const efftype_id effect_withdrawal_nicotine( "withdrawal_nicotine" );
+static const efftype_id effect_withdrawal_nicotine_detoxed( "withdrawal_nicotine_detoxed" );
+static const efftype_id effect_withdrawal_nicotine_timer( "withdrawal_nicotine_timer" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
 
@@ -90,8 +94,8 @@ static bool alcohol_add( Character &u, int in )
 
     bool ret = false;
     if( x_in_y( in, 24 ) ) {
-        if( !u.has_effect( effect_withdrawal_alcohol_timer ) ||
-            u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) {
+        if( !u.has_effect( effect_withdrawal_alcohol_detoxed ) && ( !u.has_effect( effect_withdrawal_alcohol_timer ) ||
+            u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) ) {
             u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
         }
         ret = true;
@@ -229,8 +233,19 @@ static bool nicotine_effect( Character &u, addiction &add )
 {
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
-    const int current_stim = u.get_stim();
-    if( one_in( 3000 - 20 * in ) && ( !u.in_sleep_state() || calendar::turn - last_dream > 2_hours ) ) {
+
+    int timer_int = std::min( in / 3, 3 );
+    
+    bool ret = false;
+    if( x_in_y( in, 24 ) ) {
+        if( !u.has_effect( effect_withdrawal_nicotine_detoxed ) && ( !u.has_effect( effect_withdrawal_nicotine_timer ) ||
+            u.get_effect_int( effect_withdrawal_nicotine_timer ) < timer_int ) ) {
+            u.add_effect( effect_withdrawal_nicotine_timer, 32_hours * timer_int, false, timer_int );
+        }
+        ret = true;
+    }
+
+    if( one_in( 3000 - 20 * in ) && ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
         if( u.in_sleep_state() ) {
             last_dream = calendar::turn;
         }
@@ -241,16 +256,15 @@ static bool nicotine_effect( Character &u, addiction &add )
             ( u.in_sleep_state() ? "addict_nicotine_strong_asleep" : "addict_nicotine_strong_awake" );
         u.add_msg_if_player( m_warning,
                              SNIPPET.random_from_category( msg ).value_or( translation() ).translated() );
-        u.add_morale( morale_craving_nicotine, -15, -3 * in );
+        u.add_morale( morale_craving_nicotine, -15, -3 * in, 1_hours, 30_minutes, true  );
+
         if( one_in( 800 - 30 * in ) ) {
             u.mod_fatigue( 1 );
         }
-        if( current_stim > -5 * in && one_in( 400 - 20 * in ) ) {
-            u.mod_stim( -1 );
-        }
-        return true;
+
+        return ret;
     }
-    return false;
+    return ret;
 }
 
 static bool alcohol_effect( Character &u, addiction &add )

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -94,8 +94,9 @@ static bool alcohol_add( Character &u, int in )
 
     bool ret = false;
     if( x_in_y( in, 24 ) ) {
-        if( !u.has_effect( effect_withdrawal_alcohol_detoxed ) && ( !u.has_effect( effect_withdrawal_alcohol_timer ) ||
-            u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) ) {
+        if( !u.has_effect( effect_withdrawal_alcohol_detoxed ) &&
+            ( !u.has_effect( effect_withdrawal_alcohol_timer ) ||
+              u.get_effect_int( effect_withdrawal_alcohol_timer ) < timer_int ) ) {
             u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
         }
         ret = true;
@@ -108,11 +109,13 @@ static bool alcohol_add( Character &u, int in )
             ( u.in_sleep_state() ? "addict_alcohol_mild_asleep" : "addict_alcohol_mild_awake" );
         u.add_msg_if_player( m_warning,
                              SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
-        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
-        ret = true;
         if( u.in_sleep_state() ) {
             last_alc_dream = calendar::turn;
+        } else {
+            u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         }
+
+        ret = true;
 
         // If you're in active withdrawal, you feel horrible!
     } else if( u.has_effect( effect_withdrawal_alcohol ) && in > 7 && rng( 0, 80 ) < in &&
@@ -121,11 +124,12 @@ static bool alcohol_add( Character &u, int in )
             ( u.in_sleep_state() ? "addict_alcohol_strong_asleep" : "addict_alcohol_strong_awake" );
         u.add_msg_if_player( m_bad,
                              SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
-        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
-        ret = true;
         if( u.in_sleep_state() ) {
             last_alc_dream = calendar::turn;
+        } else {
+            u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         }
+        ret = true;
     }
     return ret;
 }
@@ -231,38 +235,42 @@ static bool crack_coke_add( Character &u, int in, int stim, bool is_crack )
 
 static bool nicotine_effect( Character &u, addiction &add )
 {
+
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
-
+    add_msg( _( "nicotine_effect with int %s"), in );
     int timer_int = std::min( in / 3, 3 );
-    
+
     bool ret = false;
-    if( x_in_y( in, 24 ) ) {
-        if( !u.has_effect( effect_withdrawal_nicotine_detoxed ) && ( !u.has_effect( effect_withdrawal_nicotine_timer ) ||
-            u.get_effect_int( effect_withdrawal_nicotine_timer ) < timer_int ) ) {
+    if( x_in_y( in, 48 ) ) {
+        if( !u.has_effect( effect_withdrawal_nicotine_detoxed ) &&
+            ( !u.has_effect( effect_withdrawal_nicotine_timer ) ||
+              u.get_effect_int( effect_withdrawal_nicotine_timer ) < timer_int ) ) {
             u.add_effect( effect_withdrawal_nicotine_timer, 32_hours * timer_int, false, timer_int );
         }
         ret = true;
     }
 
-    if( one_in( 3000 - 20 * in ) && ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
+    if( x_in_y( in, 60 ) && ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
         if( u.in_sleep_state() ) {
             last_dream = calendar::turn;
         }
-        const bool strong = rng( 0, 6 ) < in;
+        const bool strong = rng( 0, 10 ) < in;
         const std::string msg =
             !strong ?
             ( u.in_sleep_state() ? "addict_nicotine_mild_asleep" : "addict_nicotine_mild_awake" ) :
             ( u.in_sleep_state() ? "addict_nicotine_strong_asleep" : "addict_nicotine_strong_awake" );
         u.add_msg_if_player( m_warning,
                              SNIPPET.random_from_category( msg ).value_or( translation() ).translated() );
-        u.add_morale( morale_craving_nicotine, -15, -3 * in, 1_hours, 30_minutes, true  );
-
-        if( one_in( 800 - 30 * in ) ) {
-            u.mod_fatigue( 1 );
+        if( !u.in_sleep_state() ) {
+            u.add_morale( morale_craving_nicotine, -15, -3 * in, 1_hours, 30_minutes, true );
         }
 
-        return ret;
+        ret = true;
+    }
+
+    if( one_in( 90 - 3 * in ) ) {
+        u.mod_fatigue( 1 );
     }
     return ret;
 }

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -61,7 +61,7 @@ class addiction
     public:
         addiction_id type;
         int intensity = 0;
-        time_duration sated = 5_hours;
+        time_duration sated = 2_hours;
 
         addiction() = default;
         explicit addiction( const addiction_id &t, const int i = 1 ) : type {t}, intensity {i} { }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -439,6 +439,7 @@ void suffer::while_grabbed( Character &you )
 
 void suffer::from_addictions( Character &you )
 {
+    add_msg( _( "suffer::from_addictions()" ) );
     time_duration timer = -9_hours;
     if( you.has_trait( trait_ADDICTIVE ) ) {
         timer = -12_hours;
@@ -446,10 +447,12 @@ void suffer::from_addictions( Character &you )
         timer = -6_hours;
     }
     for( addiction &cur_addiction : you.addictions ) {
+        add_msg( _( "addiction found: intensity %s" ), cur_addiction.intensity );
         if( cur_addiction.sated <= 0_turns && cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
+            add_msg( _( "running effect" ) );
             cur_addiction.run_effect( you );
         }
-        cur_addiction.sated -= 1_turns;
+        cur_addiction.sated -= 5_minutes;
         // Higher intensity addictions heal faster
         if( cur_addiction.sated - 10_minutes * cur_addiction.intensity < timer ) {
             if( cur_addiction.intensity <= 2 ) {


### PR DESCRIPTION
#### Summary
Redo Nicotine Addiction

#### Purpose of change
Followup to #2376 and #2380 

#### Describe the solution
- Touch up the alcoholism effect, especially the way it (tries to) apply pain and its stat mods.
- Nicotine is a simpler addiction with simpler withdrawals. The withdrawal phase is longer (up to 96 hours), but not as serious.
- Nicotine withdrawal has two effect levels. For the first 24 hours, you have only mild symptoms.
- Nicotine withdrawal symptoms include pain and int/dex/per penalties.
- After 24 hours, you have mild or severe symptoms for 48 hours.
- After that there's another 24 hours of mild symptoms.
- This timeline is reduced at lower addiction levels.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
