### PR TITLE
Blocking flags for more weapons

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2891,7 +2891,15 @@
     "warmth": 1,
     "material_thickness": 1,
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": 4, "volume_encumber_modifier": 0.25, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "armor": [
+      {
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.25,
+        "coverage": 20,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ]
   },
   {
     "id": "rifle_case_soft_leather",
@@ -2927,7 +2935,15 @@
     "warmth": 1,
     "material_thickness": 2,
     "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ],
-    "armor": [ { "encumbrance": 4, "volume_encumber_modifier": 0.25, "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "armor": [
+      {
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.25,
+        "coverage": 20,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ]
   },
   {
     "id": "rifle_case_soft_2",
@@ -2979,7 +2995,15 @@
     "warmth": 1,
     "material_thickness": 1,
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": 5, "volume_encumber_modifier": 0.25, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "armor": [
+      {
+        "encumbrance": 5,
+        "volume_encumber_modifier": 0.25,
+        "coverage": 30,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ]
   },
   {
     "id": "rifle_case_soft_leather_2",
@@ -3030,8 +3054,16 @@
     ],
     "warmth": 1,
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ],    
-    "armor": [ { "encumbrance": 5, "volume_encumber_modifier": 0.25, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ],
+    "armor": [
+      {
+        "encumbrance": 5,
+        "volume_encumber_modifier": 0.25,
+        "coverage": 30,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ]
   },
   {
     "id": "rifle_case_xl_soft_leather",
@@ -3067,7 +3099,15 @@
     "warmth": 1,
     "material_thickness": 2,
     "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE" ],
-    "armor": [ { "encumbrance": 5, "volume_encumber_modifier": 0.25, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+    "armor": [
+      {
+        "encumbrance": 5,
+        "volume_encumber_modifier": 0.25,
+        "coverage": 30,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ]
   },
   {
     "id": "camera_bag",

--- a/data/json/items/ranged/slings.json
+++ b/data/json/items/ranged/slings.json
@@ -12,7 +12,7 @@
     "//": "It's little more than a piece of slightly shaped leather",
     "material": [ "leather" ],
     "flags": [ "RELOAD_AND_SHOOT", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "BELT_CLIP", "WATERPROOF_GUN" ],
-    "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ],
+    "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES", "ALLOWS_BODY_BLOCK" ],
     "skill": "throw",
     "ammo": [ "pebble" ],
     "weight": "96 g",
@@ -37,7 +37,15 @@
     "description": "A forked piece of wood with an elastic band stretched between two of its tips.  Can launch tiny pebbles and similar things at high speeds.",
     "price": "5 USD",
     "material": [ "wood" ],
-    "flags": [ "FIRE_TWOHAND", "RELOAD_AND_SHOOT", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "BELT_CLIP", "WATERPROOF_GUN" ],
+    "flags": [
+      "FIRE_TWOHAND",
+      "RELOAD_AND_SHOOT",
+      "NEVER_JAMS",
+      "PRIMITIVE_RANGED_WEAPON",
+      "BELT_CLIP",
+      "WATERPROOF_GUN",
+      "ALLOWS_BODY_BLOCK"
+    ],
     "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ],
     "skill": "throw",
     "ammo": [ "gravel" ],
@@ -74,7 +82,8 @@
       "SHEATH_SPEAR",
       "ALWAYS_TWOHAND",
       "FIRE_TWOHAND",
-      "WATERPROOF_GUN"
+      "WATERPROOF_GUN",
+      "ALLOWS_BODY_BLOCK"
     ],
     "weapon_category": [ "QUARTERSTAVES" ],
     "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ],
@@ -107,7 +116,15 @@
     "description": "A modern slingshot with a wrist brace, allowing it to fire tiny objects slightly more forcefully than a simple wooden slingshot.",
     "price": "30 USD",
     "material": [ "steel", "plastic" ],
-    "flags": [ "FIRE_TWOHAND", "RELOAD_AND_SHOOT", "NEVER_JAMS", "PRIMITIVE_RANGED_WEAPON", "BELT_CLIP", "WATERPROOF_GUN" ],
+    "flags": [
+      "FIRE_TWOHAND",
+      "RELOAD_AND_SHOOT",
+      "NEVER_JAMS",
+      "PRIMITIVE_RANGED_WEAPON",
+      "BELT_CLIP",
+      "WATERPROOF_GUN",
+      "ALLOWS_BODY_BLOCK"
+    ],
     "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES" ],
     "skill": "throw",
     "ammo": [ "gravel" ],

--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -16,7 +16,7 @@
     "color": "blue",
     "to_hit": -1,
     "ammo_type": "thrown",
-    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
+    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON", "ALLOWS_BODY_BLOCK" ]
   },
   {
     "type": "ITEM",
@@ -66,7 +66,7 @@
     "color": "white",
     "to_hit": -2,
     "ammo_type": "thrown",
-    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON" ]
+    "flags": [ "NOGIB", "TANGLE", "PRIMITIVE_RANGED_WEAPON", "ALLOWS_BODY_BLOCK" ]
   },
   {
     "type": "ITEM",
@@ -84,7 +84,8 @@
     "longest_side": "30 cm",
     "to_hit": -1,
     "thrown_damage": [ { "damage_type": "stab", "amount": 16 } ],
-    "melee_damage": { "cut": 8 }
+    "melee_damage": { "cut": 8 },
+    "flags": [ "ALLOWS_BODY_BLOCK" ]
   },
   {
     "type": "ITEM",
@@ -103,7 +104,8 @@
     "longest_side": "30 cm",
     "to_hit": -1,
     "thrown_damage": [ { "damage_type": "stab", "amount": 18 }, { "damage_type": "bash", "amount": 4 } ],
-    "melee_damage": { "cut": 8 }
+    "melee_damage": { "cut": 8 },
+    "flags": [ "ALLOWS_BODY_BLOCK" ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
Blocking flags for more weapons

#### Purpose of change
A bunch of weapons needed ALLOWS_BODY_BLOCK and didn't have it.

#### Describe the solution
This flag system is a bad way to do it. Why aren't leg blocks basically always allowed?

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
