### PR TITLE
Fix fencing mask

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -117,7 +117,7 @@
     "volume": "1250 ml",
     "price": "35 USD",
     "price_postapoc": "3 USD",
-    "material": [ "cotton", "steel" ],
+    "material": [ "cotton", "steel_chain" ],
     "symbol": "[",
     "looks_like": "balaclava",
     "color": "dark_gray",
@@ -127,23 +127,21 @@
         "coverage": 90,
         "encumbrance": 12,
         "material": [
-          { "type": "cotton", "covered_by_mat": 100, "thickness": 4 },
-          { "type": "steel", "covered_by_mat": 90, "thickness": 1.5 }
+          { "type": "steel_chain", "covered_by_mat": 70, "thickness": 1.2 },
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 4 }
         ]
       },
       {
         "covers": [ "eyes" ],
         "coverage": 100,
-        "encumbrance": 10,
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.5 } ],
-        "breathability": "GOOD"
+        "encumbrance": 25,
+        "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       },
       {
         "covers": [ "mouth" ],
         "coverage": 100,
         "encumbrance": 3,
-        "material": [ { "type": "steel", "covered_by_mat": 100, "thickness": 1.5 } ],
-        "breathability": "GOOD"
+        "material": [ { "type": "steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ]
       }
     ],
     "flags": [ "STURDY", "PADDED" ],


### PR DESCRIPTION
#### Summary
Fix fencing mask

#### Purpose of change
Fencing masks were made of solid steel

#### Describe the solution
They're made of steel chain. That's not quite the same as the weird mesh they're made of, but it's good enough and makes sense for patchwork repairs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
