### PR TITLE
Throw damage for short spears

### DIFF
--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -336,7 +336,8 @@
     "price": "130 USD",
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
-    "melee_damage": { "bash": 5, "stab": 24 }
+    "melee_damage": { "bash": 5, "stab": 24 },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 3 }, { "damage_type": "stab", "amount": 12 } ]
   },
   {
     "id": "spear_short_bronze",
@@ -358,7 +359,8 @@
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "flags": [ "SPEAR", "SHEATH_SPEAR", "NONCONDUCTIVE", "WALKING_AID" ],
     "weapon_category": [ "SPEARS" ],
-    "melee_damage": { "bash": 5, "stab": 23 }
+    "melee_damage": { "bash": 5, "stab": 23 },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 3 }, { "damage_type": "stab", "amount": 11 } ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
Throw damage for short spears

#### Purpose of change
Short spears aren't ideal for throwing, but you can throw them OK IRL

#### Describe the solution
The steel one does slightly more damage than a steel javelin, the bronze does a bit less than that.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
