### PR TITLE
Fix gas mask protection display

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -2080,7 +2080,7 @@
     "symbol": "[",
     "color": "dark_gray",
     "warmth": 0,
-    "environmental_protection": 15,
+    "environmental_protection": 16,
     "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3865,23 +3865,13 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
                                               space,
                                               _( "Negligible Protection" ) ) );
         }
-        if( type->can_use( "GASMASK" ) ||
+        if( type->can_use( "GASMASK_ACTIVATE" ) ||
             type->can_use( "DIVE_TANK" ) ) {
             info.emplace_back(
                 "ARMOR",
                 string_format(
                     "<bold>%s</bold>:",
                     _( "Protection when active" ) ) );
-            info.emplace_back( bp_cat,
-                               space + _( "Acid Resistance: " ),
-                               "",
-                               iteminfo::no_newline | iteminfo::is_decimal,
-                               resist( damage_acid, false, sbp ) );
-            info.emplace_back( bp_cat,
-                               space + _( "Fire: " ),
-                               "",
-                               iteminfo::no_newline | iteminfo::is_decimal,
-                               resist( damage_heat, false, sbp ) );
             info.emplace_back(
                 bp_cat,
                 space + _( "Environmental: " ),


### PR DESCRIPTION
#### Summary
Fix gas mask protection display

#### Purpose of change
Gas masks weren't displaying their proper protection while active because the activation aciton changed from GASMASK to GASMASK_ACTIVATE but the code was not updated to reflect this.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
