### PR TITLE
Make a few minor updates

### DIFF
--- a/data/json/itemgroups/SUS/gunstore.json
+++ b/data/json/itemgroups/SUS/gunstore.json
@@ -118,6 +118,7 @@
       { "item": "helmet_army", "prob": 5 },
       { "item": "knee_pads", "prob": 20 },
       { "item": "ballistic_vest_concealable", "prob": 5 },
+      { "item": "ballistic_vest_concealable_xs", "prob": 1 },
       { "item": "elbow_pads", "prob": 20 },
       { "item": "nylon_holster", "prob": 25 },
       { "item": "holster", "prob": 20 },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -18,7 +18,7 @@
     "volume": "2700 ml",
     "price": "500 USD",
     "price_postapoc": "20 USD",
-    "melee_damage": { "bash": 34 }
+    "melee_damage": { "bash": 36 }
   },
   {
     "type": "ITEM",

--- a/data/json/npcs/NC_JUNK_SHOPKEEP.json
+++ b/data/json/npcs/NC_JUNK_SHOPKEEP.json
@@ -26,6 +26,7 @@
     "entries": [
       { "item": "vest", "prob": 40 },
       { "item": "ballistic_vest_concealable", "prob": 15 },
+      { "item": "ballistic_vest_concealable_xs", "prob": 1 },
       { "item": "jacket_army", "prob": 30 },
       { "item": "longcoat", "prob": 25 },
       { "item": "longcoat_leather", "prob": 20 },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
@@ -110,6 +110,7 @@
       { "item": "case_cigar", "prob": 5 },
       [ "vest", 40 ],
       [ "ballistic_vest_concealable", 15 ],
+      { "item": "ballistic_vest_concealable_xs", "prob": 1 },
       [ "jacket_army_modern", 30 ],
       [ "longcoat", 25 ],
       [ "longcoat_leather", 20 ],

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -726,7 +726,7 @@
       [ [ "kevlar_sheet_layered", 6 ] ],
       [ [ "duct_tape", 150 ] ],
       [
-        [ "ballistic_vest_concealable", 1 ],
+        [ "ballistic_vest_concealable_xs", 1 ],
         [ "ballistic_vest_light", 1 ],
         [ "ballistic_vest_esapi", 1 ],
         [ "kevlar_sheet_layered", 18 ]

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -89,6 +89,7 @@ static const bionic_id bio_voice( "bio_voice" );
 
 static const efftype_id effect_amphetamine_eff( "amphetamine_eff" );
 static const efftype_id effect_bouldering( "bouldering" );
+static const efftype_id effect_cocaine( "cocaine" );
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_high( "high" );
@@ -1761,7 +1762,7 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
     npc_values.trust -= u_ugly / 3;
 
 
-    // Weed and booze make you less frightening.  Amphetamines makes you scarier.
+    // Weed and booze make you less frightening.  Stimulants makes you scarier.
     // TODO: Jaded characters shouldn't care.
     if( you.has_effect( effect_high ) ) {
         npc_values.fear -= you.get_effect_int( effect_high ) - 1;
@@ -1771,6 +1772,9 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
     }
     if( you.has_effect( effect_amphetamine_eff ) ) {
         npc_values.fear += you.get_effect_int( effect_amphetamine_eff ) - 1;
+    }
+    if( you.has_effect( effect_cocaine ) ) {
+        npc_values.fear += you.get_effect_int( effect_cocaine ) - 1;
     }
 
     // TRUST
@@ -1811,6 +1815,9 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
     }
     if( you.has_effect( effect_amphetamine_eff ) ) {
         npc_values.trust -= you.get_effect_int( effect_amphetamine_eff ) - 1;
+    }
+    if( you.has_effect( effect_cocaine ) ) {
+        npc_values.trust -= you.get_effect_int( effect_cocaine ) - 1;
     }
 
     if( op_of_u.trust > 0 ) {


### PR DESCRIPTION
#### Summary
Make a few minor updates

#### Purpose of change

#### Describe the solution
- XS concealable ballistic vest spawns in gun stores and some NPC shops rarely
- Reviewed and slightly raised damage on the kanabo. It does less damage than the war clubs and is significantly slower, but note that it has +2 accuracy instead of 0 or -1, and it has WBLOCK2 and WIDE and SWEEP. Damage isn't everything!
- Cocaine now has the same effect on NPC opinions as amphetamines.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
