### PR TITLE
Fix weird earmuff text

### DIFF
--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -26,9 +26,9 @@
     ],
     "use_action": {
       "type": "transform",
-      "menu_text": "Press tightly to ears",
+      "menu_text": "Wear",
       "target": "attachable_ear_muffs_on",
-      "msg": "You put the ear muffs tightly to your ears.",
+      "msg": "You move the ear muffs over your ears.",
       "moves": 100
     }
   },
@@ -42,9 +42,9 @@
     "extend": { "flags": [ "DEAF" ] },
     "use_action": {
       "type": "transform",
-      "menu_text": "Put away from ears",
+      "menu_text": "Remove",
       "target": "attachable_ear_muffs",
-      "msg": "You put the ear muffs away from your ears.",
+      "msg": "You move the ear muffs away from your ears.",
       "moves": 100
     }
   },


### PR DESCRIPTION
#### Summary
Fix weird earmuff text

#### Purpose of change
The activate/deactivate message read strangely

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
