### PR TITLE
Fix velocity check for offroading and tires

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1152,7 +1152,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                 continue;
             }
             const int velocity = std::max( std::abs( veh.velocity ), 1 );
-            if( velocity <= 5 ) {
+            if( velocity <= 500 ) {
                 continue;
             }
 


### PR DESCRIPTION
#### Summary
Fix velocity check for offroading and tires

#### Purpose of change
The velocity check for damaging non-offroad tires when driving offroad was supposed to be mph * 100, but it was just mph

#### Describe the solution
fix

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
