### PR TITLE
Carpet and blade fixes

### DIFF
--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -179,6 +179,7 @@
     "skill_used": "fabrication",
     "time": "15 m",
     "autolearn": true,
+    "reversible": true,
     "components": [ [ [ "carpet_scrap", 4 ] ], [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
   },
@@ -191,6 +192,7 @@
     "skill_used": "fabrication",
     "time": "15 m",
     "autolearn": true,
+    "reversible": true,
     "components": [ [ [ "carpet_scrap", 2 ] ], [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
   },

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -501,6 +501,7 @@
     "skill_used": "fabrication",
     "time": "15 m",
     "autolearn": true,
+    "reversible": true,
     "components": [ [ [ "carpet_scrap", 4 ] ], [ [ "cordage", 4, "LIST" ], [ "duct_tape", 50 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
   },
@@ -513,6 +514,7 @@
     "skill_used": "fabrication",
     "time": "15 m",
     "autolearn": true,
+    "reversible": true,
     "components": [ [ [ "carpet_scrap", 2 ] ], [ [ "cordage", 2, "LIST" ], [ "duct_tape", 25 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -168,6 +168,7 @@
     "skill_used": "fabrication",
     "time": "10 m",
     "autolearn": true,
+    "reversible": true,
     "components": [ [ [ "carpet_scrap", 8 ] ], [ [ "cordage", 8, "LIST" ], [ "duct_tape", 200 ] ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ]
   },

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2357,7 +2357,7 @@
     "result": "knife_meat_cleaver",
     "time": "5 m",
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "blade", 1 ], [ "scrap", 10 ] ] ]
+    "components": [ [ [ "scrap", 10 ] ] ]
   },
   {
     "type": "uncraft",

--- a/data/json/uncraft/tools.json
+++ b/data/json/uncraft/tools.json
@@ -49,10 +49,9 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "plastic_chunk", 4 ] ],
-      [ [ "blade", 2 ] ],
       [ [ "motor_micro", 1 ] ],
       [ [ "power_supply", 1 ] ],
-      [ [ "scrap", 1 ] ],
+      [ [ "scrap", 5 ] ],
       [ [ "cable", 4 ] ]
     ]
   },

--- a/data/json/vehicleparts/rams.json
+++ b/data/json/vehicleparts/rams.json
@@ -257,7 +257,7 @@
     "name": { "str": "blade" },
     "damage_modifier": 250,
     "durability": 200,
-    "description": "A blade, welded to the vehicle, for cutting up zombies.",
+    "description": "A blade welded to the vehicle for cutting up zombies.",
     "item": "blade",
     "folded_volume": "750 ml",
     "requirements": {
@@ -279,7 +279,7 @@
     "color": "white",
     "extend": { "flags": [ "NO_COVER" ] },
     "broken_color": "white",
-    "description": "A metal spike, welded to the vehicle, to increase injury when crashing into things.",
+    "description": "A metal spike welded to the vehicle to increase injury when crashing into things.",
     "item": "spike",
     "folded_volume": "250 ml",
     "breaks_into": [ { "item": "steel_fragment", "count": [ 1, 2 ] } ],
@@ -295,7 +295,7 @@
     "broken_color": "brown",
     "damage_modifier": 115,
     "durability": 150,
-    "description": "A wooden spike, attached to the vehicle, to increase injury when crashing into things.",
+    "description": "A wooden spike attached to the vehicle to increase injury when crashing into things.",
     "item": "pointy_stick",
     "folded_volume": "1250 ml",
     "requirements": {


### PR DESCRIPTION
#### Summary
Carpet and blade fixes

#### Purpose of change
- It was possible to deconstruct some ordinary knives for huge mower blades.
- Carpet armor wasn't reversible.

#### Describe the solution
- reversible: true for carpet armor recipes
- electric carver and meat cleaver do not yield mower blades

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
