### PR TITLE
Fix autotarget after reach or throw attack

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1192,6 +1192,11 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost,
 
     reach_attacking = true;
     melee_attack_abstract( *critter, true, force_technique, false, forced_movecost );
+    last_target_pos = std::nullopt;
+    shared_ptr_fast<Creature> last_target = this->last_target.lock();
+    if( !last_target || last_target->is_dead_state() ) {
+        this->last_target.reset();
+    }
     reach_attacking = false;
 }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1640,6 +1640,10 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
     }
     // Reset last target pos
     last_target_pos = std::nullopt;
+    shared_ptr_fast<Creature> last_target = this->last_target.lock();
+    if( !last_target || last_target->is_dead_state() ) {
+        this->last_target.reset();
+    }
     recoil = MAX_RECOIL;
     // MLB pitchers can throw around 100 times a day.
     const float str_ratio = static_cast<float>( weight / 100.0_gram ) / str_cur;


### PR DESCRIPTION
#### Summary
Fix autotarget after reach or throw attack

#### Purpose of change
fixes #2441 

#### Describe the solution
Reset last_target after reach and throw attacks if it's dead.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
