### PR TITLE
Fix EOD tech profession and earplugs

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1148,7 +1148,8 @@
         "covers": [ "head" ],
         "coverage": 100,
         "layers": [ "OUTER", "NORMAL" ],
-        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ]
+        "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ],
+        "rigid_layer_only": true
       },
       {
         "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 20.0 } ],
@@ -3362,7 +3363,7 @@
     "name": { "str": "attached ear plugs (in)", "str_pl": "pairs of attached ear plugs (in)" },
     "description": "A pair of industrial-grade ear plugs attached together by some string.  They are inside your ears, activate them to take them out.",
     "copy-from": "ear_plugs",
-    "flags": [ "DEAF" ],
+    "flags": [ "DEAF", "OVERSIZE", "SKINTIGHT", "SOFT", "UNRESTRICTED" ],
     "use_action": {
       "type": "transform",
       "msg": "You take the ear plugs out.",
@@ -3395,7 +3396,7 @@
     "description": "A pair of makeshift ear plugs made from lumps of wax on the ends of a piece of string.  They are inside your ears, activate them to take them out.",
     "copy-from": "ear_plugs",
     "material": [ "beeswax", "cotton" ],
-    "flags": [ "SPAWN_ACTIVE" ],
+    "flags": [ "SPAWN_ACTIVE", "OVERSIZE", "SKINTIGHT", "SOFT", "UNRESTRICTED", "DEAF" ],
     "use_action": {
       "type": "transform",
       "msg": "You take the ear plugs out.",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6047,7 +6047,7 @@
           { "item": "pants_army" },
           { "item": "socks" },
           { "item": "boots_combat" },
-          { "item": "attached_ear_plugs_off" },
+          { "item": "attached_ear_plugs_off", "custom-flags": [ "no_auto_equip" ] },
           { "item": "helmet_eod" },
           { "item": "nomex_gloves" },
           { "item": "gloves_eod" },


### PR DESCRIPTION
#### Summary
Fix EOD tech profession and earplugs

#### Purpose of change
fixes #2385 

#### Describe the solution
- Make the EOD tech spawn without their earplugs worn.
- Fix flags for attached and makeshift earplugs so they're actually soft and fit all sized people.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
