### PR TITLE
Fix vertical feral spear ranges, grapplers burying you

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3976,6 +3976,12 @@
   },
   {
     "type": "effect_type",
+    "id": "pulled",
+    "//": "Dummy effect to prevent multiple creatures from pulling a creature in the same turn",
+    "max_duration": "1 s"
+  },
+  {
+    "type": "effect_type",
     "id": "grabbing",
     "name": [ "Grabbing" ],
     "desc": [ "Grabbing another creature and holding them in place." ],

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -146,11 +146,12 @@
     "condition": {
       "and": [
         { "not": { "u_has_flag": "GRAB_FILTER" } },
-        { "not": { "u_has_effect": "maimed_arm" } },
-        { "not": { "u_has_flag": "NO_GRAB" } },
-        { "not": { "npc_has_effect": "incorporeal" } }
+        { "not": { "npc_has_flag": "GRAB" } },
+        { "not": { "npc_has_effect": "pulled" } },
+        { "not": { "u_has_effect": "incorporeal" } }
       ]
     },
+    "effects": [ { "id": "pulled", "duration": 1 } ],
     "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
     "grab_data": { "exclusive_grab": true, "pull_chance": 100, "pull_weight_ratio": 0.75 },
     "no_dmg_msg_u": "",
@@ -171,9 +172,11 @@
         { "not": { "u_has_flag": "GRAB_FILTER" } },
         { "not": { "u_has_effect": "maimed_arm" } },
         { "not": { "u_has_flag": "NO_GRAB" } },
+        { "not": { "npc_has_effect": "pulled" } },
         { "not": { "npc_has_effect": "incorporeal" } }
       ]
     },
+    "effects": [ { "id": "pulled", "duration": 1 } ],
     "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
     "grab": true,
     "grab_data": {
@@ -204,6 +207,7 @@
         { "u_has_flag": "GRAB_FILTER" },
         { "npc_has_flag": "GRAB" },
         { "not": { "u_has_flag": "NO_GRAB" } },
+        { "not": { "npc_has_effect": "pulled" } },
         { "not": { "npc_has_effect": "incorporeal" } }
       ]
     },
@@ -216,6 +220,7 @@
       "drag_grab_break_distance": 2,
       "grab_effect": "null"
     },
+    "effects": [ { "id": "pulled", "duration": 1 } ],
     "hit_dmg_u": "%1$s drags you!",
     "hit_dmg_npc": "%1$s drags <npcname>!",
     "miss_msg_u": "",
@@ -808,10 +813,12 @@
       "and": [
         { "not": { "u_has_flag": "GRAB_FILTER" } },
         { "not": { "npc_has_flag": "GRAB" } },
+        { "not": { "npc_has_effect": "pulled" } },
+        { "not": { "u_has_effect": "incorporeal" } },
         { "not": { "u_has_effect": "sectioned_filaments" } }
       ]
     },
-    "effects": [ { "id": "venom_pain", "duration": 54000, "affect_hit_bp": true } ],
+    "effects": [ { "id": "venom_pain", "duration": 54000, "affect_hit_bp": true }, { "id": "pulled", "duration": 1 } ],
     "hit_dmg_u": "Using its filaments, the %s pulls you close.",
     "hit_dmg_npc": "Using its filaments, the %s pulls <npcname> close.",
     "miss_msg_u": "The %s spews filaments at you but misses.",

--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -211,6 +211,7 @@
         { "not": { "npc_has_effect": "incorporeal" } }
       ]
     },
+    "effects": [ { "id": "pulled", "duration": 1 } ],
     "grab": true,
     "grab_data": {
       "exclusive_grab": true,
@@ -220,7 +221,6 @@
       "drag_grab_break_distance": 2,
       "grab_effect": "null"
     },
-    "effects": [ { "id": "pulled", "duration": 1 } ],
     "hit_dmg_u": "%1$s drags you!",
     "hit_dmg_npc": "%1$s drags <npcname>!",
     "miss_msg_u": "",

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -960,48 +960,55 @@ bool Creature::is_adjacent( const Creature *target, const bool allow_z_levels ) 
         return false;
     }
 
-    if( rl_dist( pos_bub(), target->pos_bub() ) != 1 ) {
+    const int dz = std::abs( posz() - target->posz() );
+
+    // Too far apart vertically.
+    if( dz > 1 ) {
         return false;
     }
 
-    // Diagonally offset targets are not adjacent.
-    if( posz() != target->posz() && pos_bub().xy() != target->pos_bub().xy() ) {
-        return false;
+    const point_rel_ms delta = pos_bub().xy() - target->pos_bub().xy();
+    const int dx = std::abs( delta.x() );
+    const int dy = std::abs( delta.y() );
+
+    if( dz == 0 ) {
+        // Same Z level:
+        // adjacent if within the surrounding 8 tiles.
+        if( dx > 1 || dy > 1 || ( dx == 0 && dy == 0 ) ) {
+            return false;
+        }
+    } else {
+        // Different Z levels:
+        // adjacent only if directly above/below.
+        if( !allow_z_levels || dx != 0 || dy != 0 ) {
+            return false;
+        }
     }
 
-    if( !can_squeeze_to( target->pos_bub() ) ) {
-        return false;
-    }
-
-    // Explicitly check for Z difference > 1
-    if( std::abs( posz() - target->posz() ) > 1 ) {
-
+    if( !vehicle_not_blocking( target->pos_bub() ) ) {
         return false;
     }
 
     map &here = get_map();
-    if( posz() == target->posz() ) {
-        return
-            /* either target or attacker are underwater and separated by vehicle tiles */
-            !( underwater != target->underwater &&
-               here.veh_at( pos_bub() ) && here.veh_at( target->pos_bub() ) );
+
+    if( dz == 0 ) {
+        return !( underwater != target->underwater &&
+                  here.veh_at( pos_bub() ) &&
+                  here.veh_at( target->pos_bub() ) );
     }
 
-    if( !allow_z_levels ) {
-        return false;
-    }
-
-    // The square above must have no floor.
-    // The square below must have no ceiling (i.e. no floor on the tile above it).
     const bool target_above = target->posz() > posz();
     const tripoint_bub_ms up = target_above ? target->pos_bub() : pos_bub();
     const tripoint_bub_ms down = target_above ? pos_bub() : target->pos_bub();
-    const tripoint_bub_ms above{ down.xy(), up.z()};
-    return ( !here.has_floor( up ) || here.ter( up )->has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) &&
-           ( !here.has_floor( above ) || here.ter( above )->has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) );
+    const tripoint_bub_ms above{ down.xy(), up.z() };
+
+    return ( !here.has_floor( up ) ||
+             here.ter( up )->has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) &&
+           ( !here.has_floor( above ) ||
+             here.ter( above )->has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) );
 }
 
-bool Creature::can_squeeze_to( const tripoint_bub_ms &p ) const
+bool Creature::vehicle_not_blocking( const tripoint_bub_ms &p ) const
 {
     map &here = get_map();
     return !here.obstructed_by_vehicle_rotation( pos_bub(), p );

--- a/src/creature.h
+++ b/src/creature.h
@@ -330,7 +330,7 @@ class Creature : public viewer
         /** Helper overload for when the boolean is discardable */
         bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc ) const;
         /** Checks for and excludes vehicle gaps that only exist due to diagonal skew. */
-        bool can_squeeze_to( const tripoint_bub_ms &p ) const;
+        bool vehicle_not_blocking( const tripoint_bub_ms &p ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
         virtual int climbing_cost( const tripoint_bub_ms &from, const tripoint_bub_ms &to ) const;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3463,9 +3463,10 @@ void basecamp::start_crafting( const std::string &type, const mission_id &miss_i
             return;
         }
 
-    const crafting_cost_context ctx = crafting_cost_context::for_recipe(
-            get_player_character(), making );
-        time_duration work_days = base_camps::to_workdays( making.batch_duration( get_player_character(), ctx,
+        const crafting_cost_context ctx = crafting_cost_context::for_recipe(
+                                              get_player_character(), making );
+        time_duration work_days = base_camps::to_workdays( making.batch_duration( get_player_character(),
+                                  ctx,
                                   batch_size ) );
         npc_ptr comp = start_mission( miss_id, work_days, true,
                                       _( "begins to work…" ), false, {}, making.exertion_level(),
@@ -4712,9 +4713,9 @@ int basecamp::recipe_batch_max( const recipe &making ) const
     int max_batch = 0;
     const int max_checks = 9;
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
-        for( int iter = 0; iter < max_checks; iter++ ) {    
+        for( int iter = 0; iter < max_checks; iter++ ) {
             const crafting_cost_context ctx = crafting_cost_context::for_recipe(
-            get_player_character(), making );
+                                                  get_player_character(), making );
             time_duration work_days = base_camps::to_workdays( making.batch_duration(
                                           get_player_character(), ctx, max_batch + batch_size ) );
             int food_req = time_to_food( work_days );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -331,11 +331,21 @@ bool mon_spellcasting_actor::call( monster &mon ) const
 
     spell spell_instance = spell_data.get_spell( mon );
     spell_instance.set_message( spell_data.trigger_message );
-
-    // Bail out if the target is out of range.
-    if( !spell_data.self && target &&
-        trig_dist( mon.pos_bub(), target_pos ) > spell_instance.range( mon ) ) {
-        return false;
+    if( !spell_data.self && target ) {
+        // Bail out if the target is out of range.
+        if( mon.pos_bub().z() == target->pos_bub().z() ) {
+            if( !spell_data.self && target &&
+                trig_dist( mon.pos_bub(), target_pos ) > spell_instance.range( mon ) ) {
+                return false;
+            }
+        } else {
+            // Round up to ensure Z levels count properly as 2.
+            if( !spell_data.self && target &&
+                static_cast<int>( std::ceil( trig_dist_precise( mon.pos_bub(),
+                                             target_pos ) ) ) > spell_instance.range( mon ) ) {
+                return false;
+            }
+        }
     }
 
     std::string target_name;
@@ -487,11 +497,23 @@ Creature *melee_actor::find_target( monster &z ) const
     }
 
     if( range > 1 ) {
-        if( !z.sees( here, *target ) ||
-            !here.clear_path( z.pos_bub( here ), target->pos_bub( here ), range, 1, 200 ) ) {
-            return nullptr;
+        bool in_range = false;
+
+        if( z.posz() == target->posz() ) {
+            in_range = trig_dist( z.pos_bub(), target->pos_bub() ) <= range;
+        } else {
+            in_range = static_cast<int>(
+                           std::ceil(
+                               trig_dist_precise(
+                                   z.pos_bub(), target->pos_bub() ) ) ) <= range;
         }
 
+        if( !in_range ||
+            !z.sees( here, *target ) ||
+            !here.clear_path( z.pos_bub( here ), target->pos_bub( here ),
+                              range, 1, 200 ) ) {
+            return nullptr;
+        }
     } else if( !z.is_adjacent( target, false ) ) {
         return nullptr;
     }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -60,6 +60,7 @@ static const efftype_id effect_laserlocked( "laserlocked" );
 static const efftype_id effect_null( "null" );
 static const efftype_id effect_poison( "poison" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
+static const efftype_id effect_pulled( "pulled" );
 static const efftype_id effect_run( "run" );
 static const efftype_id effect_sensor_stun( "sensor_stun" );
 static const efftype_id effect_stunned( "stunned" );
@@ -545,7 +546,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
                    eff_grab_strength, grab_data.pull_chance );
 
     // Handle seatbelts and weight limits for pulls/drags TODO: tear you out depending on grab str?
-    if( grab_data.pull_chance > -1 || grab_data.drag_distance > 0 ) {
+    if( ( grab_data.pull_chance > -1 || grab_data.drag_distance > 0 ) && !target->has_effect( effect_pulled ) ) {
         if( target->get_weight() > z.get_weight() * grab_data.pull_weight_ratio ) {
             target->add_msg_player_or_npc( msg_type, grab_data.pull_fail_msg_u, grab_data.pull_fail_msg_npc,
                                            mon_name );
@@ -596,7 +597,7 @@ int melee_actor::do_grab( monster &z, Creature *target, bodypart_id bp_id ) cons
             tdir.advance();
             pt.x() = target_pos.x() + tdir.dx();
             pt.y() = target_pos.y() + tdir.dy();
-            //Cancel the grab if the space is occupied by something
+            // Cancel the grab if the space is occupied by something
             if( !g->is_empty( pt ) ) {
                 break;
             }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -235,11 +235,6 @@ static const ter_str_id ter_t_underbrush( "t_underbrush" );
 static const trait_id trait_MARLOSS( "MARLOSS" );
 static const trait_id trait_MARLOSS_BLUE( "MARLOSS_BLUE" );
 static const trait_id trait_PARAIMMUNE( "PARAIMMUNE" );
-static const trait_id trait_PROF_CHURL( "PROF_CHURL" );
-static const trait_id trait_PROF_FED( "PROF_FED" );
-static const trait_id trait_PROF_PD_DET( "PROF_PD_DET" );
-static const trait_id trait_PROF_POLICE( "PROF_POLICE" );
-static const trait_id trait_PROF_SWAT( "PROF_SWAT" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 
@@ -253,14 +248,26 @@ static bool within_visual_range( monster *z, int max_range )
               !z->sees( here, player_character ) );
 }
 
-static bool within_target_range( const monster *const z, const Creature *const target, int range )
+static bool within_target_range( const monster *const z, const Creature *const target,
+                                 int range )
 {
+    if( target == nullptr ) {
+        return false;
+    }
     const map &here = get_map();
-
-    return target != nullptr &&
-           ( z->is_adjacent( target, true ) ||
-             trig_dist( z->pos_bub(), target->pos_bub() ) <= range ) &&
-           z->sees( here, *target );
+    if( z->is_adjacent( target, true ) ) {
+        return z->sees( here, *target );
+    }
+    bool in_range = false;
+    if( z->pos_bub().z() == target->pos_bub().z() ) {
+        in_range = trig_dist( z->pos_bub(), target->pos_bub() ) <= range;
+    } else {
+        // If we're on different Z levels, round up to make sure they count properly for 2.
+        in_range = static_cast<int>(
+                       std::ceil(
+                           trig_dist_precise( z->pos_bub(), target->pos_bub() ) ) ) <= range;
+    }
+    return in_range && z->sees( here, *target );
 }
 
 static Creature *sting_get_target( monster *z, float range = 5.0f )
@@ -1079,7 +1086,7 @@ bool mattack::pull_metal_weapon( monster *z )
                     proj.speed = 50;
                     proj.impact = damage_instance( damage_bash, pulled_weapon.weight() / 250_gram );
                     // make the projectile stop one tile short to prevent hitting the monster
-                    proj.range = rl_dist( foe->pos_bub(), z->pos_bub() ) - 1;
+                    proj.range = trig_dist( foe->pos_bub(), z->pos_bub() ) - 1;
                     proj.proj_effects = { { ammo_effect_NO_ITEM_DAMAGE, ammo_effect_DRAW_AS_LINE, ammo_effect_NO_DAMAGE_SCALING, ammo_effect_JET } };
 
                     dealt_projectile_attack dealt;
@@ -2684,72 +2691,64 @@ bool mattack::photograph( monster *z )
     // Badges should NOT be swappable between roles.
     // Hence separate checking.
     // If you are in fact listed as a police officer
-    if( player_character.has_trait( trait_PROF_POLICE ) ) {
+    if( player_character.is_wearing( itype_badge_deputy ) ) {
         // And you're wearing your badge
-        if( player_character.is_wearing( itype_badge_deputy ) ) {
-            if( one_in( 3 ) ) {
-                add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
-                         z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
-                z->die( &here, nullptr );
-                return false;
-            } else {
-                add_msg( m_info,
-                         _( "The %s acknowledges you as an officer responding, but hangs around to watch." ),
-                         z->name() );
-                add_msg( m_info, _( "Probably some now-obsolete Internal Affairs subroutine…" ) );
-                return true;
-            }
-        }
-    }
-
-    if( player_character.has_trait( trait_PROF_PD_DET ) ) {
-        // And you have your shield on
-        if( player_character.is_wearing( itype_badge_detective ) ) {
-            if( one_in( 4 ) ) {
-                add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
-                         z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
-                z->die( &here, nullptr );
-                return false;
-            } else {
-                add_msg( m_info,
-                         _( "The %s acknowledges you as an officer responding, but hangs around to watch." ),
-                         z->name() );
-                add_msg( m_info, _( "Ops used to do that in case you needed backup…" ) );
-                return true;
-            }
-        }
-    } else if( player_character.has_trait( trait_PROF_SWAT ) ) {
-        // And you're wearing your badge
-        if( player_character.is_wearing( itype_badge_swat ) ) {
-            if( one_in( 3 ) ) {
-                add_msg( m_info, _( "The %s flashes a LED and departs.  SWAT's working the area." ),
-                         z->name() );
-                z->no_corpse_quiet = true;
-                z->no_extra_death_drops = true;
-                z->die( &here, nullptr );
-                return false;
-            } else {
-                add_msg( m_info, _( "The %s acknowledges you as SWAT onsite, but hangs around to watch." ),
-                         z->name() );
-                add_msg( m_info, _( "Probably some now-obsolete Internal Affairs subroutine…" ) );
-                return true;
-            }
-        }
-    }
-
-    if( player_character.has_trait( trait_PROF_FED ) ) {
-        // And you're wearing your badge
-        if( player_character.is_wearing( itype_badge_marshal ) ) {
-            add_msg( m_info, _( "The %s flashes a LED and departs.  The Feds got this." ), z->name() );
+        if( one_in( 3 ) ) {
+            add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
+                     z->name() );
             z->no_corpse_quiet = true;
             z->no_extra_death_drops = true;
             z->die( &here, nullptr );
             return false;
+        } else {
+            add_msg( m_info,
+                     _( "The %s acknowledges you as an officer responding, but hangs around to watch." ),
+                     z->name() );
+            add_msg( m_info, _( "Probably some now-obsolete Internal Affairs subroutine…" ) );
+            return true;
         }
+    }
+
+    if( player_character.is_wearing( itype_badge_detective ) ) {
+        // And you have your shield on
+        if( one_in( 4 ) ) {
+            add_msg( m_info, _( "The %s flashes a LED and departs.  Human officer on scene." ),
+                     z->name() );
+            z->no_corpse_quiet = true;
+            z->no_extra_death_drops = true;
+            z->die( &here, nullptr );
+            return false;
+        } else {
+            add_msg( m_info,
+                     _( "The %s acknowledges you as an officer responding, but hangs around to watch." ),
+                     z->name() );
+            add_msg( m_info, _( "Ops used to do that in case you needed backup…" ) );
+            return true;
+        }
+    } else if( player_character.is_wearing( itype_badge_swat ) ) {
+        // And you're wearing your badge
+        if( one_in( 3 ) ) {
+            add_msg( m_info, _( "The %s flashes a LED and departs.  SWAT's working the area." ),
+                     z->name() );
+            z->no_corpse_quiet = true;
+            z->no_extra_death_drops = true;
+            z->die( &here, nullptr );
+            return false;
+        } else {
+            add_msg( m_info, _( "The %s acknowledges you as SWAT onsite, but hangs around to watch." ),
+                     z->name() );
+            add_msg( m_info, _( "Probably some now-obsolete Internal Affairs subroutine…" ) );
+            return true;
+        }
+    }
+
+    if( player_character.is_wearing( itype_badge_marshal ) ) {
+        // And you're wearing your badge
+        add_msg( m_info, _( "The %s flashes a LED and departs.  The Feds got this." ), z->name() );
+        z->no_corpse_quiet = true;
+        z->no_extra_death_drops = true;
+        z->die( &here, nullptr );
+        return false;
     }
 
     if( z->friendly || ( weapon && weapon->typeId() == itype_e_handcuffs ) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1009,7 +1009,7 @@ void monster::move()
     // Check z-level neighbors too so creatures on stairs aren't falsely stuck
     for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1, 1 ) ) {
         if( dest != pos_bub() ) {
-            if( can_move_to( dest ) && can_squeeze_to( dest ) &&
+            if( can_move_to( dest ) && vehicle_not_blocking( dest ) &&
                 creatures.creature_at( dest, true ) == nullptr ) {
                 try_to_move = true;
                 break;
@@ -1234,7 +1234,7 @@ void monster::move()
             // Try to shove vehicle out of the way
             shove_vehicle( destination, tripoint_bub_ms( candidate ) );
             // Bail out if we can't move there and we can't bash.
-            if( !pathed && ( !can_move_to( candidate ) || !can_squeeze_to( candidate ) ) ) {
+            if( !pathed && ( !can_move_to( candidate ) || !vehicle_not_blocking( candidate ) ) ) {
                 if( !can_bash || has_flag( json_flag_CANNOT_ATTACK ) ) {
                     continue;
                 }
@@ -1922,7 +1922,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     if( critter != nullptr && !step_on_critter ) {
         return false;
     }
-    if( !can_squeeze_to( destination ) ) {
+    if( !vehicle_not_blocking( destination ) ) {
         return false;
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2036,7 +2036,7 @@ bool monster::melee_attack( Creature &target, float accuracy )
         // We don't hit, so just return
         return true;
     }
-    if( !can_squeeze_to( target.pos_bub() ) ) {
+    if( !vehicle_not_blocking( target.pos_bub() ) ) {
         return false;
     }
 

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -412,7 +412,9 @@ void vehicle::print_fuel_indicator( map &here, const catacurses::window &win, co
     int cap = fuel_capacity( here, fuel_type );
     int f_left = fuel_left( here, fuel_type );
     nc_color f_color = item::find_type( fuel_type )->color;
-    if( f_color == nc_color() ) { f_color = c_light_gray; }
+    if( f_color == nc_color() ) {
+        f_color = c_light_gray;
+    }
     // NOLINTNEXTLINE(cata-text-style): not an ellipsis
     mvwprintz( win, p, col_indf1, "E...F" );
     int amnt = cap > 0 ? f_left * 99 / cap : 0;


### PR DESCRIPTION
#### Summary
Fix vertical feral spear ranges, grapplers burying you, badges

#### Describe the solution
- All monattacks(?) now properly evaluate range, ensuring that Z levels count for 2 so ferals with spears can't stab you on roofs when you cannot stab them.
- Pull attacks add a "pulled" effect for 1 second which prevents further pulls. This way, you can't get multipulled in the same turn and won't wind up buried underground. Attacks which pull you more than one tile or do multi-stage pulls still work.
- The (currently unused) eyebots required both a profession and a badge. That's dumb. They just need to see a badge now to assume you're friendly.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
