### PR TITLE
Raincoat/tentacle fix

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -335,6 +335,10 @@
         "covers": [ "leg_l", "leg_r" ],
         "coverage": 75,
         "encumbrance": [ 8, 8 ],
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
+        ],
         "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
         "layers": [ "BELTED" ]
       },
@@ -342,6 +346,10 @@
         "covers": [ "gastropod_foot" ],
         "coverage": 60,
         "encumbrance": 6,
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
+        ],
         "specifically_covers": [ "gastropod_foot_draped" ],
         "layers": [ "BELTED" ]
       },
@@ -349,6 +357,10 @@
         "covers": [ "long_tail" ],
         "coverage": 75,
         "encumbrance": 8,
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
+        ],
         "specifically_covers": [ "long_tail_draped" ],
         "layers": [ "BELTED" ]
       },
@@ -370,6 +382,10 @@
           "cephalopod_arm_4_draped",
           "cephalopod_arm_5_draped",
           "cephalopod_arm_6_draped"
+        ],
+        "material": [
+          { "type": "vinyl", "covered_by_mat": 100, "thickness": 0.3 },
+          { "type": "nylon", "covered_by_mat": 100, "thickness": 0.1 }
         ],
         "layers": [ "BELTED" ]
       }

--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -1022,7 +1022,7 @@
     "name_multiple": "arm (draped)",
     "name": "first left arm (draped)",
     "opposite": "cephalopod_arm_4_draped",
-    "locations_under": [ "cephalopod_arm_1_upper" ]
+    "locations_under": [ "cephalopod_arm_1_base" ]
   },
   {
     "id": "cephalopod_arm_2",
@@ -1151,7 +1151,7 @@
     "name_multiple": "arm (draped)",
     "name": "second left arm (draped)",
     "opposite": "cephalopod_arm_5_draped",
-    "locations_under": [ "cephalopod_arm_2_upper" ]
+    "locations_under": [ "cephalopod_arm_2_base" ]
   },
   {
     "id": "cephalopod_arm_3",
@@ -1280,7 +1280,7 @@
     "name_multiple": "arm (draped)",
     "name": "third left arm (draped)",
     "opposite": "cephalopod_arm_6_draped",
-    "locations_under": [ "cephalopod_arm_3_upper" ]
+    "locations_under": [ "cephalopod_arm_3_base" ]
   },
   {
     "id": "cephalopod_arm_4",
@@ -1409,7 +1409,7 @@
     "name_multiple": "arm (draped)",
     "name": "first right arm (draped)",
     "opposite": "cephalopod_arm_1_draped",
-    "locations_under": [ "cephalopod_arm_4_upper" ]
+    "locations_under": [ "cephalopod_arm_4_base" ]
   },
   {
     "id": "cephalopod_arm_5",
@@ -1538,7 +1538,7 @@
     "name_multiple": "arm (draped)",
     "name": "second right arm (draped)",
     "opposite": "cephalopod_arm_2_draped",
-    "locations_under": [ "cephalopod_arm_5_upper" ]
+    "locations_under": [ "cephalopod_arm_5_base" ]
   },
   {
     "id": "cephalopod_arm_6",
@@ -1667,7 +1667,7 @@
     "name_multiple": "arm (draped)",
     "name": "third right arm (draped)",
     "opposite": "cephalopod_arm_3_draped",
-    "locations_under": [ "cephalopod_arm_6_upper" ]
+    "locations_under": [ "cephalopod_arm_6_base" ]
   },
   {
     "id": "cephalopod_tentacle_l",


### PR DESCRIPTION
#### Summary
Raincoat/tentacle fix

#### Purpose of change
- Raincoats didn't have material data for their draped layers.
- cephalopod_arm_draped was calling an improper parent limb.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
