### PR TITLE
Rabbits have fur again

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -456,7 +456,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "category": "armor",
-    "name": { "str_sp": "fur" },
+    "name": { "str_sp": "rabbit fur" },
     "description": "A soft, fluffy coating of fur.  It isn't the best protection against predators, but stays warm in bad weather.",
     "weight": "400 g",
     "volume": "400 ml",

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -388,7 +388,9 @@
           "cephalopod_arm_4",
           "cephalopod_arm_5",
           "cephalopod_arm_6",
-          "gastropod_foot"
+          "gastropod_foot",
+          "wing_bird_l",
+          "wing_bird_r"
         ],
         "coverage": 80,
         "encumbrance": 2
@@ -412,7 +414,7 @@
     "color": "light_gray",
     "warmth": 20,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT" ],
     "armor": [
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 2 } ],
@@ -440,6 +442,69 @@
         ],
         "coverage": 80,
         "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1 } ],
+        "covers": [ "mouth" ],
+        "coverage": 85,
+        "encumbrance": 0
+      }
+    ]
+  },
+  {
+    "id": "integrated_rabbit_fur",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "fur" },
+    "description": "A soft, fluffy coating of fur.  It isn't the best protection against predators, but stays warm in bad weather.",
+    "weight": "400 g",
+    "volume": "400 ml",
+    "to_hit": 0,
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "fur" ],
+    "symbol": "x",
+    "color": "light_gray",
+    "warmth": 25,
+    "environmental_protection": 1,
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "RAINPROOF" ],
+    "armor": [
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1.8 } ],
+        "covers": [ "leg_l", "leg_r", "arm_l", "arm_r", "torso" ],
+        "coverage": 100,
+        "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1.8 } ],
+        "covers": [
+          "hand_l",
+          "hand_r",
+          "foot_l",
+          "foot_r",
+          "head",
+          "cephalopod_tentacle_l",
+          "cephalopod_tentacle_r",
+          "cephalopod_arm_1",
+          "cephalopod_arm_2",
+          "cephalopod_arm_3",
+          "cephalopod_arm_4",
+          "cephalopod_arm_5",
+          "cephalopod_arm_6",
+          "gastropod_foot"
+        ],
+        "coverage": 80,
+        "encumbrance": 6
+      },
+      {
+        "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1.8 } ],
+        "covers": [
+          "wing_bird_l",
+          "wing_bird_r"
+        ],
+        "coverage": 60,
+        "encumbrance": 3
       },
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 1 } ],
@@ -574,7 +639,7 @@
     "color": "dark_gray",
     "warmth": 25,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT" ],
     "armor": [
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 4 } ],
@@ -635,7 +700,7 @@
     "color": "dark_gray",
     "warmth": 18,
     "environmental_protection": 1,
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "SKINTIGHT" ],
     "armor": [
       {
         "material": [ { "type": "fur", "covered_by_mat": 100, "thickness": 3.5 } ],
@@ -827,7 +892,7 @@
           { "type": "leather_arthropod", "covered_by_mat": 20, "thickness": 1 },
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 1 }
         ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "wing_bird_l", "wing_bird_r" ],
         "coverage": 100,
         "encumbrance": 5
       }
@@ -900,7 +965,7 @@
           { "type": "leather_arthropod", "covered_by_mat": 20, "thickness": 1 },
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 1 }
         ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "wing_bird_l", "wing_bird_r" ],
         "coverage": 100,
         "encumbrance": 8
       }
@@ -978,7 +1043,7 @@
           { "type": "flesh", "covered_by_mat": 33, "thickness": 1 },
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 1 }
         ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r" ],
+        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "wing_bird_l", "wing_bird_r" ],
         "coverage": 100,
         "encumbrance": 10
       }

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -9080,13 +9080,12 @@
     "points": 2,
     "visibility": 10,
     "ugliness": 3,
-    "bodytemp_modifiers": [ 750, 1500 ],
-    "enchantments": [ { "values": [ { "value": "BODYTEMP_SLEEP", "add": 1 } ] } ],
+    "enchantments": [ { "values": [ { "value": "BODYTEMP_SLEEP", "add": 1 }, { "value": "SWEAT_MULTIPLIER", "multiply": -0.7 } ] } ],
     "description": "Your fur keeps you covered in winter, maintaining heat and allowing you to better tolerate cold temperatures.",
     "types": [ "SKIN" ],
     "prereqs": [ "LIGHTFUR" ],
     "category": [ "RABBIT" ],
-    "armor": [ { "part_types": [ "torso", "head", "arm", "hand", "leg", "foot", "mouth", "tail" ], "bash": 1 } ]
+    "integrated_armor": [ "integrated_rabbit_fur" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Rabbits have fur again

#### Purpose of change
Rabbit fur didn't have an integrated item, so rabbits would lose their apparent fur when they mutated it.

#### Describe the solution
Add integrated rabbit fur. It is between regular and light fur and is warmer and rainproof.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
