### PR TITLE
Make duffel bag waterloose

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -932,7 +932,6 @@
         "max_contains_volume": "60 L",
         "max_contains_weight": "90 kg",
         "max_item_length": "65 cm",
-        "watertight": true,
         "magazine_well": "5 L",
         "moves": 450
       },


### PR DESCRIPTION
#### Summary
Make duffel bag not watertight

#### Purpose of change
The duffel bag could carry liquids, that doesn't seem right.

#### Describe the solution
Make it not so.

#### Describe alternatives you've considered
The dry (waterproof) version of the duffel bag can still carry liquids, that seems more appropriate, although I'm not quite sure there either.

#### Testing
Tried to insert liquid fertilizer into my duffel bag, could before, couldn't now.

#### Additional context
bags are not bottles