### PR TITLE
Various fixes

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -392,8 +392,7 @@
     "light_emitted": 50,
     "heat_radiation": 3,
     "trap": "tr_lava",
-    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "DESTROY_ITEM", "USABLE_FIRE" ],
-    "//": "lava-seared moose meat? yes, please"
+    "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "DESTROY_ITEM", "USABLE_FIRE", "TIRE_DAMAGE" ]
   },
   {
     "type": "terrain",
@@ -568,7 +567,7 @@
     "color": "light_blue",
     "move_cost": 3,
     "liquid_source": { "id": "water_murky", "count": [ 40, 240 ], "min_temp": 2.2 },
-    "flags": [ "TRANSPARENT", "LIQUIDCONT", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER" ],
+    "flags": [ "TRANSPARENT", "LIQUIDCONT", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER", "TIRE_DAMAGE" ],
     "examine_action": "finite_water_source",
     "phase_targets": [ "t_ice_sh_thick", "t_ice_sh_thin", "t_pseudo_phase" ],
     "phase_temps": [ -15, -10 ],
@@ -585,7 +584,7 @@
     "move_cost": 3,
     "connect_groups": "INDOORFLOOR",
     "liquid_source": { "id": "water_murky", "count": [ 40, 240 ], "min_temp": 2.2 },
-    "flags": [ "TRANSPARENT", "LIQUIDCONT", "INDOORS", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER" ],
+    "flags": [ "TRANSPARENT", "LIQUIDCONT", "INDOORS", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER", "TIRE_DAMAGE" ],
     "examine_action": "finite_water_source",
     "phase_targets": [ "t_ice_sh_thick", "t_ice_sh_thin", "t_pseudo_phase" ],
     "phase_temps": [ -15, -10 ],

--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -7,7 +7,7 @@
     "symbol": "0",
     "color": "yellow",
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "DIGGABLE_CAN_DEEPEN", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -28,7 +28,7 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 10,
     "trap": "tr_pit",
-    "flags": [ "TRANSPARENT" ],
+    "flags": [ "TRANSPARENT", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -47,7 +47,7 @@
     "symbol": "#",
     "color": "green",
     "move_cost": 5,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "PIT_FILLABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "PIT_FILLABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -90,7 +90,7 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 10,
     "trap": "tr_spike_pit",
-    "flags": [ "TRANSPARENT", "PIT_FILLABLE" ],
+    "flags": [ "TRANSPARENT", "PIT_FILLABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -111,7 +111,7 @@
     "connect_groups": "PIT_DEEP",
     "connects_to": "PIT_DEEP",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "ROAD" ],
+    "flags": [ "TRANSPARENT", "ROAD", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -133,7 +133,7 @@
     "connects_to": "PIT_DEEP",
     "move_cost": 10,
     "trap": "tr_glass_pit",
-    "flags": [ "TRANSPARENT", "PIT_FILLABLE" ],
+    "flags": [ "TRANSPARENT", "PIT_FILLABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -211,7 +211,7 @@
     "color": "yellow",
     "looks_like": "t_den_large",
     "move_cost": 3,
-    "flags": [ "TRANSPARENT", "DIGGABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",
@@ -230,7 +230,7 @@
     "color": "yellow",
     "looks_like": "t_pit_shallow",
     "move_cost": 6,
-    "flags": [ "TRANSPARENT", "DIGGABLE" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "TIRE_DAMAGE" ],
     "bash": {
       "sound": "thump",
       "ter_set": "t_open_air",

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -114,13 +114,13 @@
   {
     "id": "cattails_winter_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cattail_rhizome", "difficulty": 7 }, { "drop": "withered", "base_num": [ 1, 5 ], "difficulty": 3 } ]
+    "entries": [ { "drop": "cattail_rhizome", "base_num": [ 0, 2 ], "difficulty": 8 }, { "drop": "withered", "base_num": [ 1, 5 ], "difficulty": 3 } ]
   },
   {
     "id": "cattails_summer_harv",
     "type": "harvest",
     "entries": [
-      { "drop": "cattail_rhizome", "base_num": [ 0, 1 ], "difficulty": 7 },
+      { "drop": "cattail_rhizome", "base_num": [ 0, 2 ], "difficulty": 9 },
       { "drop": "cattail_stalk", "base_num": [ 1, 4 ], "difficulty": 6 },
       { "drop": "withered", "base_num": [ 1, 3 ], "difficulty": 3 }
     ]

--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -20,7 +20,7 @@
     "id": "SUS_shelf_commercial_sauces_dressings",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sauces_dressings", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_sauces_dressings", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_spices_seasoning",
@@ -43,7 +43,7 @@
     "id": "SUS_shelf_commercial_spices_seasoning",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_spices_seasoning", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_spices_seasoning", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_oil_vinegar",
@@ -55,7 +55,7 @@
     "id": "SUS_shelf_commercial_oil_vinegar",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_oil_vinegar", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_oil_vinegar", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_exotic_food",
@@ -67,7 +67,7 @@
     "id": "SUS_shelf_commercial_exotic_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_exotic_food", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_exotic_food", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_grains",
@@ -79,7 +79,7 @@
     "id": "SUS_shelf_commercial_grains",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_grains", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_grains", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_baking",
@@ -100,7 +100,7 @@
     "id": "SUS_shelf_commercial_baking",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baking", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_baking", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_pasta",
@@ -112,7 +112,7 @@
     "id": "SUS_shelf_commercial_pasta",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_pasta", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_pasta", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_canned_vegetables",
@@ -124,7 +124,7 @@
     "id": "SUS_shelf_commercial_canned_vegetables",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_vegetables", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_canned_vegetables", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_canned_fruits",
@@ -136,7 +136,7 @@
     "id": "SUS_shelf_commercial_canned_fruits",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_fruits", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_canned_fruits", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_canned_meat",
@@ -160,7 +160,7 @@
     "id": "SUS_shelf_commercial_canned_meat",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_meat", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_canned_meat", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_canned_meals",
@@ -185,7 +185,7 @@
     "id": "SUS_shelf_commercial_canned_meals",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_canned_meals", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_canned_meals", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_coffee",
@@ -197,7 +197,7 @@
     "id": "SUS_shelf_commercial_coffee",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_coffee", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_coffee", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_tea",
@@ -216,7 +216,7 @@
     "id": "SUS_shelf_commercial_tea",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_tea", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_tea", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_breakfast_cereal",
@@ -244,7 +244,7 @@
     "id": "SUS_shelf_commercial_breakfast_mixes",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_breakfast_mixes", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_breakfast_mixes", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_spreads",
@@ -256,7 +256,7 @@
     "id": "SUS_shelf_commercial_spreads",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_spreads", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_spreads", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_sweet_snacks",
@@ -268,7 +268,7 @@
     "id": "SUS_shelf_commercial_sweet_snacks",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sweet_snacks", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_sweet_snacks", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_butter_cream",
@@ -280,7 +280,7 @@
     "id": "SUS_shelf_commercial_butter_cream",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_butter_cream", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_butter_cream", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_yogurt",
@@ -292,7 +292,7 @@
     "id": "SUS_shelf_commercial_yogurt",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_yogurt", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_yogurt", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_cheese",
@@ -329,13 +329,13 @@
     "id": "SUS_shelf_commercial_cheese",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_cheese", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_cheese", "count": [ 1, 3 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_milk",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "any_milk", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "any_milk", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_eggs",
@@ -347,7 +347,7 @@
     "id": "SUS_shelf_commercial_eggs",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_eggs", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_eggs", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_deli",
@@ -360,7 +360,7 @@
     "id": "SUS_shelf_commercial_deli",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_deli", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_deli", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_meat",
@@ -372,7 +372,7 @@
     "id": "SUS_shelf_commercial_meat",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_meat", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_meat", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_seafood",
@@ -384,7 +384,7 @@
     "id": "SUS_shelf_commercial_seafood",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_seafood", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_seafood", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_icecream",
@@ -405,7 +405,7 @@
     "id": "SUS_shelf_commercial_icecream",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_icecream", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_icecream", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_frozen_dessert",
@@ -417,7 +417,7 @@
     "id": "SUS_shelf_commercial_frozen_dessert",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_dessert", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_frozen_dessert", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_water",
@@ -429,29 +429,29 @@
     "id": "SUS_shelf_commercial_water",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_water", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_water", "count": [ 1, 3 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_soda",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "soda_in_container_full", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "soda_in_container_full", "count": [ 1, 3 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_soda",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "cola", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "rootbeer", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "lemonlime", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "orangesoda", "prob": 15, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "colamdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "zerocola", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "zeroorange", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "zerotropical", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "zeromdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
-      { "item": "tonic_water", "prob": 5, "container-item": "can_drink", "sealed": true, "count": [ 1, 4 ] },
+      { "item": "cola", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "rootbeer", "prob": 20, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "lemonlime", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "orangesoda", "prob": 15, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "colamdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "zerocola", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "zeroorange", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "zerotropical", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "zeromdew", "prob": 10, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
+      { "item": "tonic_water", "prob": 5, "container-item": "can_drink", "sealed": true, "count": [ 1, 3 ] },
       { "item": "cola", "prob": 20, "container-item": "bottle_twoliter", "sealed": true },
       { "item": "rootbeer", "prob": 20, "container-item": "bottle_twoliter", "sealed": true },
       { "item": "lemonlime", "prob": 10, "container-item": "bottle_twoliter", "sealed": true },
@@ -474,7 +474,7 @@
     "id": "SUS_shelf_commercial_juices",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_juices", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_juices", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_sports_drink",
@@ -486,7 +486,7 @@
     "id": "SUS_shelf_commercial_sports_drink",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_sports_drink", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_sports_drink", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_snacks_chips",
@@ -498,7 +498,7 @@
     "id": "SUS_shelf_commercial_chips",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_snacks_chips", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_snacks_chips", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_snacks_nuts_crackers",
@@ -522,7 +522,7 @@
     "id": "SUS_shelf_commercial_nuts_crackers",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_snacks_nuts_crackers", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_snacks_nuts_crackers", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_chocolate",
@@ -534,7 +534,7 @@
     "id": "SUS_shelf_commercial_chocolate",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_chocolate", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_chocolate", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_candy",
@@ -556,7 +556,7 @@
     "id": "SUS_shelf_commercial_candy",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_candy", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_candy", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_pet_food",
@@ -568,7 +568,7 @@
     "id": "SUS_shelf_commercial_pet_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_pet_food", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_pet_food", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_pet_accessories",
@@ -587,7 +587,7 @@
     "id": "SUS_shelf_commercial_pet_accessories",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_pet_accessories", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_pet_accessories", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_baby_accessories_food",
@@ -599,7 +599,7 @@
     "id": "SUS_shelf_commercial_baby_accessories_food",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baby_accessories_food", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_baby_accessories_food", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_baby_hygiene",
@@ -611,7 +611,7 @@
     "id": "SUS_shelf_commercial_baby_hygiene",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_baby_hygiene", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_baby_hygiene", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_office_supplies",
@@ -631,7 +631,7 @@
     "id": "SUS_shelf_commercial_office_supplies",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_office_supplies", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_office_supplies", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_electronics_accessories",
@@ -643,7 +643,7 @@
     "id": "SUS_shelf_commercial_electronics_accessories",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_electronics_accessories", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_electronics_accessories", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_books",
@@ -655,7 +655,7 @@
     "id": "SUS_shelf_commercial_books",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_books", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_books", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_magazines",
@@ -667,7 +667,7 @@
     "id": "SUS_shelf_commercial_magazines",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_magazines", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_magazines", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_household_laundry",
@@ -679,7 +679,7 @@
     "id": "SUS_shelf_commercial_laundry",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_household_laundry", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_household_laundry", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_household_dish_cleaning",
@@ -691,7 +691,7 @@
     "id": "SUS_shelf_commercial_dish_cleaning",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_household_dish_cleaning", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_household_dish_cleaning", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_cleaning_supplies",
@@ -753,7 +753,7 @@
     "id": "SUS_shelf_commercial_shower_supplies",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_shower_supplies", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_shower_supplies", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_personal_care",
@@ -772,23 +772,23 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "broccoli", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "cabbage_head", "count": [ 1, 4 ], "prob": 2 },
-      { "item": "spinach", "count": [ 1, 4 ], "prob": 2 },
-      { "item": "carrot", "count": [ 1, 4 ], "prob": 3 },
-      { "item": "celery", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "chili_pepper", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "cucumber", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "garlic", "count": [ 1, 4 ], "prob": 4 },
-      { "item": "horseradish_root", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "lettuce_head", "count": [ 1, 4 ], "prob": 4 },
-      { "item": "onion", "count": [ 1, 4 ], "prob": 4 },
-      { "item": "potato", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "rhubarb", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "tomato", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "zucchini", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "bell_pepper", "count": [ 1, 4 ], "prob": 2 },
-      { "item": "eggplant", "count": [ 1, 4 ], "prob": 1 }
+      { "item": "broccoli", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "cabbage_head", "count": [ 1, 3 ], "prob": 2 },
+      { "item": "spinach", "count": [ 1, 3 ], "prob": 2 },
+      { "item": "carrot", "count": [ 1, 3 ], "prob": 3 },
+      { "item": "celery", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "chili_pepper", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "cucumber", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "garlic", "count": [ 1, 3 ], "prob": 4 },
+      { "item": "horseradish_root", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "lettuce_head", "count": [ 1, 3 ], "prob": 4 },
+      { "item": "onion", "count": [ 1, 3 ], "prob": 4 },
+      { "item": "potato", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "rhubarb", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "tomato", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "zucchini", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "bell_pepper", "count": [ 1, 3 ], "prob": 2 },
+      { "item": "eggplant", "count": [ 1, 3 ], "prob": 1 }
     ]
   },
   {
@@ -803,11 +803,11 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "blueberries", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "strawberries", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "cranberries", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "raspberries", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "blackberries", "count": [ 1, 4 ], "prob": 1 }
+      { "item": "blueberries", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "strawberries", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "cranberries", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "raspberries", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "blackberries", "count": [ 1, 3 ], "prob": 1 }
     ]
   },
   {
@@ -816,21 +816,21 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "item": "apple", "count": [ 1, 4 ], "prob": 5 },
-      { "item": "banana", "count": [ 1, 4 ], "prob": 5 },
-      { "item": "orange", "count": [ 1, 4 ], "prob": 4 },
-      { "item": "lemon", "count": [ 1, 4 ], "prob": 2 },
-      { "item": "pear", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "grapefruit", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "cherries", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "plums", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "grapes", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "pineapple", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "peach", "count": [ 1, 4 ], "prob": 1 },
+      { "item": "apple", "count": [ 1, 3 ], "prob": 5 },
+      { "item": "banana", "count": [ 1, 3 ], "prob": 5 },
+      { "item": "orange", "count": [ 1, 3 ], "prob": 4 },
+      { "item": "lemon", "count": [ 1, 3 ], "prob": 2 },
+      { "item": "pear", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "grapefruit", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "cherries", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "plums", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "grapes", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "pineapple", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "peach", "count": [ 1, 3 ], "prob": 1 },
       { "item": "watermelon", "count": [ 1, 2 ], "prob": 1 },
-      { "item": "melon", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "kiwi", "count": [ 1, 4 ], "prob": 1 },
-      { "item": "apricot", "count": [ 1, 4 ], "prob": 1 }
+      { "item": "melon", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "kiwi", "count": [ 1, 3 ], "prob": 1 },
+      { "item": "apricot", "count": [ 1, 3 ], "prob": 1 }
     ]
   },
   {
@@ -864,13 +864,13 @@
     "id": "SUS_shelf_commercial_bread_specialty",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_bread_specialty", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_bread_specialty", "count": [ 1, 3 ] } ]
   },
   {
     "id": "SUS_shelf_commercial_bread_sweet",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "baked_goods", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "baked_goods", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_bread",
@@ -882,7 +882,7 @@
     "id": "SUS_shelf_commercial_bread",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_bread", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_bread", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_frozen_meals",
@@ -901,7 +901,7 @@
     "id": "SUS_shelf_commercial_frozen_meals",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_meals", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_frozen_meals", "count": [ 1, 3 ] } ]
   },
   {
     "id": "commercial_frozen_vegetables",
@@ -921,7 +921,7 @@
     "id": "SUS_shelf_commercial_frozen_vegetables",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "group": "commercial_frozen_vegetables", "count": [ 1, 4 ] } ]
+    "entries": [ { "group": "commercial_frozen_vegetables", "count": [ 1, 3 ] } ]
   },
   {
     "id": "any_supermarket_SUS",

--- a/data/json/mapgen/supermarket.json
+++ b/data/json/mapgen/supermarket.json
@@ -247,13 +247,13 @@
       "toilets": { "t": {  } },
       "items": {
         "W": { "item": "SUS_janitors_closet" },
-        "H": { "item": "SUS_shelf_any", "chance": 18 },
-        "E": { "item": "SUS_commercial_chewing_gum", "chance": 50 },
-        "N": { "item": "SUS_shelf_commercial_vegetables", "chance": 50 },
-        "z": { "item": "any_supermarket_SUS_freezer", "chance": 18 },
-        "Z": { "item": "any_supermarket_SUS_fridge", "chance": 18 },
-        "X": [ { "item": "SUS_shelf_commercial_meat", "chance": 18 } ],
-        "b": [ { "item": "SUS_shelf_commercial_meat", "chance": 18 } ],
+        "H": { "item": "SUS_shelf_any", "chance": 16 },
+        "E": { "item": "SUS_commercial_chewing_gum", "chance": 40 },
+        "N": { "item": "SUS_shelf_commercial_vegetables", "chance": 40 },
+        "z": { "item": "any_supermarket_SUS_freezer", "chance": 16 },
+        "Z": { "item": "any_supermarket_SUS_fridge", "chance": 16 },
+        "X": [ { "item": "SUS_shelf_commercial_meat", "chance": 16 } ],
+        "b": [ { "item": "SUS_shelf_commercial_meat", "chance": 16 } ],
         "t": { "item": "SUS_toilet" },
         "p": { "item": "SUS_business_bookcase" },
         "f": { "item": "SUS_fridge" },
@@ -264,7 +264,7 @@
           { "item": "SUS_appliances_cupboard", "chance": 18 },
           { "item": "SUS_coffee_cupboard", "chance": 18 },
           { "item": "SUS_breakfast_cupboard", "chance": 18 },
-          { "item": "SUS_spice_collection", "chance": 18 }
+          { "item": "SUS_spice_collection", "chance": 16 }
         ],
         "L": { "item": "fast_locker" },
         "d": { "item": "SUS_office_desk" },
@@ -438,7 +438,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_exotic_food", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_exotic_food", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -447,7 +447,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_spices_seasoning", "x": 0, "y": 0, "chance": 40 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_spices_seasoning", "x": 0, "y": 0, "chance": 30 } ]
     }
   },
   {
@@ -456,7 +456,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 168 } ]
     }
   },
   {
@@ -465,7 +465,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_grains", "x": 0, "y": 0, "chance": 25 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_grains", "x": 0, "y": 0, "chance": 20 } ]
     }
   },
   {
@@ -483,7 +483,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_pasta", "x": 0, "y": 0, "chance": 25 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_pasta", "x": 0, "y": 0, "chance": 18 } ]
     }
   },
   {
@@ -492,7 +492,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_vegetables", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_vegetables", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -501,7 +501,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_fruits", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_fruits", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -510,7 +510,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_meat", "x": 0, "y": 0, "chance": 25 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_meat", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -519,7 +519,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_canned_meals", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_canned_meals", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -546,7 +546,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_cereal", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_cereal", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -555,7 +555,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_mixes", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_breakfast_mixes", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -573,7 +573,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_sweet_snacks", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_sweet_snacks", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -618,7 +618,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_eggs", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_eggs", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -627,7 +627,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_deli", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_deli", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -645,7 +645,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_display_fridge", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_seafood", "x": 0, "y": 0, "chance": 50 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_seafood", "x": 0, "y": 0, "chance": 30 } ]
     }
   },
   {
@@ -690,7 +690,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_juices", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_juices", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -699,7 +699,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_sports_drink", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_sports_drink", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -708,7 +708,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_chips", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_chips", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -717,7 +717,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_nuts_crackers", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_nuts_crackers", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -726,7 +726,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_chocolate", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_chocolate", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -735,7 +735,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_candy", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_candy", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {
@@ -753,7 +753,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_pet_accessories", "x": 0, "y": 0, "chance": 18 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_pet_accessories", "x": 0, "y": 0, "chance": 16 } ]
     }
   },
   {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1152,17 +1152,19 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                 continue;
             }
             const int velocity = std::max( std::abs( veh.velocity ), 1 );
-
+            const bool extra_hazard = has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) || has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p );
             const bool hazard =
-                has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) ||
-                has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p ) ||
+                extra_hazard ||
                 ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
                   !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 
 
             float divisor = 250000.0f / velocity;
-            const int chance = std::clamp( static_cast<int>( divisor ), 50, 150 );
+            int chance = std::clamp( static_cast<int>( divisor ), 50, 150 );
+            if( extra_hazard ) {
+                chance = std::max( 1, chance - 10 );
+            }
             add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %s.", chance );
             if( !hazard ||
                 vp_wheel.info().wheel_info->offroad_rating >= 0.6f ||

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1153,22 +1153,23 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             }
             const int velocity = std::max( std::abs( veh.velocity ), 1 );
             const bool extra_hazard = has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) || has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p );
-            const bool hazard =
-                extra_hazard ||
-                ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
-                  !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
-                  !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 
+            const bool hazard = extra_hazard || ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) && !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
+                !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 
-            float divisor = 250000.0f / velocity;
-            int chance = std::clamp( static_cast<int>( divisor ), 50, 150 );
-            if( extra_hazard ) {
-                chance = std::max( 1, chance - 10 );
+            if( !hazard || ( vp_wheel.info().wheel_info->offroad_rating >= 0.6f && !extra_hazard ) ) {
+                continue;
             }
-            add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %s.", chance );
-            if( !hazard ||
-                vp_wheel.info().wheel_info->offroad_rating >= 0.6f ||
-                !one_in( chance ) ) {
+
+            int chance = std::clamp( 250000 / velocity, 50, 150 );
+
+            if( extra_hazard ) {
+                chance *= 0.75;
+            }
+
+            add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %d.", chance );
+
+            if( !one_in( chance ) ) {
                 continue;
             }
 


### PR DESCRIPTION
#### Summary
Various fixes

#### Purpose of change
- Slightly nerf food in supermarkets (slightly!)
- Slightly boost cattail rhizome yield (slightly!)
- Driving on terrain that specifically is bad about damaging tires (rocky soil etc) has a higher chance to do so.
- Driving on terrain that is specifically bad about damaging tires (rocky soil etc) can still damage offroad tires. This terrain is super sparse so it should only rarely happen.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
