### PR TITLE
Gorger mutation and Sweet Tooth changes

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -172,7 +172,7 @@
   {
     "id": "morale_sweettooth",
     "type": "morale_type",
-    "text": "Enjoyed something sugary"
+    "text": "Ate junk food"
   },
   {
     "id": "morale_no_digest",
@@ -212,7 +212,7 @@
   {
     "id": "morale_killed_friend",
     "type": "morale_type",
-    "text": "Killed a friend"
+    "text": "Killed an ally"
   },
   {
     "id": "morale_killed_monster",
@@ -232,7 +232,7 @@
   {
     "id": "morale_mutagen_chimera",
     "type": "morale_type",
-    "text": "Chimerical mutation"
+    "text": "Chimera mutation"
   },
   {
     "id": "morale_mutagen_mutation",
@@ -352,7 +352,7 @@
   {
     "id": "morale_butcher",
     "type": "morale_type",
-    "text": "Anguished by memories of butchering a human corpse"
+    "text": "Butchered a human like an animal"
   },
   {
     "id": "morale_gravedigger",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1581,7 +1581,7 @@
     "id": "PROJUNK",
     "name": { "str": "Sweet Tooth" },
     "points": 1,
-    "description": "You have a soft spot for processed foods, and gain a morale bonus from eating them.",
+    "description": "You have a soft spot for sweets, snacks, and empty calories.  Junk food is more enjoyable, but everything else is a bit less so.",
     "starting_trait": true,
     "cancels": [ "ANTIJUNK" ],
     "changes_to": [ "PROJUNK2" ],

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -677,6 +677,18 @@
   },
   {
     "type": "mutation",
+    "id": "GORGER",
+    "name": { "str": "Gorger" },
+    "points": 1,
+    "description": "Your stomach can expand quite a bit.  This comes in handy as you tend to swallow food whole.",
+    "cancels": [ "GOURMAND" ],
+    "category": [ "FISH", "LIZARD", "CHIMERA", "BATRACHIAN" ],
+    "enchantments": [
+      { "values": [ { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.4 }, { "value": "CONSUME_TIME_MOD", "multiply": -0.5 } ] }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "EASYSLEEPER",
     "name": { "str": "Easy Sleeper" },
     "points": 1,

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -489,19 +489,19 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
     // As float to avoid rounding too many times
     float fun = comest.get_comestible_fun();
     // Food doesn't taste as good when you're sick
-    if( ( has_effect( effect_common_cold ) || has_effect( effect_flu ) ) && fun > 0 ) {
-        fun /= 3;
+    if( ( has_effect( effect_common_cold ) || has_effect( effect_flu ) ) && fun > 0.f ) {
+        fun /= 3.f;
     }
     // Rotten food should be pretty disgusting
     const float relative_rot = comest.get_relative_rot();
     if( relative_rot > 1.0f && !has_trait( trait_SAPROPHAGE ) && !has_trait( trait_SAPROVORE ) ) {
-        const float rottedness = clamp( 2 * relative_rot - 2.0f, 0.1f, 1.0f );
+        const float rottedness = clamp( 2.f * relative_rot - 2.0f, 0.1f, 1.0f );
         // Three effects:
         // penalty for rot goes from -2 to -20
         // bonus for tasty food drops from 90% to 0%
         // disgusting food unfun increases from 110% to 200%
-        fun -= rottedness * 10;
-        if( fun > 0 ) {
+        fun -= rottedness * 10.f;
+        if( fun > 0.f ) {
             fun *= ( 1.0f - rottedness );
         } else {
             fun *= ( 1.0f + rottedness );
@@ -516,34 +516,35 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
                 fun -= comest.get_comestible()->monotony_penalty;
                 // This effect can't drop fun below 0, unless the food has the right flag.
                 // 0 is the lowest we'll go, no need to keep looping.
-                if( fun <= 0 && !comest.has_flag( flag_NEGATIVE_MONOTONY_OK ) ) {
-                    fun = 0;
+                if( fun <= 0.f && !comest.has_flag( flag_NEGATIVE_MONOTONY_OK ) ) {
+                    fun = 0.f;
                     break;
                 }
             }
         }
     }
 
-    float fun_max = fun < 0 ? fun * 6.0f : fun * 3.0f;
+    float fun_max = fun < 0.f ? fun * 6.0f : fun * 3.0f;
     if( comest.has_flag( flag_EATEN_COLD ) && comest.has_flag( flag_COLD ) ) {
-        if( fun > 0 ) {
-            fun *= 2;
+        if( fun > 0.f ) {
+            fun *= 2.f;
         } else {
-            fun = 1;
-            fun_max = 5;
+            fun = 1.f;
+            fun_max = 5.f;
         }
     }
 
     if( comest.has_flag( flag_MELTS ) && !comest.has_flag( flag_FROZEN ) ) {
         if( fun > 0 ) {
-            fun *= 0.5;
+            fun *= 0.5f;
         } else {
             // Melted freezable food tastes 25% worse than frozen freezable food.
             // Frozen freezable food... say that 5 times fast
-            fun *= 1.25;
+            fun *= 1.25f;
         }
     }
 
+    // Foods designed for specific animals are tasty to those sorts of mutants, and (usually) gross to humans, so invert and half.
     if( ( comest.has_flag( flag_LUPINE ) && has_trait( trait_THRESH_LUPINE ) ) ||
         ( comest.has_flag( flag_CATTLE ) && has_trait( trait_THRESH_CATTLE ) ) ||
         ( comest.has_flag( flag_RABBIT ) && has_trait( trait_THRESH_RABBIT ) ) ||
@@ -551,12 +552,9 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
         ( comest.has_flag( flag_RAT ) && has_trait( trait_THRESH_RAT ) ) ||
         ( comest.has_flag( flag_BIRD ) && has_trait( trait_THRESH_BIRD ) ) ||
         ( comest.has_flag( flag_FELINE ) && has_trait( trait_THRESH_FELINE ) ) ) {
-        if( fun < 0 ) {
+        if( fun < 0.f ) {
             fun = -fun;
-            fun /= 2;
-        }
-        if( fun == 0 ) {
-            fun = 2;
+            fun /= 2.f;
         }
     }
 
@@ -564,25 +562,25 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
     // This is automatically handled by raw blood having negative fun
     if( comest.has_flag( flag_HEMOVORE_FUN ) ) {
         if( has_flag( json_flag_BLOODFEEDER ) ) {
-            if( fun <= 0 ) {
-                fun += 25;
+            if( fun <= 0.f ) {
+                fun += 25.f;
             } else {
-                fun *= 1.2;
+                fun *= 1.2f;
             }
         } else if( has_flag( json_flag_HEMOVORE ) ) {
-            if( fun <= 0 ) {
-                fun += 13;
+            if( fun <= 0.f ) {
+                fun += 13.f;
             } else {
                 fun *= 1.1;
             }
         }
-        fun_max = 25;
+        fun_max = 25.f;
     }
 
     // Non junk food is less enjoyable to sweet tooth/snackaholic characters.
     if( !comest.has_flag( flag_ALLERGEN_JUNK ) ) {
         if( has_trait( trait_PROJUNK ) || has_trait( trait_PROJUNK2 ) ) {
-            if( fun > 0 ) {
+            if( fun > 0.f ) {
                 fun *= 0.75f;
             }
         }
@@ -590,15 +588,15 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
 
     // This cherry soda's just not the same...
     if( has_flag( json_flag_BLOODFEEDER ) && !comest.has_flag( flag_HEMOVORE_FUN ) && fun > 0 ) {
-        fun *= 0.5;
+        fun *= 0.5f;
     }
 
     if( has_trait( trait_GOURMAND ) ) {
         if( fun < -1.f ) {
             fun_max = fun;
             fun *= 0.75f;
-        } else if( fun > 0 ) {
-            fun_max *= 3;
+        } else if( fun > 0.f ) {
+            fun_max *= 3.f;
             fun = fun * 3 / 2;
         }
     }
@@ -606,7 +604,7 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
     if( fun < 0 && has_active_bionic( bio_taste_blocker ) &&
         get_power_level() > units::from_kilojoule( static_cast<std::int64_t>( std::abs(
                     comest.get_comestible_fun() ) ) ) ) {
-        fun = 0;
+        fun = 0.f;
     }
 
     // Zombie meat doesn't taste good, but it's tolerable for those who can eat it.
@@ -617,7 +615,7 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
         }
     }
 
-    return { static_cast< int >( fun ), static_cast< int >( fun_max ) };
+    return { static_cast< int >( std::round( fun ) ), static_cast< int >( std::round( fun_max ) ) };
 }
 
 time_duration Character::vitamin_rate( const vitamin_id &vit ) const

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -580,10 +580,10 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
     }
 
     // Non junk food is less enjoyable to sweet tooth/snackaholic characters.
-    if( comest.has_flag( flag_ALLERGEN_JUNK ) ) {
+    if( !comest.has_flag( flag_ALLERGEN_JUNK ) ) {
         if( has_trait( trait_PROJUNK ) || has_trait( trait_PROJUNK2 ) ) {
             if( fun > 0 ) {
-                fun *= 0.75;
+                fun *= 0.75f;
             }
         }
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -579,6 +579,15 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
         fun_max = 25;
     }
 
+    // Non junk food is less enjoyable to sweet tooth/snackaholic characters.
+    if( comest.has_flag( flag_ALLERGEN_JUNK ) ) {
+        if( has_trait( trait_PROJUNK ) || has_trait( trait_PROJUNK2 ) ) {
+            if( fun > 0 ) {
+                fun *= 0.75;
+            }
+        }
+    }
+
     // This cherry soda's just not the same...
     if( has_flag( json_flag_BLOODFEEDER ) && !comest.has_flag( flag_HEMOVORE_FUN ) && fun > 0 ) {
         fun *= 0.5;
@@ -1467,15 +1476,16 @@ void Character::modify_morale( item &food, const int nutr )
         if( food.has_flag( flag_ALLERGEN_JUNK ) ) {
             if( has_trait( trait_PROJUNK ) ) {
                 add_msg_if_player( m_good, _( "Mmm, junk food." ) );
-                add_morale( morale_sweettooth, 5, 25, 2_hours, 1_hours, true );
+                add_morale( morale_sweettooth, 5, 15, 2_hours, 30_minutes, true );
             }
             if( has_trait( trait_PROJUNK2 ) ) {
                 if( !one_in( 100 ) ) {
-                    add_msg_if_player( m_good, _( "When life's got you down, there's always sugar." ) );
+                    //~ Translators: This is a quote from the 1973 animated film Charlotte's Web, where a rat is singing about eating trash off the ground. Do what you will with that information.
+                    add_msg_if_player( m_good, _( "A veritable smorgasbord!" ) );
                 } else {
                     add_msg_if_player( m_good, _( "Snack attack!" ) );
                 }
-                add_morale( morale_sweettooth, 10, 30, 2_hours, 1_hours, true );
+                add_morale( morale_sweettooth, 5, 30, 2_hours, 30_minutes, true );
             }
             // Carnivores CAN eat junk food, but they won't like it much.
             // Pizza-scraping happens in consume_effects.


### PR DESCRIPTION
#### Summary
Gorger mutation and Sweet Tooth changes

#### Describe the solution
- Adds gorger, a mutation for batrachian, piscine, reptilian, and chimera. It increases stomach size by 40% and cuts consume time by 50%. It cancels gourmand.
- Sweet Tooth and Snackaholic have slightly reduced morale bonuses, and these start falling off after 30 minutes, not 1 hour. You have to keep snacking if you want to be happy!
- Sweet Tooth and Snackaholic now reduce positive morale effects from non junk food by 25%.
- Fixed a bunch of integer/float math in fun_for().
- Fixed some morale wording.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
