### PR TITLE
Consistently hide food expiration time under 12 hours

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2030,14 +2030,10 @@ static std::string get_freshness_description( const item &food_item )
         }
     } else if( food_item.is_going_bad() ) {
         // Old food likewise is assumed to be fairly obvious.
-        if( player_character.can_estimate_rot() ) {
-            return string_format( _( "* This food looks <bad>old</bad>.  "
-                                     "It's just <info>%s</info> from becoming inedible." ),
-                                  to_string_approx( time_left ) );
-        } else {
-            return _( "* This food looks <bad>old</bad>.  "
-                      "It's on the brink of becoming inedible." );
-        }
+        // At this point, even skilled characters cannot tell the exact time of expiration
+        // (which would be at hour or minute precision).
+        return _( "* This food looks <bad>old</bad>.  "
+                  "It's on the brink of becoming inedible." );
     }
 
     if( !player_character.can_estimate_rot() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1174,7 +1174,7 @@ class item : public visitable
 
         /** an item is about to become rotten when shelf life has nearly elapsed */
         bool is_going_bad() const {
-            return get_relative_rot() > 0.9;
+            return goes_bad() && get_shelf_life() - rot < 12_hours;
         }
 
         /** returns true if item is now rotten after all shelf life has elapsed */


### PR DESCRIPTION
#### Summary
Consistently hide food expiration time under 12 hours

#### Purpose of change
For characters skilled in cooking, the [E]at menu would replace the "SPOILS IN" value with "soon!" if the relative rot progress of the item was over 90%.
For items like pemmican, this could still be over a week until expiry.
Also, the [e]xamine menu would still let the player see a more precise estimate, getting around the information-hiding of that table.

#### Describe the solution
Stop showing the estimate in both views when the absolute time to expiry is under 12 hours.

#### Describe alternatives you've considered
Show "less than 12 hours" or "under half a day" for skilled cooks in the examination window in this case, to let players know the exact threshold without checking the code or reading the pull requests, but this can also be inferred by checking the last few estimates before the transition.

Alternatively, keep printing an estimate in all cases, but never drop to a finer granularity than 12 hours. This would be a slightly bigger change, since the fuzzy estimate printing is also used elsewhere, like for fire durations.  It might be better though, because it's questionable whether it's possible to distinguish 13 hours from expiry vs. 14 hours from expiry etc., as it is now.

#### Testing
Cooked liver (1 day shelf life), less than 12h but more than 10% from expiry:
<img width="1063" height="955" alt="image" src="https://github.com/user-attachments/assets/2b7a483a-5bff-4e5e-b37d-a68ff120ff0d" />

Pemmican (3 seasons shelf life), 6 days (less than 10%) from expiry:
<img width="1063" height="955" alt="image" src="https://github.com/user-attachments/assets/7675207b-7630-4e67-92a2-1a9605cc04a9" />

Pemmican, less than 12 hours from expiry:
<img width="1063" height="955" alt="image" src="https://github.com/user-attachments/assets/dd801403-c933-439f-a4a5-7d82b113484b" />

#### Additional context
The fuzzy "less than 4 days" etc. formatting seemed busted during testing (flipping back and forth between "less than X" and "more than X" and "about X" with time going forward), maybe I'll investigate that code...