### PR TITLE
Make offroading way shittier and harder because autodrivers

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -9,6 +9,7 @@
     "sym": "o",
     "color": "red",
     "autonote": false,
+    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -21,6 +22,7 @@
     "sym": "o",
     "color": "red",
     "autonote": false,
+    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -163,6 +165,18 @@
     "description": "Helicopter crashed here.",
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_helicopter" },
     "min_max_zlevel": [ 0, 0 ],
+    "sym": "X",
+    "color": "light_blue",
+    "autonote": false,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
+  },
+  {
+    "id": "mx_helicopter_ravine",
+    "type": "map_extra",
+    "name": { "str": "Helicopter Crash" },
+    "description": "Helicopter crashed here.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_helicopter" },
+    "min_max_zlevel": [ -2, -2 ],
     "sym": "X",
     "color": "light_blue",
     "autonote": false,
@@ -329,6 +343,7 @@
     "sym": "p",
     "color": "blue",
     "autonote": false,
+    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -339,6 +354,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest" },
     "min_max_zlevel": [ 0, 0 ],
     "autonote": false,
+    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -348,6 +364,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest_2" },
     "min_max_zlevel": [ 0, 0 ],
     "autonote": false,
+    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {

--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -991,7 +991,7 @@
       [ "mx_rock_formation", 500 ],
       [ "mx_spider", 200 ],
       [ "mx_knotweed_patch", 120 ],
-      [ "mx_helicopter", 1 ],
+      [ "mx_helicopter_ravine", 2 ],
       [ "mx_nest_wasp_ravine", 50 ],
       [ "mx_grass2_ravine", 40 ],
       [ "mx_casings", 30 ],
@@ -1001,7 +1001,7 @@
       [ "mx_crater_ravine", 10 ],
       [ "mx_portal", 3 ],
       [ "mx_portal_in", 3 ],
-      [ "mx_jabberwock", 2 ],
+      [ "mx_jabberwock", 4 ],
       [ "mx_beehive_natural_ravine", 20 ]
     ]
   },

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -221,6 +221,7 @@
     "durability": 200,
     "description": "A wheel.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.35,
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 1, 2 ] },
       { "item": "steel_fragment", "count": [ 1, 2 ] },
@@ -243,7 +244,7 @@
     "type": "vehicle_part",
     "name": { "str": "racing slick" },
     "item": "wheel_slick",
-    "wheel_offroad_rating": 0.3,
+    "wheel_offroad_rating": 0.2,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
     "contact_area": 180,
     "damage_reduction": { "bash": 12 }
@@ -315,6 +316,7 @@
     "durability": 40,
     "description": "A thin bicycle wheel.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.4,
     "folded_volume": "3500 ml",
     "breaks_into": [
       { "item": "steel_chunk", "prob": 50 },
@@ -492,6 +494,7 @@
     "durability": 90,
     "description": "A small wheel from a motorcycle.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.4,
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 1, 3 ] },
       { "item": "steel_fragment", "count": [ 1, 3 ] },
@@ -564,6 +567,7 @@
     "durability": 30,
     "description": "A set of three plastic wheels, with a larger one in the front, mounted with bolts.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.4,
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 3 ] } ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
@@ -589,6 +593,7 @@
     "durability": 40,
     "description": "A small wheel.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.35,
     "folded_volume": "3500 ml",
     "breaks_into": [
       { "item": "steel_chunk", "prob": 50 },

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1015,9 +1015,10 @@ overmap_path_params overmap_path_params::for_land_vehicle( float offroad_coeff, 
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::highway, 3 );
     ret.set_cost( oter_travel_cost_type::road, 8 ); // limited by vehicle autodrive speed
-    const int field_cost = can_offroad ? std::lround( 12 / std::min( 1.0f, offroad_coeff ) ) : -1;
+    const int field_cost = can_offroad ? std::lround( 16 / offroad_coeff ) : -1;
+    const int dirt_road_cost = can_offroad ? std::lround( 12 / offroad_coeff ) : -1;
     ret.set_cost( oter_travel_cost_type::field, field_cost );
-    ret.set_cost( oter_travel_cost_type::dirt_road, field_cost );
+    ret.set_cost( oter_travel_cost_type::dirt_road, dirt_road_cost );
     ret.set_cost( oter_travel_cost_type::trail,
                   ( can_offroad && tiny ) ? field_cost + 10 : -1 );
     if( amphibious ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1575,7 +1575,6 @@ void vehicle::pldrive( map &here, Character &driver, const int trn, const int ac
     // This is a very rough check to try to figure out if we're offroad and should be training offroad driving proficiency.
     bool is_offroad = !( is_flying || in_deep_water || wheelcache.empty() ) &&
                       ( here.vehicle_wheel_traction( *this ) < wheel_area() * 0.80f );
-    // Check if you're piloting on land or water, and reduce effective driving skill proportional to relevant proficiencies (10% Boat Proficiency = 10% driving skill on water)
     if( !driver.has_proficiency( proficiency_prof_driver ) && !in_deep_water && is_offroad ) {
         is_non_proficient = true;
         vehicle_proficiency = driver.get_proficiency_practice( proficiency_prof_driver );


### PR DESCRIPTION
#### Summary
Make offroading way shittier and harder because autodrivers

#### Purpose of change
People will not stop mindlessly autodriving into craters.

#### Describe the solution
- Craters are now marked as totally impassable in autotravel of any kind.
- So are ponds and ravines.
- Upped the autodrive cost for fields by 33%. This is just for pathfinding, it doesn't affect the actual driving stats.
- Made non-offroad wheels far worse at offroading. This applies to unicycles, motorcycles, and bicycles. Some others took a slight hit.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
