### PR TITLE
Make Offroading Worse II

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-outdoors.json
+++ b/data/json/furniture_and_terrain/terrain-floors-outdoors.json
@@ -10,7 +10,7 @@
     "coverage": 0,
     "connects_to": [ "DIRT", "CLAY", "SAND", "MUD", "DIRTMOUND", "CLAYMOUND", "SANDMOUND", "SANDGLASS", "CONCRETE" ],
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE", "TIRE_SAFE" ],
     "bash": { "sound": "thump", "ter_set": "t_open_air", "str_min": 50, "str_max": 100, "bash_below": true }
   },
   {
@@ -23,7 +23,7 @@
     "color": "light_gray",
     "looks_like": "t_railroad_rubble",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -43,7 +43,7 @@
     "looks_like": "t_moss",
     "move_cost": 2,
     "coverage": 0,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -107,7 +107,7 @@
     "connects_to": [ "CLAY", "CLAYMOUND" ],
     "move_cost": 2,
     "coverage": 0,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "TIRE_SAFE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -173,7 +173,7 @@
     "connects_to": "SANDGLASS",
     "move_cost": 3,
     "coverage": 0,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "TIRE_DAMAGE" ],
     "bash": { "sound": "crunch", "ter_set": "t_sand", "str_min": 25, "str_max": 100, "str_min_supported": 100 }
   },
   {
@@ -187,7 +187,7 @@
     "connects_to": "DIRTMOUND",
     "move_cost": 3,
     "coverage": 0,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE", "TREE_PLANTABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "MOUNTABLE", "NOCOLLIDE", "PLANTABLE", "TREE_PLANTABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",

--- a/data/json/furniture_and_terrain/terrain-railroads.json
+++ b/data/json/furniture_and_terrain/terrain-railroads.json
@@ -24,7 +24,7 @@
         { "item": "rock", "count": [ 4, 12 ] }
       ]
     },
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ]
+    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "TIRE_SAFE" ]
   },
   {
     "id": "t_railroad_track",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -27,6 +27,20 @@
   },
   {
     "type": "ITEM",
+    "id": "rough_terrain",
+    "symbol": "$",
+    "color": "light_gray",
+    "name": { "str_sp": "rough terrain" },
+    "//": "pseudo item, only used for damaging vehicle tires when offroading",
+    "description": "Seeing this is a bug.",
+    "material": [ "stone" ],
+    "weight": "657 g",
+    "volume": "250 ml",
+    "flags": [ "DAMAGE_VEHICLE_WHEELS" ],
+    "price": "0 cent"
+  },
+  {
+    "type": "ITEM",
     "id": "cottonwood_tree_boll",
     "name": { "str": "cottonwood tree boll" },
     "category": "other",

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -9,7 +9,6 @@
     "sym": "o",
     "color": "red",
     "autonote": false,
-    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -22,7 +21,6 @@
     "sym": "o",
     "color": "red",
     "autonote": false,
-    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -343,7 +341,6 @@
     "sym": "p",
     "color": "blue",
     "autonote": false,
-    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -354,7 +351,6 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest" },
     "min_max_zlevel": [ 0, 0 ],
     "autonote": false,
-    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -364,7 +360,6 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_pond_forest_2" },
     "min_max_zlevel": [ 0, 0 ],
     "autonote": false,
-    "travel_cost_type": "impassable",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -655,6 +655,7 @@
     "durability": 400,
     "description": "A wide wheel that provides more traction and better off-road performance.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.4,
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 2, 3 ] },
       { "item": "steel_fragment", "count": [ 2, 3 ] },

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -176,6 +176,7 @@ static const itype_id itype_maple_sap( "maple_sap" );
 static const itype_id itype_nail( "nail" );
 static const itype_id itype_pipe( "pipe" );
 static const itype_id itype_rock( "rock" );
+static const itype_id itype_rough_terrain( "rough_terrain" );
 static const itype_id itype_scrap( "scrap" );
 static const itype_id itype_splinter( "splinter" );
 static const itype_id itype_steel_chunk( "steel_chunk" );
@@ -1132,17 +1133,73 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
 
             veh.handle_trap( this, wheel_p, vp_wheel );
             // dont use vp_wheel or vp_wheel_idx below this - handle_trap might've removed it from parts
+            bool has_item = has_items( wheel_p ) &&
+                            !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p );
 
-            if( has_items( wheel_p ) && !has_flag( ter_furn_flag::TFLAG_SEALED, wheel_p ) ) {
-                // Damage is calculated based on the weight of the vehicle,
-                // The area of it's wheels, and the area of the wheel running over the items.
-                // This number is multiplied by weight_to_damage_factor to get reasonable results, damage-wise.
-                const int wheel_damage = vpi_wheel.wheel_info->contact_area / vehicle_grounded_wheel_area *
-                                         vehicle_mass_kg * weight_to_damage_factor;
+            if( has_item ) {
+                const int wheel_damage =
+                    vpi_wheel.wheel_info->contact_area /
+                    vehicle_grounded_wheel_area *
+                    vehicle_mass_kg * weight_to_damage_factor;
 
-                //~ %1$s: vehicle name
-                smash_items( wheel_p, wheel_damage, string_format( _( "weight of %1$s" ), veh.disp_name() ),
+                smash_items( wheel_p, wheel_damage,
+                             string_format( _( "weight of %1$s" ), veh.disp_name() ),
                              &vp_wheel, &veh );
+            }
+
+            auto *driver = veh.get_driver( *this );
+            if( driver == nullptr ) {
+                continue;
+            }
+            const int velocity = std::max( std::abs( veh.velocity ), 1 );
+            if( velocity <= 5 ) {
+                continue;
+            }
+
+            const bool hazard =
+                has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) ||
+                has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p ) ||
+                ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
+                  !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
+                  !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
+
+
+            float divisor = 250000.0f / velocity;
+            const int chance = std::clamp( static_cast<int>( divisor ), 50, 150 );
+            add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %s.", chance );
+            if( !hazard ||
+                vp_wheel.info().wheel_info->offroad_rating >= 0.6f ||
+                !one_in( chance ) ) {
+                continue;
+            }
+
+            float driver_skill = driver->get_skill_level( skill_driving );
+            float driver_spot  = driver->spot_check();
+            float avoidance = std::min(
+                                  driver_skill * 0.02f + driver_spot * 0.01f,
+                                  0.75f
+                              );
+            item rough_terrain( itype_rough_terrain, calendar::turn );
+            float hit_chance = vehicle::hit_probability( rough_terrain, &vp_wheel );
+            float effective_hit = hit_chance * ( 1.f - avoidance );
+            if( rng_float( 0.f, 1.f ) < effective_hit ) {
+                int damage_levels = 1;
+                std::vector<std::string> wheel_damage_messages;
+                veh.damage_wheel_on_item(
+                    &vp_wheel, rough_terrain,
+                    &damage_levels,
+                    &wheel_damage_messages
+                );
+                if( damage_levels > 0 ) {
+                    veh.damage_direct( *this, vp_wheel, damage_levels );
+                    const bool player_is_driver = &get_player_character() == veh.get_driver( *this );
+                    const bool player_sees_damage = get_player_character().sees( *this, wheel_p );
+                    if( !wheel_damage_messages.empty() && ( player_is_driver || player_sees_damage ) ) {
+                        for( const std::string &msg : wheel_damage_messages ) {
+                            add_msg( m_bad, msg );
+                        }
+                    }
+                }
             }
         }
     }
@@ -2558,6 +2615,8 @@ std::string map::features( const tripoint_bub_ms &p ) const
     add_if( has_flag( ter_furn_flag::TFLAG_FLAMMABLE, p ) ||
             has_flag( ter_furn_flag::TFLAG_FLAMMABLE_ASH, p ) ||
             has_flag( ter_furn_flag::TFLAG_FLAMMABLE_HARD, p ), _( "Flammable." ) );
+    add_if( has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, p ), _( "Damages Tires." ) );
+    add_if( has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, p ), _( "Safe for Tires." ) );
     return result;
 }
 
@@ -4258,9 +4317,6 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
                 i++;
                 continue;
             }
-        }
-
-        if( vp_wheel != nullptr ) {
             veh->damage_wheel_on_item( vp_wheel, *i, &damage_levels, &wheel_damage_messages );
         }
 
@@ -4378,17 +4434,6 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
             for( const std::string &msg : wheel_damage_messages ) {
                 add_msg( m_bad, msg );
             }
-        }
-
-        bool existing = false;
-        for( int wheel : veh->wheelcache ) {
-            if( veh->bub_part_pos( *this, veh->part( wheel ) ) == p ) {
-                existing = true;
-                break;
-            }
-        }
-        if( existing ) {
-            add_msg( m_bad, _( "The %s has been degraded by the damage" ), vp_wheel->name() );
         }
     }
 

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -11,6 +11,7 @@
 #include "color.h"
 #include "coords_fwd.h"
 #include "flat_set.h"
+#include "omdata.h"
 #include "string_id.h"
 #include "translations.h"
 #include "type_id.h"

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -337,6 +337,8 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_REGION_PSEUDO: return "REGION_PSEUDO";
         case ter_furn_flag::TFLAG_PHASE_BACK: return "PHASE_BACK";
         case ter_furn_flag::TFLAG_SOAKING_TUB: return "SOAKING_TUB";
+        case ter_furn_flag::TFLAG_TIRE_DAMAGE: return "TIRE_DAMAGE";
+        case ter_furn_flag::TFLAG_TIRE_SAFE: return "TIRE_SAFE";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -382,6 +382,8 @@ enum class ter_furn_flag : int {
     TFLAG_MON_AVOID_STRICT,
     TFLAG_REGION_PSEUDO,
     TFLAG_SOAKING_TUB,
+    TFLAG_TIRE_DAMAGE,
+    TFLAG_TIRE_SAFE,
 
     NUM_TFLAG_FLAGS
 };

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1015,10 +1015,10 @@ overmap_path_params overmap_path_params::for_land_vehicle( float offroad_coeff, 
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::highway, 3 );
     ret.set_cost( oter_travel_cost_type::road, 8 ); // limited by vehicle autodrive speed
-    const int field_cost = can_offroad ? std::lround( 16 / offroad_coeff ) : -1;
     const int dirt_road_cost = can_offroad ? std::lround( 12 / offroad_coeff ) : -1;
-    ret.set_cost( oter_travel_cost_type::field, field_cost );
+    const int field_cost = can_offroad ? std::lround( 18 / offroad_coeff ) : -1;
     ret.set_cost( oter_travel_cost_type::dirt_road, dirt_road_cost );
+    ret.set_cost( oter_travel_cost_type::field, field_cost );
     ret.set_cost( oter_travel_cost_type::trail,
                   ( can_offroad && tiny ) ? field_cost + 10 : -1 );
     if( amphibious ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -733,6 +733,26 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
         return &ovp->vehicle() == &driven_veh;
     }
 
+    constexpr int ramp_padding = 3;
+
+    for( int dx = -ramp_padding; dx <= ramp_padding; ++dx ) {
+        for( int dy = -ramp_padding; dy <= ramp_padding; ++dy ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            const tripoint_bub_ms neighbor(
+                pt.x() + dx,
+                pt.y() + dy,
+                pt.z()
+            );
+            if( ( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, neighbor ) ||
+                here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, neighbor ) ) &&
+                !here.has_flag( ter_furn_flag::TFLAG_ROAD, neighbor ) ) {
+                return false;
+            }
+        }
+    }
+
     const tripoint_abs_ms pt_abs = here.get_abs( pt );
     const tripoint_abs_omt pt_omt = project_to<coords::omt>( pt_abs );
     // only check visibility for the current OMT, we'll check other OMTs when
@@ -786,6 +806,14 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
     if( terrain == ter_str_id::NULL_ID() ) {
         return false;
     }
+
+    const bool is_ramp =
+        here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, pt ) ||
+        here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, pt );
+
+    if( is_ramp && !here.has_flag( ter_furn_flag::TFLAG_ROAD, pt ) ) {
+        return false;
+    }
     // open air is an obstacle to non-flying vehicles; it is drivable
     // for flying vehicles
     if( terrain == ter_t_open_air ) {
@@ -834,24 +862,28 @@ void vehicle::autodrive_controller::compute_obstacles( map &here )
     compute_obstacles_from_enqueued_ramp_points( ramp_points, here );
 }
 
-// Checks whether `p` is a drivable ramp up or down,
-// and if so adds the ramp's destination tripoint to `ramp_points`
-void vehicle::autodrive_controller::enqueue_if_ramp( point_queue &ramp_points,
-        const map &here, const tripoint_bub_ms &p ) const
+void vehicle::autodrive_controller::enqueue_if_ramp(
+    point_queue &ramp_points,
+    const map &here,
+    const tripoint_bub_ms &p ) const
 {
     if( !data.land_ok ) {
         return;
     }
-    // Please don't drive into craters.
-    if( !here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ) {
-        ramp_points.visited.emplace( p );
+    const bool road = here.has_flag( ter_furn_flag::TFLAG_ROAD, p );
+    if( !road ) {
+        return;
+    }
+    const bool ramp_up = here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, p );
+    const bool ramp_down = here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, p );
+    if( !ramp_up && !ramp_down ) {
         return;
     }
     ramp_points.visited.emplace( p );
-    if( p.z() < OVERMAP_HEIGHT && here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, p ) ) {
+    if( ramp_up && p.z() < OVERMAP_HEIGHT ) {
         ramp_points.enqueue( p + tripoint::above );
     }
-    if( p.z() > -OVERMAP_DEPTH && here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, p ) ) {
+    if( ramp_down && p.z() > -OVERMAP_DEPTH ) {
         ramp_points.enqueue( p + tripoint::below );
     }
 }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1341,7 +1341,8 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
     // Items attempting to do damage use the best/hardest possible value, the pointy bits.
     double item_hardness = item_hardness_calc( it ).second;
     // It is exponentially more difficult for soft items to damage wheels, even if you're hitting a lot of them.
-    const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ), 1.0 );
+    const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ) / 10,
+                                    0.5 );
     add_msg_debug( debugmode::DF_VEHICLE_MOVE,
                    "Vehicle %s running over item %s."
                    "\n Chance to damage: %f%%."
@@ -1361,7 +1362,8 @@ void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int 
                                  ( static_cast<double>( itype::damage_scale ) / vp_wheel->max_damage() );
 
     const double chance_to_damage = wheel_damage_chance_vs_item( it, *vp_wheel );
-
+    add_msg_debug( debugmode::DF_VEHICLE_MOVE,
+                   "Final chance to damage: %f%%.", chance_to_damage * 100 );
     if( chance_to_damage > 0.0 ) {
         if( chance_to_damage >= rng_float( 0.0, 1.0 ) ) {
             *damage_levels += one_damage_level;


### PR DESCRIPTION
#### Summary
Make Offroading Worse II

#### Purpose of change
More autodriver woes, some bugs from before.

#### Describe the solution
- Autodrive will now try harder to stay on roads if your car isn't offroad-capable. You are ultimately responsible for your own route though.
- Non-offroad tires will periodically take damage if driving on rough terrain. Dirt roads and gravel are OK, but anything else that isn't a road or a smooth floor is going to be bad. This is based on your speed and driving skill. At 5mph or below, your tires take no damage.
- Autodrive now much more aggressively avoids non-road ramps, adding 3 tiles of padding around them as no-go zones.
- Fixed some bugs with how damage from running over items was being calculated.
- Fixed an error message from the last update's attempt to make craters not autodrivable.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
