### PR TITLE
Fix alcohol and opioid detox

### DIFF
--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -206,9 +206,7 @@
     "condition": {
       "and": [
         { "compare_string": [ "withdrawal_alcohol_timer", { "context_val": "effect" } ] },
-        { "not": { "u_has_effect": "drunk" } },
-        { "not": { "u_has_effect": "sleep" } },
-        { "not": { "u_has_effect": "narcosis" } }
+        { "not": { "u_has_effect": "drunk" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_alcohol_detoxed", "duration": "PERMANENT" }
@@ -458,9 +456,7 @@
     "condition": {
       "and": [
         { "compare_string": [ "withdrawal_opioid_timer", { "context_val": "effect" } ] },
-        { "not": { "u_has_effect": "drunk" } },
-        { "not": { "u_has_effect": "sleep" } },
-        { "not": { "u_has_effect": "narcosis" } }
+        { "not": { "u_has_effect": "opioid_eff" } }
       ]
     },
     "effect": { "u_add_effect": "withdrawal_opioid_detoxed", "duration": "PERMANENT" }


### PR DESCRIPTION
#### Summary
Fix alcohol and opioid detox

#### Purpose of change
The detox EOCs for these substances accidentally required that you be awake, even though you could lose the timer effect while sleeping.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
