### PR TITLE
Cereal improvements

### DIFF
--- a/data/json/items/comestibles/cereal.json
+++ b/data/json/items/comestibles/cereal.json
@@ -19,8 +19,8 @@
     "material": [ "wheat" ],
     "flags": [ "EDIBLE_FROZEN", "USE_EAT_VERB" ],
     "looks_like": "cereal",
-    "vitamins": [ [ "vitC", 7 ], [ "calcium", 7 ], [ "iron", 32 ], [ "wheat_allergen", 1 ] ],
-    "fun": 8
+    "vitamins": [ [ "vitC", 10 ], [ "calcium", 10 ], [ "iron", 45 ], [ "wheat_allergen", 1 ] ],
+    "fun": 5
   },
   {
     "type": "ITEM",
@@ -40,8 +40,8 @@
     "price_postapoc": "25 cent",
     "material": [ "junk" ],
     "volume": "62 ml",
-    "vitamins": [ [ "vitC", 17 ], [ "calcium", 13 ], [ "iron", 48 ], [ "junk_allergen", 1 ] ],
-    "fun": 10
+    "vitamins": [ [ "vitC", 7 ], [ "calcium", 8 ], [ "iron", 44 ], [ "junk_allergen", 1 ], [ "meat_allergen", 1 ] ],
+    "fun": 8
   },
   {
     "type": "ITEM",
@@ -50,12 +50,13 @@
     "name": { "str_sp": "wheat cereal" },
     "weight": "52 g",
     "volume": "62 ml",
-    "calories": 180,
-    "description": "Whole-grain wheat cereal.  It's surprisingly good, and allegedly good for your heart.",
+    "calories": 140,
+    "description": "Whole-grain wheat cereal.  It's allegedly good for your heart.",
     "price_postapoc": "150 cent",
     "flags": [ "EDIBLE_FROZEN" ],
-    "vitamins": [ [ "vitC", 2 ], [ "calcium", 2 ], [ "iron", 9 ] ],
-    "copy-from": "cereal_tpl"
+    "vitamins": [ [ "vitC", 10 ], [ "calcium", 10 ], [ "iron", 45 ], [ "wheat_allergen", 1 ] ],
+    "copy-from": "cereal_tpl",
+    "fun": 3
   },
   {
     "type": "ITEM",
@@ -69,14 +70,14 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "quench": -2,
-    "calories": 155,
-    "description": "Plain cornflake cereal.  They're not that good, but it beats nothing.",
+    "calories": 140,
+    "description": "Unsweetened breakfast cereal made from corn.  As cereals go it's a healthier choice, but not the most exciting.",
     "price": "75 cent",
     "price_postapoc": "18 cent",
     "material": [ "junk" ],
     "volume": "62 ml",
     "flags": [ "EDIBLE_FROZEN" ],
-    "vitamins": [ [ "iron", 42 ], [ "junk_allergen", 1 ] ],
+    "vitamins": [ [ "iron", 45 ] ],
     "fun": 3
   }
 ]


### PR DESCRIPTION
#### Summary
Cereal improvements

#### Purpose of change
The various breakfast cereals had incorrect nutrition and allergen info

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
