### PR TITLE
Nerf the shit out of Barbaran Montante

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -161,12 +161,13 @@
       {
         "id": "buff_barbaran_static",
         "name": "Barbaran Represa",
-        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 75% of Strength.",
+        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 50% of Strength.",
         "melee_allowed": true,
+        "forbidden_buffs_all": [ "buff_barbaran_onmove" ],
         "flat_bonuses": [
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.75 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.75 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.5 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.5 }
         ]
       }
     ],
@@ -209,14 +210,14 @@
       {
         "id": "buff_barbaran_onpause",
         "name": "Vulgar Preparation",
-        "description": "You prepare for the final crushing strike.\n\nAccuracy increased by 15% of Strength, armor penetration increased by 225% of Strength.\nLasts 1 second.",
+        "description": "You prepare for the final crushing strike.\n\nAccuracy increased by 15% of Strength, armor penetration increased by 50% of Strength.\nLasts 1 second.",
         "skill_requirements": [ { "name": "melee", "level": 4 } ],
         "melee_allowed": true,
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "str", "scale": 0.15 },
-          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 2.25 },
-          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 2.25 },
-          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 2.25 }
+          { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+          { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.5 },
+          { "stat": "arpen", "type": "stab", "scaling-stat": "str", "scale": 0.5 }
         ],
         "buff_duration": 1
       }


### PR DESCRIPTION
#### Summary
Nerf the shit out of Barbaran Montante

#### Purpose of change
Barbaran montante was granting 75% of strength as arpen to all damage types as a passive and ALSO had an onpause that granted 225% of strength as arpen to all damage types. So if you had 10 strength you could push . and ignore 30 points of armor for all melee damage types against any enemy. Fuck off!

#### Describe the solution
- Barbaran's static buff now grants only 50% of strength as arpen.
- Barbaran's onmove buff now cancels its static for the duration.
- Barbaran's onpause buff now grants only 50% of strength as arpen.

Now if you have 10 strength and push . you ignore 10 points of armor for all melee damage types against any enemy, provided you're not in block mode from moving. That's still pretty good, and still scales really well with strength buffs.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
