### PR TITLE
Fix ravines more better

### DIFF
--- a/data/mods/innawood/mapgen/ravine_mutable.json
+++ b/data/mods/innawood/mapgen/ravine_mutable.json
@@ -11,7 +11,8 @@
     "flags": [ "WILDERNESS" ],
     "check_for_locations_area": [
       { "type": [ "field", "forest_with_swamp" ], "from": [ -4, -4, 0 ], "to": [ 4, 4, 0 ] },
-      { "type": [ "subterranean_empty" ], "from": [ -16, -16, -1 ], "to": [ 16, 16, -2 ] }
+      { "type": [ "subterranean_empty" ], "from": [ -16, -16, -1 ], "to": [ 16, 16, -1 ] },
+      { "type": [ "subterranean_empty" ], "from": [ -16, -16, -2 ], "to": [ 16, 16, -2 ] }
     ],
     "joins": [ "ravine_to_ravine", "ravine_to_edge", "ravine_to_bottom" ],
     "overmaps": {
@@ -58,7 +59,7 @@
       "ravine_filler": { "overmap": "open_air" },
       "ravine_root_filler": { "overmap": "open_air", "above": { "id": "ravine_to_bottom", "alternatives": [ "ravine_to_edge" ] } },
       "ravine_bottom": { "overmap": "ravine_bottom_forest" },
-      "ravine_edge": { "overmap": "ravine_edge_north" },
+      "ravine_edge_mid": { "overmap": "ravine_edge_mid_north" },
       "ravine_corner": { "overmap": "ravine_corner_north" },
       "ravine_2way": { "overmap": "ravine_2way_east" },
       "ravine_3way": { "overmap": "ravine_3way_north" },
@@ -180,7 +181,7 @@
           "name": "ravine edge",
           "chunk": [
             { "overmap": "ravine_edge_ground", "pos": [ 0, 0, 0 ] },
-            { "overmap": "ravine_edge", "pos": [ 0, 0, -1 ] },
+            { "overmap": "ravine_edge_mid", "pos": [ 0, 0, -1 ] },
             { "overmap": "ravine_edge_bottom", "pos": [ 0, 0, -2 ] }
           ],
           "weight": 1
@@ -261,7 +262,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": "ravine_edge",
+    "om_terrain": "ravine_edge_mid",
     "object": {
       "predecessor_mapgen": "open_air",
       "palettes": [ "ravine_edge_parameters" ],

--- a/data/mods/innawood/overmap/overmap_terrain.json
+++ b/data/mods/innawood/overmap/overmap_terrain.json
@@ -49,7 +49,7 @@
     "id": [
       "ravine_2way",
       "ravine_3way",
-      "ravine_edge",
+      "ravine_edge_mid",
       "ravine_corner",
       "ravine_2way_bottom",
       "ravine_3way_bottom",


### PR DESCRIPTION
#### Summary
Fix ravines more better

#### Purpose of change
Ravines still had cutaways at z-1 on ravine_edge. After a lot of fuss, I tried renaming it to ravine_edge_mid, and for some reason, that worked. Alright fine.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
