### PR TITLE
Remove bionic gills and fix bio filter

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -487,8 +487,8 @@
       { "condition": "ACTIVE", "values": [ { "value": "DEXTERITY", "add": 2 } ] },
       { "condition": "INACTIVE", "values": [ { "value": "DEXTERITY", "add": -1 } ] }
     ],
-    "act_cost": "4 J",
-    "react_cost": "4 J",
+    "act_cost": "5 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {
@@ -613,8 +613,8 @@
       { "condition": "INACTIVE", "values": [ { "value": "PERCEPTION", "add": -1 } ] }
     ],
     "flags": [ "BIONIC_NPC_USABLE", "BIONIC_TOGGLED", "BIONIC_SLEEP_FRIENDLY" ],
-    "act_cost": "4 J",
-    "react_cost": "4 J",
+    "act_cost": "5 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {
@@ -764,15 +764,6 @@
     "act_cost": "10 kJ"
   },
   {
-    "id": "bio_gills",
-    "type": "bionic",
-    "name": { "str": "Respirator" },
-    "description": "A complex respiration augmentation system.  Improves respiration ability in air and allows breathing water.  Will automatically turn on when drowning.  Turn on to recharge stamina faster, at moderate power cost.  Asthmatics may also use it to stop asthma attacks.",
-    "occupied_bodyparts": [ [ "torso", 8 ], [ "head", 2 ], [ "mouth", 2 ] ],
-    "flags": [ "BIONIC_TOGGLED" ],
-    "trigger_cost": "25 kJ"
-  },
-  {
     "id": "bio_ground_sonar",
     "type": "bionic",
     "name": { "str": "Terranian Sonar" },
@@ -887,8 +878,8 @@
       { "condition": "ACTIVE", "values": [ { "value": "INTELLIGENCE", "add": 2 } ] },
       { "condition": "INACTIVE", "values": [ { "value": "INTELLIGENCE", "add": -1 } ] }
     ],
-    "act_cost": "4 J",
-    "react_cost": "4 J",
+    "act_cost": "5 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {
@@ -1132,10 +1123,15 @@
     "id": "bio_purifier",
     "type": "bionic",
     "name": { "str": "Air Filtration System" },
-    "description": "Surgically implanted in your trachea is an advanced filtration system.  If toxins or airborne diseases find their way into your windpipe, the filter will attempt to remove them.",
+    "description": "An advanced system of filters have been surgically implanted throughout your airway.  They provide minor protection from smoke and irritants even while unpowered, and when powered will filter out most all harmful airborne compounds.",
     "occupied_bodyparts": [ [ "torso", 5 ], [ "mouth", 1 ] ],
-    "env_protec": [ [ "mouth", 15 ] ],
-    "flags": [ "BIONIC_NPC_USABLE" ]
+    "env_protec": [ [ "mouth", 8 ] ],
+    "encumbrance": [ [ "mouth", 10 ] ],
+    "toggled_pseudo_items": [ "armor_bio_filter" ],
+    "flags": [ "BIONIC_SLEEP_FRIENDLY", "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
+    "act_cost": "15 J",
+    "react_cost": "15 J",
+    "time": "1 s"
   },
   {
     "id": "bio_radio",
@@ -1321,8 +1317,8 @@
       { "condition": "ACTIVE", "values": [ { "value": "STRENGTH", "add": 2 } ] },
       { "condition": "INACTIVE", "values": [ { "value": "STRENGTH", "add": -1 } ] }
     ],
-    "act_cost": "4 J",
-    "react_cost": "4 J",
+    "act_cost": "5 J",
+    "react_cost": "5 J",
     "time": "1 s"
   },
   {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2199,6 +2199,12 @@
   },
   {
     "type": "effect_type",
+    "id": "took_analgesic",
+    "//": "Helps NPCs know if they took pain medicine.",
+    "max_duration": 1200
+  },
+  {
+    "type": "effect_type",
     "id": "no_sight",
     "name": [ "Poor Sight" ],
     "desc": [ "You can't see very far from this spot." ],

--- a/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
@@ -152,7 +152,6 @@
       [ "bio_digestion", 15 ],
       [ "bio_evap", 15 ],
       [ "bio_fingerhack", 20 ],
-      [ "bio_gills", 10 ],
       [ "bio_purifier", 10 ],
       [ "bio_radscrubber", 20 ],
       [ "bio_recycler", 20 ],

--- a/data/json/itemgroups/bionics.json
+++ b/data/json/itemgroups/bionics.json
@@ -28,7 +28,6 @@
       [ "bio_targeting", 10 ],
       [ "bio_ground_sonar", 10 ],
       [ "bio_membrane", 10 ],
-      [ "bio_gills", 10 ],
       [ "bio_purifier", 10 ],
       [ "bio_climate", 10 ],
       [ "bio_heatsink", 10 ],

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -2065,6 +2065,35 @@
     ]
   },
   {
+    "id": "armor_bio_filter",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "bionic filtration system" },
+    "description": "A powered system of filters working to keep the airways clear of dust, smoke, and airborne toxins.",
+    "weight": "180 g",
+    "volume": "250 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "to_hit": -2,
+    "material": [ "plastic", "steel" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "warmth": 0,
+    "environmental_protection": 15,
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "NO_REPAIR", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "steel", "covered_by_mat": 20, "thickness": 0.1 }
+        ],
+        "covers": [ "mouth" ],
+        "coverage": 0
+      }
+    ]
+  },
+  {
     "id": "armor_bio_eyes",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -504,19 +504,6 @@
     "difficulty": 3
   },
   {
-    "id": "bio_gills",
-    "copy-from": "bionic_general",
-    "type": "ITEM",
-    "subtypes": [ "BIONIC_ITEM" ],
-    "name": { "str": "Respirator CBM" },
-    "looks_like": "bio_int_enhancer",
-    "description": "A complex respiration augmentation system that increases the user's maximal oxygen uptake and allows for underwater breathing akin to gills.  Will automatically activate if the user is drowning.",
-    "price": "4500 USD",
-    "price_postapoc": "15 USD",
-    "weight": "700 g",
-    "difficulty": 6
-  },
-  {
     "id": "bio_ground_sonar",
     "copy-from": "bionic_general",
     "type": "ITEM",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -817,7 +817,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Air Filtration System CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "An advanced filtration system that is implanted in the user's trachea.  If toxins or airborne diseases find their way into the windpipe, the filter will attempt to remove them.",
+    "description": "A system of complex filters to be installed throughout the user's airways.  These will restrict breathing slightly, but will offer decent protection from smoke, dust, and airborne contaminants when unpowered, and unparalleled protection when powered.",
     "price": "4500 USD",
     "price_postapoc": "60 USD",
     "weight": "100 g",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -143,7 +143,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take an aspirin.",
-      "vitamins": [ [ "vit_bloodthinner", 2160 ], [ "vit_nsaid", 500 ], [ "vit_nsaid_bp", 420 ] ]
+      "vitamins": [ [ "vit_bloodthinner", 2160 ], [ "vit_nsaid", 500 ], [ "vit_nsaid_bp", 420 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
     }
   },
   {
@@ -166,7 +167,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take an ibuprofen.",
-      "vitamins": [ [ "vit_nsaid", 400 ], [ "vit_nsaid_bp", 420 ] ]
+      "vitamins": [ [ "vit_nsaid", 400 ], [ "vit_nsaid_bp", 420 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
     }
   },
   {
@@ -186,7 +188,12 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a naproxen tablet.", "vitamins": [ [ "vit_naproxen", 250 ] ] }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take a naproxen tablet.",
+      "vitamins": [ [ "vit_naproxen", 250 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
+    }
   },
   {
     "id": "acetaminophen",
@@ -208,7 +215,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some acetaminophen.",
-      "vitamins": [ [ "vit_acetaminophen", 500 ] ]
+      "vitamins": [ [ "vit_acetaminophen", 500 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
     }
   },
   {
@@ -463,7 +471,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some codeine.",
-      "effects": [ { "id": "cough_suppress", "duration": "2 h" } ],
+      "effects": [ { "id": "cough_suppress", "duration": "2 h" }, { "id": "took_analgesic", "duration": "30 m" } ],
       "vitamins": [ [ "vit_mme", 450 ] ]
     }
   },
@@ -880,7 +888,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink your cough syrup.",
-      "vitamins": [ [ "vit_acetaminophen", 500 ], [ "dextromethorphan", 30 ] ]
+      "vitamins": [ [ "vit_acetaminophen", 500 ], [ "dextromethorphan", 30 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
     }
   },
   {
@@ -1137,7 +1146,7 @@
       "activation_message": "You shoot up.",
       "tools_needed": { "syringe": -1 },
       "charges_needed": { "fire": 1 },
-      "effects": [ { "id": "cough_suppress", "duration": "60 m" } ],
+      "effects": [ { "id": "cough_suppress", "duration": "60 m" }, { "id": "took_analgesic", "duration": "30 m" } ],
       "vitamins": [ [ "vit_mme", 2000, 7700 ] ]
     }
   },
@@ -1276,7 +1285,8 @@
       "type": "consume_drug",
       "activation_message": "You shoot up.",
       "tools_needed": { "syringe": -1 },
-      "vitamins": [ [ "vit_mme", 1000 ] ]
+      "vitamins": [ [ "vit_mme", 1000 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" }, { "id": "took_analgesic", "duration": "30 m" } ]
     }
   },
   {
@@ -1437,7 +1447,12 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "addiction_potential": 16,
     "addiction_type": "opioid",
-    "use_action": { "type": "consume_drug", "activation_message": "You take some oxycodone.", "vitamins": [ [ "vit_mme", 750 ] ] }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take some oxycodone.",
+      "vitamins": [ [ "vit_mme", 750 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
+    }
   },
   {
     "id": "pills_sleep",
@@ -1483,7 +1498,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You swallow some opium.",
-      "effects": [ { "id": "cough_suppress", "duration": "90 m" } ],
+      "effects": [ { "id": "cough_suppress", "duration": "90 m" }, { "id": "took_analgesic", "duration": "30 m" } ],
       "vitamins": [ [ "vit_mme", 200, 500 ] ]
     }
   },
@@ -1678,7 +1693,12 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "addiction_potential": 6,
     "addiction_type": "opioid",
-    "use_action": { "type": "consume_drug", "activation_message": "You take some tramadol.", "vitamins": [ [ "vit_tramadol", 5 ] ] }
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take some tramadol.",
+      "vitamins": [ [ "vit_tramadol", 5 ] ],
+      "effects": [ { "id": "took_analgesic", "duration": "30 m" } ]
+    }
   },
   {
     "id": "vitamins",

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -2434,6 +2434,11 @@
     "replace": "bio_sleep_shutdown"
   },
   {
+    "type": "MIGRATION",
+    "id": "bio_gills",
+    "replace": "bio_purifier"
+  },
+  {
     "id": "generator_7500w",
     "type": "MIGRATION",
     "replace": "diesel_generator"

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -109,7 +109,6 @@ static const bionic_id bio_emp( "bio_emp" );
 static const bionic_id bio_evap( "bio_evap" );
 static const bionic_id bio_flashbang( "bio_flashbang" );
 static const bionic_id bio_geiger( "bio_geiger" );
-static const bionic_id bio_gills( "bio_gills" );
 static const bionic_id bio_jointservo( "bio_jointservo" );
 static const bionic_id bio_lighter( "bio_lighter" );
 static const bionic_id bio_lockpick( "bio_lockpick" );
@@ -1834,22 +1833,9 @@ void Character::process_bionic( bionic &bio )
         int max_pkill = std::min( 150, pain );
         if( pkill < max_pkill ) {
             mod_painkiller( 1 );
-            mod_power_level( -trigger_cost );
-        }
-
-        // Only dull pain so extreme that we can't pkill it safely
-        if( pkill >= 150 && pain > pkill && get_stim() > -150 ) {
-            mod_pain( -1 );
-            // Negative side effect: negative stim
-            mod_stim( -1 );
-            mod_power_level( -trigger_cost );
-        }
-    } else if( bio.id == bio_gills ) {
-        const units::energy trigger_cost = bio.info().power_trigger / 8;
-        if( has_effect( effect_asthma ) && get_power_level() >= trigger_cost ) {
-            add_msg_if_player( m_good,
-                               _( "You feel your throat open up and air filling your lungs!" ) );
-            remove_effect( effect_asthma );
+            if( one_in( 10 ) ) {
+                mod_fatigue( 1 );
+            }
             mod_power_level( -trigger_cost );
         }
     } else if( bio.id == bio_evap ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -165,7 +165,6 @@ static const ammotype ammo_battery( "battery" );
 static const anatomy_id anatomy_human_anatomy( "human_anatomy" );
 
 static const bionic_id bio_armor_torso( "bio_armor_torso" );
-static const bionic_id bio_gills( "bio_gills" );
 static const bionic_id bio_ground_sonar( "bio_ground_sonar" );
 static const bionic_id bio_memory( "bio_memory" );
 static const bionic_id bio_ods( "bio_ods" );
@@ -263,11 +262,6 @@ static const efftype_id effect_nausea( "nausea" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_paincysts( "paincysts" );
-static const efftype_id effect_pkill1_acetaminophen( "pkill1_acetaminophen" );
-static const efftype_id effect_pkill1_generic( "pkill1_generic" );
-static const efftype_id effect_pkill1_nsaid( "pkill1_nsaid" );
-static const efftype_id effect_pkill2( "pkill2" );
-static const efftype_id effect_pkill3( "pkill3" );
 static const efftype_id effect_pre_conjunctivitis_bacterial( "pre_conjunctivitis_bacterial" );
 static const efftype_id effect_pre_conjunctivitis_viral( "pre_conjunctivitis_viral" );
 static const efftype_id effect_quadruped_full( "quadruped_full" );
@@ -791,7 +785,7 @@ int Character::get_oxygen_max() const
 bool Character::can_recover_oxygen() const
 {
     return get_limb_score( limb_score_breathing ) > 0.5f && ( !is_underwater() &&
-            !has_active_bionic( bio_gills ) && !has_trait( trait_GILLS ) && !has_trait( trait_GILLS_CEPH ) ) &&
+            !has_trait( trait_GILLS ) && !has_trait( trait_GILLS_CEPH ) ) &&
            !has_effect_with_flag( json_flag_GRAB ) && !( has_bionic( bio_synlungs ) &&
                    !has_active_bionic( bio_synlungs ) );
 }
@@ -7409,18 +7403,6 @@ void Character::update_stamina( int turns )
         }
     }
     const int max_stam = get_stamina_max();
-    if( get_power_level() >= 3_kJ && has_active_bionic( bio_gills ) ) {
-        int bonus = std::min<int>( units::to_kilojoule( get_power_level() ) / 3,
-                                   max_stam - get_stamina() - stamina_recovery * turns );
-        // so the effective recovery is up to 5x default
-        bonus = std::min( bonus, 4 * static_cast<int>( effective_regen_rate ) );
-        if( bonus > 0 ) {
-            stamina_recovery += bonus;
-            bonus /= 10;
-            bonus = std::max( bonus, 1 );
-            mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( -bonus ) ) );
-        }
-    }
 
     // Roll to determine actual stamina recovery over this period
     int recover_amount = std::ceil( stamina_recovery * turns );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -121,7 +121,6 @@ static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_infected( "infected" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_pblue( "pblue" );
-static const efftype_id effect_pkill2( "pkill2" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_slow_descent( "slow_descent" );
 static const efftype_id effect_strong_antibiotic( "strong_antibiotic" );

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -38,6 +38,9 @@
 
 static const itype_id itype_acetaminophen( "acetaminophen" );
 static const itype_id itype_aspirin( "aspirin" );
+static const itype_id itype_naproxen( "naproxen" );
+static const itype_id itype_morphine( "morphine" );
+static const itype_id itype_opium_tar( "opium_tar" );
 static const itype_id itype_brick_oven_pseudo( "brick_oven_pseudo" );
 static const itype_id itype_butchery_tree_pseudo( "butchery_tree_pseudo" );
 static const itype_id itype_codeine( "codeine" );
@@ -812,7 +815,8 @@ bool inventory::has_enough_painkiller( int pain ) const
 {
     for( const auto &elem : items ) {
         const item &it = elem.front();
-        if( ( pain <= 35 && ( it.typeId() == itype_aspirin  || it.typeId() == itype_acetaminophen ||
+        if( ( pain <= 35 && ( it.typeId() == itype_aspirin || it.typeId() == itype_naproxen  ||
+                              it.typeId() == itype_acetaminophen ||
                               it.typeId() == itype_ibuprofen ) ) ||
             ( pain >= 50 && it.typeId() == itype_oxycodone ) ||
             it.typeId() == itype_tramadol || it.typeId() == itype_codeine ) {
@@ -829,12 +833,17 @@ item *inventory::most_appropriate_painkiller( int pain )
     for( auto &elem : items ) {
         int diff = 9999;
         itype_id type = elem.front().typeId();
-        if( type == itype_aspirin || type == itype_acetaminophen || type == itype_ibuprofen ) {
+        if( type == itype_aspirin || type == itype_acetaminophen || type == itype_naproxen ||
+            type == itype_acetaminophen || type == itype_ibuprofen ) {
             diff = std::abs( pain - 15 );
+        } else if( type == itype_opium_tar ) {
+            diff = std::abs( pain - 30 );
         } else if( type == itype_codeine ) {
             diff = std::abs( pain - 30 );
         } else if( type == itype_oxycodone ) {
             diff = std::abs( pain - 60 );
+        } else if( type == itype_morphine ) {
+            diff = std::abs( pain - 100 );
         } else if( type == itype_heroin ) {
             diff = std::abs( pain - 100 );
         } else if( type == itype_tramadol ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -94,12 +94,7 @@ static const efftype_id effect_infection( "infection" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_npc_flee_player( "npc_flee_player" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
-static const efftype_id effect_pkill1_acetaminophen( "pkill1_acetaminophen" );
-static const efftype_id effect_pkill1_generic( "pkill1_generic" );
-static const efftype_id effect_pkill1_nsaid( "pkill1_nsaid" );
-static const efftype_id effect_pkill2( "pkill2" );
-static const efftype_id effect_pkill3( "pkill3" );
-static const efftype_id effect_pkill_l( "pkill_l" );
+static const efftype_id effect_took_analgesic( "took_analgesic" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
 static const efftype_id effect_sleep( "sleep" );
@@ -2522,9 +2517,7 @@ bool npc::has_painkiller()
 
 bool npc::took_painkiller() const
 {
-    return has_effect( effect_pkill1_generic )  || has_effect( effect_pkill1_acetaminophen ) ||
-           has_effect( effect_pkill1_nsaid ) || has_effect( effect_pkill2 ) ||
-           has_effect( effect_pkill3 ) || has_effect( effect_pkill_l );
+    return has_effect( effect_took_analgesic );
 }
 
 int npc::get_faction_ver() const

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -71,7 +71,6 @@ static const addiction_id addiction_nicotine( "nicotine" );
 static const bionic_id bio_dis_acid( "bio_dis_acid" );
 static const bionic_id bio_dis_shock( "bio_dis_shock" );
 static const bionic_id bio_geiger( "bio_geiger" );
-static const bionic_id bio_gills( "bio_gills" );
 static const bionic_id bio_power_weakness( "bio_power_weakness" );
 static const bionic_id bio_radleak( "bio_radleak" );
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
@@ -86,6 +85,7 @@ static const efftype_id effect_deaf( "deaf" );
 static const efftype_id effect_disabled( "disabled" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_drunk( "drunk" );
+static const efftype_id effect_formication( "formication" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_incorporeal( "incorporeal" );
 static const efftype_id effect_iodine( "iodine" );
@@ -322,13 +322,8 @@ void suffer::while_underwater( Character &you )
         you.oxygen += 12;
     }
     if( you.oxygen <= 5 ) {
-        if( you.has_bionic( bio_gills ) && you.get_power_level() >= bio_gills->power_trigger ) {
-            you.oxygen += 5;
-            you.mod_power_level( -bio_gills->power_trigger );
-        } else {
-            you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
-            you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
-        }
+        you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
+        you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
     }
     if( you.has_trait( trait_FRESHWATEROSMOSIS ) &&
         !get_map().has_flag_ter( ter_furn_flag::TFLAG_SALT_WATER, you.pos_bub() ) &&
@@ -564,62 +559,47 @@ void suffer::while_awake( Character &you, const int current_stim )
 void suffer::from_chemimbalance( Character &you )
 {
     if( one_turn_in( 6_hours ) && !you.has_flag( json_flag_PAIN_IMMUNE ) && rng( 0, 1 ) == 1 ) {
-        you.add_msg_if_player( m_bad, _( "You suddenly feel sharp pain for no reason." ) );
+        you.add_msg_if_player( m_bad, _( "Your body aches." ) );
         you.mod_pain( 3 * rng( 1, 3 ) );
     }
-    if( one_turn_in( 6_hours ) && rng( 0, 1 ) == 1 ) {
-        int pkilladd = 5 * rng( -1, 2 );
-        if( pkilladd > 0 ) {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel numb." ) );
-        } else if( ( pkilladd < 0 ) && ( !you.has_flag( json_flag_PAIN_IMMUNE ) ) ) {
-            you.add_msg_if_player( m_bad, _( "You suddenly ache." ) );
-        }
-        you.mod_painkiller( pkilladd );
-    }
     if( one_turn_in( 6_hours ) && !you.has_effect( effect_sleep ) && rng( 0, 1 ) == 1 ) {
-        you.add_msg_if_player( m_bad, _( "You feel dizzy for a moment." ) );
+        if( one_in( 2 ) ) {
+            you.add_msg_if_player( m_bad, _( "You feel dizzy for a moment." ) );
+        }
         you.mod_moves( -to_moves<int>( 1_seconds ) * rng_float( 0.1, 0.3 ) );
     }
     if( one_turn_in( 6_hours )  && rng( 0, 1 ) == 1 ) {
-        int hungadd = 5 * rng( -1, 3 );
-        if( hungadd > 0 ) {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel hungry." ) );
-        } else {
-            you.add_msg_if_player( m_good, _( "You suddenly feel a little full." ) );
+        if( one_in( 2 ) ) {
+            you.add_msg_if_player( m_bad, _( "Your mouth feels dry." ) );
         }
-        you.mod_hunger( hungadd );
-    }
-    if( one_turn_in( 6_hours )  && rng( 0, 1 ) == 1 ) {
-        you.add_msg_if_player( m_bad, _( "You suddenly feel thirsty." ) );
         you.mod_thirst( 5 * rng( 1, 3 ) );
     }
     if( one_turn_in( 6_hours ) && rng( 0, 1 ) == 1 ) {
-        you.add_msg_if_player( m_good, _( "You feel fatigued all of a sudden." ) );
+        if( one_in( 2 ) ) {
+            you.add_msg_if_player( m_good, _( "You feel sleepy." ) );
+        }
         you.mod_fatigue( 10 * rng( 2, 4 ) );
+    }
+    if( one_turn_in( 8_hours ) && rng( 0, 2 ) == 1 ) {
+        if( one_in( 2 ) ) {
+            you.add_msg_if_player( m_good, _( "You feel restless." ) );
+        }
+        you.mod_fatigue( -10 * rng( 1, 2 ) );
+    }
+    if( one_turn_in( 8_hours ) && rng( 0, 2 ) == 1 ) {
+        const bodypart_id &itch = you.random_body_part( true );
+        you.schedule_effect( effect_formication, 10_minutes * rng_float( 0.25f, 1.25f ), itch );
+    }
+    if( one_turn_in( 8_hours ) && rng( 0, 3 ) == 1 ) {
+        if( you.get_effect_int( effect_deaf ) < 2 ) {
+            you.add_effect( effect_deaf, 250_seconds );
+        }
     }
     if( one_turn_in( 8_hours ) && rng( 0, 1 ) == 1 ) {
         if( one_in( 3 ) ) {
             you.add_morale( morale_feeling_good, 20, 100 );
         } else {
             you.add_morale( morale_feeling_bad, -20, -100 );
-        }
-    }
-    if( one_turn_in( 6_hours ) && rng( 0, 1 ) == 1 ) {
-        if( one_in( 3 ) ) {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel very cold." ) );
-            you.set_all_parts_temp_cur( BODYTEMP_VERY_COLD );
-        } else {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel cold." ) );
-            you.set_all_parts_temp_cur( BODYTEMP_COLD );
-        }
-    }
-    if( one_turn_in( 6_hours ) && rng( 0, 1 ) == 1 ) {
-        if( one_in( 3 ) ) {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel very hot." ) );
-            you.set_all_parts_temp_cur( BODYTEMP_VERY_HOT );
-        } else {
-            you.add_msg_if_player( m_bad, _( "You suddenly feel hot." ) );
-            you.set_all_parts_temp_cur( BODYTEMP_HOT );
         }
     }
 }
@@ -639,8 +619,6 @@ void suffer::from_asthma( Character &you, const int current_stim )
     }
     bool auto_use = you.has_charges( itype_inhaler, 1 ) || you.has_charges( itype_oxygen_tank, 1 ) ||
                     you.has_charges( itype_smoxygen_tank, 1 );
-    bool oxygenator = you.has_bionic( bio_gills ) &&
-                      you.get_power_level() >= ( bio_gills->power_trigger / 8 );
     if( you.underwater ) {
         you.oxygen = you.oxygen / 2;
         auto_use = false;
@@ -654,15 +632,10 @@ void suffer::from_asthma( Character &you, const int current_stim )
         inventory map_inv;
         map_inv.form_from_map( you.pos_bub(), 2, &you );
         // check if an inhaler is somewhere near
-        bool nearby_use = auto_use || oxygenator || map_inv.has_charges( itype_inhaler, 1 ) ||
+        bool nearby_use = auto_use || map_inv.has_charges( itype_inhaler, 1 ) ||
                           map_inv.has_charges( itype_oxygen_tank, 1 ) ||
                           map_inv.has_charges( itype_smoxygen_tank, 1 );
-        // check if character has an oxygenator first
-        if( oxygenator ) {
-            you.mod_power_level( -bio_gills->power_trigger / 8 );
-            you.add_msg_if_player( m_info, _( "You use your Oxygenator to clear it up, "
-                                              "then go back to sleep." ) );
-        } else if( auto_use  && !you.has_bionic( bio_sleep_shutdown ) ) {
+        if( auto_use  && !you.has_bionic( bio_sleep_shutdown ) ) {
             if( you.use_charges_if_avail( itype_inhaler, 1 ) ) {
                 you.add_msg_if_player( m_info, _( "You use your inhaler and go back to sleep." ) );
                 you.add_effect( effect_took_antiasthmatic, rng( 6_hours, 12_hours ) );


### PR DESCRIPTION
#### Summary
Remove bionic gills and fix bio filter

#### Purpose of change
- Remove bionic gills. Bionics don't allow you to just ignore game mechanics, and these had a bunch of weird extra effects that didn't make sense.
- Bionic filter was too good and a no-brainer.

#### Describe the solution
- Bionic filtration system now gives 10 face encumbrance and 8 enviro protection at all times. When powered, it offers 15 enviro protection.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
