### PR TITLE
Fix bone skewer

### DIFF
--- a/data/json/items/resources/bone.json
+++ b/data/json/items/resources/bone.json
@@ -143,7 +143,7 @@
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "into": "meal_bone",
-    "recipe": "meal_bone_mill_6_1"
+    "recipe": "meal_bone_mill_20_1"
   },
   {
     "type": "ITEM",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -149,8 +149,6 @@ static const efftype_id effect_sleep( "sleep" );
 static const fault_id fault_emp_reboot( "fault_emp_reboot" );
 static const fault_id fault_overheat_safety( "fault_overheat_safety" );
 
-static const flag_id json_flag_LOCATION_PRECISE_CLOSEST_CITY( "LOCATION_PRECISE_CLOSEST_CITY" );
-
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
 static const furn_str_id furn_f_smoking_rack_active( "f_smoking_rack_active" );
 static const furn_str_id furn_f_water_mill_active( "f_water_mill_active" );
@@ -1600,32 +1598,6 @@ bool _stacks_location_hint( item const &lhs, item const &rhs )
             }
         };
         return get_bucket( this_dist ) == get_bucket( that_dist );
-    }
-    return false;
-}
-
-bool _stacks_location_precise_closest_city( item const &lhs, item const &rhs )
-{
-    // Skip the closest_city sort unless both items can actually display the segment.
-    if( !lhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ||
-        !rhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ) {
-        return true;
-    }
-    static const std::string omt_loc_var = "spawn_location";
-    const tripoint_abs_ms this_loc( lhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );
-    const tripoint_abs_ms that_loc( rhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );
-    if( this_loc == that_loc ) {
-        return true;
-    } else if( this_loc != tripoint_abs_ms::invalid && that_loc != tripoint_abs_ms::invalid ) {
-        const tripoint_abs_omt this_omt = project_to<coords::omt>( this_loc );
-        const tripoint_abs_sm this_sm = project_to<coords::sm>( this_omt );
-        const city_reference this_city = overmap_buffer.closest_city( this_sm );
-
-        const tripoint_abs_omt that_omt = project_to<coords::omt>( that_loc );
-        const tripoint_abs_sm that_sm = project_to<coords::sm>( that_omt );
-        const city_reference that_city = overmap_buffer.closest_city( that_sm );
-
-        return this_city.city == that_city.city;
     }
     return false;
 }


### PR DESCRIPTION
#### Summary
Fix bone skewer

#### Purpose of change
Bone skewers had an invalid milling recipe.

#### Describe the solution
Fix, remove some unrelated dead code that was accidentally ported.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
