### PR TITLE
Fix and improve pemmican recipes

### DIFF
--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -733,7 +733,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "pemmican",
-    "name": { "str_sp": "pemmican" },
+    "name": { "str_sp": "pemmican with fruit" },
     "conditional_names": [
       { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "prepper %s" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "pernicious %s" } }
@@ -758,7 +758,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "pemmican_vegetable",
-    "name": { "str_sp": "pemmican" },
+    "name": { "str_sp": "pemmican with vegetables" },
     "conditional_names": [
       { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "prepper %s" } },
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "pernicious %s" } }
@@ -783,7 +783,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "pemmican_meat",
-    "name": { "str_sp": "pemmican (meat only)" },
+    "name": { "str_sp": "pemmican" },
     "conditional_names": [
       { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "prepper %s" } },
       { "type": "COMPONENT_ID", "condition": "mutant", "name": { "str_sp": "pernicious %s" } }

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2258,7 +2258,7 @@
     "name": "pemmican",
     "description": "Recipes related to making pemmican.",
     "skill_used": "cooking",
-    "nested_category_data": [ "pemmican", "pemmican_vegetable", "pemmican_meat" ]
+    "nested_category_data": [ "pemmican", "pemmican_with_food_processor", "pemmican_vegetable", "pemmican_vegetable_with_food_processor", "pemmican_meat", "pemmican_meat_with_food_processor" ]
   },
   {
     "id": "nested_chairs",

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -3460,9 +3460,9 @@
     "time": "45 m",
     "batch_time_factors": [ 80, 1 ],
     "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
-    "//": "meat = 20u, fat = 15u, vegetable/fruit = 4u, give or take",
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "BOIL", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
+    "proficiencies": [ { "proficiency": "prof_knife_skills" }, { "proficiency": "prof_preservation" } ],
     "components": [
       [ [ "any_shortening", 6, "LIST" ] ],
       [
@@ -3489,8 +3489,9 @@
     "time": "45 m",
     "batch_time_factors": [ 80, 1 ],
     "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "BOIL", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
+    "proficiencies": [ { "proficiency": "prof_knife_skills" }, { "proficiency": "prof_preservation" } ],
     "components": [
       [ [ "any_shortening", 6, "LIST" ] ],
       [
@@ -3517,9 +3518,99 @@
     "time": "40 m",
     "batch_time_factors": [ 80, 1 ],
     "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 36, "LIST" ] ] ],
-    "//": "meat = 20u, fat = 15u, give or take",
+    "qualities": [ { "id": "CUT", "level": 2 }, { "id": "BOIL", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ] ],
+    "proficiencies": [ { "proficiency": "prof_knife_skills" }, { "proficiency": "prof_preservation" } ],
+    "components": [
+      [ [ "any_shortening", 6, "LIST" ] ],
+      [
+        [ "jerky", 2 ],
+        [ "dry_meat", 2 ],
+        [ "meat_smoked", 2 ],
+        [ "dry_fish", 2 ],
+        [ "fish_smoked", 2 ],
+        [ "dry_lobster", 2 ],
+        [ "lobster_smoked", 2 ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "pemmican",
+    "id_suffix": "with_food_processor",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_MEAT",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "charges": 4,
+    "time": "20 m",
+    "batch_time_factors": [ 80, 1 ],
+    "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ], [ [ "food_processor", 20 ] ] ],
+    "qualities": [ { "id": "BOIL", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_preservation" } ],
+    "//": "meat = 20u, fat = 15u, vegetable/fruit = 4u, give or take",
+    "components": [
+      [ [ "any_shortening", 6, "LIST" ] ],
+      [
+        [ "jerky", 2 ],
+        [ "dry_meat", 2 ],
+        [ "meat_smoked", 2 ],
+        [ "dry_fish", 2 ],
+        [ "fish_smoked", 2 ],
+        [ "dry_lobster", 2 ],
+        [ "lobster_smoked", 2 ]
+      ],
+      [ [ "dry_fruit", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "pemmican_vegetable",
+    "id_suffix": "with_food_processor",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "charges": 4,
+    "time": "20 m",
+    "batch_time_factors": [ 80, 1 ],
+    "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ], [ [ "food_processor", 20 ] ] ],
+    "qualities": [ { "id": "BOIL", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_preservation" } ],
+    "components": [
+      [ [ "any_shortening", 6, "LIST" ] ],
+      [
+        [ "jerky", 2 ],
+        [ "dry_meat", 2 ],
+        [ "meat_smoked", 2 ],
+        [ "dry_fish", 2 ],
+        [ "fish_smoked", 2 ],
+        [ "dry_lobster", 2 ],
+        [ "lobster_smoked", 2 ]
+      ],
+      [ [ "dry_vegetable", 2 ], [ "dry_corn", 2 ], [ "dry_mushroom", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "pemmican_meat",
+    "id_suffix": "with_food_processor",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "charges": 4,
+    "time": "20 m",
+    "batch_time_factors": [ 80, 1 ],
+    "book_learn": [ [ "cookbook_native", 1 ], [ "survival_book", 1 ] ],
+    "tools": [ [ [ "surface_heat", 15, "LIST" ] ], [ [ "food_processor", 20 ] ] ],
+    "qualities": [ { "id": "BOIL", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_preservation" } ],
     "components": [
       [ [ "any_shortening", 6, "LIST" ] ],
       [


### PR DESCRIPTION
#### Summary
Fix and improve pemmican recipes

#### Purpose of change
Pemmican recipes required too much heat, didn't need anything to melt the fat in, didn't use any proficiencies, and there was no option to use a food processor.

#### Describe the solution
- Pemmican now uses the knife skills and food preservation proficiencies
- Added recipes for food processor versions which require no knife proficiency, no knife, and take 20 minutes per instead of 45
- Fixed names of pemmican types

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
