### PR TITLE
(Innawood) (mostly) fix ravines

### DIFF
--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -378,6 +378,16 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "1x1_solid_earth",
+    "object": { "mapgensize": [ 1, 1 ], "terrain": { " ": "t_soil" }, "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "1x1_solid_rock",
+    "object": { "mapgensize": [ 1, 1 ], "terrain": { " ": "t_rock" }, "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
+  },
+  {
+    "type": "mapgen",
     "//": "A nested map bash damage.",
     "nested_mapgen_id": "1x1_2z_bash",
     "object": {

--- a/data/mods/innawood/mapgen/ravine_mutable.json
+++ b/data/mods/innawood/mapgen/ravine_mutable.json
@@ -240,8 +240,18 @@
     ]
   },
   {
+    "type": "palette",
+    "id": "ravine_edge_parameters",
+    "parameters": {
+      "variant": {
+        "type": "nested_mapgen_id",
+        "scope": "omt_stack",
+        "default": { "distribution": [ "24x24_ravine_edge_v1", "24x24_ravine_edge_v2" ] }
+      }
+    }
+  },
+  {
     "type": "mapgen",
-    "//": "z0",
     "om_terrain": "ravine_edge_ground",
     "object": {
       "fallback_predecessor_mapgen": "forest",
@@ -251,7 +261,6 @@
   },
   {
     "type": "mapgen",
-    "//": "z-1",
     "om_terrain": "ravine_edge",
     "object": {
       "predecessor_mapgen": "open_air",
@@ -261,7 +270,6 @@
   },
   {
     "type": "mapgen",
-    "//": "z-2",
     "om_terrain": "ravine_edge_bottom",
     "object": {
       "predecessor_mapgen": "forest",

--- a/data/mods/innawood/mapgen_palettes/ravine.json
+++ b/data/mods/innawood/mapgen_palettes/ravine.json
@@ -2,17 +2,13 @@
   {
     "type": "palette",
     "id": "ravine",
-    "nested": { "#": { "else_chunks": [ "1x1_ground" ], "check_z": [ 0 ] }, " ": { "chunks": [ "1x1_open_air" ], "check_z": [ 0 ] } }
-  },
-  {
-    "type": "palette",
-    "id": "ravine_edge_parameters",
-    "parameters": {
-      "variant": {
-        "type": "nested_mapgen_id",
-        "scope": "omt_stack",
-        "default": { "distribution": [ "24x24_ravine_edge_v1", "24x24_ravine_edge_v2" ] }
-      }
+    "nested": {
+      "#": [
+        { "chunks": [ "1x1_ground" ], "check_z": [ 0 ] },
+        { "chunks": [ "1x1_solid_earth" ], "check_z": [ -1 ] },
+        { "chunks": [ "1x1_solid_rock" ], "check_z": [ -2 ] }
+      ],
+      " ": { "chunks": [ "1x1_open_air" ], "check_z": [ 0 ] }
     }
   }
 ]

--- a/data/mods/innawood/region_settings/region_settings/region_overlay.json
+++ b/data/mods/innawood/region_settings/region_settings/region_overlay.json
@@ -88,13 +88,13 @@
     "type": "forest_biome_mapgen",
     "id": "biome_forest_thick_default",
     "copy-from": "biome_forest_thick_default",
-    "extend": { "terrains": [ "ravine", "ravine_2way", "ravine_3way", "ravine_edge", "ravine_corner", "ravine_edge_ground" ] }
+    "extend": { "terrains": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_edge_ground", "ravine_corner_ground" ] }
   },
   {
     "type": "forest_biome_mapgen",
     "id": "biome_forest_default",
     "copy-from": "biome_forest_default",
-    "extend": { "terrains": [ "ravine", "ravine_2way", "ravine_3way", "ravine_edge", "ravine_corner", "ravine_edge_ground" ] }
+    "extend": { "terrains": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_edge_ground", "ravine_corner_ground" ] }
   },
   {
     "type": "region_settings",


### PR DESCRIPTION
#### Summary
(mostly) fix ravines

#### Purpose of change
Ravines were really weird, they generated perfectly well on the surface, but left huge open square spaces beneath the natural-looking ledge. This was clearly unintentional.

#### Describe the solution
- Specify in the palette when ground chunks get placed (when z is 0) and when solid earth or solid rock chunks get placed (-1 and -2).
- Clean up some of the formatting.

#### Testing
- ravine_edge at z-1 sometimes fails to place a chunk. There is no error message. I cannot fathom what could be happening here except that the mutable is somehow malformed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
