### PR TITLE
Fix tool and trap sounds

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -103,7 +103,6 @@
     "effect": {
       "if": { "one_in_chance": { "context_val": "sound_chance" } },
       "then": [
-        { "message": { "context_val": "sound_message" }, "sound": true },
         {
           "npc_make_sound": { "context_val": "sound_message" },
           "type": "activity",
@@ -113,14 +112,14 @@
       ]
     },
     "false_effect": [
-      { "u_message": "Your <npc_name> gurgles in the water and stops." },
+      { "u_message": "The <npc_name> gurgles in the water and stops." },
       { "transform_item": { "context_val": "revert_to" } }
     ]
   },
   {
     "id": "EOC_toolweapon_deactivate",
     "type": "effect_on_condition",
-    "effect": [ { "u_message": "Your <npc_name> goes quiet." }, { "transform_item": { "context_val": "transform_target" } } ]
+    "effect": [ { "u_message": "The <npc_name> goes quiet." }, { "transform_item": { "context_val": "transform_target" } } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -151,7 +151,7 @@
             "variables": {
               "sound_chance": 10,
               "sound_message": { "i18n": true, "str": "Your electric carver buzzes." },
-              "volume": 8,
+              "volume": 10,
               "revert_to": "carver_off"
             }
           }

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -149,8 +149,8 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 10,
-              "sound_message": { "i18n": true, "str": "Your electric carver buzzes." },
+              "sound_chance": 5,
+              "sound_message": { "i18n": true, "str": "The electric carver buzzes." },
               "volume": 10,
               "revert_to": "carver_off"
             }

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -234,8 +234,8 @@
     "material": [ "paper" ],
     "symbol": ";",
     "color": "red",
-    "tick_action": [ { "type": "sound", "sound_message": "ssss…", "sound_volume": 0, "sound_id": "misc", "sound_variant": "lit_fuse" } ],
-    "countdown_action": { "type": "sound", "sound_message": "Bang!", "sound_volume": 20, "sound_id": "explosion", "sound_variant": "small" },
+    "tick_action": [ { "type": "sound", "sound_message": "ssss…", "sound_volume": 4, "sound_id": "misc", "sound_variant": "lit_fuse" } ],
+    "countdown_action": { "type": "sound", "sound_message": "Bang!", "sound_volume": 40, "sound_id": "explosion", "sound_variant": "small" },
     "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 1 }
   },

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -357,8 +357,8 @@
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your hedge trimmer rumbles." },
-              "volume": 10,
+              "sound_message": { "i18n": true, "str": "The hedge trimmer rumbles." },
+              "volume": 40,
               "revert_to": "trimmer_off"
             }
           }

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -314,7 +314,7 @@
               "turn_cost": 0.8,
               "transform_target": "trimmer_on",
               "success_message": { "i18n": true, "str": "With a roar, the hedge trimmer leaps to life!" },
-              "volume": 15,
+              "volume": 40,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
@@ -356,7 +356,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
+              "sound_chance": 5,
               "sound_message": { "i18n": true, "str": "The hedge trimmer rumbles." },
               "volume": 40,
               "revert_to": "trimmer_off"

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -30,7 +30,7 @@
               "turn_cost": 0.8,
               "transform_target": "masonrysaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
-              "volume": 20,
+              "volume": 50,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
@@ -76,7 +76,7 @@
             "variables": {
               "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your masonry saw buzzes." },
-              "volume": 7,
+              "volume": 45,
               "revert_to": "masonrysaw_off"
             }
           }
@@ -163,7 +163,7 @@
             "variables": {
               "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your electric masonry saw buzzes." },
-              "volume": 7,
+              "volume": 40,
               "revert_to": "electric_masonrysaw_off"
             }
           }
@@ -235,7 +235,7 @@
               "turn_cost": "0.8",
               "transform_target": "heavy_masonrysaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
-              "volume": "20",
+              "volume": 60,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
@@ -269,9 +269,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your heavy masonry saw buzzes." },
-              "volume": "25",
+              "volume": 60,
               "revert_to": "heavy_masonrysaw_off"
             }
           }

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -74,8 +74,8 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your masonry saw buzzes." },
+              "sound_chance": 5,
+              "sound_message": { "i18n": true, "str": "The masonry saw buzzes." },
               "volume": 45,
               "revert_to": "masonrysaw_off"
             }
@@ -161,8 +161,8 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your electric masonry saw buzzes." },
+              "sound_chance": 5,
+              "sound_message": { "i18n": true, "str": "The electric masonry saw buzzes." },
               "volume": 40,
               "revert_to": "electric_masonrysaw_off"
             }
@@ -260,7 +260,7 @@
     "revert_to": "heavy_masonrysaw_off",
     "techniques": [ "SWEEP" ],
     "qualities": [ [ "AXE", 3 ], [ "BUTCHER", -100 ] ],
-    "use_action": { "target": "heavy_masonrysaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
+    "use_action": { "target": "heavy_masonrysaw_off", "msg": "The %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -269,8 +269,8 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your heavy masonry saw buzzes." },
+              "sound_chance": 5,
+              "sound_message": { "i18n": true, "str": "The heavy masonry saw buzzes." },
               "volume": 60,
               "revert_to": "heavy_masonrysaw_off"
             }

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -72,7 +72,7 @@
       {
         "type": "sound",
         "sound_message": "buzzz…",
-        "sound_volume": 0,
+        "sound_volume": 8,
         "sound_id": "misc",
         "sound_variant": "rc_car_drives"
       }

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -94,7 +94,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
+              "sound_chance": 5,
               "sound_message": { "i18n": true, "str": "The chainsaw rumbles." },
               "volume": 60,
               "revert_to": "chainsaw_off"
@@ -180,7 +180,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
+              "sound_chance": 5,
               "sound_message": { "i18n": true, "str": "The pole saw rumbles." },
               "volume": 50,
               "revert_to": "polesaw_off"
@@ -265,8 +265,8 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your circular saw buzzes." },
+              "sound_chance": 5,
+              "sound_message": { "i18n": true, "str": "The circular saw buzzes." },
               "volume": 50,
               "revert_to": "circsaw_off"
             }

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -45,7 +45,7 @@
           "condition": { "and": [ { "math": [ "rng(0, 10) - n_damage_level()", ">", "5" ] }, { "not": "u_is_underwater" }, "has_ammo" ] },
           "effect": [
             { "turn_cost": 0.8 },
-            { "u_make_sound": "With a roar, the chainsaw screams to life!", "type": "combat", "volume": 20 },
+            { "u_make_sound": "With a roar, the chainsaw screams to life!", "type": "combat", "volume": 60 },
             { "u_message": "With a roar, the chainsaw screams to life!" },
             { "transform_item": "chainsaw_on", "active": true },
             { "sound_effect": "chainsaw_on", "id": "chainsaw_cord" },
@@ -95,8 +95,8 @@
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your chainsaw rumbles." },
-              "volume": 12,
+              "sound_message": { "i18n": true, "str": "The chainsaw rumbles." },
+              "volume": 60,
               "revert_to": "chainsaw_off"
             }
           }
@@ -137,7 +137,7 @@
               "turn_cost": 0.8,
               "transform_target": "polesaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the pole saw screams to life!" },
-              "volume": 15,
+              "volume": 50,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           }
@@ -181,8 +181,8 @@
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": 15,
-              "sound_message": { "i18n": true, "str": "Your pole saw rumbles." },
-              "volume": 12,
+              "sound_message": { "i18n": true, "str": "The pole saw rumbles." },
+              "volume": 50,
               "revert_to": "polesaw_off"
             }
           }
@@ -220,7 +220,7 @@
               "turn_cost": 0.6,
               "transform_target": "circsaw_on",
               "success_message": { "i18n": true, "str": "With a loud buzz, the <npc_name> roars to life!" },
-              "volume": 15,
+              "volume": 50,
               "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           }
@@ -267,7 +267,7 @@
             "variables": {
               "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your circular saw buzzes." },
-              "volume": 7,
+              "volume": 50,
               "revert_to": "circsaw_off"
             }
           }
@@ -327,7 +327,7 @@
               "turn_cost": 0.6,
               "transform_target": "elec_chainsaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the electric chainsaw screams to life!" },
-              "volume": 20,
+              "volume": 50,
               "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           },
@@ -374,8 +374,8 @@
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": 5,
-              "sound_message": { "i18n": true, "str": "Your electric chainsaw rumbles." },
-              "volume": 12,
+              "sound_message": { "i18n": true, "str": "The electric chainsaw rumbles." },
+              "volume": 50,
               "revert_to": "elec_chainsaw_off"
             }
           }
@@ -408,7 +408,7 @@
                 "turn_cost": 0.6,
                 "transform_target": "elec_chainsaw_cord_on",
                 "success_message": { "i18n": true, "str": "With a roar, the corded electric chainsaw screams to life!" },
-                "volume": 20,
+                "volume": 50,
                 "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
               }
             },
@@ -450,8 +450,8 @@
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
               "sound_chance": 5,
-              "sound_message": { "i18n": true, "str": "Your corded electric chainsaw rumbles." },
-              "volume": 12,
+              "sound_message": { "i18n": true, "str": "The corded electric chainsaw rumbles." },
+              "volume": 50,
               "revert_to": "elec_chainsaw_cord_off"
             }
           }

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -232,7 +232,7 @@
     "flags": [ "ECHOLOCATION_DETECTABLE" ],
     "vehicle_data": {
       "damage": 300,
-      "sound_volume": 8,
+      "sound_volume": 16,
       "sound": "SNAP!",
       "sound_type": "trap",
       "sound_variant": "bear_trap",
@@ -257,7 +257,7 @@
     "flags": [ "SONAR_DETECTABLE" ],
     "vehicle_data": {
       "damage": 300,
-      "sound_volume": 8,
+      "sound_volume": 16,
       "sound": "SNAP!",
       "sound_type": "trap",
       "sound_variant": "bear_trap",
@@ -343,7 +343,7 @@
     "vehicle_data": {
       "chance": 30,
       "damage": 300,
-      "sound_volume": 1,
+      "sound_volume": 10,
       "sound": "Clank!",
       "sound_type": "fire_gun",
       "sound_variant": "crossbow",
@@ -394,7 +394,7 @@
     "vehicle_data": {
       "chance": 70,
       "damage": 300,
-      "sound_volume": 60,
+      "sound_volume": 160,
       "sound": "Bang!",
       "sound_type": "fire_gun",
       "sound_variant": "shotgun_d",
@@ -420,7 +420,7 @@
     "vehicle_data": {
       "chance": 70,
       "damage": 300,
-      "sound_volume": 60,
+      "sound_volume": 160,
       "sound": "Bang!",
       "sound_type": "fire_gun",
       "sound_variant": "shotgun_s",
@@ -447,7 +447,7 @@
       "do_explosion": true,
       "damage": 1000,
       "shrapnel": 8,
-      "sound_volume": 10,
+      "sound_volume": 90,
       "sound": "Boom!",
       "sound_type": "explosion",
       "sound_variant": "default"
@@ -472,7 +472,7 @@
       "do_explosion": true,
       "damage": 1000,
       "shrapnel": 8,
-      "sound_volume": 10,
+      "sound_volume": 90,
       "sound": "Boom!",
       "sound_type": "explosion",
       "sound_variant": "default"

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -552,7 +552,6 @@ std::optional<int> sound_iuse::use( Character *, item &,
                                     map *here, const tripoint_bub_ms &pos ) const
 {
     map &bubble_map = reality_bubble();
-
     if( bubble_map.inbounds( here->get_abs( pos ) ) ) {
         sounds::sound( bubble_map.get_bub( here->get_abs( pos ) ), sound_volume, sound_type,
                        sound_message.translated(), true,


### PR DESCRIPTION
#### Summary
Fix tool and trap sounds

#### Purpose of change
Chainsaws and the like were really really quiet, making like 5 or 10 sound, which is nothing! These are really loud items IRL. They were also just displaying their sound_message to the player irrespective of whether the character could actually hear the thing, because it was just calling the message and not making it anything to do with sound. Very strange.

fixes #2458 

I also discovered that crossbow traps, shotgun traps, and land mines were super quiet. Why???

#### Describe the solution
Chainsaws, hedge trimmers, pole saws, etc. are now loud as hell. Have fun.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
