### PR TITLE
Opioid withdrawals

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3776,6 +3776,70 @@
   },
   {
     "type": "effect_type",
+    "id": "withdrawal_opioid_timer",
+    "max_intensity": 3,
+    "int_dur_factor": "48 h",
+    "max_duration": "144 h",
+    "//": "Helper effect to track progression of withdrawals."
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_opoid_detoxed",
+    "//": "Safe from withdrawals until you dose again."
+  },
+  {
+    "type": "effect_type",
+    "id": "withdrawal_opioid",
+    "name": [ "Mild Opioid Withdrawal", "Moderate Opioid Withdrawal", "Severe Opioid Withdrawal" ],
+    "desc": [
+      "You feel sick and everything hurts more than it should.",
+      "You swing between fever and chills, and you can't stop thinking about painkillers.",
+      "You're horribly sick.  Everything hurts, and not a moment goes by that you aren't desperate to get your fix."
+    ],
+    "max_intensity": 3,
+    "apply_message": "A chill runs through your body.",
+    "miss_messages": [ [ "You feel horrible.", 1 ] ],
+    "rating": "bad",
+    "base_mods": {
+      "thirst_tick": [ 1800 ],
+      "thirst_min": [ 1 ],
+      "fatigue_tick": [ 300 ],
+      "fatigue_min": [ 1 ],
+      "pain_max_val": [ 15 ],
+      "pain_min": [ 1, 0 ],
+      "pain_chance": [ 3600 ],
+      "stamina_min": [ -100 ],
+      "stamina_max": [ -200 ],
+      "stamina_chance": [ 1200 ],
+      "h_mod_min": [ -1 ],
+      "h_mod_chance": [ 43200 ],
+      "vomit_chance": [ 100 ],
+      "vomit_tick": [ 1800 ]
+    },
+    "scaling_mods": {
+      "str_mod": [ -1.0 ],
+      "per_mod": [ -0.67 ],
+      "dex_mod": [ -1.34 ],
+      "int_mod": [ -1.67 ],
+      "pain_chance": [ -600 ],
+      "stamina_max": [ -500 ],
+      "stamina_chance": [ -300 ],
+      "vomit_chance": [ -12 ]
+    },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "block", "modifier": 1.0, "scaling": -0.1 },
+      { "limb_score": "vision", "modifier": 1.0, "scaling": -0.05 },
+      { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 },
+      { "limb_score": "move_speed", "modifier": 0.95, "scaling": -0.1 },
+      { "limb_score": "balance", "modifier": 0.9, "scaling": -0.1 },
+      { "limb_score": "footing", "modifier": 0.8, "scaling": -0.1 },
+      { "limb_score": "swim", "modifier": 1.0, "scaling": -0.2 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
     "id": "fearparalyze",
     "name": [ "Frightened" ],
     "desc": [ "You are paralyzed by fear." ],

--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -326,5 +326,155 @@
       ]
     },
     "effect": [ { "u_lose_effect": "withdrawal_nicotine_detoxed" }, { "u_lose_effect": "withdrawal_nicotine" } ]
+  },
+    {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_1",
+    "recurrence": [ "10 minutes", "20 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 1 },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_2_1",
+    "recurrence": [ "10 minutes", "48 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 2 },
+        { "not": { "u_has_effect": "withdrawal_opioid", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_2_2",
+    "recurrence": [ "12 hours", "48 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 2 },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_3_1",
+    "recurrence": [ "10 minutes", "10 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 3 },
+        { "not": { "u_has_effect": "withdrawal_opioid", "intensity": 2 } },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 1, "duration": { "math": [ "7200 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_3_2",
+    "recurrence": [ "12 hours", "72 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 3 },
+        { "not": { "u_has_effect": "withdrawal_opioid", "intensity": 3 } },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 2, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_3_3",
+    "recurrence": [ "18 hours", "30 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid_timer", "intensity": 3 },
+        { "not": { "u_has_effect": "withdrawal_opioid_detoxed" } },
+        { "not": { "u_has_effect": "opioid_eff" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid", "intensity": 3, "duration": { "math": [ "14400 + rand(2) * 7200" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_3_SHAKES",
+    "recurrence": [ "18 minutes", "24 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid", "intensity": 3 },
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "drunk" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "shakes", "intensity": 3, "duration": { "math": [ "300 + rand(5) * 60" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_WITHDRAWAL_3_HALLU",
+    "recurrence": [ "18 minutes", "100 hours" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "withdrawal_opioid", "intensity": 3 },
+        { "not": { "u_has_effect": "valium" } },
+        { "not": { "u_has_effect": "drunk" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "hallu", "duration": { "math": [ "1800 + rand(6) * 3600" ] } }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_DETOX",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": {
+      "and": [
+        { "compare_string": [ "withdrawal_opioid_timer", { "context_val": "effect" } ] },
+        { "not": { "u_has_effect": "drunk" } },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "narcosis" } }
+      ]
+    },
+    "effect": { "u_add_effect": "withdrawal_opioid_detoxed", "duration": "PERMANENT" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_OPIOID_RETOX",
+    "recurrence": [ "30 seconds", "5 minutes" ],
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_effect": "withdrawal_opioid" }, { "u_has_effect": "withdrawal_opioid_detoxed" } ] },
+        { "u_has_effect": "drunk" }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "withdrawal_opioid_detoxed" }, { "u_lose_effect": "withdrawal_opioid" } ]
   }
 ]

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -29,13 +29,16 @@
 static const efftype_id effect_amphetamine_eff( "amphetamine_eff" );
 static const efftype_id effect_cig( "cig" );
 static const efftype_id effect_nausea( "nausea" );
-static const efftype_id effect_opioid_effect( "opioid_effect" );
+static const efftype_id effect_opioid_eff( "opioid_eff" );
 static const efftype_id effect_withdrawal_alcohol( "withdrawal_alcohol" );
 static const efftype_id effect_withdrawal_alcohol_detoxed( "withdrawal_alcohol_detoxed" );
 static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
 static const efftype_id effect_withdrawal_nicotine( "withdrawal_nicotine" );
 static const efftype_id effect_withdrawal_nicotine_detoxed( "withdrawal_nicotine_detoxed" );
 static const efftype_id effect_withdrawal_nicotine_timer( "withdrawal_nicotine_timer" );
+static const efftype_id effect_withdrawal_opioid( "withdrawal_opioid" );
+static const efftype_id effect_withdrawal_opioid_detoxed( "withdrawal_opioid_detoxed" );
+static const efftype_id effect_withdrawal_opioid_timer( "withdrawal_opioid_timer" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
 
@@ -293,13 +296,26 @@ static bool diazepam_effect( Character &u, addiction &add )
 
 static bool opioid_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_opioid_effect ) ) {
+    if( u.has_effect( effect_opioid_eff ) ) {
         add.sated = 0_turns;
         u.remove_effect( effect_shakes );
         return false;
     }
-    static time_point last_dream = calendar::turn_zero;
+
+    bool ret;
+    
     const int in = std::min( 20, add.intensity );
+    int timer_int = std::min( in / 3, 3 );
+
+    if( x_in_y( in, 24 ) && !u.in_sleep_state() ) {
+        if( !u.has_effect( effect_withdrawal_opioid_detoxed ) &&
+            ( !u.has_effect( effect_withdrawal_opioid_timer ) ||
+              u.get_effect_int( effect_withdrawal_opioid_timer ) < timer_int ) ) {
+            u.add_effect( effect_withdrawal_opioid_timer, 48_hours * timer_int, false, timer_int );
+        }
+        ret = true;
+    }
+    static time_point last_dream = calendar::turn_zero;
     if( u.get_pain() < in * 2 ) {
         u.mod_pain( 1 );
     }
@@ -313,8 +329,8 @@ static bool opioid_effect( Character &u, addiction &add )
             last_dream = calendar::turn;
         } else {
             u.add_morale( morale_craving_opioid, -40, -4 * in, 1_hours, 30_minutes, true );
-            u.add_effect( effect_shakes, 2_minutes + in * 30_seconds );
         }
+        ret = true;
     } else if( one_in( 40 ) && dice( 2, 30 ) < in &&
                ( !u.in_sleep_state() || calendar::turn - last_dream > 4_hours ) ) {
         const std::string msg =
@@ -326,10 +342,12 @@ static bool opioid_effect( Character &u, addiction &add )
         } else {
             u.add_morale( morale_craving_opioid, -30, -4 * in, 1_hours, 30_minutes, true );
         }
+        ret = true;
     } else if( one_in( 50 ) && dice( 3, 50 ) < in ) {
         u.vomit();
+        ret = true;
     }
-    return true;
+    return ret;
 }
 
 static bool amphetamine_effect( Character &u, addiction &add )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -923,7 +923,7 @@ bool game::start_game()
 
     background_pane background;
     static_popup popup;
-    popup.message( "%s", _( "Please wait as we build your world" ) );
+    popup.message( "%s", _( "Please wait while the world is built." ) );
     ui_manager::redraw();
     refresh_display();
 


### PR DESCRIPTION
#### Summary
Opioid withdrawals

#### Purpose of change
Opioids didn't have withdrawals and were therefore less punishing and more annoying than intended.

#### Describe the solution
Withdrawals can take from 48 hours up to a max of 144 hours (6 days) to clear. You remain addicted afterwards, but the addiction is just cravings, painkiller tolerance, and dreams, not physical effects.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
