### PR TITLE
Further withdrawal timer fix

### DIFF
--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -104,8 +104,8 @@ static bool alcohol_add( Character &u, int in )
         if( !u.has_effect( effect_withdrawal_alcohol_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_alcohol_timer ) ) ) {
             u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
+            ret = true;
         }
-        ret = true;
     }
 
     // If you're not drunk, you want to be.
@@ -218,8 +218,8 @@ static bool nicotine_effect( Character &u, addiction &add )
         if( !u.has_effect( effect_withdrawal_nicotine_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_nicotine_timer ) ) ) {
             u.add_effect( effect_withdrawal_nicotine_timer, 32_hours * timer_int, false, timer_int );
+            ret = true;
         }
-        ret = true;
     }
 
     if( x_in_y( in, 60 ) && ( !u.in_sleep_state() || calendar::turn - last_dream > 3_hours ) ) {
@@ -309,8 +309,8 @@ static bool opioid_effect( Character &u, addiction &add )
         if( !u.has_effect( effect_withdrawal_opioid_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_opioid_timer ) ) ) {
             u.add_effect( effect_withdrawal_opioid_timer, 48_hours * timer_int, false, timer_int );
+            ret = true;
         }
-        ret = true;
     }
     static time_point last_dream = calendar::turn_zero;
     if( u.get_pain() < in * 2 ) {


### PR DESCRIPTION
#### Summary
Further withdrawal timer fix

#### Purpose of change
ret was set to true in the withdrawal timer application check even if the timer was not applied.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
