### PR TITLE
Backport DDA 83763 - Fix type in some switch statements, add missing case

### DIFF
--- a/data/json/mapgen_palettes/apartment_complex.json
+++ b/data/json/mapgen_palettes/apartment_complex.json
@@ -88,7 +88,7 @@
     },
     "furniture": {
       "Ŧ": {
-        "switch": { "param": "fencing_type", "fallback": "f_null" },
+        "switch": { "param": "fencing_type", "fallback": "t_region_soil" },
         "cases": {
           "t_region_shrub_decorative": "f_null",
           "t_region_soil": "f_hedge_short",
@@ -100,7 +100,7 @@
         }
       },
       "%": {
-        "switch": { "param": "shrubbery_type", "fallback": "f_null" },
+        "switch": { "param": "shrubbery_type", "fallback": "t_region_soil" },
         "cases": {
           "t_region_shrub_decorative": "f_null",
           "t_region_soil": "f_hedge_short",

--- a/data/json/mapgen_palettes/park_palette.json
+++ b/data/json/mapgen_palettes/park_palette.json
@@ -125,7 +125,7 @@
     },
     "furniture": {
       "Y": {
-        "switch": { "param": "walkway", "fallback": "f_null" },
+        "switch": { "param": "walkway", "fallback": "t_region_soil" },
         "cases": {
           "t_railroad_rubble": "f_null",
           "t_region_soil": "f_null",


### PR DESCRIPTION
#### Summary
Backport DDA 83763 - Fix type in some switch statements, add missing case

#### Purpose of change
Fixes "switch does not handle case f_null" error.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
