### PR TITLE
Remove leftover generic names for 9mm guns

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -5,17 +5,8 @@
     "looks_like": "hk_mp5",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Calico automatic carbine" },
+    "name": { "str": "Calico M960 carbine" },
     "description": "The Calico automatic carbine is a submachine gun with a unique circular magazine that allows for high capacities and reduced recoil.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "calico",
-        "name": { "str": "Calico M960 carbine" },
-        "//": "Automatic variant.  Cyclic fire rate: 750 rpm",
-        "description": "A compact submachine gun designed evidently under the 'spray and pray' mentality, this Calico M960 automatic carbine is not notably powerful, or dependable, or even particularly accurate to shoot.  Intended for military and law enforcement use, it never saw any noteworthy service due to its poor reliability and overall performance, and would be an unremarkable weapon in all respects, save for its enormous magazine capacity.  Making use of uniquely designed 50 or 100 round circular magazines, the Calico might not be a particularly good gun, but will throw an overwhelming amount of lead down range for a long time providing that it doesn't choke, jam, and die."
-      }
-    ],
     "weight": "2270 g",
     "volume": "2420 ml",
     "longest_side": "655 mm",
@@ -51,16 +42,8 @@
     "looks_like": "modular_ar15",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "9x19mm pistol-caliber carbine" },
+    "name": { "str": "Beretta Cx4 Storm carbine" },
     "description": "Designed to be a companion rifle with provided M9 handguns, this compact and light weight pistol-caliber carbine makes use of the same 9x19mm magazines.  Originally intended for use by law enforcement units, this style of small caliber, semi-automatic carbine failed to achieve the same level of popularity as regular and more potent rifles.  However, despite being inadequate for their original purpose, before the Cataclysm these modestly sized weapons still found a home in sport shooting and self-defense civilian roles.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "cx4",
-        "name": { "str": "Beretta Cx4 Storm carbine" },
-        "description": "A small pistol caliber carbine designed for police use and civilian self-defense, the Cx4 Storm uses magazines that are interchangeable with other Beretta 9x19mm handguns."
-      }
-    ],
     "weight": "2575 g",
     "volume": "4458 ml",
     "longest_side": "762 mm",
@@ -104,16 +87,8 @@
     "looks_like": "glock_17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Glock carry pistol" },
+    "name": { "str": "Glock 19 pistol" },
     "description": "A common 9x19mm pistol of modest proportions, produced by the popular Glock gun company and mainly built from plastic polymers.  Making use of aptly-named Glock magazines and being a decades-long popular concealed carry option for civilians due to its small size, it is a tried, tested, and reliable design.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "glock_19",
-        "name": { "str": "Glock 19 pistol" },
-        "description": "Possibly the most popular pistol in existence, the Glock 19 can be summed up as being fundamentally a more compact brother to the full-sized Glock 17 pistol.  Sporting a mainly polymer-based design, the Glock 19 is often derided for its plastic construction which lends the handgun a deceptively flimsy feel.  Even so, the Glock 19 remains both a remarkably reliable firearm and a quite shootable gun in its own right."
-      }
-    ],
     "weight": "600 g",
     "volume": "386 ml",
     "longest_side": "211 mm",
@@ -339,16 +314,8 @@
     "looks_like": "hk_mp5",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "MP 18 submachine gun" },
+    "name": { "str": "Bergmann MP 18 SMG" },
     "description": "An early German submachine gun introduced near the end of the First World War, the MP 18 chambers 9x19mm cartridges and makes use of Luger magazines.  Sporting a fixed wooden stock, the weapon more than likely entered the US as a personal holdover from the Great War.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mp18",
-        "name": { "str": "Bergmann MP 18 SMG" },
-        "description": "An incredibly rare German automatic firearm developed by Hugo Schmeisser whilst working under Bergmann Waffenfabrik during 1918; the MP 18 holds the reputation of being the world's first proper and practical submachine gun.  Chambered for 9x19mm and designed for use in close quarters trench-based combat by assault troops, a role in which it excelled, the weapon was outlawed from military use by the Versailles treaty and was relegated to police and counterinsurgency use in the interwar period.  More than likely entering the US as a personal holdover from the Great War, this century-old grandfather to most classic SMGs just might be better off coming out of retirement now that the world's entered the true greatest war."
-      }
-    ],
     "weight": "4180 g",
     "volume": "2630 ml",
     "longest_side": "832 mm",
@@ -374,16 +341,8 @@
     "looks_like": "glock_17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Broomhandle pistol" },
+    "name": { "str": "Mauser C96 Broomhandle pistol" },
     "description": "A semi-automatic German pistol developed prior to 1900, the firearm features a burned and painted number '9' on its broom handle-shaped grip to signify its chambering, 9x19mm parabellum, and makes use of appropriate stripper clips or single round loading.  Quite possibly the most aesthetically steampunk weapon that one could ever possibly get their hands on, this example likely found its way into the US via early import or as a holdover from the Great War.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mauser_c96",
-        "name": { "str": "Mauser C96 Broomhandle pistol" },
-        "description": "A late 19th century semi-automatic German pistol with an integral magazine loaded from the top via stripper clips, and quite possibly the most steampunk gun one could ever possibly lay their hands on.  A red number '9' burned and painted into the weapon's broom handle-shaped grip marks it as a variant chambered for 9x19mm rounds.  Both exported for commercial use and produced for the German military during the First World War to make up for production shortages of the standard Luger, this example likely entered the US as a holdover from the Great War.  You suppose that it's only fitting that one of the globe's first produced and oldest semi-automatic handguns gets reinstated into service now that the planet's facing its end."
-      }
-    ],
     "weight": "1134 g",
     "volume": "640 ml",
     "longest_side": "312 mm",
@@ -417,16 +376,8 @@
     "copy-from": "mauser_c96",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "reproduction Broomhandle pistol" },
+    "name": { "str": "Federal Ordnance M714 Broomhandle pistol" },
     "description": "A modern take on the original Mauser design, this variant is chambered for 9x19mm cartridges and, unlike its elder brother, the pre-1900 Mauser Broomhandle, this firearm feeds from detachable box magazines.  Whilst it features surplus Mauser parts in its construction, the frame of the pistol is of relatively modern manufacture.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mauser_m714",
-        "name": { "str": "Federal Ordnance M714 Broomhandle pistol" },
-        "description": "Recognized the world over as one of the first practical self-loading pistols, the Mauser C96 and its derivatives are nearly universally regarded as some of the most classic and rugged guns in history, with the model being praised as a true marvel of industrial craftsmanship.  However, what rests before you is not an original production C96, but rather a modern American spin on the original Mauser recipe.  Feeding from detachable box magazines rather than an internal clip, the M714 is crafted out of a mix of modern and surplus parts, being chambered for 9x19mm rounds, with some other models being offered in the Mauser's own 7.63x25mm cartridge."
-      }
-    ],
     "weight": "1070 g",
     "volume": "615 ml",
     "price": "900 USD",
@@ -441,16 +392,8 @@
     "looks_like": "hk_mp5",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "MP 40 submachine gun" },
+    "name": { "str": "Vollmer MP 40 SMG" },
     "description": "An antique German-issued submachine gun from the Second World War, likely having entered the United States as a personal holdover by a veteran.  Chambered in 9x19mm and utilizing proprietary box magazines, the firearm has an integrated under folding wire stock.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mp40",
-        "name": { "str": "Vollmer MP 40 SMG" },
-        "description": "A simple and renowned 9x19mm submachine gun developed by Heinrich Vollmer for the German army.  Adopted  in 1940, it saw extensive service on both fronts of the Second World War and was much regarded by soldiers who fielded the weapon in combat, being praised for its reliability and relatively modern design.  Featuring an integral folding wire butt stock, this weapon more than likely entered the United States as a war trophy by a returning veteran.  It was often called \"Schmeisser\" by the Allies, after Hugo Schmeisser, who designed the MP 18, although he was not involved in the design or production of the MP 40."
-      }
-    ],
     "weight": "3969 g",
     "volume": "2320 ml",
     "longest_side": "648 mm",
@@ -549,7 +492,7 @@
     "looks_like": "glock_17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "M9 combat pistol" },
+    "name": { "str": "Beretta M9A1 pistol" },
     "description": "A rugged, iconic, and long-serving 9mm handgun, the M9 is a sleek pistol that has enjoyed fame in military, law enforcement, and civilian circles ever since its inception.  Adopted as the primary service sidearm across all United States armed branches from the early eighties until the late two thousand and tens, the weapon has seen a great deal of popular media coverage in both videogames and television alike.",
     "weight": "961 g",
     "volume": "570 ml",
@@ -557,19 +500,6 @@
     "barrel_length": "125 mm",
     "price": "650 USD",
     "price_postapoc": "25 USD",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "m9",
-        "name": { "str": "Beretta M9A1 pistol" },
-        "description": "An iconic 9x19mm pistol, the M9 was the standard issue sidearm of the US armed forces from 1985 until only recently.  It was formerly popular amongst law enforcement before the advent of commercially available polymer-framed handguns and the FBI's adoption of .40 S&W."
-      },
-      {
-        "id": "90two",
-        "name": { "str": "Beretta 90-two pistol" },
-        "description": "A more modern version of Beretta's popular 92 series of handguns, the 90-two performs largely the same.  The main difference is a sleeker, almost futuristic-looking design owed in large part to the polymer underbarrel rail cover."
-      }
-    ],
     "to_hit": -2,
     "material": [ "steel", "aluminum" ],
     "symbol": "(",
@@ -862,16 +792,8 @@
     "//": "Tilelist whitelist for pistols.",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Glock duty pistol" },
+    "name": { "str": "Glock 17 pistol" },
     "description": "Designed for all shooters, this offering from the Glock gun company is a full-sized 9x19mm pistol marketed towards law-enforcement and military users.  Because of the long magazine well, it can't fit magazines shorter than the standard 17-round ones.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "glock_17",
-        "name": { "str": "Glock 17 pistol" },
-        "description": "Commonly seen tucked away in the holsters of police officers, certain military professionals, and civilian shooters, this is a larger, older, service-oriented version of the popular Glock 19.  Similarly firing the 9x19mm cartridge and using higher capacity magazines, it performs largely the same, but due to the longer magazine well, it can't fit magazines shorter than the standard 17-round ones."
-      }
-    ],
     "weight": "630 g",
     "volume": "427 ml",
     "longest_side": "233 mm",
@@ -903,16 +825,8 @@
     "copy-from": "glock_17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Glock machine pistol" },
-    "description": "A military, fully automatic capable version of the popular 9x19mm handguns produced by the Glock arms company, this machine pistol makes use of Glock magazines.  The weapon has had its barrel modified to lessen recoil, a useful feature considering its high rate of fire and lack of a default buttstock.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "glock_18c",
-        "name": { "str": "Glock 18C pistol" },
-        "description": "A selective-fire variation on the Glock 17, originally designed for Austria's EKO Cobra unit.  It has compensator cuts along its barrel to make recoil more manageable."
-      }
-    ],
+    "name": { "str": "Glock 18C pistol" },
+    "description": "A selective-fire variation on the Glock 17, originally designed for Austria's EKO Cobra unit.  It has compensator cuts along its barrel to make recoil more manageable.",
     "weight": "620 g",
     "price": "1000 USD",
     "price_postapoc": "25 USD",
@@ -968,16 +882,8 @@
     "looks_like": "glock_17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "service handgun" },
+    "name": { "str": "SIG M17 pistol" },
     "description": "The general-issue military handgun of the United States army before the Cataclysm, this is a sizable pistol that fires 9x19mm cartridges.  Based off successful civilian designs and capable of taking magazines of various round capacities, the gun features a plastic polymer frame which helps to reduce overall weight.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "m17",
-        "name": { "str": "SIG M17 pistol" },
-        "description": "The M17 is an army issued semi-automatic, short recoil operated pistol derived from the SIG Sauer P320."
-      }
-    ],
     "weight": "840 g",
     "volume": "470 ml",
     "longest_side": "238 mm",
@@ -1007,16 +913,8 @@
     "copy-from": "m17",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "compact service handgun" },
+    "name": { "str": "SIG M18 pistol" },
     "description": "A more petite version of the United States army's general issue sidearm, this is a modestly-sized pistol firing 9x19mm rounds.  Making use of the same magazines as its larger brother, the weapon features a shorter barrel and frame which helps to reduce its overall profile and make it more concealable as a result.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "m18",
-        "name": { "str": "SIG M18 pistol" },
-        "description": "The M18 is a compact, semi-automatic, short recoil operated pistol derived from the SIG Sauer P320 Carry, used by US Armed Forces.  Practically the same as its big brother, the M17, in every respect, the M18 features a moderately shorter slide and barrel which terminates at the end of the frame rather than extending partway beyond it like the M17."
-      }
-    ],
     "weight": "737 g",
     "volume": "457 ml",
     "barrel_length": "98 mm",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7708,7 +7708,7 @@ void Character::cough( bool harmful, int loudness )
         const int stam = get_stamina();
         const int malus = get_stamina_max() * 0.05; // 5% max stamina
         mod_stamina( -malus );
-        if( stam < malus && x_in_y( malus - stam, malus ) && one_in( 6 ) ) {
+        if( stam < malus && x_in_y( malus - stam, malus ) && one_in( 12 ) ) {
             apply_damage( nullptr, body_part_torso, 1 );
         }
     }


### PR DESCRIPTION
#### Summary
Remove leftover generic names for 9mm guns

#### Purpose of change
The old unused generic names were still left over for a bunch of guns and I didn't realize but those names are still being displayed in some cases.

#### Describe the solution
Devariantize.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
