### PR TITLE
Very rough terrain doesn't skip tire damage

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1152,14 +1152,11 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                 continue;
             }
             const int velocity = std::max( std::abs( veh.velocity ), 1 );
-            if( velocity <= 500 ) {
-                continue;
-            }
 
             const bool hazard =
                 has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) ||
                 has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p ) ||
-                ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
+                ( velocity > 500 && has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -746,7 +746,7 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
                 pt.z()
             );
             if( ( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, neighbor ) ||
-                here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, neighbor ) ) &&
+                  here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, neighbor ) ) &&
                 !here.has_flag( ter_furn_flag::TFLAG_ROAD, neighbor ) ) {
                 return false;
             }


### PR DESCRIPTION
#### Summary
Very rough terrain doesn't skip tire damage

#### Purpose of change
Going slow won't save your tires from driving on sharp stuff.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
