### PR TITLE
Fix some random weapon stuff

### DIFF
--- a/data/json/recipes/practice/melee.json
+++ b/data/json/recipes/practice/melee.json
@@ -34,6 +34,33 @@
     "components": [ [ [ "duct_tape", 10 ] ], [ [ "stick", 1 ], [ "2x4", 1 ] ], [ [ "paper", 10 ] ] ]
   },
   {
+    "id": "prac_stabbing_dummy",
+    "type": "practice",
+    "activity_level": "BRISK_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_MELEE",
+    "name": "stabbing",
+    "description": "Practice your stabbing weapon skill by stabbing a dummy made of rolls of wet paper on a stand.",
+    "skill_used": "stabbing",
+    "skills_required": [ [ "melee", 1 ] ],
+    "time": "1 h",
+    "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
+    "autolearn": [ [ "cutting", 2 ] ],
+    "book_learn": [ [ "mag_stabbing", 1 ], [ "manual_stabbing", 1 ] ],
+    "//": "Only real and powerful stabbing weapons.",
+    "tools": [
+      [
+        [ "real_shivs", 1, "LIST" ],
+        [ "real_knives", 1, "LIST" ],
+        [ "real_thrusting_swords", 1, "LIST" ],
+        [ "real_spears", 1, "LIST" ]
+      ],
+      [ "water", "water_clean" ]
+    ],
+    "//1": "A bunch of duct tape and scrap to repair the dummy with each training session.",
+    "components": [ [ [ "duct_tape", 10 ] ], [ [ "stick", 1 ], [ "2x4", 1 ] ], [ [ "paper", 10 ] ] ]
+  },
+  {
     "id": "prac_bashing_dummy",
     "type": "practice",
     "activity_level": "BRISK_EXERCISE",

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -326,7 +326,7 @@
     "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "drift", -1 ] ] ],
-    "components": [ [ [ "long_pole", 1 ] ], [ [ "leather_patch", 2 ], [ "duct_tape", 4 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "leather_patch", 2 ], [ "duct_tape", 4 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -190,7 +190,7 @@
     "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ], [ "drift", -1 ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -226,14 +226,17 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "skill_used": "fabrication",
-    "difficulty": 2,
-    "time": "20 m",
-    "reversible": true,
-    "decomp_learn": 1,
+    "difficulty": 1,
+    "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.5, "skill_penalty": 0 } ],
-    "components": [ [ [ "duct_tape", 50 ] ], [ [ "blade_scythe", 1 ] ], [ [ "stick_long", 1 ] ] ]
+    "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.5, "skill_penalty": 0.15 } ],
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "HAMMER", "level": 1 }, { "id": "DRILL", "level": 1 } ],
+    "components": [
+      [ [ "spear_shaft", 1 ] ],
+      [ [ "blade_scythe", 1 ] ],
+      [ [ "nails", 2, "LIST" ], [ "nuts_bolts", 2 ] ],
+      [ [ "cordage", 2, "LIST" ], [ "duct_tape", 100 ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -254,7 +257,7 @@
     "using": [ [ "blacksmithing_standard", 24 ], [ "steel_standard", 6 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ], [ "drift", -1 ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -825,7 +828,7 @@
     "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ], [ "drift", -1 ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -846,7 +849,7 @@
     "using": [ [ "blacksmithing_standard", 8 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -867,7 +870,7 @@
     "using": [ [ "blacksmithing_standard", 8 ], [ "steel_standard", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "fur_patch", 2 ], [ "leather_patch", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -889,7 +892,7 @@
     ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "components": [ [ [ "katana", 1 ], [ "wakizashi", 1 ] ], [ [ "stick_long", 1 ] ] ]
+    "components": [ [ [ "katana", 1 ], [ "wakizashi", 1 ] ], [ [ "spear_shaft", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/weapon/stabbing.json
+++ b/data/json/recipes/weapon/stabbing.json
@@ -77,7 +77,7 @@
     ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "components": [ [ [ "stick_long", 1 ] ] ]
+    "components": [ [ [ "spear_shaft", 1 ] ] ]
   },
   {
     "result": "sword_cane",
@@ -251,7 +251,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
       [ [ "bronze_fragment", 4 ] ],
-      [ [ "stick_long", 1 ] ],
+      [ [ "spear_shaft", 1 ] ],
       [ [ "cotton_patch", 2 ], [ "felt_patch", 2 ], [ "leather_patch", 2 ], [ "fur_patch", 2 ] ]
     ]
   },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2844,7 +2844,7 @@
     "time": "6 m",
     "activity_level": "MODERATE_EXERCISE",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "blade_scythe", 1 ] ], [ [ "stick_long", 1 ] ] ]
+    "components": [ [ [ "blade_scythe", 1 ] ], [ [ "spear_shaft", 1 ] ] ]
   },
   {
     "result": "sf_watch",


### PR DESCRIPTION
#### Summary
Fix some random weapon stuff

#### Describe the solution
- A bunch of polearms still used long sticks. Updated them to use spear shafts.
- There wasn't a stabbing practice recipe. I am sure at some point I had a plan for this but it is lost now, so I just copied the cuting one and changed out the weapons.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
