### PR TITLE
Backport DDA 86301 - Smart watch link_up CTD fix

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -554,8 +554,69 @@
     ],
     "symbol": "[",
     "charges_per_use": 1,
-    "use_action": [ "CAMERA", "MP3", "CALORIES_INTAKE_TRACKER", "FITNESS_CHECK" ],
-    "tool_ammo": "battery",
+    "use_action": [
+      "CALORIES_INTAKE_TRACKER",
+      "FITNESS_CHECK",
+      "PORTABLE_GAME",
+      {
+        "type": "mp3",
+        "transform": "smart_watch_music",
+        "message": "You put in the earbuds and start listening to music.",
+        "activate": true
+      }
+    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } } ],
+    "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ],
+    "tool_ammo": "battery"
+  },
+  {
+    "id": "smart_watch_music",
+    "copy-from": "smart_watch",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "smart watch - music", "str_pl": "smart watches - music" },
+    "description": "This smart watch is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
+    "power_draw": "200 mW",
+    "revert_to": "smart_watch",
+    "use_action": [
+      "CALORIES_INTAKE_TRACKER",
+      "FITNESS_CHECK",
+      "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch", "message": "The smart watch turns off.", "activate": false }
+    ],
+    "tick_action": [ "MP3_ON" ],
+    "extend": { "flags": [ "TRADER_AVOID" ] }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "id": "smart_watch_adv",
+    "name": { "str": "advanced smart watch", "str_pl": "advanced smart watches" },
+    "copy-from": "smart_watch",
+    "description": "A touchscreen watch that comes with many uses, such as a calendar, alarm, and even a fitness app, for when you want to check your health on the go!  This is a more expensive model, featuring a shock-resistant and waterproof case and a bunch of additional sensors.",
+    "price": "700 USD",
+    "price_postapoc": "10 USD",
+    "etransfer_rate": "30 MB",
+    "e_port": "phone",
+    "e_ports_banned": [ "USB-A", "memory card", "camera" ],
+    "extend": { "flags": [ "WATER_FRIENDLY", "THERMOMETER", "HYGROMETER", "BAROMETER", "CAN_USE_IN_DARK" ] },
+    "delete": { "flags": [ "WATER_BREAK", "FRAGILE" ] },
+    "use_action": [
+      "E_FILE_DEVICE",
+      "EBOOKSAVE",
+      "CAMERA",
+      "CALORIES_INTAKE_TRACKER",
+      "FITNESS_CHECK",
+      "WEATHER_TOOL",
+      "PORTABLE_GAME",
+      {
+        "type": "mp3",
+        "transform": "smart_watch_adv_music",
+        "message": "You put in the earbuds and start listening to music.",
+        "activate": true
+      },
+      { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
+    ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } },
       {
@@ -566,6 +627,26 @@
         "weight_multiplier": 0,
         "ememory_max": "256 GB"
       }
+    ]
+  },
+  {
+    "id": "smart_watch_adv_music",
+    "copy-from": "smart_watch_adv",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "advanced smart watch - music", "str_pl": "advanced smart watches - music" },
+    "description": "This advanced smart watch is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
+    "power_draw": "200 mW",
+    "revert_to": "smart_watch_adv",
+    "use_action": [
+      "E_FILE_DEVICE",
+      "EBOOKSAVE",
+      "CAMERA",
+      "CALORIES_INTAKE_TRACKER",
+      "FITNESS_CHECK",
+      "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch_adv", "message": "The smart watch turns off.", "activate": false },
+      { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ]
   },

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14275,7 +14275,13 @@ bool item::has_link_data() const
 
 bool item::can_link_up() const
 {
-    return has_link_data() || type->can_use( "link_up" );
+    const bool can_link = has_link_data() || type->can_use( "link_up" );
+    if( can_link && !get_use( "link_up" ) ) {
+        debugmsg( "can_link_up() found no link_up use function for %s. Most likely missing link_up in item transform",
+                  type_name() );
+        return false;
+    }
+    return can_link;
 }
 
 bool item::link_has_state( link_state state ) const


### PR DESCRIPTION
#### Summary
Backport DDA 86301 - Smart watch link_up CTD fix

#### Purpose of change

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
