### PR TITLE
Don't hide "spoils in" time on old food in eat-menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -796,7 +796,7 @@ class comestible_inventory_preset : public inventory_selector_preset
                 if( player_character.can_estimate_rot() ) {
                     if( loc->is_comestible() && loc->get_comestible()->spoils > 0_turns ) {
                         if( !loc->rotten() ) {
-                            return get_time_left_rounded( loc );
+                            return to_string_approx( get_time_left( loc ) );
                         }
                     }
                     return std::string( "---" );
@@ -898,16 +898,6 @@ class comestible_inventory_preset : public inventory_selector_preset
             }
 
             return time_left;
-        }
-
-        std::string get_time_left_rounded( const item_location &loc ) const {
-            const item &it = *loc;
-            if( it.is_going_bad() ) {
-                return _( "soon!" );
-            }
-
-            time_duration time_left = get_time_left( loc );
-            return to_string_approx( time_left );
         }
 
         std::string get_freshness( const item_location &loc ) {


### PR DESCRIPTION
#### Summary
Don't hide "spoils in" time on old food in eat-menu

#### Purpose of change
In the [E]at menu, with a sufficiently high cooking skill, there is a convenient "SPOILS IN" column that shows the time to spoil of food items, just like in the item's [e]xamine window.

However, on food that's getting old (considering *relative* spoilage, not an absolute time threshold), this entry was replaced by "soon!", forcing the player to check the examine-window for the actual time.
On old food, the row of the item is colored yellow, and the "FRESHNESS" column also shows "old", so I don't see the point in obscuring this information for extra warning-ness.

#### Describe the solution
Just print the time unconditionally.

#### Describe alternatives you've considered
Use the absolute spoilage time instead of the relative spoilage to consider food "old", since you'll still want to eat berries expiring in a day before eating pemmican expiring in 5 weeks, but fortunately this list is already sorted that way.  And I still wouldn't want the information to be obscured like this.

#### Testing
Before:
<img width="1387" height="135" alt="image" src="https://github.com/user-attachments/assets/21dd86f5-a495-4456-9f6e-ab21008ff51c" />

After:
<img width="1376" height="132" alt="image" src="https://github.com/user-attachments/assets/cd712b3d-80a6-429c-9729-7f5ee5b3120b" />

Also tested this with a low-cooking-skill character.

#### Additional context
eating is important