### PR TITLE
Reptilians are venomous, troglobites are not.

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -767,7 +767,8 @@
       "BATRACHIAN",
       "CHIMERA",
       "GASTROPOD",
-      "CRUSTACEAN"
+      "CRUSTACEAN",
+      "LIZARD"
     ]
   },
   {
@@ -3890,7 +3891,7 @@
     "prereqs": [ "POISRESIST" ],
     "changes_to": [ "POISONOUS2" ],
     "flags": [ "VENOM1" ],
-    "category": [ "SLIME", "TROGLOBITE", "SPIDER", "CEPHALOPOD", "GASTROPOD", "CHIMERA", "INSECT" ]
+    "category": [ "SLIME", "SPIDER", "CEPHALOPOD", "GASTROPOD", "CHIMERA", "INSECT", "LIZARD" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Reptilians are venomous, troglobites are not.

#### Purpose of change
It never made sense that troglobite was venomous. Stranger still, reptilian did not get venom, despite having fangs.

#### Describe the solution
Reptilian gets venomous and poison resistant. Trog keeps poison resistant but loses venomous.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
