### PR TITLE
Fix rough terrain movecost

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10732,14 +10732,13 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
         if( flatground && !is_on_ground() ) {
             float flatground_mult = enchantment_cache->modify_value( enchant_vals::mod::MOVECOST_FLATGROUND_MOD,
                                     1 );
-            run_cost_effect_mul( flatground_mult, _( "Flat Ground Mut." ) );
+            run_cost_effect_mul( flatground_mult, _( "Flat Ground" ) );
         }
 
-
-        if( movecost > 105 ) {
+        if( here.move_cost( pos_bub() ) > 2 ) {
             float obstacle_mult = enchantment_cache->modify_value( enchant_vals::mod::MOVECOST_OBSTACLE_MOD,
                                   1 );
-            run_cost_effect_mul( obstacle_mult, _( "Obstacle Muts." ) );
+            run_cost_effect_mul( obstacle_mult, _( "Rough Terrain" ) );
 
             if( has_proficiency( proficiency_prof_parkour ) && is_running() ) {
                 run_cost_effect_mul( 0.5, _( "Parkour" ) );
@@ -10751,6 +10750,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                 movecost = 100;
             }
         }
+        
         if( has_trait( trait_M_IMMUNE ) && on_fungus ) {
             if( movecost > 75 ) {
                 // Mycal characters are faster on their home territory, even through things like shrubs


### PR DESCRIPTION
#### Summary
Fix rough terrain movecost

#### Purpose of change
Rough terrain movecost penalties from e.g. Bad Knees was being applied whenever move cost was over 100, which would happen whenever the player had any leg encumbrance. This is not how that's supposed to work!

#### Describe the solution
Check the terrain move_cost, not movecost.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
