### PR TITLE
Backport power connection fixes

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10750,7 +10750,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                 movecost = 100;
             }
         }
-        
+
         if( has_trait( trait_M_IMMUNE ) && on_fungus ) {
             if( movecost > 75 ) {
                 // Mycal characters are faster on their home territory, even through things like shrubs

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14618,6 +14618,12 @@ bool item::process_link( map &here, Character *carrier, const tripoint_bub_ms &p
     if( !link().t_veh ) {
         vehicle *found_veh = vehicle::find_vehicle( here, link().t_abs_pos );
         if( !found_veh ) {
+            if( last_t_abs_pos_is_oob ) {
+                // Target is outside the reality bubble -- its submap is probably
+                // just unloaded. Skip processing this turn; the cable will
+                // reconnect when the target submap loads back in.
+                return false;
+            }
             return reset_link( true, carrier, -2, true, pos );
         }
         if( debug_mode ) {
@@ -14825,7 +14831,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Avoid rounding error on full charge
             int received_charges = spent_charges == required_charges
                                    ? wanted_charges
-                                  : static_cast<int>( spent_charges * link().efficiency );
+                                   : static_cast<int>( spent_charges * link().efficiency );
 
             int surplus = linked_veh.charge_battery( here, received_charges, true );
             int actual_received = received_charges - surplus;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14754,7 +14754,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
     }
 
     // Normally efficiency is the chance to get a charge every charge_interval, but if we're catching up from
-    // time spent ouside the reality bubble it should be applied as a percentage of the total instead.
+    // time spent outside the reality bubble it should be applied as a percentage of the total instead.
     bool short_time_passed = turns_elapsed <= link().charge_interval;
 
     if( turns_elapsed < 1 || ( short_time_passed &&
@@ -14763,13 +14763,9 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
         return link().charge_rate;
     }
 
-
-
-
-
     if( power_in ) {
-        int available_charges = linked_veh.battery_power_level( ).first;
-        int wanted_charges = ammo_capacity( itype_battery->ammo->type ) - ammo_remaining( );
+        int available_charges = linked_veh.connected_battery_power_level( here ).first;
+        int wanted_charges = ammo_capacity( ammo_battery ) - ammo_remaining( );
 
         // Nothing to charge or nothing to charge with
         if( wanted_charges == 0 || available_charges == 0 ) {
@@ -14778,27 +14774,28 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
         if( short_time_passed ) {
             // Single charge - subtract one from source, roll against efficiency to add one to destination
-            linked_veh.discharge_battery( here, 1, true );
-            if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
+            int deficit = linked_veh.discharge_battery( here, 1, true );
+            if( deficit == 0 && rng_float( 0.0, 1.0 ) <= link().efficiency ) {
                 ammo_set( itype_battery, ammo_remaining( ) + 1 );
             }
         } else {
             // Multiple charges - get minimum from available charges, possible transfer in given time and
             // amount of charges destination needs to charge itself to full with given efficiency.
             // Subtract that value from the source and after reduction by efficiency add it to the destination.
-            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int possible_transfer =
+                static_cast<int>( turns_elapsed * 1.0f / link().charge_interval );
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
+            int deficit = linked_veh.discharge_battery( here, spent_charges, true );
+            int actual_spent = spent_charges - deficit;
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges
+            int received_charges = actual_spent >= required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
-
-            linked_veh.discharge_battery( here, spent_charges, true );
+                                   : static_cast<int>( actual_spent * link().efficiency );
             ammo_set( itype_battery, ammo_remaining( ) + received_charges );
         }
     } else {
-        const auto [bat_remaining, bat_capacity] = linked_veh.battery_power_level( );
+        const auto [bat_remaining, bat_capacity] = linked_veh.connected_battery_power_level( here );
         int available_charges = ammo_remaining( );
         int wanted_charges = bat_capacity - bat_remaining;
 
@@ -14811,22 +14808,35 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Single charge - subtract one from source, roll against efficiency to add one to destination
             ammo_set( itype_battery, ammo_remaining( ) - 1 );
             if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
-                linked_veh.charge_battery( here, 1, true );
+                int surplus = linked_veh.charge_battery( here, 1, true );
+                if( surplus != 0 ) {
+                    // Battery couldn't accept the charge, refund it
+                    ammo_set( itype_battery, ammo_remaining( ) + 1 );
+                }
             }
         } else {
             // Multiple charges - get minimum from available charges, possible transfer in given time and
             // amount of charges destination needs to charge itself to full with given efficiency.
             // Subtract that value from the source and after reduction by efficiency add it to the destination.
-            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int possible_transfer =
+                static_cast<int>( turns_elapsed * 1.0f / link().charge_interval );
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
             int received_charges = spent_charges == required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
+                                  : static_cast<int>( spent_charges * link().efficiency );
 
-            ammo_set( itype_battery, ammo_remaining( ) - spent_charges );
-            linked_veh.charge_battery( here, received_charges, true );
+            int surplus = linked_veh.charge_battery( here, received_charges, true );
+            int actual_received = received_charges - surplus;
+            // Only deduct from source what was actually accepted (accounting for efficiency)
+            int actual_spent = actual_received == wanted_charges
+                               ? required_charges
+                               : static_cast<int>( actual_received / link().efficiency );
+            // Ensure we don't spend more than planned
+            actual_spent = std::min( actual_spent, spent_charges );
+
+            ammo_set( itype_battery, ammo_remaining( ) - actual_spent );
         }
     }
     return link().charge_rate;


### PR DESCRIPTION
#### Summary
Backport power connection fixes

#### Purpose of change
85175 - Fix grid charging
85846 - don't disconnect cables outside the reality bubble

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
