### PR TITLE
Move machete to real short swords

### DIFF
--- a/data/json/requirements/melee.json
+++ b/data/json/requirements/melee.json
@@ -150,7 +150,7 @@
     "id": "basic_short_swords",
     "type": "requirement",
     "//": "Any basic thing you could use as a short sword, exlcudes high-quality things.",
-    "tools": [ [ [ "makeshift_machete", -1 ], [ "machete_gimmick", -1 ], [ "machete", -1 ] ] ]
+    "tools": [ [ [ "makeshift_machete", -1 ], [ "machete_gimmick", -1 ] ] ]
   },
   {
     "id": "real_short_swords",
@@ -163,7 +163,8 @@
         [ "sword_bronze", -1 ],
         [ "sword_bayonet", -1 ],
         [ "butterfly_swords", -1 ],
-        [ "arisaka_bayonet", -1 ]
+        [ "arisaka_bayonet", -1 ],
+        [ "machete", -1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Move machete to real short swords

#### Purpose of change
The standard machete was under makeshift short swords, but it is a good, solid weapon, and ought to be counted among the real ones. This makes it valid for short sword training.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
