### PR TITLE
Backport 86668 - speed up item spawning

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -41,6 +41,7 @@
 #include "enums.h"
 #include "faction.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"

--- a/src/event_field_transformations.cpp
+++ b/src/event_field_transformations.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "coordinates.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "itype.h"
 #include "mapdata.h"
 #include "mtype.h"

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -39,6 +39,7 @@
 #include "event_bus.h"
 #include "field_type.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "fungal_effects.h"
 #include "game.h"
 #include "game_constants.h"

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6597,7 +6597,7 @@ void item::update_inherited_flags()
     auto const inehrit_flags = [this]( FlagsSetType const & Flags ) {
         for( flag_id const &f : Flags ) {
             if( f->inherit() ) {
-                inherited_tags_cache.emplace( f );
+                inherited_tags_cache.insert( f );
             }
         }
     };
@@ -6646,10 +6646,10 @@ void item::update_prefix_suffix_flags()
 void item::update_prefix_suffix_flags( const flag_id &f )
 {
     if( !f->item_prefix().empty() ) {
-        prefix_tags_cache.emplace( f );
+        prefix_tags_cache.insert( f );
     }
     if( !f->item_suffix().empty() ) {
-        suffix_tags_cache.emplace( f );
+        suffix_tags_cache.insert( f );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1900,12 +1900,14 @@ int item::insert_cost( const item &it ) const
 }
 
 ret_val<void> item::put_in( const item &payload, pocket_type pk_type,
-                            const bool unseal_pockets, Character *carrier )
+                            const bool unseal_pockets, Character *carrier, const bool quiet )
 {
     ret_val<item *> result = contents.insert_item( payload, pk_type, false, unseal_pockets );
     if( !result.success() ) {
-        debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
-                  payload.typeId().str(), payload.count(), typeId().str(), result.str() );
+                if( !quiet ) {
+            debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
+                      payload.typeId().str(), payload.count(), typeId().str(), result.str() );
+        }
         return ret_val<void>::make_failure( result.str() );
     }
     if( pk_type == pocket_type::MOD ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1737,15 +1737,16 @@ bool _stacks_components( item const &lhs, item const &rhs, bool check_components
 stacking_info item::stacks_with( const item &rhs, bool check_components, bool combine_liquid,
                                  bool check_cat, int depth, int maxdepth, bool precise ) const
 {
+    // Type mismatch cannot stack without a CATEGORY check.
+    if( type != rhs.type && !check_cat ) {
+        return {};
+    }
+
     tname::segment_bitset bits;
     if( type == rhs.type ) {
         bits.set( tname::segments::TYPE );
         bits.set( tname::segments::WHEEL_DIAMETER );
         bits.set( tname::segments::WHITEBLACKLIST, _stacks_whiteblacklist( *this, rhs ) );
-    }
-
-    if( !check_cat && bits.none() ) {
-        return {};
     }
 
     bits.set( tname::segments::CATEGORY,
@@ -7572,26 +7573,19 @@ bool item::has_own_flag( const flag_id &f ) const
 
 bool item::has_flag( const flag_id &f ) const
 {
-    bool ret = false;
     if( !f.is_valid() ) {
         debugmsg( "Attempted to check invalid flag_id %s", f.str() );
         return false;
     }
 
-    ret = inherited_tags_cache.find( f ) != inherited_tags_cache.end();
-    if( ret ) {
-        return ret;
+    // Itype flags cover the common case; check them first.
+    if( type->has_flag( f ) ) {
+        return true;
     }
-
-    // other item type flags
-    ret = type->has_flag( f );
-    if( ret ) {
-        return ret;
+    if( inherited_tags_cache.find( f ) != inherited_tags_cache.end() ) {
+        return true;
     }
-
-    // now check for item specific flags
-    ret = has_own_flag( f );
-    return ret;
+    return has_own_flag( f );
 }
 
 item &item::set_flag( const flag_id &flag )

--- a/src/item.h
+++ b/src/item.h
@@ -996,10 +996,12 @@ class item : public visitable
         int insert_cost( const item &it ) const;
 
         /**
-         * Puts the given item into this one.
+         * Puts the given item into this one. When @p quiet is true, failure
+         * returns silently instead of triggering a debugmsg.
          */
         ret_val<void> put_in( const item &payload, pocket_type pk_type,
-                              bool unseal_pockets = false, Character *carrier = nullptr );
+                              bool unseal_pockets = false, Character *carrier = nullptr,
+                              bool quiet = false );
         void force_insert_item( const item &it, pocket_type pk_type );
 
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -25,6 +25,7 @@
 #include "craft_command.h"
 #include "crafting_enums.h"
 #include "enums.h"
+#include "flat_set.h"
 #include "global_vars.h"
 #include "gun_mode.h"
 #include "io_tags.h"
@@ -207,7 +208,7 @@ struct stacking_info {
 class item : public visitable
 {
     public:
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         item();
 

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1028,7 +1028,9 @@ std::set<flag_id> item_contents::magazine_flag_restrictions() const
     std::set<flag_id> ret;
     for( const item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            ret = pocket.get_pocket_data()->get_flag_restrictions();
+            const pocket_data::FlagsSetType &src = pocket.get_pocket_data()->get_flag_restrictions();
+            ret.clear();
+            ret.insert( src.begin(), src.end() );
         }
     }
     return ret;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -137,31 +137,32 @@ static void put_into_container(
     // a group spawns many items into one container, e.g. container depots).
     ctr.begin_bulk_fill();
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
-        ret_val<void> ret = ctr.can_contain_directly( *it );
+        // quiet=true: caller handles failure via the overflow path below.
+        const pocket_type pk_type = guess_pocket_for( ctr, *it );
+        ret_val<void> ret = ctr.put_in( *it, pk_type, false, nullptr, /*quiet=*/true );
         if( ret.success() ) {
-            const pocket_type pk_type = guess_pocket_for( ctr, *it );
-            ctr.put_in( *it, pk_type );
-        } else if( ctr.is_corpse() ) {
-            const pocket_type pk_type = guess_pocket_for( ctr, *it );
+            continue;
+        }
+        if( ctr.is_corpse() ) {
             ctr.force_insert_item( *it, pk_type );
-        } else {
-            switch( on_overflow ) {
-                case Item_spawn_data::overflow_behaviour::none:
-                    debugmsg( "item %s could not be put in container %s when spawning item group %s: %s.  "
-                              "This can be resolved either by changing the container or contents "
-                              "to ensure that they fit, or by specifying an overflow behaviour via "
-                              "\"on_overflow\" on the item group.",
-                              it->typeId().str(), container_type->str(), context, ret.str() );
-                    break;
-                case Item_spawn_data::overflow_behaviour::spill:
-                    excess.push_back( *it );
-                    break;
-                case Item_spawn_data::overflow_behaviour::discard:
-                    break;
-                case Item_spawn_data::overflow_behaviour::last:
-                    debugmsg( "Invalid overflow_behaviour" );
-                    break;
-            }
+            continue;
+        }
+        switch( on_overflow ) {
+            case Item_spawn_data::overflow_behaviour::none:
+                debugmsg( "item %s could not be put in container %s when spawning item group %s: %s.  "
+                          "This can be resolved either by changing the container or contents "
+                          "to ensure that they fit, or by specifying an overflow behaviour via "
+                          "\"on_overflow\" on the item group.",
+                          it->typeId().str(), container_type->str(), context, ret.str() );
+                break;
+            case Item_spawn_data::overflow_behaviour::spill:
+                excess.push_back( *it );
+                break;
+            case Item_spawn_data::overflow_behaviour::discard:
+                break;
+            case Item_spawn_data::overflow_behaviour::last:
+                debugmsg( "Invalid overflow_behaviour" );
+                break;
         }
     }
     ctr.end_bulk_fill();
@@ -833,6 +834,7 @@ void Item_group::add_entry( std::unique_ptr<Item_spawn_data> ptr )
         sic->inherit_ammo_mag_chances( with_ammo, with_magazine );
     }
     items.push_back( std::move( ptr ) );
+    cached_cum_prob.clear();
 }
 
 std::size_t Item_group::create( Item_spawn_data::ItemList &list,
@@ -847,17 +849,8 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
             elem->create( list, birthday, rec, flags );
         }
     } else if( type == G_DISTRIBUTION ) {
-        int p = rng( 0, sum_prob - 1 );
-        for( const auto &elem : items ) {
-            bool ev_based = elem->is_event_based();
-            int prob = elem->get_probability( false );
-            int real_prob = elem->get_probability( true );
-            p -= real_prob;
-            if( ( ev_based && prob == 0 ) || p >= 0 ) {
-                continue;
-            }
+        if( const Item_spawn_data *elem = pick_distribution_entry() ) {
             elem->create( list, birthday, rec, flags );
-            break;
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
@@ -877,19 +870,40 @@ item Item_group::create_single( const time_point &birthday, RecursionList &rec )
             return elem->create_single( birthday, rec );
         }
     } else if( type == G_DISTRIBUTION ) {
-        int p = rng( 0, sum_prob - 1 );
-        for( const auto &elem : items ) {
-            bool ev_based = elem->is_event_based();
-            int prob = elem->get_probability( false );
-            int real_prob = elem->get_probability( true );
-            p -= real_prob;
-            if( ( ev_based && prob == 0 ) || p >= 0 ) {
-                continue;
-            }
+        if( const Item_spawn_data *elem = pick_distribution_entry() ) {
             return elem->create_single( birthday, rec );
         }
     }
     return item( itype_id::NULL_ID(), birthday );
+}
+
+const Item_spawn_data *Item_group::pick_distribution_entry() const
+{
+    if( sum_prob <= 0 || items.empty() ) {
+        return nullptr;
+    }
+    // Lazy cumulative-probability table for binary-search picks.
+    if( cached_cum_prob.size() != items.size() ) {
+        cached_cum_prob.clear();
+        cached_cum_prob.reserve( items.size() );
+        int acc = 0;
+        for( const std::unique_ptr<Item_spawn_data> &elem : items ) {
+            acc += elem->get_probability( true );
+            cached_cum_prob.push_back( acc );
+        }
+    }
+    const int picked = rng( 1, sum_prob );
+    const auto it = std::lower_bound( cached_cum_prob.begin(), cached_cum_prob.end(), picked );
+    if( it == cached_cum_prob.end() ) {
+        return nullptr;
+    }
+    const Item_spawn_data *elem = items[std::distance( cached_cum_prob.begin(), it )].get();
+    // Event-based entries reserve their slot in sum_prob even when inactive:
+    // a pick that lands on one yields no spawn rather than falling through.
+    if( elem->is_event_based() && elem->get_probability( false ) == 0 ) {
+        return nullptr;
+    }
+    return elem;
 }
 
 void Item_group::check_consistency( bool actually_spawn ) const
@@ -926,6 +940,7 @@ bool Item_group::remove_item( const itype_id &itemid )
         if( ( *a )->remove_item( itemid ) ) {
             sum_prob -= ( *a )->get_probability( true );
             a = items.erase( a );
+            cached_cum_prob.clear();
         } else {
             ++a;
         }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -410,6 +410,12 @@ class Item_group : public Item_spawn_data
 
     protected:
         /**
+         * Sample one entry from a G_DISTRIBUTION. Returns nullptr when the
+         * distribution is empty or the pick lands on an inactive event-based
+         * entry. Requires type == G_DISTRIBUTION.
+         */
+        const Item_spawn_data *pick_distribution_entry() const;
+        /**
          * Contains the sum of the probability of all entries
          * that this group contains.
          */
@@ -418,6 +424,11 @@ class Item_group : public Item_spawn_data
          * Links to the entries in this group.
          */
         prop_list items;
+        /**
+         * Cumulative probability table, lazily built for binary-search
+         * picks; cleared when @ref items mutates.
+         */
+        mutable std::vector<int> cached_cum_prob;
 };
 
 #endif // CATA_SRC_ITEM_GROUP_H

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2519,27 +2519,28 @@ units::mass item_pocket::remaining_weight() const
 
 int item_pocket::charges_per_remaining_volume( const item &it ) const
 {
-    if( it.count_by_charges() ) {
-        units::volume non_it_volume = volume_capacity();
-        int contained_charges = 0;
-        for( const item &contained : contents ) {
-            if( contained.stacks_with( it ) ) {
-                contained_charges += contained.charges;
-            } else {
-                non_it_volume -= contained.volume();
-            }
-        }
-        return it.charges_per_volume( non_it_volume, true ) - contained_charges;
-    } else {
+    if( !it.count_by_charges() ) {
         return it.charges_per_volume( remaining_volume(), true );
     }
-    // Single pass: subtract the volume of every item that doesn't stack with
-    // `it`, and tally charges of those that do. When nothing stacks this
-    // reduces to volume_capacity() - contains_volume() == remaining_volume().
+    // Skip contents walk when no typeId match is possible.
+    bool any_same_type = false;
+    for( const item &contained : contents ) {
+        if( contained.typeId() == it.typeId() ) {
+            any_same_type = true;
+            break;
+        }
+    }
+    if( !any_same_type ) {
+        return it.charges_per_volume( remaining_volume(), true );
+    }
     units::volume non_it_volume = volume_capacity();
     int contained_charges = 0;
     for( const item &contained : contents ) {
-        if( contained.typeId() == it.typeId() && contained.stacks_with( it ) ) {
+        if( contained.typeId() != it.typeId() ) {
+            non_it_volume -= contained.volume();
+            continue;
+        }
+        if( contained.stacks_with( it ) ) {
             contained_charges += contained.charges;
         } else {
             non_it_volume -= contained.volume();
@@ -2550,27 +2551,27 @@ int item_pocket::charges_per_remaining_volume( const item &it ) const
 
 int item_pocket::charges_per_remaining_weight( const item &it ) const
 {
-    if( it.count_by_charges() ) {
-        units::mass non_it_weight = weight_capacity();
-        int contained_charges = 0;
-        for( const item &contained : contents ) {
-            if( contained.stacks_with( it ) ) {
-                contained_charges += contained.charges;
-            } else {
-                non_it_weight -= contained.weight();
-            }
-        }
-        return it.charges_per_weight( non_it_weight, true ) - contained_charges;
-    } else {
+    if( !it.count_by_charges() ) {
         return it.charges_per_weight( remaining_weight(), true );
     }
-    // Single pass: subtract the weight of every item that doesn't stack with
-    // `it`, and tally charges of those that do. When nothing stacks this
-    // reduces to weight_capacity() - contains_weight() == remaining_weight().
+    bool any_same_type = false;
+    for( const item &contained : contents ) {
+        if( contained.typeId() == it.typeId() ) {
+            any_same_type = true;
+            break;
+        }
+    }
+    if( !any_same_type ) {
+        return it.charges_per_weight( remaining_weight(), true );
+    }
     units::mass non_it_weight = weight_capacity();
     int contained_charges = 0;
     for( const item &contained : contents ) {
-        if( contained.typeId() == it.typeId() && contained.stacks_with( it ) ) {
+        if( contained.typeId() != it.typeId() ) {
+            non_it_weight -= contained.weight();
+            continue;
+        }
+        if( contained.stacks_with( it ) ) {
             contained_charges += contained.charges;
         } else {
             non_it_weight -= contained.weight();

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -471,7 +471,7 @@ struct pocket_noise {
 class pocket_data
 {
     public:
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         bool was_loaded = false;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -19,6 +19,7 @@
 #include "damage.h"
 #include "enums.h" // point
 #include "explosion.h"
+#include "flat_set.h"
 #include "flexbuffer_json.h"
 #include "game_constants.h"
 #include "global_vars.h"
@@ -1272,7 +1273,7 @@ struct itype {
         friend class Item_factory;
         friend struct mod_tracker;
 
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         /**
          * Slots for various item type properties. Each slot may contain a valid pointer or null, check

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -49,6 +49,8 @@
 #include "field.h"
 #include "field_type.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
+#include "flexbuffer_json.h"
 #include "fungal_effects.h"
 #include "game.h"
 #include "game_constants.h"

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -282,30 +282,33 @@ template <typename T> struct weighted_int_list : public weighted_list<T, int> {
             if( this->objects.size() == 1 ) {
                 return 0;
             }
-            size_t i;
             const int picked = ( randi % ( this->total_weight ) ) + 1;
             if( !precalc_array.empty() ) {
                 // if the precalc_array is populated, use it for O(1) lookup
-                i = precalc_array[picked - 1];
-            } else {
-                // otherwise do O(N) search through items
-                int accumulated_weight = 0;
-                for( i = 0; i < this->objects.size(); i++ ) {
-                    accumulated_weight += this->objects[i].second;
-                    if( accumulated_weight >= picked ) {
-                        break;
-                    }
+                return precalc_array[picked - 1];
+            }
+            // lazy-populate cumulative-weight table for O(log N) binary search
+            if( cum_weights.size() != this->objects.size() ) {
+                cum_weights.clear();
+                cum_weights.reserve( this->objects.size() );
+                int acc = 0;
+                for( const std::pair<T, int> &o : this->objects ) {
+                    acc += o.second;
+                    cum_weights.push_back( acc );
                 }
             }
-            return i;
+            return std::distance( cum_weights.begin(),
+                                  std::lower_bound( cum_weights.begin(), cum_weights.end(), picked ) );
         }
 
         void invalidate_precalc() override {
             precalc_array.clear();
+            cum_weights.clear();
         }
 
         int default_weight = 1;
         std::vector<int> precalc_array;
+        mutable std::vector<int> cum_weights;
 };
 
 static_assert( std::is_nothrow_move_constructible_v<weighted_int_list<int>> );


### PR DESCRIPTION
#### Summary
Backport 86668 - speed up item spawning

#### Purpose of change

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
