### PR TITLE
Fix fire resistance

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -567,7 +567,7 @@
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
       { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
-    "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 0, "bullet": 1 },
+    "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 },
     "repair_difficulty": 1
   },
   {
@@ -578,7 +578,7 @@
     "copy-from": "cotton",
     "repaired_with": "null",
     "wind_resist": 75,
-    "resist": { "bash": 2, "cut": 2, "acid": 2, "heat": 0, "bullet": 1.5 }
+    "resist": { "bash": 2, "cut": 2, "acid": 2, "heat": 2, "bullet": 1.5 }
   },
   {
     "type": "material",
@@ -604,7 +604,7 @@
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
       { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
-    "resist": { "bash": 2, "cut": 2.25, "acid": 3, "heat": 0, "bullet": 2 },
+    "resist": { "bash": 2, "cut": 2.25, "acid": 3, "heat": 2, "bullet": 2 },
     "repair_difficulty": 2
   },
   {
@@ -630,7 +630,7 @@
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
       { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
-    "resist": { "bash": 2, "cut": 2.5, "acid": 4, "heat": 0, "bullet": 2 },
+    "resist": { "bash": 2, "cut": 2.5, "acid": 4, "heat": 2, "bullet": 2 },
     "repair_difficulty": 2
   },
   {
@@ -641,7 +641,7 @@
     "copy-from": "canvas",
     "repaired_with": "null",
     "wind_resist": 90,
-    "resist": { "bash": 2, "cut": 3, "acid": 4, "heat": 0, "bullet": 2 }
+    "resist": { "bash": 2, "cut": 3, "acid": 4, "heat": 2, "bullet": 2 }
   },
   {
     "type": "material",
@@ -2727,7 +2727,7 @@
       { "fuel": 1.8, "smoke": 1, "burn": 0.075 }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 0, "bullet": 1 },
+    "resist": { "bash": 1, "cut": 1, "acid": 4, "heat": 1, "bullet": 1 },
     "repair_difficulty": 1
   },
   {
@@ -2738,7 +2738,7 @@
     "copy-from": "wool",
     "repaired_with": "null",
     "wind_resist": 65,
-    "resist": { "bash": 2, "cut": 2, "acid": 4, "heat": 0, "bullet": 1.5 }
+    "resist": { "bash": 2, "cut": 2, "acid": 4, "heat": 1, "bullet": 1.5 }
   },
   {
     "type": "material",
@@ -2790,7 +2790,7 @@
       { "fuel": 0, "smoke": 3, "burn": 0.002 },
       { "fuel": 0, "smoke": 5, "burn": 0.005 }
     ],
-    "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 1, "bullet": 1 }
+    "resist": { "bash": 1, "cut": 1, "acid": 2, "heat": 0, "bullet": 1 }
   },
   {
     "type": "material",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9239,7 +9239,7 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
             // thickness - when it comes to chemicals, a material burns, or it does not. Nonphysical attacks
             // don't respect thickness, but average the protection of all layers, surface or no. Acid rolls
             // for portion total (and thus can bypass layers that dont fully cover), other stuff doesn't.
-            const int total = type->mat_portion_total == 0 ? 1 : type->mat_portion_total;
+
             // Iterate through armor_mats in order. Outermost layers come first both here and in json entries.
             for( auto it = armor_mats.begin(); it != armor_mats.end(); ++it ) {
                 const part_material *m = *it;
@@ -9276,10 +9276,6 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
                     resist += tmp_add;
                 }
             }
-            if( !dmg_type->physical ) {
-                // Average by portion of materials
-                resist /= total;
-            }
         }
         // The end result of all these checks is averaged to give us the item's final overall armor value.
         return resist + mod;
@@ -9296,8 +9292,8 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
             } else {
                 tmp_add = m.first->resist( dmg_type ) * m.second;
             }
+            resist += tmp_add;
         }
-        resist += tmp_add;
         // Average by portion of materials
         resist /= total;
     }


### PR DESCRIPTION
#### Summary
Fix fire resistance

#### Purpose of change
- Fire-resistant gear wasn't working because the coverage was being double normalized.
- Regular fabrics weren't protecting from fire. They do a little!

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
