### PR TITLE
increase clay bullet result amount

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -24,6 +24,7 @@
     "time": "45 m",
     "autolearn": true,
     "tools": [ [ [ "fake_clay_kiln", 10 ], [ "kiln", 10 ], [ "surface_heat", 10, "LIST" ] ] ],
+    "result_mult": 10,
     "components": [ [ [ "any_water", 1, "LIST" ] ], [ [ "clay_lump", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Increase clay bullet result amount. For comparison, one unit of rock creates 10 units of pebble. One lump of clay has the same volume as one rock. The recipe for lead sling bullets also results in 10 units.

#### Purpose of change
Increase the result of clay sling bullet recipe to 10.

#### Describe the solution
Add `"result_mult": 10,` to the clay sling bullet recipe json

#### Describe alternatives you've considered
None.

#### Testing
Before:
<img width="894" height="497" alt="image" src="https://github.com/user-attachments/assets/2290d5a4-9d5f-4cac-8459-65cb7e122b56" />

After:
<img width="1015" height="562" alt="image" src="https://github.com/user-attachments/assets/bfe97e83-3ae1-4dbf-ac32-a1433c5d0aad" />

#### Additional context
None.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
