### PR TITLE
Fix consuming

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1387,7 +1387,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
     "name": { "str": "nicotine patch", "str_pl": "nicotine patches" },
-    "description": "An adhesive patch that promises to fight cravings and help smokers quit by slowly delivering nicotine into the body over the course of 16 hours as a replacement for smoking.  ",
+    "description": "An adhesive patch that promises to fight cravings and help smokers quit by slowly delivering nicotine into the body over the course of 16 hours as a replacement for smoking.",
     "weight": "3 g",
     "volume": "2 ml",
     "price": "10 cent",
@@ -1397,7 +1397,7 @@
     "addiction_type": "nicotine",
     "addiction_potential": 75,
     "flags": [ "NO_INGEST", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You apply a nicotine patch.", "vitamins": [ [ "nicotine_slow", 48 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You apply a nicotine patch.", "vitamins": [ [ "nicotine_slow", 24 ] ] }
   },
   {
     "id": "nyquil",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -111,8 +111,8 @@
     "name": { "str": "Slow-release Nicotine" },
     "min": 0,
     "max": 48,
-    "rate": "20 m",
-    "decays_into": [ [ "nicotine", 2 ] ]
+    "rate": "40 m",
+    "decays_into": [ [ "nicotine", 1 ] ]
   },
   {
     "id": "nicotine",

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -927,7 +927,6 @@ void avatar_action::eat( avatar &you, item_location &loc )
 
     if( !loc ) {
         you.cancel_activity();
-        add_msg( _( "Nevermind." ) );
         return;
     }
     loc.overflow( here );
@@ -937,10 +936,12 @@ void avatar_action::eat( avatar &you, item_location &loc )
 
 void avatar_action::eat_or_use( avatar &you, item_location loc )
 {
-    if( loc && loc->is_medical_tool() ) {
-        avatar_action::use_item( you, loc, "heal" );
-    } else {
-        avatar_action::eat( you, loc );
+    if( loc ) {
+        if( loc->is_medical_tool() ) {
+            avatar_action::use_item( you, loc, "heal" );
+        } else {
+            avatar_action::eat( you, loc );
+        }
     }
 }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -184,9 +184,14 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
     }
 
     if( inv_s.empty() ) {
+        if( using_consume_menu && !cm_uistate.consume_menu_selected_items.empty() ) {
+            return item_location();
+        }
+
         const std::string msg = none_message.empty()
                                 ? _( "You don't have the necessary item at hand." )
                                 : none_message;
+
         popup( msg, PF_GET_KEY );
         return item_location();
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14104,38 +14104,33 @@ bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoin
 
 bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms &pos )
 {
-    // cig dies out
+    bool is_joint = ( carrier != nullptr && typeId() == itype_joint_lit );
+    // It dies out.
     if( item_counter == 0 ) {
         if( carrier != nullptr ) {
             carrier->add_msg_if_player( m_neutral, _( "You finish your %s." ), type_name() );
         }
-        if( type->transform_into ) {
-            type->transform_into.value().transform( carrier, *this, true );
-            if( !this->is_null() ) {
-                here.add_item_or_charges( carrier->pos_bub(), *this );
-                on_drop( carrier->pos_bub(), here );
-                carrier->i_rem( this );
-            }
+        const bool had_transform = ( type->transform_into.operator bool() );
+        if( had_transform ) {
+            auto transform_item = type->transform_into.value();
+            transform_item.transform( carrier, *this, true );
         } else {
             type->invoke( carrier, *this, pos, "transform" );
-            if( !this->is_null() ) {
-                here.add_item_or_charges( carrier->pos_bub(), *this );
-                on_drop( carrier->pos_bub(), here );
-                carrier->i_rem( this );
-            }
         }
-        if( typeId() == itype_joint_lit && carrier != nullptr ) {
+        if( carrier != nullptr ) {
+            carrier->i_rem( this );
+        }
+        active = false;
+        if( is_joint && carrier != nullptr ) {
             carrier->vitamin_mod( vitamin_cannabis, 2 ); // one last puff
             here.add_field( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), field_type_id( "fd_weedsmoke" ), 2 );
             weed_msg( *carrier );
         }
-        active = false;
         return false;
     }
-
     if( carrier != nullptr ) {
-        // No lit cigs in inventory, only in hands or in mouth
-        // So if we're taking cig off or unwielding it, extinguish it first
+        // No lit cigs in inventory, only in hands or in mouth, so if we're taking
+        // cig off or unwielding it, extinguish it first.
         if( !carrier->is_worn( *this ) && !carrier->is_wielding( *this ) ) {
             if( type->transform_into ) {
                 carrier->add_msg_if_player( m_neutral, _( "You extinguish your %s and put it away." ),
@@ -14148,56 +14143,50 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
             return false;
         }
     }
-
     if( !one_in( 10 ) ) {
         return false;
     }
     process_extinguish( here, carrier, pos );
-    // process_extinguish might have extinguished the item already
     if( !active ) {
         return false;
     }
-    // if carried by someone:
     if( carrier != nullptr ) {
         int puff_chance = 4;
-        if( has_flag( flag_TOBACCO ) ) {
-            // Try not to go over 3mg nicotine if we started at 0.
+        bool is_tobacco = has_flag( flag_TOBACCO );
+        if( is_tobacco ) {
             if( typeId() == itype_cigar_lit ) {
                 puff_chance = 30;
             } else {
                 puff_chance = 20;
             }
-            if( one_in( puff_chance ) ) {
+        }
+        if( one_in( puff_chance ) ) {
+            if( is_tobacco ) {
                 carrier->vitamin_mod( vitamin_nicotine, 1 );
-                carrier->add_msg_if_player( m_neutral, _( "You take a puff of your %s." ), type_name() );
-            }
-        } else {
-            // Aim for around 10mg cannabis per joint.
-            if( one_in( puff_chance ) ) {
+            } else {
                 carrier->vitamin_mod( vitamin_cannabis, 1 );
-                carrier->add_msg_if_player( m_neutral, _( "You take a puff of your %s." ), type_name() );
             }
+            carrier->add_msg_if_player( m_neutral, _( "You take a puff of your %s." ), type_name() );
         }
         carrier->mod_moves( -to_moves<int>( 1_seconds ) * 0.15 );
-
         if( ( carrier->has_effect( effect_shakes ) && one_in( 10 ) ) ||
             ( carrier->has_trait( trait_JITTERY ) && one_in( 200 ) ) ) {
             carrier->add_msg_if_player( m_bad, _( "Your shaking hand causes you to drop your %s." ),
                                         type_name() );
             here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
-            return true; // removes the item that has just been added to the map
+            return true;
         }
 
         if( carrier->has_effect( effect_sleep ) ) {
             carrier->add_msg_if_player( m_bad, _( "You fall asleep and drop your %s." ),
                                         type_name() );
             here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
-            return true; // removes the item that has just been added to the map
+            return true;
         }
     } else {
         // If not carried by someone, but laying on the ground:
         if( item_counter % 5 == 0 ) {
-            // lit cigarette can start fires
+            // Lit cigarette can start fires.
             for( const item &i : here.i_at( pos ) ) {
                 if( i.typeId() == typeId() ) {
                     if( here.has_flag( ter_furn_flag::TFLAG_FLAMMABLE, pos ) ||
@@ -14212,8 +14201,7 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
             }
         }
     }
-
-    // Item remains
+    // Item remains.
     return false;
 }
 

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -973,6 +973,7 @@ void Character::disp_medical()
             avatar *a = this->as_avatar();
             if( a ) {
                 avatar_action::use_item( *a );
+                break;
             } else {
                 popup( _( "Applying not implemented for NPCs." ) );
             }


### PR DESCRIPTION
#### Summary
Fix consuming

#### Purpose of change
Consuming stuff was accessing item location in a weird way and also popping up a message inappropriately when you ate the last of your consumables. There was also a use-after-free with smoking.

#### Describe the solution
Guard against UAF in the smoking function, clean up the loc access and message popup in consumption so that it doesn't give a popup after you eat your last item, but does when you try to eat when you have nothing.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
