### PR TITLE
Backport 86614 and 86239

### DIFF
--- a/data/json/construction/terrain.json
+++ b/data/json/construction/terrain.json
@@ -363,7 +363,7 @@
     "time": "300 m",
     "tools": [ [ [ "pickaxe_list", 1, "LIST" ], [ "jackhammer", 140 ], [ "elec_jackhammer", 1848 ] ] ],
     "byproducts": [ { "group": "mining_rock" } ],
-    "pre_terrain": "t_rock_floor",
+    "pre_terrain": [ "t_rock_floor", "t_rock_floor_no_roof" ],
     "post_terrain": "t_pit",
     "activity_level": "EXTRA_EXERCISE",
     "do_turn_special": "do_turn_shovel"

--- a/data/json/construction/zlvels_transition.json
+++ b/data/json/construction/zlvels_transition.json
@@ -116,7 +116,7 @@
     "byproducts": [ { "group": "mining_rock" } ],
     "activity_level": "EXTRA_EXERCISE",
     "pre_special": "check_down_OK",
-    "pre_terrain": "t_rock_floor",
+    "pre_terrain": [ "t_rock_floor", "t_rock_floor_no_roof" ],
     "post_special": "done_mine_downstair"
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -3493,7 +3493,7 @@
       { "point": [ 2, 0, 1 ], "overmap": "rural_church_steeple_north" },
       { "point": [ 2, 0, 2 ], "overmap": "rural_church_steeple_roof_north" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true } ],
     "locations": [ "forest", "field" ],
     "city_distance": [ 8, 50 ],
     "occurrences": [ 0, 2 ],


### PR DESCRIPTION
#### Summary
Backport 86614 and 86239

#### Purpose of change
86614 - Mine stairs/pits in stone floors with no roof.
86239 - Make rural churches use existing bridges

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
