### PR TITLE
Fix NSAID timers

### DIFF
--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -92,8 +92,8 @@
     "max": 500,
     "//": "1mg ibuprofen equivalent.",
     "//2": "Takes 30 min to kick in, lasts 6 hours. TODO: Overdose when we can adjust rate at different amounts.",
-    "rate": "100 s",
-    "disease_excess": [ [ 10, 216 ] ]
+    "rate": "44 s",
+    "disease_excess": [ [ 10, 500 ] ]
   },
   {
     "id": "vit_nsaid",
@@ -105,8 +105,8 @@
     "max": 500,
     "//": "1mg ibuprofen equivalent.",
     "//2": "Takes 30 min to kick in, lasts 6 hours. TODO: Overdose when we can adjust rate at different amounts.",
-    "rate": "100 s",
-    "disease_excess": [ [ 10, 216 ] ]
+    "rate": "44 s",
+    "disease_excess": [ [ 10, 500 ] ]
   },
   {
     "id": "vit_acetaminophen",


### PR DESCRIPTION
#### Summary
Fix NSAID timers

#### Purpose of change
The NSAID timers were slightly off, making them last an hour or three longer than intended.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
