### PR TITLE
Backport 86899 - add item-targeted wakeup scheduler

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -263,6 +263,17 @@
     "auto_needs": true
   },
   {
+    "id": "ACT_CRAFT_WAIT",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "waiting for craft step",
+    "rooted": true,
+    "based_on": "time",
+    "can_resume": false,
+    "refuel_fires": true,
+    "auto_needs": true
+  },
+  {
     "id": "ACT_DISASSEMBLE",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -103,15 +103,22 @@
     "components": [ [ [ "flour", 22 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "sugar", 4 ] ] ],
     "steps": [
       {
-        "name": "Mix dough",
+        "name": "mixing the dough",
         "time": "5 m",
         "activity_level": "MODERATE_EXERCISE",
         "batch_time_factors": [ 25, 4 ],
         "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_baking" }, { "proficiency": "prof_baking_bread" } ]
       },
-      { "name": "Let dough rise", "time": "10 m", "activity_level": "NO_EXERCISE", "batch_time_factors": [ 5, 4 ] },
       {
-        "name": "Bake",
+        "name": "letting the dough rise",
+        "time": "10 m",
+        "activity_level": "NO_EXERCISE",
+        "batch_time_factors": [ 5, 4 ],
+        "attention": "unattended",
+        "unattend_message": "The dough has finished rising."
+      },
+      {
+        "name": "baking",
         "time": "5 m",
         "activity_level": "LIGHT_EXERCISE",
         "batch_time_factors": [ 50, 4 ],

--- a/data/mods/TEST_DATA/item_wakeup_test_items.json
+++ b/data/mods/TEST_DATA/item_wakeup_test_items.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "test_wakeup_dummy",
+    "type": "ITEM",
+    "subtypes": [ "GENERIC" ],
+    "category": "spare_parts",
+    "name": { "str": "wakeup test dummy" },
+    "description": "A test item used by the item-wakeup test suite.  Tests register a C++ handler against this id.",
+    "material": [ "test_material" ],
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "*",
+    "color": "white"
+  },
+  {
+    "id": "test_wakeup_no_handler",
+    "type": "ITEM",
+    "subtypes": [ "GENERIC" ],
+    "category": "spare_parts",
+    "name": { "str": "wakeup test (no handler)" },
+    "description": "A test item with no registered wakeup handler.  Used to exercise the dispatcher's no-op path.",
+    "material": [ "test_material" ],
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "*",
+    "color": "white"
+  }
+]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -38,6 +38,8 @@
 #include "coordinates.h"
 #include "craft_command.h"
 #include "crafting_gui.h"
+#include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -63,6 +65,7 @@
 #include "item_components.h"
 #include "item_contents.h"
 #include "item_location.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -4463,6 +4466,73 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 break;
             }
             accumulated -= budget;
+        }
+    }
+
+    // Mode is derived from craft state every turn so wakeup handlers that
+    // advance current_step do not need to reach into the live actor.
+    auto derive_mode = [&]() -> mode {
+        if( !rec.has_steps() )
+        {
+            return mode::active;
+        }
+        const recipe_step &s = rec.steps()[craft.get_current_step()];
+        if( s.attention != step_attention::unattended )
+        {
+            return mode::active;
+        }
+        if( craft.get_passive_started_at() == calendar::before_time_starts )
+        {
+            return mode::active;
+        }
+        const std::vector<attention_plan> &plans = craft.get_step_plans();
+        const int idx = craft.get_current_step();
+        if( idx >= static_cast<int>( plans.size() ) )
+        {
+            return mode::waiting;
+        }
+        return plans[idx].choice == step_choice::do_wait ? mode::waiting : mode::active;
+    };
+    mode_ = derive_mode();
+
+    if( rec.has_steps() ) {
+        const recipe_step &cur_step = rec.steps()[craft.get_current_step()];
+        if( cur_step.attention == step_attention::unattended ) {
+            const std::vector<attention_plan> &plans = craft.get_step_plans();
+            const int idx = craft.get_current_step();
+            const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                        attention_plan{};
+
+            if( craft.get_passive_started_at() == calendar::before_time_starts ) {
+                craft.set_passive_started_at( calendar::turn );
+                const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
+                        compute_tool_speeds( rec, crafter ) };
+                const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
+                                               crafter, idx, craft.get_making_batch_size(),
+                                               passive_ctx, recipe_time_flag::ignore_proficiencies ) );
+                craft.set_ready_at( calendar::turn + time_duration::from_moves( step_moves ) );
+                if( cur_step.max_time.has_value() ) {
+                    time_duration fail_dur = *cur_step.max_time;
+                    if( cur_step.grace_period.has_value() ) {
+                        fail_dur += *cur_step.grace_period;
+                    }
+                    craft.set_fail_at( calendar::turn + fail_dur );
+                }
+                if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+                    craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
+                }
+                mode_ = derive_mode();
+                get_item_wakeups().rebuild_for_item( *craft_item );
+            }
+
+            if( plan.choice == step_choice::do_wait ) {
+                crafter.set_moves( 0 );
+                return;
+            }
+            // do_something / set_timer: end activity without backlog.
+            act.set_to_null();
+            crafter.set_moves( 0 );
+            return;
         }
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4503,50 +4503,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
                                         attention_plan{};
 
+            // Past-due wakeup (off-bubble drop or same-turn race): advance inline.
+            if( craft.get_passive_started_at() != calendar::before_time_starts &&
+                craft.get_ready_at() != calendar::before_time_starts &&
+                calendar::turn >= craft.get_ready_at() ) {
+                craft_actualize_scheduled( craft, item_wakeup_kind::ready_check,
+                                           calendar::turn, craft_item );
+                return;
+            }
+
             if( craft.get_passive_started_at() == calendar::before_time_starts ) {
-                craft.set_passive_started_at( calendar::turn );
-                const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
-                        compute_tool_speeds( rec, crafter ) };
-                const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
-                                               crafter, idx, craft.get_making_batch_size(),
-                                               passive_ctx, recipe_time_flag::ignore_proficiencies ) );
-                craft.set_ready_at( calendar::turn + time_duration::from_moves( step_moves ) );
-                if( cur_step.max_time.has_value() ) {
-                    time_duration fail_dur = *cur_step.max_time;
-                    if( cur_step.grace_period.has_value() ) {
-                        fail_dur += *cur_step.grace_period;
-                    }
-                    craft.set_fail_at( calendar::turn + fail_dur );
-                }
-                if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
-                    craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
-                }
-                // Snapshot counter bounds so item_tname can project without mutation.
-                // Bounds derive from prior steps' budgets to drop any active-step
-                // overshoot in item_counter from carrying into this passive step.
-                double prior_moves = 0.0;
-                double base_default = 0.0;
-                double step_default = 0.0;
-                for( size_t i = 0; i < rec.steps().size(); ++i ) {
-                    const double budget = rec.step_budget_moves(
-                                              crafter, i, craft.get_making_batch_size(), passive_ctx );
-                    base_default += budget;
-                    if( static_cast<int>( i ) < idx ) {
-                        prior_moves += budget;
-                    } else if( static_cast<int>( i ) == idx ) {
-                        step_default = budget;
-                    }
-                }
-                base_default = std::max( 1.0, base_default );
-                const int start_counter = static_cast<int>( std::round(
-                                              prior_moves / base_default * 10000000.0 ) );
-                const int end_counter = std::min( 10000000,
-                                                  static_cast<int>( std::round(
-                                                          ( prior_moves + step_default ) / base_default * 10000000.0 ) ) );
-                craft.set_passive_start_counter( start_counter );
-                craft.set_passive_end_counter( end_counter );
+                craft_stamp_passive_entry( craft, crafter, calendar::turn, craft_item );
                 mode_ = derive_mode();
-                get_item_wakeups().rebuild_for_item( *craft_item );
             }
 
             if( plan.choice == step_choice::do_wait ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4521,6 +4521,30 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
                 if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
                     craft.set_alarm_at( calendar::turn + *plan.alarm_offset );
                 }
+                // Snapshot counter bounds so item_tname can project without mutation.
+                // Bounds derive from prior steps' budgets to drop any active-step
+                // overshoot in item_counter from carrying into this passive step.
+                double prior_moves = 0.0;
+                double base_default = 0.0;
+                double step_default = 0.0;
+                for( size_t i = 0; i < rec.steps().size(); ++i ) {
+                    const double budget = rec.step_budget_moves(
+                                              crafter, i, craft.get_making_batch_size(), passive_ctx );
+                    base_default += budget;
+                    if( static_cast<int>( i ) < idx ) {
+                        prior_moves += budget;
+                    } else if( static_cast<int>( i ) == idx ) {
+                        step_default = budget;
+                    }
+                }
+                base_default = std::max( 1.0, base_default );
+                const int start_counter = static_cast<int>( std::round(
+                                              prior_moves / base_default * 10000000.0 ) );
+                const int end_counter = std::min( 10000000,
+                                                  static_cast<int>( std::round(
+                                                          ( prior_moves + step_default ) / base_default * 10000000.0 ) ) );
+                craft.set_passive_start_counter( start_counter );
+                craft.set_passive_end_counter( end_counter );
                 mode_ = derive_mode();
                 get_item_wakeups().rebuild_for_item( *craft_item );
             }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -130,6 +130,7 @@ static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
 static const activity_id ACT_CONSUME( "ACT_CONSUME" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
 static const activity_id ACT_DISABLE( "ACT_DISABLE" );
 static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_DROP( "ACT_DROP" );
@@ -4680,6 +4681,9 @@ void craft_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "craft_loc", craft_item );
     jsout.member( "long", is_long );
     jsout.member( "activity_override", activity_override );
+    if( mode_ == mode::waiting ) {
+        jsout.member( "mode", "waiting" );
+    }
 
     jsout.end_object();
 }
@@ -4693,6 +4697,10 @@ std::unique_ptr<activity_actor> craft_activity_actor::deserialize( JsonValue &js
     data.read( "craft_loc", actor.craft_item );
     data.read( "long", actor.is_long );
     data.read( "activity_override", actor.activity_override );
+    std::string mode_str;
+    if( data.read( "mode", mode_str ) && mode_str == "waiting" ) {
+        actor.mode_ = mode::waiting;
+    }
 
     return actor.clone();
 }
@@ -9147,6 +9155,7 @@ deserialize_functions = {
     { ACT_CONSUME, &consume_activity_actor::deserialize },
     { ACT_CRACKING, &safecracking_activity_actor::deserialize },
     { ACT_CRAFT, &craft_activity_actor::deserialize },
+    { ACT_CRAFT_WAIT, &craft_activity_actor::deserialize },
     { ACT_DISABLE, &disable_activity_actor::deserialize },
     { ACT_DISASSEMBLE, &disassemble_activity_actor::deserialize },
     { ACT_DROP, &drop_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1174,11 +1174,14 @@ class unload_activity_actor : public activity_actor
 
 class craft_activity_actor : public activity_actor
 {
+    public:
+        enum class mode : uint8_t { active, waiting };
     private:
         craft_activity_actor() = default;
 
         item_location craft_item;
         bool is_long;
+        mode mode_ = mode::active;
 
         float activity_override = NO_EXERCISE;
         std::optional<requirement_data> cached_continuation_requirements; // NOLINT(cata-serialize)
@@ -1195,7 +1198,8 @@ class craft_activity_actor : public activity_actor
 
         const activity_id &get_type() const override {
             static const activity_id ACT_CRAFT( "ACT_CRAFT" );
-            return ACT_CRAFT;
+            static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
+            return mode_ == mode::waiting ? ACT_CRAFT_WAIT : ACT_CRAFT;
         }
 
         void start( player_activity &act, Character &crafter ) override;

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -79,6 +79,7 @@ std::string enum_to_string<distraction_type>( distraction_type data )
         case distraction_type::mutation: return "mutation";
         case distraction_type::oxygen: return "oxygen";
         case distraction_type::withdrawal: return "withdrawal";
+        case distraction_type::craft_step_complete: return "craft_step_complete";
         // *INDENT-ON*
         default:
             cata_fatal( "Invalid distraction_type in enum_to_string" );

--- a/src/character.h
+++ b/src/character.h
@@ -92,6 +92,16 @@ namespace catacurses
 {
 class window;
 }  // namespace catacurses
+namespace Pickup
+{
+struct pick_info;
+} // namespace Pickup
+
+enum action_id : int;
+enum class recipe_filter_flags : int;
+enum class steed_type : int;
+enum npc_attitude : int;
+struct attention_plan;
 struct bionic;
 struct construction;
 struct dealt_projectile_attack;
@@ -3722,7 +3732,8 @@ class Character : public Creature, public visitable
         void make_all_craft( const recipe_id &id, int batch_size,
                              const std::optional<tripoint_bub_ms> &loc );
         /** consume components and create an active, in progress craft containing them */
-        void start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc );
+        void start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,
+                          std::vector<attention_plan> plans = {} );
 
         struct craft_roll_data {
             float center;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -215,7 +215,7 @@ void craft_command::execute( bool only_cache_comps )
     std::vector<attention_plan> plans;
     if( rec->has_attention_steps() && crafter->is_avatar() ) {
         std::optional<std::vector<attention_plan>> chosen =
-                show_craft_planning_modal( *rec, *crafter, batch_size, {} );
+                show_craft_planning_modal( *rec, *crafter, batch_size, /*from_step=*/0, {} );
         if( !chosen ) {
             return;
         }

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -12,6 +12,7 @@
 #include "activity_actor_definitions.h"
 #include "character.h"
 #include "crafting.h"
+#include "crafting_enums.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "enum_traits.h"
@@ -211,7 +212,16 @@ void craft_command::execute( bool only_cache_comps )
         return;
     }
 
-    crafter->start_craft( *this, loc );
+    std::vector<attention_plan> plans;
+    if( rec->has_attention_steps() && crafter->is_avatar() ) {
+        std::optional<std::vector<attention_plan>> chosen =
+                show_craft_planning_modal( *rec, *crafter, batch_size, {} );
+        if( !chosen ) {
+            return;
+        }
+        plans = std::move( *chosen );
+    }
+    crafter->start_craft( *this, loc, std::move( plans ) );
     crafter->last_batch = batch_size;
     crafter->lastrecipe = rec->ident();
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -73,6 +73,7 @@
 #include "ret_val.h"
 #include "rng.h"
 #include "skill.h"
+#include "sounds.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "talker.h"
@@ -981,7 +982,9 @@ static item_location place_craft_or_disassembly(
     return craft_in_world;
 }
 
-void fire_step_complete_distraction( const std::string &msg, const item_location &loc )
+void fire_step_complete_distraction( const std::string &interrupt_msg,
+                                     const std::string &no_watch_msg,
+                                     const item_location &loc )
 {
     avatar &u = get_avatar();
     if( ( u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT )
@@ -989,19 +992,23 @@ void fire_step_complete_distraction( const std::string &msg, const item_location
         && u.activity.targets.back() == loc ) {
         return;
     }
+    if( !u.has_watch() && !u.has_alarm_clock() ) {
+        add_msg( m_info, no_watch_msg );
+        return;
+    }
     if( !uistate.distraction_craft_step_complete ) {
-        add_msg( m_info, msg );
+        add_msg( m_info, interrupt_msg );
         return;
     }
     const bool interrupted =
-        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, msg );
+        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, interrupt_msg );
     if( !interrupted && u.activity.id().is_null() && !u.has_destination() ) {
-        add_msg( m_info, msg );
+        add_msg( m_info, interrupt_msg );
     }
 }
 
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
-        const recipe &rec, const Character &crafter, int batch,
+        const recipe &rec, const Character &crafter, int batch, int from_step,
         const std::vector<attention_plan> &existing )
 {
     const std::vector<recipe_step> &steps = rec.steps();
@@ -1014,7 +1021,8 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
     const crafting_cost_context ctx{ crafter.book_bonuses_nearby(),
                                      compute_tool_speeds( rec, crafter ) };
 
-    for( size_t i = 0; i < steps.size(); ++i ) {
+    const size_t start_idx = from_step < 0 ? 0 : static_cast<size_t>( from_step );
+    for( size_t i = start_idx; i < steps.size(); ++i ) {
         const recipe_step &step = steps[i];
         if( step.attention != step_attention::unattended ) {
             continue;
@@ -1183,13 +1191,19 @@ static void craft_actualize_alarm( item &craft, time_point now, const item_locat
 
     const recipe &rec = craft.get_making();
     const int step_idx = craft.get_current_step();
-    std::string msg;
-    if( step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() ) ) {
-        msg = compose_unattend_message( craft, rec.steps()[step_idx] );
-    } else {
-        msg = string_format( _( "%s is ready." ), rec.result_name() );
+    const std::string ready_msg = step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() )
+                                  ? compose_unattend_message( craft, rec.steps()[step_idx] )
+                                  : string_format( _( "%s is ready." ), rec.result_name() );
+    const std::string alarm_msg = string_format( _( "Your timer goes off: %s" ), ready_msg );
+
+    avatar &u = get_avatar();
+    sounds::sound( u.pos_bub(), 16, sounds::sound_t::alarm,
+                   _( "beep-beep-beep!" ), false, "tool", "alarm_clock" );
+    if( !u.activity.id().is_null() ) {
+        g->cancel_activity_or_ignore_query( distraction_type::noise, alarm_msg );
+    } else if( !u.has_destination() ) {
+        add_msg( m_info, alarm_msg );
     }
-    fire_step_complete_distraction( msg, loc );
     get_item_wakeups().rebuild_for_item( loc );
 }
 
@@ -1269,6 +1283,22 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
         return;
     }
     const recipe_step &step = rec.steps()[step_idx];
+    // Recipe-edit migration: stale passive state on what is now an active step
+    // would otherwise advance/finalize the wrong step.  Clear and bail.
+    if( step.attention != step_attention::unattended ) {
+        craft.set_passive_started_at( calendar::before_time_starts );
+        craft.set_ready_at( calendar::before_time_starts );
+        craft.set_alarm_at( calendar::before_time_starts );
+        craft.set_fail_at( calendar::before_time_starts );
+        craft.set_pause_started_at( calendar::before_time_starts );
+        craft.set_saved_ready_at( calendar::before_time_starts );
+        craft.set_saved_alarm_at( calendar::before_time_starts );
+        craft.set_saved_fail_at( calendar::before_time_starts );
+        craft.set_passive_start_counter( 0 );
+        craft.set_passive_end_counter( 0 );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
 
     if( !env_satisfied_for_step( step, craft, loc ) ) {
         if( craft.get_pause_started_at() == calendar::before_time_starts ) {
@@ -1304,19 +1334,172 @@ static void craft_actualize_ready( item &craft, time_point now, const item_locat
     }
 
     const std::string completion_msg = compose_unattend_message( craft, step );
+    const std::string flavor_msg = string_format(
+                                       _( "You suddenly remember that the %s may have finished %s." ),
+                                       rec.result_name(), step.name.translated() );
     const bool was_last_step = step_idx == static_cast<int>( rec.steps().size() ) - 1;
 
     if( was_last_step ) {
         const bool was_on_craft = activity_targets_loc( get_avatar(), loc );
         finalize_passive_craft( craft, loc );
         if( !was_on_craft ) {
-            fire_step_complete_distraction( completion_msg, loc );
+            fire_step_complete_distraction( completion_msg, flavor_msg, loc );
         }
         return;
     }
+    // Stamp consecutive unattended step at the just-consumed ready_at so a
+    // chain catches up without losing wall-clock between them.
+    const time_point step_end = craft.get_ready_at();
     advance_passive_step( craft );
+    const int new_idx = craft.get_current_step();
+    bool wakeups_rebuilt = false;
+    if( new_idx < static_cast<int>( rec.steps().size() ) &&
+        rec.steps()[new_idx].attention == step_attention::unattended ) {
+        Character *next_crafter = resolve_crafter( craft.get_crafter_id() );
+        if( next_crafter != nullptr ) {
+            craft_stamp_passive_entry( craft, *next_crafter, step_end, loc );
+            wakeups_rebuilt = true;
+        }
+    }
+    if( !wakeups_rebuilt ) {
+        get_item_wakeups().rebuild_for_item( loc );
+    }
+    fire_step_complete_distraction( completion_msg, flavor_msg, loc );
+}
+
+void craft_resolve_overdue_passive( item &craft, time_point now, item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    // Each iteration either advances the step (and the ready handler chains
+    // the next unattended step inline) or terminates.  Bounded by step count.
+    const int max_iters = static_cast<int>( craft.get_making().steps().size() ) + 1;
+    item *cur = &craft;
+    for( int i = 0; i < max_iters; ++i ) {
+        if( cur->get_passive_started_at() == calendar::before_time_starts ) {
+            return;
+        }
+        if( cur->get_ready_at() == calendar::before_time_starts ) {
+            return;
+        }
+        if( now < cur->get_ready_at() ) {
+            return;
+        }
+        craft_actualize_scheduled( *cur, item_wakeup_kind::ready_check, now, loc );
+        // Terminal step finalization removes the craft via complete_craft.
+        cur = loc.get_item();
+        if( cur == nullptr ) {
+            return;
+        }
+    }
+}
+
+void craft_stamp_passive_entry( item &craft, const Character &crafter, time_point now,
+                                const item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    const recipe &rec = craft.get_making();
+    if( !rec.has_steps() ) {
+        return;
+    }
+    const int idx = craft.get_current_step();
+    if( idx < 0 || idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    const recipe_step &cur_step = rec.steps()[idx];
+    if( cur_step.attention != step_attention::unattended ) {
+        return;
+    }
+    const std::vector<attention_plan> &plans = craft.get_step_plans();
+    const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                attention_plan{};
+
+    craft.set_passive_started_at( now );
+    const crafting_cost_context passive_ctx{ crafter.book_bonuses_nearby(),
+            compute_tool_speeds( rec, crafter ) };
+    const int64_t step_moves = static_cast<int64_t>( rec.step_budget_moves(
+                                   crafter, idx, craft.get_making_batch_size(),
+                                   passive_ctx, recipe_time_flag::ignore_proficiencies ) );
+    craft.set_ready_at( now + time_duration::from_moves( step_moves ) );
+    if( cur_step.max_time.has_value() ) {
+        time_duration fail_dur = *cur_step.max_time;
+        if( cur_step.grace_period.has_value() ) {
+            fail_dur += *cur_step.grace_period;
+        }
+        craft.set_fail_at( now + fail_dur );
+    }
+    if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+        craft.set_alarm_at( now + *plan.alarm_offset );
+    }
+    // Counter bounds derive from prior steps' budgets (default flags) so any
+    // active-step overshoot in item_counter does not carry into this passive
+    // step.  Matches the active accumulator's batch_time(default) basis.
+    double prior_moves = 0.0;
+    double base_default = 0.0;
+    double step_default = 0.0;
+    for( size_t i = 0; i < rec.steps().size(); ++i ) {
+        const double budget = rec.step_budget_moves(
+                                  crafter, i, craft.get_making_batch_size(), passive_ctx );
+        base_default += budget;
+        if( static_cast<int>( i ) < idx ) {
+            prior_moves += budget;
+        } else if( static_cast<int>( i ) == idx ) {
+            step_default = budget;
+        }
+    }
+    // Truncate the denominator the same way batch_time() does so passive
+    // boundary identity matches the active accumulator's normalization.
+    const double base_total = std::max( 1.0,
+                                        static_cast<double>( static_cast<int64_t>( base_default ) ) );
+    const int start_counter = static_cast<int>( std::round(
+                                  prior_moves / base_total * 10000000.0 ) );
+    const int end_counter = std::min( 10000000,
+                                      static_cast<int>( std::round(
+                                              ( prior_moves + step_default ) / base_total * 10000000.0 ) ) );
+    craft.set_passive_start_counter( start_counter );
+    craft.set_passive_end_counter( end_counter );
     get_item_wakeups().rebuild_for_item( loc );
-    fire_step_complete_distraction( completion_msg, loc );
+}
+
+void craft_apply_resume_replan( item_location &loc )
+{
+    item *craft = loc.get_item();
+    if( craft == nullptr || !craft->is_craft() ) {
+        return;
+    }
+    if( craft->get_passive_started_at() == calendar::before_time_starts ) {
+        return;
+    }
+    const recipe &rec = craft->get_making();
+    const int idx = craft->get_current_step();
+    if( idx < 0 || idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    if( rec.steps()[idx].attention != step_attention::unattended ) {
+        return;
+    }
+    const std::vector<attention_plan> &plans = craft->get_step_plans();
+    const attention_plan plan = idx < static_cast<int>( plans.size() ) ? plans[idx] :
+                                attention_plan{};
+    // While env-paused, alarm_at is zeroed and saved_alarm_at carries the
+    // authoritative deadline restored on unpause.  Edit whichever is live so
+    // the replan survives the restore.
+    const bool paused = craft->get_saved_ready_at() != calendar::before_time_starts;
+    if( plan.choice == step_choice::set_timer && plan.alarm_offset.has_value() ) {
+        const time_point alarm_at = craft->get_passive_started_at() + *plan.alarm_offset;
+        if( paused ) {
+            craft->set_saved_alarm_at( alarm_at );
+        } else {
+            craft->set_alarm_at( alarm_at );
+        }
+    } else {
+        craft->set_alarm_at( calendar::before_time_starts );
+        craft->set_saved_alarm_at( calendar::before_time_starts );
+    }
+    get_item_wakeups().rebuild_for_item( loc );
 }
 
 void craft_actualize_scheduled( item &craft, item_wakeup_kind kind, time_point now,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -30,6 +30,7 @@
 #include "color.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_enums.h"
 #include "crafting_gui.h"
 #include "creature.h"
 #include "debug.h"
@@ -75,9 +76,11 @@
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "talker.h"
+#include "translation.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui.h"
+#include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
 #include "veh_type.h"
@@ -1066,6 +1069,270 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
     }
 
     return plans;
+}
+
+std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
+    const item &craft, const item_location & /*loc*/ )
+{
+    std::vector<desired_wakeup> result;
+    if( !craft.is_craft() ) {
+        return result;
+    }
+    const time_point ready_at = craft.get_ready_at();
+    const time_point alarm_at = craft.get_alarm_at();
+    const time_point fail_at = craft.get_fail_at();
+    if( ready_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::ready_check, ready_at } );
+    }
+    if( alarm_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::alarm, alarm_at } );
+    }
+    if( fail_at != calendar::before_time_starts ) {
+        result.push_back( desired_wakeup{ item_wakeup_kind::fail_check, fail_at } );
+    }
+    return result;
+}
+
+static bool step_has_env_requirements( const recipe_step &step )
+{
+    return !step.requirements.get_tools().empty()
+           || !step.requirements.get_qualities().empty();
+}
+
+static Character *resolve_crafter( const character_id &cid )
+{
+    if( !cid.is_valid() ) {
+        return nullptr;
+    }
+    avatar &u = get_avatar();
+    if( u.getID() == cid ) {
+        return &u;
+    }
+    return g->find_npc( cid );
+}
+
+static bool env_satisfied_for_step( const recipe_step &step, const item &craft,
+                                    const item_location &loc )
+{
+    if( !step_has_env_requirements( step ) ) {
+        return true;
+    }
+    map &m = get_map();
+    const tripoint_bub_ms craft_pos = m.get_bub( loc.pos_abs() );
+
+    inventory inv;
+    if( loc.where() == item_location::type::character ) {
+        Character *holder = loc.carrier();
+        if( holder != nullptr ) {
+            inv = holder->crafting_inventory( craft_pos, PICKUP_RANGE );
+        }
+    } else {
+        Character *crafter = resolve_crafter( craft.get_crafter_id() );
+        if( crafter != nullptr
+            && rl_dist( crafter->pos_bub( m ), craft_pos ) <= PICKUP_RANGE ) {
+            inv = crafter->crafting_inventory( craft_pos, PICKUP_RANGE );
+        } else {
+            inv.form_from_map( &m, craft_pos, PICKUP_RANGE, /*pl=*/nullptr );
+        }
+    }
+    return step.requirements.can_make_with_inventory(
+               inv, return_true<item>, /*batch=*/1, craft_flags::start_only );
+}
+
+static std::string compose_unattend_message( const item &craft, const recipe_step &step )
+{
+    if( !step.unattend_message.empty() ) {
+        return step.unattend_message.translated();
+    }
+    return string_format( _( "%s is ready." ), craft.get_making().result_name() );
+}
+
+static void advance_passive_step( item &craft )
+{
+    craft.set_passive_started_at( calendar::before_time_starts );
+    craft.set_ready_at( calendar::before_time_starts );
+    craft.set_alarm_at( calendar::before_time_starts );
+    craft.set_fail_at( calendar::before_time_starts );
+    craft.set_pause_started_at( calendar::before_time_starts );
+    craft.set_saved_ready_at( calendar::before_time_starts );
+    craft.set_saved_alarm_at( calendar::before_time_starts );
+    craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_current_step( craft.get_current_step() + 1 );
+    craft.set_step_progress( 0.0 );
+}
+
+static void craft_actualize_alarm( item &craft, time_point now, const item_location &loc )
+{
+    if( craft.get_alarm_at() == calendar::before_time_starts ) {
+        return;
+    }
+    // Same-turn collision: ready_check fires next in (kind, when, uid) order
+    // and will produce its own distraction.  Suppress redundant alarm.
+    if( craft.get_ready_at() != calendar::before_time_starts
+        && now >= craft.get_ready_at() ) {
+        craft.set_alarm_at( calendar::before_time_starts );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
+    craft.set_alarm_at( calendar::before_time_starts );
+
+    const recipe &rec = craft.get_making();
+    const int step_idx = craft.get_current_step();
+    std::string msg;
+    if( step_idx >= 0 && step_idx < static_cast<int>( rec.steps().size() ) ) {
+        msg = compose_unattend_message( craft, rec.steps()[step_idx] );
+    } else {
+        msg = string_format( _( "%s is ready." ), rec.result_name() );
+    }
+    fire_step_complete_distraction( msg, loc );
+    get_item_wakeups().rebuild_for_item( loc );
+}
+
+static bool activity_targets_loc( const Character &c, const item_location &loc )
+{
+    return ( c.activity.id() == ACT_CRAFT || c.activity.id() == ACT_CRAFT_WAIT )
+           && !c.activity.targets.empty()
+           && c.activity.targets.back() == loc;
+}
+
+static void end_live_wait_for( const item_location &loc )
+{
+    avatar &u = get_avatar();
+    if( activity_targets_loc( u, loc ) ) {
+        u.activity.set_to_null();
+    }
+    for( npc &n : g->all_npcs() ) {
+        if( activity_targets_loc( n, loc ) ) {
+            n.activity.set_to_null();
+        }
+    }
+}
+
+static std::optional<tripoint_bub_ms> craft_loc_for_complete( const item_location &loc )
+{
+    if( loc.where() == item_location::type::character ) {
+        return std::nullopt;
+    }
+    return get_map().get_bub( loc.pos_abs() );
+}
+
+static void craft_actualize_fail( item &craft, time_point now,
+                                  const item_location &loc )
+{
+    if( craft.get_fail_at() == calendar::before_time_starts ) {
+        return;
+    }
+    if( now < craft.get_fail_at() ) {
+        return;
+    }
+    end_live_wait_for( loc );
+    item_location mut_loc = loc;
+    mut_loc.remove_item();
+}
+
+static void finalize_passive_craft( item &craft, const item_location &loc )
+{
+    Character *crafter = resolve_crafter( craft.get_crafter_id() );
+    if( crafter == nullptr ) {
+        debugmsg( "crafter %d gone before terminal unattended step finalized; "
+                  "destroying craft for recipe %s",
+                  craft.get_crafter_id().get_value(),
+                  craft.get_making().ident().str() );
+        item_location mut_loc = loc;
+        mut_loc.remove_item();
+        return;
+    }
+    end_live_wait_for( loc );
+    item craft_copy = craft;
+    const std::optional<tripoint_bub_ms> finalize_loc = craft_loc_for_complete( loc );
+    item_location mut_loc = loc;
+    mut_loc.remove_item();
+    crafter->complete_craft( craft_copy, finalize_loc );
+}
+
+static void craft_actualize_ready( item &craft, time_point now, const item_location &loc )
+{
+    if( craft.get_ready_at() == calendar::before_time_starts ) {
+        return;
+    }
+    if( now < craft.get_ready_at() ) {
+        return;
+    }
+    const recipe &rec = craft.get_making();
+    const int step_idx = craft.get_current_step();
+    if( step_idx < 0 || step_idx >= static_cast<int>( rec.steps().size() ) ) {
+        return;
+    }
+    const recipe_step &step = rec.steps()[step_idx];
+
+    if( !env_satisfied_for_step( step, craft, loc ) ) {
+        if( craft.get_pause_started_at() == calendar::before_time_starts ) {
+            craft.set_pause_started_at( now );
+            craft.set_saved_ready_at( craft.get_ready_at() );
+            craft.set_saved_alarm_at( craft.get_alarm_at() );
+            craft.set_saved_fail_at( craft.get_fail_at() );
+            craft.set_alarm_at( calendar::before_time_starts );
+            craft.set_fail_at( calendar::before_time_starts );
+        }
+        craft.set_ready_at( now + 1_minutes );
+        get_item_wakeups().rebuild_for_item( loc );
+        return;
+    }
+
+    if( craft.get_pause_started_at() != calendar::before_time_starts ) {
+        const time_duration paused_for = now - craft.get_pause_started_at();
+        craft.set_ready_at( craft.get_saved_ready_at() + paused_for );
+        if( craft.get_saved_alarm_at() != calendar::before_time_starts ) {
+            craft.set_alarm_at( craft.get_saved_alarm_at() + paused_for );
+        }
+        if( craft.get_saved_fail_at() != calendar::before_time_starts ) {
+            craft.set_fail_at( craft.get_saved_fail_at() + paused_for );
+        }
+        craft.set_pause_started_at( calendar::before_time_starts );
+        craft.set_saved_ready_at( calendar::before_time_starts );
+        craft.set_saved_alarm_at( calendar::before_time_starts );
+        craft.set_saved_fail_at( calendar::before_time_starts );
+        if( now < craft.get_ready_at() ) {
+            get_item_wakeups().rebuild_for_item( loc );
+            return;
+        }
+    }
+
+    const std::string completion_msg = compose_unattend_message( craft, step );
+    const bool was_last_step = step_idx == static_cast<int>( rec.steps().size() ) - 1;
+
+    if( was_last_step ) {
+        const bool was_on_craft = activity_targets_loc( get_avatar(), loc );
+        finalize_passive_craft( craft, loc );
+        if( !was_on_craft ) {
+            fire_step_complete_distraction( completion_msg, loc );
+        }
+        return;
+    }
+    advance_passive_step( craft );
+    get_item_wakeups().rebuild_for_item( loc );
+    fire_step_complete_distraction( completion_msg, loc );
+}
+
+void craft_actualize_scheduled( item &craft, item_wakeup_kind kind, time_point now,
+                                const item_location &loc )
+{
+    if( !craft.is_craft() ) {
+        return;
+    }
+    switch( kind ) {
+        case item_wakeup_kind::alarm:
+            craft_actualize_alarm( craft, now, loc );
+            return;
+        case item_wakeup_kind::ready_check:
+            craft_actualize_ready( craft, now, loc );
+            return;
+        case item_wakeup_kind::fail_check:
+            craft_actualize_fail( craft, now, loc );
+            return;
+        case item_wakeup_kind::last:
+            return;
+    }
 }
 
 void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1149,6 +1149,9 @@ static std::string compose_unattend_message( const item &craft, const recipe_ste
 
 static void advance_passive_step( item &craft )
 {
+    if( craft.get_passive_end_counter() > craft.item_counter ) {
+        craft.item_counter = std::min( 10000000, craft.get_passive_end_counter() );
+    }
     craft.set_passive_started_at( calendar::before_time_starts );
     craft.set_ready_at( calendar::before_time_starts );
     craft.set_alarm_at( calendar::before_time_starts );
@@ -1157,6 +1160,8 @@ static void advance_passive_step( item &craft )
     craft.set_saved_ready_at( calendar::before_time_starts );
     craft.set_saved_alarm_at( calendar::before_time_starts );
     craft.set_saved_fail_at( calendar::before_time_starts );
+    craft.set_passive_start_counter( 0 );
+    craft.set_passive_end_counter( 0 );
     craft.set_current_step( craft.get_current_step() + 1 );
     craft.set_step_progress( 0.0 );
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -977,7 +977,79 @@ static item_location place_craft_or_disassembly(
     return craft_in_world;
 }
 
-void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc )
+std::optional<std::vector<attention_plan>> show_craft_planning_modal(
+        const recipe &rec, const Character &crafter, int batch,
+        const std::vector<attention_plan> &existing )
+{
+    const std::vector<recipe_step> &steps = rec.steps();
+    std::vector<attention_plan> plans( steps.size() );
+    for( size_t i = 0; i < std::min( existing.size(), plans.size() ); ++i ) {
+        plans[i] = existing[i];
+    }
+
+    const bool has_timepiece = crafter.has_watch() || crafter.has_alarm_clock();
+    const crafting_cost_context ctx{ crafter.book_bonuses_nearby(),
+                                     compute_tool_speeds( rec, crafter ) };
+
+    for( size_t i = 0; i < steps.size(); ++i ) {
+        const recipe_step &step = steps[i];
+        if( step.attention != step_attention::unattended ) {
+            continue;
+        }
+
+        const time_duration step_dur = time_duration::from_moves(
+                                           rec.step_budget_moves( crafter, i, batch, ctx,
+                                                   recipe_time_flag::ignore_proficiencies ) );
+
+        uilist menu;
+        menu.text = string_format(
+                        _( "Step: %s (%s)\nWhat do you want to do?" ),
+                        step.name.translated(),
+                        to_string_approx( step_dur ) );
+        menu.addentry( 0, true, 'w', _( "Wait for it to finish" ) );
+        menu.addentry( 1, true, 'd', _( "Do something else" ) );
+        if( has_timepiece ) {
+            menu.addentry( 2, true, 't', _( "Set a timer" ) );
+        }
+        menu.query();
+
+        if( menu.ret == UILIST_CANCEL ) {
+            return std::nullopt;
+        }
+
+        if( menu.ret == 0 ) {
+            plans[i].choice = step_choice::do_wait;
+            plans[i].alarm_offset.reset();
+        } else if( menu.ret == 1 ) {
+            plans[i].choice = step_choice::do_something;
+            plans[i].alarm_offset.reset();
+        } else if( menu.ret == 2 ) {
+            uilist alarm;
+            alarm.text = _( "Set an alarm for when?" );
+            alarm.addentry( 1, true, '1',
+                            string_format( _( "When the step finishes (%s)" ),
+                                           to_string( step_dur ) ) );
+            alarm.addentry( 2, step_dur > 5_minutes, '2',
+                            string_format( _( "5 minutes before (%s in)" ),
+                                           to_string( step_dur - 5_minutes ) ) );
+            alarm.query();
+            if( alarm.ret == UILIST_CANCEL ) {
+                return std::nullopt;
+            }
+            plans[i].choice = step_choice::set_timer;
+            if( alarm.ret == 2 ) {
+                plans[i].alarm_offset = step_dur - 5_minutes;
+            } else {
+                plans[i].alarm_offset = step_dur;
+            }
+        }
+    }
+
+    return plans;
+}
+
+void Character::start_craft( craft_command &command, const std::optional<tripoint_bub_ms> &loc,
+                             std::vector<attention_plan> plans )
 {
     if( command.empty() ) {
         debugmsg( "Attempted to start craft with empty command" );
@@ -991,6 +1063,13 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
     const recipe &making = craft.get_making();
     if( static_cast<int>( get_skill_level( command.get_skill_id() ) ) > making.get_skill_cap() ) {
         handle_skill_warning( command.get_skill_id(), true );
+    }
+
+    if( making.has_attention_steps() ) {
+        craft.set_crafter_id( getID() );
+    }
+    if( !plans.empty() ) {
+        craft.set_step_plans( std::move( plans ) );
     }
 
     // In case we were wearing something just consumed

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -88,6 +88,7 @@
 #include "weather.h"
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+static const activity_id ACT_CRAFT_WAIT( "ACT_CRAFT_WAIT" );
 static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 
@@ -975,6 +976,25 @@ static item_location place_craft_or_disassembly(
     }
 
     return craft_in_world;
+}
+
+void fire_step_complete_distraction( const std::string &msg, const item_location &loc )
+{
+    avatar &u = get_avatar();
+    if( ( u.activity.id() == ACT_CRAFT || u.activity.id() == ACT_CRAFT_WAIT )
+        && !u.activity.targets.empty()
+        && u.activity.targets.back() == loc ) {
+        return;
+    }
+    if( !uistate.distraction_craft_step_complete ) {
+        add_msg( m_info, msg );
+        return;
+    }
+    const bool interrupted =
+        g->cancel_activity_or_ignore_query( distraction_type::craft_step_complete, msg );
+    if( !interrupted && u.activity.id().is_null() && !u.has_destination() ) {
+        add_msg( m_info, msg );
+    }
 }
 
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -7,10 +7,13 @@
 #include <string>
 #include <vector>
 
+#include "item_wakeup.h"
+
 class Character;
 class item;
 class item_location;
 class recipe;
+class time_point;
 struct attention_plan;
 template <typename E> struct enum_traits;
 
@@ -44,5 +47,12 @@ std::optional<std::vector<attention_plan>> show_craft_planning_modal(
 // auto-traveling.
 void fire_step_complete_distraction( const std::string &msg,
                                      const item_location &loc );
+
+// Wakeup hooks for in-progress craft items.  Called by item_wakeup
+// dispatchers when the item is a craft.
+std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
+    const item &craft, const item_location &loc );
+void craft_actualize_scheduled( item &craft, item_wakeup_kind kind,
+                                time_point now, const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -4,10 +4,12 @@
 
 #include <list>
 #include <optional>
+#include <string>
 #include <vector>
 
 class Character;
 class item;
+class item_location;
 class recipe;
 struct attention_plan;
 template <typename E> struct enum_traits;
@@ -35,5 +37,12 @@ void drop_or_handle( const item &newit, Character &p );
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
         const recipe &rec, const Character &crafter, int batch,
         const std::vector<attention_plan> &existing );
+
+// Interrupts the avatar's current activity with a craft_step_complete
+// distraction.  Suppresses if the avatar is already engaged on this same
+// craft.  Falls back to a log message if the avatar is idle and not
+// auto-traveling.
+void fire_step_complete_distraction( const std::string &msg,
+                                     const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -3,9 +3,13 @@
 #define CATA_SRC_CRAFTING_H
 
 #include <list>
+#include <optional>
+#include <vector>
 
 class Character;
 class item;
+class recipe;
+struct attention_plan;
 template <typename E> struct enum_traits;
 
 enum class craft_flags : int {
@@ -25,4 +29,11 @@ void remove_ammo( item &dis_item, Character &p );
 void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
+
+// Asks the avatar what to do at each attention step.  Returns nullopt if the
+// avatar cancelled.  `existing` pre-fills choices on resume.
+std::optional<std::vector<attention_plan>> show_craft_planning_modal(
+        const recipe &rec, const Character &crafter, int batch,
+        const std::vector<attention_plan> &existing );
+
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -35,17 +35,19 @@ void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
 
-// Asks the avatar what to do at each attention step.  Returns nullopt if the
-// avatar cancelled.  `existing` pre-fills choices on resume.
+// Asks the avatar what to do at each remaining unattended step (skipping
+// any step before `from_step`).  Returns nullopt if the avatar cancelled.
+// `existing` pre-fills choices on resume.
 std::optional<std::vector<attention_plan>> show_craft_planning_modal(
-        const recipe &rec, const Character &crafter, int batch,
+        const recipe &rec, const Character &crafter, int batch, int from_step,
         const std::vector<attention_plan> &existing );
 
 // Interrupts the avatar's current activity with a craft_step_complete
-// distraction.  Suppresses if the avatar is already engaged on this same
-// craft.  Falls back to a log message if the avatar is idle and not
-// auto-traveling.
-void fire_step_complete_distraction( const std::string &msg,
+// distraction when the avatar can read time; falls back to a vague flavor
+// message otherwise.  Suppresses entirely if the avatar is already engaged
+// on this same craft.
+void fire_step_complete_distraction( const std::string &interrupt_msg,
+                                     const std::string &no_watch_msg,
                                      const item_location &loc );
 
 // Wakeup hooks for in-progress craft items.  Called by item_wakeup
@@ -53,6 +55,25 @@ void fire_step_complete_distraction( const std::string &msg,
 std::vector<desired_wakeup> craft_enumerate_scheduled_wakeups(
     const item &craft, const item_location &loc );
 void craft_actualize_scheduled( item &craft, item_wakeup_kind kind,
+                                time_point now, const item_location &loc );
+
+// Inline ready-transition for past-due passive steps: when the wakeup did not
+// dispatch (off-bubble drop, save reload, same-turn race), this advances the
+// step or finalizes the craft so callers do not see stale current_step.
+// No-op when not in a passive step or when ready_at is still in the future.
+void craft_resolve_overdue_passive( item &craft, time_point now, item_location &loc );
+
+// Re-arms or clears alarm_at on an already-entered passive step when the
+// player has just edited that step's plan via the resume modal.  Without
+// this, switching to or away from set_timer mid-step has no effect.
+void craft_apply_resume_replan( item_location &loc );
+
+// Stamps passive-step runtime state (passive_started_at, ready_at, alarm_at,
+// fail_at, counter bounds) on a craft sitting at the start of an unattended
+// step, then rebuilds wakeups.  Called from the actor's first-entry path and
+// from craft_resolve_overdue_passive when chaining through consecutive
+// unattended steps.
+void craft_stamp_passive_entry( item &craft, const Character &crafter,
                                 time_point now, const item_location &loc );
 
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting_enums.h
+++ b/src/crafting_enums.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef CATA_SRC_CRAFTING_ENUMS_H
+#define CATA_SRC_CRAFTING_ENUMS_H
+
+#include <optional>
+
+#include "calendar.h"
+
+enum class step_attention : int {
+    none = 0,
+    unattended,
+    supervised,
+};
+
+enum class step_choice : int {
+    do_wait = 0,
+    do_something,
+    set_timer,
+};
+
+// Per-step choice from the planning modal.
+struct attention_plan {
+    step_choice choice = step_choice::do_wait;
+    std::optional<time_duration> alarm_offset;
+};
+
+#endif // CATA_SRC_CRAFTING_ENUMS_H

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -21,6 +21,7 @@
 #include "character_id.h"
 #include "color.h"
 #include "crafting.h"
+#include "crafting_enums.h"
 #include "crafting_gui_helpers.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -42,7 +42,8 @@ static const std::vector<configurable_distraction> &get_configurable_distraction
         {&uistate.distraction_mutation,        translate_marker( "Mutation" ),                     translate_marker( "This distraction will interrupt your activity when you gain or lose a mutation." )},
         {&uistate.distraction_oxygen,          translate_marker( "Asphyxiation" ),                 translate_marker( "This distraction will interrupt your activity when you can't breathe." )},
         {&uistate.distraction_withdrawal,      translate_marker( "Withdrawal" ),                  translate_marker( "This distraction will interrupt your activity when you have withdrawals." )},
-        {&uistate.distraction_all,             translate_marker( "Toggle all" ),                   translate_marker( "Toggle all distractions" ), uistate.is_toggle = true }
+        {&uistate.distraction_craft_step_complete, translate_marker( "Craft step complete" ),      translate_marker( "This distraction will interrupt your activity when an unattended crafting step completes." )},
+        {&uistate.distraction_all,             translate_marker( "Toggle all" ),                   translate_marker( "Toggle all distractions" ), true }
     };
     return configurable_distractions;
 }
@@ -170,6 +171,7 @@ void distraction_manager_gui::show()
                 uistate.distraction_mutation = toggle_state;
                 uistate.distraction_oxygen = toggle_state;
                 uistate.distraction_withdrawal = toggle_state;
+                uistate.distraction_craft_step_complete = toggle_state;
             }
         }
     }

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -35,9 +35,11 @@
 #include "game_constants.h"
 #include "gamemode.h"
 #include "help.h"
+#include "item_wakeup.h"
 #include "input.h"
 #include "input_context.h"
 #include "line.h"
+#include "magic_enchantment.h"
 #include "make_static.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -481,6 +483,7 @@ bool do_turn()
 
     timed_event_manager &timed_events = get_timed_events();
     timed_events.process();
+    get_item_wakeups().process( calendar::turn );
     mission::process_all();
     avatar &u = get_avatar();
     map &m = get_map();

--- a/src/enums.h
+++ b/src/enums.h
@@ -336,6 +336,7 @@ enum class distraction_type : int {
     mutation,
     oxygen,
     withdrawal,
+    craft_step_complete,
     last,
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -118,6 +118,7 @@
 #include "item_pocket.h"
 #include "item_search.h"
 #include "item_stack.h"
+#include "item_wakeup.h"
 #include "iteminfo_query.h"
 #include "itype.h"
 #include "iuse.h"
@@ -14029,6 +14030,11 @@ stats_tracker &get_stats()
 timed_event_manager &get_timed_events()
 {
     return g->timed_events;
+}
+
+item_wakeup_manager &get_item_wakeups()
+{
+    return *g->item_wakeup_manager_ptr;
 }
 
 weather_manager &get_weather()

--- a/src/game.h
+++ b/src/game.h
@@ -99,6 +99,7 @@ class spell_events;
 class static_popup;
 class stats_tracker;
 class timed_event_manager;
+class item_wakeup_manager;
 class ui_adaptor;
 class uilist;
 class vehicle;
@@ -164,6 +165,7 @@ class game
         friend stats_tracker &get_stats();
         friend scent_map &get_scent();
         friend timed_event_manager &get_timed_events();
+        friend item_wakeup_manager &get_item_wakeups();
         friend memorial_logger &get_memorial();
         friend bool do_turn();
         friend bool turn_handler::cleanup_at_end();
@@ -1125,6 +1127,7 @@ class game
         live_view &liveview; // NOLINT(cata-serialize)
         pimpl<scent_map> scent_ptr; // NOLINT(cata-serialize)
         pimpl<timed_event_manager> timed_event_manager_ptr; // NOLINT(cata-serialize)
+        pimpl<item_wakeup_manager> item_wakeup_manager_ptr;
         pimpl<event_bus> event_bus_ptr; // NOLINT(cata-serialize)
         pimpl<stats_tracker> stats_tracker_ptr;
         pimpl<achievements_tracker> achievements_tracker_ptr;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -27,6 +27,8 @@
 #include "construction_group.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "cursesdef.h"
@@ -7175,10 +7177,21 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
             if( selected_craft->typeId() == itype_disassembly ) {
                 you.disassemble( crafts[amenu2.ret], true );
             } else {
+                const recipe &rec = selected_craft->get_making();
+                if( rec.has_attention_steps() && you.is_avatar() ) {
+                    std::optional<std::vector<attention_plan>> chosen =
+                            show_craft_planning_modal( rec, you,
+                                                       selected_craft->get_making_batch_size(),
+                                                       selected_craft->get_step_plans() );
+                    if( !chosen ) {
+                        break;
+                    }
+                    selected_craft->set_step_plans( std::move( *chosen ) );
+                    selected_craft->set_crafter_id( you.getID() );
+                }
                 if( !you.can_continue_craft( *selected_craft ) ) {
                     break;
                 }
-                const recipe &rec = selected_craft->get_making();
                 if( !you.has_recipe( &rec ) ) {
                     you.add_msg_player_or_npc(
                         _( "You don't know the recipe for the %s and can't continue crafting." ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -7177,17 +7177,22 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
             if( selected_craft->typeId() == itype_disassembly ) {
                 you.disassemble( crafts[amenu2.ret], true );
             } else {
+                craft_resolve_overdue_passive( *selected_craft, calendar::turn, crafts[amenu2.ret] );
+                if( !crafts[amenu2.ret] || !crafts[amenu2.ret].get_item() ) {
+                    break;
+                }
+                selected_craft = crafts[amenu2.ret].get_item();
                 const recipe &rec = selected_craft->get_making();
-                if( rec.has_attention_steps() && you.is_avatar() ) {
-                    std::optional<std::vector<attention_plan>> chosen =
-                            show_craft_planning_modal( rec, you,
-                                                       selected_craft->get_making_batch_size(),
-                                                       selected_craft->get_step_plans() );
+                std::optional<std::vector<attention_plan>> chosen;
+                if( rec.has_remaining_attention_steps( selected_craft->get_current_step() )
+                    && you.is_avatar() ) {
+                    chosen = show_craft_planning_modal( rec, you,
+                                                        selected_craft->get_making_batch_size(),
+                                                        selected_craft->get_current_step(),
+                                                        selected_craft->get_step_plans() );
                     if( !chosen ) {
                         break;
                     }
-                    selected_craft->set_step_plans( std::move( *chosen ) );
-                    selected_craft->set_crafter_id( you.getID() );
                 }
                 if( !you.can_continue_craft( *selected_craft ) ) {
                     break;
@@ -7198,6 +7203,11 @@ void iexamine::workbench_internal( Character &you, const tripoint_bub_ms &examp,
                         _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),
                         rec.result_name() );
                     break;
+                }
+                if( chosen ) {
+                    selected_craft->set_step_plans( std::move( *chosen ) );
+                    selected_craft->set_crafter_id( you.getID() );
+                    craft_apply_resume_replan( crafts[amenu2.ret] );
                 }
                 you.add_msg_player_or_npc(
                     pgettext( "in progress craft", "You start working on the %s." ),

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -397,6 +397,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_mutation", distraction_mutation );
     json.member( "distraction_oxygen", distraction_oxygen );
     json.member( "distraction_withdrawal", distraction_withdrawal );
+    json.member( "distraction_craft_step_complete", distraction_craft_step_complete );
     json.member( "numpad_navigation", numpad_navigation );
 
     json.member( "consume_menu_uistate" );
@@ -474,6 +475,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_mutation", distraction_mutation );
     jo.read( "distraction_oxygen", distraction_oxygen );
     jo.read( "distraction_withdrawal", distraction_withdrawal );
+    jo.read( "distraction_craft_step_complete", distraction_craft_step_complete );
     jo.read( "numpad_navigation", numpad_navigation );
 
     if( !jo.read( "vmenu_show_items", vmenu_show_items ) ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -65,6 +65,7 @@
 #include "item_tname.h"
 #include "item_transformation.h"
 #include "iteminfo_query.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -15085,6 +15086,15 @@ bool item::process_gun_cooling( Character *carrier )
         }
     }
     return false;
+}
+
+std::vector<desired_wakeup> item::enumerate_scheduled_wakeups() const
+{
+    return {};
+}
+
+void item::actualize_scheduled( item_wakeup_kind /*kind*/, time_point /*now*/ )
+{
 }
 
 bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -16067,6 +16067,30 @@ void item::set_crafter_id( character_id id )
     craft_data_->crafter_id = id;
 }
 
+int item::get_passive_start_counter() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_start_counter;
+}
+
+void item::set_passive_start_counter( int c )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_start_counter = c;
+}
+
+int item::get_passive_end_counter() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_end_counter;
+}
+
+void item::set_passive_end_counter( int c )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_end_counter = c;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15090,11 +15090,12 @@ bool item::process_gun_cooling( Character *carrier )
 
 std::vector<desired_wakeup> item::enumerate_scheduled_wakeups() const
 {
-    return {};
+    return enumerate_scheduled_dispatch( *this );
 }
 
-void item::actualize_scheduled( item_wakeup_kind /*kind*/, time_point /*now*/ )
+void item::actualize_scheduled( item_wakeup_kind kind, time_point now )
 {
+    actualize_scheduled_dispatch( *this, kind, now );
 }
 
 bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, float insulation,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15947,6 +15947,126 @@ void item::mod_step_progress( double delta )
     craft_data_->step_progress += delta;
 }
 
+const std::vector<attention_plan> &item::get_step_plans() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->step_plans;
+}
+
+void item::set_step_plans( std::vector<attention_plan> plans )
+{
+    cata_assert( craft_data_ );
+    craft_data_->step_plans = std::move( plans );
+}
+
+time_point item::get_passive_started_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->passive_started_at;
+}
+
+void item::set_passive_started_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->passive_started_at = t;
+}
+
+time_point item::get_ready_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->ready_at;
+}
+
+void item::set_ready_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->ready_at = t;
+}
+
+time_point item::get_alarm_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->alarm_at;
+}
+
+void item::set_alarm_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->alarm_at = t;
+}
+
+time_point item::get_fail_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->fail_at;
+}
+
+void item::set_fail_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->fail_at = t;
+}
+
+time_point item::get_pause_started_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->pause_started_at;
+}
+
+void item::set_pause_started_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->pause_started_at = t;
+}
+
+time_point item::get_saved_ready_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_ready_at;
+}
+
+void item::set_saved_ready_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_ready_at = t;
+}
+
+time_point item::get_saved_alarm_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_alarm_at;
+}
+
+void item::set_saved_alarm_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_alarm_at = t;
+}
+
+time_point item::get_saved_fail_at() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->saved_fail_at;
+}
+
+void item::set_saved_fail_at( time_point t )
+{
+    cata_assert( craft_data_ );
+    craft_data_->saved_fail_at = t;
+}
+
+character_id item::get_crafter_id() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->crafter_id;
+}
+
+void item::set_crafter_id( character_id id )
+{
+    cata_assert( craft_data_ );
+    craft_data_->crafter_id = id;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.h
+++ b/src/item.h
@@ -3060,6 +3060,11 @@ class item : public visitable
         character_id get_crafter_id() const;
         void set_crafter_id( character_id id );
 
+        int get_passive_start_counter() const;
+        void set_passive_start_counter( int c );
+        int get_passive_end_counter() const;
+        void set_passive_end_counter( int c );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3340,6 +3345,11 @@ class item : public visitable
                 time_point saved_ready_at = calendar::before_time_starts;
                 time_point saved_alarm_at = calendar::before_time_starts;
                 time_point saved_fail_at  = calendar::before_time_starts;
+
+                // Counter bounds snapshotted at passive-step entry; item_tname
+                // projects linearly between them without mutation.
+                int passive_start_counter = 0;
+                int passive_end_counter = 0;
 
                 // Original crafter (for env-check fallback when craft is on
                 // map/vehicle and the crafter is no longer on top of it).

--- a/src/item.h
+++ b/src/item.h
@@ -46,6 +46,8 @@ class Character;
 class Creature;
 class JsonObject;
 class JsonOut;
+struct desired_wakeup;
+enum class item_wakeup_kind : uint8_t;
 class book_proficiency_bonuses;
 class enchantment;
 class enchant_cache;
@@ -1508,6 +1510,15 @@ class item : public visitable
 
         bool leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                    item_pocket *pocke = nullptr );
+
+        // Producer contract for the item wakeup scheduler.  Returns the
+        // (kind, when) pairs this item currently wants scheduled.  Default
+        // empty; only items with their own time-based state override.
+        std::vector<desired_wakeup> enumerate_scheduled_wakeups() const;
+
+        // Consumer for a fired wakeup.  Must be idempotent: receiving the
+        // same (kind, now) twice must not corrupt state.
+        void actualize_scheduled( item_wakeup_kind kind, time_point now );
 
         struct link_data {
             /// State of the link's source connection, the end usually represented by the device/cable item itself. @ref link_state.

--- a/src/item.h
+++ b/src/item.h
@@ -1511,13 +1511,10 @@ class item : public visitable
         bool leak( map &here, Character *carrier, const tripoint_bub_ms &pos,
                    item_pocket *pocke = nullptr );
 
-        // Producer contract for the item wakeup scheduler.  Returns the
-        // (kind, when) pairs this item currently wants scheduled.  Default
-        // empty; only items with their own time-based state override.
+        // Producer for the wakeup scheduler.  Default empty.
         std::vector<desired_wakeup> enumerate_scheduled_wakeups() const;
 
-        // Consumer for a fired wakeup.  Must be idempotent: receiving the
-        // same (kind, now) twice must not corrupt state.
+        // Idempotent: receiving (kind, now) twice must not corrupt state.
         void actualize_scheduled( item_wakeup_kind kind, time_point now );
 
         struct link_data {

--- a/src/item.h
+++ b/src/item.h
@@ -19,7 +19,11 @@
 #include "calendar.h"
 #include "cata_lazy.h"
 #include "cata_utility.h"
+#include "character_id.h"
 #include "compatibility.h"
+#include "coordinates.h"
+#include "craft_command.h"
+#include "crafting_enums.h"
 #include "enums.h"
 #include "global_vars.h"
 #include "gun_mode.h"
@@ -3031,6 +3035,31 @@ class item : public visitable
         void set_step_progress( double progress );
         void mod_step_progress( double delta );
 
+        // Per-step plan from the craft planning modal.
+        const std::vector<attention_plan> &get_step_plans() const;
+        void set_step_plans( std::vector<attention_plan> plans );
+
+        // Calendar tracking for the active passive step.
+        time_point get_passive_started_at() const;
+        void set_passive_started_at( time_point t );
+        time_point get_ready_at() const;
+        void set_ready_at( time_point t );
+        time_point get_alarm_at() const;
+        void set_alarm_at( time_point t );
+        time_point get_fail_at() const;
+        void set_fail_at( time_point t );
+        time_point get_pause_started_at() const;
+        void set_pause_started_at( time_point t );
+        time_point get_saved_ready_at() const;
+        void set_saved_ready_at( time_point t );
+        time_point get_saved_alarm_at() const;
+        void set_saved_alarm_at( time_point t );
+        time_point get_saved_fail_at() const;
+        void set_saved_fail_at( time_point t );
+
+        character_id get_crafter_id() const;
+        void set_crafter_id( character_id id );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3293,6 +3322,28 @@ class item : public visitable
                 // Authoritative: advanced by tracking consumed work against step budgets.
                 int current_step = 0;
                 double step_progress = 0.0; // base-speed moves consumed within current step
+
+                // Per-step plan from the planning modal.  Aligned with recipe steps_.
+                std::vector<attention_plan> step_plans;
+
+                // Calendar tracking for the active passive step.
+                // before_time_starts when no passive step is in flight.
+                time_point passive_started_at = calendar::before_time_starts;
+                time_point ready_at  = calendar::before_time_starts;
+                time_point alarm_at  = calendar::before_time_starts;
+                time_point fail_at   = calendar::before_time_starts;
+                // While paused, ready_at is the polling cursor; saved_* park
+                // the originals for restoration on unpause (slid by paused
+                // duration).  Without saving ready_at too, multiple pause
+                // polls would mutate it and lose the original deadline.
+                time_point pause_started_at = calendar::before_time_starts;
+                time_point saved_ready_at = calendar::before_time_starts;
+                time_point saved_alarm_at = calendar::before_time_starts;
+                time_point saved_fail_at  = calendar::before_time_starts;
+
+                // Original crafter (for env-check fallback when craft is on
+                // map/vehicle and the crafter is no longer on top of it).
+                character_id crafter_id;
 
                 // if this is an in progress disassembly as opposed to craft
                 bool disassembly = false;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1482,7 +1482,7 @@ item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint )
                         candidates.push_back( vh->part_index );
                     }
                     const std::vector<int> at_mount = veh.parts_at_relative(
-                                                          vh->mount_offset, true, false );
+                                                          vh->mount_offset, true );
                     for( int p : at_mount ) {
                         if( p != vh->part_index ) {
                             candidates.push_back( p );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -51,6 +51,7 @@
 #include "visitable.h"
 #include "vpart_position.h"
 #include "value_ptr.h"
+#include "vpart_range.h"
 #include "weighted_list.h"
 
 template <typename T>

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1393,3 +1393,8 @@ int item_location::get_quality( const std::string &quality, bool strict ) const
     quality_id qualityid( quality );
     return tool->get_quality_nonrecursive( qualityid, strict );
 }
+
+item_location find_item_by_uid( int64_t /*uid*/, const item_locator_hint &/*hint*/ )
+{
+    return item_location::nowhere;
+}

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -11,6 +11,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "character.h"
@@ -26,12 +27,15 @@
 #include "item.h"
 #include "item_pocket.h"
 #include "item_uid.h"
+#include "item_wakeup.h"
 #include "itype.h"
 #include "json.h"
 #include "line.h"
 #include "map.h"
+#include "map_iterator.h"
 #include "map_selector.h"
 #include "messages.h"
+#include "npc.h"
 #include "pimpl.h"
 #include "point.h"
 #include "ret_val.h"
@@ -1394,7 +1398,152 @@ int item_location::get_quality( const std::string &quality, bool strict ) const
     return tool->get_quality_nonrecursive( qualityid, strict );
 }
 
-item_location find_item_by_uid( int64_t /*uid*/, const item_locator_hint &/*hint*/ )
+// Hint-driven uid resolution with bounded fallback.  No world-wide scan.
+// Returns invalid for items in monster stomachs, portals, or off-bubble.
+item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint )
 {
+    if( uid <= 0 ) {
+        return item_location::nowhere;
+    }
+
+    map &here = get_map();
+
+    auto try_character = [uid]( Character * c ) -> item_location {
+        if( c == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        item *found = retrieve_by_uid( *c, uid );
+        if( found == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        return item_location( *c, found );
+    };
+
+    // Off-bubble would wrap a pointer into a temporary tinymap; gate to
+    // in-bounds.  Owners must call rebuild_for_item once back in range.
+    auto try_map_at = [uid, &here]( const tripoint_abs_ms & abs ) -> item_location {
+        if( !here.inbounds( here.get_bub( abs ) ) )
+        {
+            return item_location::nowhere;
+        }
+        map_cursor mc( abs );
+        item *found = retrieve_by_uid( mc, uid );
+        if( found == nullptr )
+        {
+            return item_location::nowhere;
+        }
+        return item_location( mc, found );
+    };
+
+    switch( hint.where ) {
+        case item_locator_hint::place::character: {
+            const character_id *cid = std::get_if<character_id>( &hint.location );
+            if( cid != nullptr && cid->is_valid() ) {
+                Character &u = get_player_character();
+                if( u.getID() == *cid ) {
+                    item_location loc = try_character( &u );
+                    if( loc ) {
+                        return loc;
+                    }
+                }
+                npc *n = g->find_npc( *cid );
+                if( n != nullptr ) {
+                    item_location loc = try_character( n );
+                    if( loc ) {
+                        return loc;
+                    }
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::map: {
+            const tripoint_abs_ms *p = std::get_if<tripoint_abs_ms>( &hint.location );
+            if( p != nullptr ) {
+                item_location loc = try_map_at( *p );
+                if( loc ) {
+                    return loc;
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::vehicle: {
+            const vehicle_hint *vh = std::get_if<vehicle_hint>( &hint.location );
+            if( vh != nullptr && here.inbounds( here.get_bub( vh->cargo_square ) ) ) {
+                const optional_vpart_position vp = here.veh_at( vh->cargo_square );
+                if( vp ) {
+                    vehicle &veh = vp->vehicle();
+                    // Try in order: stored part_index (if in range), then
+                    // mount_offset lookup, then the cargo-square part.
+                    std::vector<int> candidates;
+                    if( vh->part_index >= 0 && vh->part_index < veh.part_count() ) {
+                        candidates.push_back( vh->part_index );
+                    }
+                    const std::vector<int> at_mount = veh.parts_at_relative(
+                                                          vh->mount_offset, true, false );
+                    for( int p : at_mount ) {
+                        if( p != vh->part_index ) {
+                            candidates.push_back( p );
+                        }
+                    }
+                    const int square_part = static_cast<int>( vp->part_index() );
+                    if( std::find( candidates.begin(), candidates.end(),
+                                   square_part ) == candidates.end() ) {
+                        candidates.push_back( square_part );
+                    }
+                    for( int part : candidates ) {
+                        if( part < 0 || part >= veh.part_count() ) {
+                            continue;
+                        }
+                        vehicle_cursor vc( veh, part );
+                        item *found = retrieve_by_uid( vc, uid );
+                        if( found != nullptr ) {
+                            return item_location( vc, found );
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        case item_locator_hint::place::unknown:
+            break;
+    }
+
+    // Bounded fallback: avatar + nearby NPCs + loaded vehicles + map tiles.
+    // No world-wide scan.
+    item_location loc = try_character( &get_player_character() );
+    if( loc ) {
+        return loc;
+    }
+    for( npc &n : g->all_npcs() ) {
+        item_location l2 = try_character( &n );
+        if( l2 ) {
+            return l2;
+        }
+    }
+    for( const wrapped_vehicle &wv : here.get_vehicles() ) {
+        if( wv.v == nullptr ) {
+            continue;
+        }
+        for( const vpart_reference &vpr : wv.v->get_all_parts() ) {
+            vehicle_cursor vc( *wv.v, vpr.part_index() );
+            item *found = retrieve_by_uid( vc, uid );
+            if( found != nullptr ) {
+                return item_location( vc, found );
+            }
+        }
+    }
+    for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
+        if( !here.has_items( p ) ) {
+            continue;
+        }
+        map_cursor mc( here.get_abs( p ) );
+        item *found = retrieve_by_uid( mc, uid );
+        if( found != nullptr ) {
+            return item_location( mc, found );
+        }
+    }
+
     return item_location::nowhere;
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_ITEM_LOCATION_H
 #define CATA_SRC_ITEM_LOCATION_H
 
+#include <cstdint>
+#include <list>
 #include <memory>
 #include <string>
 
@@ -193,4 +195,14 @@ class item_location
 std::unique_ptr<talker> get_talker_for( item_location &it );
 std::unique_ptr<const_talker> get_const_talker_for( const item_location &it );
 std::unique_ptr<talker> get_talker_for( item_location *it );
+
+struct item_locator_hint;
+
+// Resolve an item by its uid, starting from the hint.  Returns invalid
+// item_location if not found within the accepted resolution boundary.
+item_location find_item_by_uid( int64_t uid, const item_locator_hint &hint );
+
+using drop_location = std::pair<item_location, int>;
+using drop_locations = std::list<drop_location>;
+
 #endif // CATA_SRC_ITEM_LOCATION_H

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -213,7 +213,30 @@ std::string craft( item const &it, unsigned int /* quantity */,
         if( it.charges > 1 ) {
             maintext += string_format( " (%d)", it.charges );
         }
-        const int percent_progress = it.item_counter / 100000;
+        int effective_counter = it.item_counter;
+        const time_point pstart = it.get_passive_started_at();
+        const time_point saved_ready = it.get_saved_ready_at();
+        const time_point ready = saved_ready != calendar::before_time_starts
+                                 ? saved_ready : it.get_ready_at();
+        const int start_counter = it.get_passive_start_counter();
+        const int end_counter = it.get_passive_end_counter();
+        if( pstart != calendar::before_time_starts && ready > pstart && end_counter > start_counter ) {
+            const time_duration step_dur = ready - pstart;
+            time_duration elapsed = calendar::turn - pstart;
+            if( elapsed < 0_seconds ) {
+                elapsed = 0_seconds;
+            }
+            if( elapsed > step_dur ) {
+                elapsed = step_dur;
+            }
+            const int64_t step_dur_moves = std::max( static_cast<int64_t>( 1 ),
+                                           to_moves<int64_t>( step_dur ) );
+            const double fraction = static_cast<double>( to_moves<int64_t>( elapsed ) ) / step_dur_moves;
+            const int projected = static_cast<int>( std::round( start_counter +
+                                                    fraction * ( end_counter - start_counter ) ) );
+            effective_counter = std::max( effective_counter, projected );
+        }
+        const int percent_progress = effective_counter / 100000;
         return string_format( "%s (%d%%)", maintext, percent_progress );
     }
     return {};

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <map>
+#include <queue>
 #include <string>
 #include <utility>
 
@@ -214,40 +215,63 @@ static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now 
     }
 }
 
+// Min-heap comparator: top is smallest by (when, uid, kind).  push_heap and
+// friends produce a max-heap, so this returns true when `a` should sink
+// below `b`, i.e. `a` is greater.
+bool item_wakeup_manager::heap_greater( const entry_iter &a, const entry_iter &b )
+{
+    if( a->when != b->when ) {
+        return a->when > b->when;
+    }
+    if( a->uid != b->uid ) {
+        return a->uid > b->uid;
+    }
+    return static_cast<int>( a->kind ) > static_cast<int>( b->kind );
+}
+
+bool item_wakeup_manager::is_live( const entry_iter &it ) const
+{
+    const auto map_it = by_key_.find( {it->uid, it->kind} );
+    return map_it != by_key_.end() && map_it->second == it;
+}
+
+void item_wakeup_manager::clean_heap_top()
+{
+    while( !heap_.empty() && !is_live( heap_.front() ) ) {
+        const entry_iter top = heap_.front();
+        std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+        heap_.pop_back();
+        entries_.erase( top );
+    }
+}
+
 void item_wakeup_manager::schedule_or_update( int64_t uid, time_point when,
         item_wakeup_kind kind, item_locator_hint hint )
 {
-    auto match = std::find_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
-    if( match != entries_.end() ) {
-        match->when = when;
-        match->hint = hint;
-        return;
-    }
     entry e;
     e.uid = uid;
     e.kind = kind;
     e.when = when;
     e.hint = hint;
-    entries_.push_back( e );
+    const entry_iter new_it = entries_.insert( e );
+    by_key_[ {uid, kind}] = new_it;
+    heap_.push_back( new_it );
+    std::push_heap( heap_.begin(), heap_.end(), heap_greater );
+    clean_heap_top();
 }
 
 void item_wakeup_manager::cancel( int64_t uid, item_wakeup_kind kind )
 {
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } ), entries_.end() );
+    by_key_.erase( {uid, kind} );
+    clean_heap_top();
 }
 
 void item_wakeup_manager::cancel_all( int64_t uid )
 {
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid]( const entry & e ) {
-        return e.uid == uid;
-    } ), entries_.end() );
+    for( int k = 0; k < static_cast<int>( item_wakeup_kind::last ); ++k ) {
+        by_key_.erase( {uid, static_cast<item_wakeup_kind>( k )} );
+    }
+    clean_heap_top();
 }
 
 void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
@@ -255,66 +279,62 @@ void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
     const int64_t uid = it.uid().get_value();
     const std::vector<desired_wakeup> desired = it.enumerate_scheduled_wakeups();
 
-    // Cancel kinds the item no longer wants.
-    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
-    [uid, &desired]( const entry & e ) {
-        if( e.uid != uid ) {
-            return false;
+    for( int k = 0; k < static_cast<int>( item_wakeup_kind::last ); ++k ) {
+        const item_wakeup_kind kind = static_cast<item_wakeup_kind>( k );
+        const bool wanted = std::any_of( desired.begin(), desired.end(),
+        [kind]( const desired_wakeup & d ) {
+            return d.kind == kind;
+        } );
+        if( !wanted ) {
+            by_key_.erase( {uid, kind} );
         }
-        for( const desired_wakeup &d : desired ) {
-            if( d.kind == e.kind ) {
-                return false;
-            }
-        }
-        return true;
-    } ), entries_.end() );
-
-    // Add or update each desired wakeup.
+    }
     for( const desired_wakeup &d : desired ) {
         schedule_or_update( uid, d.when, d.kind, hint );
     }
+    clean_heap_top();
 }
 
 bool item_wakeup_manager::is_scheduled( int64_t uid, item_wakeup_kind kind ) const
 {
-    return std::any_of( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
+    return by_key_.count( {uid, kind} ) > 0;
 }
 
 std::optional<time_point> item_wakeup_manager::get( int64_t uid,
         item_wakeup_kind kind ) const
 {
-    auto match = std::find_if( entries_.begin(), entries_.end(),
-    [uid, kind]( const entry & e ) {
-        return e.uid == uid && e.kind == kind;
-    } );
-    if( match == entries_.end() ) {
+    const auto map_it = by_key_.find( {uid, kind} );
+    if( map_it == by_key_.end() ) {
         return std::nullopt;
     }
-    return match->when;
+    return map_it->second->when;
 }
 
 std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
 {
-    std::vector<scheduled_wakeup_info> all = dump();
-    if( all.empty() ) {
+    if( heap_.empty() ) {
         return std::nullopt;
     }
-    return all.front();
+    const entry_iter top = heap_.front();
+    scheduled_wakeup_info info;
+    info.uid = top->uid;
+    info.kind = top->kind;
+    info.when = top->when;
+    info.hint = top->hint;
+    return info;
 }
 
 std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
 {
     std::vector<scheduled_wakeup_info> out;
-    out.reserve( entries_.size() );
-    for( const entry &e : entries_ ) {
+    out.reserve( by_key_.size() );
+    for( const auto &kv : by_key_ ) {
+        const entry_iter it = kv.second;
         scheduled_wakeup_info info;
-        info.uid = e.uid;
-        info.kind = e.kind;
-        info.when = e.when;
-        info.hint = e.hint;
+        info.uid = it->uid;
+        info.kind = it->kind;
+        info.when = it->when;
+        info.hint = it->hint;
         out.push_back( info );
     }
     std::sort( out.begin(), out.end(),
@@ -333,7 +353,7 @@ std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
 item_wakeup_manager::stats item_wakeup_manager::get_stats() const
 {
     stats s = stats_;
-    s.total_pending = static_cast<int>( entries_.size() );
+    s.total_pending = static_cast<int>( by_key_.size() );
     return s;
 }
 
@@ -342,28 +362,25 @@ void item_wakeup_manager::process( time_point now )
     cata_assert( !processing_active );
     processing_active = true;
 
-    // Snapshot expired entries in deterministic order, erase from live queue.
     std::vector<entry> snapshot;
-    snapshot.reserve( entries_.size() );
-    auto first_pending = std::partition( entries_.begin(), entries_.end(),
-    [now]( const entry & e ) {
-        return e.when > now;
-    } );
-    snapshot.assign( first_pending, entries_.end() );
-    entries_.erase( first_pending, entries_.end() );
-    std::sort( snapshot.begin(), snapshot.end(),
-    []( const entry & a, const entry & b ) {
-        if( a.when != b.when ) {
-            return a.when < b.when;
+    while( !heap_.empty() ) {
+        const entry_iter top = heap_.front();
+        if( !is_live( top ) ) {
+            std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+            heap_.pop_back();
+            entries_.erase( top );
+            continue;
         }
-        if( a.uid != b.uid ) {
-            return a.uid < b.uid;
+        if( top->when > now ) {
+            break;
         }
-        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
-    } );
+        snapshot.push_back( *top );
+        std::pop_heap( heap_.begin(), heap_.end(), heap_greater );
+        heap_.pop_back();
+        by_key_.erase( {top->uid, top->kind} );
+        entries_.erase( top );
+    }
 
-    // Dispatch each.  Stale uids increment the counter; threshold breach
-    // emits a single debugmsg per manager lifetime (reset by clear()).
     for( const entry &e : snapshot ) {
         item_location loc = find_item_by_uid( e.uid, e.hint );
         if( !loc ) {
@@ -379,12 +396,15 @@ void item_wakeup_manager::process( time_point now )
         loc->actualize_scheduled( e.kind, now );
     }
 
+    clean_heap_top();
     processing_active = false;
 }
 
 void item_wakeup_manager::clear()
 {
     entries_.clear();
+    by_key_.clear();
+    heap_.clear();
     stats_ = stats{};
     stale_seen_uids_ = 0;
     stale_msg_emitted_ = false;
@@ -396,18 +416,24 @@ void item_wakeup_manager::serialize( JsonOut &jsout ) const
     jsout.member( "version", CURRENT_VERSION );
     jsout.member( "wakeups" );
     jsout.start_array();
-    std::vector<entry> sorted = entries_;
-    std::sort( sorted.begin(), sorted.end(),
-    []( const entry & a, const entry & b ) {
-        if( a.when != b.when ) {
-            return a.when < b.when;
+    std::vector<entry_iter> live;
+    live.reserve( by_key_.size() );
+    for( const std::pair<const key_t, entry_iter> &kv : by_key_ ) {
+        live.push_back( kv.second );
+    }
+    std::sort( live.begin(), live.end(),
+    []( const entry_iter & a, const entry_iter & b ) {
+        if( a->when != b->when ) {
+            return a->when < b->when;
         }
-        if( a.uid != b.uid ) {
-            return a.uid < b.uid;
+        if( a->uid != b->uid ) {
+            return a->uid < b->uid;
         }
-        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+        return static_cast<int>( a->kind ) < static_cast<int>( b->kind );
     } );
-    for( const entry &e : sorted ) {
+    cata_assert( entries_.size() >= live.size() );
+    for( const entry_iter &it : live ) {
+        const entry &e = *it;
         jsout.start_object();
         jsout.member( "uid", e.uid );
         jsout.member( "kind", kind_to_string( e.kind ) );
@@ -422,10 +448,7 @@ void item_wakeup_manager::serialize( JsonOut &jsout ) const
 
 void item_wakeup_manager::deserialize( const JsonObject &jo )
 {
-    entries_.clear();
-    stats_ = stats{};
-    stale_seen_uids_ = 0;
-    stale_msg_emitted_ = false;
+    clear();
 
     int version = 0;
     if( !jo.read( "version", version ) ) {
@@ -443,8 +466,6 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
     std::map<std::pair<int64_t, item_wakeup_kind>, entry> dedup;
     int dropped = 0;
     for( JsonObject row : jo.get_array( "wakeups" ) ) {
-        // Consume every field unconditionally so the strict JSON parser
-        // does not flag unread members on bad entries.
         row.allow_omitted_members();
         int64_t uid = 0;
         std::string kind_str;
@@ -470,9 +491,9 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
         e.kind = kind;
         e.when = when;
         e.hint = hint;
-        // Dedupe by (uid, kind), keeping the latest when.
-        auto key = std::make_pair( uid, kind );
-        auto existing = dedup.find( key );
+        const std::pair<int64_t, item_wakeup_kind> key{ uid, kind };
+        const std::map<std::pair<int64_t, item_wakeup_kind>, entry>::const_iterator existing
+            = dedup.find( key );
         if( existing == dedup.end() ) {
             dedup[key] = e;
         } else {
@@ -482,10 +503,12 @@ void item_wakeup_manager::deserialize( const JsonObject &jo )
             }
         }
     }
-    entries_.reserve( dedup.size() );
     for( const auto &kv : dedup ) {
-        entries_.push_back( kv.second );
+        const entry_iter it = entries_.insert( kv.second );
+        by_key_[kv.first] = it;
+        heap_.push_back( it );
     }
+    std::make_heap( heap_.begin(), heap_.end(), heap_greater );
     stats_.dropped_on_load = dropped;
 }
 

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -1,0 +1,94 @@
+#include "item_wakeup.h"
+
+#include <map>
+
+#include "json.h"
+#include "type_id.h"
+
+void item_wakeup_manager::schedule_or_update( int64_t /*uid*/, time_point /*when*/,
+        item_wakeup_kind /*kind*/, item_locator_hint /*hint*/ )
+{
+}
+
+void item_wakeup_manager::cancel( int64_t /*uid*/, item_wakeup_kind /*kind*/ )
+{
+}
+
+void item_wakeup_manager::cancel_all( int64_t /*uid*/ )
+{
+}
+
+void item_wakeup_manager::rebuild_for_item( item &/*it*/, item_locator_hint /*hint*/ )
+{
+}
+
+bool item_wakeup_manager::is_scheduled( int64_t /*uid*/, item_wakeup_kind /*kind*/ ) const
+{
+    return false;
+}
+
+std::optional<time_point> item_wakeup_manager::get( int64_t /*uid*/,
+        item_wakeup_kind /*kind*/ ) const
+{
+    return std::nullopt;
+}
+
+std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+{
+    return std::nullopt;
+}
+
+std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
+{
+    return {};
+}
+
+item_wakeup_manager::stats item_wakeup_manager::get_stats() const
+{
+    return stats_;
+}
+
+void item_wakeup_manager::process( time_point /*now*/ )
+{
+}
+
+void item_wakeup_manager::clear()
+{
+    entries_.clear();
+    stats_ = stats{};
+}
+
+void item_wakeup_manager::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "version", 1 );
+    jsout.member( "wakeups" );
+    jsout.start_array();
+    jsout.end_array();
+    jsout.end_object();
+}
+
+void item_wakeup_manager::deserialize( const JsonObject &/*jo*/ )
+{
+}
+
+#ifdef CATA_TESTS
+namespace
+{
+std::map<itype_id, item_wakeup_test_handler> &test_handler_registry()
+{
+    static std::map<itype_id, item_wakeup_test_handler> registry;
+    return registry;
+}
+}  // namespace
+
+void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn )
+{
+    test_handler_registry()[id] = fn;
+}
+
+void clear_test_wakeup_handlers()
+{
+    test_handler_registry().clear();
+}
+#endif

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -1,85 +1,177 @@
 #include "item_wakeup.h"
 
+#include <algorithm>
 #include <map>
+#include <string>
+#include <utility>
 
+#include "cata_assert.h"
+#include "character_id.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_location.h"
+#include "item_uid.h"
 #include "json.h"
 #include "type_id.h"
 
-void item_wakeup_manager::schedule_or_update( int64_t /*uid*/, time_point /*when*/,
-        item_wakeup_kind /*kind*/, item_locator_hint /*hint*/ )
+namespace
 {
+
+constexpr int CURRENT_VERSION = 1;
+
+// Stale dispatches before a single noise-control debugmsg fires.
+// Reset by clear() and deserialize().
+constexpr int STALE_DEBUGMSG_THRESHOLD = 32;
+
+const char *kind_to_string( item_wakeup_kind k )
+{
+    switch( k ) {
+        case item_wakeup_kind::alarm:
+            return "alarm";
+        case item_wakeup_kind::ready_check:
+            return "ready_check";
+        case item_wakeup_kind::fail_check:
+            return "fail_check";
+        case item_wakeup_kind::last:
+            break;
+    }
+    return "invalid";
 }
 
-void item_wakeup_manager::cancel( int64_t /*uid*/, item_wakeup_kind /*kind*/ )
+bool string_to_kind( const std::string &s, item_wakeup_kind &out )
 {
-}
-
-void item_wakeup_manager::cancel_all( int64_t /*uid*/ )
-{
-}
-
-void item_wakeup_manager::rebuild_for_item( item &/*it*/, item_locator_hint /*hint*/ )
-{
-}
-
-bool item_wakeup_manager::is_scheduled( int64_t /*uid*/, item_wakeup_kind /*kind*/ ) const
-{
+    if( s == "alarm" ) {
+        out = item_wakeup_kind::alarm;
+        return true;
+    }
+    if( s == "ready_check" ) {
+        out = item_wakeup_kind::ready_check;
+        return true;
+    }
+    if( s == "fail_check" ) {
+        out = item_wakeup_kind::fail_check;
+        return true;
+    }
     return false;
 }
 
-std::optional<time_point> item_wakeup_manager::get( int64_t /*uid*/,
-        item_wakeup_kind /*kind*/ ) const
+const char *place_to_string( item_locator_hint::place p )
 {
-    return std::nullopt;
+    switch( p ) {
+        case item_locator_hint::place::map:
+            return "map";
+        case item_locator_hint::place::vehicle:
+            return "vehicle";
+        case item_locator_hint::place::character:
+            return "character";
+        case item_locator_hint::place::unknown:
+            break;
+    }
+    return "unknown";
 }
 
-std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+bool string_to_place( const std::string &s, item_locator_hint::place &out )
 {
-    return std::nullopt;
+    if( s == "map" ) {
+        out = item_locator_hint::place::map;
+        return true;
+    }
+    if( s == "vehicle" ) {
+        out = item_locator_hint::place::vehicle;
+        return true;
+    }
+    if( s == "character" ) {
+        out = item_locator_hint::place::character;
+        return true;
+    }
+    if( s == "unknown" ) {
+        out = item_locator_hint::place::unknown;
+        return true;
+    }
+    return false;
 }
 
-std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
-{
-    return {};
-}
-
-item_wakeup_manager::stats item_wakeup_manager::get_stats() const
-{
-    return stats_;
-}
-
-void item_wakeup_manager::process( time_point /*now*/ )
-{
-}
-
-void item_wakeup_manager::clear()
-{
-    entries_.clear();
-    stats_ = stats{};
-}
-
-void item_wakeup_manager::serialize( JsonOut &jsout ) const
+void serialize_hint( JsonOut &jsout, const item_locator_hint &hint )
 {
     jsout.start_object();
-    jsout.member( "version", 1 );
-    jsout.member( "wakeups" );
-    jsout.start_array();
-    jsout.end_array();
+    jsout.member( "where", place_to_string( hint.where ) );
+    if( hint.where == item_locator_hint::place::map ) {
+        const tripoint_abs_ms *p = std::get_if<tripoint_abs_ms>( &hint.location );
+        if( p != nullptr ) {
+            jsout.member( "abs_ms", *p );
+        }
+    } else if( hint.where == item_locator_hint::place::vehicle ) {
+        const vehicle_hint *v = std::get_if<vehicle_hint>( &hint.location );
+        if( v != nullptr ) {
+            jsout.member( "cargo_square", v->cargo_square );
+            jsout.member( "part_index", v->part_index );
+            jsout.member( "mount_offset", v->mount_offset );
+        }
+    } else if( hint.where == item_locator_hint::place::character ) {
+        const character_id *c = std::get_if<character_id>( &hint.location );
+        if( c != nullptr ) {
+            jsout.member( "character", c->get_value() );
+        }
+    }
     jsout.end_object();
 }
 
-void item_wakeup_manager::deserialize( const JsonObject &/*jo*/ )
+bool deserialize_hint( const JsonObject &jo, item_locator_hint &hint )
 {
+    std::string where_str;
+    if( !jo.read( "where", where_str ) ) {
+        return false;
+    }
+    if( !string_to_place( where_str, hint.where ) ) {
+        return false;
+    }
+    if( hint.where == item_locator_hint::place::map ) {
+        tripoint_abs_ms p;
+        if( !jo.read( "abs_ms", p ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        hint.location = p;
+    } else if( hint.where == item_locator_hint::place::vehicle ) {
+        vehicle_hint v;
+        if( !jo.read( "cargo_square", v.cargo_square ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        jo.read( "part_index", v.part_index );
+        jo.read( "mount_offset", v.mount_offset );
+        hint.location = v;
+    } else if( hint.where == item_locator_hint::place::character ) {
+        int64_t cid = 0;
+        if( !jo.read( "character", cid ) ) {
+            hint.where = item_locator_hint::place::unknown;
+            hint.location = std::monostate{};
+            return true;
+        }
+        hint.location = character_id( static_cast<int>( cid ) );
+    } else {
+        hint.location = std::monostate{};
+    }
+    return true;
 }
 
-#ifdef CATA_TESTS
-namespace
-{
 std::map<itype_id, item_wakeup_test_handler> &test_handler_registry()
 {
     static std::map<itype_id, item_wakeup_test_handler> registry;
     return registry;
 }
+
+std::map<itype_id, item_wakeup_test_enumerator> &test_enumerator_registry()
+{
+    static std::map<itype_id, item_wakeup_test_enumerator> registry;
+    return registry;
+}
+
+bool processing_active = false;
+
 }  // namespace
 
 void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn )
@@ -91,4 +183,314 @@ void clear_test_wakeup_handlers()
 {
     test_handler_registry().clear();
 }
-#endif
+
+void register_test_enumerate_handler( const itype_id &id, item_wakeup_test_enumerator fn )
+{
+    test_enumerator_registry()[id] = fn;
+}
+
+void clear_test_enumerate_handlers()
+{
+    test_enumerator_registry().clear();
+}
+
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it )
+{
+    const std::map<itype_id, item_wakeup_test_enumerator> &reg = test_enumerator_registry();
+    const auto entry = reg.find( it.typeId() );
+    if( entry != reg.end() ) {
+        return entry->second( it );
+    }
+    return {};
+}
+
+// Dispatcher called from item::actualize_scheduled.
+static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now )
+{
+    const std::map<itype_id, item_wakeup_test_handler> &reg = test_handler_registry();
+    const auto it_handler = reg.find( it.typeId() );
+    if( it_handler != reg.end() ) {
+        it_handler->second( it, kind, now );
+    }
+}
+
+void item_wakeup_manager::schedule_or_update( int64_t uid, time_point when,
+        item_wakeup_kind kind, item_locator_hint hint )
+{
+    auto match = std::find_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+    if( match != entries_.end() ) {
+        match->when = when;
+        match->hint = hint;
+        return;
+    }
+    entry e;
+    e.uid = uid;
+    e.kind = kind;
+    e.when = when;
+    e.hint = hint;
+    entries_.push_back( e );
+}
+
+void item_wakeup_manager::cancel( int64_t uid, item_wakeup_kind kind )
+{
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } ), entries_.end() );
+}
+
+void item_wakeup_manager::cancel_all( int64_t uid )
+{
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid]( const entry & e ) {
+        return e.uid == uid;
+    } ), entries_.end() );
+}
+
+void item_wakeup_manager::rebuild_for_item( item &it, item_locator_hint hint )
+{
+    const int64_t uid = it.uid().get_value();
+    const std::vector<desired_wakeup> desired = it.enumerate_scheduled_wakeups();
+
+    // Cancel kinds the item no longer wants.
+    entries_.erase( std::remove_if( entries_.begin(), entries_.end(),
+    [uid, &desired]( const entry & e ) {
+        if( e.uid != uid ) {
+            return false;
+        }
+        for( const desired_wakeup &d : desired ) {
+            if( d.kind == e.kind ) {
+                return false;
+            }
+        }
+        return true;
+    } ), entries_.end() );
+
+    // Add or update each desired wakeup.
+    for( const desired_wakeup &d : desired ) {
+        schedule_or_update( uid, d.when, d.kind, hint );
+    }
+}
+
+bool item_wakeup_manager::is_scheduled( int64_t uid, item_wakeup_kind kind ) const
+{
+    return std::any_of( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+}
+
+std::optional<time_point> item_wakeup_manager::get( int64_t uid,
+        item_wakeup_kind kind ) const
+{
+    auto match = std::find_if( entries_.begin(), entries_.end(),
+    [uid, kind]( const entry & e ) {
+        return e.uid == uid && e.kind == kind;
+    } );
+    if( match == entries_.end() ) {
+        return std::nullopt;
+    }
+    return match->when;
+}
+
+std::optional<scheduled_wakeup_info> item_wakeup_manager::peek_next_wakeup() const
+{
+    std::vector<scheduled_wakeup_info> all = dump();
+    if( all.empty() ) {
+        return std::nullopt;
+    }
+    return all.front();
+}
+
+std::vector<scheduled_wakeup_info> item_wakeup_manager::dump() const
+{
+    std::vector<scheduled_wakeup_info> out;
+    out.reserve( entries_.size() );
+    for( const entry &e : entries_ ) {
+        scheduled_wakeup_info info;
+        info.uid = e.uid;
+        info.kind = e.kind;
+        info.when = e.when;
+        info.hint = e.hint;
+        out.push_back( info );
+    }
+    std::sort( out.begin(), out.end(),
+    []( const scheduled_wakeup_info & a, const scheduled_wakeup_info & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+    return out;
+}
+
+item_wakeup_manager::stats item_wakeup_manager::get_stats() const
+{
+    stats s = stats_;
+    s.total_pending = static_cast<int>( entries_.size() );
+    return s;
+}
+
+void item_wakeup_manager::process( time_point now )
+{
+    cata_assert( !processing_active );
+    processing_active = true;
+
+    // Snapshot expired entries in deterministic order, erase from live queue.
+    std::vector<entry> snapshot;
+    snapshot.reserve( entries_.size() );
+    auto first_pending = std::partition( entries_.begin(), entries_.end(),
+    [now]( const entry & e ) {
+        return e.when > now;
+    } );
+    snapshot.assign( first_pending, entries_.end() );
+    entries_.erase( first_pending, entries_.end() );
+    std::sort( snapshot.begin(), snapshot.end(),
+    []( const entry & a, const entry & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+
+    // Dispatch each.  Stale uids increment the counter; threshold breach
+    // emits a single debugmsg per manager lifetime (reset by clear()).
+    for( const entry &e : snapshot ) {
+        item_location loc = find_item_by_uid( e.uid, e.hint );
+        if( !loc ) {
+            stats_.stale_resolution++;
+            stale_seen_uids_++;
+            if( stale_seen_uids_ >= STALE_DEBUGMSG_THRESHOLD && !stale_msg_emitted_ ) {
+                debugmsg( "item_wakeup_manager: %d stale uids unresolved",
+                          stale_seen_uids_ );
+                stale_msg_emitted_ = true;
+            }
+            continue;
+        }
+        loc->actualize_scheduled( e.kind, now );
+    }
+
+    processing_active = false;
+}
+
+void item_wakeup_manager::clear()
+{
+    entries_.clear();
+    stats_ = stats{};
+    stale_seen_uids_ = 0;
+    stale_msg_emitted_ = false;
+}
+
+void item_wakeup_manager::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "version", CURRENT_VERSION );
+    jsout.member( "wakeups" );
+    jsout.start_array();
+    std::vector<entry> sorted = entries_;
+    std::sort( sorted.begin(), sorted.end(),
+    []( const entry & a, const entry & b ) {
+        if( a.when != b.when ) {
+            return a.when < b.when;
+        }
+        if( a.uid != b.uid ) {
+            return a.uid < b.uid;
+        }
+        return static_cast<int>( a.kind ) < static_cast<int>( b.kind );
+    } );
+    for( const entry &e : sorted ) {
+        jsout.start_object();
+        jsout.member( "uid", e.uid );
+        jsout.member( "kind", kind_to_string( e.kind ) );
+        jsout.member( "when", e.when );
+        jsout.member( "hint" );
+        serialize_hint( jsout, e.hint );
+        jsout.end_object();
+    }
+    jsout.end_array();
+    jsout.end_object();
+}
+
+void item_wakeup_manager::deserialize( const JsonObject &jo )
+{
+    entries_.clear();
+    stats_ = stats{};
+    stale_seen_uids_ = 0;
+    stale_msg_emitted_ = false;
+
+    int version = 0;
+    if( !jo.read( "version", version ) ) {
+        debugmsg( "item_wakeup_manager: save without version, treating as v1" );
+    } else if( version != CURRENT_VERSION ) {
+        debugmsg( "item_wakeup_manager: unknown save version %d, dropping queue",
+                  version );
+        return;
+    }
+
+    if( !jo.has_array( "wakeups" ) ) {
+        return;
+    }
+
+    std::map<std::pair<int64_t, item_wakeup_kind>, entry> dedup;
+    int dropped = 0;
+    for( JsonObject row : jo.get_array( "wakeups" ) ) {
+        // Consume every field unconditionally so the strict JSON parser
+        // does not flag unread members on bad entries.
+        row.allow_omitted_members();
+        int64_t uid = 0;
+        std::string kind_str;
+        time_point when;
+        item_wakeup_kind kind = item_wakeup_kind::alarm;
+        const bool got_uid = row.read( "uid", uid );
+        const bool got_kind = row.read( "kind", kind_str );
+        const bool got_when = row.read( "when", when );
+        item_locator_hint hint;
+        if( row.has_object( "hint" ) ) {
+            JsonObject hint_obj = row.get_object( "hint" );
+            if( !deserialize_hint( hint_obj, hint ) ) {
+                hint = item_locator_hint{};
+            }
+        }
+        if( !got_uid || uid <= 0 || !got_kind || !string_to_kind( kind_str, kind )
+            || !got_when ) {
+            dropped++;
+            continue;
+        }
+        entry e;
+        e.uid = uid;
+        e.kind = kind;
+        e.when = when;
+        e.hint = hint;
+        // Dedupe by (uid, kind), keeping the latest when.
+        auto key = std::make_pair( uid, kind );
+        auto existing = dedup.find( key );
+        if( existing == dedup.end() ) {
+            dedup[key] = e;
+        } else {
+            stats_.duplicate_event++;
+            if( existing->second.when < when ) {
+                dedup[key] = e;
+            }
+        }
+    }
+    entries_.reserve( dedup.size() );
+    for( const auto &kv : dedup ) {
+        entries_.push_back( kv.second );
+    }
+    stats_.dropped_on_load = dropped;
+}
+
+// Item-side dispatch entry called from item.cpp.
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now )
+{
+    dispatch_actualize( it, kind, now );
+}

--- a/src/item_wakeup.cpp
+++ b/src/item_wakeup.cpp
@@ -8,6 +8,7 @@
 
 #include "cata_assert.h"
 #include "character_id.h"
+#include "crafting.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "item.h"
@@ -197,6 +198,9 @@ void clear_test_enumerate_handlers()
 
 std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it )
 {
+    if( it.is_craft() ) {
+        return craft_enumerate_scheduled_wakeups( it, loc );
+    }
     const std::map<itype_id, item_wakeup_test_enumerator> &reg = test_enumerator_registry();
     const auto entry = reg.find( it.typeId() );
     if( entry != reg.end() ) {
@@ -208,6 +212,10 @@ std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it )
 // Dispatcher called from item::actualize_scheduled.
 static void dispatch_actualize( item &it, item_wakeup_kind kind, time_point now )
 {
+    if( it.is_craft() ) {
+        craft_actualize_scheduled( it, kind, now, loc );
+        return;
+    }
     const std::map<itype_id, item_wakeup_test_handler> &reg = test_handler_registry();
     const auto it_handler = reg.find( it.typeId() );
     if( it_handler != reg.end() ) {

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -18,8 +18,7 @@ class JsonObject;
 class JsonOut;
 class item;
 
-// Categorizes what a scheduled wakeup is for.  Distinct kinds for one item
-// coexist independently.
+// Distinct kinds coexist per item.
 enum class item_wakeup_kind : uint8_t {
     alarm = 0,
     ready_check,
@@ -27,18 +26,15 @@ enum class item_wakeup_kind : uint8_t {
     last
 };
 
-// Persisted vehicle hint.  vpart_reference is a runtime handle and must
-// not appear on disk; this struct stores only stable values.  The cargo
-// square is authoritative; part_index/mount_offset are fallback hints
-// that may be stale after vehicle moves or repairs.
+// Persisted vehicle hint.  cargo_square is authoritative; part_index and
+// mount_offset are fallbacks that may be stale across moves or repairs.
 struct vehicle_hint {
     tripoint_abs_ms cargo_square;
     int part_index = -1;
     point_rel_ms mount_offset;
 };
 
-// Hint for resolving an item by uid.  Drives the lookup order in
-// find_item_by_uid; never the source of truth for item identity.
+// Hint for find_item_by_uid lookup; never authoritative.
 struct item_locator_hint {
     enum class place : uint8_t { map, vehicle, character, unknown };
     place where = place::unknown;
@@ -47,9 +43,7 @@ struct item_locator_hint {
     item_locator_hint() = default;
 };
 
-// Producer record returned by item::enumerate_scheduled_wakeups.  Items
-// describe their desired wakeups by (kind, when); the manager stamps the
-// caller-supplied hint when (re)scheduling.
+// Producer record.  Manager stamps the caller-supplied hint when scheduling.
 struct desired_wakeup {
     item_wakeup_kind kind;
     time_point when;
@@ -63,9 +57,8 @@ struct scheduled_wakeup_info {
     item_locator_hint hint;
 };
 
-// Item-targeted wakeup scheduler.  Items remain authoritative for runtime
-// state; this queue is advisory and can be reconstructed via
-// rebuild_for_item from item state.
+// Item-targeted wakeup scheduler.  Items are authoritative; this queue is
+// advisory and reconstructible via rebuild_for_item.
 class item_wakeup_manager
 {
     public:
@@ -82,10 +75,8 @@ class item_wakeup_manager
         void cancel( int64_t uid, item_wakeup_kind kind );
         void cancel_all( int64_t uid );
 
-        // Reconcile the manager's queue for a single item against the item's
-        // own enumerate_scheduled_wakeups().  Items the manager has but the
-        // item no longer wants are cancelled; new desires are scheduled.
-        // Idempotent.  Hint is stamped onto every (re)scheduled entry.
+        // Reconcile this item's entries against its enumerate_scheduled_wakeups().
+        // Idempotent.
         void rebuild_for_item( item &it, item_locator_hint hint );
 
         bool is_scheduled( int64_t uid, item_wakeup_kind kind ) const;
@@ -95,11 +86,8 @@ class item_wakeup_manager
         std::vector<scheduled_wakeup_info> dump() const;
         stats get_stats() const;
 
-        // Two-phase, non-reentrant.  Snapshot all entries with when <= now,
-        // erase from live queue, then dispatch handlers from the snapshot.
-        // Recursion guard asserts process() is not called from a handler.
-        // Wakeups newly scheduled for <= now during a handler do NOT fire
-        // again in the same pass.
+        // Two-phase: snapshot expired entries, erase, dispatch from snapshot.
+        // Asserts non-reentrant.  Same-pass reschedule does not double-fire.
         void process( time_point now );
 
         // Test isolation only.  Drops every entry and zeroes stats.
@@ -117,20 +105,31 @@ class item_wakeup_manager
         };
 
         std::vector<entry> entries_;
-        stats stats_;
+        stats stats_; // NOLINT(cata-serialize)
+        int stale_seen_uids_ = 0; // NOLINT(cata-serialize)
+        bool stale_msg_emitted_ = false; // NOLINT(cata-serialize)
 };
 
-// Game-owned accessor.
 item_wakeup_manager &get_item_wakeups();
 
-// find_item_by_uid is declared in item_location.h.
-
-// Test-only handler registry.  Production builds compile this out.
-#ifdef CATA_TESTS
+// Test handler registry.  Always compiled in; production cost is one
+// empty-map lookup per dispatch.
 using item_wakeup_test_handler =
     void( * )( item &it, item_wakeup_kind kind, time_point now );
 void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn );
 void clear_test_wakeup_handlers();
-#endif
+
+// Dispatch entry called from item::actualize_scheduled.
+void actualize_scheduled_dispatch( item &it, item_wakeup_kind kind, time_point now );
+
+// Test producer registry.  See test handler registry note above.
+using item_wakeup_test_enumerator =
+    std::vector<desired_wakeup>( * )( const item &it );
+void register_test_enumerate_handler( const itype_id &id,
+                                      item_wakeup_test_enumerator fn );
+void clear_test_enumerate_handlers();
+
+// Dispatch entry called from item::enumerate_scheduled_wakeups.
+std::vector<desired_wakeup> enumerate_scheduled_dispatch( const item &it );
 
 #endif // CATA_SRC_ITEM_WAKEUP_H

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -1,0 +1,136 @@
+#pragma once
+#ifndef CATA_SRC_ITEM_WAKEUP_H
+#define CATA_SRC_ITEM_WAKEUP_H
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "calendar.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "point.h"
+#include "type_id.h"
+
+class JsonObject;
+class JsonOut;
+class item;
+
+// Categorizes what a scheduled wakeup is for.  Distinct kinds for one item
+// coexist independently.
+enum class item_wakeup_kind : uint8_t {
+    alarm = 0,
+    ready_check,
+    fail_check,
+    last
+};
+
+// Persisted vehicle hint.  vpart_reference is a runtime handle and must
+// not appear on disk; this struct stores only stable values.  The cargo
+// square is authoritative; part_index/mount_offset are fallback hints
+// that may be stale after vehicle moves or repairs.
+struct vehicle_hint {
+    tripoint_abs_ms cargo_square;
+    int part_index = -1;
+    point_rel_ms mount_offset;
+};
+
+// Hint for resolving an item by uid.  Drives the lookup order in
+// find_item_by_uid; never the source of truth for item identity.
+struct item_locator_hint {
+    enum class place : uint8_t { map, vehicle, character, unknown };
+    place where = place::unknown;
+    std::variant<std::monostate, tripoint_abs_ms, vehicle_hint, character_id> location;
+
+    item_locator_hint() = default;
+};
+
+// Producer record returned by item::enumerate_scheduled_wakeups.  Items
+// describe their desired wakeups by (kind, when); the manager stamps the
+// caller-supplied hint when (re)scheduling.
+struct desired_wakeup {
+    item_wakeup_kind kind;
+    time_point when;
+};
+
+// Diagnostics row.
+struct scheduled_wakeup_info {
+    int64_t uid;
+    item_wakeup_kind kind;
+    time_point when;
+    item_locator_hint hint;
+};
+
+// Item-targeted wakeup scheduler.  Items remain authoritative for runtime
+// state; this queue is advisory and can be reconstructed via
+// rebuild_for_item from item state.
+class item_wakeup_manager
+{
+    public:
+        struct stats {
+            int total_pending = 0;
+            int stale_resolution = 0;
+            int duplicate_event = 0;
+            int dropped_on_load = 0;
+        };
+
+        // Insert or replace the (uid, kind) entry.  Newer when always wins.
+        void schedule_or_update( int64_t uid, time_point when,
+                                 item_wakeup_kind kind, item_locator_hint hint );
+        void cancel( int64_t uid, item_wakeup_kind kind );
+        void cancel_all( int64_t uid );
+
+        // Reconcile the manager's queue for a single item against the item's
+        // own enumerate_scheduled_wakeups().  Items the manager has but the
+        // item no longer wants are cancelled; new desires are scheduled.
+        // Idempotent.  Hint is stamped onto every (re)scheduled entry.
+        void rebuild_for_item( item &it, item_locator_hint hint );
+
+        bool is_scheduled( int64_t uid, item_wakeup_kind kind ) const;
+        std::optional<time_point> get( int64_t uid, item_wakeup_kind kind ) const;
+        std::optional<scheduled_wakeup_info> peek_next_wakeup() const;
+        // Sorted by (when, uid, kind).
+        std::vector<scheduled_wakeup_info> dump() const;
+        stats get_stats() const;
+
+        // Two-phase, non-reentrant.  Snapshot all entries with when <= now,
+        // erase from live queue, then dispatch handlers from the snapshot.
+        // Recursion guard asserts process() is not called from a handler.
+        // Wakeups newly scheduled for <= now during a handler do NOT fire
+        // again in the same pass.
+        void process( time_point now );
+
+        // Test isolation only.  Drops every entry and zeroes stats.
+        void clear();
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( const JsonObject &jo );
+
+    private:
+        struct entry {
+            int64_t uid = 0;
+            item_wakeup_kind kind = item_wakeup_kind::alarm;
+            time_point when = calendar::before_time_starts;
+            item_locator_hint hint;
+        };
+
+        std::vector<entry> entries_;
+        stats stats_;
+};
+
+// Game-owned accessor.
+item_wakeup_manager &get_item_wakeups();
+
+// find_item_by_uid is declared in item_location.h.
+
+// Test-only handler registry.  Production builds compile this out.
+#ifdef CATA_TESTS
+using item_wakeup_test_handler =
+    void( * )( item &it, item_wakeup_kind kind, time_point now );
+void register_test_wakeup_handler( const itype_id &id, item_wakeup_test_handler fn );
+void clear_test_wakeup_handlers();
+#endif
+
+#endif // CATA_SRC_ITEM_WAKEUP_H

--- a/src/item_wakeup.h
+++ b/src/item_wakeup.h
@@ -3,13 +3,15 @@
 #define CATA_SRC_ITEM_WAKEUP_H
 
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <utility>
 #include <variant>
 #include <vector>
 
 #include "calendar.h"
-#include "character_id.h"
+#include "character_id.h" // IWYU pragma: keep
+#include "colony.h"
 #include "coordinates.h"
 #include "point.h"
 #include "type_id.h"
@@ -104,7 +106,22 @@ class item_wakeup_manager
             item_locator_hint hint;
         };
 
-        std::vector<entry> entries_;
+        using entry_iter = cata::colony<entry>::iterator;
+        using key_t = std::pair<int64_t, item_wakeup_kind>;
+
+        // Pop tombstoned entries off heap_ until top points to a live node.
+        void clean_heap_top();
+        bool is_live( const entry_iter &it ) const;
+        static bool heap_greater( const entry_iter &a, const entry_iter &b );
+
+        cata::colony<entry> entries_;
+        // Source of liveness truth.  An entry_iter is live iff
+        // by_key_[{uid, kind}] == iter.  Stale heap nodes are reaped on
+        // pop or via clean_heap_top.
+        std::map<key_t, entry_iter> by_key_;
+        // Min-heap by (when, uid, kind), maintained via push_heap/pop_heap.
+        // Pure cache, reconstructible from entries_ + by_key_ on load.
+        std::vector<entry_iter> heap_; // NOLINT(cata-serialize)
         stats stats_; // NOLINT(cata-serialize)
         int stale_seen_uids_ = 0; // NOLINT(cata-serialize)
         bool stale_msg_emitted_ = false; // NOLINT(cata-serialize)

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8108,16 +8108,21 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
         return std::nullopt;
     }
 
+    item_location craft_loc( *p, it );
+    craft_resolve_overdue_passive( *it, calendar::turn, craft_loc );
+    if( !craft_loc || !craft_loc.get_item() ) {
+        return std::nullopt;
+    }
+    it = craft_loc.get_item();
     const recipe &rec = it->get_making();
-    if( rec.has_attention_steps() && p->is_avatar() ) {
-        std::optional<std::vector<attention_plan>> chosen =
-                show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
-                                           it->get_step_plans() );
+    std::optional<std::vector<attention_plan>> chosen;
+    if( rec.has_remaining_attention_steps( it->get_current_step() ) && p->is_avatar() ) {
+        chosen = show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
+                                            it->get_current_step(),
+                                            it->get_step_plans() );
         if( !chosen ) {
             return std::nullopt;
         }
-        it->set_step_plans( std::move( *chosen ) );
-        it->set_crafter_id( p->getID() );
     }
     if( !p->can_continue_craft( *it ) ) {
         return std::nullopt;
@@ -8129,10 +8134,14 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
             rec.result_name() );
         return 0;
     }
+    if( chosen ) {
+        it->set_step_plans( std::move( *chosen ) );
+        it->set_crafter_id( p->getID() );
+        craft_apply_resume_replan( craft_loc );
+    }
     p->add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ), craft_name );
-    item_location craft_loc = item_location( *p, it );
     p->assign_activity( craft_activity_actor( craft_loc, false ) );
 
     return 0;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -34,6 +34,8 @@
 #include "city.h"
 #include "color.h"
 #include "coordinates.h"
+#include "crafting.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
@@ -8106,10 +8108,20 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
         return std::nullopt;
     }
 
+    const recipe &rec = it->get_making();
+    if( rec.has_attention_steps() && p->is_avatar() ) {
+        std::optional<std::vector<attention_plan>> chosen =
+                show_craft_planning_modal( rec, *p, it->get_making_batch_size(),
+                                           it->get_step_plans() );
+        if( !chosen ) {
+            return std::nullopt;
+        }
+        it->set_step_plans( std::move( *chosen ) );
+        it->set_crafter_id( p->getID() );
+    }
     if( !p->can_continue_craft( *it ) ) {
         return std::nullopt;
     }
-    const recipe &rec = it->get_making();
     if( !p->has_recipe( &rec ) ) {
         p->add_msg_player_or_npc(
             _( "You don't know the recipe for the %s and can't continue crafting." ),

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9266,6 +9266,19 @@ void map::load( const tripoint_abs_sm &w, const bool update_vehicle,
             }
         }
     }
+
+    auto walk_character = [&wakeups]( Character & c ) {
+        // all_items_loc() is already recursive; rebuild per location directly.
+        for( item_location &loc : c.all_items_loc() ) {
+            if( loc && loc.get_item() != nullptr ) {
+                wakeups.rebuild_for_item( loc );
+            }
+        }
+    };
+    walk_character( get_avatar() );
+    for( npc &n : g->all_npcs() ) {
+        walk_character( n );
+    }
 }
 
 void map::shift_traps( const point_rel_sm &shift )

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1824,6 +1824,19 @@ bool recipe::has_attention_steps() const
     return false;
 }
 
+bool recipe::has_remaining_attention_steps( int from_step ) const
+{
+    if( from_step < 0 ) {
+        from_step = 0;
+    }
+    for( int i = from_step; i < static_cast<int>( steps_.size() ); ++i ) {
+        if( steps_[i].attention != step_attention::none ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool recipe::is_practice() const
 {
     return practice_data.has_value();

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -647,6 +647,37 @@ void recipe_step::load( const JsonObject &jo, const std::string &recipe_name, in
                                       + std::to_string( step_index ) );
     requirement_data::load_requirement( jo, step_req_id, false, false );
     reqs_internal.emplace_back( step_req_id, 1 );
+
+    if( jo.has_member( "attention" ) ) {
+        const std::string s = jo.get_string( "attention" );
+        if( s == "none" ) {
+            attention = step_attention::none;
+        } else if( s == "unattended" ) {
+            attention = step_attention::unattended;
+        } else if( s == "supervised" ) {
+            jo.throw_error( "supervised attention not yet supported" );
+        } else {
+            jo.throw_error( "invalid value for \"attention\": " + s );
+        }
+    }
+
+    if( jo.has_member( "max_time" ) ) {
+        time_duration d;
+        mandatory( jo, false, "max_time", d );
+        if( d <= time_duration::from_moves( time ) ) {
+            jo.throw_error( "max_time must exceed step time" );
+        }
+        max_time = d;
+    }
+    if( jo.has_member( "grace_period" ) ) {
+        if( !max_time.has_value() ) {
+            jo.throw_error( "grace_period requires max_time" );
+        }
+        time_duration d;
+        mandatory( jo, false, "grace_period", d );
+        grace_period = d;
+    }
+    optional( jo, false, "unattend_message", unattend_message );
 }
 
 static cata::value_ptr<parameterized_build_reqs> calculate_all_blueprint_reqs(
@@ -776,6 +807,20 @@ void recipe::finalize()
             step.requirements = std::accumulate(
                                     step.reqs_internal.begin(), step.reqs_internal.end(),
                                     step.requirements );
+            // TODO: charged-tool consumption is not modeled on unattended steps
+            // (the active 5%-loop debit path is bypassed).  Reject after
+            // requirements are fully resolved so step-level "using" injections
+            // are also caught.  Lift once metered charge debit is implemented.
+            if( step.attention == step_attention::unattended ) {
+                for( const std::vector<tool_comp> &tool_group : step.requirements.get_tools() ) {
+                    for( const tool_comp &t : tool_group ) {
+                        if( t.by_charges() ) {
+                            debugmsg( "recipe %s step '%s' is unattended and cannot require charged tools yet",
+                                      ident().str(), step.name.translated() );
+                        }
+                    }
+                }
+            }
             // Merge step requirements into recipe-level for whole-recipe gating
             requirements_ = requirements_ + step.requirements;
             step.reqs_internal.clear();
@@ -1763,6 +1808,16 @@ std::function<bool( const item & )> recipe::get_component_filter(
 bool recipe::npc_can_craft( std::string & ) const
 {
     return true;
+}
+
+bool recipe::has_attention_steps() const
+{
+    for( const recipe_step &s : steps_ ) {
+        if( s.attention != step_attention::none ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 bool recipe::is_practice() const

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1427,11 +1427,15 @@ float recipe::proficiency_time_maluses_for_step(
 }
 
 double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const crafting_cost_context &ctx ) const
+                                  const crafting_cost_context &ctx,
+                                  recipe_time_flag flags ) const
 {
     cata_assert( step_idx < steps_.size() );
     const recipe_step &s = steps_[step_idx];
-    double t = s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
+    double t = s.time;
+    if( ( flags & recipe_time_flag::ignore_proficiencies ) != recipe_time_flag::ignore_proficiencies ) {
+        t *= proficiency_time_maluses_for_step( guy, s, ctx.books );
+    }
     if( step_idx < ctx.tool_speeds.size() ) {
         t *= ctx.tool_speeds[step_idx];
     }

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -318,6 +318,7 @@ class recipe
             return steps_;
         }
         bool has_attention_steps() const;
+        bool has_remaining_attention_steps( int from_step ) const;
         // Returns aggregate proficiencies for step recipes, or the legacy
         // proficiencies field for stepless recipes.  This is a conservative
         // whole-recipe approximation used for display, gating, approximate

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -332,8 +332,11 @@ class recipe
             const book_proficiency_bonuses &books );
         // Per-step time budget in base moves (with proficiency malus and batch savings).
         // Same per-step formula that batch_time() uses internally.
+        // ignore_proficiencies skips the proficiency malus (passive steps run on
+        // wall-clock independent of crafter skill).
         double step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const crafting_cost_context &ctx ) const;
+                                  const crafting_cost_context &ctx,
+                                  recipe_time_flag flags = recipe_time_flag::none ) const;
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -18,6 +18,7 @@
 
 #include "build_reqs.h"
 #include "calendar.h"
+#include "crafting_enums.h"
 #include "proficiency.h"
 #include "requirements.h"
 #include "translations.h"
@@ -125,6 +126,13 @@ struct recipe_step {
     std::vector<std::pair<requirement_id, int>> reqs_internal;
     // Populated during finalize from reqs_internal
     requirement_data requirements;
+
+    step_attention attention = step_attention::none;
+    // nullopt = step waits indefinitely.
+    std::optional<time_duration> max_time;
+    // Buffer past max_time before destruction.  Requires max_time.
+    std::optional<time_duration> grace_period;
+    translation unattend_message;
 
     void load( const JsonObject &jo, const std::string &recipe_name, int step_index );
 };
@@ -309,6 +317,7 @@ class recipe
         const std::vector<recipe_step> &steps() const {
             return steps_;
         }
+        bool has_attention_steps() const;
         // Returns aggregate proficiencies for step recipes, or the legacy
         // proficiencies field for stepless recipes.  This is a conservative
         // whole-recipe approximation used for display, gating, approximate

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -24,6 +24,7 @@
 #include "hash_utils.h"
 #include "horde_entity.h"
 #include "input.h"
+#include "item_wakeup.h"
 #include "json.h"
 #include "json_loader.h"
 #include "kill_tracker.h"
@@ -1667,6 +1668,9 @@ void game::unserialize_master( const cata_path &file_name, std::istream &fin )
 
 void game::unserialize_master( const JsonValue &jv )
 {
+    // Reset state that has no clear-on-load hook of its own; otherwise a
+    // save without the field inherits the previous game's queue.
+    get_item_wakeups().clear();
     JsonObject game_json = jv;
     for( JsonMember jsin : game_json ) {
         std::string name = jsin.name();
@@ -1686,6 +1690,8 @@ void game::unserialize_master( const JsonValue &jv )
             weather_manager::unserialize_all( jsin );
         } else if( name == "timed_events" ) {
             timed_event_manager::unserialize_all( jsin );
+        } else if( name == "item_wakeups" ) {
+            get_item_wakeups().deserialize( jsin );
         } else if( name == "overmapbuffer" ) {
             overmap_buffer.global_state.deserialize( jsin );
         } else if( name == "placed_unique_specials" ) {
@@ -1887,6 +1893,9 @@ void game::serialize_master( std::ostream &fout )
 
         json.member( "timed_events" );
         timed_event_manager::serialize_all( json );
+
+        json.member( "item_wakeups" );
+        get_item_wakeups().serialize( json );
 
         json.member( "factions", *faction_manager_ptr );
         json.member( "seed", seed );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -55,6 +55,7 @@
 #include "construction.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting_enums.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "damage.h"
@@ -2816,6 +2817,12 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     if( crafter_id.is_valid() ) {
         jsout.member( "crafter_id", crafter_id );
     }
+    if( passive_start_counter != 0 ) {
+        jsout.member( "passive_start_counter", passive_start_counter );
+    }
+    if( passive_end_counter != 0 ) {
+        jsout.member( "passive_end_counter", passive_end_counter );
+    }
     jsout.end_object();
 }
 
@@ -2891,6 +2898,8 @@ void item::craft_data::deserialize( const JsonObject &obj )
     if( obj.has_member( "crafter_id" ) ) {
         obj.read( "crafter_id", crafter_id );
     }
+    passive_start_counter = obj.get_int( "passive_start_counter", 0 );
+    passive_end_counter = obj.get_int( "passive_end_counter", 0 );
     // Recipe-edit migration: drop stale passive runtime on shape mismatch.
     bool stale = false;
     if( making && !disassembly ) {
@@ -2899,11 +2908,12 @@ void item::craft_data::deserialize( const JsonObject &obj )
             stale = true;
         }
         if( !stale && passive_started_at != calendar::before_time_starts ) {
-            if( !making->has_steps() ) {
-                stale = true;
-            } else if( current_step >= 0
-                       && current_step < static_cast<int>( making->steps().size() )
-                       && making->steps()[current_step].attention != step_attention::unattended ) {
+            const bool no_steps = !making->has_steps();
+            const bool current_step_attended = making->has_steps()
+                                               && current_step >= 0
+                                               && current_step < static_cast<int>( making->steps().size() )
+                                               && making->steps()[current_step].attention != step_attention::unattended;
+            if( no_steps || current_step_attended ) {
                 stale = true;
             }
         }
@@ -2918,6 +2928,8 @@ void item::craft_data::deserialize( const JsonObject &obj )
         saved_ready_at = calendar::before_time_starts;
         saved_alarm_at = calendar::before_time_starts;
         saved_fail_at = calendar::before_time_starts;
+        passive_start_counter = 0;
+        passive_end_counter = 0;
     }
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2740,6 +2740,30 @@ void time_duration::deserialize( const JsonValue &jsin )
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 ///// item.h
 
+static const char *step_choice_to_string( step_choice c )
+{
+    switch( c ) {
+        case step_choice::do_wait:
+            return "do_wait";
+        case step_choice::do_something:
+            return "do_something";
+        case step_choice::set_timer:
+            return "set_timer";
+    }
+    return "do_wait";
+}
+
+static step_choice step_choice_from_string( const std::string &s )
+{
+    if( s == "do_something" ) {
+        return step_choice::do_something;
+    }
+    if( s == "set_timer" ) {
+        return step_choice::set_timer;
+    }
+    return step_choice::do_wait;
+}
+
 void item::craft_data::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
@@ -2752,6 +2776,46 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     jsout.member( "cached_tool_selections", cached_tool_selections );
     jsout.member( "current_step", current_step );
     jsout.member( "step_progress", step_progress );
+    if( !step_plans.empty() ) {
+        jsout.member( "step_plans" );
+        jsout.start_array();
+        for( const attention_plan &p : step_plans ) {
+            jsout.start_object();
+            jsout.member( "choice", step_choice_to_string( p.choice ) );
+            if( p.alarm_offset.has_value() ) {
+                jsout.member( "alarm_offset", *p.alarm_offset );
+            }
+            jsout.end_object();
+        }
+        jsout.end_array();
+    }
+    if( passive_started_at != calendar::before_time_starts ) {
+        jsout.member( "passive_started_at", passive_started_at );
+    }
+    if( ready_at != calendar::before_time_starts ) {
+        jsout.member( "ready_at", ready_at );
+    }
+    if( alarm_at != calendar::before_time_starts ) {
+        jsout.member( "alarm_at", alarm_at );
+    }
+    if( fail_at != calendar::before_time_starts ) {
+        jsout.member( "fail_at", fail_at );
+    }
+    if( pause_started_at != calendar::before_time_starts ) {
+        jsout.member( "pause_started_at", pause_started_at );
+    }
+    if( saved_ready_at != calendar::before_time_starts ) {
+        jsout.member( "saved_ready_at", saved_ready_at );
+    }
+    if( saved_alarm_at != calendar::before_time_starts ) {
+        jsout.member( "saved_alarm_at", saved_alarm_at );
+    }
+    if( saved_fail_at != calendar::before_time_starts ) {
+        jsout.member( "saved_fail_at", saved_fail_at );
+    }
+    if( crafter_id.is_valid() ) {
+        jsout.member( "crafter_id", crafter_id );
+    }
     jsout.end_object();
 }
 
@@ -2785,6 +2849,75 @@ void item::craft_data::deserialize( const JsonObject &obj )
     } else {
         current_step = 0;
         step_progress = 0.0;
+    }
+    step_plans.clear();
+    if( obj.has_array( "step_plans" ) ) {
+        for( JsonObject row : obj.get_array( "step_plans" ) ) {
+            row.allow_omitted_members();
+            attention_plan p;
+            p.choice = step_choice_from_string( row.get_string( "choice", "do_wait" ) );
+            if( row.has_member( "alarm_offset" ) ) {
+                time_duration d;
+                row.read( "alarm_offset", d );
+                p.alarm_offset = d;
+            }
+            step_plans.push_back( p );
+        }
+    }
+    if( obj.has_member( "passive_started_at" ) ) {
+        obj.read( "passive_started_at", passive_started_at );
+    }
+    if( obj.has_member( "ready_at" ) ) {
+        obj.read( "ready_at", ready_at );
+    }
+    if( obj.has_member( "alarm_at" ) ) {
+        obj.read( "alarm_at", alarm_at );
+    }
+    if( obj.has_member( "fail_at" ) ) {
+        obj.read( "fail_at", fail_at );
+    }
+    if( obj.has_member( "pause_started_at" ) ) {
+        obj.read( "pause_started_at", pause_started_at );
+    }
+    if( obj.has_member( "saved_ready_at" ) ) {
+        obj.read( "saved_ready_at", saved_ready_at );
+    }
+    if( obj.has_member( "saved_alarm_at" ) ) {
+        obj.read( "saved_alarm_at", saved_alarm_at );
+    }
+    if( obj.has_member( "saved_fail_at" ) ) {
+        obj.read( "saved_fail_at", saved_fail_at );
+    }
+    if( obj.has_member( "crafter_id" ) ) {
+        obj.read( "crafter_id", crafter_id );
+    }
+    // Recipe-edit migration: drop stale passive runtime on shape mismatch.
+    bool stale = false;
+    if( making && !disassembly ) {
+        if( !step_plans.empty() && making->has_steps() &&
+            step_plans.size() != making->steps().size() ) {
+            stale = true;
+        }
+        if( !stale && passive_started_at != calendar::before_time_starts ) {
+            if( !making->has_steps() ) {
+                stale = true;
+            } else if( current_step >= 0
+                       && current_step < static_cast<int>( making->steps().size() )
+                       && making->steps()[current_step].attention != step_attention::unattended ) {
+                stale = true;
+            }
+        }
+    }
+    if( stale ) {
+        step_plans.clear();
+        passive_started_at = calendar::before_time_starts;
+        ready_at = calendar::before_time_starts;
+        alarm_at = calendar::before_time_starts;
+        fail_at = calendar::before_time_starts;
+        pause_started_at = calendar::before_time_starts;
+        saved_ready_at = calendar::before_time_starts;
+        saved_alarm_at = calendar::before_time_starts;
+        saved_fail_at = calendar::before_time_starts;
     }
 }
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -190,6 +190,7 @@ class uistatedata
         bool distraction_mutation = true;
         bool distraction_oxygen = true;
         bool distraction_withdrawal = true;
+        bool distraction_craft_step_complete = true;
         bool distraction_all = true; // NOLINT(cata-serialize)
         bool numpad_navigation = false;
         bool is_toggle = false; // NOLINT(cata-serialize)

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -1,0 +1,847 @@
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_location.h"
+#include "item_uid.h"
+#include "item_wakeup.h"
+#include "json.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+
+static const itype_id itype_test_wakeup_dummy( "test_wakeup_dummy" );
+static const itype_id itype_test_wakeup_no_handler( "test_wakeup_no_handler" );
+static const vproto_id vehicle_prototype_bicycle( "bicycle" );
+
+namespace
+{
+
+struct fire_record {
+    int64_t uid;
+    item_wakeup_kind kind;
+    time_point when;
+};
+
+std::vector<fire_record> &fire_log()
+{
+    static std::vector<fire_record> log;
+    return log;
+}
+
+void dummy_handler( item &it, item_wakeup_kind kind, time_point now )
+{
+    fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
+}
+
+void install_test_handler()
+{
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+    register_test_wakeup_handler( itype_test_wakeup_dummy, &dummy_handler );
+}
+
+item_locator_hint hint_for_map( const tripoint_abs_ms &p )
+{
+    item_locator_hint h;
+    h.where = item_locator_hint::place::map;
+    h.location = p;
+    return h;
+}
+
+item_locator_hint hint_unknown()
+{
+    return item_locator_hint{};
+}
+
+}  // namespace
+
+
+TEST_CASE( "item_wakeup_lifecycle_basic", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 1, t, item_wakeup_kind::ready_check, hint_unknown() );
+
+    SECTION( "scheduled item appears in dump" ) {
+        REQUIRE( mgr.dump().size() == 1 );
+        CHECK( mgr.dump().front().uid == 1 );
+        CHECK( mgr.dump().front().kind == item_wakeup_kind::ready_check );
+        CHECK( mgr.dump().front().when == t );
+    }
+
+    SECTION( "is_scheduled and get reflect the entry" ) {
+        CHECK( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+        CHECK( mgr.get( 1, item_wakeup_kind::ready_check ).value() == t );
+        CHECK_FALSE( mgr.get( 2, item_wakeup_kind::ready_check ).has_value() );
+    }
+
+    SECTION( "cancel removes only matching kind" ) {
+        mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        mgr.cancel( 1, item_wakeup_kind::ready_check );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+    }
+
+    SECTION( "cancel_all removes every kind for uid" ) {
+        mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        mgr.schedule_or_update( 2, t, item_wakeup_kind::ready_check, hint_unknown() );
+        mgr.cancel_all( 1 );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::ready_check ) );
+        CHECK_FALSE( mgr.is_scheduled( 1, item_wakeup_kind::alarm ) );
+        CHECK( mgr.is_scheduled( 2, item_wakeup_kind::ready_check ) );
+    }
+}
+
+TEST_CASE( "item_wakeup_schedule_or_update_overwrites", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t1 = calendar::turn_zero + 5_minutes;
+    const time_point t2 = calendar::turn_zero + 10_minutes;
+    mgr.schedule_or_update( 1, t1, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 1, t2, item_wakeup_kind::ready_check, hint_unknown() );
+
+    REQUIRE( mgr.dump().size() == 1 );
+    CHECK( mgr.dump().front().when == t2 );
+}
+
+TEST_CASE( "item_wakeup_clear_resets_state", "[item_wakeup][lifecycle]" )
+{
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( 1, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.clear();
+    CHECK( mgr.dump().empty() );
+    CHECK( mgr.get_stats().total_pending == 0 );
+}
+
+
+TEST_CASE( "item_wakeup_fires_at_or_after_when", "[item_wakeup][firing]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item placed = item( itype_test_wakeup_dummy, calendar::turn );
+    item &on_map = here.add_item( origin, placed );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point fire_at = calendar::turn + 5_minutes;
+    mgr.schedule_or_update( uid, fire_at, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    SECTION( "before fire time, nothing fires" ) {
+        mgr.process( fire_at - 1_minutes );
+        CHECK( fire_log().empty() );
+        CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    }
+
+    SECTION( "at fire time, handler fires once and entry is consumed" ) {
+        mgr.process( fire_at );
+        REQUIRE( fire_log().size() == 1 );
+        CHECK( fire_log().front().uid == uid );
+        CHECK( fire_log().front().kind == item_wakeup_kind::ready_check );
+        CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    }
+
+    SECTION( "process well after fire time still fires once" ) {
+        mgr.process( fire_at + 1_hours );
+        CHECK( fire_log().size() == 1 );
+    }
+}
+
+TEST_CASE( "item_wakeup_fires_in_time_order", "[item_wakeup][firing]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &a = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    item &b = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid_a = a.uid().get_value();
+    const int64_t uid_b = b.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point t1 = calendar::turn + 1_minutes;
+    const time_point t2 = calendar::turn + 2_minutes;
+    const item_locator_hint h = hint_for_map( here.get_abs( origin ) );
+    mgr.schedule_or_update( uid_b, t2, item_wakeup_kind::ready_check, h );
+    mgr.schedule_or_update( uid_a, t1, item_wakeup_kind::ready_check, h );
+
+    mgr.process( t2 );
+    REQUIRE( fire_log().size() == 2 );
+    // Handlers receive `now`, not the original wakeup time, so uid order is
+    // the contract: earlier-scheduled wakeups dispatch first.
+    CHECK( fire_log()[0].uid == uid_a );
+    CHECK( fire_log()[1].uid == uid_b );
+}
+
+TEST_CASE( "item_wakeup_same_pass_reschedule_does_not_double_fire",
+           "[item_wakeup][firing]" )
+{
+    clear_map();
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager *mgr_ptr = nullptr;
+    auto rescheduling_handler = []( item & it, item_wakeup_kind kind, time_point now ) {
+        fire_log().push_back( fire_record{ it.uid().get_value(), kind, now } );
+        // Item handler reschedules itself for "now"; this MUST NOT fire again
+        // in the same process pass.
+        get_item_wakeups().schedule_or_update( it.uid().get_value(), now,
+                                               item_wakeup_kind::ready_check, hint_unknown() );
+    };
+    register_test_wakeup_handler( itype_test_wakeup_dummy, rescheduling_handler );
+
+    item_wakeup_manager &mgr = get_item_wakeups();
+    mgr.clear();
+    mgr_ptr = &mgr;
+    const time_point t = calendar::turn + 1_minutes;
+    mgr.schedule_or_update( uid, t, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    mgr.process( t );
+    CHECK( fire_log().size() == 1 );
+    // Re-scheduled entry remains pending until the next process pass.
+    CHECK( mgr_ptr->is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    mgr.clear();
+    clear_test_wakeup_handlers();
+}
+
+
+TEST_CASE( "item_wakeup_handler_called_once_per_fire", "[item_wakeup][idempotency]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn + 1_minutes;
+    mgr.schedule_or_update( uid, t, item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    mgr.process( t );
+    mgr.process( t + 1_hours );
+
+    CHECK( fire_log().size() == 1 );
+}
+
+
+TEST_CASE( "item_wakeup_default_enumerate_is_empty", "[item_wakeup][rebuild]" )
+{
+    item it( itype_test_wakeup_dummy, calendar::turn );
+    CHECK( it.enumerate_scheduled_wakeups().empty() );
+}
+
+TEST_CASE( "item_wakeup_rebuild_schedules_from_item", "[item_wakeup][rebuild]" )
+{
+    // Default-enumerate is empty, so rebuild_for_item must cancel any
+    // pre-existing entry for the item's uid.
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( uid, calendar::turn + 5_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+    CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+}
+
+
+TEST_CASE( "item_wakeup_resolve_on_map", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_location loc = find_item_by_uid( uid, hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_on_character", "[item_wakeup][resolve]" )
+{
+    clear_avatar();
+    avatar &u = get_avatar();
+    item carried( itype_test_wakeup_dummy, calendar::turn );
+    item_location placed = u.i_add( carried );
+    REQUIRE( placed );
+    const int64_t uid = placed->uid().get_value();
+
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::character;
+    hint.location = u.getID();
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_destroyed_item_returns_invalid", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    item_location loc = find_item_by_uid( 999999999, hint_unknown() );
+    CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_resolve_invalid_uid_returns_invalid", "[item_wakeup][resolve]" )
+{
+    item_location loc = find_item_by_uid( 0, hint_unknown() );
+    CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_resolve_falls_back_to_loaded_map", "[item_wakeup][resolve]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    const tripoint_bub_ms elsewhere( 65, 65, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( elsewhere,
+                                  item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    // Hint is wrong (points to origin, item is at elsewhere).  Map fallback
+    // should still resolve via reality-bubble scan.
+    item_location loc = find_item_by_uid( uid, hint_for_map( here.get_abs( origin ) ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_wrong_hint_falls_back_to_avatar", "[item_wakeup][resolve]" )
+{
+    clear_avatar();
+    avatar &u = get_avatar();
+    item carried( itype_test_wakeup_dummy, calendar::turn );
+    item_location placed = u.i_add( carried );
+    REQUIRE( placed );
+    const int64_t uid = placed->uid().get_value();
+
+    // Hint says map, but item is in inventory.  Fallback should find it.
+    item_location loc = find_item_by_uid( uid,
+                                          hint_for_map( tripoint_abs_ms{ 1, 1, 0 } ) );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+
+TEST_CASE( "item_wakeup_save_load_roundtrip", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    const time_point t = calendar::turn_zero + 10_minutes;
+    src.schedule_or_update( 100, t, item_wakeup_kind::ready_check,
+                            hint_for_map( tripoint_abs_ms{ 1, 2, 0 } ) );
+    src.schedule_or_update( 100, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+    src.schedule_or_update( 200, t + 2_minutes, item_wakeup_kind::fail_check, hint_unknown() );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.dump().size() == 3 );
+    CHECK( dst.is_scheduled( 100, item_wakeup_kind::ready_check ) );
+    CHECK( dst.is_scheduled( 100, item_wakeup_kind::alarm ) );
+    CHECK( dst.is_scheduled( 200, item_wakeup_kind::fail_check ) );
+}
+
+TEST_CASE( "item_wakeup_save_load_character_hint", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::character;
+    hint.location = character_id( 42 );
+    src.schedule_or_update( 7, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::alarm, hint );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.is_scheduled( 7, item_wakeup_kind::alarm ) );
+}
+
+TEST_CASE( "item_wakeup_save_load_vehicle_hint", "[item_wakeup][persistence]" )
+{
+    item_wakeup_manager src;
+    vehicle_hint vh;
+    vh.cargo_square = tripoint_abs_ms{ 10, 20, 0 };
+    vh.part_index = 3;
+    vh.mount_offset = point_rel_ms{ 1, 0 };
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+    src.schedule_or_update( 99, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    REQUIRE( dst.is_scheduled( 99, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_load_absent_version_treats_as_v1",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        JsonValue jv = json_loader::from_string( raw );
+        JsonObject jo = jv.get_object();
+        mgr.deserialize( jo );
+    } );
+    CHECK_FALSE( dmsg.empty() );
+    CHECK( mgr.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_load_dedupe_increments_duplicate_event_counter",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 200 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    CHECK( mgr.dump().size() == 1 );
+    CHECK( mgr.get_stats().duplicate_event == 1 );
+}
+
+TEST_CASE( "item_wakeup_load_drops_bad_entries", "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 0, "kind": "alarm", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 7, "kind": "garbage_kind", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    CHECK( mgr.dump().size() == 1 );
+    CHECK( mgr.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+    CHECK( mgr.get_stats().dropped_on_load == 2 );
+}
+
+TEST_CASE( "item_wakeup_load_unknown_version_drops_queue",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 999,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        JsonValue jv = json_loader::from_string( raw );
+        JsonObject jo = jv.get_object();
+        mgr.deserialize( jo );
+    } );
+    CHECK_FALSE( dmsg.empty() );
+    CHECK( mgr.dump().empty() );
+}
+
+TEST_CASE( "item_wakeup_load_dedupes_uid_kind_keeping_latest",
+           "[item_wakeup][persistence]" )
+{
+    const std::string raw = R"(
+        {
+            "version": 1,
+            "wakeups": [
+                { "uid": 5, "kind": "ready_check", "when": 100 },
+                { "uid": 5, "kind": "ready_check", "when": 200 }
+            ]
+        }
+    )";
+
+    item_wakeup_manager mgr;
+    JsonValue jv = json_loader::from_string( raw );
+    JsonObject jo = jv.get_object();
+    mgr.deserialize( jo );
+
+    REQUIRE( mgr.dump().size() == 1 );
+    const time_point persisted = mgr.get( 5, item_wakeup_kind::ready_check ).value();
+    CHECK( to_turn<int>( persisted ) == 200 );
+}
+
+
+TEST_CASE( "item_wakeup_dump_is_sorted_deterministically", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 3, t + 1_minutes, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 1, t + 1_minutes, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 2, t, item_wakeup_kind::alarm, hint_unknown() );
+    mgr.schedule_or_update( 2, t, item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::vector<scheduled_wakeup_info> d = mgr.dump();
+    REQUIRE( d.size() == 4 );
+    // Sorted by (when, uid, kind)
+    CHECK( d[0].uid == 2 );
+    CHECK( d[0].kind == item_wakeup_kind::alarm );
+    CHECK( d[1].uid == 2 );
+    CHECK( d[1].kind == item_wakeup_kind::ready_check );
+    CHECK( d[2].uid == 1 );
+    CHECK( d[3].uid == 3 );
+}
+
+TEST_CASE( "item_wakeup_peek_matches_dump_front", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+
+    SECTION( "empty manager returns nullopt" ) {
+        CHECK_FALSE( mgr.peek_next_wakeup().has_value() );
+    }
+
+    SECTION( "non-empty manager matches dump front" ) {
+        mgr.schedule_or_update( 5, t, item_wakeup_kind::ready_check, hint_unknown() );
+        mgr.schedule_or_update( 3, t + 1_minutes, item_wakeup_kind::alarm, hint_unknown() );
+        std::optional<scheduled_wakeup_info> peek = mgr.peek_next_wakeup();
+        REQUIRE( peek.has_value() );
+        CHECK( peek->uid == mgr.dump().front().uid );
+        CHECK( peek->kind == mgr.dump().front().kind );
+        CHECK( peek->when == mgr.dump().front().when );
+    }
+}
+
+TEST_CASE( "item_wakeup_total_pending_tracks_entry_count", "[item_wakeup][diag]" )
+{
+    item_wakeup_manager mgr;
+    CHECK( mgr.get_stats().total_pending == 0 );
+    mgr.schedule_or_update( 1, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::alarm, hint_unknown() );
+    CHECK( mgr.get_stats().total_pending == 1 );
+    mgr.schedule_or_update( 2, calendar::turn_zero + 2_minutes,
+                            item_wakeup_kind::alarm, hint_unknown() );
+    CHECK( mgr.get_stats().total_pending == 2 );
+    mgr.cancel( 1, item_wakeup_kind::alarm );
+    CHECK( mgr.get_stats().total_pending == 1 );
+}
+
+
+TEST_CASE( "item_wakeup_no_registered_handler_is_noop",
+           "[item_wakeup][firing]" )
+{
+    clear_map();
+    clear_test_wakeup_handlers();
+    fire_log().clear();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin,
+                                  item( itype_test_wakeup_no_handler, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.schedule_or_update( uid, calendar::turn + 1_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+    mgr.process( calendar::turn + 5_minutes );
+
+    CHECK( fire_log().empty() );
+    CHECK_FALSE( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+}
+
+
+namespace
+{
+std::vector<desired_wakeup> dummy_enumerator( const item &/*it*/ )
+{
+    return {
+        desired_wakeup{ item_wakeup_kind::ready_check, calendar::turn_zero + 5_minutes },
+        desired_wakeup{ item_wakeup_kind::fail_check, calendar::turn_zero + 10_minutes },
+    };
+}
+}  // namespace
+
+TEST_CASE( "item_wakeup_rebuild_schedules_from_producer", "[item_wakeup][rebuild]" )
+{
+    clear_map();
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, &dummy_enumerator );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::ready_check ) );
+    CHECK( mgr.is_scheduled( uid, item_wakeup_kind::fail_check ) );
+    CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
+           == calendar::turn_zero + 5_minutes );
+
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_rebuild_updates_existing_when", "[item_wakeup][rebuild]" )
+{
+    clear_map();
+    clear_test_enumerate_handlers();
+    register_test_enumerate_handler( itype_test_wakeup_dummy, &dummy_enumerator );
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &on_map = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid = on_map.uid().get_value();
+
+    item_wakeup_manager mgr;
+    // Pre-existing entry with a different time.
+    mgr.schedule_or_update( uid, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check,
+                            hint_for_map( here.get_abs( origin ) ) );
+
+    mgr.rebuild_for_item( on_map, hint_for_map( here.get_abs( origin ) ) );
+
+    CHECK( mgr.get( uid, item_wakeup_kind::ready_check ).value()
+           == calendar::turn_zero + 5_minutes );
+    clear_test_enumerate_handlers();
+}
+
+TEST_CASE( "item_wakeup_resolve_on_vehicle_cargo", "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    item dummy( itype_test_wakeup_dummy, calendar::turn );
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part, dummy );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    vehicle_hint vh;
+    vh.cargo_square = here.get_abs( veh->bub_part_pos( here, cargo_part ) );
+    vh.part_index = cargo_part_idx;
+    vh.mount_offset = cargo_part.mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_vehicle_stale_part_index_uses_mount",
+           "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms veh_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    const point_rel_ms saved_mount = cargo_part.mount;
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part,
+                       item( itype_test_wakeup_dummy, calendar::turn ) );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    vehicle_hint vh;
+    vh.cargo_square = here.get_abs( veh->bub_part_pos( here, cargo_part ) );
+    // Deliberately wrong part_index but valid mount_offset.
+    vh.part_index = veh->part_count() + 100;
+    vh.mount_offset = saved_mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+TEST_CASE( "item_wakeup_resolve_vehicle_moved_uses_loaded_scan",
+           "[item_wakeup][resolve][vehicle]" )
+{
+    clear_map();
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+
+    const tripoint_bub_ms initial_pos( 65, 65, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_bicycle, initial_pos,
+                                     0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    int cargo_part_idx = -1;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            cargo_part_idx = vpr.part_index();
+            break;
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    vehicle_part &cargo_part = veh->part( cargo_part_idx );
+    const tripoint_abs_ms saved_square = here.get_abs(
+            veh->bub_part_pos( here, cargo_part ) );
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( here, cargo_part,
+                       item( itype_test_wakeup_dummy, calendar::turn ) );
+    REQUIRE( added.has_value() );
+    const int64_t uid = ( *added )->uid().get_value();
+
+    // Move the vehicle one tile so the saved cargo_square no longer matches.
+    here.displace_vehicle( *veh, tripoint_rel_ms{ 1, 0, 0 } );
+
+    vehicle_hint vh;
+    vh.cargo_square = saved_square;
+    vh.part_index = cargo_part_idx;
+    vh.mount_offset = cargo_part.mount;
+    item_locator_hint hint;
+    hint.where = item_locator_hint::place::vehicle;
+    hint.location = vh;
+
+    item_location loc = find_item_by_uid( uid, hint );
+    REQUIRE( loc );
+    CHECK( loc.get_item()->uid().get_value() == uid );
+}
+
+
+TEST_CASE( "item_wakeup_resolve_off_bubble_returns_invalid",
+           "[item_wakeup][resolve]" )
+{
+    clear_map();
+    // tripoint_abs_ms far from the reality bubble origin.  inbounds() must
+    // reject it; resolution returns invalid without crashing.
+    const tripoint_abs_ms far_away{ 1000000, 1000000, 0 };
+    item_location loc = find_item_by_uid( 12345, hint_for_map( far_away ) );
+    CHECK_FALSE( loc );
+}

--- a/tests/item_wakeup_test.cpp
+++ b/tests/item_wakeup_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -844,4 +845,131 @@ TEST_CASE( "item_wakeup_resolve_off_bubble_returns_invalid",
     const tripoint_abs_ms far_away{ 1000000, 1000000, 0 };
     item_location loc = find_item_by_uid( 12345, hint_for_map( far_away ) );
     CHECK_FALSE( loc );
+}
+
+TEST_CASE( "item_wakeup_update_displaces_top", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t_early = calendar::turn_zero + 1_minutes;
+    const time_point t_late = calendar::turn_zero + 10_minutes;
+
+    mgr.schedule_or_update( 5, t_early, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 9, t_early + 1_minutes, item_wakeup_kind::ready_check,
+                            hint_unknown() );
+    mgr.schedule_or_update( 5, t_late, item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 9 );
+    CHECK( top->when == t_early + 1_minutes );
+    CHECK( mgr.get_stats().total_pending == 2 );
+}
+
+TEST_CASE( "item_wakeup_cancel_top_lets_next_fire", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t_early = calendar::turn_zero + 1_minutes;
+    const time_point t_late = calendar::turn_zero + 5_minutes;
+
+    mgr.schedule_or_update( 1, t_early, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 2, t_late, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.cancel( 1, item_wakeup_kind::ready_check );
+
+    std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 2 );
+    CHECK( top->when == t_late );
+}
+
+TEST_CASE( "item_wakeup_serialize_after_update_drops_tombstones",
+           "[item_wakeup][heap][persistence]" )
+{
+    item_wakeup_manager src;
+    src.schedule_or_update( 5, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.schedule_or_update( 5, calendar::turn_zero + 10_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.cancel( 5, item_wakeup_kind::ready_check );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    CHECK( dst.get_stats().total_pending == 0 );
+    CHECK_FALSE( dst.is_scheduled( 5, item_wakeup_kind::ready_check ) );
+}
+
+TEST_CASE( "item_wakeup_peek_tiebreak_matches_dump_order", "[item_wakeup][heap]" )
+{
+    item_wakeup_manager mgr;
+    const time_point t = calendar::turn_zero + 5_minutes;
+    mgr.schedule_or_update( 5, t, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 5, t, item_wakeup_kind::alarm, hint_unknown() );
+    mgr.schedule_or_update( 3, t, item_wakeup_kind::ready_check, hint_unknown() );
+    mgr.schedule_or_update( 3, t, item_wakeup_kind::alarm, hint_unknown() );
+
+    const std::vector<scheduled_wakeup_info> sorted = mgr.dump();
+    REQUIRE( sorted.size() == 4 );
+    const std::optional<scheduled_wakeup_info> top = mgr.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == sorted.front().uid );
+    CHECK( top->kind == sorted.front().kind );
+    CHECK( top->when == sorted.front().when );
+}
+
+TEST_CASE( "item_wakeup_dispatch_order_with_equal_when", "[item_wakeup][heap]" )
+{
+    clear_map();
+    install_test_handler();
+
+    avatar &u = get_avatar();
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    u.setpos( here, origin );
+    item &a = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    item &b = here.add_item( origin, item( itype_test_wakeup_dummy, calendar::turn ) );
+    const int64_t uid_a = a.uid().get_value();
+    const int64_t uid_b = b.uid().get_value();
+    const int64_t small_uid = std::min( uid_a, uid_b );
+    const int64_t large_uid = std::max( uid_a, uid_b );
+
+    item_wakeup_manager mgr;
+    const time_point fire_at = calendar::turn + 1_minutes;
+    const item_locator_hint h = hint_for_map( here.get_abs( origin ) );
+    mgr.schedule_or_update( large_uid, fire_at, item_wakeup_kind::ready_check, h );
+    mgr.schedule_or_update( small_uid, fire_at, item_wakeup_kind::ready_check, h );
+
+    mgr.process( fire_at );
+    REQUIRE( fire_log().size() == 2 );
+    CHECK( fire_log()[0].uid == small_uid );
+    CHECK( fire_log()[1].uid == large_uid );
+}
+
+TEST_CASE( "item_wakeup_deserialize_restores_heap_invariant",
+           "[item_wakeup][heap][persistence]" )
+{
+    item_wakeup_manager src;
+    src.schedule_or_update( 9, calendar::turn_zero + 5_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+    src.schedule_or_update( 1, calendar::turn_zero + 1_minutes,
+                            item_wakeup_kind::ready_check, hint_unknown() );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    src.serialize( jsout );
+
+    item_wakeup_manager dst;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv.get_object();
+    dst.deserialize( jo );
+
+    std::optional<scheduled_wakeup_info> top = dst.peek_next_wakeup();
+    REQUIRE( top.has_value() );
+    CHECK( top->uid == 1 );
+    CHECK( top->when == calendar::turn_zero + 1_minutes );
 }


### PR DESCRIPTION
#### Summary
Backport 86899 - add item-targeted wakeup scheduler

#### Purpose of change

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
