### PR TITLE
Fix sword cane

### DIFF
--- a/data/json/items/melee/long_blades.json
+++ b/data/json/items/melee/long_blades.json
@@ -789,18 +789,18 @@
     "price": "20 USD",
     "price_postapoc": "7 USD 50 cent",
     "material": [ "wood" ],
-    "weight": "200 g",
-    "volume": "600 ml",
-    "longest_side": "80 cm",
+    "weight": "700 g",
+    "volume": "1400 ml",
+    "longest_side": "100 cm",
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },
     "looks_like": "cane",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
-        "max_contains_volume": "320 ml",
-        "max_contains_weight": "450 g",
-        "max_item_length": "80 cm",
+        "max_contains_volume": "1360 ml",
+        "max_contains_weight": "950 g",
+        "max_item_length": "95 cm",
         "moves": 80,
         "flag_restriction": [ "SHEATH_SWORD" ]
       }
@@ -821,15 +821,15 @@
     "price": "20 USD",
     "price_postapoc": "30 USD",
     "material": [ "steel" ],
-    "weight": "450 g",
-    "volume": "320 ml",
-    "longest_side": "80 cm",
+    "weight": "950 g",
+    "volume": "1360 ml",
+    "longest_side": "90 cm",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "point", "balance": "good" },
     "looks_like": "rapier",
-    "techniques": [ "PRECISE", "RAPID", "WBLOCK_2" ],
+    "techniques": [ "PRECISE", "RAPID", "WBLOCK_1" ],
     "flags": [ "SHEATH_SWORD" ],
-    "weapon_category": [ "MEDIUM_SWORDS", "FENCING_WEAPONRY" ],
-    "melee_damage": { "bash": 2, "stab": 25 }
+    "weapon_category": [ "FENCING_WEAPONRY" ],
+    "melee_damage": { "bash": 1, "stab": 23 }
   },
   {
     "id": "broadsword",


### PR DESCRIPTION
#### Summary
Fix sword cane

#### Purpose of change
Sword cane was ridiculously light and small.

#### Describe the solution
- Remove wblock_2 since it doesn't have a hilt guard. It now has wblock_1 and is a bit smaller than the rapier. Its sheath has been resized to accommodate it.
- Removed medium_swords from sword cane. It's only fencing_weaponry.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
