### PR TITLE
Some DDA backports

### DIFF
--- a/data/json/mapgen/veterinarian.json
+++ b/data/json/mapgen/veterinarian.json
@@ -104,7 +104,7 @@
       "place_vehicles": [
         { "vehicle": "VETS", "x": 7, "y": 2, "chance": 20, "rotation": 1 },
         { "vehicle": "VETS", "x": 15, "y": 2, "chance": 20, "rotation": 1 },
-        { "vehicle": "VETS", "x": 23, "y": 2, "chance": 20, "rotation": 1 }
+        { "vehicle": "VETS", "x": 20, "y": 2, "chance": 20, "rotation": 1 }
       ]
     }
   },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11908,11 +11908,12 @@ npc_attitude Character::get_attitude() const
     return NPCATT_NULL;
 }
 
-bool Character::sees( const map &here, const tripoint_bub_ms &t, bool, int ) const
+bool Character::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+                      int range_mod ) const
 {
     const int wanted_range = rl_dist( pos_bub( here ), t );
     bool can_see = this->is_avatar() ? here.pl_sees( t, std::min( sight_max, wanted_range ) ) :
-                   Creature::sees( here, t );
+                   Creature::sees( here, t, is_avatar, range_mod );
     // Clairvoyance is now pretty cheap, so we can check it early
     if( wanted_range < MAX_CLAIRVOYANCE && wanted_range < clairvoyance() ) {
         return true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1368,7 +1368,7 @@ void game::on_witness_theft( const item &target )
     std::vector<npc *> witnesses;
     for( npc &elem : g->all_npcs() ) {
         if( rl_dist( elem.pos_bub(), p.pos_bub() ) < MAX_VIEW_DISTANCE &&
-            elem.sees( here, p.pos_bub( here ) ) &&
+            elem.sees( here, p ) &&
             target.is_owned_by( elem ) ) {
             witnesses.push_back( &elem );
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -613,13 +613,18 @@ void inventory_entry::cache_denial( inventory_selector_preset const &preset ) co
 
 const item_category *inventory_entry::get_category_ptr() const
 {
+    if( cached_category_ptr != nullptr ) {
+        return cached_category_ptr;
+    }
     if( custom_category != nullptr ) {
-        return custom_category;
+        cached_category_ptr = custom_category;
+        return cached_category_ptr;
     }
     if( !is_item() ) {
         return nullptr;
     }
-    return &any_item()->get_category_of_contents();
+    cached_category_ptr = &any_item()->get_category_of_contents();
+    return cached_category_ptr;
 }
 
 inventory_column::inventory_column( const inventory_selector_preset &preset ) :
@@ -1299,15 +1304,16 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
     paging_is_valid = false;
     if( entry.is_item() ) {
         item_location entry_item = entry.locations.front();
+        item_category const *entry_cat_ptr = entry.get_category_ptr();
 
         auto entry_with_loc = std::find_if( dest.begin(),
-        dest.end(), [&entry, &entry_item, this]( const inventory_entry & e ) {
+        dest.end(), [&entry_item, entry_cat_ptr, this]( const inventory_entry & e ) {
             if( !e.is_item() ) {
                 return false;
             }
             item_location found_entry_item = e.locations.front();
             return !e.is_collated() &&
-                   e.get_category_ptr() == entry.get_category_ptr() &&
+                   e.get_category_ptr() == entry_cat_ptr &&
                    entry_item.where() == found_entry_item.where() &&
                    entry_item.pos_abs() == found_entry_item.pos_abs() &&
                    entry_item.parent_item() == found_entry_item.parent_item() &&

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -93,6 +93,7 @@ class inventory_entry
         inventory_entry( const inventory_entry &entry, const item_category *custom_category ) :
             inventory_entry( entry ) {
             this->custom_category = custom_category;
+            this->cached_category_ptr = nullptr;
         }
 
         explicit inventory_entry( const std::vector<item_location> &locations,
@@ -197,6 +198,7 @@ class inventory_entry
 
         void set_custom_category( const item_category *category ) {
             custom_category = category;
+            cached_category_ptr = nullptr;
         }
 
         void reset_collation() {
@@ -218,6 +220,7 @@ class inventory_entry
 
     private:
         mutable item_category const *custom_category = nullptr;
+        mutable item_category const *cached_category_ptr = nullptr;
     protected:
         // indents the entry if it is contained in an item
         bool _indent = true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13337,6 +13337,9 @@ const item_category &item::get_category_of_contents( int depth, int maxdepth ) c
             cached_category = { cat.get_id(), calendar::turn };
             return cat;
         }
+        item_category const &cat = this->get_category_shallow();
+        cached_category = { cat.get_id(), calendar::turn };
+        return cat;
     }
     return this->get_category_shallow();
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6535,7 +6535,7 @@ void item::handle_pickup_ownership( Character &c )
                     owned_by = is_owned_by( *as_monster );
                 }
                 return &cr != &c && owned_by && rl_dist( cr.pos_abs(), c.pos_abs() ) < MAX_VIEW_DISTANCE &&
-                       cr.sees( here, c.pos_bub( here ) );
+                       cr.sees( here, c );
             };
             const auto sort_criteria = []( const Creature * lhs, const Creature * rhs ) {
                 const npc *const lnpc = lhs->as_npc();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6435,7 +6435,7 @@ static ret_val<void> apply_mapgen_in_phases(
     }
     cata_assert( setmap_point == setmap_points.end() );
 
-    resolve_regional_terrain_and_furniture( md );
+    resolve_regional_terrain_and_furniture( md, offset.z() );
 
     return ret_val<void>::make_success();
 }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3166,23 +3166,6 @@ class jmapgen_monster : public jmapgen_piece
         }
 };
 
-static inclusive_rectangle<point> vehicle_bounds( const vehicle_prototype &vp )
-{
-    point min( INT_MAX, INT_MAX );
-    point max( INT_MIN, INT_MIN );
-
-    cata_assert( !vp.parts.empty() );
-
-    for( const vehicle_prototype::part_def &part : vp.parts ) {
-        min.x = std::min( min.x, part.pos.x() );
-        max.x = std::max( max.x, part.pos.x() );
-        min.y = std::min( min.y, part.pos.y() );
-        max.y = std::max( max.y, part.pos.y() );
-    }
-
-    return { min, max };
-}
-
 /**
  * Place a vehicle.
  * "vehicle": id of the vehicle.
@@ -3250,120 +3233,60 @@ class jmapgen_vehicle : public jmapgen_piece_with_has_vehicle_collision
                 return;
             }
 
-            // The rest of this function is devoted to ensuring that this
-            // vehicle placement does not lead to a vehicle overlapping an OMT
-            // boundary, because that causes issues (e.g. if the vehicle is
-            // damaged and tries to drop items during mapgen, they may drop on
-            // points outside the map).
-
-            point min( INT_MAX, INT_MAX );
-            point max( INT_MIN, INT_MIN );
-            vgroup_id min_x_vg;
-            vproto_id min_x_vp;
-            vgroup_id max_x_vg;
-            vproto_id max_x_vp;
-            vgroup_id min_y_vg;
-            vproto_id min_y_vp;
-            vgroup_id max_y_vg;
-            vproto_id max_y_vp;
-            for( const vgroup_id &vg_id : type.all_possible_results( parameters ) ) {
-                for( const vproto_id &vp_id : vg_id->all_possible_results() ) {
-                    inclusive_rectangle<point> bounds = vehicle_bounds( *vp_id );
-                    if( bounds.p_min.x < min.x ) {
-                        min_x_vg = vg_id;
-                        min_x_vp = vp_id;
-                        min.x = bounds.p_min.x;
-                    }
-                    if( bounds.p_max.x > max.x ) {
-                        max_x_vg = vg_id;
-                        max_x_vp = vp_id;
-                        max.x = bounds.p_max.x;
-                    }
-                    if( bounds.p_min.y < min.y ) {
-                        min_y_vg = vg_id;
-                        min_y_vp = vp_id;
-                        min.y = bounds.p_min.y;
-                    }
-                    if( bounds.p_max.y > max.y ) {
-                        max_y_vg = vg_id;
-                        max_y_vp = vp_id;
-                        max.y = bounds.p_max.y;
-                    }
-                }
-            }
-
+            // Mirror vehicle::precalc_mounts to detect parts landing OOB
             for( units::angle rot : rotation ) {
-                int degrees = to_degrees( rot );
-                while( degrees < 0 ) {
-                    degrees += 360;
+                int degrees = ( ( static_cast<int>( to_degrees( rot ) ) % 360 ) + 360 ) % 360;
+                for( const vgroup_id &vg_id : type.all_possible_results( parameters ) ) {
+                    for( const vproto_id &vp_id : vg_id->all_possible_results() ) {
+                        point worst_min( INT_MAX, INT_MAX );
+                        point worst_max( INT_MIN, INT_MIN );
+                        tileray tdir( rot );
+                        for( const vehicle_prototype::part_def &part : vp_id->parts ) {
+                            tdir.clear_advance();
+                            tdir.advance( part.pos.x() );
+                            point d( tdir.dx() + tdir.ortho_dx( part.pos.y() ),
+                                     tdir.dy() + tdir.ortho_dy( part.pos.y() ) );
+                            worst_min.x = std::min( worst_min.x, d.x );
+                            worst_max.x = std::max( worst_max.x, d.x );
+                            worst_min.y = std::min( worst_min.y, d.y );
+                            worst_max.y = std::max( worst_max.y, d.y );
+                        }
+                        point new_min = worst_min + point( x.val, y.val );
+                        point new_max = worst_max + point( x.valmax, y.valmax );
+
+                        cube_direction bad_dir = cube_direction::last;
+                        std::string extreme_coord;
+                        if( new_min.x < 0 ) {
+                            bad_dir = cube_direction::west;
+                            extreme_coord = string_format(
+                                                "x = %d (should be at least 0)", new_min.x );
+                        } else if( new_max.x >= 24 ) {
+                            bad_dir = cube_direction::east;
+                            extreme_coord = string_format(
+                                                "x = %d (should be at most 23)", new_max.x );
+                        } else if( new_min.y < 0 ) {
+                            bad_dir = cube_direction::north;
+                            extreme_coord = string_format(
+                                                "y = %d (should be at least 0)", new_min.y );
+                        } else if( new_max.y >= 24 ) {
+                            bad_dir = cube_direction::south;
+                            extreme_coord = string_format(
+                                                "y = %d (should be at most 23)", new_max.y );
+                        } else {
+                            continue;
+                        }
+                        debugmsg( "In %s, vehicle placement at x:[%d,%d], y:[%d,%d]: "
+                                  "potential placement of vehicle out of bounds.  "
+                                  "At rotation %d the vehicle "
+                                  "[vgroup_id %s; vproto_id %s] extends too far %s, "
+                                  "reaching coordinate %s",
+                                  context, x.val, x.valmax, y.val, y.valmax, degrees,
+                                  vg_id.str(), vp_id.str(),
+                                  io::enum_to_string( bad_dir ), extreme_coord );
+                        // Early exit per (vgroup, vproto) pair to limit spam
+                        return;
+                    }
                 }
-                if( degrees % 90 != 0 ) {
-                    // TODO: support non-rectilinear vehicle placement
-                    continue;
-                }
-                int turns = degrees / 90;
-                point rotated_min = min.rotate( turns );
-                point rotated_max = max.rotate( turns );
-                point new_min( std::min( rotated_min.x, rotated_max.x ),
-                               std::min( rotated_min.y, rotated_max.y ) );
-                point new_max( std::max( rotated_min.x, rotated_max.x ),
-                               std::max( rotated_min.y, rotated_max.y ) );
-
-                new_min += point( x.val, y.val );
-                new_max += point( x.valmax, y.valmax );
-
-                cube_direction bad_rotated_direction = cube_direction::last;
-                std::string extreme_coord;
-
-                if( new_min.x < 0 ) {
-                    bad_rotated_direction = cube_direction::west;
-                    extreme_coord = string_format( "x = %d (should be at least 0)", new_min.x );
-                } else if( new_max.x >= 24 ) {
-                    bad_rotated_direction = cube_direction::east;
-                    extreme_coord = string_format( "x = %d (should be at most 23)", new_max.x );
-                } else if( new_min.y < 0 ) {
-                    extreme_coord = string_format( "y = %d (should be at least 0)", new_min.y );
-                    bad_rotated_direction = cube_direction::north;
-                } else if( new_max.y >= 24 ) {
-                    bad_rotated_direction = cube_direction::south;
-                    extreme_coord = string_format( "y = %d (should be at most 23)", new_max.y );
-                } else {
-                    continue;
-                }
-
-                cube_direction bad_direction = bad_rotated_direction - turns;
-
-                std::string bad_vehicle;
-                auto format_option = []( const vgroup_id & vg, const vproto_id & vp ) {
-                    return string_format(
-                               "[vgroup_id %s; vproto_id %s]", vg.str(), vp.str() );
-                };
-                switch( bad_direction ) {
-                    case cube_direction::north:
-                        bad_vehicle = format_option( min_y_vg, min_y_vp );
-                        break;
-                    case cube_direction::south:
-                        bad_vehicle = format_option( max_y_vg, max_y_vp );
-                        break;
-                    case cube_direction::east:
-                        bad_vehicle = format_option( max_x_vg, max_x_vp );
-                        break;
-                    case cube_direction::west:
-                        bad_vehicle = format_option( min_x_vg, min_x_vp );
-                        break;
-                    default:
-                        cata_fatal( "Invalid bad_direction %d", bad_direction );
-                }
-                debugmsg( "In %s, vehicle placement at x:[%d,%d], y:[%d,%d]: "
-                          "potential placement of vehicle out of bounds.  "
-                          "At rotation %d the vehicle %s extends too far %s, "
-                          "reaching coordinate %s",
-                          context, x.val, x.valmax, y.val, y.valmax, degrees,
-                          bad_vehicle, io::enum_to_string( bad_rotated_direction ),
-                          extreme_coord );
-                // Early exit because we don't want too much error spam
-                // from the same mapgen piece
-                return;
             }
         }
 };

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2227,12 +2227,12 @@ void mremove_fields( map *m, const tripoint_bub_ms &p )
     m->clear_fields( p );
 }
 
-void resolve_regional_terrain_and_furniture( const mapgendata &dat )
+void resolve_regional_terrain_and_furniture( const mapgendata &dat, int z_offset /*= 0*/ )
 {
     if( dat.region.id.is_valid() ) {
         const region_settings_terrain_furniture &settings_terfurn =
             dat.region.get_settings_terrain_furniture();
-        for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
+        for( const tripoint_bub_ms &p : dat.m.points_on_zlevel( dat.m.get_abs_sub().z() + z_offset ) ) {
             const ter_id &tid_before = dat.m.ter( p );
             if( !tid_before.id().is_null() && tid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
                 const ter_id &tid_after = settings_terfurn.resolve( tid_before );

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -67,6 +67,6 @@ std::pair<std::map<ter_id, int>, std::map<furn_id, int>> get_changed_ids_from_up
             ter_id const &base_ter = ter_str_id( "t_dirt" ).id() );
 mapgen_parameters get_map_special_params( const std::string &mapgen_id );
 
-void resolve_regional_terrain_and_furniture( const mapgendata &dat );
+void resolve_regional_terrain_and_furniture( const mapgendata &dat, int z_offset = 0 );
 
 #endif // CATA_SRC_MAPGEN_FUNCTIONS_H

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2295,9 +2295,27 @@ void monster::stumble()
             }
         }
     }
-    const tripoint_bub_ms below( pos_bub() + tripoint::below );
-    if( here.valid_move( pos_bub(), below, false, true ) ) {
-        valid_stumbles.push_back( below );
+
+    // The same-z radius scan above cannot produce straight-up or straight-down
+    // candidates; add them here, gated by stair / climb / swim / fly rules.
+    if( is_voluntary ) {
+        const tripoint_bub_ms below( pos_bub() + tripoint::below );
+        if( here.valid_move( pos_bub(), below, false, true ) ) {
+            valid_stumbles.push_back( below );
+        }
+        const tripoint_bub_ms above( pos_bub() + tripoint::above );
+        const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
+                              !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
+        const bool ladder_up = here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() ) &&
+                               can_climb() &&
+                               here.has_floor_or_support( above );
+        const bool swim_up = swims() &&
+                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
+                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
+        if( ( flies() || stair_up || ladder_up || swim_up ) &&
+            here.valid_move( pos_bub(), above, false, flies() ) ) {
+            valid_stumbles.push_back( above );
+        }
     }
 
     creature_tracker &creatures = get_creature_tracker();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2298,24 +2298,22 @@ void monster::stumble()
 
     // The same-z radius scan above cannot produce straight-up or straight-down
     // candidates; add them here, gated by stair / climb / swim / fly rules.
-    if( is_voluntary ) {
-        const tripoint_bub_ms below( pos_bub() + tripoint::below );
-        if( here.valid_move( pos_bub(), below, false, true ) ) {
-            valid_stumbles.push_back( below );
-        }
-        const tripoint_bub_ms above( pos_bub() + tripoint::above );
-        const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
-                              !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
-        const bool ladder_up = here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() ) &&
-                               can_climb() &&
-                               here.has_floor_or_support( above );
-        const bool swim_up = swims() &&
-                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
-                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
-        if( ( flies() || stair_up || ladder_up || swim_up ) &&
-            here.valid_move( pos_bub(), above, false, flies() ) ) {
-            valid_stumbles.push_back( above );
-        }
+    const tripoint_bub_ms below( pos_bub() + tripoint::below );
+    if( here.valid_move( pos_bub(), below, false, true ) ) {
+        valid_stumbles.push_back( below );
+    }
+    const tripoint_bub_ms above( pos_bub() + tripoint::above );
+    const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
+                            !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
+    const bool ladder_up = here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() ) &&
+                            can_climb() &&
+                            here.has_floor_or_support( above );
+    const bool swim_up = swims() &&
+                            here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
+                            here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
+    if( ( flies() || stair_up || ladder_up || swim_up ) &&
+        here.valid_move( pos_bub(), above, false, flies() ) ) {
+        valid_stumbles.push_back( above );
     }
 
     creature_tracker &creatures = get_creature_tracker();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2087,7 +2087,7 @@ int npc::indoor_voice() const
     const int distance_to_player = rl_dist( pos_abs(), player.pos_abs() );
     if( is_following() || is_ally( player ) ) {
         wanted_volume = distance_to_player;
-    } else if( is_enemy() && sees( here, player.pos_bub( here ) ) ) {
+    } else if( is_enemy() && sees( here, player ) ) {
         // Battle cry! Bandits have no concept of indoor voice, even when not threatened.
         wanted_volume = max_volume;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -841,7 +841,7 @@ void npc::assess_danger()
     preferred_close_range = std::min( preferred_close_range, preferred_medium_range / 2 );
 
     Character &player_character = get_player_character();
-    bool sees_player = sees( here, player_character.pos_bub( here ) );
+    bool sees_player = sees( here, player_character );
     const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
                                    rules.engagement == combat_engagement::NONE;
     const bool no_fighting = rules.has_flag( ally_rule::forbid_engage );
@@ -1271,8 +1271,10 @@ void npc::act_on_danger_assessment()
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s upgrades reposition to flat out retreat.", name );
                 mem_combat.repositioning = false; // we're not just moving, we're running.
                 warn_about( "run_away", run_away_for );
-                set_attitude( NPCATT_FLEE_TEMP );
-                if( mem_combat.panic > 5 && is_player_ally() && sees( here, player_character.pos_bub( here ) ) ) {
+                if( !is_player_ally() ) {
+                    set_attitude( NPCATT_FLEE_TEMP );
+                }
+                if( mem_combat.panic > 5 && is_player_ally() && sees( here, player_character ) ) {
                     // consider warning player about panic
                     int panic_alert = trig_dist( pos_bub(), player_character.pos_bub() ) - player_character.get_per();
                     if( mem_combat.panic - personality.bravery > panic_alert ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -613,7 +613,7 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
 
     // Additional 50% chance for heavy damage to disabled vehicles
     if( veh_status == 1 && one_in( 2 ) ) {
-        smash( placed_on, 0.5 );
+        damage_all_parts( 0.5 );
     }
 
     for( const int p : engines ) {
@@ -905,11 +905,11 @@ units::angle vehicle::get_angle_from_targ( const tripoint_abs_ms &targ ) const
  * (i.e., any spot with multiple frames) will be completely destroyed, as that
  * was the collision point.
  */
-void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_max,
-                     float percent_of_parts_to_affect, point_rel_ms damage_origin, float damage_size )
+void vehicle::damage_all_parts( float hp_percent_loss_min, float hp_percent_loss_max,
+                                float percent_of_parts_to_affect, point_rel_ms damage_origin,
+                                float damage_size )
 {
     for( vehicle_part &part : parts ) {
-        //Skip any parts already mashed up or removed.
         if( part.is_broken() || part.removed ) {
             continue;
         }
@@ -924,7 +924,6 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
         }
 
         if( structures_found > 1 ) {
-            //Destroy everything in the square
             for( int idx : parts_in_square ) {
                 vehicle_part &vp = parts[idx];
                 vp.ammo_unset();
@@ -939,19 +938,29 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
             double dist = damage_size == 0.0f ? 1.0f :
                           clamp( 1.0f - trig_dist( damage_origin, part.precalc[0].xy() ) /
                                  damage_size, 0.0f, 1.0f );
-            //Everywhere else, drop by 10-120% of max HP (anything over 100 = broken)
+            // Drop by 10-120% of max HP (anything over 100 = broken)
             const float roll = rng_float( hp_percent_loss_min * dist, hp_percent_loss_max * dist );
             if( mod_hp( part, -part.info().durability * roll ) ) {
                 part.ammo_unset();
             }
         }
     }
+}
+
+void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_max,
+                     float percent_of_parts_to_affect, point_rel_ms damage_origin, float damage_size )
+{
+    damage_all_parts( hp_percent_loss_min, hp_percent_loss_max,
+                      percent_of_parts_to_affect, damage_origin, damage_size );
 
     std::unique_ptr<RemovePartHandler> handler_ptr;
-    // clear out any duplicated locations
     for( int p = static_cast<int>( parts.size() ) - 1; p >= 0; p-- ) {
         vehicle_part &part = parts[p];
         if( part.removed ) {
+            continue;
+        }
+        // OOB parts belong to a neighboring map; leave them alone
+        if( !m.inbounds( bub_part_pos( m, part ) ) ) {
             continue;
         }
         std::vector<int> parts_here = parts_at_relative( part.mount, true );
@@ -967,12 +976,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
 
             if( vpi1.id == vpi2.id ||
                 ( !vpi1.location.empty() && vpi1.location == vpi2.location ) ) {
-                // Deferred creation of the handler to here so it is only created when actually needed.
                 if( !handler_ptr ) {
-                    // This is a heuristic: we just assume the default handler is good enough when called
-                    // on the main game map. And assume that we run from some mapgen code if called on
-                    // another instance.
-                    // TODO: Make this capable of distinguishing between mapgen and non bubble active maps.
                     if( g && &reality_bubble() == &m ) {
                         handler_ptr = std::make_unique<DefaultRemovePartHandler>();
                     } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5161,7 +5161,7 @@ bool vehicle::handle_potential_theft( Character const &you, bool check_only, boo
         Character const *const elem = cr.as_character();
         return elem != nullptr && you.getID() != elem->getID() && is_owned_by( *elem ) &&
                rl_dist( elem->pos_bub( here ), you.pos_bub( here ) ) < MAX_VIEW_DISTANCE &&
-               elem->sees( here, you.pos_bub( here ) );
+               elem->sees( here, you );
     } );
     if( !has_owner() || ( witnesses.empty() && ( has_old_owner() || you.is_npc() ) ) ) {
         if( !has_owner() ||

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -982,6 +982,12 @@ class vehicle
                          bool force_status = false );
 
         // damages all parts of a vehicle by a random amount
+        void damage_all_parts( float hp_percent_loss_min = 0.1f, float hp_percent_loss_max = 1.2f,
+                               float percent_of_parts_to_affect = 1.0f,
+                               point_rel_ms damage_origin = point_rel_ms::zero,
+                               float damage_size = 0 );
+
+        // damage_all_parts, plus deduplication of overlapping parts
         void smash( map &m, float hp_percent_loss_min = 0.1f, float hp_percent_loss_max = 1.2f,
                     float percent_of_parts_to_affect = 1.0f, point_rel_ms damage_origin = point_rel_ms::zero,
                     float damage_size = 0 );


### PR DESCRIPTION
#### Summary
Some DDA backports

#### Purpose of change
86618 - fix stair stumble
86682 - fix npcs not seeing player when player can see npcs
86705 - fix vehicle wrecks
86728 - cache item category pointer
86905 - fix regional terrain not working when spawned at different zlevels

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
