### PR TITLE
Hostile NPCs are a bit more aggressive

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3228,8 +3228,14 @@ bool npc::is_valid_sleep_candidate( const tripoint_bub_ms &p ) const
 
 bool npc::can_open_door( const tripoint_bub_ms &p, const bool inside ) const
 {
-    return !is_hallucination() && !rules.has_flag( ally_rule::avoid_doors ) &&
-           get_map().open_door( *this, p, inside, true );
+    if( is_hallucination() ) {
+        return false;
+    }
+    if( !( guaranteed_hostile() || is_enemy() ) &&
+        rules.has_flag( ally_rule::avoid_doors ) ) {
+        return false;
+    }
+    return get_map().open_door( *this, p, inside, true );
 }
 
 bool npc::can_move_to( const tripoint_bub_ms &p, bool no_bashing ) const

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1522,10 +1522,13 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
     }
     // patrolling guards will investigate more readily than stationary NPCS
     int investigate_dist = 10;
+    if( guaranteed_hostile() || is_enemy() ) {
+        investigate_dist = 25;
+    }
     if( mission == NPC_MISSION_GUARD_ALLY || mission == NPC_MISSION_GUARD_PATROL ) {
         investigate_dist = 50;
     }
-    if( rules.has_flag( ally_rule::ignore_noise ) ) {
+    if( ( !guaranteed_hostile() && !is_enemy() ) && rules.has_flag( ally_rule::ignore_noise ) ) {
         investigate_dist = 0;
     }
     if( ai_cache.total_danger < 1.0f ) {
@@ -1539,7 +1542,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
             } else if( spriority > sounds::sound_t::activity ) {
                 warn_about( "combat_noise", rng( 1, 10 ) * 1_minutes );
             }
-            bool should_check = rl_dist( pos_bub(), spos ) < investigate_dist;
+            bool should_check = trig_dist( pos_bub(), spos ) < investigate_dist;
             if( should_check ) {
                 const zone_manager &mgr = zone_manager::get_manager();
                 // NOLINTNEXTLINE(bugprone-branch-clone)

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -792,38 +792,42 @@ void talk_function::give_aid( npc &p )
             }
         }
     }
-    if( ( x_in_y( medic_skill, 9.0 ) ) && ( patient.has_effect( effect_tapeworm ) || patient.has_effect( effect_bloodworms ) || patient.has_effect( effect_brainworms ) || patient.has_effect( effect_paincysts ) || patient.has_effect( effect_dermatik ) ) ) {
-        p.say( _( "You've got some kind of parasite.  It probably isn't immediately life-threatening, but taking antiparasitic medication should clear it up.") );
+    if( ( x_in_y( medic_skill, 9.0 ) ) && ( patient.has_effect( effect_tapeworm ) ||
+                                            patient.has_effect( effect_bloodworms ) || patient.has_effect( effect_brainworms ) ||
+                                            patient.has_effect( effect_paincysts ) || patient.has_effect( effect_dermatik ) ) ) {
+        p.say( _( "You've got some kind of parasite.  It probably isn't immediately life-threatening, but taking antiparasitic medication should clear it up." ) );
     }
     if( x_in_y( medic_skill, 7.0 ) && patient.has_effect( effect_fungus ) ) {
         p.say( _( "Looks like you have a pretty serious fungal infection.  Taking antifungal medication should clear it up, but I'd hurry if I were you." ) );
     }
     if( x_in_y( medic_skill, 7.0 ) && patient.has_effect( effect_irradiated ) ) {
-        p.say( _( "You have acute radiation syndrome.  Taking prussian blue every three hours should help treat it.  Most exposure comes from fine ash or dust in the environment, so in the future, try to mask up and wear clothing designed for environmental protection.") );
+        p.say( _( "You have acute radiation syndrome.  Taking prussian blue every three hours should help treat it.  Most exposure comes from fine ash or dust in the environment, so in the future, try to mask up and wear clothing designed for environmental protection." ) );
     }
     if( x_in_y( medic_skill, 3.0 ) && patient.has_effect( effect_infected ) ) {
-        p.say( _( "You have a bacterial infection.  There's a chance a healthy person can fight this sort of thing off, but it can be lethal for just about anybody.  Find the strongest antibiotics you can and take one every twelve hours until it's cleared up.") );
+        p.say( _( "You have a bacterial infection.  There's a chance a healthy person can fight this sort of thing off, but it can be lethal for just about anybody.  Find the strongest antibiotics you can and take one every twelve hours until it's cleared up." ) );
     }
     if( x_in_y( medic_skill, 3.0 ) && patient.has_effect( effect_flu ) ) {
-        p.say( _( "You probably feel pretty horrible, but it's just the flu.  It should resolve itself within two to twelve days from the time you first started noticing symptoms.  Until then, you can take cough syrup to suppress most symptoms, or opioids and antihistamines if you can't find any.") );
+        p.say( _( "You probably feel pretty horrible, but it's just the flu.  It should resolve itself within two to twelve days from the time you first started noticing symptoms.  Until then, you can take cough syrup to suppress most symptoms, or opioids and antihistamines if you can't find any." ) );
     }
     if( x_in_y( medic_skill, 3.0 ) && patient.has_effect( effect_common_cold ) ) {
-        p.say( _( "It seems you've caught a cold.  It should resolve itself within two days to three weeks from the time you first started noticing symptoms.  Until then, you can take cough syrup to suppress most symptoms, or opioids and antihistamines if you can't find any.") );
+        p.say( _( "It seems you've caught a cold.  It should resolve itself within two days to three weeks from the time you first started noticing symptoms.  Until then, you can take cough syrup to suppress most symptoms, or opioids and antihistamines if you can't find any." ) );
     }
-    if( x_in_y( medic_skill, 3.0 ) && ( patient.has_effect( effect_conjunctivitis_viral ) || patient.has_effect( effect_conjunctivitis_bacterial ) ) ) {
-        p.say( _( "You have a minor infenction of the conjunctiva - that is, pinkeye.  It should resolve itself within a couple of days.  If the itching is bothering you, try taking some antihistamines.  Cough syrup might also do the trick, but not the non-drowsy kind.  You could also try taking an antibiotic every twelve hours, but if the infection is viral, that won't have any effect.") );
+    if( x_in_y( medic_skill, 3.0 ) && ( patient.has_effect( effect_conjunctivitis_viral ) ||
+                                        patient.has_effect( effect_conjunctivitis_bacterial ) ) ) {
+        p.say( _( "You have a minor infenction of the conjunctiva - that is, pinkeye.  It should resolve itself within a couple of days.  If the itching is bothering you, try taking some antihistamines.  Cough syrup might also do the trick, but not the non-drowsy kind.  You could also try taking an antibiotic every twelve hours, but if the infection is viral, that won't have any effect." ) );
     }
     if( x_in_y( medic_skill, 5.0 ) && ( patient.has_effect( effect_rat_bite_fever ) ) ) {
-        p.say( _( "Those irritated scratches look like rat bite fever.  You could try taking some aspirin or ibuprofen to relieve the symptoms.  It's safe to wait it out and let your body fight it off, but you can also take one antibiotic every twelve hours to deal with it.") );
+        p.say( _( "Those irritated scratches look like rat bite fever.  You could try taking some aspirin or ibuprofen to relieve the symptoms.  It's safe to wait it out and let your body fight it off, but you can also take one antibiotic every twelve hours to deal with it." ) );
     }
     if( x_in_y( medic_skill, 5.0 ) && ( patient.has_effect( effect_tetanus ) ) ) {
-        p.say( _( "Your muscle cramps are caused by tetanus.  A dose of antibiotics every twelve hours might get rid of it, otherwise you should look for benzodiazepines to relieve the symptoms.") );
+        p.say( _( "Your muscle cramps are caused by tetanus.  A dose of antibiotics every twelve hours might get rid of it, otherwise you should look for benzodiazepines to relieve the symptoms." ) );
     }
     if( x_in_y( medic_skill, 6.0 ) && patient.get_effect_int( effect_toxin_buildup ) > 1 ) {
-        p.say( _( "Neuropathy, cramps, and tremors.  I'm not sure what exactly is the matter with you, but if I had to guess, you've been eating or drinking something toxic.  Stop doing that, and maybe your body will filter out the poison over time.") );
+        p.say( _( "Neuropathy, cramps, and tremors.  I'm not sure what exactly is the matter with you, but if I had to guess, you've been eating or drinking something toxic.  Stop doing that, and maybe your body will filter out the poison over time." ) );
     }
-    if( x_in_y( medic_skill, 4.0 ) && ( patient.has_effect( effect_anemia ) || patient.has_effect( effect_redcells_anemia ) ) ) {
-        p.say( _( "You've got anemia.  It's often caused by bleeding, but sometimes a poor diet will do it, both are equally likely these days.  You need iron, either from leafy greens, multivitamins, or red meat, and you need rest so your body can rebuild itself.") );
+    if( x_in_y( medic_skill, 4.0 ) && ( patient.has_effect( effect_anemia ) ||
+                                        patient.has_effect( effect_redcells_anemia ) ) ) {
+        p.say( _( "You've got anemia.  It's often caused by bleeding, but sometimes a poor diet will do it, both are equally likely these days.  You need iron, either from leafy greens, multivitamins, or red meat, and you need rest so your body can rebuild itself." ) );
     }
     if( x_in_y( medic_skill, 4.0 ) && patient.has_effect( effect_scurvy ) ) {
         p.say( _( "Scurvy.  That's a vitamin C deficiency.  You're going to want to look for fruit, greens, or organ meat, and it's got to be fresh, the preserved stuff usually won't do.  Vitamin supplements would also do the trick." ) );


### PR DESCRIPTION
#### Summary
Hostile NPCs are a bit more aggressive

#### Purpose of change
Throw in some checks to ensure hostile NPCs are properly motivated to check out sounds and will not be shy about opening doors.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
