### PR TITLE
Build "Fix macOS build warnings and clean up Makefile"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ cata_test
 cata_test-tiles
 cataclysm
 *cataclysm-tiles
+*cataclysm-tlg
+*cataclysm-tlg-tiles
 cataclysm-vcpkg
 cataclysmdda-*
 chkjson*
@@ -52,6 +54,10 @@ DartConfiguration.tcl
 debug.log
 logg.txt
 json_formatter
+/zzip
+
+# macOS debug symbol bundles
+*.dSYM/
 
 # Visual Studio files
 *.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,6 @@
 #  make ASTYLE=0
 # Disable format check of whitelisted json files.
 #  make LINTJSON=0
-# Disable building tests.
-#  make TESTS=0
-# Enable running tests.
-#  make RUNTESTS=1
 # Build source files in order of how often the matching header is included
 #  make HEADERPOPULARITY=1
 
@@ -184,48 +180,6 @@ endif
 # Enable json format check by default
 ifndef LINTJSON
   LINTJSON = 1
-endif
-
-# We don't want to have both 'check' and 'tests' as targets, because that will
-# result in make trying to build the tests twice in parallel, wasting time
-# (The tests target will be launched parallel to the check target, and both
-#  will build the tests executable)
-# There are three possible outcomes we expect:
-#   a. Tests are built and run (check)
-#   b. Tests are built (tests)
-#   c. Tests are not built
-#
-# This table defines the expected behavior for the possible values of TESTS and
-# RUNTESTS.
-# TESTS defaults to 1, RUNTESTS defaults to 0.
-#
-#   RUNTESTS
-# T # | 0 | 1
-# E ----------
-# S 0 | c | c
-# T ----------
-# S 1 | b | a
-#
-
-# Disable building tests by default
-ifndef TESTS
-  TESTS = 0
-endif
-
-# Disable running tests by default
-ifndef RUNTESTS
-  RUNTESTS = 0
-endif
-
-# Can't run tests if we aren't going to build them
-ifeq ($(TESTS), 1)
-  ifeq ($(RUNTESTS), 1)
-    # Build and run the tests
-    TESTSTARGET = check
-  else
-    # Only build the tests
-    TESTSTARGET = tests
-  endif
 endif
 
 ifndef PCH
@@ -1053,7 +1007,7 @@ endif
 
 LDFLAGS += -lz
 
-all: version prefix $(CHECKS) $(TARGET) $(L10N) $(TESTSTARGET) $(ZZIP_BIN)
+all: version prefix $(CHECKS) $(TARGET) $(L10N) $(ZZIP_BIN)
 	@
 
 $(TARGET): $(OBJS)
@@ -1100,7 +1054,6 @@ $(ODIR)/%.inc: $(SRC_DIR)/%.c
 
 .PHONY: includes
 includes: $(OBJS:.o=.inc)
-	+make -C tests includes
 
 $(ODIR)/third-party/%.o: $(SRC_DIR)/third-party/%.cpp
 	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -w -MMD -MP $(MJFLAG) -c $< -o $@
@@ -1142,7 +1095,7 @@ $(CHKJSON_BIN): $(CHKJSON_SOURCES)
 json-check: $(CHKJSON_BIN)
 	./$(CHKJSON_BIN)
 
-clean: clean-tests clean-object_creator clean-pch clean-lang
+clean: clean-object_creator clean-pch clean-lang
 	rm -rf *$(TARGET_NAME) *$(TILES_TARGET_NAME)
 	rm -rf *$(TILES_TARGET_NAME).exe *$(TARGET_NAME).exe *$(TARGET_NAME).a
 	rm -rf *obj *objwin
@@ -1410,15 +1363,6 @@ $(ZZIP_BIN): $(ZZIP_SOURCES) $(BUILD_PREFIX)zstd.a
 python-check:
 	flake8
 
-tests: version $(BUILD_PREFIX)cataclysm.a $(LOCALIZE_TEST_DEPS)
-	$(MAKE) -C tests
-
-check: version $(BUILD_PREFIX)cataclysm.a $(LOCALIZE_TEST_DEPS)
-	$(MAKE) -C tests check
-
-clean-tests:
-	$(MAKE) -C tests clean
-
 object_creator: version $(BUILD_PREFIX)cataclysm.a
 	$(MAKE) -C object_creator
 
@@ -1432,11 +1376,10 @@ clean-pch:
 	rm -f pch/*pch.hpp.gch
 	rm -f pch/*pch.hpp.pch
 	rm -f pch/*pch.hpp.d
-	$(MAKE) -C tests clean-pch
 
 clean-lang:
 	$(MAKE) -C lang clean
 
-.PHONY: tests check ctags etags clean-tests clean-object_creator clean-pch clean-lang install lint
+.PHONY: ctags etags clean-object_creator clean-pch clean-lang install lint
 
 -include ${OBJS:.o=.d}

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -761,7 +761,7 @@ void math_exp::math_exp_impl::new_func()
             },
             []( auto /* v */ )
             {
-                throw math::internal_error( "Internal func error.  That's all we know." );
+                math::raise<math::internal_error>( "Internal func error.  That's all we know." );
             },
         },
         ops.top().op );
@@ -885,7 +885,7 @@ void math_exp::math_exp_impl::new_oper()
         []( auto /* v */ )
         {
             // we should never get here due to paren validation
-            throw math::internal_error( "Internal oper error.  That's all we know." );
+            math::raise<math::internal_error>( "Internal oper error.  That's all we know." );
         }
     },
     op.op );

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -70,8 +70,8 @@ template <typename T>
 T _read_from_string( std::string_view s, const std::vector<std::pair<std::string, T>> &units )
 {
     auto const error = [s]( char const * suffix, size_t /* offset */ ) {
-        throw math::runtime_error( R"(Failed to convert "%s" to a %s value: %s)", s,
-                                   _str_type_of<T>(), suffix );
+        math::raise<math::runtime_error>( R"(Failed to convert "%s" to a %s value: %s)", s,
+                                          _str_type_of<T>(), suffix );
     };
     return detail::read_from_json_string_common<T>( s, units, error );
 }

--- a/src/math_parser_type.h
+++ b/src/math_parser_type.h
@@ -4,6 +4,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "string_formatter.h"
 
@@ -43,6 +44,15 @@ using syntax_error = math_exception_impl<0>;
 using runtime_error = math_exception_impl<5>;
 // math parser entered an unexpected state
 using internal_error = math_exception_impl<10>;
+
+// Throw the given math exception. Marked [[noreturn]] so callers that always
+// throw -- notably lambdas, which cannot themselves be marked [[noreturn]] --
+// don't trip -Wmissing-noreturn.
+template<typename Exception, typename... Args>
+[[noreturn]] inline void raise( Args &&...args )
+{
+    throw Exception( std::forward<Args>( args )... );
+}
 
 template<int severity>
 constexpr std::string_view _severity_str()

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1171,7 +1171,7 @@ void game::chat()
             message = _( "loudly." );
             break;
         case NPC_CHAT_SENTENCE: {
-            std::string popupdesc = ( _( "Enter a sentence to %s" ), shout_sound );
+            std::string popupdesc = string_format( _( "Enter a sentence to %s" ), shout_sound );
             string_input_popup popup;
             popup.title _( "Yell a sentence" )
             .width( 64 )


### PR DESCRIPTION
#### Summary
Fix macOS build warnings on Tahoe (26.x), dangling Makefile targets (`make test` etc), and update .gitignore to ignore intermediate build artifacts and the final binaries.

#### Purpose of change
macOS builds emit `-Werror` failures and `make clean` is broken after the test suite was removed.

#### Describe the solution
- `math_parser*.cpp`: route always-throwing lambdas through a new `[[noreturn]]` `math::raise` helper to satisfy `-Wmissing-noreturn` (lambdas can't take the attribute directly).
- `npctalk.cpp`: fix `string_format` operator issue.
- `Makefile`: drop the dangling `tests`/`check`/`clean-tests` targets and `-C tests` recursion left over from test-suite removal, fixing `make clean`.
- `.gitignore`: ignore macOS build outputs (`cataclysm-tlg[-tiles]`, `zzip`, `*.dSYM/`).

#### Describe alternatives you've considered
Marking the lambdas `[[noreturn]]` directly — rejected, invalid in C++17 (attribute applies to the type, not the function).

#### Testing
`make TILES=1 SOUND=1` compiles clean (no `-Werror` warnings); `make clean` succeeds.

#### Additional context
None.
