### PR TITLE
fix mending limbs

### DIFF
--- a/data/json/mutations/mutation_limbs.json
+++ b/data/json/mutations/mutation_limbs.json
@@ -693,6 +693,7 @@
     "squeamish_penalty": 5,
     "base_hp": 46,
     "drench_capacity": 600,
+    "mend_rate": 150,
     "smash_message": "You tail-slap the %s.",
     "flags": [ "LIMB_LOWER", "LIMB_BONELESS" ],
     "sub_parts": [ "fish_tail_base", "fish_tail_tip", "fish_tail_draped" ],
@@ -806,6 +807,7 @@
     "squeamish_penalty": 5,
     "base_hp": 46,
     "drench_capacity": 600,
+    "mend_rate": 150,
     "smash_message": "You tail-whip the %s.",
     "flags": [ "LIMB_LOWER", "LIMB_BONELESS" ],
     "sub_parts": [ "long_tail_base", "long_tail_tip", "long_tail_draped" ],
@@ -912,7 +914,7 @@
     "opposite_part": "cephalopod_arm_4",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],
@@ -1041,7 +1043,7 @@
     "opposite_part": "cephalopod_arm_5",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],
@@ -1170,7 +1172,7 @@
     "opposite_part": "cephalopod_arm_6",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],
@@ -1299,7 +1301,7 @@
     "opposite_part": "cephalopod_arm_1",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],
@@ -1428,7 +1430,7 @@
     "opposite_part": "cephalopod_arm_2",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],
@@ -1557,7 +1559,7 @@
     "opposite_part": "cephalopod_arm_3",
     "hit_size": 4,
     "hit_difficulty": 0.85,
-    "mend_rate": 400,
+    "mend_rate": 300,
     "limb_types": [ [ "arm", 1.0 ], [ "hand", 1.0 ], [ "leg", 1.0 ], [ "foot", 1.0 ] ],
     "limb_scores": [
       [ "manip", 0.12, 1.1 ],

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1282,8 +1282,8 @@ bodypart_id Character::body_window( const std::string &menu_header,
         const nc_color all_state_col = display::limb_color( *this, bp, true, true, true );
         // Broken means no HP can be restored, it requires surgical attention.
         const bool limb_is_broken = is_limb_broken( bp );
-        const bool limb_is_mending = worn_with_flag( flag_SPLINT, bp ) ||
-                                     bp->has_flag( json_flag_LIMB_BONELESS );
+        const bool limb_is_mending = limb_is_broken && ( worn_with_flag( flag_SPLINT, bp ) ||
+                                     bp->has_flag( json_flag_LIMB_BONELESS ) );
         // How much this treatment would help, if applied to this bodypart.
         // The value itself is just a sorting number and has no actual meaning in itself, but is roughly ranged at:
         // 0-30=bandage, 30-60=disinfectant, 60-70=bitten/infected, 70-80=bleeding

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1905,7 +1905,7 @@ ret_val<void> item::put_in( const item &payload, pocket_type pk_type,
 {
     ret_val<item *> result = contents.insert_item( payload, pk_type, false, unseal_pockets );
     if( !result.success() ) {
-                if( !quiet ) {
+        if( !quiet ) {
             debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
                       payload.typeId().str(), payload.count(), typeId().str(), result.str() );
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2304,13 +2304,13 @@ void monster::stumble()
     }
     const tripoint_bub_ms above( pos_bub() + tripoint::above );
     const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
-                            !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
+                          !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
     const bool ladder_up = here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() ) &&
-                            can_climb() &&
-                            here.has_floor_or_support( above );
+                           can_climb() &&
+                           here.has_floor_or_support( above );
     const bool swim_up = swims() &&
-                            here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
-                            here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
+                         here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
+                         here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
     if( ( flies() || stair_up || ladder_up || swim_up ) &&
         here.valid_move( pos_bub(), above, false, flies() ) ) {
         valid_stumbles.push_back( above );


### PR DESCRIPTION
#### Summary
fix mending limbs

#### Purpose of change
Mending limbs had a bad check that was making cephalopod limbs count as broken when you tried to apply bandages to them, even though they weren't. It was also making mended limbs look like they were still broken if you had a splint on.

#### Describe the solution
Add a check to see if the limb is broken before we assess its splintability.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
