### PR TITLE
Further blocking improvements

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1574,10 +1574,9 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
     std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> basics;
 
     for( const matec_id &tec_id : all ) {
-        add_msg_debug( debugmode::DF_MELEE, "Evaluating technique %s", tec_id->name );
 
         if( find( blacklist.begin(), blacklist.end(), tec_id ) != blacklist.end() ) {
-            add_msg_debug( debugmode::DF_MELEE, "Technique is on the blacklist, discarded" );
+            add_msg_debug( debugmode::DF_MELEE, "Technique %s is on the blacklist, discarded", tec_id->name );
             continue;
         }
 
@@ -1629,13 +1628,13 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
 
     // ignore "dummy" techniques like WBLOCK_1
     if( tec_id->dummy ) {
-        add_msg_debug( debugmode::DF_MELEE, "Dummy technique, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE, "%s is a dummy technique, attack discarded", tec_id->name );
         return std::nullopt;
     }
 
     // skip defensive techniques
     if( tec_id->defensive ) {
-        add_msg_debug( debugmode::DF_MELEE, "Defensive technique, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE, "%s is a defensive technique, attack discarded", tec_id->name );
         return std::nullopt;
     }
 
@@ -1643,26 +1642,29 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     if( tec_id->has_condition ) {
         const_dialogue d( get_const_talker_for( *this ), get_const_talker_for( t ) );
         if( !tec_id->condition( d ) ) {
-            add_msg_debug( debugmode::DF_MELEE, "Conditionals failed, attack discarded" );
+            add_msg_debug( debugmode::DF_MELEE, "%s conditionals failed, attack discarded", tec_id->name );
             return std::nullopt;
         }
     }
 
     // skip wall adjacent techniques if not next to a wall
     if( tec_id->wall_adjacent && !get_map().is_wall_adjacent( pos_bub() ) ) {
-        add_msg_debug( debugmode::DF_MELEE, "No adjacent walls found, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE, "No adjacent walls found for %s, attack discarded",
+                       tec_id->name );
         return std::nullopt;
     }
 
     // skip non reach ok techniques if reach attacking
     if( !( tec_id->reach_ok || tec_id->reach_tec ) && reach_attacking ) {
-        add_msg_debug( debugmode::DF_MELEE, "Not usable with reach attack, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE, "%s not usable with reach attack, attack discarded",
+                       tec_id->name );
         return std::nullopt;
     }
 
     // skip reach techniques if not reach attacking
     if( tec_id->reach_tec && !reach_attacking ) {
-        add_msg_debug( debugmode::DF_MELEE, "Only usable with reach attack, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE, "%s only usable with reach attack, attack discarded",
+                       tec_id->name );
         return std::nullopt;
     }
 
@@ -1714,7 +1716,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     // dice(p->dex_cur + p->get_skill_level("melee"),   10))
     if( tec_id->disarms && !t.has_weapon() ) {
         add_msg_debug( debugmode::DF_MELEE,
-                       "Disarming technique against unarmed opponent, attack discarded" );
+                       "Disarming technique %s against unarmed opponent, attack discarded", tec_id->name );
         return std::nullopt;
     }
 
@@ -1726,7 +1728,8 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
 
     // if aoe, check if there are valid targets
     if( !tec_id->aoe.empty() && !valid_aoe_technique( t, tec_id.obj() ) ) {
-        add_msg_debug( debugmode::DF_MELEE, "AoE technique witout valid AoE targets, attack discarded" );
+        add_msg_debug( debugmode::DF_MELEE,
+                       "%s is an AoE technique witout valid AoE targets, attack discarded", tec_id->name );
         return std::nullopt;
     }
 
@@ -1734,7 +1737,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
     if( tec_id->weighting < 0 && !one_in( std::abs( tec_id->weighting ) ) ) {
         if( !tec_id->fallback ) {
             add_msg_debug( debugmode::DF_MELEE,
-                           "Negative technique weighting failed weight roll, attack discarded" );
+                           "Negative tech weighting failed roll, attack %s discarded", tec_id->name );
         } else {
             // Fallback techs should always fire in place of tec_none if possible, even if they failed their roll.
             if( tec_id->is_valid_character( *this ) ) {
@@ -1745,7 +1748,8 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
                     fallbacks.push_back( std::make_tuple( tec_id, vector->first, vector->second ) );
                     add_msg_debug( debugmode::DF_MELEE, "Adding fallback tech %s to the tech list", tec_id->name );
                 } else {
-                    add_msg_debug( debugmode::DF_MELEE, "No valid attack vector found, fallback attack discarded" );
+                    add_msg_debug( debugmode::DF_MELEE, "No valid attack vector found, fallback attack %s discarded",
+                                   tec_id->name );
                 }
             }
         }
@@ -1760,7 +1764,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
         if( vector ) {
             return std::make_tuple( tec_id, vector->first, vector->second );
         } else {
-            add_msg_debug( debugmode::DF_MELEE, "No valid attack vector found, attack discarded" );
+            add_msg_debug( debugmode::DF_MELEE, "No valid attack vector found, %s discarded", tec_id->name );
             return std::nullopt;
         }
     }
@@ -2187,20 +2191,6 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         return false;
     }
 
-    // Melee skill and reaction score governs if you can react in time.
-    // Skill of 5 with full stamina and no relevant encumbrance guarantees a block attempt.
-    // Skill of 10 and no relevant encumbrance almost guarantees a block attempt regardless of stamina.
-    // The + 0.01 is a safety margin to prevent floating point precision errors in x_in_y.
-    // TODO: No guaranteed anything, checks vs monster skill.
-    float melee_skill = has_active_bionic( bio_cqb ) ? 5 : get_skill_level( skill_melee );
-    if( !x_in_y( melee_skill * 40.0 * get_limb_score( limb_score_reaction ) - 100 *
-                 get_stamina_dodge_modifier(), 200 ) ) {
-        add_msg_debug( debugmode::DF_MELEE, "Block reaction roll failed" );
-        return false;
-    }
-
-    blocks_left--;
-
     // This bonus absorbs damage from incoming attacks before they land,
     // but it still counts as a block even if it absorbs all the damage.
     float total_phys_block = mabuff_block_bonus();
@@ -2229,18 +2219,11 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     int body_block_score = 1;
     bool can_block_unarmed = false;
 
-    if( has_shield ) {
-        /** @ARM_STR increases attack blocking effectiveness with a worn/wielded item */
-        block_bonus = melee::blocking_ability( *shield );
-        conductive_shield = shield->conductive();
-        weapon_block_score = get_arm_str() + block_bonus + melee_skill;
-    }
-
     if( ( arm_block || leg_block || nonstandard_block ) && ( !has_shield || armed_body_block ) ) {
         can_block_unarmed = true;
         /** @EFFECT_UNARMED increases attack blocking effectiveness with a limb or worn item */
         // get_str instead of get_arm_str, we're not lifting an item & limb scores are checked later.
-        body_block_score = get_str() + unarmed_skill;
+        body_block_score = get_str() + unarmed_skill + mabuff_block_effectiveness_bonus();
     }
 
     if( !has_shield && !can_block_unarmed ) {
@@ -2248,16 +2231,49 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         return false;
     }
 
+    // Melee skill and reaction score governs if you can react in time.
+    // Skill of 5 with full stamina and no relevant encumbrance guarantees a block attempt.
+    // Skill of 10 and no relevant encumbrance almost guarantees a block attempt regardless of stamina.
+    // The + 0.01 is a safety margin to prevent floating point precision errors in x_in_y.
+    // TODO: No guaranteed anything, checks vs monster skill.
+    float melee_skill = has_active_bionic( bio_cqb ) ? 5 : get_skill_level( skill_melee );
+    if( !x_in_y( melee_skill * 40.0 * get_limb_score( limb_score_reaction ) - 100 *
+                 get_stamina_dodge_modifier(), 200 ) ) {
+        add_msg_debug( debugmode::DF_MELEE, "Block reaction roll failed" );
+        return false;
+    }
+
+    // We only decrement blocks and make the reaction roll if we can actually block.
+    blocks_left--;
+
+    if( has_shield ) {
+        /** @ARM_STR increases attack blocking effectiveness with a worn/wielded item */
+        block_bonus = melee::blocking_ability( *shield );
+        conductive_shield = shield->conductive();
+        weapon_block_score = get_arm_str() + block_bonus + melee_skill + mabuff_block_effectiveness_bonus();
+    }
+
     bool will_weapon_block = false;
     bool will_body_block = false;
     int block_score = 0;
 
+    // Get the rest of our block modifiers to tally up a final score.
+    if( can_block_unarmed ) {
+        bp_hit = select_blocking_part( arm_block, leg_block, nonstandard_block );
+        body_block_score *= get_part( bp_hit )->get_limb_score( limb_score_block );
+        add_msg_debug( debugmode::DF_MELEE, "Body block score after limb score multiplier: %d",
+                       body_block_score );
+        if( worn_shield && shield->covers( bp_hit ) ) {
+            // BLOCK_WHILE_WORN is largely deprecated, but here we conditionally grant the bonus if it exists.
+            body_block_score += block_bonus;
+        }
+    }
+
+    // Use the best thing available.
     if( has_shield && ( !can_block_unarmed || weapon_block_score >= body_block_score ) ) {
         will_weapon_block = true;
-        block_score = weapon_block_score;
     } else if( can_block_unarmed && ( !has_shield || body_block_score > weapon_block_score ) ) {
         will_body_block = true;
-        block_score = body_block_score;
     }
 
     if( !will_weapon_block && !will_body_block ) {
@@ -2265,13 +2281,10 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         return false;
     }
 
-    // add martial arts block effectiveness bonus
-    block_score += mabuff_block_effectiveness_bonus();
-
-    // Weapon blocks are preferred to limb blocks.
     std::string thing_blocked_with;
-    // Do we block with a weapon? Handle melee wear but leave bp the same.
     if( will_weapon_block ) {
+        add_msg_debug( debugmode::DF_MELEE, "Weapon block score: %d", weapon_block_score );
+        block_score = weapon_block_score;
         thing_blocked_with = shield->tname();
         // Scaling modifier from incoming damage.
         float base_wear = 0.1f;
@@ -2283,10 +2296,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         }
         handle_melee_wear( shield, wear_modifier );
     } else {
-        // Select part to block with, preferring worn blocking armor if applicable
-        bp_hit = select_blocking_part( arm_block, leg_block, nonstandard_block );
-        block_score *= get_part( bp_hit )->get_limb_score( limb_score_block );
-        add_msg_debug( debugmode::DF_MELEE, "Block score after multiplier %d", block_score );
+        block_score = body_block_score;
         if( worn_shield && shield->covers( bp_hit ) ) {
             thing_blocked_with = shield->tname();
             if( source != nullptr && !source->is_hallucination() ) {
@@ -2295,9 +2305,6 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                                                      enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
                 }
             }
-
-            block_score += block_bonus;
-
         } else {
             thing_blocked_with = body_part_name( bp_hit );
         }


### PR DESCRIPTION
#### Summary
Further blocking improvements

#### Purpose of change
Blocking needed a few extra touches

#### Describe the solution
Blocking now evaluates the final block score (including limb block score and everything) before deciding whether to weapon or body block.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
