### PR TITLE
Remove stray debug messages

### DIFF
--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -238,7 +238,6 @@ static bool nicotine_effect( Character &u, addiction &add )
 
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
-    add_msg( _( "nicotine_effect with int %s"), in );
     int timer_int = std::min( in / 3, 3 );
 
     bool ret = false;
@@ -425,7 +424,6 @@ bool addiction::run_effect( Character &u )
 {
     bool ret = false;
     if( !type->get_effect().is_null() ) {
-        add_msg( _( "effect for type is not null" ) );
         dialogue d( get_talker_for( u ), nullptr );
         ret = type->get_effect()->activate( d );
     } else {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -439,7 +439,6 @@ void suffer::while_grabbed( Character &you )
 
 void suffer::from_addictions( Character &you )
 {
-    add_msg( _( "suffer::from_addictions()" ) );
     time_duration timer = -9_hours;
     if( you.has_trait( trait_ADDICTIVE ) ) {
         timer = -12_hours;
@@ -447,9 +446,7 @@ void suffer::from_addictions( Character &you )
         timer = -6_hours;
     }
     for( addiction &cur_addiction : you.addictions ) {
-        add_msg( _( "addiction found: intensity %s" ), cur_addiction.intensity );
         if( cur_addiction.sated <= 0_turns && cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
-            add_msg( _( "running effect" ) );
             cur_addiction.run_effect( you );
         }
         cur_addiction.sated -= 5_minutes;


### PR DESCRIPTION
#### Summary
Remove stray debug messages

#### Purpose of change
Due to my brains I left some debug messages in by accident

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
