### PR TITLE
Fix and modernize cocaine

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3419,7 +3419,7 @@
       "fatigue_tick": [ 10 ],
       "fatigue_min_val": [ -50 ],
       "stamina_min": [ 100 ],
-      "stamina_max": [ 200 ],
+      "stamina_max": [ 300 ],
       "stamina_chance": [ 50 ],
       "thirst_min": [ 1 ],
       "thirst_max": [ 2 ],
@@ -3440,6 +3440,56 @@
       "thirst_tick": [ -100 ]
     },
     "blood_analysis_description": "Amphetamines"
+  },
+  {
+    "type": "effect_type",
+    "id": "cocaine",
+    "name": [ "Sharp", "Wired", "Geeked", "Whiteout" ],
+    "desc": [
+      "You've got a mild cocaine buzz going.  Feels good, feels clean.",
+      "You're feeling chatty and energized, and probably way too confident.",
+      "The cocaine has you jittery, irritable, and anxious, but somehow spacey at the same time.",
+      "You are completely fucked off the cocaine.  Your chest hurts, and you can't stop clenching your jaw."
+    ],
+    "chance_kill": [ [ -1, 1 ], [ -1, 1 ], [ -1, 1 ], [ 1, 25000 ] ],
+    "death_msg": "You have a heart attack!",
+    "max_intensity": 4,
+    "base_mods": {
+      "focus_min": [ 1 ],
+      "focus_max": [ 2 ],
+      "speed_mod": [ 3 ],
+      "focus_max_val": [ 6 ],
+      "focus_chance": [ 40 ],
+      "int_mod": [ 1 ],
+      "per_mod": [ 0.5 ],
+      "fatigue_min": [ -1 ],
+      "fatigue_max": [ -1 ],
+      "fatigue_tick": [ 10 ],
+      "fatigue_min_val": [ -30 ],
+      "stamina_min": [ 50 ],
+      "stamina_max": [ 500 ],
+      "stamina_chance": [ 40 ],
+      "thirst_min": [ 1 ],
+      "thirst_max": [ 2 ],
+      "thirst_tick": [ 1000 ]
+    },
+    "scaling_mods": {
+      "focus_min": [ -1 ],
+      "focus_min_val": [ -5 ],
+      "focus_max_val": [ 4 ],
+      "speed_mod": [ 2 ],
+      "str_mod": [ 0.5 ],
+      "int_mod": [ -1 ],
+      "per_mod": [ 0.5 ],
+      "fatigue_min": [ -1 ],
+      "fatigue_max": [ -5 ],
+      "stamina_min": [ -150 ],
+      "stamina_max": [ -150 ],
+      "stamina_chance": [ -5 ],
+      "fatigue_min_val": [ -50 ],
+      "thirst_tick": [ -100 ]
+    },
+    "blood_analysis_description": "Cocaine"
   },
   {
     "type": "effect_type",
@@ -3574,9 +3624,12 @@
       "pkill_tick": [ 45 ],
       "thirst_min": [ 1 ],
       "thirst_max": [ 2 ],
-      "thirst_tick": [ 1000 ]
+      "thirst_tick": [ 1000 ],
+      "str_mod": [ 0.5 ]
     },
     "scaling_mods": {
+      "speed_mod": [ -2 ],
+      "str_mod": [ 0.5 ],
       "per_mod": [ -0.5 ],
       "dex_mod": [ -0.5 ],
       "int_mod": [ -0.75 ],

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -463,9 +463,9 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
     "name": { "str_sp": "cocaine" },
-    "description": "Crystalline extract of the coca leaf, or at least, a white powder with some of that in it.  A topical analgesic, it is more commonly used for its stimulatory properties.  Highly addictive.",
-    "weight": "1 g",
-    "volume": "2 ml",
+    "description": "Crystalline extract of the coca leaf, or at least, a white powder with some of that in it.  It is a highly addictive stimulant.",
+    "weight": "100 mg",
+    "volume": "1 ml",
     "price": "1 USD",
     "price_postapoc": "25 cent",
     "material": [ "powder" ],
@@ -474,10 +474,11 @@
     "container": "bag_zipper",
     "healthy": -2,
     "fun": 15,
-    "addiction_potential": 50,
+    "addiction_potential": 30,
     "addiction_type": "cocaine",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": [ "COKE" ]
+    "vitamins": [ [ "cocaine", 1 ] ],
+    "use_action": { "type": "consume_drug", "activation_message": "You snort a bump of cocaine.", "vitamins": [ [ "cocaine", 1, 2 ] ] }
   },
   {
     "id": "myopia_contacts_weekly",
@@ -836,16 +837,17 @@
     "container": "bag_zipper",
     "healthy": -2,
     "fun": 15,
-    "addiction_potential": 80,
+    "addiction_potential": 30,
     "addiction_type": "cocaine",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
+    "vitamins": [ [ "cocaine", 1 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke your crack rocks.",
-      "effects": [ { "id": "high", "duration": 15 } ],
       "fields_produced": { "fd_cracksmoke": 2 },
       "charges_needed": { "fire": 1 },
-      "tools_needed": { "apparatus": -1 }
+      "tools_needed": { "apparatus": -1 },
+      "vitamins": [ [ "cocaine", 1, 2 ] ]
     }
   },
   {
@@ -1124,7 +1126,8 @@
       "activation_message": "You shoot up.",
       "tools_needed": { "syringe": -1 },
       "charges_needed": { "fire": 1 },
-      "effects": [ { "id": "cough_suppress", "duration": "60 m" } ]
+      "effects": [ { "id": "cough_suppress", "duration": "60 m" } ],
+      "vitamins": [ [ "vit_mme", 2000, 7700 ] ]
     }
   },
   {
@@ -1212,7 +1215,8 @@
     "addiction_potential": 50,
     "addiction_type": "amphetamine",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "amphetamine", 17 ] ]
+    "vitamins": [ [ "amphetamine", 17 ] ],
+    "use_action": { "type": "consume_drug", "activation_message": "You snort some speed.", "vitamins": [ [ "amphetamine", 14, 22 ] ] }
   },
   {
     "id": "pure_meth",
@@ -1220,7 +1224,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
     "name": { "str_sp": "crystal meth" },
-    "description": "Tiny crystals of methamphetamine, one of the most potent and addictive stimulants around.  This sample looks quite pure.",
+    "description": "Tiny crystals of methamphetamine, one of the most potent and addictive stimulants around.  This sample is quite pure and should lead to a strong, reliable high.",
     "looks_like": "meth",
     "weight": "1 g",
     "volume": "2 ml",
@@ -1236,7 +1240,8 @@
     "addiction_potential": 40,
     "addiction_type": "amphetamine",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "amphetamine", 25 ] ]
+    "vitamins": [ [ "amphetamine", 25 ] ],
+    "use_action": { "type": "consume_drug", "activation_message": "You snort some crystal meth." }
   },
   {
     "id": "morphine",
@@ -2053,7 +2058,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
     "name": { "str_sp": "cocaine topical cream" },
-    "description": "A medical cream that provides both vascular restriction and anesthetic properties.",
+    "description": "A medical cream that provides both vascular restriction and anesthetic properties.  It won't get you high, but if used too frequently it may still be habit-forming.",
     "weight": "5 g",
     "volume": "250 ml",
     "price": "5 USD 50 cent",

--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -97,7 +97,7 @@
   {
     "id": "morale_craving_speed",
     "type": "morale_type",
-    "text": "Craving speed"
+    "text": "Craving amphetamines"
   },
   {
     "id": "morale_craving_cocaine",
@@ -112,7 +112,7 @@
   {
     "id": "morale_craving_diazepam",
     "type": "morale_type",
-    "text": "Craving prescription sedatives"
+    "text": "Craving benzodiazepines"
   },
   {
     "id": "morale_craving_marloss",
@@ -227,7 +227,7 @@
   {
     "id": "morale_mutagen_elf",
     "type": "morale_type",
-    "text": "Fey mutation"
+    "text": "Sylvan mutation"
   },
   {
     "id": "morale_mutagen_chimera",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -59,6 +59,17 @@
     "disease_excess": [ [ 1, 15 ], [ 16, 20 ], [ 21, 35 ], [ 36, 50 ] ]
   },
   {
+    "id": "cocaine",
+    "type": "vitamin",
+    "vit_type": "drug",
+    "name": { "str": "Cocaine" },
+    "excess": "cocaine",
+    "min": 0,
+    "max": 15,
+    "rate": "20 m",
+    "disease_excess": [ [ 1, 3 ], [ 4, 7 ], [ 8, 10 ], [ 11, 15 ] ]
+  },
+  {
     "id": "betablocker",
     "type": "vitamin",
     "vit_type": "drug",

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -141,21 +141,15 @@ static bool alcohol_add( Character &u, int in )
 static bool benzodiazepine_add( Character &u, int in )
 {
     static time_point last_dia_dream = calendar::turn_zero;
-    const bool recent_dream = ( calendar::turn - last_dia_dream < 2_hours );
+    const bool recent_dream = ( calendar::turn - last_dia_dream < 3_hours );
     const morale_type morale_type = morale_craving_diazepam;
     bool ret = false;
-    u.mod_per_bonus( -1 );
-    u.mod_int_bonus( -1 );
-    if( x_in_y( in, to_turns<int>( 2_hours ) ) ) {
-        u.mod_daily_health( -1, -in * 10 );
-        ret = true;
-    }
     if( one_in( 40 ) && rng( 0, 30 ) < in && ( !u.in_sleep_state() || !recent_dream ) ) {
         const std::string msg_1 = ( u.in_sleep_state() ? "addict_diazepam_mild_asleep" :
                                     "addict_diazepam_mild_awake" );
         u.add_msg_if_player( m_warning,
                              SNIPPET.random_from_category( msg_1 ).value_or( translation() ).translated() );
-        u.add_morale( morale_type, -35, -4 * in );
+        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
         if( u.in_sleep_state() ) {
             last_dia_dream = calendar::turn;
@@ -165,7 +159,7 @@ static bool benzodiazepine_add( Character &u, int in )
                                     "addict_diazepam_strong_awake" );
         u.add_msg_if_player( m_bad,
                              SNIPPET.random_from_category( msg_2 ).value_or( translation() ).translated() );
-        u.add_morale( morale_type, -35, -4 * in );
+        u.add_morale( morale_type, -35, -4 * in, 1_hours, 30_minutes, true );
         u.add_effect( effect_shakes, 5_minutes );
         ret = true;
         if( u.in_sleep_state() ) {
@@ -181,22 +175,21 @@ static bool benzodiazepine_add( Character &u, int in )
 static bool cocaine_add( Character &u, int in )
 {
     static time_point last_coke_dream = calendar::turn_zero;
-    const bool recent_dream = ( calendar::turn - last_coke_dream < 2_hours );
+    const bool recent_dream = ( calendar::turn - last_coke_dream < 3_hours );
     const std::string cur_msg = ( u.in_sleep_state() ? "addict_coke_asleep" : "addict_coke_awake" );
     const morale_type morale_type = morale_craving_cocaine;
     bool ret = false;
     auto run_addict_eff = [&ret, &morale_type]( Character & u, int in, const std::string & snippet ) {
         u.add_msg_if_player( m_warning,
                              SNIPPET.random_from_category( snippet ).value_or( translation() ).translated() );
-        u.add_morale( morale_type, -20, -4 * in );
-        ret = true;
         if( u.in_sleep_state() ) {
             last_coke_dream = calendar::turn;
+        } else {
+            u.add_morale( morale_type, -20, -4 * in, 1_hours, 30_minutes, true );
         }
+        ret = true;
     };
 
-    u.mod_int_bonus( -1 );
-    u.mod_per_bonus( -1 );
     if( one_in( 1000 - 20 * in ) && ( !u.in_sleep_state() || !recent_dream ) ) {
         run_addict_eff( u, in, cur_msg );
     }
@@ -300,22 +293,13 @@ static bool diazepam_effect( Character &u, addiction &add )
 
 static bool opioid_effect( Character &u, addiction &add )
 {
-    static time_point last_dream = calendar::turn_zero;
-    const int in = std::min( 20, add.intensity );
-    if( calendar::once_every( time_duration::from_turns( 100 - in * 4 ) ) &&
-        u.get_painkiller() > 20 - in ) {
-        // Tolerance increases!
-        u.mod_painkiller( -1 );
-    }
-    // No further effects if we're doped up.
     if( u.has_effect( effect_opioid_effect ) ) {
         add.sated = 0_turns;
         u.remove_effect( effect_shakes );
         return false;
     }
-    u.mod_str_bonus( -1 );
-    u.mod_per_bonus( -1 );
-    u.mod_dex_bonus( -1 );
+    static time_point last_dream = calendar::turn_zero;
+    const int in = std::min( 20, add.intensity );
     if( u.get_pain() < in * 2 ) {
         u.mod_pain( 1 );
     }
@@ -357,9 +341,7 @@ static bool amphetamine_effect( Character &u, addiction &add )
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( add.intensity, 20 );
     bool ret = false;
-    u.mod_int_bonus( -1 );
-    u.mod_str_bonus( -1 );
-    if( dice( 2, 100 ) < in && ( !u.in_sleep_state() || calendar::turn - last_dream > 2_hours ) ) {
+    if( dice( 2, 100 ) < in && ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
         const std::string msg =
             u.in_sleep_state() ? "addict_amphetamine_mild_asleep" : "addict_amphetamine_mild_awake";
         u.add_msg_if_player( m_warning,
@@ -371,7 +353,7 @@ static bool amphetamine_effect( Character &u, addiction &add )
         }
         ret = true;
     } else if( one_in( 20 ) && dice( 2, 80 ) < in &&
-               ( !u.in_sleep_state() || calendar::turn - last_dream > 2_hours ) ) {
+               ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
         if( u.in_sleep_state() ) {
             last_dream = calendar::turn;
         }
@@ -382,7 +364,7 @@ static bool amphetamine_effect( Character &u, addiction &add )
         u.add_morale( morale_craving_speed, -25, -4 * in, 1_hours, 30_minutes, true );
         ret = true;
     } else if( one_in( 50 ) && dice( 2, 100 ) < in &&
-               ( !u.in_sleep_state() || calendar::turn - last_dream > 2_hours ) ) {
+               ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
         if( u.in_sleep_state() ) {
             last_dream = calendar::turn;
         }

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -909,16 +909,16 @@ std::string effect::disp_desc( bool reduced ) const
                          _( "pain" ) );
     val = get_avg_mod( "HURT", reduced );
     values.emplace_back( get_percentage( "HURT", val, reduced ), val, _( "damage" ),
-                         _( "damage" ) );
+                         _( "healing" ) );
     val = get_avg_mod( "STAMINA", reduced );
     values.emplace_back( get_percentage( "STAMINA", val, reduced ), val,
-                         _( "stamina recovery" ), _( "fatigue" ) );
+                         _( "invigoration" ), _( "dyspnea" ) );
     val = get_avg_mod( "THIRST", reduced );
     values.emplace_back( get_percentage( "THIRST", val, reduced ), val, _( "thirst" ),
                          _( "quench" ) );
     val = get_avg_mod( "HUNGER", reduced );
     values.emplace_back( get_percentage( "HUNGER", val, reduced ), val, _( "hunger" ),
-                         _( "sate" ) );
+                         _( "satiation" ) );
     val = get_avg_mod( "FATIGUE", reduced );
     values.emplace_back( get_percentage( "FATIGUE", val, reduced ), val, _( "fatigue" ),
                          _( "alertness" ) );


### PR DESCRIPTION
#### Summary
Fix and modernize cocaine

#### Purpose of change
Cocaine was next on the list

#### Describe the solution
- Cocaine and crack are pretty much the same thing, crack's a bit more addictive
- There are four intensities for cocaine, at max intensity you have a small chance of having a heart attack, so uhh don't do that much cocaine
- Illicit drugs (heroin, cocaine, crack, speed) have inconsistent dosing. Crystal meth is pure enough to be consistent. Prescription drugs are consistent.
- Cocaine adds a bit of speed and boosts int, the int boost falls off as you do more, but you get per and eventually even strength bonuses, for that crackhead strength.
- Alcohol gives +1 strength why not.
- Cocaine gives unreliable stamina boosts that start to more frequently become penalties as you get higher.
- Cocaine topical cream doesn't get you high, but it still adds a tiny bit to your addiction.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
