### PR TITLE
Musical instrument updates

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -100,6 +100,7 @@ static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 
 static const efftype_id effect_contacts( "contacts" );
+static const efftype_id effect_playing_instrument( "playing_instrument" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 
 static const furn_str_id furn_f_fake_bench_hands( "f_fake_bench_hands" );
@@ -168,7 +169,15 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
         // One day, NPCs may be able to drive.
         p.add_msg_player_or_npc( m_info,
                                  _( "You can't craft while driving!" ),
-                                 _( "<npcname> refuses to violate road safety guidelines by crafting while driving!" ) );
+                                 _( "<npcname> can't craft while driving!" ) );
+        return false;
+    }
+
+    if( p.has_effect( effect_playing_instrument ) ) {
+        // One day, NPCs may be able to drive.
+        p.add_msg_player_or_npc( m_info,
+                                 _( "You can't craft while playing an instrument!" ),
+                                 _( "<npcname> can't craft while playing an instrument!" ) );
         return false;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -263,6 +263,7 @@ static const efftype_id effect_led_by_leash( "led_by_leash" );
 static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_pet( "pet" );
+static const efftype_id effect_playing_instrument( "playing_instrument" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
@@ -9492,6 +9493,9 @@ void game::butcher()
         }
     }
 
+    if( u.has_effect( effect_playing_instrument ) ) {
+            add_msg( m_info, _( "You can't do that while playing an instrument." ) );
+    }
     if( !u.has_morale_to_craft() ) {
         if( butcher_select == BUTCHER_CORPSE || indexer_index == MULTIBUTCHER ) {
             add_msg( m_info,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2354,8 +2354,8 @@ ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
     if( p.is_mounted() ) {
         return ret_val<void>::make_failure( _( "You can't do that while mounted." ) );
     }
-    if( !p.is_worn( it ) && !p.is_wielding( it ) ) {
-        return ret_val<void>::make_failure( _( "You need to hold or wear %s to play it." ),
+    if( !p.is_wielding( it ) ) {
+        return ret_val<void>::make_failure( _( "You need to hold %s to play it." ),
                                             it.type_name() );
     }
     // No one-man band for now
@@ -2399,6 +2399,10 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
+    if ( it.is_null() ) {
+        return std::nullopt;
+    }
+
     if( !p->is_npc() && music::is_active_music_id( music::music_id::instrument ) ) {
         music::deactivate_music_id( music::music_id::instrument );
         // Because musical instrument creates musical sound too
@@ -2423,7 +2427,7 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
 
     // Stop playing a wind instrument when winded or even eventually become winded while playing it?
     // It's impossible to distinguish instruments for now anyways.
-    if( p->has_effect( effect_sleep ) || p->has_effect( effect_stunned ) ||
+    if( p->in_sleep_state() || p->has_effect( effect_stunned ) ||
         p->has_effect( effect_asthma ) ) {
         p->add_msg_player_or_npc( m_bad,
                                   _( "You stop playing your %s." ),
@@ -2433,19 +2437,27 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
-    // Check for worn or wielded - no "floating"/bionic instruments for now
-    // TODO: Distinguish instruments played with hands and with mouth, consider encumbrance
-    const int inv_pos = p->get_item_position( &it );
-    if( inv_pos >= 0 || inv_pos == INT_MIN ) {
+    // TODO: Allow playing instruments while deaf if extremely skilled.
+    if( p->is_deaf() ) {
         p->add_msg_player_or_npc( m_bad,
-                                  _( "You need to hold or wear %s to play it." ),
-                                  _( "<npcname> needs to hold or wear %s to play it." ),
+                                  _( "You can't hear anything, so you stop playing your %s." ),
+                                  _( "<npcname> can't hear anything, so they stops playing their %s." ),
                                   it.display_name() );
         it.active = false;
         return std::nullopt;
     }
 
-    // At speed this low you can't coordinate your actions well enough to play the instrument
+    // TODO: Distinguish instruments played with hands and with mouth, consider encumbrance.
+    if( &it != p->get_wielded_item().get_item() ) {
+        p->add_msg_player_or_npc( m_bad,
+                                  _( "You need to hold %s to play it." ),
+                                  _( "<npcname> needs to hold %s to play it." ),
+                                  it.display_name() );
+        it.active = false;
+        return std::nullopt;
+    }
+
+    // At speed this low you can't coordinate your actions well enough to play the instrument.
     if( p->get_speed() <= 25 + speed_penalty ) {
         p->add_msg_player_or_npc( m_bad,
                                   _( "You feel too weak to play your %s." ),
@@ -2455,7 +2467,7 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
-    // We can play the music now
+    // We can play the music now.
     if( !p->is_npc() ) {
         music::activate_music_id( music::music_id::instrument );
     }
@@ -2496,13 +2508,13 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
     }
 
     if( !p->has_effect( effect_music ) && p->can_hear( p->pos_bub( *here ), volume ) ) {
-        // Sound code doesn't describe noises at the player position
+        // Sound code doesn't describe noises at the player position.
         if( desc != "music" ) {
             p->add_msg_if_player( m_info, desc );
         }
     }
 
-    // We already played the sounds, just handle applying effects now
+    // We already played the sounds, just handle applying effects now.
     iuse::play_music( p, p->pos_bub( *here ), volume, morale_effect, /*play_sounds=*/false );
 
     return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2358,6 +2358,9 @@ ret_val<void> play_instrument_iuse::can_use( const Character &p, const item &it,
         return ret_val<void>::make_failure( _( "You need to hold %s to play it." ),
                                             it.type_name() );
     }
+    if( p.controlling_vehicle ) {
+        return ret_val<void>::make_failure( _( "You can't do that while driving." ) );
+    }
     // No one-man band for now
     // Remove/rework this check after we will be able to distinguish between wind, string, and percussion instruments
     // TODO: allow playing several string/percussion instruments if you have additional arms

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -33,6 +33,7 @@
 #include "contents_change_handler.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "effect.h"
 #include "enums.h"
 #include "faction.h"
 #include "fault.h"
@@ -78,6 +79,8 @@
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
 static const ammotype ammo_battery( "battery" );
+
+static const efftype_id effect_playing_instrument( "effect_playing_instrument" );
 
 static const faction_id faction_no_faction( "no_faction" );
 
@@ -635,6 +638,7 @@ void veh_interact::cache_tool_availability_update_lifting( const tripoint_bub_ms
  *         LACK_SKILL if the player's skill isn't high enough,
  *         LOW_MORALE if the player's morale is too low while trying to perform
  *             an action requiring a minimum morale,
+ *         BUSY if playing an instrument or something.
  *         UNKNOWN_TASK if the requested operation is unrecognized.
  */
 task_reason veh_interact::cant_do( const map &here,  char mode )
@@ -647,6 +651,7 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
     bool enough_light = true;
     const vehicle_part_range vpr = veh->get_all_parts();
     avatar &player_character = get_avatar();
+    bool busy = !player_character.has_effect( effect_playing_instrument );
     switch( mode ) {
         case 'i':
             // install mode
@@ -774,6 +779,9 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
     // TODO: that is always false!
     if( !has_skill ) {
         return task_reason::LACK_SKILL;
+    }
+    if( busy ) {
+        return task_reason::BUSY;
     }
     return task_reason::CAN_DO;
 }
@@ -1053,6 +1061,9 @@ void veh_interact::do_install( map &here )
                 case task_reason::MOVING_VEHICLE:
                     msg = _( "You can't install parts while driving." );
                     return;
+                            case task_reason::BUSY:
+                        msg = _( "You are busy doing something else." );
+                        return;
                 default:
                     break;
             }
@@ -1145,6 +1156,9 @@ void veh_interact::do_repair( map &here )
                 return false;
             case task_reason::INVALID_TARGET:
                 msg = _( "There are no parts which can be repaired on this vehicle." );
+                return false;
+            case task_reason::BUSY:
+                msg = _( "You are busy doing something else." );
                 return false;
             default:
                 break;
@@ -1275,6 +1289,9 @@ void veh_interact::do_mend( map &here )
         case task_reason::MOVING_VEHICLE:
             msg = _( "You can't mend stuff while driving." );
             return;
+        case task_reason::BUSY:
+                msg = _( "You are busy doing something else." );
+                return;
         default:
             break;
     }
@@ -1309,6 +1326,10 @@ void veh_interact::do_refill( map &here )
 
         case task_reason::INVALID_TARGET:
             msg = _( "No parts can currently be refilled." );
+            return;
+
+        case task_reason::BUSY:
+            msg = _( "You are busy doing something else." );
             return;
 
         default:
@@ -1870,6 +1891,9 @@ void veh_interact::do_remove( map &here )
                 case task_reason::MOVING_VEHICLE:
                     msg = _( "Better not remove something while driving." );
                     return;
+                case task_reason::BUSY:
+                        msg = _( "You are busy doing something else." );
+                        return;
                 default:
                     break;
             }
@@ -1913,6 +1937,10 @@ void veh_interact::do_siphon( map &here )
             msg = _( "You can't siphon from a moving vehicle." );
             return;
 
+        case task_reason::BUSY:
+            msg = _( "You are busy doing something else." );
+            return;
+
         default:
             break;
     }
@@ -1951,6 +1979,10 @@ bool veh_interact::do_unload( map &here )
 
         case task_reason::MOVING_VEHICLE:
             msg = _( "You can't unload from a moving vehicle." );
+            return false;
+
+        case task_reason::BUSY:
+            msg = _( "You are busy doing something else." );
             return false;
 
         default:

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -29,15 +29,16 @@ struct requirement_data;
 
 /** Represents possible return values from the cant_do function. */
 enum class task_reason : int {
-    UNKNOWN_TASK = -1, //No such task
-    CAN_DO, //Task can be done
-    INVALID_TARGET, //No valid target i.e. can't "change tire" if no tire present
-    LACK_TOOLS, //Player doesn't have all the tools they need
-    NOT_FREE, //Part is attached to something else and can't be unmounted
-    LACK_SKILL, //Player doesn't have high enough mechanics skill
-    MOVING_VEHICLE, // vehicle is moving, no modifications allowed
-    LOW_MORALE, // Player has too low morale (for operations that require it)
-    LOW_LIGHT // Player cannot see enough to work (for operations that require it)
+    UNKNOWN_TASK = -1, // No such task.
+    CAN_DO, // Task can be done.
+    INVALID_TARGET, // No valid target i.e. can't "change tire" if no tire present.
+    LACK_TOOLS, // Lacking necessary tools.
+    NOT_FREE, // Part is attached to something else and can't be unmounted.
+    LACK_SKILL, // Not enough mechanics skill.
+    MOVING_VEHICLE, // Behicle is moving, no modifications allowed.
+    LOW_MORALE, // Morale too low (for operations that require it).
+    LOW_LIGHT, // Cannot see enough to work (for operations that require it).
+    BUSY, // Occupied with some other task.
 };
 
 class ui_adaptor;


### PR DESCRIPTION
#### Summary
Musical instrument updates

#### Purpose of change
It was possible to wear an instrument and craft, work on vehicles, drive, fight, etc. while playing it. That's dumb.

#### Describe the solution
- Musical instruments must be wielded to be played.
- It's not possible to play an instrument while driving, crafting, or butchering.
- You can't play an instrument while deaf.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
