### PR TITLE
Devariantize Shotguns

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1292,7 +1292,7 @@
     "type": "harvest",
     "message": "<arachnid_harvest>",
     "entries": [
-      { "drop": "mutant_meat", "type": "flesh", "mass_ratio":0.2 },
+      { "drop": "mutant_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.03 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.01 },
       { "drop": "endochitin", "type": "bone", "mass_ratio": 0.1 },

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1611,7 +1611,7 @@
       { "item": "3006", "prob": 5, "charges": [ 1, 20 ] },
       { "item": "ksg", "prob": 8, "charges": [ 0, 7 ] },
       { "item": "remington_870_express", "prob": 8, "charges": [ 0, 7 ] },
-      { "item": "benelli_tsa", "variant": "mossberg_500_security", "prob": 8, "charges": [ 0, 6 ] },
+      { "item": "mossberg_500_security", "prob": 8, "charges": [ 0, 6 ] },
       { "item": "shot_beanbag", "prob": 25, "charges": [ 1, 10 ] },
       { "item": "gasbomb", "count": [ 1, 6 ], "prob": 20 },
       { "item": "m79", "prob": 8, "charges": 0 },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
@@ -1936,11 +1936,11 @@
     "//": "Pick a random police shotgun.",
     "subtype": "distribution",
     "entries": [
-      { "item": "benelli_tsa", "variant": "mossberg_500_security", "prob": 30 },
+      { "item": "mossberg_500_security", "prob": 30 },
       { "item": "remington_870_express", "prob": 35 },
-      { "item": "mossberg_590", "variant": "mossberg_590", "prob": 23 },
-      { "item": "mossberg_930", "variant": "mossberg_930", "prob": 8 },
-      { "item": "mossberg_930", "variant": "m1014", "prob": 2 },
+      { "item": "mossberg_590", "prob": 23 },
+      { "item": "mossberg_930", "prob": 8 },
+      { "item": "m1014", "prob": 2 },
       { "item": "remington_870_breacher", "prob": 2 }
     ]
   },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/shot.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/shot.json
@@ -29,7 +29,7 @@
     "type": "item_group",
     "id": "milspec_arsenal_shot",
     "items": [
-      { "item": "mossberg_930", "variant": "m1014", "prob": 100 },
+      { "item": "m1014", "prob": 100 },
       { "item": "mossberg_590", "prob": 70 },
       { "item": "mossberg_500", "prob": 50 },
       { "group": "nested_m26_mass_no_ammo", "prob": 30 }

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -223,7 +223,7 @@
     "id": "guns_pistol_rare_display",
     "//": "Empty uncommon pistols found exclusively at gun stores.",
     "items": [
-      { "item": "m9", "variant": "90two", "prob": 25 },
+      { "item": "90two", "prob": 25 },
       { "item": "90two40", "prob": 10 },
       { "item": "bond_410", "prob": 10 },
       { "group": "modular_deagle_357", "prob": 4 },
@@ -887,21 +887,15 @@
     "items": [
       { "item": "mossberg_500", "prob": 33, "charges": [ 0, 6 ] },
       { "item": "remington_870", "prob": 35, "charges": [ 0, 5 ] },
-      { "item": "benelli_tsa", "variant": "mossberg_500_security", "prob": 17, "charges": [ 0, 6 ] },
+      { "item": "mossberg_500_security", "prob": 17, "charges": [ 0, 6 ] },
       { "item": "remington_870_express", "prob": 18, "charges": [ 0, 6 ] },
-      { "item": "remington_870", "variant": "browning_a5", "prob": 14, "charges": [ 0, 5 ] },
-      { "item": "benelli_sa", "variant": "m2", "prob": 17, "charges": [ 0, 4 ] },
-      { "item": "benelli_sa", "variant": "sbe", "prob": 37, "charges": [ 0, 4 ] },
-      {
-        "item": "benelli_tsa",
-        "variant": "m2_tac",
-        "contents-item": [ "rail_mount" ],
-        "prob": 12,
-        "charges": [ 0, 6 ]
-      },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 6, "charges": [ 0, 9 ] },
-      { "item": "remington_870", "variant": "ithaca37", "prob": 6, "charges": [ 0, 5 ] },
-      { "item": "remington_870", "variant": "remington_1100", "prob": 17, "charges": [ 0, 5 ] },
+      { "item": "browning_a5", "prob": 14, "charges": [ 0, 5 ] },
+      { "item": "m2", "prob": 17, "charges": [ 0, 4 ] },
+      { "item": "sbe", "prob": 37, "charges": [ 0, 4 ] },
+      { "item": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 12, "charges": [ 0, 6 ] },
+      { "group": "nested_slp", "prob": 6 },
+      { "item": "ithaca37", "prob": 6, "charges": [ 0, 5 ] },
+      { "item": "remington_1100", "prob": 17, "charges": [ 0, 5 ] },
       { "item": "mossberg_930", "prob": 15, "charges": [ 0, 6 ] },
       { "item": "shotgun_410", "prob": 30, "charges": [ 0, 1 ] },
       { "item": "shotgun_d", "prob": 30, "charges": [ 0, 2 ] },
@@ -916,16 +910,16 @@
     "items": [
       { "item": "mossberg_500", "prob": 33 },
       { "item": "remington_870", "prob": 35 },
-      { "item": "benelli_tsa", "variant": "mossberg_500_security", "prob": 17 },
+      { "item": "mossberg_500_security", "prob": 17 },
       { "item": "remington_870_express", "prob": 18 },
-      { "item": "remington_870", "variant": "browning_a5", "prob": 14 },
-      { "item": "benelli_sa", "variant": "m2", "prob": 17 },
-      { "item": "benelli_sa", "variant": "sbe", "prob": 37 },
-      { "item": "benelli_tsa", "variant": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 12 },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 6 },
+      { "item": "browning_a5", "prob": 14 },
+      { "item": "m2", "prob": 17 },
+      { "item": "sbe", "prob": 37 },
+      { "item": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 12 },
+      { "group": "nested_slp", "prob": 6 },
       { "item": "mossberg_590m", "prob": 1 },
-      { "item": "remington_870", "variant": "ithaca37", "prob": 6 },
-      { "item": "remington_870", "variant": "remington_1100", "prob": 17 },
+      { "item": "ithaca37", "prob": 6 },
+      { "item": "remington_1100", "prob": 17 },
       { "item": "mossberg_930", "prob": 15 },
       { "item": "shotgun_410", "prob": 30 },
       { "item": "shotgun_d", "prob": 30 },
@@ -945,7 +939,7 @@
       { "group": "nested_srm_1216", "prob": 2 },
       { "group": "nested_tavor_12", "prob": 5 },
       { "group": "nested_m1014", "prob": 10 },
-      { "group": "nested_SPAS_12", "prob": 2 },
+      { "group": "nested_spas_12", "prob": 2 },
       { "group": "nested_slp", "prob": 10 },
       { "group": "nested_mossberg_590m", "prob": 2 }
     ]
@@ -962,9 +956,9 @@
       { "item": "srm_1216", "prob": 1, "charges": [ 0, 16 ] },
       { "item": "dp_12", "prob": 2, "charges": [ 0, 14 ] },
       { "item": "tavor_12", "prob": 5, "charges": [ 0, 5 ] },
-      { "group": "nested_SPAS_12", "prob": 2 },
-      { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges": [ 0, 8 ] },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10, "charges": [ 0, 9 ] },
+      { "group": "nested_spas_12", "prob": 2 },
+      { "item": "m1014", "prob": 10, "charges": [ 0, 8 ] },
+      { "group": "nested_slp", "prob": 10 },
       { "item": "mossberg_590m", "prob": 2, "charges": [ 0, 5 ] }
     ]
   },
@@ -976,11 +970,11 @@
     "entries": [
       { "item": "ksg", "prob": 5 },
       { "item": "tavor_12", "prob": 5 },
-      { "group": "nested_SPAS_12", "prob": 2 },
+      { "group": "nested_spas_12", "prob": 2 },
       { "item": "srm_1216", "prob": 3 },
       { "item": "dp_12", "prob": 4 },
-      { "item": "mossberg_930", "variant": "m1014", "prob": 10 },
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "prob": 10 },
+      { "item": "m1014", "prob": 10 },
+      { "group": "nested_slp", "prob": 4 },
       { "item": "mossberg_590m", "prob": 2 }
     ]
   },
@@ -1037,7 +1031,7 @@
       { "item": "streetsweeper", "prob": 4 },
       { "item": "winchester_1887", "prob": 10 },
       { "item": "winchester_1897", "prob": 20 },
-      { "group": "nested_SPAS_12", "prob": 2 },
+      { "group": "nested_spas_12", "prob": 2 },
       { "item": "saiga_410", "prob": 10 }
     ]
   },
@@ -1269,34 +1263,10 @@
         "contents-item": "shoulder_strap",
         "prob": 1
       },
-      {
-        "item": "benelli_tsa",
-        "variant": "mossberg_500_security",
-        "charges": [ 0, 6 ],
-        "contents-item": "shoulder_strap",
-        "prob": 40
-      },
-      {
-        "item": "mossberg_590",
-        "variant": "mossberg_590",
-        "charges": [ 0, 9 ],
-        "contents-item": "shoulder_strap",
-        "prob": 15
-      },
-      {
-        "item": "mossberg_930",
-        "variant": "mossberg_930",
-        "charges": [ 0, 8 ],
-        "contents-item": "shoulder_strap",
-        "prob": 7
-      },
-      {
-        "item": "mossberg_930",
-        "variant": "m1014",
-        "charges": [ 0, 8 ],
-        "contents-item": "shoulder_strap",
-        "prob": 2
-      },
+      { "item": "mossberg_500_security", "charges": [ 0, 6 ], "contents-item": "shoulder_strap", "prob": 40 },
+      { "item": "mossberg_590", "charges": [ 0, 9 ], "contents-item": "shoulder_strap", "prob": 15 },
+      { "item": "mossberg_930", "charges": [ 0, 8 ], "contents-item": "shoulder_strap", "prob": 7 },
+      { "item": "m1014", "charges": [ 0, 8 ], "contents-item": "shoulder_strap", "prob": 2 },
       { "item": "remington_870_express", "charges": [ 0, 7 ], "contents-item": "shoulder_strap", "prob": 70 },
       { "item": "remington_700", "charges": [ 0, 4 ], "contents-item": "shoulder_strap", "prob": 2 },
       { "item": "M24", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "prob": 10 }
@@ -1336,28 +1306,10 @@
       { "item": "ruger_mini", "ammo-item": "223", "charges": 20, "contents-item": "shoulder_strap", "prob": 5 },
       { "item": "steyr_aug", "ammo-item": "556_mk318", "charges": 30, "contents-item": "shoulder_strap", "prob": 1 },
       { "item": "hk_g36", "ammo-item": "556_mk318", "charges": 30, "contents-item": "shoulder_strap", "prob": 1 },
-      {
-        "item": "benelli_tsa",
-        "variant": "mossberg_500_security",
-        "charges": 6,
-        "contents-item": "shoulder_strap",
-        "prob": 40
-      },
-      {
-        "item": "mossberg_590",
-        "variant": "mossberg_590",
-        "charges": 9,
-        "contents-item": "shoulder_strap",
-        "prob": 15
-      },
-      {
-        "item": "mossberg_930",
-        "variant": "mossberg_930",
-        "charges": 8,
-        "contents-item": "shoulder_strap",
-        "prob": 7
-      },
-      { "item": "mossberg_930", "variant": "m1014", "charges": 8, "contents-item": "shoulder_strap", "prob": 2 },
+      { "item": "mossberg_500_security", "charges": 6, "contents-item": "shoulder_strap", "prob": 40 },
+      { "item": "mossberg_590", "charges": 9, "contents-item": "shoulder_strap", "prob": 15 },
+      { "item": "mossberg_930", "charges": 8, "contents-item": "shoulder_strap", "prob": 7 },
+      { "item": "m1014", "charges": 8, "contents-item": "shoulder_strap", "prob": 2 },
       { "item": "remington_870_express", "charges": 7, "contents-item": "shoulder_strap", "prob": 70 }
     ]
   },
@@ -1515,8 +1467,7 @@
       {
         "collection": [
           {
-            "item": "benelli_tsa",
-            "variant": "mossberg_500_security",
+            "item": "mossberg_500_security",
             "charges": [ 0, 6 ],
             "contents-item": "shoulder_strap",
             "damage": [ 0, 3 ],
@@ -1530,7 +1481,6 @@
         "collection": [
           {
             "item": "mossberg_590",
-            "variant": "mossberg_590",
             "charges": [ 0, 9 ],
             "contents-item": "shoulder_strap",
             "damage": [ 0, 3 ],
@@ -1544,7 +1494,6 @@
         "collection": [
           {
             "item": "mossberg_930",
-            "variant": "mossberg_930",
             "charges": [ 0, 8 ],
             "contents-item": "shoulder_strap",
             "damage": [ 0, 3 ],
@@ -1556,14 +1505,7 @@
       },
       {
         "collection": [
-          {
-            "item": "mossberg_930",
-            "variant": "m1014",
-            "charges": [ 0, 8 ],
-            "contents-item": "shoulder_strap",
-            "damage": [ 0, 3 ],
-            "dirt": [ 0, 7050 ]
-          },
+          { "item": "m1014", "charges": [ 0, 8 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_shotgun" }
         ],
         "prob": 2
@@ -1935,14 +1877,7 @@
       },
       {
         "collection": [
-          {
-            "item": "mossberg_930",
-            "variant": "m1014",
-            "charges": [ 0, 8 ],
-            "contents-item": "shoulder_strap",
-            "damage": [ 0, 3 ],
-            "dirt": [ 0, 7050 ]
-          },
+          { "item": "m1014", "charges": [ 0, 8 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_shotgun" }
         ],
         "prob": 5
@@ -2116,16 +2051,10 @@
       { "item": "plr16", "prob": 1, "charges": [ 0, 30 ] },
       { "item": "mossberg_500", "prob": 10, "charges": [ 0, 6 ] },
       { "item": "remington_870", "prob": 11, "charges": [ 0, 5 ] },
-      { "item": "benelli_sa", "variant": "m2", "prob": 7, "charges": [ 0, 4 ] },
-      { "item": "benelli_sa", "variant": "sbe", "prob": 11, "charges": [ 0, 4 ] },
-      {
-        "item": "benelli_tsa",
-        "variant": "m2_tac",
-        "contents-item": [ "rail_mount" ],
-        "prob": 4,
-        "charges": [ 0, 6 ]
-      },
-      { "item": "remington_870", "variant": "ithaca37", "prob": 4, "charges": [ 0, 5 ] },
+      { "item": "m2", "prob": 7, "charges": [ 0, 4 ] },
+      { "item": "sbe", "prob": 11, "charges": [ 0, 4 ] },
+      { "item": "m2_tac", "contents-item": [ "rail_mount" ], "prob": 4, "charges": [ 0, 6 ] },
+      { "item": "ithaca37", "prob": 4, "charges": [ 0, 5 ] },
       { "group": "cz600", "prob": 5, "charges": [ 0, 10 ] },
       { "item": "ruger_1022", "prob": 7, "charges": [ 0, 10 ] },
       { "item": "shotgun_410", "prob": 1, "charges": [ 0, 1 ] },
@@ -2133,7 +2062,7 @@
       { "item": "shotgun_d", "prob": 10, "charges": [ 0, 2 ] },
       { "item": "sks", "prob": 1, "charges": [ 0, 10 ] },
       { "item": "aksemi", "prob": 2, "charges": [ 0, 30 ] },
-      { "item": "mosin44", "variant": "mosin44", "prob": 2, "charges": [ 0, 5 ] },
+      { "item": "mosin44", "prob": 2, "charges": [ 0, 5 ] },
       { "item": "remington700_270", "prob": 1, "charges": [ 0, 4 ] },
       { "item": "ruger_m77", "prob": 1, "charges": [ 0, 4 ] },
       { "item": "ruger_arr", "prob": 1, "charges": [ 0, 3 ] },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -32,7 +32,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_20", "variant": "glock_20", "charges": [ 0, 15 ] },
+      { "item": "glock_20", "charges": [ 0, 15 ] },
       { "item": "glock_20mag" },
       { "item": "glock_20mag", "prob": 50 },
       { "group": "on_hand_10mm" }
@@ -123,7 +123,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_40", "variant": "glock_40", "charges": [ 0, 15 ] },
+      { "item": "glock_40", "charges": [ 0, 15 ] },
       { "item": "glock_20mag" },
       { "item": "glock_20mag", "prob": 50 },
       { "group": "on_hand_10mm" }
@@ -188,7 +188,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m9", "variant": "m9", "charges": [ 0, 15 ] },
+      { "item": "m9", "charges": [ 0, 15 ] },
       { "item": "m9mag" },
       { "item": "m9mag", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -678,7 +678,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "m9", "variant": "90two", "charges": [ 0, 15 ] },
+      { "item": "90two", "charges": [ 0, 15 ] },
       { "item": "m9mag_17rd" },
       { "item": "m9mag_17rd", "prob": 50 },
       { "group": "on_hand_9mm" }
@@ -2310,7 +2310,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "benelli_tsa", "variant": "mossberg_500_security", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "mossberg_500_security", "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_870_express",
@@ -2326,7 +2326,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870", "variant": "browning_a5", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "browning_a5", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_remington_1100",
@@ -2334,7 +2334,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870", "variant": "remington_1100", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "remington_1100", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_mossberg_930",
@@ -2419,15 +2419,15 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_930", "variant": "m1014", "charges": [ 0, 8 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "m1014", "charges": [ 0, 8 ] }, { "group": "on_hand_shot" } ]
   },
   {
-    "id": "nested_SPAS_12",
+    "id": "nested_spas_12",
     "type": "item_group",
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "mossberg_590", "variant": "SPAS_12", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "spas_12", "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_slp",
@@ -2436,10 +2436,7 @@
     "subtype": "collection",
     "ammo": 100,
     "//2": "The FN SLP Mk I is drilled and tapped for rail mounts: https://fnamerica.wpenginepowered.com/wp-content/uploads/2016/10/1608_FN_SLP_sellsheet_R5.pdf",
-    "entries": [
-      { "item": "mossberg_590", "variant": "slp", "contents-item": [ "rail_mount" ], "charges": [ 0, 9 ] },
-      { "group": "on_hand_shot" }
-    ]
+    "entries": [ { "item": "slp", "contents-item": [ "rail_mount" ], "charges": [ 0, 9 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_benelli_m2",
@@ -2447,7 +2444,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "benelli_sa", "variant": "m2", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "m2", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_black_eagle",
@@ -2455,7 +2452,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "benelli_sa", "variant": "sbe", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "sbe", "charges": [ 0, 4 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_benelli_m2_tac",
@@ -2464,10 +2461,7 @@
     "subtype": "collection",
     "ammo": 100,
     "//2": "Benelli M2 tactical shotguns are drilled and tapped for rail mounts: https://www.benelliusa.com/shotguns/m2-tactical-shotguns",
-    "entries": [
-      { "item": "benelli_tsa", "variant": "m2_tac", "contents-item": [ "rail_mount" ], "charges": [ 0, 6 ] },
-      { "group": "on_hand_shot" }
-    ]
+    "entries": [ { "item": "m2_tac", "contents-item": [ "rail_mount" ], "charges": [ 0, 6 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_mossberg_590",
@@ -2850,7 +2844,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "remington_870", "variant": "ithaca37", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
+    "entries": [ { "item": "ithaca37", "charges": [ 0, 5 ] }, { "group": "on_hand_shot" } ]
   },
   {
     "id": "nested_cz600",

--- a/data/json/itemgroups/faction_trading.json
+++ b/data/json/itemgroups/faction_trading.json
@@ -3,13 +3,7 @@
     "type": "item_group",
     "id": "toiletries",
     "subtype": "collection",
-    "items": [
-      "soap",
-      "menstrual_pad",
-      "menstrual_cup",
-      "toilet_paper",
-      "liquid_soap"
-    ]
+    "items": [ "soap", "menstrual_pad", "menstrual_cup", "toilet_paper", "liquid_soap" ]
   },
   {
     "type": "item_group",
@@ -107,7 +101,7 @@
       [ "prussian_blue", 1 ]
     ]
   },
-    {
+  {
     "type": "item_group",
     "subtype": "collection",
     "//": "All board games grouped together.  Currently used to inflate their prices for specific factions.",

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -304,7 +304,7 @@
     "id": "military_standard_shotguns",
     "subtype": "distribution",
     "entries": [
-      { "item": "mossberg_930", "variant": "m1014", "prob": 60, "charges": [ 0, 8 ] },
+      { "item": "m1014", "prob": 60, "charges": [ 0, 8 ] },
       { "item": "mossberg_590", "prob": 40, "charges": [ 0, 9 ] },
       { "item": "m26_mass_standalone", "prob": 5, "charges": [ 0, 3 ] }
     ]
@@ -511,7 +511,7 @@
       { "item": "p226_9mm", "prob": 1 },
       { "item": "sp2022", "prob": 1 },
       { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "prob": 7 },
-      { "item": "mossberg_930", "variant": "m1014", "prob": 2 },
+      { "item": "m1014", "prob": 2 },
       { "item": "m26_mass_standalone", "prob": 1 },
       { "item": "scar_l", "prob": 6 },
       { "item": "scar_h", "prob": 5 },

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -521,6 +521,39 @@
     "melee_damage": { "bash": 8 }
   },
   {
+    "id": "90two",
+    "copy-from": "pistol_base",
+    "looks_like": "glock_17",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Beretta 90-two pistol" },
+    "description": "A more modern version of Beretta's popular 92 series of handguns, the 90-two performs largely the same.  The main difference is a sleeker, almost futuristic-looking design owed in large part to the polymer underbarrel rail cover.  This one is chambered in 9x19mm.",
+    "weight": "905 g",
+    "volume": "554 ml",
+    "longest_side": "250 mm",
+    "barrel_length": "125 mm",
+    "price": "650 USD",
+    "price_postapoc": "20 USD",
+    "to_hit": -2,
+    "material": [ "steel", "plastic" ],
+    "symbol": "(",
+    "color": "dark_gray",
+    "ammo": [ "9mm" ],
+    "range": 6,
+    "dispersion": 480,
+    "durability": 7,
+    "min_cycle_recoil": 450,
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ],
+    "pocket_data": [
+      {
+        "magazine_well": "250 ml",
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [ "m9mag", "m9mag_10rd", "m9mag_17rd", "m9mag_18rd", "m9mag_20rd", "m9bigmag", "m9mag_32rd", "m9mag_35rd" ]
+      }
+    ],
+    "melee_damage": { "bash": 8 }
+  },
+  {
     "id": "px4",
     "copy-from": "pistol_base",
     "looks_like": "glock_17",

--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -100,16 +100,8 @@
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "compact bullpup shotgun" },
+    "name": { "str": "Kel-Tec KSG shotgun" },
     "description": "This pump-action shotgun uses a system of twin magazines to carry 14 total rounds of 12-gauge shotgun shells.  As the weapon's trigger is situated forwards of the chamber in what is termed as a 'bullpup' design, the firearm's notably more compact than its peers despite having a higher capacity when compared against more classically designed shotguns.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "ksg",
-        "name": { "str": "Kel-Tec KSG shotgun" },
-        "description": "A bullpup pump-action shotgun, the Kel-Tec KSG uses a pair of magazine tubes to increase its capacity."
-      }
-    ],
     "weight": "1550 g",
     "volume": "3371 ml",
     "longest_side": "672 mm",
@@ -142,16 +134,8 @@
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "extended bullpup shotgun" },
+    "name": { "str": "Kel-Tec KSG-25 shotgun" },
     "description": "This pump-action shotgun uses a system of twin magazines to carry 24 total rounds of 12-gauge shotgun shells.  Each tube must be loaded separately, but this offers the option of loading different ammunition for different situations.  As the weapon's trigger is situated forwards of the chamber in what is termed as a 'bullpup' design, the firearm's still only as long as conventional shotguns despite having a comparatively far higher capacity.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "ksg-25",
-        "name": { "str": "Kel-Tec KSG-25 shotgun" },
-        "description": "A bullpup pump-action shotgun, the Kel-Tec KSG-25 uses a pair of magazine tubes to increase its capacity.  Each tube has to be loaded separately, but this offers the option of loading different ammunition for different situations.  The big brother of the KSG, it has a longer barrel and longer magazine tubes."
-      }
-    ],
     "weight": "2100 g",
     "volume": "4495 ml",
     "longest_side": "971 mm",
@@ -186,17 +170,8 @@
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "6-round combat shotgun" },
-    "//": "Not exactly a combat shotgun, but I was hard-pressed to think of a name which wasn't just, \"6-round shotgun.\" In its proper descriptions it's referenced as often being used by militaries, therefore I'm calling this a combat shotgun.",
-    "description": "The faithful friend of law-enforcement officers, military personnel, and zombie-hunting action heroes alike, this quaint firearm with its over 20 inch long barrel, 6-round magazine tube, and iconic pump-action design is as simple as it is effective.  One of the most popular firearm designs in all of history, this weapon can be reliably counted upon to do the job whether one's simply looking to hunt, or to, with the right loads, turn the heads of the living dead into a chunky zombie puree.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mossberg_500",
-        "name": { "str": "Mossberg 500 Field shotgun" },
-        "description": "The Mossberg 500 is a popular series of pump-action shotguns, often acquired for military use.  It is noted for its high durability and low recoil.  This one is fitted with a 28 inch barrel with sight rib."
-      }
-    ],
+    "name": { "str": "Mossberg 500 Field shotgun" },
+    "description": "The faithful friend of law-enforcement officers, military personnel, and zombie-hunting action heroes alike, this quaint firearm with its over 20 inch long barrel, 6-round magazine tube, and iconic pump-action design is as simple as it is effective.  One of the most popular firearm designs in all of history, this weapon can be reliably counted upon to do the job.",
     "weight": "3402 g",
     "volume": "2450 ml",
     "longest_side": "1166 mm",
@@ -226,31 +201,13 @@
     "melee_damage": { "bash": 13 }
   },
   {
-    "id": "mossberg_590",
+    "id": "slp",
     "copy-from": "mossberg_500",
     "looks_like": "mossberg_500",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "9-round combat shotgun" },
-    "description": "A military oriented spin on the classic pump-action shotgun recipe, this firearm features an extended magazine tube capable of fielding nine rounds of 12 gauge shotshells.  Sporting a heavier barrel and a bayonet lug, it makes for a highly intimidating weapon, as well as a satisfying answer to most of the nasties you're liable to find in the post-apocalypse.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mossberg_590",
-        "name": { "str": "Mossberg 590A1 shotgun" },
-        "description": "The Mossberg 590A1 is a military and police oriented version of the Mossberg 500.  It features a heavier barrel, a bayonet lug, and a different magazine tube for easier cleaning and maintenance."
-      },
-      {
-        "id": "SPAS_12",
-        "name": { "str": "Franchi SPAS-12 shotgun" },
-        "description": "Mean and intimidating looking, the SPAS-12 has the dubious honor of being declared a destructive device and being banned from import by name, adding to its already considerable appeal.  It is a combination pump-action and semi-automatic firearm, with an arm stabilizing hook for one handed shooting."
-      },
-      {
-        "id": "slp",
-        "name": { "str": "FN SLP MK I shotgun" },
-        "description": "An eminently practical semi-automatic shotgun, Fabrique Nationale's Mk I iteration of their Self-Loading Police brings together an 8-round magazine tube, accessory-ready Picatinny rail, and comfortably rubber-padded grip surfaces.  Per the company's claims, it can dispense 8 servings of 12-gauge-diameter medicine in under a second, and, while you're not sure if that's true or even a good thing, the gun's certain to serve as a good educational tool for disciplining the dead."
-      }
-    ],
+    "name": { "str": "FN SLP MK I shotgun" },
+    "description": "An eminently practical semi-automatic shotgun, Fabrique Nationale's Mk I iteration of their Self-Loading Police brings together an 8-round magazine tube, accessory-ready Picatinny rail, and comfortably rubber-padded grip surfaces.",
     "weight": "3289 g",
     "volume": "2548 ml",
     "longest_side": "1043 mm",
@@ -276,21 +233,76 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 9 } } ]
   },
   {
+    "id": "spas_12",
+    "copy-from": "mossberg_500",
+    "looks_like": "mossberg_500",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Franchi SPAS-12 shotgun" },
+    "description": "Mean and intimidating looking, the SPAS-12 has the dubious honor of being declared a destructive device and being banned from import by name, adding to its already considerable appeal.  It is a combination pump-action and semi-automatic firearm, with an arm stabilizing hook for one handed shooting.",
+    "weight": "3289 g",
+    "volume": "2548 ml",
+    "longest_side": "1043 mm",
+    "barrel_length": "508 mm",
+    "//": "The true dimensions of the FN SLP are 1092 mm overall length, 558mm barrel length, and 3583 gramme weight.",
+    "default_mods": [ "sights_mount", "underbarrel_mount" ],
+    "price": "700 USD",
+    "price_postapoc": "24 USD",
+    "clip_size": 9,
+    "barrel_volume": "0 ml",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 9 } } ]
+  },
+  {
+    "id": "mossberg_590",
+    "copy-from": "mossberg_500",
+    "looks_like": "mossberg_500",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Mossberg 590A1 shotgun" },
+    "description": "The Mossberg 590A1 is a military and police oriented version of the Mossberg 500.  It features a heavier barrel, a bayonet lug, and a different magazine tube for easier cleaning and maintenance.",
+    "weight": "3289 g",
+    "volume": "2548 ml",
+    "longest_side": "1043 mm",
+    "barrel_length": "508 mm",
+    "default_mods": [ "sights_mount", "underbarrel_mount" ],
+    "price": "700 USD",
+    "price_postapoc": "24 USD",
+    "clip_size": 9,
+    "barrel_volume": "0 ml",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 9 } } ]
+  },
+  {
     "id": "mossberg_590m",
     "copy-from": "mossberg_590",
     "looks_like": "mossberg_590",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "magazine-fed pump shotgun" },
+    "name": { "str": "Mossberg 590M shotgun" },
     "description": "A classic pump-action shotgun, all save for the fact that the manufacturer has modified it to use detachable box magazines instead of a standard shotgun tube.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mossberg_590",
-        "name": { "str": "Mossberg 590M shotgun" },
-        "description": "A classic Mossberg 590 pump-action shotgun, modified by the manufacturer to utilize box magazines."
-      }
-    ],
     "weight": "3628 g",
     "volume": "2548 ml",
     "longest_side": "1033 mm",
@@ -320,21 +332,44 @@
     "copy-from": "shotgun_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "8-round auto-loading shotgun" },
-    "description": "A semi-automatic smooth-bore shotgun, this weapon features respectable ergonomics and room for 8 shotshells within its tubular magazine.  Suitable both for competition shooting and offensive combat roles, this firearm is faster to shoot than a traditional pump-action model, with the caveat that it's harder to maintain than its manually operated siblings as it relies on an internal gas system to cycle rounds rather than the user's own physical input.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "mossberg_930",
-        "name": { "str": "Mossberg 930 SPX shotgun" },
-        "description": "This semi-automatic offering from Mossberg features a recoil reducing gas system, rifle style sights and a factory-installed Picatinny rail.  Affordable pricing and decent ergonomics make this a popular entry-level 3-gun shotgun."
-      },
-      {
-        "id": "m1014",
-        "name": { "str": "M1014 shotgun" },
-        "description": "Benelli's first gas-operated shotgun, featuring dual pistons for enhanced reliability with various loads and a collapsible buttstock that reduces length by almost 8 inches.  Adopted in 1999 as the M1014 Joint Service Combat Shotgun, the Benelli M4 is one of the finest combat shotguns available."
-      }
+    "name": { "str": "Mossberg 930 SPX shotgun" },
+    "description": "This semi-automatic offering from Mossberg features a recoil reducing gas system, rifle style sights and a factory-installed Picatinny rail.  Affordable pricing and decent ergonomics make this a popular entry-level 3-gun shotgun.",
+    "weight": "3402 g",
+    "volume": "2623 ml",
+    "longest_side": "994 mm",
+    "barrel_length": "470 mm",
+    "looks_like": "remington_870",
+    "price": "600 USD",
+    "price_postapoc": "22 USD 50 cent",
+    "to_hit": -1,
+    "material": [ "steel", "aluminum", "plastic" ],
+    "dispersion": 345,
+    "durability": 7,
+    "clip_size": 8,
+    "built_in_mods": [ "wire_stock" ],
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
     ],
+    "extend": { "flags": [ "RELOAD_ONE" ] },
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 8 } } ],
+    "melee_damage": { "bash": 12 }
+  },
+  {
+    "id": "m1014",
+    "copy-from": "shotgun_base",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "M1014 shotgun" },
+    "description": "Benelli's first gas-operated shotgun, featuring dual pistons for enhanced reliability with various loads and a collapsible buttstock that reduces length by almost 8 inches.  Adopted in 1999 as the M1014 Joint Service Combat Shotgun, the Benelli M4 is one of the finest combat shotguns available.",
     "weight": "3402 g",
     "volume": "2623 ml",
     "longest_side": "994 mm",
@@ -407,36 +442,121 @@
     "melee_damage": { "bash": 12 }
   },
   {
+    "id": "remington_1100",
+    "copy-from": "shotgun_pump_3gun",
+    "//": "Tileset whitelist for shotguns.",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Remington 1100 competition shotgun" },
+    "description": "This semi-automatic shotgun features a self compensating gas system that will feed a wide array of shells while also reducing recoil.  Introduced in 1963, it is favored by law enforcement, hunters and competition shooters, and has been the best-selling autoloading shotgun in U.S. history.  This is the nickel finished, teflon coated competition model, with a full length magazine tube and 30 inch barrel.",
+    "weight": "3400 g",
+    "volume": "2487 ml",
+    "longest_side": "1234 mm",
+    "barrel_length": "762 mm",
+    "price": "587 USD",
+    "price_postapoc": "25 USD",
+    "to_hit": -1,
+    "material": [ "steel", "plastic" ],
+    "dispersion": 305,
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
+    "durability": 8,
+    "clip_size": 5,
+    "barrel_volume": "229 ml",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ],
+    "melee_damage": { "bash": 13 }
+  },
+  {
+    "id": "browning_a5",
+    "copy-from": "shotgun_pump_3gun",
+    "//": "Tileset whitelist for shotguns.",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Browning Auto 5 shotgun" },
+    "description": "This humble looking shotgun was the earliest successful semi-automatic shotgun, and the second most successful in U.S. history, with over 2.7 million made between 1902 and 1998.  The recoil tuning mechanism under the handguard and long dwell time of the action make for pleasant shooting.",
+    "weight": "3400 g",
+    "volume": "2487 ml",
+    "longest_side": "1234 mm",
+    "barrel_length": "762 mm",
+    "price": "587 USD",
+    "price_postapoc": "25 USD",
+    "to_hit": -1,
+    "material": [ "steel", "plastic" ],
+    "dispersion": 305,
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
+    "durability": 8,
+    "clip_size": 5,
+    "barrel_volume": "229 ml",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ],
+    "melee_damage": { "bash": 13 }
+  },
+  {
+    "id": "ithaca37",
+    "copy-from": "shotgun_pump_3gun",
+    "//": "Tileset whitelist for shotguns.",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Ithaca M37 Featherlight shotgun" },
+    "description": "A seasoned veteran of America's sporting culture, the Ithaca M37 is the oldest pump-action shotgun still in active production.  The M37 has served hunters and officers for over eight decades, featuring a bottom-feeding and ejecting design that keeps the action sealed from the elements.  An heirloom that retains its utility all the way from pre-Cataclysm hunting expeditions up into the depths of alien environments, it would be wise to keep it handy, for close encounters.",
+    "weight": "3400 g",
+    "volume": "2487 ml",
+    "longest_side": "1234 mm",
+    "barrel_length": "762 mm",
+    "price": "587 USD",
+    "price_postapoc": "25 USD",
+    "to_hit": -1,
+    "material": [ "steel", "plastic" ],
+    "dispersion": 305,
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
+    "durability": 8,
+    "clip_size": 5,
+    "barrel_volume": "229 ml",
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 5 } } ],
+    "melee_damage": { "bash": 13 }
+  },
+  {
     "id": "remington_870",
     "copy-from": "shotgun_pump_3gun",
     "//": "Tileset whitelist for shotguns.",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "5-round hunting shotgun" },
-    "description": "A classic shotgun in nearly every respect; big, bulky, and intimidating, guns such as this one have been made for over a century in one form or another, coming in both pump-action and semi-automatic models.  Serving both competition-shooting, law-enforcement, and hunting roles, this firearm is sporting a standard-capacity 5-round magazine tube.  Despite the firearm's low magazine space, what it lacks in capacity it makes up for in sheer close-range effectiveness and stopping power.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "remington_870",
-        "name": { "str": "Remington 870 Wingmaster shotgun" },
-        "description": "With over 10 million made, the Remington 870 is one of the most popular shotguns on the market, and finds use with hunters and law enforcement agencies alike thanks to its high accuracy and muzzle velocity.  This one is a 28 inch barreled model for hunting fowl and game."
-      },
-      {
-        "id": "remington_1100",
-        "name": { "str": "Remington 1100 competition shotgun" },
-        "description": "This semi-automatic shotgun features a self compensating gas system that will feed a wide array of shells while also reducing recoil.  Introduced in 1963, it is favored by law enforcement, hunters and competition shooters, and has been the best-selling autoloading shotgun in U.S. history.  This is the nickel finished, teflon coated competition model, with a full length magazine tube and 30 inch barrel."
-      },
-      {
-        "id": "browning_a5",
-        "name": { "str": "Browning Auto 5 shotgun" },
-        "description": "This humble looking shotgun was the earliest successful semi-automatic shotgun, and the second most successful in U.S. history, with over 2.7 million made between 1902 and 1998.  The recoil tuning mechanism under the handguard and long dwell time of the action make for pleasant shooting."
-      },
-      {
-        "id": "ithaca37",
-        "name": { "str": "Ithaca M37 Featherlight shotgun" },
-        "description": "A seasoned veteran of America's sporting culture, the Ithaca M37 is the oldest pump-action shotgun still in active production.  The M37 has served hunters and officers for over eight decades, featuring a bottom-feeding and ejecting design that keeps the action sealed from the elements.  An heirloom that retains its utility all the way from pre-Cataclysm hunting expeditions up into the depths of alien environments, it would be wise to keep it handy, for close encounters."
-      }
-    ],
+    "name": { "str": "Remington 870 Wingmaster shotgun" },
+    "description": "With over 10 million made, the Remington 870 is one of the most popular shotguns on the market, and finds use with hunters and law enforcement agencies alike thanks to its high accuracy and muzzle velocity.  This one is a 28 inch barreled model for hunting fowl and game.",
     "weight": "3400 g",
     "volume": "2487 ml",
     "longest_side": "1234 mm",
@@ -470,16 +590,8 @@
     "copy-from": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "breaching shotgun" },
+    "name": { "str": "Remington 870 MCS shotgun" },
     "description": "This shotgun has a short barrel and no stock, and is set up for breaching doors.  It is small enough to carry as a secondary weapon, but has fairly unpleasant recoil and no sights.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "remington_870_breacher",
-        "name": { "str": "Remington 870 MCS shotgun" },
-        "description": "This Remington 870 Modular Combat System shotgun is currently set up for breaching operations, with a 10 inch barrel and no stock.  It is small enough to carry as a secondary weapon, specifically to pop open any pesky doors you might come across.  The grip's design makes for controllable yet unpleasant recoil, and the barrel lacks any sights."
-      }
-    ],
     "weight": "2812 g",
     "volume": "1284 ml",
     "longest_side": "53 cm",
@@ -513,16 +625,8 @@
     "copy-from": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "7-round riot shotgun" },
-    "description": "A brother of more typical hunting style shotguns, this particular model was most often seen utilized for self-defense or law-enforcement purposes.  Featuring a shortened 18.5 inch barrel and extended 7-round magazine tube, it's a very versatile and reliable weapon.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "remington_870_express",
-        "name": { "str": "Remington 870 Express shotgun" },
-        "description": "With over 10 million made, the Remington 870 is one of the most popular shotguns on the market, and finds use with hunters and law enforcement agencies alike thanks to its high accuracy and muzzle velocity.  This one is an 18.5 inch barreled defensive model."
-      }
-    ],
+    "name": { "str": "Remington 870 Express shotgun" },
+    "description": "With over 10 million made, the Remington 870 is one of the most popular shotguns on the market, and finds use with hunters and law enforcement agencies alike thanks to its high accuracy and muzzle velocity.  This one is an 18.5 inch barreled defensive model.",
     "weight": "3402 g",
     "volume": "2365 ml",
     "longest_side": "983 mm",
@@ -579,16 +683,8 @@
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "assault shotgun" },
+    "name": { "str": "Saiga-12 shotgun" },
     "description": "Built in the same style as the venerable AK series of rifles, this Russian exported firearm feeds from detachable magazines rather than making use of a standard tubular design like most commercial shotguns.  With 10 and 30-round magazines available, reloading is rendered a much quicker procedure than can ever be accomplished with conventional bottom-feeding firearms.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "saiga_12",
-        "name": { "str": "Saiga-12 shotgun" },
-        "description": "The Saiga-12 is a semi-automatic shotgun designed on the same Kalashnikov pattern as the AK-47 rifle.  It reloads with a magazine, rather than one shell at a time like most shotguns.  It is one of the last designs of Mikhail Kalashnikov, and was popular in open division shotgun competitions prior to its ban from import via executive order."
-      }
-    ],
     "weight": "3225 g",
     "volume": "3064 ml",
     "longest_side": "1068 mm",
@@ -685,16 +781,8 @@
     "copy-from": "shotgun_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "automatic shotgun" },
-    "description": "This shotgun, deemed a destructive device, resembles a comically oversized revolver.  It can hold 12 rounds of 12 gauge shot, and fire all of them in under 3 seconds",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "streetsweeper",
-        "name": { "str": "Cobray Streetsweeper shotgun" },
-        "description": "Less shotgun and more comically oversized revolver, the Cobray Streetsweeper sold poorly before it was deemed a destructive device.  The cylinder is driven by a clockspring, cannot be indexed by hand, and must be ejected with an ejector rod.  Its unique design allows for all 12 shells to be fired in under 3 seconds, as demonstrated by the ATF technical branch."
-      }
-    ],
+    "name": { "str": "Cobray Streetsweeper shotgun" },
+    "description": "This weapon looks like someone's Frankensteined a comically oversized revolver together with a shotgun, resulting in a weapon that looks cumbersome to fire and downright miserable to reload.",
     "weight": "4200 g",
     "volume": "3193 ml",
     "longest_side": "592 mm",
@@ -703,7 +791,7 @@
     "price": "1200 USD",
     "price_postapoc": "35 USD",
     "to_hit": -1,
-    "material": [ "steel", "wood" ],
+    "material": [ "steel", "plastic" ],
     "dispersion": 855,
     "durability": 6,
     "clip_size": 12,
@@ -731,16 +819,8 @@
     "copy-from": "shotgun_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "auto-loading bullpup shotgun" },
+    "name": { "str": "Tavor TS12 shotgun" },
     "description": "Looking more like some form of sci-fi prop gun than an actual firearm, this weapon uses a system of three different magazines to field 15 12-gauge shotgun shells within a comparatively compact design.  As the weapon's trigger assembly is situated forwards of the chamber and magazines in what is termed as a 'bullpup' design, the firearm's notably more compact than its peers despite having a higher capacity when compared against more classically designed shotguns.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "tavor_12",
-        "name": { "str": "Tavor TS12 shotgun" },
-        "description": "A triple tube magazine fed, gas-operated bullpup shotgun of Israeli Weapon Industries make.  It is capable of loading 15 shells, all in a relatively small package.  Like many other modern IWI designs, this looks more like a sci-fi prop gun than a firearm.  An integral top rail is provided for mounting sights."
-      }
-    ],
     "weight": "3429 g",
     "volume": "4040 ml",
     "longest_side": "725 mm",
@@ -775,16 +855,8 @@
     "copy-from": "shotgun_pump",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "double-barrelled pump shotgun" },
+    "name": { "str": "DP-12 shotgun" },
     "description": "A hefty shotgun with a double-barrel configuration, though each barrel feeds from its own magazine, making the weapon actually two firearms in a single frame.  While each barrel has its own associated trigger, considering there is a single pump to actuate both mechanisms, one can't really use it precisely.  This, however, isn't to say that the weapon isn't fit for the service of shooting zombies at point blank ranges.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "dp_12",
-        "name": { "str": "DP-12 shotgun" },
-        "description": "A bullpup, 12-gauge, pump-action, double-barrelled mouthful of a shotgun.  Each barrel feeds from its own magazine, making the weapon actually two firearms in a single frame, and, while each barrel has its own associated trigger, the presence of a single pump to actuate both mechanisms means that it cannot be used precisely.  This, however, isn't to say that the weapon isn't fit for the service of shooting zombies at point blank ranges."
-      }
-    ],
     "weight": "4989 g",
     "volume": "8862 ml",
     "//": "180 x 750 x 101 mm, trimmed about 35% down for empty spaces",
@@ -816,16 +888,8 @@
     "copy-from": "shotgun_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "bootleg lever-action shotgun" },
-    "description": "A lever-action shotgun with a very short barrel and no stock, with room for 6 rounds of 12 gauge shotshells.  Likely a bootlegged replica of a pre-1900 firearm, it would pair nicely with a motorcycle jacket and a Harley Davidson, and seems ready to terminate your cataclysmic adversaries.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "winchester_1887",
-        "name": { "str": "1887 bootleg shotgun" },
-        "description": "One of the first commercially successful repeating shotguns, the Winchester 1887 was specifically made lever-action at Winchester's request.  Though later overshadowed in success by pump designs, the 1887 remains popular today.  This one has a very short barrel, no stock, and would pair nicely with a motorcycle jacket and a Harley Davidson."
-      }
-    ],
+    "name": { "str": "1887 bootleg shotgun" },
+    "description": "One of the first commercially successful repeating shotguns, the Winchester 1887 was specifically made lever-action at Winchester's request.  Though later overshadowed in success by pump designs, the 1887 remains popular today.  This one has a very short barrel, no stock, and would pair nicely with a motorcycle jacket and a Harley Davidson.",
     "weight": "2994 g",
     "volume": "1127 ml",
     "longest_side": "708 mm",
@@ -861,16 +925,8 @@
     "copy-from": "shotgun_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "6-round trenchgun" },
-    "description": "Whether or not you ever wondered what would happen if one was to attach a shotgun atop a sword, the result of such an inquiry now rests before you in all its metallic glory.  Coming outfitted with a large 17 inch sword bayonet and a wooden heat shield to protect the user's hands from the barrel when it heats up during firing, this pump-action shotgun practically drips menace and looks like it's straight out of the trenches of World War I.  There aren't any more trenches to clear, so the next zombie-infested town will have to suffice.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "winchester_1897",
-        "name": { "str": "M1897 Trench Gun" },
-        "description": "The Winchester 1897 was one of the first commercially-successful pump-action shotguns.  In its 'trench' configuration it has become a heavily-romanticized American icon of World War I.  With its barrel shroud, bayonet lug, and 17 inch bayonet, this shotgun is undeniably fearsome in appearance.  There aren't any more trenches to clear, so the next zombie-infested town will have to suffice."
-      }
-    ],
+    "name": { "str": "M1897 Trench Gun" },
+    "description": "The Winchester 1897 was one of the first commercially-successful pump-action shotguns.  In its 'trench' configuration it has become a heavily-romanticized American icon of World War I.  With its barrel shroud, bayonet lug, and 17 inch bayonet, this shotgun is undeniably fearsome in appearance.",
     "weight": "3629 g",
     "volume": "2564 ml",
     "longest_side": "989 mm",
@@ -899,26 +955,13 @@
     "melee_damage": { "bash": 11 }
   },
   {
-    "id": "benelli_sa",
+    "id": "m2",
     "copy-from": "shotgun_base",
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "4-round waterfowl shotgun" },
-    "description": "This is a lanky, though relatively light, semi-automatic shotgun fitted with a plastic, dimple buttstock and forend, a representative of many such guns employed in fighting the true, greatest foe: geese.  An under-slung magazine tube retains three shells in complement with a chambered cartridge, lending the gun a somewhat modest capacity despite its durability and reliable action.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "m2",
-        "name": { "str": "Benelli M2 shotgun" },
-        "description": "Workhorse, companion, and Italian hole-puncher: the M2 forms the backbone of the Benelli's venerable line of Super 90 shotguns, utilizing the company's signature inertia-driven system to snap out 12-gauge shells with alacrity.  Though possessing a 3-round magazine tube, the shotgun's dimpled, synthetic furniture, cryogenically treated barrel, and robust action capable of withstanding magnum loads make it a hardy option, even for the post-cataclysm survivor."
-      },
-      {
-        "id": "sbe",
-        "name": { "str": "Benelli SBE 3 shotgun" },
-        "description": "A relatively light, semi-automatic fowling peace finished in black furniture with trim lines and a slender forend, the Super Black Eagle (SBE) shotgun operates off of Benelli's inertia-driven recoil system.  Synonymous with versatility and reliability, it's a decades-beloved design incorporating one of the earliest actions rated to chamber 3-inch magnum shotgun shells, with this 2023 updated version coming fitted with a recoil pad."
-      }
-    ],
+    "name": { "str": "Benelli M2 shotgun" },
+    "description": "Workhorse, companion, and Italian hole-puncher: the M2 forms the backbone of the Benelli's venerable line of Super 90 shotguns, utilizing the company's signature inertia-driven system to snap out 12-gauge shells with alacrity.  Though possessing a 3-round magazine tube, the shotgun's dimpled, synthetic furniture, cryogenically treated barrel, and robust action capable of withstanding magnum loads make it a hardy option, even for the post-cataclysm survivor.",
     "weight": "3039 g",
     "volume": "2600  ml",
     "longest_side": "1213 mm",
@@ -951,35 +994,101 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 4 } } ]
   },
   {
-    "id": "benelli_tsa",
-    "copy-from": "benelli_sa",
+    "id": "sbe",
+    "copy-from": "shotgun_base",
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "6-round tactical shotgun" },
-    "description": "A black-finished shotgun fit for the gentlemanly pursuit of blowing very large holes through the residence of the cataclysm, be it zombie, goose, or tiny abomination, this semi-automatic longarm fields five shotgun shells within its tubular magazine.  Aesthetically pleasing with its dimpled buttstock and forend, the weapon features an underslung pistol-style grip and a gel cushion on the back of the stock for recoil mitigation.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "m2_tac",
-        "name": { "str": "Benelli M2 Tactical shotgun" },
-        "description": "Where the full-sized Benelli M2 shotgun is a hefty stallion, this mission-oriented tactical iteration is a trim race horse, with an 18.5-inch barrel, dimpled grip surfaces, and an underslung pistol grip.  Ghost-ring aperture-sights, a recoil-padded buttstock, and a cryogenically-treated barrel all join hands to ensure that you can carry out your post-cataclysm farming duties: seeding lead shot into fields of zombies."
-      },
-      {
-        "id": "mossberg_500_security",
-        "name": { "str": "Mossberg 500 Security shotgun" },
-        "description": "The Mossberg 500 is a popular series of pump-action shotguns, often acquired for military use.  It is noted for its high durability and low recoil.  This one is fitted with an 18.5 inch barrel."
-      }
+    "name": { "str": "Benelli SBE 3 shotgun" },
+    "description": "A relatively light, semi-automatic fowling peace finished in black furniture with trim lines and a slender forend, the Super Black Eagle (SBE) shotgun operates off of Benelli's inertia-driven recoil system.  Synonymous with versatility and reliability, it's a decades-beloved design incorporating one of the earliest actions rated to chamber 3-inch magnum shotgun shells, with this 2023 updated version coming fitted with a recoil pad.",
+    "weight": "3039 g",
+    "volume": "2600  ml",
+    "longest_side": "1213 mm",
+    "barrel_length": "660 mm",
+    "//": "Based on a 26-inch-barrel field configuration.",
+    "price": "1499 USD",
+    "price_postapoc": "18 USD",
+    "clip_size": 4,
+    "//2": "The capacity of an unmodified M2 is three shells in the tube plus one in the chamber. We're assuming that the player takes the time to rack a cartridge into the chamber and top off the tube when loading in shell number 4.",
+    "durability": 10,
+    "barrel_volume": "86 ml",
+    "//3": "The number's simulating the cubic volume of a 7.5-inch stretch of 20-mm bore barrel being removed.",
+    "dispersion": 300,
+    "to_hit": -1,
+    "material": [ "steel", "aluminum", "plastic" ],
+    "default_mods": [ "recoil_stock" ],
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "loading port", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
     ],
-    "volume": "2519  ml",
+    "flags": [ "FIRE_TWOHAND", "NO_TURRET", "RELOAD_ONE" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 4 } } ]
+  },
+  {
+    "id": "m2_tac",
+    "copy-from": "m2",
+    "looks_like": "remington_870",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Benelli M2 Tactical shotgun" },
+    "description": "Where the full-sized Benelli M2 shotgun is a hefty stallion, this mission-oriented tactical iteration is a trim race horse.  Its dimpled grip surfaces and cryogenically-treated barrel come together to present a compact, reliable weapon for any kind of field work.",
+    "volume": "2519 ml",
     "longest_side": "1010 mm",
     "barrel_length": "470 mm",
-    "//": "The true dimensions of a Mossberg 500 Security are 1003 mm in length, 457 mm in barrel length, and 3062 grammes.",
     "price": "1599 USD",
     "price_postapoc": "27 USD 60 cent",
     "clip_size": 6,
-    "//2": "The capacity of an unmodified M2 Tactical is five shells in the tube plus one in the chamber. We're assuming that the player takes the time to rack a cartridge into the chamber and top off the tube when loading in shell number six.",
+    "//": "Five round rube mag plus one in the chamber. TODO: Are all pump actions like this?",
     "barrel_volume": "0 ml",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "default_mods": [ "pistol_grip", "recoil_stock" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ]
+  },
+  {
+    "id": "mossberg_500_security",
+    "copy-from": "m2",
+    "looks_like": "remington_870",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "Mossberg 500 Security shotgun" },
+    "description": "The Mossberg 500 is a popular series of pump-action shotguns, often acquired for military use.  It is noted for its high durability and low recoil.  This one is fitted with an 18.5 inch barrel.",
+    "volume": "2519 ml",
+    "longest_side": "1003 mm",
+    "barrel_length": "457 mm",
+    "weight": "3062 g",
+    "price": "1599 USD",
+    "price_postapoc": "27 USD 60 cent",
+    "clip_size": 6,
+    "barrel_volume": "0 ml",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "mechanism", 2 ],
+      [ "muzzle", 1 ],
+      [ "rail mount", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
     "default_mods": [ "pistol_grip", "recoil_stock" ],
     "//3": "Benelli's assumed to be coming with the ComforTech buttstock fitted.",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "shot": 6 } } ]
@@ -1031,16 +1140,8 @@
     "looks_like": "remington_870",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "rotary-magazine shotgun" },
-    "description": "A lengthy shotgun that accepts revolving 16-round magazines.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "srm_1216",
-        "name": { "str": "SRM Arms Model 1216 shotgun" },
-        "description": "A delayed blowback semi-automatic shotgun feeding from detachable 16-round rotary magazines."
-      }
-    ],
+    "name": { "str": "SRM Arms Model 1216 shotgun" },
+    "description": "A delayed blowback semi-automatic shotgun feeding from detachable 16-round rotary magazines.",
     "weight": "3062 g",
     "volume": "8015 ml",
     "//": "857 x 195 x 97 mm, trimmed about 30% down for empty spaces, minus 3670 ml of magazine volume.",
@@ -1074,7 +1175,6 @@
     "subtypes": [ "GUN" ],
     "name": { "str": "M26-MASS standalone shotgun" },
     "description": "The Modular Accessory Shotgun System is an underbarrel bolt-action shotgun that was inspired by the \"Masterkey\" and which fixed most of its predecessor's problems.  This one is configured for standalone usage.",
-    "variant_type": "gun",
     "weight": "1900 g",
     "volume": "2390 ml",
     "longest_side": "610 mm",

--- a/data/json/items/gunmod/loading_port.json
+++ b/data/json/items/gunmod/loading_port.json
@@ -23,10 +23,10 @@
     "id": "arredondo_chute_benelli_sa",
     "type": "ITEM",
     "subtypes": [ "GUNMOD" ],
-    "name": { "str": "speedloader chute, 4-round waterfowl shotgun" },
-    "description": "A metal ramp that is installed near a shotgun's feeding port to index speedloader tubes.  This one is for 4-round waterfowl shotgun.",
+    "name": { "str": "speedloader chute, Benelli Super" },
+    "description": "A metal ramp that is installed near a shotgun's feeding port to index speedloader tubes.  This one is for Benelli's Super line of shotguns.",
     "copy-from": "arredondo_chute",
-    "mod_targets": [ "benelli_sa" ],
+    "mod_targets": [ "sbe", "m2", "m2_tac" ],
     "pocket_mods": [
       {
         "pocket_type": "MAGAZINE",

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -781,7 +781,7 @@
         { "item": "556", "x": 18, "y": [ 9, 12 ], "chance": 75, "repeat": 150 },
         { "item": "m249", "x": 20, "y": 9, "chance": 75, "repeat": 6 },
         { "item": "m240", "x": 20, "y": 9, "chance": 75, "repeat": 4 },
-        { "item": "mossberg_930", "variant": "m1014", "x": 20, "y": 10, "chance": 75, "repeat": 10 },
+        { "item": "m1014", "x": 20, "y": 10, "chance": 75, "repeat": 10 },
         { "item": "mossberg_590", "x": 20, "y": 10, "chance": 75, "repeat": 8 },
         { "item": "m26_mass_standalone", "x": 20, "y": 10, "chance": 10, "repeat": 4 },
         { "item": "m2010", "x": 20, "y": 11, "magazine": 100, "chance": 75, "repeat": 2 },

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -66,7 +66,8 @@
     "fac_food_supply": [ [ 0, { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } } ] ],
     "wealth": 100000000,
     "currency": "RobofacCoin",
-    "price_rules": [ { "group": "NC_ROBOFAC_gear", "markup": 2 },
+    "price_rules": [
+      { "group": "NC_ROBOFAC_gear", "markup": 2 },
       { "item": "money_strap_FMCNote", "purchase_rate": 0 },
       { "item": "money_bundle_FMCNote", "purchase_rate": 0 },
       { "item": "FMCNote", "purchase_rate": 0 },

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -3908,7 +3908,7 @@
     "id": "poppy_cough",
     "replace": "opium_tar"
   },
-    {
+  {
     "type": "MIGRATION",
     "id": "patchwork_scarf_headwrap",
     "replace": "patchwork_scarf"

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1598,8 +1598,7 @@
           { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           { "item": "shot_00", "count": 2 },
           {
-            "item": "mossberg_930",
-            "variant": "m1014",
+            "item": "m1014",
             "ammo-item": "shot_00",
             "charges": 8,
             "contents-item": [ "shoulder_strap", "holo_sight" ]


### PR DESCRIPTION
#### Summary
Devariantize Shotguns

#### Purpose of change
Shotguns were using the old variant system to try to fake having variety. As with #2437 this was also causing problems with some item displays.

#### Describe the solution
- Shotguns no longer use the variant system.
- The old generic names are fully purged from the code.
- Fixed mod slots for some guns, particularly the Benelli.
- Made the arredondo chute work on the tactical m2


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
