### PR TITLE
Remove BP effects when losing a BP

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7998,6 +7998,25 @@ void Character::recalculate_bodyparts()
     tally_organic_size();
     recalc_limb_energy_usage();
 
+    // Remove effects from body parts that we no longer have.
+    effects_map &effs = *effects;
+    for( auto eff_it = effs.begin(); eff_it != effs.end(); ) {
+        auto &bp_map = eff_it->second;
+        for( auto bp_it = bp_map.begin(); bp_it != bp_map.end(); ) {
+            const bodypart_id &bp = bp_it->first.id();
+            if( bp != bodypart_str_id::NULL_ID().id() && !has_part( bp ) ) {
+                bp_it = bp_map.erase( bp_it );
+            } else {
+                ++bp_it;
+            }
+        }
+        if( bp_map.empty() ) {
+            eff_it = effs.erase( eff_it );
+        } else {
+            ++eff_it;
+        }
+    }
+
     add_msg_debug( debugmode::DF_ANATOMY_BP, "New healthy kcal %d",
                    get_healthy_kcal() );
     calc_encumbrance();


### PR DESCRIPTION
#### Summary
Remove BP effects when losing a BP

#### Purpose of change
BP-related effects could persist through BP changes (such as a mutation). This is not ideal.

#### Solution
In recalculate_bodyparts(), check all BP-specific effects and remove any for which we no longer have the part.

Theoretically it might be better to move the effect to a bodypart which is replacing it (e.g. right arm to right wing) but not all BP transformations come with a 1:1 replacement, some effects wouldn't make sense on the new part, and at least as far as mutation goes, the tissue is growing and changing like the end of Akira so it's fine if you lose your grabs or bleeding wounds.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
