### PR TITLE
Remove clothes when losing BPs

### DIFF
--- a/data/json/flags/flags.json
+++ b/data/json/flags/flags.json
@@ -1320,6 +1320,7 @@
   },
   {
     "id": "CHALLENGE",
+    "//": "Scenario flag.",
     "type": "json_flag"
   },
   {
@@ -1328,6 +1329,7 @@
   },
   {
     "id": "CITY_START",
+    "//": "Scenario flag.",
     "type": "json_flag"
   },
   {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8017,6 +8017,40 @@ void Character::recalculate_bodyparts()
         }
     }
 
+    // Remove any items which were worn exclusively on parts we no longer have.
+    std::list<item> removed = worn.remove_worn_items_with(
+    [this]( item &it ) {
+        if( it.has_flag( flag_INTEGRATED ) ) {
+            return false;
+        }
+        const body_part_set covered_bps  = it.get_covered_body_parts( nullptr );
+        const std::vector<sub_bodypart_id> covered_sbps = it.get_covered_sub_body_parts( nullptr );
+        if( covered_bps.none() && covered_sbps.empty() ) {
+            return false;
+        }
+        for( const bodypart_str_id &bp : covered_bps ) {
+            if( has_part( bp.id() ) ) {
+                return false;
+            }
+        }
+        for( const int_id<sub_body_part_type> &sbp : covered_sbps ) {
+            if( has_part( sbp->parent ) ) {
+                return false;
+            }
+        }
+        return true;
+    }, *this, false );
+
+    map &here = get_map();
+
+    for( item &it : removed ) {
+        add_msg_player_or_npc( m_bad,
+                               _( "Your %s comes free!" ),
+                               _( "<npcname>'s %s comes free!" ),
+                               it.tname() );
+        here.add_item_or_charges( pos_bub(), it );
+    }
+
     add_msg_debug( debugmode::DF_ANATOMY_BP, "New healthy kcal %d",
                    get_healthy_kcal() );
     calc_encumbrance();

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3101,7 +3101,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts( get_body_part_flags flags
         sort_body_parts( all_bps, this );
     }
 
-    return  all_bps;
+    return all_bps;
 }
 
 std::vector<bodypart_id> Creature::get_random_body_parts( const std::vector<bodypart_id> &bp_list,


### PR DESCRIPTION
#### Summary
Remove clothes when losing BPs

#### Purpose of change
When mutating, if you lost your arms and got wings or something, your wrist watch or other worn arm items would just hang out in limbo, attached to body parts you no longer had.

#### Describe the solution
Check all possible BPs and sub BPs for every worn item in recalculate_bodyparts(). If it has any, and you do not have any of the BPs it goes on, it falls off and prints a message.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
