### PR TITLE
Fix mutation endless loop (backport 81424)

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1161,7 +1161,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         try_opposite = false;
     } else if( cat_list.get_weight() > 0 ) {
         cat = *cat_list.pick();
-        cat_list.add_or_replace( cat, 0 );
+        cat_list.remove( cat );
         add_msg_debug( debugmode::DF_MUTATION, "Picked category %s", cat.c_str() );
         // Only decide if it's good or bad after we pick the category.
         if( roll_bad_mutation( cat ) ) {
@@ -1315,7 +1315,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 cat = *cat_list.pick();
                 add_msg_debug( debugmode::DF_MUTATION, "No valid traits in category found, new category %s",
                                cat.c_str() );
-                cat_list.add_or_replace( cat, 0 );
+                cat_list.remove( cat );
             } else {
                 // Every option we have vitamins for is invalid.
                 add_msg_if_player( m_bad,

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -84,6 +84,10 @@ template <typename T, typename W> struct weighted_list {
          */
         //TODO: Shouldn't this remove on weight <= 0?
         T *add_or_replace( const T &obj, const W &weight ) {
+            if( weight == 0 ) {
+                remove( obj );
+                return nullptr;
+            }
             if( weight > 0 ) {
                 invalidate_precalc();
                 for( auto &itr : objects ) {


### PR DESCRIPTION
#### Summary
Fix mutation endless loop (backport 81424)

#### Purpose of change
fixes #2542 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
