### PR TITLE
Limb and martial art updates

### DIFF
--- a/data/json/character_modifiers.json
+++ b/data/json/character_modifiers.json
@@ -205,10 +205,11 @@
     "description": "Dodge chance modifier <color_dark_gray>(Balance, Movement, Footing)</color>",
     "mod_type": "x",
     "value": {
-      "limb_score": [ [ "balance", 1.5 ], "move_speed", "footing" ],
+      "limb_score": [ [ "balance", 1.25 ], "move_speed", "footing" ],
       "override_encumb": true,
       "limb_score_op": "x",
-      "min": 0.0
+      "min": 0.0,
+      "max": 4.0
     }
   }
 ]

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4550,8 +4550,8 @@
     "name": [ { "ctxt": "physically", "str": "Disabled" } ],
     "desc": [ "This limb is damaged beyond use and may require a splint to recover." ],
     "//": "This sounds weird. We need <bp_affected> tag or something",
-    "apply_message": "Your limb breaks!",
-    "remove_message": "The broken limb has mended.",
+    "apply_message": "A body part has been critically injured!",
+    "remove_message": "Your disabled body part has recovered enough for use.",
     "max_duration": "2 s",
     "rating": "bad"
   },

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -114,7 +114,7 @@
     "type": "ITEM",
     "subtypes": [ "GUN" ],
     "name": { "str": "McMillan TAC-50 rifle" },
-    "description": "A long-range anti-materiel and anti-personnel sniper rifle made by McMillan Firearms, serving the Canadian Army since 2000 as the C15, and the Navy Seals as the Mk 15 Mod 0.  This .50 caliber bolt-action rifle is capable of defeating light vehicles, radar installations and crew-served weapons at extreme distances.  It notably holds the longest-range confirmed sniper kill, as well as the 4th and 5th longest.",
+    "description": "A long-range anti-materiel and anti-personnel sniper rifle made by McMillan Firearms, serving the Canadian Army since 2000 as the C15, and the Navy Seals as the Mk 15 Mod 0.  This .50 caliber bolt-action rifle is capable of defeating light vehicles, radar installations and crew-served weapons at extreme distances.",
     "weight": "11790 g",
     "volume": "6500 ml",
     "longest_side": "146 cm",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -17,7 +17,7 @@
     "warmth": 8,
     "material_thickness": 1,
     "flags": [ "OUTER", "SPLINT" ],
-    "armor": [ { "encumbrance": 70, "coverage": 75, "covers": [ "arm_l", "arm_r" ] } ]
+    "armor": [ { "encumbrance": 70, "coverage": 75, "covers": [ "arm_l", "arm_r", "wing_bird_l", "wing_bird_r" ] } ]
   },
   {
     "id": "arm_xlsplint",
@@ -330,23 +330,7 @@
     "warmth": 5,
     "material_thickness": 1,
     "flags": [ "OUTER", "SPLINT", "ALLOWS_TAIL" ],
-    "armor": [
-      {
-        "encumbrance": 70,
-        "coverage": 75,
-        "covers": [
-          "leg_l",
-          "leg_r",
-          "cephalopod_arm_1",
-          "cephalopod_arm_2",
-          "cephalopod_arm_3",
-          "cephalopod_arm_4",
-          "cephalopod_arm_5",
-          "cephalopod_arm_6",
-          "long_tail"
-        ]
-      }
-    ]
+    "armor": [ { "encumbrance": 70, "coverage": 75, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
     "id": "leg_xlsplint",

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -33,9 +33,10 @@
       {
         "id": "buff_aikido_static1",
         "name": "Aikido Stance",
-        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nBlocked damage reduced by 100% of Dexterity, +2 blocking effectiveness, +! Dodge ability.",
+        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 100% of Dexterity, +2 blocking effectiveness, +1 Dodge ability.",
         "unarmed_allowed": true,
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "block", "scaling-stat": "dex", "scale": 1.0 },
           { "stat": "block_effectiveness", "scale": 2.0 },
@@ -45,10 +46,11 @@
       {
         "id": "buff_aikido_static2",
         "name": "Intermediate Aikido",
-        "description": "An intermediate Aikido practitioner can protect themselves against multiple opponents.\n\nBlocked damage reduced by 100% of Dexterity, +1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
+        "description": "An intermediate Aikido practitioner can protect themselves against multiple opponents.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 100% of Dexterity, +1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_dodges": 1,
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "dex", "scale": 1.0 }, { "stat": "block_effectiveness", "scale": 1.0 } ]
@@ -56,10 +58,11 @@
       {
         "id": "buff_aikido_static3",
         "name": "Advanced Aikido",
-        "description": "An advanced Aikido practitioner can protect themselves against even more opponents than normal.\n\n+1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
+        "description": "An advanced Aikido practitioner can protect themselves against even more opponents than normal.\n\nEffects lost if downed, stunned, or staggered.\n+1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_dodges": 1,
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 1.0 } ]
@@ -110,14 +113,16 @@
       {
         "id": "buff_bojutsu_static",
         "name": "Bōjutsu Stance",
-        "description": "A agile stance that allows your blocks to reduce incoming damage.\n\nBlocked damage reduced by 100% of Dexterity.",
+        "description": "A agile stance that allows your blocks to reduce incoming damage.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 100% of Dexterity.",
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "dex", "scale": 1 } ]
       },
       {
         "id": "buff_bojutsu_static2",
         "name": "Skilled Striking",
-        "description": "As you get more skilled you're able to begin targeting striking points that allow more for damage.\n\nMelee skill increases bash damage cap.",
+        "description": "As you get more skilled you're able to begin targeting striking points that allow more for damage.\n\nEffects lost if downed, stunned, or staggered.\nMelee skill increases bash damage cap.",
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "melee_bash_damage_cap_bonus": true,
         "skill_requirements": [ { "name": "melee", "level": 1 } ]
@@ -127,8 +132,9 @@
       {
         "id": "buff_bojutsu_onmove",
         "name": "Rolling Staff",
-        "description": "As you move you begin to rapidly and fluidly roll your staff between your hands.\n\n+10% bash damage.\nEnables \"Rolling Strike\" technique.\nLasts 1 second.",
+        "description": "As you move you begin to rapidly and fluidly roll your staff between your hands.\n\nEffects lost if downed, stunned, or staggered.\n+10% bash damage.\nEnables \"Rolling Strike\" technique.\nLasts 1 second.",
         "skill_requirements": [ { "name": "melee", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "buff_duration": 1,
         "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.1 } ]
@@ -161,9 +167,10 @@
       {
         "id": "buff_barbaran_static",
         "name": "Barbaran Represa",
-        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nArmor penetration increased by 50% of Strength.",
+        "description": "Sliding footwork enhances the crushing continuity of your attacks.\n\nEffects lost if downed, stunned, or staggered.\nArmor penetration increased by 50% of Strength.",
         "melee_allowed": true,
         "forbidden_buffs_all": [ "buff_barbaran_onmove" ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
           { "stat": "arpen", "type": "cut", "scaling-stat": "str", "scale": 0.5 },
@@ -175,8 +182,9 @@
       {
         "id": "buff_barbaran_onblock",
         "name": "Reversing Destreza",
-        "description": "Blocking a key strike will turn the battle around.\n\n+5% move speed.\nLasts 3 seconds.  Stacks 2 times.",
+        "description": "Blocking a key strike will turn the battle around.\n\nEffects lost if downed, stunned, or staggered.\n+5% move speed.\nLasts 3 seconds.  Stacks 2 times.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "max_stacks": 2,
         "mult_bonuses": [ { "stat": "movecost", "scale": 0.95 } ],
@@ -187,8 +195,9 @@
       {
         "id": "buff_barbaran_onkill",
         "name": "Movimiento Natural",
-        "description": "Formal victory is attained, and your mind is cleared to focus on your next moves.\n\n+1 block attempt.\nLasts 5 seconds.",
+        "description": "Formal victory is attained, and your mind is cleared to focus on your next moves.\n\nEffects lost if downed, stunned, or staggered.\n+1 block attempt.\nLasts 5 seconds.",
         "skill_requirements": [ { "name": "melee", "level": 5 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "buff_duration": 5,
         "bonus_blocks": 1
@@ -198,8 +207,9 @@
       {
         "id": "buff_barbaran_onmove",
         "name": "Ricasso Step",
-        "description": "You switch or sturdy your grip mid-step to aid your blocking.\n\nBlocked damage reduced by 40% of Strength.\nLasts 3 seconds.  Stacks 3 times.",
+        "description": "You switch or sturdy your grip mid-step to aid your blocking.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 40% of Strength.\nLasts 3 seconds.  Stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "melee_allowed": true,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.4 } ],
@@ -238,8 +248,9 @@
       {
         "id": "buff_boxing_static",
         "name": "Boxing Stance",
-        "description": "A solid stance allows you block more damage than normal and deliver better punches.\n\n+1 accuracy, blocked damage reduced by 50% of Strength.",
+        "description": "A solid stance allows you block more damage than normal and deliver better punches.\n\nEffects lost if downed, stunned, or staggered.\n+1 accuracy, blocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 }, { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ]
       }
     ],
@@ -247,8 +258,9 @@
       {
         "id": "buff_boxing_onmove",
         "name": "Footwork",
-        "description": "You make yourself harder to hit by bobbing and weaving as you move.\n\n+! Dodge ability.\nLasts 1 second.  Stacks 2 times.",
+        "description": "You make yourself harder to hit by bobbing and weaving as you move.\n\nEffects lost if downed, stunned, or staggered.\n+1 Dodge ability.\nLasts 1 second.  Stacks 2 times.",
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "unarmed_allowed": true,
         "buff_duration": 1,
         "max_stacks": 2,
@@ -297,8 +309,8 @@
     "onpause_buffs": [
       {
         "id": "buff_brawling_onpause",
-        "name": "Preparation to Hit",
-        "description": "You take a moment to prepare your stance before the enemy, allowing you to hit a little more accurately.\n\n+1 accuracy.  Lasts 2 seconds.  Stacks 2 times",
+        "name": "Wind-Up",
+        "description": "By taking a moment to prepare your swing, you can be more confident it will connect.\n\n+1 accuracy.  Lasts 2 seconds.  Stacks 2 times",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
@@ -331,8 +343,9 @@
       {
         "id": "buff_capoeira_static",
         "name": "Capoeira Stance",
-        "description": "You never stop moving while performing the ginga.  This makes you very mobile while fighting.\n\n+! Dodge ability, +1 dodge attempt.",
+        "description": "You never stop moving while performing the ginga.  This makes you very mobile while fighting.\n\nEffects lost if stunned or staggered.\n+1 Dodge ability, +1 dodge attempt.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "bonus_dodges": 1,
         "flat_bonuses": [ { "stat": "dodge", "scale": 1.0 } ]
       }
@@ -341,9 +354,10 @@
       {
         "id": "buff_capoeira_onmiss",
         "name": "Capoeira Tempo",
-        "description": "Hit or miss, it's just part of the dance!  And the best part is about to start!\n\n+5% damage.\nLasts 1 second.  Stacks 3 times.",
+        "description": "Hit or miss, it's just part of the dance!  And the best part is about to start!\n\nEffects lost if stunned or staggered.\n+5% damage.\nLasts 1 second.  Stacks 3 times.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "buff_duration": 1,
         "max_stacks": 3,
         "mult_bonuses": [
@@ -357,9 +371,10 @@
       {
         "id": "buff_capoeira_onmove",
         "name": "Capoeira Momentum",
-        "description": "You can feel the rhythm as you move.  You are harder to hit, and your kicks are even more amazing!\n\n+! Dodge ability.\nEnables \"Spin Kick\" and \"Sweep Kick\" techniques.\nLasts 3 seconds.",
+        "description": "You can feel the rhythm as you move.  You are harder to hit, and your kicks are even more amazing!\n\nEffects lost if stunned or staggered.\n+1 Dodge ability.\nEnables \"Spin Kick\" and \"Sweep Kick\" techniques.\nLasts 3 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "buff_duration": 3,
         "flat_bonuses": [ { "stat": "dodge", "scale": 1.0 } ]
       }
@@ -385,8 +400,9 @@
       {
         "id": "buff_crane_static1",
         "name": "Crane's Precision",
-        "description": "Your attacks strike at your opponents' weak spots with speed and precision instead of brute force.\n\nBash damage increased by 75% of Dexterity but decreased by 75% of Strength.",
+        "description": "Your attacks strike at your opponents' weak spots with speed and precision instead of brute force.\n\nEffects lost if downed, stunned, or staggered.\nBash damage increased by 75% of Dexterity but decreased by 75% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "damage", "type": "bash", "scaling-stat": "dex", "scale": 0.75 },
           { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": -0.75 }
@@ -395,14 +411,16 @@
       {
         "id": "buff_crane_static2",
         "name": "Crane's Stance",
-        "description": "Like the beautiful crane, you are very skilled at evading danger.\n\n+2.0 Dodging skill.",
+        "description": "Like the beautiful crane, you are very skilled at evading danger.\n\nEffects lost if downed, stunned, or staggered.\n+2.0 Dodging skill.",
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "unarmed_allowed": true,
         "flat_bonuses": [ { "stat": "dodge", "scale": 2.0 } ]
       },
       {
         "id": "buff_crane_static3",
         "name": "Crane's Grace",
-        "description": "Masters of the Crane style can evade multiple foes with ease.\n\n+2 dodge attempts.",
+        "description": "Masters of the Crane style can evade multiple foes with ease.\n\nEffects lost if downed, stunned, or staggered.\n+2 dodge attempts.",
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
         "bonus_dodges": 2
@@ -412,9 +430,10 @@
       {
         "id": "buff_crane_ondodge",
         "name": "Crane's Flight",
-        "description": "Much like the crane, you are quick to avoid danger and strike back.\n\n+1 accuracy, +! Dodge ability.\nEnables \"Crane Kick\" and \"Crane Strike\" techniques.\nLasts 3 seconds.",
+        "description": "Much like the crane, you are quick to avoid danger and strike back.\n\nEffects lost if downed, stunned, or staggered.\n+1 accuracy, +1 Dodge ability.\nEnables \"Crane Kick\" and \"Crane Strike\" techniques.\nLasts 3 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 3,
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 }, { "stat": "dodge", "scale": 1.0 } ]
       }
@@ -442,8 +461,9 @@
       {
         "id": "buff_dragon_static",
         "name": "Dragon's Knowledge",
-        "description": "You plan your attacks far in advance, relying on your intuition instead of your speed to strike true.\n\nAccuracy increased by 25% of Intelligence but decreased by 25% of Dexterity, bash damage increased by 75% of Intelligence but decreased by 75% of Strength.",
+        "description": "You plan your attacks far in advance, relying on your intuition instead of your speed to strike true.\n\nEffects lost if stunned.\nAccuracy increased by 25% of Intelligence but decreased by 25% of Dexterity, bash damage increased by 75% of Intelligence but decreased by 75% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "stunned" ],
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "int", "scale": 0.25 },
           { "stat": "hit", "scaling-stat": "dex", "scale": -0.25 },
@@ -456,9 +476,10 @@
       {
         "id": "buff_dragon_onblock",
         "name": "Dragon's Vortex",
-        "description": "Life and combat are a circle.  An attack leads to a counter and to an attack once again.  Seek to complete this loop.\n\n+10% damage.\nLasts 3 seconds.",
+        "description": "Life and combat are a circle.  An attack leads to a counter and to an attack once again.  Seek to complete this loop.\n\nEffects lost if stunned.\n+10% damage.\nLasts 3 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+        "forbidden_effects_any": [ "stunned" ],
         "buff_duration": 3,
         "mult_bonuses": [
           { "stat": "damage", "type": "bash", "scale": 1.1 },
@@ -471,9 +492,10 @@
       {
         "id": "buff_dragon_ondodge",
         "name": "Dragon Wing",
-        "description": "Life and combat are a circle.  An attack leads to a counter and to an attack once again.  Seek to complete this loop.\n\n+10% damage.\nLasts 3 seconds.",
+        "description": "Life and combat are a circle.  An attack leads to a counter and to an attack once again.  Seek to complete this loop.\n\nEffects lost if stunned.\n+10% damage.\nLasts 3 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "forbidden_effects_any": [ "stunned" ],
         "buff_duration": 3,
         "mult_bonuses": [
           { "stat": "damage", "type": "bash", "scale": 1.1 },
@@ -486,9 +508,10 @@
       {
         "id": "buff_dragon_onpause",
         "name": "Dragon Power",
-        "description": "You take a moment to reflect on battles past and to come.  This insight will protect you from future harm.\n\n+2 blocking effectiveness, blocked damage reduced by 100% of Intelligence, +! Dodge ability.\nLasts 2 seconds.",
+        "description": "You take a moment to reflect on battles past and to come.  This insight will protect you from future harm.\n\nEffects lost if stunned.\n+2 blocking effectiveness, blocked damage reduced by 100% of Intelligence, +1 Dodge ability.\nLasts 2 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "forbidden_effects_any": [ "stunned" ],
         "buff_duration": 2,
         "flat_bonuses": [
           { "stat": "block_effectiveness", "scale": 2.0 },
@@ -514,8 +537,9 @@
       {
         "id": "buff_eskrima_static",
         "name": "Eskrima Stance",
-        "description": "You are skilled at getting the most out of your weapons.  The term 'weapon' might be very subjective.\n\n+2 accuracy.",
+        "description": "You are skilled at getting the most out of your weapons.  The term 'weapon' might be very subjective.\n\nEffects lost if downed, stunned, or staggered.\n+2 accuracy.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "hit", "scale": 2.0 } ]
       }
     ],
@@ -559,8 +583,9 @@
       {
         "id": "buff_fencing_static",
         "name": "Fencing Stance",
-        "description": "Your side stance reduces the chance that you will be harmed in combat.\n\nBlocked damage reduced by 50% of Dexterity.",
+        "description": "Your side stance reduces the chance that you will be harmed in combat.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 50% of Dexterity.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "dex", "scale": 0.5 } ]
       }
     ],
@@ -568,9 +593,10 @@
       {
         "id": "buff_fencing_onblock",
         "name": "Parry",
-        "description": "Your next strike will find its mark much easier after your parry.\n\n+1 accuracy.\nLasts 1 second.",
+        "description": "Your next strike will find its mark much easier after your parry.\n\nEffects lost if downed, stunned, or staggered.\n+1 accuracy.\nLasts 1 second.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 1,
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
       }
@@ -614,8 +640,9 @@
       {
         "id": "buff_medievalpole_static",
         "name": "Stand Your Ground",
-        "description": "You are stalwart and will not budge against any threat.\n\n+2 blocking effectiveness, +1 block attempt, -1 Dodge ability, blocked damage reduced by 50% of Strength.",
+        "description": "You are stalwart and will not budge against any threat.\n\nEffects lost if downed, stunned, or staggered.\n+2 blocking effectiveness, +1 block attempt, -1 Dodge ability, blocked damage reduced by 50% of Strength.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_blocks": 1,
         "flat_bonuses": [
           { "stat": "block_effectiveness", "scale": 2.0 },
@@ -628,7 +655,7 @@
       {
         "id": "buff_medievalpole_onmove",
         "name": "Tactical Retreat",
-        "description": "You moved and nullified the effects of Stand Your Ground!\n\n-2 blocking effectiveness, -1 block attempt, +! Dodge ability, blocked damage increased by 50% of Strength.\nPrevents \"High Round Strike\" technique.\nLasts 2 seconds.",
+        "description": "You moved and nullified the effects of Stand Your Ground!\n\n-2 blocking effectiveness, -1 block attempt, +1 Dodge ability, blocked damage increased by 50% of Strength.\nPrevents \"High Round Strike\" technique.\nLasts 2 seconds.",
         "melee_allowed": true,
         "persists": true,
         "buff_duration": 2,
@@ -644,8 +671,9 @@
       {
         "id": "buff_medievalpole_onmiss",
         "name": "Tactical Feinting",
-        "description": "They fell for your feint!\n\nEnables \"Hook and Drag\" technique.\nLasts 1 second.",
+        "description": "They fell for your feint!\n\nEffects lost if downed, stunned, or staggered.\nEnables \"Hook and Drag\" technique.\nLasts 1 second.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "skill_requirements": [ { "name": "melee", "level": 3 } ],
         "buff_duration": 1
       }
@@ -654,9 +682,10 @@
       {
         "id": "buff_medievalpole_onblock",
         "name": "Defense Break",
-        "description": "Each successful block reveals an opening in your opponent's guard.\n\n+1 accuracy.\nEnables \"Displace and Hook\" technique.\nLasts 1 second.  Stacks 3 times.",
+        "description": "Each successful block reveals an opening in your opponent's guard.\n\nEffects lost if downed, stunned, or staggered.\n+1 accuracy.\nEnables \"Displace and Hook\" technique.\nLasts 1 second.  Stacks 3 times.",
         "melee_allowed": true,
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 1,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
@@ -721,9 +750,10 @@
       {
         "id": "buff_karate_static",
         "name": "Karate Stance",
-        "description": "Your no-nonsense stance allows you hit more accurately.\n\n+2 accuracy.",
+        "description": "Your no-nonsense stance allows you hit more accurately.\n\nEffects lost if downed, stunned, or staggered.\n+2 accuracy.",
         "unarmed_allowed": true,
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "hit", "scale": 2.0 } ]
       }
     ],
@@ -731,13 +761,14 @@
       {
         "id": "buff_karate_onhit",
         "name": "Karate Kata",
-        "description": "Landing a hit allows you to perfectly position yourself for maximum defense against multiple opponents.\n\n+1 block attempt, +1 dodge attempt, blocked damage reduced by 50% of Strength, +10% move speed.\nLasts 2 seconds.",
+        "description": "Landing a hit allows you to perfectly position yourself for maximum defense against multiple opponents.\n\nEffects lost if downed, stunned, or staggered.\n+1 block attempt, +1 dodge attempt, blocked damage reduced by 50% of Strength, +10% move speed.\nLasts 2 seconds.",
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 2,
         "bonus_blocks": 1,
         "bonus_dodges": 1,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ],
         "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
@@ -757,10 +788,11 @@
       {
         "id": "buff_kalaripayattu_chuvadu",
         "name": "Chuvadu",
-        "description": "The steps for attack keep you mobile and centered as you seek an opening.\n\n+1 Dodge ability,\n+1 Dodge attempt.",
+        "description": "The steps for attack keep you mobile and centered as you seek an opening.\n\nEffects lost if downed, stunned, or staggered.\n+1 Dodge ability,\n+1 Dodge attempt.",
         "melee_allowed": true,
         "bonus_dodges": 1,
         "forbidden_buffs_all": [ "buff_kalaripayattu_simha_vadivu" ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "dodge", "scale": 1.0 } ]
       }
     ],
@@ -796,8 +828,9 @@
       {
         "id": "buff_kickboxing_stance_static",
         "name": "Kick stance",
-        "description": "You have adopted a stance which allows for greater mobility and stability.  Your hands are in a guard position with elbows forward to protect yourself.\n\nBlocked damage reduced by 25% of Strength.\n+1 Dodge ability",
+        "description": "You have adopted a stance which allows for greater mobility and stability.  Your hands are in a guard position with elbows forward to protect yourself.\n\nEffects lost if stunned, or staggered.\nBlocked damage reduced by 25% of Strength.\n+1 Dodge ability",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 }, { "stat": "dodge", "scale": 1.0 } ]
       }
     ],
@@ -823,10 +856,11 @@
       {
         "id": "buff_krav_maga_static",
         "name": "Krav Maga Stance",
-        "description": "Your training makes it easier to land hits and fight multiple opponents.\n\n+1 accuracy, +1 block attempt.",
+        "description": "Your training makes it easier to land hits and fight multiple opponents.\n\nEffects lost if stunned, or staggered.\n+1 accuracy, +1 block attempt.",
         "melee_allowed": true,
         "unarmed_allowed": true,
         "bonus_blocks": 1,
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
       }
     ],
@@ -864,8 +898,9 @@
       {
         "id": "buff_leopard_static1",
         "name": "Leopard's Strategy",
-        "description": "You fight by overwhelming your opponents with speedy strikes that are much harder to defend against.\n\nBash damage increased by 75% of Dexterity but decreased by 75% of Strength.",
+        "description": "You fight by overwhelming your opponents with speedy strikes that are much harder to defend against.\n\nEffects lost if downed, stunned, or staggered.\nBash damage increased by 75% of Dexterity but decreased by 75% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "damage", "type": "bash", "scaling-stat": "dex", "scale": 0.75 },
           { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": -0.75 }
@@ -874,8 +909,9 @@
       {
         "id": "buff_leopard_static2",
         "name": "Leopard's Ambush",
-        "description": "Go for the throat and take out your foes immediately!\n\nCritical hit chance increased by 100% of Dexterity.",
+        "description": "Go for the throat and take out your foes immediately!\n\nEffects lost if stunned or staggered.\nCritical hit chance increased by 100% of Dexterity.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "crit_chance", "scaling-stat": "dex", "scale": 1.0 } ]
       }
     ],
@@ -915,9 +951,10 @@
       {
         "id": "buff_swordsmanship_static",
         "name": "Swordsman's Stance",
-        "description": "Through chivalry and vigilance, your defense with a blade has increased.\n\n+1 block attempt, blocked damage reduced by 50% of Strength.",
+        "description": "Through chivalry and vigilance, your defense with a blade has increased.\n\nEffects lost if downed, stunned, or staggered.\n+1 block attempt, blocked damage reduced by 50% of Strength.",
         "melee_allowed": true,
         "bonus_blocks": 1,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ]
       }
     ],
@@ -978,6 +1015,7 @@
         "name": "Muay Thai Stance",
         "description": "Strength is everything in Muay Thai and you know how to make the most of yours.\n\nBlocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ]
       }
     ],
@@ -1018,19 +1056,21 @@
       {
         "id": "buff_ninjutsu_static1",
         "name": "Ninjutsu Stance",
-        "description": "Your training allows you to make no noise when attacking and less noise when moving around.\n\nMelee and unarmed attacks generate 0 noise, moving generates 1/2 as much noise.",
+        "description": "Your training allows you to make no noise when attacking and less noise when moving around.\n\nEffects lost if downed, stunned, or staggered.\nMelee and unarmed attacks generate 0 noise, moving generates 1/2 as much noise.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "quiet": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "stealthy": true
       },
       {
         "id": "buff_ninjutsu_static2",
         "name": "Sneak Attack",
-        "description": "To a true shinobi, the first strike and the last strike are one and the same.\n\n+25% critical hit chance.",
+        "description": "To a true shinobi, the first strike and the last strike are one and the same.\n\nEffects lost if downed, stunned, or staggered.\n+25% critical hit chance.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "forbidden_buffs_all": [ "buff_ninjutsu_onattack" ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "crit_chance", "scale": 25.0 } ]
       }
     ],
@@ -1049,10 +1089,11 @@
       {
         "id": "buff_ninjutsu_onmove",
         "name": "Momentum Shift",
-        "description": "Ninja are trained to be extremely agile and mobile.\n\n+! Dodge ability, accuracy increased by 20% of Dexterity.\nLasts 1 second.",
+        "description": "Ninja are trained to be extremely agile and mobile.\n\nEffects lost if downed, stunned, or staggered.\n+1 Dodge ability, accuracy increased by 20% of Dexterity.\nLasts 1 second.",
         "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
         "unarmed_allowed": true,
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 1,
         "flat_bonuses": [ { "stat": "dodge", "scale": 1.0 }, { "stat": "hit", "scaling-stat": "dex", "scale": 0.2 } ]
       }
@@ -1096,8 +1137,9 @@
       {
         "id": "buff_niten_static",
         "name": "Niten Ichi-Ryu Stance",
-        "description": "Cautious watchful eyes,\nmeasure and display your skill.\nPractice makes perfect.\n\nArmor penetration increased by 50% of Perception, blocked damage reduced by 100% of Perception.",
+        "description": "Cautious watchful eyes,\nmeasure and display your skill.\nPractice makes perfect.\n\nEffects lost if downed, stunned, or staggered.\nArmor penetration increased by 50% of Perception, blocked damage reduced by 100% of Perception.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "arpen", "type": "bash", "scaling-stat": "per", "scale": 0.5 },
           { "stat": "arpen", "type": "cut", "scaling-stat": "per", "scale": 0.5 },
@@ -1171,8 +1213,9 @@
       {
         "id": "buff_pankration_ondodge",
         "name": "Counter Chance",
-        "description": "The enemy has presented an opening in their defense.\n\n+10% damage.\nEnables \"Close Combat\" buff.\nLasts 1 second.",
+        "description": "The enemy has presented an opening in their defense.\n\nEffects lost if stunned or staggered.\n+10% damage.\nEnables \"Close Combat\" buff.\nLasts 1 second.",
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "unarmed_allowed": true,
         "buff_duration": 1,
         "mult_bonuses": [
@@ -1186,10 +1229,11 @@
       {
         "id": "buff_pankration_oncrit",
         "name": "Close Combat",
-        "description": "You have your opponent right where you want them!\n\n+20% damage.\nLasts 1 second.",
+        "description": "You have your opponent right where you want them!\n\nEffects lost if stunned or staggered.\n+20% damage.\nLasts 1 second.",
         "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
         "unarmed_allowed": true,
         "required_buffs_all": [ "buff_pankration_ondodge" ],
+        "forbidden_effects_any": [ "staggered", "stunned" ],
         "buff_duration": 1,
         "mult_bonuses": [
           { "stat": "damage", "type": "bash", "scale": 1.2 },
@@ -1220,8 +1264,9 @@
       {
         "id": "buff_silat_static",
         "name": "Silat Stance",
-        "description": "You try to stay as loose as possible when fighting to have more chances to dodge.\n\n+1 dodge attempt.",
+        "description": "You try to stay as loose as possible when fighting to have more chances to dodge.\n\nEffects lost if downed, stunned, or staggered.\n+1 dodge attempt.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_dodges": 1
       }
     ],
@@ -1229,9 +1274,10 @@
       {
         "id": "buff_silat_ondodge",
         "name": "Silat Appraisal",
-        "description": "Each time you dodge an attack, you learn a bit more about your opponent's fighting style.  This allows you to make more precise attacks against them.\n\nAccuracy increased by 15% of Dexterity.\nLasts 2 seconds.  Stacks 3 times.",
+        "description": "Each time you dodge an attack, you learn a bit more about your opponent's fighting style.  This allows you to make more precise attacks against them.\n\nEffects lost if downed, stunned, or staggered.\nAccuracy increased by 15% of Dexterity.\nLasts 2 seconds.  Stacks 3 times.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 2,
         "max_stacks": 3,
         "flat_bonuses": [ { "stat": "hit", "scaling-stat": "dex", "scale": 0.15 } ]
@@ -1241,9 +1287,10 @@
       {
         "id": "buff_silat_onmove",
         "name": "Silat Ambush",
-        "description": "You stay low as you move, making it harder for enemies to defend against you.\n\n+5% critical hit chance.\nLasts 1 second.",
+        "description": "You stay low as you move, making it harder for enemies to defend against you.\n\nEffects lost if downed, stunned, or staggered.\n+5% critical hit chance.\nLasts 1 second.",
         "skill_requirements": [ { "name": "melee", "level": 1 } ],
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 1,
         "flat_bonuses": [ { "stat": "crit_chance", "scale": 5.0 } ]
       }
@@ -1264,8 +1311,9 @@
       {
         "id": "buff_snake_static",
         "name": "Snake's Sight",
-        "description": "You are patient and know where to hit your opponent for best results.\n\nAccuracy increased by 25% of Perception but decreased by 25% of Dexterity, bash damage increased by 75% of Perception but decreased by 75% of Strength.",
+        "description": "You are patient and know where to hit your opponent for best results.\n\nEffects lost if downed, stunned, or staggered.\nAccuracy increased by 25% of Perception but decreased by 25% of Dexterity, bash damage increased by 75% of Perception but decreased by 75% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [
           { "stat": "hit", "scaling-stat": "per", "scale": 0.25 },
           { "stat": "hit", "scaling-stat": "dex", "scale": -0.25 },
@@ -1278,9 +1326,10 @@
       {
         "id": "buff_snake_onhit",
         "name": "Snake Bite",
-        "description": "Each snake bite is more painful than the last.\n\nArmor penetration increased by 25% of Perception.\nLasts 2 seconds.  Stacks 4 times.",
+        "description": "Each snake bite is more painful than the last.\n\nEffects lost if downed, stunned, or staggered.\nArmor penetration increased by 25% of Perception.\nLasts 2 seconds.  Stacks 4 times.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 2,
         "max_stacks": 4,
         "flat_bonuses": [
@@ -1294,9 +1343,10 @@
       {
         "id": "buff_snake_oncrit",
         "name": "Snake Fang",
-        "description": "You hit a weakpoint!  Your next attack will be extra painful.\n\nArmor penetration increased by 100% of Perception.\nLasts 1 second.",
+        "description": "You hit a weakpoint!  Your next attack will be extra painful.\n\nEffects lost if downed, stunned, or staggered.\nArmor penetration increased by 100% of Perception.\nLasts 1 second.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 1,
         "flat_bonuses": [
           { "stat": "arpen", "type": "bash", "scaling-stat": "per", "scale": 1.0 },
@@ -1309,8 +1359,9 @@
       {
         "id": "buff_snake_onpause",
         "name": "Snake's Coil",
-        "description": "Every snake waits for the perfect moment to strike.  Aim as your opponents approach and attack their weak spots without mercy!\n\n+1 accuracy, +1 blocking effectiveness, +5% critical hit chance.\nLasts 4 seconds.  Stacks 3 times.",
+        "description": "Every snake waits for the perfect moment to strike.  Aim as your opponents approach and attack their weak spots without mercy!\n\nEffects lost if downed, stunned, or staggered.\n+1 accuracy, +1 blocking effectiveness, +5% critical hit chance.\nLasts 4 seconds.  Stacks 3 times.",
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "unarmed_allowed": true,
         "buff_duration": 4,
         "max_stacks": 3,
@@ -1345,8 +1396,9 @@
       {
         "id": "buff_sojutsu_static",
         "name": "Sōjutsu Stance",
-        "description": "Your training grants better defense while using a spear.\n\n+1 block attempt, +2 blocking effectiveness.",
+        "description": "Your training grants better defense while using a spear.\n\nEffects lost if downed, stunned, or staggered.\n+1 block attempt, +2 blocking effectiveness.",
         "melee_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 2.0 } ]
       }
@@ -1386,16 +1438,18 @@
       {
         "id": "buff_taekwondo_static",
         "name": "Taekwondo Stance",
-        "description": "Using your legs to attack keeps your hands free for better defense.\n\nBlocked damage reduced by 50% of Strength.",
+        "description": "Using your legs to attack keeps your hands free for better defense.\n\nEffects lost if downed, stunned, or staggered.\nBlocked damage reduced by 50% of Strength.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "str", "scale": 0.5 } ]
       },
       {
         "id": "buff_taekwondo_static2",
         "name": "Unhindered",
-        "description": "Your attacks are stronger if you are not holding anything in your hands.\n\n+33% damage when not using a weapon.",
+        "description": "Your attacks are stronger if you are not holding anything in your hands.\n\nEffects lost if downed, stunned, or staggered.\n+33% damage when not using a weapon.",
         "unarmed_allowed": true,
         "strictly_unarmed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "mult_bonuses": [
           { "stat": "damage", "type": "bash", "scale": 1.33 },
           { "stat": "damage", "type": "cut", "scale": 1.33 },
@@ -1425,8 +1479,9 @@
       {
         "id": "buff_tai_chi_static",
         "name": "Tai Chi Stance",
-        "description": "You are focused on defense and predicting your opponents' attacks.\n\n+1 block attempt, blocked damage reduced by 100% Perception.",
+        "description": "You are focused on defense and predicting your opponents' attacks.\n\nEffects lost if downed, stunned, or staggered.\n+1 block attempt, blocked damage reduced by 100% Perception.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "bonus_blocks": 1,
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "per", "scale": 1.0 } ]
       }
@@ -1435,9 +1490,10 @@
       {
         "id": "buff_tai_chi_onblock",
         "name": "Repulse the Monkey",
-        "description": "By perfectly positioning yourself and your opponent, you have become more accurate and can bypass your opponent's defenses.\n\nAccuracy increased by 20% of Perception, armor penetration increased by 50% of Perception.\nLasts 2 seconds.",
+        "description": "By perfectly positioning yourself and your opponent, you have become more accurate and can bypass your opponent's defenses.\n\nEffects lost if downed, stunned, or staggered.\nAccuracy increased by 20% of Perception, armor penetration increased by 50% of Perception.\nLasts 2 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "buff_duration": 2,
         "flat_bonuses": [
           { "stat": "arpen", "type": "bash", "scaling-stat": "per", "scale": 0.5 },
@@ -1451,10 +1507,11 @@
       {
         "id": "buff_tai_chi_onpause",
         "name": "Cross Hands",
-        "description": "By taking a moment to prepare yourself, you are able to use your entire body fully for attacking and defending.\n\n+2 blocking effectiveness, blocked damage reduced by 50% of Perception.\nEnables \"Palm Strike\" and \"Double Palm Strike\" techniques.\nLasts 3 seconds.",
+        "description": "By taking a moment to prepare yourself, you are able to use your entire body fully for attacking and defending.\n\nEffects lost if downed, stunned, or staggered.\n+2 blocking effectiveness, blocked damage reduced by 50% of Perception.\nEnables \"Palm Strike\" and \"Double Palm Strike\" techniques.\nEffects lost if downed, stunned, or staggered.\nLasts 3 seconds.",
         "unarmed_allowed": true,
         "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
         "buff_duration": 3,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 2.0 }, { "stat": "block", "scaling-stat": "per", "scale": 0.5 } ]
       }
     ],
@@ -1522,8 +1579,9 @@
       {
         "id": "buff_wingchun_static",
         "name": "Chi-Sao Sensitivity",
-        "description": "You have a greater understanding of balance and technique.  This gives you a better chance to avoid your opponent's attacks.\n\nDodging skill increased by 25% of Perception, blocked damage reduced by 50% of Perception.",
+        "description": "You have a greater understanding of balance and technique.  This gives you a better chance to avoid your opponent's attacks.\n\nEffects lost if downed, stunned, or staggered.\nEffects lost if downed, stunned, or staggered.\nDodging skill increased by 25% of Perception, blocked damage reduced by 50% of Perception.",
         "unarmed_allowed": true,
+        "forbidden_effects_any": [ "downed", "staggered", "stunned" ],
         "flat_bonuses": [ { "stat": "block", "scaling-stat": "per", "scale": 0.5 }, { "stat": "dodge", "scaling-stat": "per", "scale": 0.25 } ]
       }
     ],
@@ -1580,7 +1638,7 @@
       {
         "id": "buff_zuiquan_onmove",
         "name": "Drunken Stumble",
-        "description": "With a few quick steps, you can completely change your orientation and dodge attacks easier.\n\n+! Dodge ability.\nLasts 1 second.  Stacks 2 times.",
+        "description": "With a few quick steps, you can completely change your orientation and dodge attacks easier.\n\n+1 Dodge ability.\nLasts 1 second.  Stacks 2 times.",
         "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
         "unarmed_allowed": true,
         "buff_duration": 1,

--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -573,8 +573,8 @@
     "connected_to": "torso",
     "side": "both",
     "opposite_part": "gastropod_foot",
-    "limb_types": [ [ "leg", 0.8 ], [ "foot", 0.5 ], [ "tail", 0.2 ] ],
-    "limb_scores": [ [ "move_speed", 0.3 ], [ "crawl", 0.6 ], [ "footing", 0.8 ] ],
+    "limb_types": [ [ "leg", 1.0 ], [ "foot", 1.0 ], [ "tail", 1.0 ] ],
+    "limb_scores": [ [ "move_speed", 0.3 ], [ "crawl", 0.6 ], [ "footing", 1.5 ], [ "swim", 0.3 ] ],
     "hit_size": 30,
     "hit_difficulty": 1.2,
     "stylish_bonus": 3,
@@ -694,7 +694,7 @@
     "base_hp": 46,
     "drench_capacity": 600,
     "smash_message": "You tail-slap the %s.",
-    "flags": [ "LIMB_LOWER" ],
+    "flags": [ "LIMB_LOWER", "LIMB_BONELESS" ],
     "sub_parts": [ "fish_tail_base", "fish_tail_tip", "fish_tail_draped" ],
     "effects_on_hit": [
       {
@@ -807,7 +807,7 @@
     "base_hp": 46,
     "drench_capacity": 600,
     "smash_message": "You tail-whip the %s.",
-    "flags": [ "LIMB_LOWER" ],
+    "flags": [ "LIMB_LOWER", "LIMB_BONELESS" ],
     "sub_parts": [ "long_tail_base", "long_tail_tip", "long_tail_draped" ],
     "effects_on_hit": [
       {
@@ -912,10 +912,10 @@
     "opposite_part": "cephalopod_arm_4",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -940,7 +940,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_1_base", "cephalopod_arm_1_tip", "cephalopod_arm_1_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1041,10 +1041,10 @@
     "opposite_part": "cephalopod_arm_5",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -1069,7 +1069,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_2_base", "cephalopod_arm_2_tip", "cephalopod_arm_2_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1170,10 +1170,10 @@
     "opposite_part": "cephalopod_arm_6",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -1198,7 +1198,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_3_base", "cephalopod_arm_3_tip", "cephalopod_arm_3_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1299,10 +1299,10 @@
     "opposite_part": "cephalopod_arm_1",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -1327,7 +1327,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_4_base", "cephalopod_arm_4_tip", "cephalopod_arm_4_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1428,10 +1428,10 @@
     "opposite_part": "cephalopod_arm_2",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -1456,7 +1456,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_5_base", "cephalopod_arm_5_tip", "cephalopod_arm_5_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1557,10 +1557,10 @@
     "opposite_part": "cephalopod_arm_3",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.4 ], [ "hand", 0.3 ], [ "leg", 0.5 ], [ "foot", 0.5 ] ],
+    "mend_rate": 400,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.12, 0.22 ],
+      [ "manip", 0.12, 1.1 ],
       [ "lift", 0.05 ],
       [ "grip", 0.051 ],
       [ "block", 1.0 ],
@@ -1585,7 +1585,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_arm_6_base", "cephalopod_arm_6_tip", "cephalopod_arm_6_draped" ],
-    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_LOWER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1686,10 +1686,10 @@
     "opposite_part": "cephalopod_tentacle_r",
     "hit_size": 5,
     "hit_difficulty": 0.9,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.6 ], [ "hand", 0.5 ], [ "leg", 0.4 ], [ "foot", 0.3 ] ],
+    "mend_rate": 300,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.45, 0.95 ],
+      [ "manip", 0.25, 1.25 ],
       [ "lift", 0.35 ],
       [ "grip", 0.36 ],
       [ "block", 1.0 ],
@@ -1714,7 +1714,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_tentacle_l_base", "cephalopod_tentacle_l_tip" ],
-    "flags": [ "LIMB_UPPER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_UPPER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -1803,10 +1803,10 @@
     "opposite_part": "cephalopod_tentacle_l",
     "hit_size": 5,
     "hit_difficulty": 0.9,
-    "mend_rate": 200,
-    "limb_types": [ [ "arm", 0.6 ], [ "hand", 0.5 ], [ "leg", 0.4 ], [ "foot", 0.3 ] ],
+    "mend_rate": 300,
+    "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
-      [ "manip", 0.45, 0.95 ],
+      [ "manip", 0.25, 1.25 ],
       [ "lift", 0.35 ],
       [ "grip", 0.36 ],
       [ "block", 1.0 ],
@@ -1831,7 +1831,7 @@
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.6,
     "sub_parts": [ "cephalopod_tentacle_r_base", "cephalopod_tentacle_r_tip" ],
-    "flags": [ "LIMB_UPPER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND" ],
+    "flags": [ "LIMB_UPPER", "LIMB_FOOT", "LIMB_SOLE", "LIMB_HAND", "LIMB_BONELESS" ],
     "effects_on_hit": [
       {
         "id": "bleed",

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -3158,9 +3158,9 @@
     "condition_desc": "* Only works on a target of <info>similar or smaller</info> size, requires <info>Cross Hands</info>",
     "knockback_dist": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.25 },
-      { "stat": "damage", "type": "cut", "scale": 1.25 },
-      { "stat": "damage", "type": "stab", "scale": 1.25 }
+      { "stat": "damage", "type": "bash", "scale": 1.15 },
+      { "stat": "damage", "type": "cut", "scale": 1.15 },
+      { "stat": "damage", "type": "stab", "scale": 1.15 }
     ],
     "attack_vectors": [ "vector_palm" ]
   },
@@ -3185,12 +3185,7 @@
     },
     "condition_desc": "* Only works on a <info>non-downed</info> target of <info>similar or smaller</info> size incapable of flight, requires <info>Repulse the Monkey</info>",
     "down_dur": 1,
-    "mult_bonuses": [
-      { "stat": "movecost", "scale": 0.75 },
-      { "stat": "damage", "type": "bash", "scale": 1.25 },
-      { "stat": "damage", "type": "cut", "scale": 1.25 },
-      { "stat": "damage", "type": "stab", "scale": 1.25 }
-    ],
+    "mult_bonuses": [ { "stat": "movecost", "scale": 0.75 } ],
     "attack_vectors": [ "vector_grasp" ]
   },
   {
@@ -3230,9 +3225,9 @@
     "tech_effects": [ { "id": "staggered", "chance": 80, "duration": 200, "on_damage": true, "message": "%s is knocked off-balance!" } ],
     "knockback_dist": 1,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.75 },
-      { "stat": "damage", "type": "cut", "scale": 1.75 },
-      { "stat": "damage", "type": "stab", "scale": 1.75 }
+      { "stat": "damage", "type": "bash", "scale": 1.5 },
+      { "stat": "damage", "type": "cut", "scale": 1.5 },
+      { "stat": "damage", "type": "stab", "scale": 1.5 }
     ],
     "attack_vectors": [ "vector_palm" ]
   },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8521,10 +8521,10 @@ void Character::on_hit( map *here, Creature *source, bodypart_id bp_hit,
         if( stability_roll() < dice( rolls, 10 ) ) {
             if( !is_avatar() ) {
                 if( u_see ) {
-                    add_msg( _( "%1$s loses their balance while being hit!" ), get_name() );
+                    add_msg( _( "The hit makes %1$s lose their balance!" ), get_name() );
                 }
             } else {
-                add_msg( m_bad, _( "You lose your balance while being hit!" ) );
+                add_msg( m_bad, _( "The hit makes you lose your balance!" ) );
             }
             if( in_skater_vehicle ) {
                 g->fling_creature( this, rng_float( 0_degrees, 360_degrees ), 10 );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1282,7 +1282,8 @@ bodypart_id Character::body_window( const std::string &menu_header,
         const nc_color all_state_col = display::limb_color( *this, bp, true, true, true );
         // Broken means no HP can be restored, it requires surgical attention.
         const bool limb_is_broken = is_limb_broken( bp );
-        const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp ) || bp->has_flag( json_flag_LIMB_BONELESS );
+        const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp ) ||
+                                     bp->has_flag( json_flag_LIMB_BONELESS );
         // How much this treatment would help, if applied to this bodypart.
         // The value itself is just a sorting number and has no actual meaning in itself, but is roughly ranged at:
         // 0-30=bandage, 30-60=disinfectant, 60-70=bitten/infected, 70-80=bleeding
@@ -1323,11 +1324,11 @@ bodypart_id Character::body_window( const std::string &menu_header,
         std::string hp_str;
         if( limb_is_mending ) {
             if( bp->has_flag( json_flag_LIMB_BONELESS ) ) {
-            desc += colorize( _( "It is injured beyond use, but will recover on its own in time." ),
-                              c_blue ) + "\n";
+                desc += colorize( _( "It is injured beyond use, but will recover on its own in time." ),
+                                  c_blue ) + "\n";
             } else {
-            desc += colorize( _( "It is broken, but has been set, and just needs time to heal." ),
-                              c_blue ) + "\n";
+                desc += colorize( _( "It is broken, but has been set, and just needs time to heal." ),
+                                  c_blue ) + "\n";
             }
             if( no_feeling ) {
                 hp_str = colorize( "==%==", c_blue );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -88,6 +88,8 @@ static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_wet( "wet" );
 
+
+
 static const json_character_flag json_flag_BARKY( "BARKY" );
 static const json_character_flag json_flag_CANNOT_CHANGE_TEMPERATURE( "CANNOT_CHANGE_TEMPERATURE" );
 static const json_character_flag json_flag_COLDBLOOD( "COLDBLOOD" );
@@ -97,6 +99,7 @@ static const json_character_flag json_flag_ECTOTHERM( "ECTOTHERM" );
 static const json_character_flag json_flag_HEATSINK( "HEATSINK" );
 static const json_character_flag json_flag_HEAT_IMMUNE( "HEAT_IMMUNE" );
 static const json_character_flag json_flag_IGNORE_TEMP( "IGNORE_TEMP" );
+static const json_character_flag json_flag_LIMB_BONELESS( "LIMB_BONELESS" );
 static const json_character_flag json_flag_LIMB_LOWER( "LIMB_LOWER" );
 static const json_character_flag json_flag_NO_THIRST( "NO_THIRST" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
@@ -1279,7 +1282,7 @@ bodypart_id Character::body_window( const std::string &menu_header,
         const nc_color all_state_col = display::limb_color( *this, bp, true, true, true );
         // Broken means no HP can be restored, it requires surgical attention.
         const bool limb_is_broken = is_limb_broken( bp );
-        const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp );
+        const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp ) || bp->has_flag( json_flag_LIMB_BONELESS );
         // How much this treatment would help, if applied to this bodypart.
         // The value itself is just a sorting number and has no actual meaning in itself, but is roughly ranged at:
         // 0-30=bandage, 30-60=disinfectant, 60-70=bitten/infected, 70-80=bleeding
@@ -1319,8 +1322,13 @@ bodypart_id Character::body_window( const std::string &menu_header,
         const auto &aligned_name = std::string( max_bp_name_len - utf8_width( e.name ), ' ' ) + e.name;
         std::string hp_str;
         if( limb_is_mending ) {
+            if( bp->has_flag( json_flag_LIMB_BONELESS ) ) {
+            desc += colorize( _( "It is injured beyond use, but will recover on its own in time." ),
+                              c_blue ) + "\n";
+            } else {
             desc += colorize( _( "It is broken, but has been set, and just needs time to heal." ),
                               c_blue ) + "\n";
+            }
             if( no_feeling ) {
                 hp_str = colorize( "==%==", c_blue );
             } else {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -715,11 +715,11 @@ void clear_techniques_and_martial_arts()
 
 bool ma_requirements::buff_requirements_satisfied( const Character &u ) const
 {
-    const auto has_buff = [&u]( const mabuff_id &id ) {
+    const auto has_buff = [&u]( const mabuff_id & id ) {
         return u.has_mabuff( id );
     };
 
-    const auto has_effect = [&u]( const efftype_id &id ) {
+    const auto has_effect = [&u]( const efftype_id & id ) {
         return u.has_effect( id );
     };
 
@@ -745,7 +745,7 @@ bool ma_requirements::buff_requirements_satisfied( const Character &u ) const
     return
         std::all_of( req_buffs_all.begin(), req_buffs_all.end(), has_buff ) &&
         ( req_buffs_any.empty() ||
-        std::any_of( req_buffs_any.begin(), req_buffs_any.end(), has_buff ) );
+          std::any_of( req_buffs_any.begin(), req_buffs_any.end(), has_buff ) );
 }
 
 bool ma_requirements::is_valid_character( const Character &u ) const

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -263,6 +263,18 @@ void ma_requirements::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "required_buffs_any", req_buffs_any, string_id_reader<::ma_buff> {} );
     optional( jo, was_loaded, "forbidden_buffs_all", forbid_buffs_all, string_id_reader<::ma_buff> {} );
     optional( jo, was_loaded, "forbidden_buffs_any", forbid_buffs_any, string_id_reader<::ma_buff> {} );
+    forbid_effects_any.clear();
+    if( jo.has_array( "forbidden_effects_all" ) ) {
+        for( const JsonValue &v : jo.get_array( "forbidden_effects_all" ) ) {
+            forbid_effects_all.emplace( efftype_id( v.get_string() ) );
+        }
+    }
+    forbid_effects_any.clear();
+    if( jo.has_array( "forbidden_effects_any" ) ) {
+        for( const JsonValue &v : jo.get_array( "forbidden_effects_any" ) ) {
+            forbid_effects_any.emplace( efftype_id( v.get_string() ) );
+        }
+    }
 
     optional( jo, was_loaded, "req_flags", req_flags, string_id_reader<::json_flag> {} );
     optional( jo, was_loaded, "required_char_flags", req_char_flags );
@@ -566,6 +578,19 @@ static void check( const ma_requirements &req, const std::string &display_text )
             debugmsg( "ma buff %s of %s does not exist", r.c_str(), display_text );
         }
     }
+
+    for( const efftype_id &e : req.forbid_effects_all ) {
+        if( !e.is_valid() ) {
+            debugmsg( "effect %s of %s does not exist", e.c_str(), display_text );
+        }
+    }
+
+    for( const efftype_id &e : req.forbid_effects_any ) {
+        if( !e.is_valid() ) {
+            debugmsg( "effect %s of %s does not exist", e.c_str(), display_text );
+        }
+    }
+
 }
 
 void check_martialarts()
@@ -690,22 +715,37 @@ void clear_techniques_and_martial_arts()
 
 bool ma_requirements::buff_requirements_satisfied( const Character &u ) const
 {
-    const auto having_buff = [&u]( const mabuff_id & buff_id ) {
-        return u.has_mabuff( buff_id );
+    const auto has_buff = [&u]( const mabuff_id &id ) {
+        return u.has_mabuff( id );
     };
 
-    if( std::any_of( forbid_buffs_any.begin(), forbid_buffs_any.end(), having_buff ) ) {
+    const auto has_effect = [&u]( const efftype_id &id ) {
+        return u.has_effect( id );
+    };
+
+    if( std::any_of( forbid_buffs_any.begin(), forbid_buffs_any.end(), has_buff ) ) {
+        return false;
+    }
+
+    if( std::any_of( forbid_effects_any.begin(), forbid_effects_any.end(), has_effect ) ) {
         return false;
     }
 
     if( !forbid_buffs_all.empty() ) {
-        if( std::all_of( forbid_buffs_all.begin(), forbid_buffs_all.end(), having_buff ) ) {
+        if( std::all_of( forbid_buffs_all.begin(), forbid_buffs_all.end(), has_buff ) ) {
+            return false;
+        }
+    }
+    if( !forbid_effects_all.empty() ) {
+        if( std::all_of( forbid_effects_all.begin(), forbid_effects_all.end(), has_effect ) ) {
             return false;
         }
     }
 
-    return std::all_of( req_buffs_all.begin(), req_buffs_all.end(), having_buff ) &&
-           ( req_buffs_any.empty() || std::any_of( req_buffs_any.begin(), req_buffs_any.end(), having_buff ) );
+    return
+        std::all_of( req_buffs_all.begin(), req_buffs_all.end(), has_buff ) &&
+        ( req_buffs_any.empty() ||
+        std::any_of( req_buffs_any.begin(), req_buffs_any.end(), has_buff ) );
 }
 
 bool ma_requirements::is_valid_character( const Character &u ) const
@@ -861,7 +901,7 @@ std::string ma_requirements::get_description( bool buff ) const
     }
 
     if( !req_buffs_all.empty() ) {
-        dump += _( "<bold>Requires (all):</bold> " );
+        dump += _( "<bold>Requires:</bold> " );
 
         dump += enumerate_as_string( req_buffs_all.begin(),
         req_buffs_all.end(), []( const mabuff_id & bid ) {
@@ -870,7 +910,7 @@ std::string ma_requirements::get_description( bool buff ) const
     }
 
     if( !req_buffs_any.empty() ) {
-        dump += _( "<bold>Requires (any):</bold> " );
+        dump += _( "<bold>Requires any of:</bold> " );
 
         dump += enumerate_as_string( req_buffs_any.begin(),
         req_buffs_any.end(), []( const mabuff_id & bid ) {
@@ -879,7 +919,7 @@ std::string ma_requirements::get_description( bool buff ) const
     }
 
     if( !forbid_buffs_all.empty() ) {
-        dump += _( "<bold>Forbidden (all):</bold> " );
+        dump += _( "<bold>Lost if you have:</bold> " );
 
         dump += enumerate_as_string( forbid_buffs_all.begin(),
         forbid_buffs_all.end(), []( const mabuff_id & bid ) {
@@ -888,7 +928,7 @@ std::string ma_requirements::get_description( bool buff ) const
     }
 
     if( !forbid_buffs_any.empty() ) {
-        dump += _( "<bold>Forbidden (any):</bold> " );
+        dump += _( "<bold>Lost if you have any of:</bold> " );
 
         dump += enumerate_as_string( forbid_buffs_any.begin(),
         forbid_buffs_any.end(), []( const mabuff_id & bid ) {

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -125,6 +125,8 @@ struct ma_requirements {
     std::set<mabuff_id> req_buffs_any; // any listed buffs required to trigger this bonus
     std::set<mabuff_id> forbid_buffs_all; // all listed buffs prevent triggering this bonus
     std::set<mabuff_id> forbid_buffs_any; // any listed buffs prevent triggering this bonus
+    std::set<efftype_id> forbid_effects_all; // all listed effects prevent trigger
+    std::set<efftype_id> forbid_effects_any; // any listed effects prevent trigger
 
     std::set<flag_id> req_flags; // any item flags required for this technique
     cata::flat_set<json_character_flag> req_char_flags; // any listed character flags required

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -2037,7 +2037,8 @@ void Character::mend( int rate_multiplier )
             needs_splint = false;
         }
 
-        if( needs_splint && !worn_with_flag( flag_SPLINT, bp ) && !bp->has_flag( json_flag_LIMB_BONELESS ) ) {
+        if( needs_splint && !worn_with_flag( flag_SPLINT, bp ) &&
+            !bp->has_flag( json_flag_LIMB_BONELESS ) ) {
             continue;
         }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -126,6 +126,7 @@ static const json_character_flag json_flag_ETHEREAL( "ETHEREAL" );
 static const json_character_flag json_flag_GILLS( "GILLS" );
 static const json_character_flag json_flag_GLARE_RESIST( "GLARE_RESIST" );
 static const json_character_flag json_flag_GRAB( "GRAB" );
+static const json_character_flag json_flag_LIMB_BONELESS( "LIMB_BONELESS" );
 static const json_character_flag json_flag_MEND_ALL( "MEND_ALL" );
 static const json_character_flag json_flag_MEND_LIMB( "MEND_LIMB" );
 static const json_character_flag json_flag_NO_DRENCH( "NO_DRENCH" );
@@ -2036,7 +2037,7 @@ void Character::mend( int rate_multiplier )
             needs_splint = false;
         }
 
-        if( needs_splint && !worn_with_flag( flag_SPLINT,  bp ) ) {
+        if( needs_splint && !worn_with_flag( flag_SPLINT, bp ) && !bp->has_flag( json_flag_LIMB_BONELESS ) ) {
             continue;
         }
 


### PR DESCRIPTION
#### Summary
Limb and martial art updates

#### Purpose of change
- Tails, tentacles and cephalopod arms do not need to be splinted. They will automatically start mending themselves after a second.
- Updated the text for disabled limbs a bit.
- Increased the mending speed of cephalopod limbs.
- Cephalopod arms and tentacles now correctly calculate their manipulation and other scores. Cephalopods are now, as intended, better at crafting stuff and shooting guns than humans.
- Capped the limb score bonus to dodge ability to +4. We can use enchantments if mutations need to provide more than that.
- Reduced Balance's contribution to dodge from 1.5 to 1.25.
- Martial art buffs now fall off if you have certain effects. These are called out in the buffs' descriptions. Mostly this is downed, staggered, or stunned. Some buffs are exempt from one or all. Zui Quan is uniquely exempt as that is its thing.
- Reduced the bonus damage on tai chi techniques.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
