### PR TITLE
Better starting location search

### DIFF
--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -86,11 +86,6 @@ int start_location::targets_count() const
     return _locations.size();
 }
 
-omt_types_parameters start_location::random_target() const
-{
-    return random_entry( _locations );
-}
-
 bool start_location::requires_city() const
 {
     return constraints_.city_size.min > 0 ||
@@ -252,21 +247,46 @@ std::pair<tripoint_abs_omt, std::unordered_map<std::string, std::string>>
         start_location::find_player_initial_location( const point_abs_om &origin ) const
 {
     // Spiral out from the world origin scanning for a compatible starting location,
-    // creating overmaps as necessary.
-    const int radius = 3;
-    const omt_types_parameters chosen_target = random_target();
-    for( const point_abs_om &omp : closest_points_first( origin, radius ) ) {
-        overmap &omap = overmap_buffer.get( omp );
-        const tripoint_om_omt omtstart = omap.find_random_omt( std::make_pair( chosen_target.omt,
-                                         chosen_target.omt_type ) );
-        if( omtstart.raw() != tripoint::min ) {
-            return std::make_pair( project_combine( omp, omtstart ), chosen_target.parameters );
+    // creating overmaps as necessary. Any of this location's terrains is an
+    // acceptable match. If the initial radius comes up empty, widen the search
+    // ring by ring before giving up.
+    const int initial_radius = 3;
+    const int max_radius = 5;
+    const int min_z = constraints_.allowed_z_levels.min;
+    const int max_z = constraints_.allowed_z_levels.max;
+    for( int radius = initial_radius; radius <= max_radius; radius++ ) {
+        const int min_dist = radius == initial_radius ? 0 : radius;
+        for( const point_abs_om &omp : closest_points_first( origin, min_dist, radius ) ) {
+            overmap &omap = overmap_buffer.get( omp );
+            std::vector<std::pair<tripoint_om_omt, omt_types_parameters>> valid;
+            for( int i = 0; i < OMAPX; i++ ) {
+                for( int j = 0; j < OMAPY; j++ ) {
+                    for( int k = min_z; k <= max_z; k++ ) {
+                        const tripoint_om_omt p( i, j, k );
+                        const oter_id &ter = omap.ter( p );
+                        auto target_is_ot_match = [&]( const omt_types_parameters & target ) {
+                            return is_ot_match( target.omt, ter, target.omt_type );
+                        };
+                        auto it = std::find_if( _locations.begin(), _locations.end(),
+                                                target_is_ot_match );
+                        if( it != _locations.end() ) {
+                            valid.emplace_back( p, *it );
+                        }
+                    }
+                }
+            }
+            const std::pair<tripoint_om_omt, omt_types_parameters> random_valid = random_entry( valid,
+                    std::make_pair( tripoint_om_omt::invalid, omt_types_parameters() ) );
+            if( !random_valid.first.is_invalid() ) {
+                return std::make_pair( project_combine( omp, random_valid.first ),
+                                       random_valid.second.parameters );
+            }
         }
     }
     // Should never happen, if it does we messed up.
     popup( _( "Unable to generate a valid starting location %s [%s] in a radius of %d overmaps, please report this failure." ),
-           name(), id.str(), radius );
-    return std::make_pair( tripoint_abs_omt::invalid, chosen_target.parameters );
+           name(), id.str(), max_radius );
+    return std::make_pair( tripoint_abs_omt::invalid, std::unordered_map<std::string, std::string>() );
 }
 
 std::pair<tripoint_abs_omt, std::unordered_map<std::string, std::string>>

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -52,7 +52,6 @@ class start_location
 
         std::string name() const;
         int targets_count() const;
-        omt_types_parameters random_target() const;
         const std::set<std::string> &flags() const;
 
         /**


### PR DESCRIPTION
#### Summary
Search for any valid terrain, not just one when picking starting location. Also limits z-level search to z-levels within location constraints. Search occurs in a multi-ring method now too, which can be expanded later

#### Purpose of change
Current searches for start location can fail and afterwards they try again by genning new overmaps. This is fine when looking for one specific terrain, but it is inefficient for the purposes of looking for multiple valid terrain types since new overmaps must be generated for each terrain that is searched over.

#### Describe the solution
I added a minor thing to speed up search (only look z-levels where a desired location is valid) with start_location_placement_constraints.allowed_z_levels. Added another detail to allow further granularity of search (can specify a number of rings to search through before giving up on a search).

#### Describe alternatives you've considered
"For lake-dependent scenarios, we don't need to fully generate an overmap to know if it has a lake in it because the noise for generating lakes is independent. For a large body of water spawn, we could quickly narrow down overmaps to generate by only looking at places where the lake-noise would allow a lake. We could add an optional "feature_hint" param or something to the start_location JSON allowing us to quickly pare down which overmaps need to be generated for particular starts."
^^^ I didn't implement this yet but could do so in the future.

#### Testing
I built the game and tested a "Call of the Deep" scenario per forum poster Flesh Forge:
  {
    "type": "scenario",
    "id": "call_of_the_deep",
    "name": "Call of the Deep",
    "points": 0,
    "description": "At the start of the Cataclysm, you find yourself beside a large body of deep water.  Are you drawn to it?  Are you fleeing from it?",
    "start_name": "Beside the Water",
    "allowed_locs": [ "sloc_lake_shore", "sloc_cabin_lake", "sloc_cabin_lakeside", "sloc_lighthouse_ground", "sloc_lighthouse_small_ground" ],
    "flags": [ "LONE_START" ]
  }
It worked immediately and my generated character spawned by a lake. I didn't test all scenarios. 