### PR TITLE
Gates are not atom smashers

### DIFF
--- a/data/json/gates.json
+++ b/data/json/gates.json
@@ -13,7 +13,7 @@
       "fail": "The gate can't be closed!"
     },
     "moves": 1800,
-    "bashing_damage": 40
+    "bashing_damage": 5
   },
   {
     "type": "gate",
@@ -38,7 +38,7 @@
       "fail": "The gate can't be closed!"
     },
     "moves": 1800,
-    "bashing_damage": 40
+    "bashing_damage": 10
   },
   {
     "type": "gate",
@@ -84,7 +84,7 @@
       "fail": "The barn doors can't be closed!"
     },
     "moves": 1800,
-    "bashing_damage": 40
+    "bashing_damage": 0
   },
   {
     "type": "gate",
@@ -99,7 +99,7 @@
       "fail": "The palisade gate can't be closed!"
     },
     "moves": 1800,
-    "bashing_damage": 30
+    "bashing_damage": 5
   },
   {
     "type": "gate",
@@ -114,7 +114,7 @@
       "fail": "The palisade gate can't be closed!"
     },
     "moves": 1800,
-    "bashing_damage": 30
+    "bashing_damage": 5
   },
   {
     "type": "gate",
@@ -129,6 +129,6 @@
       "fail": "The door can't be closed!"
     },
     "moves": 1200,
-    "bashing_damage": 60
+    "bashing_damage": 5
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10726,7 +10726,8 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
             run_cost_effect_mul( 1.5f, _( "Swim Fins" ) );
         }
         const bool vehicle_floor = here.has_vehicle_floor( pos_bub() );
-        const bool flatground = ( here.move_cost( pos_bub() ) <= 2 || here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() ) );
+        const bool flatground = ( here.move_cost( pos_bub() ) <= 2 ||
+                                  here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() ) );
         const bool on_road = here.has_flag( ter_furn_flag::TFLAG_ROAD, pos_bub() );
         const bool on_fungus = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, pos_bub() );
         if( flatground && !is_on_ground() ) {

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -454,6 +454,15 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
             return false;
         }
     }
+    if( m.has_furn( p ) ) {
+        if( bash_dmg <= 0 ) {
+            return false;
+        }
+        m.bash( p, bash_dmg );
+        if( m.has_furn( p ) ) {
+            return false;
+        }
+    }
     if( bash_dmg < 0 && !m.i_at( point_bub_ms( x, y ) ).empty() ) {
         return false;
     }
@@ -471,6 +480,7 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
             return false;
         }
     }
+
 
     m.ter_set( point_bub_ms( x, y ), door_type );
     if( m.has_flag( ter_furn_flag::TFLAG_NOITEM, point_bub_ms( x, y ) ) ) {


### PR DESCRIPTION
#### Summary
Gates are not atom smashers

#### Purpose of change
Gates were bashing for 40 damage and not caring if there was furniture in the way. This meant you could close them even if there was stuff there and they'd smash open safes.

#### Describe the solution
- Gates now do 0 to 10 bash instead of 40. Most such devices IRL have safety measures so they don't obliterate toddlers.
- Gates won't close if furniture is in the way. They will try to bash it first.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
