### PR TITLE
Antler fixes

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1027,7 +1027,6 @@
       { "item": "awl_bone", "prob": 50, "damage": [ 0, 4 ] },
       { "item": "billet_bone", "prob": 20, "damage": [ 0, 4 ] },
       { "item": "billet_wood", "prob": 20, "damage": [ 0, 4 ] },
-      { "item": "button_horn", "prob": 3, "charges": [ 1, 6 ], "damage": [ 0, 4 ] },
       { "item": "button_wood", "prob": 3, "charges": [ 1, 6 ], "damage": [ 0, 4 ] },
       { "item": "button_bone", "prob": 3, "charges": [ 1, 6 ], "damage": [ 0, 4 ] },
       { "item": "loincloth_leather", "prob": 10, "damage": [ 0, 4 ] },

--- a/data/json/items/resources/fasteners.json
+++ b/data/json/items/resources/fasteners.json
@@ -75,15 +75,6 @@
     "material": [ "bone" ]
   },
   {
-    "id": "button_horn",
-    "copy-from": "button_plastic",
-    "type": "ITEM",
-    "subtypes": [ "AMMO" ],
-    "name": { "str": "horn button" },
-    "description": "A clothing button carved from horn.",
-    "material": [ "keratin" ]
-  },
-  {
     "id": "snapfastener_steel",
     "copy-from": "button_steel",
     "type": "ITEM",

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -59,13 +59,15 @@
     "name": { "str": "antler" },
     "description": "A branching length of antler, dropped by or harvested from one of the local ungulates terrorizing the region.",
     "price": "0 cent",
-    "material": [ "keratin" ],
+    "material": [ "bone" ],
     "techniques": [ "WBLOCK_1" ],
     "weight": "1400 g",
     "volume": "800 ml",
     "longest_side": "40 cm",
     "to_hit": { "grip": "solid", "length": "hand", "surface": "line", "balance": "clumsy" },
-    "melee_damage": { "bash": 3 }
+    "melee_damage": { "bash": 3 },
+    "into": "meal_bone",
+    "recipe": "meal_bone_mill_1_4"
   },
   {
     "type": "ITEM",
@@ -75,7 +77,7 @@
     "name": { "str": "antler piece" },
     "description": "A small section of antler that has been cut into more manageable pieces.",
     "price": "0 cent",
-    "material": [ "keratin" ],
+    "material": [ "bone" ],
     "techniques": [ "WBLOCK_1" ],
     "weight": "140 g",
     "volume": "80 ml",

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -53,6 +53,7 @@
   },
   {
     "type": "ITEM",
+    "subtypes": [ "MILLING" ],
     "id": "antler",
     "symbol": "%",
     "color": "white",
@@ -71,6 +72,7 @@
   },
   {
     "type": "ITEM",
+    "subtypes": [ "MILLING" ],
     "id": "antler_piece",
     "symbol": "%",
     "color": "white",
@@ -82,7 +84,9 @@
     "weight": "140 g",
     "volume": "80 ml",
     "longest_side": "4 cm",
-    "to_hit": -2
+    "to_hit": -2,
+    "into": "meal_bone",
+    "recipe": "meal_bone_mill_1_1"
   },
   {
     "type": "ITEM",

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -4052,5 +4052,10 @@
     "type": "MIGRATION",
     "id": "benelli_tsa",
     "replace": "m2"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "button_horn",
+    "replace": "button_bone"
   }
 ]

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1443,26 +1443,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "button_horn",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_MATERIALS",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "time": "30 m",
-    "charges": 3,
-    "autolearn": true,
-    "qualities": [
-      { "id": "SAW_W", "level": 1 },
-      [ { "id": "PUNCH", "level": 1 }, { "id": "DRILL", "level": 1 } ],
-      { "id": "CUT", "level": 2 },
-      { "id": "FILE", "level": 1 }
-    ],
-    "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ [ "antler_piece", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "button_bone",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -57,7 +57,7 @@
     "id": "bone_sturdy",
     "type": "requirement",
     "//": "Any kind of bones, human or not.  Tainted bones are too brittle and won't work for this purpose.",
-    "components": [ [ [ "bone", 1 ], [ "bone_human", 1 ] ] ]
+    "components": [ [ [ "bone", 1 ], [ "bone_human", 1 ], [ "antler", 1 ] ] ]
   },
   {
     "id": "bone_any",


### PR DESCRIPTION
#### Summary
Antler fixes

#### Purpose of change
Antlers are made of bone, not horn.

#### Describe the solution
Antlers and antler pieces keratin -> bone
Antlers usable for bone crafts
Migrate horn buttons to bone buttons

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
