### PR TITLE
Fix winter survivor hood encumbrance

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -204,7 +204,7 @@
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_nape" ],
         "coverage": 100,
-        "encumbrance": [ 9, 9 ]
+        "encumbrance": [ 22, 22 ]
       },
       {
         "material": [


### PR DESCRIPTION
#### Summary
Fix winter survivor hood encumbrance

#### Purpose of change
The faux fur winter survivor hood's encumbrance was too low.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
