### PR TITLE
Stop drugs from double dosing

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3424,7 +3424,7 @@
   {
     "type": "effect_type",
     "id": "cocaine",
-    "name": [ "Sharp", "Wired", "Geeked", "Whiteout" ],
+    "name": [ "Cocaine Buzz", "Coked Up", "Geeked", "Whiteout" ],
     "desc": [
       "You've got a mild cocaine buzz going.  Feels good, feels clean.",
       "You're feeling chatty and energized, and probably way too confident.",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1921,8 +1921,7 @@
     "name": { "str": "wasp venom gland" },
     "description": "A fragile, slightly quivering organ for the production and storage of wasp venom.  You could extract some very useful chemicals from it with the right know-how, but only if you hurry.",
     "color": "light_green",
-    "fun": -50,
-    "use_action": [ "POISON" ]
+    "flags": [ "INEDIBLE" ]
   },
   {
     "id": "venom_bee",
@@ -1932,8 +1931,7 @@
     "name": { "str": "bee venom gland" },
     "description": "A fragile, slightly quivering organ for the production and storage of honeybee venom.  You could extract some very useful chemicals from it with the right know-how, but only if you hurry.",
     "color": "yellow",
-    "fun": -50,
-    "use_action": [ "POISON" ]
+    "flags": [ "INEDIBLE" ]
   },
   {
     "id": "venom_paralytic",
@@ -1945,7 +1943,7 @@
     "material": [ "vegetable" ],
     "color": "light_gray",
     "fun": -50,
-    "vitamins": [ [ "vegetable_allergen", 1 ] ]
+    "flags": [ "INEDIBLE" ]
   },
   {
     "id": "triffid_fungicide",
@@ -1956,8 +1954,7 @@
     "description": "A triffid sac filled with what appears to be a triffid-produced antifungal agent.  It will likely already work as an antifungal compound for more offensive applications, but requires further refining before it can be used as a medical drug.",
     "material": [ "vegetable" ],
     "color": "light_blue",
-    "fun": -50,
-    "vitamins": [ [ "vegetable_allergen", 1 ] ]
+    "flags": [ "INEDIBLE" ]
   },
   {
     "id": "conc_venom",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -40,8 +40,11 @@
     "addiction_potential": 10,
     "addiction_type": "amphetamine",
     "flags": [ "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "amphetamine", 5 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a dextroamphetamine pill." }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take a dextroamphetamine pill.",
+      "vitamins": [ [ "amphetamine", 5 ] ]
+    }
   },
   {
     "id": "adrenaline_injector",
@@ -137,7 +140,11 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "vit_bloodthinner", 2160 ], [ "vit_nsaid", 500 ], [ "vit_nsaid_bp", 420 ] ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take an aspirin.",
+      "vitamins": [ [ "vit_bloodthinner", 2160 ], [ "vit_nsaid", 500 ], [ "vit_nsaid_bp", 420 ] ]
+    }
   },
   {
     "id": "ibuprofen",
@@ -156,8 +163,11 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take an ibuprofen tablet." },
-    "vitamins": [ [ "vit_nsaid", 400 ], [ "vit_nsaid_bp", 420 ] ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take an ibuprofen.",
+      "vitamins": [ [ "vit_nsaid", 400 ], [ "vit_nsaid_bp", 420 ] ]
+    }
   },
   {
     "id": "naproxen",
@@ -176,8 +186,7 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a naproxen tablet." },
-    "vitamins": [ [ "vit_naproxen", 250 ] ]
+    "use_action": { "type": "consume_drug", "activation_message": "You take a naproxen tablet.", "vitamins": [ [ "vit_naproxen", 250 ] ] }
   },
   {
     "id": "acetaminophen",
@@ -196,8 +205,11 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take some acetaminophen." },
-    "vitamins": [ [ "vit_acetaminophen", 500 ] ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take some acetaminophen.",
+      "vitamins": [ [ "vit_acetaminophen", 500 ] ]
+    }
   },
   {
     "id": "metaprolol",
@@ -216,8 +228,7 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take some metaprolol." },
-    "vitamins": [ [ "betablocker", 864 ] ]
+    "use_action": { "type": "consume_drug", "activation_message": "You take a metaprolol.", "vitamins": [ [ "betablocker", 864 ] ] }
   },
   {
     "id": "bfipowder",
@@ -276,8 +287,7 @@
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
     "addiction_potential": 3,
     "addiction_type": "caffeine",
-    "vitamins": [ [ "caffeine", 100 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a caffeine pill." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a caffeine pill.", "vitamins": [ [ "caffeine", 100 ] ] }
   },
   {
     "id": "chaw",
@@ -359,11 +369,12 @@
     "color": "light_cyan",
     "material": "plastic",
     "flags": [ "NO_INGEST" ],
-    "vitamins": [ [ "vit_naloxone", 400 ], [ "vit_tramadol", -200 ], [ "vit_mme", -1250 ] ],
+    "fun": -20,
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You spray the naloxone up your nose.",
-      "effects": [ { "id": "nausea", "duration": "4 m" }, { "id": "naloxone_eff", "duration": "1 s" } ]
+      "effects": [ { "id": "nausea", "duration": "4 m" }, { "id": "naloxone_eff", "duration": "1 s" } ],
+      "vitamins": [ [ "vit_naloxone", 400 ], [ "vit_tramadol", -200 ], [ "vit_mme", -1250 ] ]
     }
   },
   {
@@ -448,12 +459,12 @@
     "fun": 10,
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
     "addiction_potential": 10,
-    "vitamins": [ [ "vit_mme", 450 ] ],
     "addiction_type": "opioid",
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some codeine.",
-      "effects": [ { "id": "cough_suppress", "duration": "2 h" } ]
+      "effects": [ { "id": "cough_suppress", "duration": "2 h" } ],
+      "vitamins": [ [ "vit_mme", 450 ] ]
     }
   },
   {
@@ -476,7 +487,6 @@
     "addiction_potential": 25,
     "addiction_type": "cocaine",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "cocaine", 1 ] ],
     "use_action": { "type": "consume_drug", "activation_message": "You snort a bump of cocaine.", "vitamins": [ [ "cocaine", 1, 3 ] ] }
   },
   {
@@ -839,7 +849,6 @@
     "addiction_potential": 30,
     "addiction_type": "cocaine",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "cocaine", 1 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke your crack rocks.",
@@ -868,8 +877,11 @@
     "flags": [ "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE" ],
     "addiction_potential": 8,
     "addiction_type": "sleeping pill",
-    "vitamins": [ [ "vit_acetaminophen", 500 ], [ "dextromethorphan", 30 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You drink your cough syrup." }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You drink your cough syrup.",
+      "vitamins": [ [ "vit_acetaminophen", 500 ], [ "dextromethorphan", 30 ] ]
+    }
   },
   {
     "id": "disinfectant",
@@ -1117,7 +1129,6 @@
     "container": "bag_zipper",
     "healthy": -5,
     "fun": 30,
-    "vitamins": [ [ "vit_mme", 3500 ] ],
     "addiction_potential": 75,
     "addiction_type": "opioid",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
@@ -1215,7 +1226,6 @@
     "addiction_potential": 50,
     "addiction_type": "amphetamine",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "amphetamine", 17 ] ],
     "use_action": { "type": "consume_drug", "activation_message": "You snort some speed.", "vitamins": [ [ "amphetamine", 14, 22 ] ] }
   },
   {
@@ -1240,8 +1250,7 @@
     "addiction_potential": 40,
     "addiction_type": "amphetamine",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "NO_TEMP" ],
-    "vitamins": [ [ "amphetamine", 25 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You snort some crystal meth." }
+    "use_action": { "type": "consume_drug", "activation_message": "You snort some crystal meth.", "vitamins": [ [ "amphetamine", 25 ] ] }
   },
   {
     "id": "morphine",
@@ -1262,9 +1271,13 @@
     "fun": 20,
     "addiction_potential": 25,
     "addiction_type": "opioid",
-    "vitamins": [ [ "vit_mme", 1000 ] ],
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You shoot up.", "tools_needed": { "syringe": -1 } }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You shoot up.",
+      "tools_needed": { "syringe": -1 },
+      "vitamins": [ [ "vit_mme", 1000 ] ]
+    }
   },
   {
     "id": "wintergreen_oil",
@@ -1350,9 +1363,8 @@
     "color": "yellow",
     "addiction_type": "nicotine",
     "addiction_potential": 75,
-    "vitamins": [ [ "nicotine_slow", 48 ] ],
     "flags": [ "NO_INGEST", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You apply a nicotine patch." }
+    "use_action": { "type": "consume_drug", "activation_message": "You apply a nicotine patch.", "vitamins": [ [ "nicotine_slow", 48 ] ] }
   },
   {
     "id": "nyquil",
@@ -1374,8 +1386,11 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "addiction_potential": 14,
     "addiction_type": "sleeping pill",
-    "vitamins": [ [ "vit_acetaminophen", 500 ], [ "diphenhydramine", 30 ], [ "dextromethorphan", 30 ], [ "ethanol", 2 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You drink your cough syrup." }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You drink your cough syrup.",
+      "vitamins": [ [ "vit_acetaminophen", 500 ], [ "diphenhydramine", 30 ], [ "dextromethorphan", 30 ], [ "ethanol", 2 ] ]
+    }
   },
   {
     "id": "antihistamine",
@@ -1395,8 +1410,11 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "addiction_potential": 4,
     "addiction_type": "sleeping pill",
-    "vitamins": [ [ "diphenhydramine", 30 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take an antihistamine pill." }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take an antihistamine pill.",
+      "vitamins": [ [ "diphenhydramine", 30 ] ]
+    }
   },
   {
     "id": "oxycodone",
@@ -1418,9 +1436,8 @@
     "fun": 25,
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "addiction_potential": 16,
-    "vitamins": [ [ "vit_mme", 750 ] ],
     "addiction_type": "opioid",
-    "use_action": { "type": "consume_drug", "activation_message": "You take some oxycodone." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take some oxycodone.", "vitamins": [ [ "vit_mme", 750 ] ] }
   },
   {
     "id": "pills_sleep",
@@ -1441,8 +1458,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NO_TEMP" ],
     "addiction_potential": 30,
     "addiction_type": "sleeping pill",
-    "vitamins": [ [ "zolpidem", 5 ] ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a sleeping pill." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take a sleeping pill.", "vitamins": [ [ "zolpidem", 5 ] ] }
   },
   {
     "id": "opium_tar",
@@ -1462,7 +1478,6 @@
     "healthy": -2,
     "addiction_potential": 15,
     "addiction_type": "opioid",
-    "vitamins": [ [ "vit_mme", 350 ] ],
     "fun": 10,
     "flags": [ "NO_TEMP" ],
     "use_action": {
@@ -1634,14 +1649,14 @@
     "addiction_potential": 50,
     "addiction_type": "nicotine",
     "flags": [ "NO_INGEST", "NO_TEMP" ],
-    "vitamins": [ [ "nicotine", 2 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke some tobacco.",
       "fields_produced": { "fd_cigsmoke": 2 },
       "charges_needed": { "fire": 1 },
       "tools_needed": { "apparatus": -1 },
-      "moves": 250
+      "moves": 250,
+      "vitamins": [ [ "nicotine", 2 ] ]
     }
   },
   {
@@ -1660,11 +1675,10 @@
     "color": "yellow",
     "container": "bottle_plastic_pill_prescription",
     "fun": 8,
-    "vitamins": [ [ "vit_tramadol", 5 ] ],
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "addiction_potential": 6,
     "addiction_type": "opioid",
-    "use_action": { "type": "consume_drug", "activation_message": "You take some tramadol." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take some tramadol.", "vitamins": [ [ "vit_tramadol", 5 ] ] }
   },
   {
     "id": "vitamins",
@@ -1686,10 +1700,7 @@
       "type": "consume_drug",
       "activation_message": "You take a multivitamin.",
       "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitC", 24, 48 ] ]
-    },
-    "//": "Yes, the vitamins are intentionally duplicated here. The consume/use/iteminfo UI needs them in use_action, but to actually pass on the vitamins they need to be in the comestible data, as below.",
-    "//2": "TODO: Fix this...",
-    "vitamins": [ [ "calcium", 36 ], [ "iron", 36 ], [ "vitC", 36 ] ]
+    }
   },
   {
     "id": "calcium_tablet",
@@ -1707,8 +1718,7 @@
     "symbol": "!",
     "color": "magenta",
     "container": "bottle_plastic_pill_supplement",
-    "use_action": { "type": "consume_drug", "activation_message": "You take a calcium tablet.", "vitamins": [ [ "calcium", 75 ] ] },
-    "vitamins": [ [ "calcium", 75 ] ]
+    "use_action": { "type": "consume_drug", "activation_message": "You take a calcium tablet.", "vitamins": [ [ "calcium", 75 ] ] }
   },
   {
     "id": "bonemeal_tablet",
@@ -1729,7 +1739,7 @@
     "looks_like": "calcium_tablet",
     "flags": [ "NO_TEMP" ],
     "use_action": { "type": "consume_drug", "activation_message": "You take a bone meal tablet.", "vitamins": [ [ "calcium", 24 ] ] },
-    "vitamins": [ [ "meat_allergen", 1 ], [ "calcium", 24 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
     "id": "flavored_bonemeal_tablet",
@@ -1754,7 +1764,7 @@
       "activation_message": "You take a flavored bone meal tablet.",
       "vitamins": [ [ "calcium", 23 ] ]
     },
-    "vitamins": [ [ "meat_allergen", 1 ], [ "calcium", 23 ] ]
+    "vitamins": [ [ "meat_allergen", 1 ] ]
   },
   {
     "id": "vitc_tablet",
@@ -1771,8 +1781,7 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "symbol": "!",
     "color": "magenta",
-    "use_action": { "type": "consume_drug", "activation_message": "You take a vitamin C tablet.", "vitamins": [ [ "vitC", 556 ] ] },
-    "vitamins": [ [ "vitC", 556 ] ]
+    "use_action": { "type": "consume_drug", "activation_message": "You take a vitamin C tablet.", "vitamins": [ [ "vitC", 556 ] ] }
   },
   {
     "id": "gummy_vitamins",
@@ -1851,8 +1860,7 @@
       "activation_message": "You inject some iron.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "iron", 100 ] ]
-    },
-    "vitamins": [ [ "iron", 100 ] ]
+    }
   },
   {
     "id": "weed",
@@ -1882,8 +1890,7 @@
       "tools_needed": { "apparatus": -1 },
       "moves": 1500,
       "vitamins": [ [ "cannabis", 7 ] ]
-    },
-    "vitamins": [ [ "vegetable_allergen", 1 ] ]
+    }
   },
   {
     "id": "xanax",
@@ -1974,8 +1981,7 @@
       "activation_message": "You take an antacid tablet.",
       "effects": [ { "id": "tummy_tablet", "duration": 6400 } ],
       "vitamins": [ [ "calcium", 25 ] ]
-    },
-    "vitamins": [ [ "calcium", 25 ] ]
+    }
   },
   {
     "id": "panacea",


### PR DESCRIPTION
#### Summary
Stop drugs from double dosing

#### Purpose of change
Drugs with vitamins in their use_action and in their general comestible data were double dosing.

#### Describe the solution
Move vitamins to inside the use_action whenever possible.

#### Describe alternatives you've considered

#### Testing
Seems fine.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
