### PR TITLE
Throwing axes fit in axe rings

### DIFF
--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -121,6 +121,7 @@
     "longest_side": "43 cm",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "line", "balance": "uneven" },
     "weapon_category": [ "HAND_AXES" ],
+    "flags": [ "SHEATH_AXE" ],
     "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ],
     "melee_damage": { "bash": 10, "cut": 17 }
   },


### PR DESCRIPTION
#### Summary
Throwing axes fit in axe rings

#### Purpose of change
They didn't

#### Describe the solution
Now they do

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
