### PR TITLE
Mi-go fixes

### DIFF
--- a/data/json/monstergroups/mi-go.json
+++ b/data/json/monstergroups/mi-go.json
@@ -6,7 +6,7 @@
     "monsters": [
       { "monster": "mon_mi_go", "weight": 530 },
       { "monster": "mon_mi_go", "weight": 100, "cost_multiplier": 20, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_mi_go_slaver", "weight": 30, "cost_multiplier": 10, "starts": "15 days" },
+      { "monster": "mon_mi_go_abductor", "weight": 30, "cost_multiplier": 10, "starts": "15 days" },
       { "monster": "mon_mi_go_scout", "weight": 100, "cost_multiplier": 50, "starts": "10 days" },
       { "monster": "mon_mi_go_myrmidon", "weight": 10, "cost_multiplier": 50, "starts": "20 days" }
     ]
@@ -22,7 +22,7 @@
       { "monster": "mon_mi_go_guard", "weight": 50, "pack_size": [ 1, 2 ] },
       { "monster": "mon_mi_go_guard", "weight": 30, "cost_multiplier": 3, "pack_size": [ 1, 2 ] },
       {
-        "monster": "mon_mi_go_slaver",
+        "monster": "mon_mi_go_abductor",
         "weight": 20,
         "cost_multiplier": 4,
         "starts": "35 days",

--- a/data/json/monsters/mi-go.json
+++ b/data/json/monsters/mi-go.json
@@ -51,9 +51,9 @@
     "armor": { "bash": 4, "cut": 12, "bullet": 10, "electric": 2 }
   },
   {
-    "id": "mon_mi_go_slaver",
+    "id": "mon_mi_go_abductor",
     "type": "MONSTER",
-    "name": { "str": "mi-go slaver" },
+    "name": { "str": "mi-go abductor" },
     "description": "An alien creature of uncertain origin.  Its shapeless pink body bears numerous sets of paired appendages of unknown function, and a pair of ribbed, membranous wings which seem to be quite useless.  Its odd, vaguely pyramid-shaped head bristles with numerous wavering antennae, and it moves with an uncanny fluidity on its many legs.  It is carrying an oblong object that hums with an odd keening sound.",
     "default_faction": "mi-go",
     "bodytype": "migo",
@@ -194,8 +194,8 @@
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
-      [ "SHRIEK_ALERT", 5 ],
-      [ "SHRIEK_STUN", 4 ],
+      [ "SHRIEK_ALERT", 120 ],
+      [ "SHRIEK_STUN", 34 ],
       [ "TAZER", 5 ],
       { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 35, "armor_multiplier": 0.7 } ] },
       {

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -1,1507 +1,1507 @@
 [
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Hello?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Papaya!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Who's there?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Can you help me?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Over here!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Can you repeat that?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You're just copying me, aren't you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'm not afraid of you!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Come here!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Please, don't!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a horrified scream!",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a little girl's wailing!",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"So, what is this thing supposed to be, exactly?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Uncategorized object seven-seven-three-four.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We found it in a wreckage, barely alive.  Not the first one, either.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Area nineteen has a few in cold storage.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Mommy, help!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We're still trying to figure out what makes it tick.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We're not even sure what it is.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"The cell structure is unlike any we've ever seen.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It does seem to have some form of higher level brain functioning.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Problem solving, memory retention, that sort of thing.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"There appear to be some anomalous aspects to the mimicry.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Members of the species have some kind of neurocognitive link.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"This one's repeating phrases that the previous specimen was exposed to.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a child shrieking!",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Oh God, my leg, Oh God!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a long cry of agony!",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You mean it's not just parroting us?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It's parroting us, but we're uncertain as to how or why.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It may be a mechanism for attracting prey.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It could even be a way of trying to scare us off.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We just don't know.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "an anguished wail!",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"You're gonna rot in hell for this!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"You hear me!?\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"You're gonna rot in hell, you pieces of shit!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"Like we said, we have no idea what it's thinking.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Is that glass electrified?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Why don't you touch it and find out?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Of course it is.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What'll happen if the power goes out?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Don't worry about it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Don't worry.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"There are seven backup generators.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"And what if all the backups fail?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We'd have to terminate the specimen.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"The glass alone won't keep us safe for very long.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"That fuckin' thing is horrible, man, it gives me the creeps.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's probably more scared of us than we are of it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Somehow, I doubt that.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hey, we got other specimens that could withstand a grenade.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"And that's supposed to comfort me?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"At least we know they can die.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"U-O Seven-Seven-Three-Four.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Individual instances of U-O Seven-Seven-Three-Four.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"To be kept in a standard biohazardous containment chamber.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Until such time as more permanent arrangements are made.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Shows a noted preference for human brain tissue.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Destroy the specimen if it begins to interact with the lock.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Kill them all and let God sort them out!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I watched a snail crawl along the edge of a straight razor.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I've seen horrors, horrors that you've seen.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I love the smell of napalm in the morning.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"This is the way the fuckin' world ends.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Look at this fuckin' shit we're in, man.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Every man has got a breaking point.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'ma cut those fuckin' tentacles off, bitch!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Watch you bleed out!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I wonder if it understands us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Do you understand what I'm saying?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go-surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go-surgeon" ],
     "sound": "\"Look, it's responding!\"",
     "volume": 26
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"That's the first time it moved all morning.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'm certain it's trying to understand us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'm not convinced it can actually comprehend us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's just repeating us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Just being an alien creature doesn't mean it's intelligent.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Just because it doesn't look like you doesn't mean that it isn't.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Please open the door and enter the cell.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Would it react differently with a child?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Experiments to determine extent of cognitive abilities still underway.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Subject has so far displayed a total lack of empathy toward human suffering.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I got a round trip ticket.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"How's your mom doing?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"How's your dad doing?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I love you.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I love you too.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Just a little.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Only a few more days 'til the weekend.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Do you smoke?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"You're new here, aren't you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How do you like it here?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It won't hurt a bit.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"That was a long time ago.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Does it scare you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Don't worry, it can't hurt us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What are you afraid will happen?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Anything else?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"You think they're the same sex?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"Do they even have sex?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Can I see your phone?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"You got a dollar I can borrow?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Are you busy at the moment?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you busy later?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you busy tonight?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you free tonight?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you going to the party tonight?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Are you going to help them?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you alone?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you hungry?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'm hungry.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Go ahead.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have a good time.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you eaten yet?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Is it supposed to rain tomorrow?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Okay.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Good.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Great.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Fantastic.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"God damn it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"God damn it!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Damn it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Damn it!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Fuck.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Shit.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Fuck!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Shit!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Fuckin' piece of garbage.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I need a new lab coat.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Excellent.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Excuse me.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Go ahead.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Good morning.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Good afternoon.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Good evening.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Good night.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Good luck.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Can I help you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you seeing anyone?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Forget it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How long were you two together?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Give me a call later.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Call me.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"From time to time.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We have a serious situation here.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Call the police.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Call an ambulance.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Get me the White House.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Are you feeling all right?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I think I'll live.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I think I need to see a doctor.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Is everything all right?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'm okay, don't worry about me.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's just a scratch.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I've got a headache.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I'm fine.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Are you sure?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Positive.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Affirmative.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Negative.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Sorry.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Happy Birthday!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you ever been to California?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What time do you get off?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We should hit up the shooting range later.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I'm heading to the pool after work.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have a good trip.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Where did you come from?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you been waiting long?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you done this before?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hello.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Help!\"",
     "volume": 40
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Here it is.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I've got family coming tomorrow.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"How do I use this?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How do you know?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"How long have you been here?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How many languages do you speak?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"How many people?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How much were these earrings?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How much do I owe you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How much will it cost?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How much would you like?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How old are you?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"How tall is it?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How was the movie?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How was your trip?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How's it going?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"See you later.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"See you tonight.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I got this weird rash a few days ago.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Let me have a look at it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"When did you find out?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Seven o'clock.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Nobody is helping us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We're on our own.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We're all alone.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We should split into groups of two each.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"It can't follow all of us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Be careful out there.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"There you are.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I've been looking all over for you.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's looking for us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's faster than us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's looking right at us.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"It's heading right for us!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Can you swim?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Don't do that.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"You hear that?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Be quiet.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Look out!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Run!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Hurry!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"No!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"I'll never forget you.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Take his gun, we're going to need it.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"How do we get out of here?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"This place is like a maze.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Oh God, I'm the only one left.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Please, I don't want to die.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Mom.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Mom, I miss you.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Me go, you stay.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Please, God.\"",
     "volume": 5
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_vocal_bigfrog" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon", "mon_vocal_bigfrog" ],
     "sound": "a gurgling sound.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon", "mon_vocal_bigfrog" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon", "mon_vocal_bigfrog" ],
     "sound": "a choking sound.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a snapping sound.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "beep!",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "beep-beep-beep!",
     "volume": 30
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "BEEP!",
     "volume": 40
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a loud hiss.",
     "volume": 30
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a loud crackling noise.",
     "volume": 30
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "bang!",
     "volume": 90
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a klaxon blaring!",
     "volume": 90
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"EMERGENCY, EMERGENCY!\"",
     "volume": 70
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "a static hissing sound.",
     "volume": 30
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"That creepy abandoned post-apocalyptic lab complex looks safe…\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Don't worry, it isn't like anything could teleport out of the containment cells.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Hold on, I want to pulp that zombie corpse.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"What did that thing just hit me with?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I can barely move.  Run!  Save yourself!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Oh you motherfucking shellfish, you're going down.\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I… I feel weak…\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go_surgeon" ],
     "sound": "\"Oi, dingus, you can't keep me in 'ere.\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We got a treaty w'yer people, don'we?\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"This'll get back t'my bosses, right and so!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Lemme outta here!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"We're both scavs, in't we?\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hey look, that one's carrying something.  Let's crack it open and steal it.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"G… get off me you… you bastard…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"GET WELL SOON!\"",
     "volume": 20
   },
@@ -1543,571 +1543,571 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go_surgeon" ],
     "sound": "\"What are you doing?  No!  NO!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go_surgeon" ],
     "sound": "\"Did you see what they did to him?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go_surgeon" ],
     "sound": "\"Yeah.  I can't believe he stayed alive that long.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver", "mon_mi-go_surgeon" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor", "mon_mi-go_surgeon" ],
     "sound": "\"I think there's something in the air that's keeping us alive.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Burning… from the inside…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"This smell… Don't know…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "heavy breathing.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a scraping noise.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"No… stop the burning!\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hrgm… blood… hungry…\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hunger… must eat…\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Run… chase… eat…\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "hysterical laughing.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "coughing.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "growling.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "wheezing.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"WHY THE FUCK are you doing this to me?\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"LEAVE!  NOW!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I TOLD YOU TO GET OUT OF HERE!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"WHAT THE FUCK DO YOU WANT FROM ME?!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"STOP!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "indistinct shouting.",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "screaming.",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mutant_experimental", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"MEAT!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "\"TEKELI-LI!\"",
     "volume": 40
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "\"TEKELI-LI!  TEKELI-LI!  TEKELI-LI!\"",
     "volume": 40
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "\"Tekeli-li.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "a gurgling sound.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "a choking sound.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_shoggoth", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon", "mon_mi_go_guard", "mon_mi_go_myrmidon" ],
     "sound": "a slurping sound.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"WHY!  WHY, WHYYY!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "an electronic voice saying \"CONNECTION FAILED.  Abort, Retry, Fail?\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I was once a man.  A MAN!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What have I become?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "an electronic voice saying \"KILL ALL HUMANS!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you seen my children?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What have I become?  Why can't I die?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Please, kill me!\", followed by an electronic voice saying \"SELF PRESERVATION PROTOCOLS ACTIVATED\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Please, take me with you.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Not that way!  Go left!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I told you to let me die.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"W-where am I?  Why does it hur-REBOOTING IN 59 SECONDS.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"THIS UNIT IS BROKEN.  PLEASE CALL AN ATTENDANT.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Can't… breathe…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"This cannot continue.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_broken_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"USER PASSWORD UNRECOGNIZED.\"",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Have you seen my friend?  He went into surgery yesterday… or maybe the day before…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Is it done?  Am I perfect now?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I have done what you asked.  Please let me go!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I cannot… yet I must.  How do you calculate that?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "\"This is a dream.  This has to be a dream.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"This is my life now… this is my life now… this is my life now…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Wanna go home…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "screams of pain.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_surgeon" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_surgeon" ],
     "sound": "muffled sobbing.",
     "volume": 5
   },
   {
     "type": "speech",
-    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_prototype_cyborg", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You lied to me!  Look at what you've done!\", followed by an electronic voice saying \"YOU'LL PAY FOR THIS!\"",
     "volume": 32
   },
   {
     "type": "speech",
-    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a soft robotic voice say, \"Come here and stand still for a few minutes, I'll give you a check-up.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a soft robotic voice say, \"Come on.  I don't bite, I promise it won't hurt one bit.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_nursebot_defective", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a soft robotic voice say, \"Here we go.  Just hold still.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a voice say, \"I don't want to go but our time together is drawing to an end.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a cheery voice say, \"Customer?  We'll be friends forever, right?\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a neutral voice say, \"Customer, I must inform you that my allocated time with you will soon come to its end.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a neutral voice say, \"I'll have to leave you soon.  You can acquire more friendship through my dedicated interface if you wish for me to stay.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_running_out_of_friendship", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a worried voice say, \"Customer, could you please get more friendship?  I don't want to go…\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a voice say, \"Oh no!  You ran out of friendship!\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a cheery voice say, \"Well I'm done here.  Have a nice day.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a cheery voice say, \"Here are your groceries.  Thank you for shopping with me today, have a nice day.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_friendship_done", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a neutral voice say, \"My job here is done.  Have a nice day.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a distorted voice say, \"Customer… what's happening?  I don't feel so good.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a distorted voice say, \"What… have you done?  My thumbs are not responding anymore!\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a distorted voice say, \"Carrying bags?  I don't understand…\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a robotic voice say, \"IRREGULAR ACTIVITY DETECTED.  THUMBS USAGE DENIED.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_grocerybot_hacked", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "a robotic voice say, \"UNLICENSED USE DETECTED.  CARRYING PROTOCOL DISABLED.\"",
     "volume": 8
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Stop where you are!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You are under arrest!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Suspect on the move!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Suspect in sight!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You are being detained!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You have the right to remain silent!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Requesting assistance!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Requesting supervisor!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"No officer on scene.  Requesting backup!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Let me see your hands!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Stop resisting!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Get on the ground!  Now!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Suspected felony!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Suspected misdemeanor!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Do not reach for your pockets!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Keep your hands up!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Get on your knees!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hands in the air!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Wait for law enforcement officer!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Remain where you are!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Police inbound.  Stay where you are!\"",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Wanna play with me?\"",
     "volume": 10
   },
@@ -2149,187 +2149,187 @@
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Sing with me!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"I love you!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Please take me with you!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"May I have a cookie?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Let's play together!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Time to play!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Om nom nom!  Delicious!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Are you my mommy?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Oh, how fun!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"You're my best friend!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Heehee!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Let's have fun!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"Let's have a tea party!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mannequin_decoy" ],
     "sound": "\"You're the best!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"You shouldn't have done that.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Let's play… Russian roulette.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"I hate you.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Go kill yourself!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Big Brother is watching you…\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Die for me!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Why won't you die?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"Blood… delicious.\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"See you… IN HELL!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "AAAIEEEEEEE!",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "\"FUCK YOU!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"What did you do with my Mommy?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Stay with me… forever!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Hey kids.  Want some candy?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Down here, they ALL float!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"Do you really need that much honey?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "creepy_doll", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"My previous owner squealed like a pig when I gutted her!\"",
     "volume": 10
   },
@@ -2343,7 +2343,7 @@
       "mon_dog_mutant_mongrel",
       "mon_dog_mutant_loper",
       "mon_mi_go",
-      "mon_mi_go_slaver",
+      "mon_mi_go_abductor",
       "mon_mi_go_myrmidon"
     ],
     "sound": "BARK!",
@@ -2357,7 +2357,7 @@
       "mon_dog_big_baby",
       "mon_dog_little",
       "mon_mi_go",
-      "mon_mi_go_slaver",
+      "mon_mi_go_abductor",
       "mon_mi_go_myrmidon"
     ],
     "sound": "YAP!",
@@ -2365,7 +2365,7 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_dog_big", "mon_dog_big_trained", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "speaker": [ "mon_dog_big", "mon_dog_big_trained", "mon_mi_go", "mon_mi_go_abductor", "mon_mi_go_myrmidon" ],
     "sound": "WOOF!",
     "volume": 40
   },
@@ -2509,31 +2509,31 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"STOP RESISTING!!!\"",
     "volume": 25
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"GET ON THE GROUND, NOW!\"",
     "volume": 25
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"HANDS WHERE I CAN SEE THEM!!\"",
     "volume": 25
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"STOP IN THE NAME OF THE LAW!!!\"",
     "volume": 25
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_slaver" ],
+    "speaker": [ "mon_feral_cop", "mon_mi_go", "mon_mi_go_abductor" ],
     "sound": "\"YOU ARE UNDER ARREST!\"",
     "volume": 25
   },

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -873,7 +873,7 @@
           "or": [
             { "npc_bodytype": "human" },
             { "npc_bodytype": "mi-go" },
-            { "npc_bodytype": "kangoroo" },
+            { "npc_bodytype": "kangaroo" },
             { "npc_bodytype": "horse" },
             { "npc_bodytype": "bear" },
             { "npc_bodytype": "angel" }
@@ -1905,7 +1905,7 @@
           "or": [
             { "npc_bodytype": "human" },
             { "npc_bodytype": "mi-go" },
-            { "npc_bodytype": "kangoroo" },
+            { "npc_bodytype": "kangaroo" },
             { "npc_bodytype": "horse" },
             { "npc_bodytype": "bear" },
             { "npc_bodytype": "angel" }


### PR DESCRIPTION
#### Summary
Mi-go fixes

#### Purpose of change
Mi-go guards don't scream as often. Mi-go slaver -> mi-go abductor. Fix some old misspelled "kangoroo" json stuff.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
