### PR TITLE
Separate keybinds for rockwheel and plow

### DIFF
--- a/data/raw/keybindings/vehicle.json
+++ b/data/raw/keybindings/vehicle.json
@@ -329,6 +329,13 @@
     "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
+    "id": "TOGGLE_ROCKWHEEL",
+    "type": "keybinding",
+    "category": "VEHICLE",
+    "name": "Toggle rockwheel",
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+  },
+  {
     "id": "TOGGLE_REACTOR",
     "type": "keybinding",
     "category": "VEHICLE",

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -358,7 +358,7 @@ void vehicle::build_electronics_menu( map &here, veh_menu &menu )
     add_toggle( pgettext( "electronics menu option", "planter" ),
                 "TOGGLE_PLANTER", "PLANTER" );
     add_toggle( pgettext( "electronics menu option", "rockwheel" ),
-                "TOGGLE_PLOW", "ROCKWHEEL" );
+                "TOGGLE_ROCKWHEEL", "ROCKWHEEL" );
     add_toggle( pgettext( "electronics menu option", "roadheader" ),
                 "TOGGLE_PLOW", "ROADHEAD" );
     add_toggle( pgettext( "electronics menu option", "scoop" ),


### PR DESCRIPTION
#### Summary
Separate keybinds for rockwheel and plow

#### Purpose of change
The vehicle-interaction menu hotkey for rockwheels was fixed to be the same as for plows.

#### Describe the solution
This change separates them, allowing customization via the [?] key, but keeps the default keys the same as before ([w]).

#### Describe alternatives you've considered
Keep making little pits of failure instead of turning off the plow
<img width="471" height="388" alt="image" src="https://github.com/user-attachments/assets/850ec519-faeb-4f37-ab04-75690eade5e4" />

#### Testing
<img width="797" height="578" alt="image" src="https://github.com/user-attachments/assets/e81744db-6721-4ea1-9c01-5b7a9bcb1a8a" />
I was able to rebind the key and toggle the rockwheel separately from the plow with keyboard shortcuts.
<img width="497" height="257" alt="image" src="https://github.com/user-attachments/assets/8873645e-c096-4ead-aed6-b6df541e87d4" />

#### Additional context
Just like this chimera mutant, his tractor has features from all species of tractors.

Having a rockwheel for farming is handy to dig up rocky soil, to fill back in for farmable land.
However, unlike the "Dig a Shallow Pit" construction action, rockwheels don't create soil/rocks/earthworms/etc.
That should probably get fixed at some point.