### PR TITLE
Remove obsolete variants from stadium palette

### DIFF
--- a/data/json/mapgen_palettes/stadium_palette.json
+++ b/data/json/mapgen_palettes/stadium_palette.json
@@ -201,8 +201,8 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "tshirt", "variant": "baseball_fan_tshirt", "count": [ 1, 12 ], "prob": 60 },
-      { "item": "hat_ball", "variant": "baseball_fan_hatball", "count": [ 1, 12 ], "prob": 80 },
+      { "item": "tshirt", "count": [ 1, 12 ], "prob": 60 },
+      { "item": "hat_ball", "count": [ 1, 12 ], "prob": 80 },
       { "item": "helmet_ball", "count": [ 1, 2 ], "prob": 11 },
       { "item": "baseball", "count": [ 1, 2 ], "prob": 11 },
       { "item": "bat", "count": [ 1, 2 ], "prob": 11 },
@@ -219,8 +219,8 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "tshirt", "variant": "football_fan_tshirt", "count": [ 1, 12 ], "prob": 80 },
-      { "item": "hat_ball", "variant": "football_fan_hatball", "count": [ 1, 12 ], "prob": 60 },
+      { "item": "tshirt", "count": [ 1, 12 ], "prob": 80 },
+      { "item": "hat_ball", "count": [ 1, 12 ], "prob": 60 },
       { "item": "football", "count": [ 1, 2 ], "prob": 11 },
       { "item": "football_armor", "count": [ 1, 2 ], "prob": 11 },
       { "item": "helmet_football", "count": [ 1, 2 ], "prob": 11 },


### PR DESCRIPTION
#### Summary
Cleanup "Remove obsolete variants from stadium palette"

#### Purpose of change
Cleanup. These variants don't exist anywhere else in the codebase since 994c9327d269bff4bfd30332af561de4b3b75c46.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

Generated a baseball stadium and football stadium, walked around, and didn't observe any errors.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I noticed this while looking at https://github.com/I-am-Erk/CDDA-Tilesets/commit/7ca5a8392f40368680e5b7e1153e3399cb2c1086.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
