### PR TITLE
Improve seed drill viability checking, streamline stooking

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3084,11 +3084,6 @@ void iexamine::stook_empty( Character &, const tripoint_bub_ms &examp )
     } else if( !here.is_outside( examp ) ) {
         add_msg( _( "The stook will need to be set up outside to dry." ) );
         return;
-    } else {
-        add_msg( _( "This pile contains grain that is ready to be left out for drying." ) );
-        if( !query_yn( _( "Stand the grain up to dry?" ) ) ) {
-            return;
-        }
     }
 
     here.furn_set( examp, next_stook_type );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -117,7 +117,6 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_generic_folded_vehicle( "generic_folded_vehicle" );
 static const itype_id itype_plut_cell( "plut_cell" );
 static const itype_id itype_plut_slurry_dense( "plut_slurry_dense" );
-static const itype_id itype_seed_buckwheat( "seed_buckwheat" );
 static const itype_id itype_wall_wiring( "wall_wiring" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
@@ -6222,25 +6221,6 @@ void vehicle::idle( map &here, bool on_map )
             add_msg_if_player_sees( pos_bub( here ), _( "The %s's engine dies!" ), name );
         }
         engine_on = false;
-    }
-
-    // FIXME/HACK: Always checks buckwheat seeds!
-    // Returned string intentionally discarded!
-    // TODO: move it to planter function that tries to plant, and maybe cache it there
-    // (warm_enough_to_plant() is very expensive)
-    if( !planters.empty() && calendar::once_every( 10_minutes ) ) {
-        ret_val<void>can_plant = warm_enough_to_plant( player_character.pos_bub(), itype_seed_buckwheat );
-        if( !can_plant.success() ) {
-            for( int i : planters ) {
-                vehicle_part &vp = parts[ i ];
-                if( vp.enabled ) {
-                    add_msg_if_player_sees( pos_bub( here ),
-                                            _( "The %s's planter turns off due to unsuitable planting conditions." ),
-                                            name );
-                    vp.enabled = false;
-                }
-            }
-        }
     }
 
     linked_item_epower_this_turn = 0_W;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -38,7 +38,6 @@ static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_none( "null" );
 
 static const itype_id itype_battery( "battery" );
-static const itype_id itype_seed_buckwheat( "seed_buckwheat" );
 
 /*-----------------------------------------------------------------------------
  *                              VEHICLE_PART
@@ -735,16 +734,6 @@ bool vehicle::can_enable( map &here, const vehicle_part &pt, bool alert ) const
     }
 
     if( pt.is_broken() ) {
-        return false;
-    }
-
-    // FIXME/HACK: Always checks buckwheat seeds!
-    ret_val<void>can_plant = warm_enough_to_plant( get_player_character().pos_bub(),
-                             itype_seed_buckwheat );
-    if( pt.info().has_flag( "PLANTER" ) && !can_plant.success() ) {
-        if( alert ) {
-            add_msg( m_bad, can_plant.c_str() );
-        }
         return false;
     }
 

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1100,7 +1100,14 @@ void vehicle::operate_planter( map &here )
                     //then don't put the item there.
                     break;
                 } else if( t == ter_t_dirtmound ) {
-                    here.set( loc, ter_t_dirt, furn_f_plant_seed );
+                    ret_val<void>can_plant = warm_enough_to_plant( loc, i->typeId() );
+                    if( can_plant.success() ) {
+                        // Plant the seed once it gets dropped.
+                        here.set( loc, ter_t_dirt, furn_f_plant_seed );
+                    } else {
+                        // Leave the seed on the ground.
+                        add_msg_if_player_sees( loc, can_plant.c_str() );
+                    }
                 } else if( !here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, loc ) ) {
                     //If it isn't plowable terrain, then it will most likely be damaged.
                     damage( here, planter_id, rng( 1, 10 ), damage_bash, false );


### PR DESCRIPTION
#### Summary
Fewer keypresses to set up grain stooks, accurate weather-checking on vehicle planters

#### Purpose of change
Setting up grain stooks for large harvests took many keypresses, even when using zones.

Planters on a vehicle were checking buckwheat's grow phases, regardless of the actual seeds used, and disabled the toggle in the vehicle-interaction menu without any explanation in case of inviability.
This allowed planting seeds late (like wheat) that would die from cold, and disallowed fast-growing plants (like oats) in some viable parts of the year.

#### Describe the solution
Remove the Y/N prompt when examining a stooking spot.  This had little utility since the action can easily be undone by deconstructing the active stook.

Vehicle planters can now always be turned on, and viability is checked when a specific seed is about to be planted.
If it is too early/late to plant, the seed is dropped to the ground (like in the case of trying to plant on non-plowed ground), and a message is printed like with manual planting if the player can see the planter vehicle part.

#### Describe alternatives you've considered
Maybe it's not appropriate to have seed drills magically check which seeds can survive being planted, like a survivor can; perhaps they should just be planted unconditionally, leaving the plants to die when planted out of season or underground (I did not test if that happens, though).

Also, it would be nice to have bulk actions to set up and take down stooks, perhaps with zones (constructing the stooks and moving the grain there can already be done that way).  A zone type to execute the examine-action on everything in it?

#### Testing
Happily set up a 16x12 rectangle of wheat stooks without prompts slowing me down.

Tried planting oats/buckwheat/wheat with my tractor during different times of the year (time skipped with debug commands), observed planting/dropping happening appropriately, did not see warning message when blinded.

And since the code comments mentioned caching the results of `warm_enough_to_plant`: Performance didn't seem awful (it shouldn't be any worse than doing all the planting manually).

#### Additional context
Diesel-powered farming is fun