### PR TITLE
Chitin fixes

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5018,8 +5018,7 @@
     "type": "effect_type",
     "id": "molting_imminent",
     "name": [ "Imminent Molting" ],
-    "desc": [ "Seek shelter, you will be helpless when it begins." ],
-    "apply_message": "You can hardly move in your tightening exoskeleton, and you feel a strong impulse to hunker down somewhere safe.",
+    "desc": [ "Seek shelter now, you will be helpless when it begins." ],
     "rating": "bad",
     "base_mods": {
       "per_mod": [ -2 ],

--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -45,7 +45,15 @@
         { "not": { "u_has_trait": "CRUSTACEAN_CARAPACE" } }
       ]
     },
-    "effect": [ { "u_add_effect": "molting_imminent", "intensity": 1, "duration": "PERMANENT" }, { "u_lose_effect": "molting" } ]
+    "effect": [
+      { "u_add_effect": "molting_imminent", "intensity": 1, "duration": "PERMANENT" },
+      { "u_lose_effect": "molting" },
+      {
+        "u_message": "You can hardly move in your tightening exoskeleton, and you feel a strong impulse to hunker down somewhere safe.",
+        "type": "bad",
+        "popup": true
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -64,7 +72,8 @@
       { "u_add_effect": "sleep", "duration": "5 minutes" },
       {
         "u_message": "Your exoskeleton grows steadily more rigid until you can no longer move.  You strain against it for a few minutes, and it peels and cracks away in chunks like a plaster mold, revealing a soft and tender new layer beneath.",
-        "type": "bad"
+        "type": "bad",
+        "popup": true
       },
       { "u_lose_trait": "CHITIN2" },
       { "u_lose_trait": "CHITIN" },
@@ -121,7 +130,15 @@
         { "not": { "u_has_effect": "molting_imminent" } }
       ]
     },
-    "effect": [ { "u_add_effect": "molting_imminent", "intensity": 1, "duration": "PERMANENT" }, { "u_lose_effect": "molting" } ]
+    "effect": [
+      { "u_add_effect": "molting_imminent", "intensity": 1, "duration": "PERMANENT" },
+      { "u_lose_effect": "molting" },
+      {
+        "u_message": "You can hardly move in your tightening exoskeleton, and you feel a strong impulse to hunker down somewhere safe.",
+        "type": "bad",
+        "popup": true
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -140,7 +157,8 @@
       { "u_add_effect": "sleep", "duration": "15 minutes" },
       {
         "u_message": "Your exoskeleton locks up around you like a straitjacket, completely immobilizing you.  As you try to move, you begin to feel it painlessly rip, opening a hole through which you can slowly emerge, raw, soft, and vulnerable.",
-        "type": "bad"
+        "type": "bad",
+        "popup": true
       },
       { "u_lose_trait": "CHITIN3" },
       { "u_lose_trait": "CHITIN2" },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3004,6 +3004,7 @@
     "cancels": [ "SHELL" ],
     "category": [ "CRUSTACEAN" ],
     "leads_to": [ "CRUSTACEAN_CLAW" ],
+    "threshreq": [ "THRESH_CRUSTACEAN" ],
     "flags": [ "TOUGH_FEET" ],
     "enchantments": [
       {
@@ -3033,6 +3034,7 @@
     "points": 8,
     "visibility": 10,
     "ugliness": 8,
+    "valid": false,
     "description": "You're covered in a great chitin carapace which reduces your Dexterity by 1, however it has recently molted and will offer poor protection until it has time to harden.  Greatly reduces wet effects.",
     "types": [ "BODY_ARMOR" ],
     "prereqs": [ "CHITIN2_MOLTED" ],

--- a/data/json/obsoletion_and_migration/obsoletion_missions.json
+++ b/data/json/obsoletion_and_migration/obsoletion_missions.json
@@ -361,7 +361,7 @@
     "condition": { "u_has_mission": "directions_hub01" },
     "effect": [ { "remove_active_mission": "directions_hub01" } ]
   },
-    {
+  {
     "id": "MISSION_INVESTIGATE_TRADER",
     "type": "mission_definition",
     "name": { "str": "Investigate the shady trader." },


### PR DESCRIPTION
#### Summary
Chitin fixes

#### Purpose of change
- Chitin molting was not giving its warning message as a popup. A player crashed his car and almost died because he didn't realize he had the "molting imminent" effect.
- Crustacean Carapace was not post-threshold.

#### Describe the solution
- Molting gives its messages as popups, crustacean carapace is post-threshold.
#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
