### PR TITLE
Charge fixes

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -5591,6 +5591,13 @@
   },
   {
     "type": "effect_type",
+    "id": "dashing",
+    "max_intensity": 20,
+    "max_duration": "1 s",
+    "//": "Helper for airborne effect, handles interactions with terrain, traps etc when dashing via spells while not airborne."
+  },
+  {
+    "type": "effect_type",
     "id": "wall_crawl",
     "name": [ "Wall Crawl" ],
     "desc": [ "You are especially adept at climbing and can scale most vertical surfaces with ease." ],

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1689,7 +1689,7 @@
     "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "RANDOM_DAMAGE", "NO_EXPLOSION_SFX" ],
     "effect": "dash",
     "shape": "line",
-    "min_range": 6,
+    "min_range": 3,
     "max_range": 6,
     "extra_effects": [ { "id": "spell_charge_attack", "hit_self": false, "max_level": 1 } ]
   },

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -626,7 +626,17 @@
     "reproduction": { "baby_monster": "mon_cow_calf", "baby_count": 1, "baby_timer": 343 },
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
     "biosignature": { "biosig_item": "feces_cow", "biosig_timer": 1 },
-    "special_attacks": [ { "id": "smash", "throw_strength": 60 }, [ "GRAZE", 20 ], [ "EAT_CROP", 60 ] ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 60, "cooldown": 60 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 55
+      },
+      [ "GRAZE", 20 ],
+      [ "EAT_CROP", 60 ]
+    ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
     "flags": [
       "SEES",
@@ -1316,7 +1326,7 @@
     "aggro_character": false,
     "melee_skill": 6,
     "melee_dice": 3,
-    "melee_dice_sides": 4,
+    "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "dodge": 1,
     "stomach_size": 8000,
@@ -1333,7 +1343,17 @@
     "dissect": "dissect_cattle_sample_large",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 8 },
-    "special_attacks": [ { "id": "smash", "throw_strength": 60 }, [ "EAT_CROP", 60 ], [ "GRAZE", 50 ] ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 60, "cooldown": 40 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 55
+      },
+      [ "EAT_CROP", 60 ],
+      [ "GRAZE", 50 ]
+    ],
     "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS" ],
     "armor": { "bash": 5, "cut": 6, "bullet": 8, "electric": 1 }
   },
@@ -1399,7 +1419,17 @@
     "melee_dice": 5,
     "melee_dice_sides": 4,
     "melee_damage": [ { "damage_type": "cut", "amount": 5 } ],
-    "special_attacks": [ { "id": "smash", "throw_strength": 72 }, [ "EAT_CROP", 60 ], [ "GRAZE", 50 ] ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 72, "cooldown": 18 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 45
+      },
+      [ "EAT_CROP", 60 ],
+      [ "GRAZE", 50 ]
+    ],
     "dodge": 1,
     "stomach_size": 9000,
     "vision_night": 7,

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -410,7 +410,16 @@
     "vision_night": 6,
     "//grab": "Assuming it's grabbing with its mouth a bit grabbier than a zed should be about right",
     "grab_strength": 30,
-    "special_attacks": [ { "id": "smash", "throw_strength": 108, "cooldown": 30 }, { "id": "grab", "cooldown": 7 } ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 108, "cooldown": 30 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 35
+      },
+      { "id": "grab", "cooldown": 7 }
+    ],
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -433,6 +433,15 @@
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "upgrades": { "half_life": 168, "into_group": "GROUP_ZOOSE_UPGRADE" },
     "fungalize_into": "mon_zoose_fungus",
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 40, "cooldown": 35 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 45
+      }
+    ],
     "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
     "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 2 }
   },
@@ -617,7 +626,15 @@
     "melee_dice": 2,
     "melee_dice_sides": 10,
     "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
-    "special_attacks": [ { "id": "smash", "throw_strength": 40, "cooldown": 5 } ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 40, "cooldown": 25 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 45
+      }
+    ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "vision_day": 30,
     "vision_night": 3,
@@ -655,7 +672,15 @@
     "vision_night": 3,
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
     "harvest": "zombie_leather",
-    "special_attacks": [ { "id": "smash", "throw_strength": 72, "cooldown": 2 } ],
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 72, "cooldown": 16 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "spell_bull_charge", "min_level": 1 },
+        "monster_message": "The %s charges!",
+        "cooldown": 38
+      }
+    ],
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/mutations/mutation_spells.json
+++ b/data/json/mutations/mutation_spells.json
@@ -291,7 +291,7 @@
     "flags": [ "SILENT", "NO_LEGS", "NO_HANDS", "RANDOM_DAMAGE", "NO_EXPLOSION_SFX" ],
     "effect": "dash",
     "shape": "line",
-    "min_range": 4,
+    "min_range": 3,
     "max_range": 4,
     "extra_effects": [ { "id": "spell_bull_charge_attack", "hit_self": false, "max_level": 1 } ]
   },

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -250,6 +250,7 @@ static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_cramped_space( "cramped_space" );
+static const efftype_id effect_dashing( "dashing" );
 static const efftype_id effect_docile( "docile" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_fake_common_cold( "fake_common_cold" );
@@ -10225,7 +10226,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     }
 
     std::vector<std::string> harmful_stuff = get_dangerous_tile( dest_loc );
-    if( !shifting_furniture && !pushing && !harmful_stuff.empty() ) {
+    if( !shifting_furniture && !pushing && !harmful_stuff.empty() && !u.has_effect( effect_dashing ) ) {
         if( harmful_stuff.size() == 1 && harmful_stuff[0] == "ledge" ) {
             iexamine::ledge( u, tripoint_bub_ms( dest_loc ) );
             return true;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -73,6 +73,8 @@ static const damage_type_id damage_acid( "acid" );
 
 static const efftype_id effect_airborne( "airborne" );
 static const efftype_id effect_corroding( "corroding" );
+static const efftype_id effect_dashing( "dashing" );
+static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_invisibility( "invisibility" );
 static const efftype_id effect_jumping( "jumping" );
 static const efftype_id effect_pet( "pet" );
@@ -1936,6 +1938,8 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
         caster.add_effect( effect_airborne, 1_seconds, true );
         caster.add_effect( effect_jumping, 1_seconds, true, jump_vert );
         jumping = true;
+    } else {
+        caster.add_effect( effect_dashing, 1_seconds, true );
     }
     while( walk_point != trajectory.end() ) {
         if( caster_you != nullptr ) {
@@ -1943,7 +1947,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
             if( jumping && ( walk_point + 1 ) == trajectory.end() ) {
                 caster.remove_effect( effect_airborne );
             }
-            if( creatures.creature_at( here.get_bub( *walk_point ) ) ||
+            if( caster.has_effect( effect_downed ) || creatures.creature_at( here.get_bub( *walk_point ) ) ||
                 !g->walk_move( here.get_bub( *walk_point ), false ) ) {
                 if( walk_point != trajectory.begin() ) {
                     --walk_point;
@@ -1957,7 +1961,7 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
             if( jumping && ( walk_point + 1 ) == trajectory.end() ) {
                 caster.remove_effect( effect_airborne );
             }
-            if( creatures.creature_at( here.get_bub( *walk_point ) ) ) {
+            if( caster.has_effect( effect_downed ) || creatures.creature_at( here.get_bub( *walk_point ) ) ) {
                 if( walk_point != trajectory.begin() ) {
                     --walk_point;
                 }
@@ -1974,6 +1978,8 @@ void spell_effect::dash( const spell &sp, Creature &caster, const tripoint_bub_m
         // Redundant effect removal for safety's sake.
         caster.remove_effect( effect_airborne );
         caster.remove_effect( effect_jumping );
+    } else {
+        caster.remove_effect( effect_dashing );
     }
     caster.set_moves( cur_moves );
     tripoint_bub_ms far_target;


### PR DESCRIPTION
#### Summary
Charge fixes

#### Describe the solution
- Non-airborne dashing characters don't get prompted about ledges, they just fall and stop where they land.
- Added weaker charge attacks to all the mooses and cows except the thorny one.
- Made sure charges have a min range.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
