### PR TITLE
fix practice recipe typo & bolt batch craft

### DIFF
--- a/data/json/recipes/practice/melee.json
+++ b/data/json/recipes/practice/melee.json
@@ -45,7 +45,7 @@
     "skills_required": [ [ "melee", 1 ] ],
     "time": "1 h",
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
-    "autolearn": [ [ "cutting", 2 ] ],
+    "autolearn": [ [ "stabbing", 2 ] ],
     "book_learn": [ [ "mag_stabbing", 1 ], [ "manual_stabbing", 1 ] ],
     "//": "Only real and powerful stabbing weapons.",
     "tools": [

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -368,7 +368,6 @@
     "using": [ [ "forging_standard", 1 ] ],
     "difficulty": 5,
     "time": "30 m",
-    "batch_time_factors": [ 80, 2 ],
     "autolearn": true,
     "book_learn": [ [ "recipe_arrows", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_fletching" }, { "proficiency": "prof_carving" } ],


### PR DESCRIPTION

#### Summary

stab practice requires stab skill not cut skill

remove batch craft from monster bolts

#### Purpose of change

make stabbing practice require stabbing instead of cutting

put monster bolts in line with other bolts

#### Describe the solution

cutting > stabbing

remove batch craft from monster bolts

#### Describe alternatives you've considered

#### Testing

made char with 2 cutting, did not have practice recipe, leveled stab to 2 via debug, had practice recipe

looked at bolt recipe in crafting menu, it looks proper

#### Additional context

this somehow took me 2 hours because I forgot something minor lol
