### PR TITLE
Grabs don't passively drain stamina

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -492,7 +492,7 @@
       "sound_fail": "clang!",
       "items": [
         { "item": "scrap", "count": [ 2, 8 ] },
-		{ "item": "steel_fragment", "count": [ 2, 4 ] },
+        { "item": "steel_fragment", "count": [ 2, 4 ] },
         { "item": "sheet_metal_small", "count": [ 6, 10 ] },
         { "item": "pipe", "count": [ 0, 1 ] }
       ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2824,10 +2824,6 @@ void Character::process_turn()
                 remove_effect( effid );
             }
             grab_1.clear();
-        } else {
-            // TODO: Move stamina cost to creature escape attempts, incorporate relative size etc.
-            set_activity_level( EXPLOSIVE_EXERCISE );
-            burn_energy_arms( -200 );
         }
     }
     effect_on_conditions::process_effect_on_conditions( *this );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -236,7 +236,8 @@ bool Character::try_remove_grab( bool attacking )
         // Iterate through all our grabs and attempt to break them one by one
         for( const effect &eff : get_effects_with_flag( json_flag_GRAB ) ) {
             float escape_chance = 1.0f;
-            float grabber_roll = static_cast<float>( eff.get_intensity() );
+            int grab_str = eff.get_intensity();
+            float grabber_roll = static_cast<float>( grab_str );
             // We need to figure out which Creature is responsible for this grab early for good messaging
             // For now, one grabber per limb TODO: handle multiple grabbers and decrement intensity
             Creature *grabber = nullptr;
@@ -344,11 +345,21 @@ bool Character::try_remove_grab( bool attacking )
                 escape_chance *= 1.5f;
                 add_msg_debug( debugmode::DF_MATTACK,
                                "Pocket torn off in the attempt, escape chance increased to %.1f",
-                               escape_chance * 100 / eff.get_intensity() );
+                               escape_chance * 100 / grab_str );
             }
-
+            // Grabber burns energy trying to hold us.
+            if( grabber && !grabber->is_monster() ) {
+                int maintain_cost =
+                    std::clamp( std::max( 1, 100 - grab_str ) * ( std::max( 1,
+                                enum_size() - grabber->enum_size() ) + static_cast<int>( escape_chance / 10.f ) ),
+                                100,
+                                400
+                              );
+                grabber->as_character()->set_activity_level( EXPLOSIVE_EXERCISE );
+                grabber->as_character()->burn_energy_arms( -maintain_cost );
+            }
             // Every attempt burns some stamina - maybe some moves?
-            burn_energy_arms( -5 * eff.get_intensity() );
+            burn_energy_arms( -5 * grab_str );
             if( x_in_y( escape_chance, grabber_roll ) ) {
                 if( grabber->is_monster() ) {
                     grabber->as_monster()->remove_grab( eff.get_bp().id() );

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -261,12 +261,6 @@ float Character::get_limb_score( const limb_score_id &score, const body_part_typ
                 if( local.has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL ) ) {
                     local_mul = local.get_limb_score_mod( score, resists_effect( local ) );
                     mod *= local_mul;
-                    if( local_mul != 1.0f ) {
-                        add_msg_debug( debugmode::DF_CHARACTER,
-                                       "Local limb score modifier %s for limb score %s on BP %s found, effect multiplier %.1f, score contribution after modifier %.1f",
-                                       local.disp_name(),
-                                       score.c_str(), id.first.c_str(), local_mul, mod );
-                    }
                 }
             }
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2519,6 +2519,16 @@ bool monster::move_effects( bool, tripoint_bub_ms dest_loc )
             add_msg_debug( debugmode::DF_MONSTER,
                            "%1s attempting to break grab %2s, success %3s in intensity %4s",
                            get_name(), grab.get_id().c_str(), monster, grab_str );
+            if( grabber && !grabber->is_monster() ) {
+                int maintain_cost =
+                    std::clamp( std::max( 1, 100 - grab_str ) * ( std::max( 1,
+                                enum_size() - grabber->enum_size() ) + static_cast<int>( std::max( get_melee(), get_dodge() ) ) ),
+                                100,
+                                400
+                              );
+                grabber->as_character()->set_activity_level( EXPLOSIVE_EXERCISE );
+                grabber->as_character()->burn_energy_arms( -maintain_cost );
+            }
             if( !x_in_y( monster, grab_str ) ) {
                 return false;
             } else {


### PR DESCRIPTION
#### Summary
Grabs don't passively drain stamina

#### Purpose of change
Grabs were passively eating 200 stamina per second from the grabber. We're already draining stamina if the grabber drags someone, or throws them, or attacks, so we don't need to drain every turn on top of that.

#### Describe the solution
Instead, only drain stamina when the grabbed creature attempts to escape. This drain is clamped between 100 and 400, and is based on the target's grab resistance stats, the size difference between the two combatants, and the strength of the grab. A good grab is easier to maintain, it's easier to hold something that's smaller and less skilled than you, etc.

Overall this should be a reduction in stamina cost since you can work it down to 100 fewer than it used to be, and it doesn't apply every turn.

Also fixed a debug message that was spamming every frame.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
