### PR TITLE
Fix some minor things

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1340,7 +1340,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
-    "name": { "str": "nicotine patch" },
+    "name": { "str": "nicotine patch", "str_pl": "nicotine patches" },
     "description": "An adhesive patch that promises to fight cravings and help smokers quit by slowly delivering nicotine into the body over the course of 16 hours as a replacement for smoking.  ",
     "weight": "3 g",
     "volume": "2 ml",
@@ -1351,7 +1351,7 @@
     "addiction_type": "nicotine",
     "addiction_potential": 75,
     "vitamins": [ [ "nicotine_slow", 48 ] ],
-    "flags": [ "NO_INGEST" ],
+    "flags": [ "NO_INGEST", "NO_TEMP" ],
     "use_action": { "type": "consume_drug", "activation_message": "You apply a nicotine patch." }
   },
   {

--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -105,7 +105,7 @@
     "price_postapoc": "2 cent",
     "material": [ "powder" ],
     "volume": "62 ml",
-    "flags": [ "NO_TEMP" ],
+    "flags": [ "NO_TEMP", "INEDIBLE" ],
     "fun": -10
   },
   {
@@ -124,7 +124,7 @@
     "price_postapoc": "1 cent",
     "material": [ "powder" ],
     "volume": "62 ml",
-    "flags": [ "NO_TEMP" ],
+    "flags": [ "NO_TEMP", "INEDIBLE" ],
     "fun": -10
   },
   {
@@ -142,8 +142,8 @@
     "volume": "25 ml",
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
-    "into": "meal_bone_tainted",
-    "recipe": "meal_bone_tainted_mill_6_1"
+    "into": "meal_bone",
+    "recipe": "meal_bone_mill_6_1"
   },
   {
     "type": "ITEM",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1619,7 +1619,7 @@
     "time": "1 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "bone_sturdy", 1, "LIST" ], [ "antler", 1 ] ] ]
+    "components": [ [ [ "bone_sturdy", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Fix some minor things

#### Purpose of change
- NO_TEMP and str_pl for nicotine patches
- Bone skewers mill into bone meal, not tainted bone meal.
- You can't make antlers into bone skewers.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
