### PR TITLE
Backport 87433 and 87264 - Ravine Specials and Crafting Performance Improvement

### DIFF
--- a/data/mods/innawood/mapgen/map_extras.json
+++ b/data/mods/innawood/mapgen/map_extras.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": "mx_grove_ravine",
+    "type": "map_extra",
+    "name": { "str": "Grove" },
+    "description": "This area is covered with a single type of trees.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_grove" },
+    "min_max_zlevel": [ -2, -2 ],
+    "sym": "F",
+    "color": "light_green",
+    "flags": [ "CLASSIC" ]
+  },
+  {
+    "id": "mx_pond_ravine",
+    "type": "map_extra",
+    "name": { "str": "Pond" },
+    "description": "Small pond is here.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_pond" },
+    "min_max_zlevel": [ -2, -2 ],
+    "sym": "p",
+    "color": "blue",
+    "flags": [ "CLASSIC", "WATER" ]
+  },
+  {
+    "id": "mx_pond_forest_ravine",
+    "type": "map_extra",
+    "name": { "str": "basin" },
+    "description": "Small basin is here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest" },
+    "min_max_zlevel": [ -2, -2 ],
+    "flags": [ "CLASSIC", "WATER" ]
+  },
+  {
+    "id": "mx_pond_forest_2_ravine",
+    "type": "map_extra",
+    "copy-from": "mx_pond_forest",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest_2" },
+    "min_max_zlevel": [ -2, -2 ],
+    "flags": [ "CLASSIC", "WATER" ]
+  },
+  {
+    "id": "mx_shrubbery_ravine",
+    "type": "map_extra",
+    "name": { "str": "Shrubbery" },
+    "description": "This area is covered with a single type of shrubs.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_shrubbery" },
+    "min_max_zlevel": [ -2, -2 ],
+    "sym": "s",
+    "color": "light_green",
+    "flags": [ "CLASSIC" ]
+  }
+]

--- a/data/mods/innawood/mapgen/ravine_mutable.json
+++ b/data/mods/innawood/mapgen/ravine_mutable.json
@@ -671,7 +671,23 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "1x1_under_soil",
+    "object": { "mapgensize": [ 1, 1 ], "terrain": { " ": "t_soil" }, "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "1x1_under_stone",
+    "object": { "mapgensize": [ 1, 1 ], "terrain": { " ": "t_rock" }, "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
+  },
+  {
+    "type": "mapgen",
     "om_terrain": "ravine_bottom_forest",
     "object": { "predecessor_mapgen": "forest" }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "ravine_bottom_forest",
+    "weight": 750,
+    "object": { "predecessor_mapgen": "forest_thick" }
   }
 ]

--- a/data/mods/innawood/overmap/overmap_terrain.json
+++ b/data/mods/innawood/overmap/overmap_terrain.json
@@ -69,6 +69,7 @@
     "type": "overmap_terrain",
     "id": "ravine_bottom_forest",
     "name": "ravine floor",
+    "extras": "ravine_bottom",
     "copy-from": "forest"
   }
 ]

--- a/data/mods/innawood/region_settings/region_settings/region_overlay.json
+++ b/data/mods/innawood/region_settings/region_settings/region_overlay.json
@@ -1,5 +1,11 @@
 [
   {
+    "type": "region_settings_map_extras",
+    "id": "default",
+    "copy-from": "default",
+    "extend": { "extras": [ "ravine_bottom" ] }
+  },
+  {
     "type": "region_settings_forest_trail",
     "id": "default",
     "copy-from": "default",
@@ -10,6 +16,37 @@
     "id": "forest_water",
     "copy-from": "forest_water",
     "extend": { "extras": [ [ "mx_pond_swamp", 240 ], [ "mx_pond_swamp_2", 240 ] ] }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "ravine_bottom",
+    "chance": 30,
+    "extras": [
+      [ "mx_pond_ravine", 150 ],
+      [ "mx_grove_ravine", 300 ],
+      [ "mx_pond_forest_ravine", 100 ],
+      [ "mx_pond_forest_2_ravine", 50 ],
+      [ "mx_shrubbery_ravine", 100 ],
+      [ "mx_blackberry_patch", 300 ],
+      [ "mx_point_dead_vegetation", 800 ],
+      [ "mx_point_burned_ground", 200 ],
+      [ "mx_poison_ivy_patch_forest", 3300 ],
+      [ "mx_rock_formation", 500 ],
+      [ "mx_spider", 200 ],
+      [ "mx_clay_deposit", 125 ],
+      [ "mx_knotweed_patch", 120 ],
+      [ "mx_nest_wasp", 50 ],
+      [ "mx_grass2", 40 ],
+      [ "mx_casings", 30 ],
+      [ "mx_corpses", 5 ],
+      [ "mx_grass", 20 ],
+      [ "mx_science", 5 ],
+      [ "mx_crater", 10 ],
+      [ "mx_portal", 3 ],
+      [ "mx_portal_in", 3 ],
+      [ "mx_jabberwock", 2 ],
+      [ "mx_beehive_natural", 20 ]
+    ]
   },
   {
     "type": "region_terrain_furniture",
@@ -88,13 +125,33 @@
     "type": "forest_biome_mapgen",
     "id": "biome_forest_thick_default",
     "copy-from": "biome_forest_thick_default",
-    "extend": { "terrains": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_edge_ground", "ravine_corner_ground" ] }
+    "extend": {
+      "terrains": [
+        "ravine",
+        "ravine_2way",
+        "ravine_3way",
+        "ravine_edge_mid",
+        "ravine_corner",
+        "ravine_edge_ground",
+        "ravine_bottom_forest"
+      ]
+    }
   },
   {
     "type": "forest_biome_mapgen",
     "id": "biome_forest_default",
     "copy-from": "biome_forest_default",
-    "extend": { "terrains": [ "ravine_2way_ground", "ravine_3way_ground", "ravine_edge_ground", "ravine_corner_ground" ] }
+    "extend": {
+      "terrains": [
+        "ravine",
+        "ravine_2way",
+        "ravine_3way",
+        "ravine_edge_mid",
+        "ravine_corner",
+        "ravine_edge_ground",
+        "ravine_bottom_forest"
+      ]
+    }
   },
   {
     "type": "region_settings",
@@ -103,6 +160,6 @@
     "cities": null,
     "highways": null,
     "place_roads": false,
-    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4648,7 +4648,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         }
     }
     // Charge shortfall rewinds the turn before any skill gain.
-    if( !crafter.craft_consume_step_tools( craft ) ) {
+    if( !crafter.craft_consume_step_tools( craft, &cached_cost_ctx ) ) {
         rewind_turn();
         return;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4562,12 +4562,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         return;
     }
 
+    // Book bonuses and tool speeds come from the nearby inventory, not the
+    // crafter's proficiency, so they survive the per-5% proficiency invalidation.
+    // batch_time still applies the live proficiency malus on top of this context,
+    // so the move totals stay current without rebuilding it each step.
+    if( !cost_ctx_ready ) {
+        cached_cost_ctx = { crafter.book_bonuses_nearby(), compute_tool_speeds( rec, crafter ) };
+        cost_ctx_ready = true;
+    }
+
     if( cached_crafting_speed != crafting_speed || cached_assistants != assistants ) {
         cached_crafting_speed = crafting_speed;
         cached_assistants = assistants;
-        // Recompute cost context: tool speeds + book proficiency bonuses
-        cached_cost_ctx = { crafter.book_bonuses_nearby(), compute_tool_speeds( rec, crafter ) };
-
         // Base moves for batch size with no speed modifier or assistants
         // Must ensure >= 1 so we don't divide by 0;
         cached_base_total_moves = std::max( static_cast<int64_t>( 1 ),

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1188,6 +1188,7 @@ class craft_activity_actor : public activity_actor
         float cached_crafting_speed; // NOLINT(cata-serialize)
         int cached_assistants; // NOLINT(cata-serialize)
         crafting_cost_context cached_cost_ctx; // NOLINT(cata-serialize)
+        bool cost_ctx_ready = false; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)

--- a/src/character.h
+++ b/src/character.h
@@ -104,6 +104,7 @@ enum npc_attitude : int;
 struct attention_plan;
 struct bionic;
 struct construction;
+struct crafting_cost_context;
 struct dealt_projectile_attack;
 struct display_proficiency;
 struct field_immunity_data;
@@ -3841,8 +3842,10 @@ class Character : public Creature, public visitable
         /** Consume tools for the next multiplier * 5% progress of the craft */
         bool craft_consume_tools( item &craft, int multiplier, bool start_craft );
         /** Advance per-step tool consumption so each step's allocations match its
-         *  current progress.  Returns false (consuming nothing) if charges are short. */
-        bool craft_consume_step_tools( item &craft );
+         *  current progress.  Returns false (consuming nothing) if charges are short.
+         *  When cost_ctx is supplied, it is reused for step budgets instead of
+         *  recomputing crafting_cost_context::for_recipe. */
+        bool craft_consume_step_tools( item &craft, const crafting_cost_context *cost_ctx = nullptr );
         /** Advance the active unattended step's tool consumption to match its
          *  wall-clock progress.  Returns false (consuming nothing) if charges are short. */
         bool craft_consume_passive_step_tools( item &craft, time_point now, const item_location &loc );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3663,7 +3663,7 @@ bool Character::verify_step_tools( item &craft, int step_idx,
     return true;
 }
 
-bool Character::craft_consume_step_tools( item &craft )
+bool Character::craft_consume_step_tools( item &craft, const crafting_cost_context *cost_ctx )
 {
     if( has_trait( trait_DEBUG_HS ) ) {
         return true;
@@ -3676,7 +3676,13 @@ bool Character::craft_consume_step_tools( item &craft )
     const int cur_step = craft.get_current_step();
     const double cur_progress = craft.get_step_progress();
     const bool craft_done = craft.item_counter >= 10000000;
-    const crafting_cost_context ctx = crafting_cost_context::for_recipe( *this, rec );
+    // for_recipe rebuilds the nearby inventory and rescans qualities, too costly
+    // to run every turn in a dense base; lean on the caller's cache when given.
+    std::optional<crafting_cost_context> ctx_owned;
+    if( cost_ctx == nullptr ) {
+        ctx_owned = crafting_cost_context::for_recipe( *this, rec );
+    }
+    const crafting_cost_context &ctx = cost_ctx != nullptr ? *cost_ctx : *ctx_owned;
 
     std::vector<int> targets( n_steps, 0 );
     for( int s = 0; s < n_steps; ++s ) {


### PR DESCRIPTION
#### Summary
Backport 87433 and 87264 - Ravine Specials and Crafting Performance Improvement

#### Purpose of change
- Innawood ravine specials can spawn specials in the bottom of the ravine.
- Fixed another issue with crafting performance.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
