### PR TITLE
Increase frequency of NPC bite complaint

### DIFF
--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -1496,7 +1496,7 @@
   {
     "type": "speech",
     "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
-    "sound": "\"G… geddoff me you… you bastard…\"",
+    "sound": "\"G… get off me you… you bastard…\"",
     "volume": 10
   },
   {

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -125,7 +125,7 @@ struct dialogue_chatbin_snippets {
     translation snip_pulp_zombie = to_translation( "Hold on, I want to pulp that %s." );
     translation snip_heal_player = to_translation( "Hold still %s, I'm coming to help you." );
     translation snip_wound_infected = to_translation( "My %s wound is infected…" );
-    translation snip_wound_bite = to_translation( "The bite wound on my %s looks bad." );
+    translation snip_wound_bite = to_translation( "I need some antiseptic for my %s." );
     translation snip_bleeding = to_translation( "My %s is bleeding!" );
     translation snip_bleeding_badly = to_translation( "My %s is bleeding badly!" );
     translation snip_radiation_sickness = to_translation( "I'm suffering from radiation sickness…" );

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -125,7 +125,7 @@ struct dialogue_chatbin_snippets {
     translation snip_pulp_zombie = to_translation( "Hold on, I want to pulp that %s." );
     translation snip_heal_player = to_translation( "Hold still %s, I'm coming to help you." );
     translation snip_wound_infected = to_translation( "My %s wound is infected…" );
-    translation snip_wound_bite = to_translation( "I need some antiseptic for my %s." );
+    translation snip_wound_bite = to_translation( "I need some disinfectant for my %s wound." );
     translation snip_bleeding = to_translation( "My %s is bleeding!" );
     translation snip_bleeding_badly = to_translation( "My %s is bleeding badly!" );
     translation snip_radiation_sickness = to_translation( "I'm suffering from radiation sickness…" );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -5690,13 +5690,13 @@ bool npc::complain()
         }
     }
 
-    // When bitten, complain every hour, but respect restrictions
+    // When bitten, complain every 30 minutes, but respect restrictions.
     if( has_effect( effect_bite ) ) {
         const bodypart_id &bp =  bp_affected( *this, effect_bite );
         std::string talktag = chat_snippets().snip_wound_bite.translated();
         parse_tags( talktag, get_player_character(), *this );
         const std::string speech = string_format( talktag, body_part_name( bp ) );
-        if( complain_about( bite_string, 1_hours, speech ) ) {
+        if( complain_about( bite_string, 30_minutes, speech ) ) {
             return true;
         }
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2651,7 +2651,7 @@ npc_action npc::address_needs( float danger )
     // and swing into action with alarming alacrity.
     // no sometimes they are just looking the other way, sometimes they hestitate.
     // ( also we can get huge performance boosts )
-    if( one_in( 3 ) ) {
+    if( one_in( 5 ) ) {
         healing_options try_to_fix_me = patient_assessment( *this );
         if( try_to_fix_me.any_true() ) {
             if( !use_bionic_by_id( bio_nanobots ) ) {


### PR DESCRIPTION
#### Summary
Increase frequency of NPC bite complaint

#### Purpose of change
NPCs with filthy wounds were only complaining once per hour. The complaint was not totally clear about what was wrong.

#### Describe the solution
The NPC now asks for disinfectant for their wound, and they do it every half hour instead of every hour. This affords 12 chances for the player to notice, instead of 6. If the player has chosen to disable NPC complaints and also to not give their friends medical supplies and also they aren't periodically checking on them, well,

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
