### PR TITLE
Autodrink more

### DIFF
--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -253,7 +253,7 @@ void player_activity::do_turn( Character &you )
                     no_food_nearby_for_auto_consume = true;
                 }
             }
-            if( you.get_thirst() > 130 && !no_drink_nearby_for_auto_consume ) {
+            if( you.get_thirst() >= 40 && !no_drink_nearby_for_auto_consume ) {
                 int consume_moves = get_auto_consume_moves( you, false );
                 moves_left += consume_moves;
                 moves_total += consume_moves;


### PR DESCRIPTION
#### Summary
Autodrink more

#### Purpose of change
fixes #2425 

#### Describe the solution
Characters now autodrink from zones as soon as they get thirsty, so there's no need to micromanage to avoid speed penalties.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
