### PR TITLE
Fix Maria's longcoat craft

### DIFF
--- a/data/json/npcs/godco/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/godco/members/NPC_Maria_Serrano.json
@@ -190,16 +190,6 @@
         "topic": "TALK_GODCO_Maria_Tailor_Start"
       },
       {
-        "text": "I'll have a long coat.",
-        "condition": { "u_has_items": { "item": "icon", "count": 6 } },
-        "effect": [
-          { "npc_add_var": "general_trade_u_want_longcoat", "value": "yes" },
-          { "math": [ "n_timer_trade_knitting = time('now')" ] },
-          { "u_sell_item": "icon", "count": 6 }
-        ],
-        "topic": "TALK_GODCO_Maria_Tailor_Start"
-      },
-      {
         "text": "I'll have a backpack.",
         "condition": { "u_has_items": { "item": "icon", "count": 6 } },
         "effect": [
@@ -288,21 +278,6 @@
           { "npc_lose_var": "general_trade_u_want_dress" },
           { "npc_lose_var": "timer_trade_knitting" },
           { "u_spawn_item": "dress" }
-        ],
-        "topic": "TALK_GODCO_Maria_Tailor_Done"
-      },
-      {
-        "text": "I ordered a longcoat.",
-        "condition": {
-          "and": [
-            { "npc_has_var": "general_trade_u_want_longcoat", "value": "yes" },
-            { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
-          ]
-        },
-        "effect": [
-          { "npc_lose_var": "general_trade_u_want_longcoat" },
-          { "npc_lose_var": "timer_trade_knitting" },
-          { "u_spawn_item": "longcoat" }
         ],
         "topic": "TALK_GODCO_Maria_Tailor_Done"
       },

--- a/data/json/npcs/godco/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/godco/members/NPC_Maria_Serrano.json
@@ -180,10 +180,10 @@
         "topic": "TALK_GODCO_Maria_Tailor_Start"
       },
       {
-        "text": "I'll have a duster.",
+        "text": "I'll have a longcoat.",
         "condition": { "u_has_items": { "item": "icon", "count": 6 } },
         "effect": [
-          { "npc_add_var": "general_trade_u_want_duster", "value": "yes" },
+          { "npc_add_var": "general_trade_u_want_longcoat", "value": "yes" },
           { "math": [ "n_timer_trade_knitting = time('now')" ] },
           { "u_sell_item": "icon", "count": 6 }
         ],
@@ -292,17 +292,17 @@
         "topic": "TALK_GODCO_Maria_Tailor_Done"
       },
       {
-        "text": "I ordered a duster.",
+        "text": "I ordered a longcoat.",
         "condition": {
           "and": [
-            { "npc_has_var": "general_trade_u_want_duster", "value": "yes" },
+            { "npc_has_var": "general_trade_u_want_longcoat", "value": "yes" },
             { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
           ]
         },
         "effect": [
-          { "npc_lose_var": "general_trade_u_want_duster" },
+          { "npc_lose_var": "general_trade_u_want_longcoat" },
           { "npc_lose_var": "timer_trade_knitting" },
-          { "u_spawn_item": "duster" }
+          { "u_spawn_item": "longcoat" }
         ],
         "topic": "TALK_GODCO_Maria_Tailor_Done"
       },


### PR DESCRIPTION
#### Summary
Fix Maria's longcoat craft

#### Purpose of change
Maria at the church was still making dusters. Dusters were removed (combined with trenchcoats to make the longcoat) so that's gotta go!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
