### PR TITLE
Avoid printing black text for tank contents in vehicle display

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1470,7 +1470,7 @@ void veh_interact::calc_overview( map &here )
                         fmtstring = str_cat( "%s %s ", leak_marker, "%5.1fL", leak_marker );
                         offset = 0;
                     }
-                    right_print( w, y, offset, pt_ammo_cur->color,
+                    right_print( w, y, offset, pt_ammo_cur->color == nc_color() ? c_light_gray : pt_ammo_cur->color,
                                  string_format( fmtstring, specials, pt_ammo_cur->nname( 1 ),
                                                 round_up( units::to_liter( it.volume() ), 1 ) ) );
                 } else {

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -412,6 +412,7 @@ void vehicle::print_fuel_indicator( map &here, const catacurses::window &win, co
     int cap = fuel_capacity( here, fuel_type );
     int f_left = fuel_left( here, fuel_type );
     nc_color f_color = item::find_type( fuel_type )->color;
+    if( f_color == nc_color() ) { f_color = c_light_gray; }
     // NOLINTNEXTLINE(cata-text-style): not an ellipsis
     mvwprintz( win, p, col_indf1, "E...F" );
     int amnt = cap > 0 ? f_left * 99 / cap : 0;


### PR DESCRIPTION
#### Summary
Avoid printing black text for tank contents in vehicle display

#### Purpose of change
Storing some substances like animal blood in a vehicle's tank would print invisible text for the tank's contents in the examine window.

#### Describe the solution
Use light gray instead.

#### Describe alternatives you've considered
This is a very hacky solution, it would probably be best to set a default color for these items before it gets to the vehicle-display code, but I couldn't figure out where the appropriate place for that would be and I didn't want to break anything else.

Also it should probably only show usable fuels in the bottom right section.

#### Testing
Before (note that the highlighted tank in the left panel shows 0.5L animal blood, but it's not visible in the center panel):
<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/2259b832-3326-42f3-86cf-a8a94fa7e8f5" />

After:
<img width="1920" height="1049" alt="image" src="https://github.com/user-attachments/assets/5f617c87-b5c5-4312-935a-1f74d5d44e49" />

#### Additional context
technically, vehicles are cold-blooded