### PR TITLE
correct makeshift glaive grip

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -178,7 +178,7 @@
     "description": "A sturdy pole with a broad cutting blade securely bolted to one end.  It's intimidating despite being clearly homemade.",
     "price": "50 USD",
     "price_postapoc": "2 USD 50 cent",
-    "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "uneven" },
+    "to_hit": { "grip": "solid", "length": "long", "surface": "line", "balance": "uneven" },
     "material": [ { "type": "steel", "portion": 3 }, { "type": "wood", "portion": 7 } ],
     "symbol": "/",
     "color": "light_gray",


### PR DESCRIPTION
#### Summary
Bugfix "correct makeshift glaive grip"

#### Purpose of change
The "makeshift glaive" is essentially a variant of the knife spear, made with very similar cobbled-together components and tools. As such, I see no reason why the knife spear should have a "solid" grip, indicating a good but not purpose-made hold, while the makeshift glaive has a "weapon" grip, indicating the kind of carefully tapered ergonomic grip you find on well-made, purpose-build weapons.

#### Describe the solution
Change the makeshift glaive to have a "solid" grip

#### Describe alternatives you've considered
Changing the knife spear to have a "weapon" grip.
This would make some sense, as the knife spear uses the same "spear shaft" item for its construction as the proper spears, and there's little implication that the recipe for e.g. a steel spear involves further shaping the shaft.
However, it makes sense from both a balance and verisimilitude perspective that a Fabrication 1 recipe using basic tools to attach a meat cleaver to a stick wouldn't be quite as well-shaped and ergonomic as higher-level recipes that require a deeper understanding of weapon use and manufacture.

#### Testing

#### Additional context
If this is an intentional balance difference or something feel free to just disregard this PR obviously.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
