### PR TITLE
More tire tweaks

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1156,7 +1156,7 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             const bool hazard =
                 has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) ||
                 has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p ) ||
-                ( velocity > 500 && has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
+                ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 


### PR DESCRIPTION
#### Summary
More tire tweaks

#### Purpose of change
Someone said, "I'll just drive slow and never take damage from going offroad." So I removed the sub-5mph immunity to tire damage when offroading with non-offroad tires.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
