### PR TITLE
Fix and standardize hand/foot wraps

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1089,7 +1089,7 @@
     "id": "footrags",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "foot rags", "str_pl": "pairs of foot rags" },
+    "name": { "str": "foot wraps", "str_pl": "pairs of foot wraps" },
     "description": "Rags tied around your feet.  Not much of an improvement over being barefoot, but still better than nothing.",
     "weight": "56 g",
     "volume": "250 ml",
@@ -1103,7 +1103,7 @@
     "material_thickness": 0.4,
     "flags": [ "SKINTIGHT", "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 10, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 4,
         "coverage": 85,
@@ -1130,7 +1130,7 @@
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 6,
         "coverage": 85,
@@ -1157,7 +1157,7 @@
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 15, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 6,
         "coverage": 85,
@@ -1184,7 +1184,7 @@
     "material_thickness": 1.5,
     "flags": [ "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 14, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 5,
         "coverage": 85,
@@ -1211,7 +1211,7 @@
     "material_thickness": 0.6,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 11, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 5,
         "coverage": 85,
@@ -1238,7 +1238,7 @@
     "material_thickness": 0.4,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
-      { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
+      { "encumbrance": 10, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
       {
         "encumbrance": 4,
         "coverage": 85,

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1100,7 +1100,7 @@
     "looks_like": "socks",
     "color": "white",
     "warmth": 5,
-    "material_thickness": 1.5,
+    "material_thickness": 0.4,
     "flags": [ "SKINTIGHT", "UNRESTRICTED", "OVERSIZE", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
       { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
@@ -1208,7 +1208,7 @@
     "looks_like": "socks_wool",
     "color": "blue",
     "warmth": 15,
-    "material_thickness": 1.5,
+    "material_thickness": 0.6,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
       { "encumbrance": 13, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },
@@ -1235,7 +1235,7 @@
     "looks_like": "socks_nomex",
     "color": "blue",
     "warmth": 15,
-    "material_thickness": 1.5,
+    "material_thickness": 0.4,
     "flags": [ "SKINTIGHT", "OVERSIZE", "UNRESTRICTED", "ALLOWS_NATURAL_ATTACKS", "ALLOWS_TALONS" ],
     "armor": [
       { "encumbrance": 12, "coverage": 65, "covers": [ "foot_l", "foot_r" ] },

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -932,7 +932,7 @@
     "weight": "100 g",
     "volume": "250 ml",
     "price": "5 USD",
-    "price_postapoc": "10 cent",
+    "price_postapoc": "0 cent",
     "to_hit": 2,
     "material": [ "cotton" ],
     "symbol": "[",
@@ -941,8 +941,27 @@
     "warmth": 5,
     "material_thickness": 0.4,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
-    "armor": [ { "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
-    "melee_damage": { "bash": 1 }
+    "armor": [ { "encumbrance": 3, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ]
+  },
+  {
+    "id": "gloves_wraps_nomex",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "Nomex hand wraps", "str_pl": "pairs of Nomex hand wraps" },
+    "description": "Long pieces of Nomex fabric that are meant to be wrapped around the hands.",
+    "weight": "100 g",
+    "volume": "250 ml",
+    "price": "5 USD",
+    "price_postapoc": "5 cent",
+    "to_hit": 2,
+    "material": [ "nomex" ],
+    "symbol": "[",
+    "looks_like": "gloves_light",
+    "color": "yellow",
+    "warmth": 5,
+    "material_thickness": 0.4,
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
+    "armor": [ { "encumbrance": 3, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
     "id": "gloves_wraps_fur",
@@ -953,7 +972,7 @@
     "weight": "250 g",
     "volume": "500 ml",
     "price": "7 USD",
-    "price_postapoc": "10 cent",
+    "price_postapoc": "3 cent",
     "to_hit": 2,
     "material": [ "fur" ],
     "symbol": "[",
@@ -962,7 +981,28 @@
     "warmth": 20,
     "material_thickness": 1.5,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
-    "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
+    "armor": [ { "encumbrance": 7, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
+    "melee_damage": { "bash": 2 }
+  },
+  {
+    "id": "gloves_wraps_faux_fur",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "faux fur hand wraps", "str_pl": "pairs of faux fur hand wraps" },
+    "description": "Pieces of fake fur that are meant to be wrapped around the hands.",
+    "weight": "250 g",
+    "volume": "500 ml",
+    "price": "7 USD",
+    "price_postapoc": "3 cent",
+    "to_hit": 2,
+    "material": [ "faux_fur" ],
+    "symbol": "[",
+    "looks_like": "gloves_wraps",
+    "color": "magenta",
+    "warmth": 20,
+    "material_thickness": 1.5,
+    "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
+    "armor": [ { "encumbrance": 7, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -974,7 +1014,7 @@
     "weight": "200 g",
     "volume": "500 ml",
     "price": "5 USD 25 cent",
-    "price_postapoc": "10 cent",
+    "price_postapoc": "3 cent",
     "to_hit": 2,
     "material": [ "leather" ],
     "symbol": "[",
@@ -983,7 +1023,7 @@
     "warmth": 10,
     "material_thickness": 1.5,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
-    "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
+    "armor": [ { "encumbrance": 7, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -995,7 +1035,7 @@
     "weight": "100 g",
     "volume": "250 ml",
     "price": "5 USD",
-    "price_postapoc": "10 cent",
+    "price_postapoc": "2 cent",
     "to_hit": 2,
     "material": [ "wool" ],
     "symbol": "[",
@@ -1004,7 +1044,7 @@
     "warmth": 15,
     "material_thickness": 0.6,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
-    "armor": [ { "encumbrance": 2, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ]
+    "armor": [ { "encumbrance": 4, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ]
   },
   {
     "id": "long_glove_white",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -939,7 +939,7 @@
     "looks_like": "gloves_light",
     "color": "white",
     "warmth": 5,
-    "material_thickness": 2,
+    "material_thickness": 0.4,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
     "armor": [ { "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 1 }
@@ -960,7 +960,7 @@
     "looks_like": "gloves_wraps",
     "color": "brown",
     "warmth": 20,
-    "material_thickness": 2,
+    "material_thickness": 1.5,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
     "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
@@ -981,7 +981,7 @@
     "looks_like": "gloves_wraps",
     "color": "brown",
     "warmth": 10,
-    "material_thickness": 2,
+    "material_thickness": 1.5,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
     "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ],
     "melee_damage": { "bash": 2 }
@@ -1002,7 +1002,7 @@
     "looks_like": "gloves_wraps",
     "color": "blue",
     "warmth": 15,
-    "material_thickness": 2,
+    "material_thickness": 0.6,
     "flags": [ "ALLOWS_NATURAL_ATTACKS", "UNRESTRICTED", "OVERSIZE", "MITTS" ],
     "armor": [ { "encumbrance": 2, "coverage": 60, "covers": [ "hand_l", "hand_r" ] } ]
   },

--- a/data/json/recipes/armor/hands.json
+++ b/data/json/recipes/armor/hands.json
@@ -576,8 +576,21 @@
     "time": "1 m",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_patch_simple", 6 ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "cotton_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_wraps_nomex",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "tailor",
+    "time": "1 m",
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "nomex_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wraps_fur",
@@ -589,8 +602,21 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "fur_patch", 6 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "fur_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "gloves_wraps_faux_fur",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HANDS",
+    "skill_used": "tailor",
+    "time": "1 m 30 s",
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "faux_fur_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wraps_leather",
@@ -602,8 +628,8 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "leather_patch", 6 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "leather_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wraps_wool",
@@ -615,8 +641,8 @@
     "time": "1 m",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "felt_patch", 6 ] ] ],
-    "flags": [ "BLIND_HARD" ]
+    "components": [ [ [ "felt_sheet", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "gloves_wsurvivor",


### PR DESCRIPTION
#### Summary
Fix and standardize hand/foot wraps

#### Purpose of change
- Thicknesses were weird
- There were more types of foot than handwraps
- handwraps were made out of 6 patches(??)

#### Describe the solution
- Handwraps are now 2 sheets, like footwraps.
- Thicknesses are standardized.
- Cloth handwraps don't add unarmed damage(???)
- Reduced encumbrance for all footwraps, raised it for all handwraps.
- Added faux fur and Nomex handwraps.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
