### PR TITLE
Fix sidebar weariness transition indicator range

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5362,29 +5362,6 @@ int Character::weary_threshold() const
     return std::max( threshold, bmr / 10 );
 }
 
-std::pair<int, int> Character::weariness_transition_progress() const
-{
-    // Mostly a duplicate of the below function. No real way to clean this up
-    int amount = weariness();
-    int threshold = weary_threshold();
-    amount -= threshold;
-    // failsafe if threshold is zero; see #72242
-    if( threshold == 0 ) {
-        return { std::abs( amount ), threshold };
-    } else {
-        while( amount >= 0 ) {
-            amount -= threshold;
-            if( threshold > 20 ) {
-                threshold = static_cast<int>( std::round( threshold *= 0.75 ) );
-            }
-        }
-    }
-
-    // If we return the absolute value of the amount, it will work better
-    // Because as it decreases, we will approach a transition
-    return {std::abs( amount ), threshold};
-}
-
 int Character::weariness_level() const
 {
     int amount = weariness();
@@ -5398,7 +5375,7 @@ int Character::weariness_level() const
         while( amount >= 0 ) {
             amount -= threshold;
             if( threshold > 20 ) {
-                threshold = static_cast<int>( std::round( threshold *= 0.75 ) );
+                threshold = static_cast<int>( std::round( threshold * 0.75 ) );
             }
             ++level;
         }
@@ -5407,25 +5384,34 @@ int Character::weariness_level() const
     return level;
 }
 
-
-int Character::weariness_transition_level() const
+int Character::weariness_transition_percent() const
 {
     int amount = weariness();
     int threshold = weary_threshold();
+    int level = 0;
+    int range = threshold;
     amount -= threshold;
     // failsafe if threshold is zero; see #72242
     if( threshold == 0 ) {
-        return std::abs( amount );
+        return 100;
     } else {
         while( amount >= 0 ) {
+            range = threshold;
             amount -= threshold;
             if( threshold > 20 ) {
-                threshold = static_cast<int>( std::round( threshold *= 0.75 ) );
+                threshold = static_cast<int>( std::round( threshold * 0.75 ) );
+            }
+            ++level;
+            if( level > 5 ) {
+                // The weariness level can go beyond "Extreme",
+                // but that is the highest that the widgets show.
+                // Clamp the transition indicator to 0 at that point.
+                return 0;
             }
         }
     }
 
-    return std::abs( amount );
+    return std::round( ( -100.0f * amount ) / range );
 }
 
 float Character::maximum_exertion_level() const

--- a/src/character.h
+++ b/src/character.h
@@ -3934,9 +3934,8 @@ class Character : public Creature, public visitable
         time_duration get_consume_time( const item &it ) const;
 
         // For display purposes mainly, how far we are from the next level of weariness
-        std::pair<int, int> weariness_transition_progress() const;
         int weariness_level() const;
-        int weariness_transition_level() const;
+        int weariness_transition_percent() const;
         int weary_threshold() const;
         int weariness() const;
         float activity_level() const;

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -743,7 +743,7 @@ void widget::set_default_var_range( const avatar &ava )
             break;
         case widget_var::weary_transition_level:
             _var_min = 0;
-            _var_max = ava.weary_threshold();
+            _var_max = 100;
             break;
         case widget_var::custom:
             _custom_var.set_widget_var_range( ava, *this );
@@ -892,7 +892,7 @@ int widget::get_var_value( const avatar &ava ) const
             value = ava.weariness_level();
             break;
         case widget_var::weary_transition_level:
-            value = ava.weariness_transition_level();
+            value = ava.weariness_transition_percent();
             break;
         case widget_var::stat_str:
             value = ava.get_str();


### PR DESCRIPTION
#### Summary
Make use of the weariness transition indicator's full range.

#### Purpose of change
At weariness levels above Light, the transition indicator was using less and less of its full range.
Also, when weariness reached levels above Extreme, it kept jumping up.

#### Describe the solution
Instead of the widget using the "Fresh" weariness limit as the maximum and the weariness amount beyond the last threshold as the value, fix the maximum to 100 and calculate a normalized value in that 0 - 100 range consistent with the weariness level threshold logic.

#### Describe alternatives you've considered
There was a routine `Character::weariness_transition_progress` which seemed to provide something closer to the required data for this display, and maybe could've reduced some code duplication, but it was unused, and I think its transition range was off by one and didn't handle the looping levels going past Extreme, so I deleted that.

Also, picking a 0 - 100 range instead of 0 - INT_MAX or 0.0f - 1.0f is kind of arbitrary, but I don't think more precision than this is needed for any widgets.

Only by digging into this did I learn that the weariness level can go beyond Extreme, which caused some jumping in the transition bar which I always thought was kind of weird.  With this change, the transition gets clamped to 0 in that situation, so the player doesn't get information about how far beyond Extreme they are.  Still, I think this is better than the arbitrary-seeming flickering of the Transition indicator.

#### Testing
Took some meth and started working out to observe the Weariness going through its levels.
I saw previously unseen things:
<img width="145" height="36" alt="image" src="https://github.com/user-attachments/assets/b7a77396-617f-4dc6-9102-8d449bd19d0e" />

Before, at the same weariness, one would have seen this, even though the character is very close to the "Moderate" level:
<img width="145" height="34" alt="image" src="https://github.com/user-attachments/assets/0efe0a1b-c079-4f14-93b8-6ac948bed1a8" />

#### Additional context
The code around there is weird, but I didn't want to change much more than necessary.

Also, if I understand the level calculation loop right, the Fresh and Light weariness levels have the same range, and it only starts getting shorter at Moderate?  I'm not sure if that's intentional.