### PR TITLE
Improve flat ground and barefoot checks

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10726,7 +10726,7 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
             run_cost_effect_mul( 1.5f, _( "Swim Fins" ) );
         }
         const bool vehicle_floor = here.has_vehicle_floor( pos_bub() );
-        const bool flatground = here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() );
+        const bool flatground = ( here.move_cost( pos_bub() ) <= 2 || here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() ) );
         const bool on_road = here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() );
         const bool on_fungus = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, pos_bub() );
         if( flatground && !is_on_ground() ) {
@@ -10817,8 +10817,6 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
             run_cost_effect_add( 10, _( "Roots" ) );
         }
     }
-
-
 
     // Snow depth movement penalty (outdoor, unroofed tiles only)
     if( here.is_outside( pos_bub() ) && !here.is_roofed( pos_bub() ) ) {


### PR DESCRIPTION
#### Summary
Improve flat ground and barefoot checks

#### Purpose of change
Flatground was just checking for ROAD, but it should be ROAD and/or movecost <= 2.
Barefoot had the same issue.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
