### PR TITLE
Fix riot armor suit encumbrance from MOLLE attachments

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -769,6 +769,7 @@
       },
       {
         "covers": [ "leg_l", "leg_r" ],
+        "volume_encumber_modifier": 0,
         "encumbrance": 3,
         "coverage": 90,
         "material": [
@@ -780,6 +781,7 @@
       },
       {
         "covers": [ "foot_l", "foot_r" ],
+        "volume_encumber_modifier": 0,
         "encumbrance": 2,
         "coverage": 75,
         "material": [ { "type": "thermo_resin", "covered_by_mat": 100, "thickness": 1.5 } ],
@@ -789,6 +791,7 @@
       },
       {
         "covers": [ "arm_l", "arm_r" ],
+        "volume_encumber_modifier": 0,
         "encumbrance": 3,
         "coverage": 90,
         "material": [


### PR DESCRIPTION
#### Summary
Make MOLLE attachments on the riot armor suit only affect torso encumbrance.

#### Purpose of change
Limbs other than the torso were getting encumbered when attaching pockets to the riot armor suit (I noticed my character's feet getting encumbered in my current game).

#### Describe the solution
Add `"volume_encumber_modifier": 0` to the limb coverage definitions where it was missing.

#### Describe alternatives you've considered
Maybe it would make sense to have other limbs get encumbered a bit?  Not sure how tightly connected the pieces of the riot suit are supposed to be.

#### Testing
Attached some pockets to my riot armor suit, filled them up, observed only the torso encumbrance going up.

#### Additional context
Looks like these fields were in the JSONs before, but this change removed them, probably while copying the definitions from the individual riot armor pieces (which don't have MOLLE slots):  https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1220