### PR TITLE
fix not being able to interact with vehicles unless you are playing an instrument

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -651,7 +651,7 @@ task_reason veh_interact::cant_do( const map &here,  char mode )
     bool enough_light = true;
     const vehicle_part_range vpr = veh->get_all_parts();
     avatar &player_character = get_avatar();
-    bool busy = !player_character.has_effect( effect_playing_instrument );
+    bool busy = player_character.has_effect( effect_playing_instrument );
     switch( mode ) {
         case 'i':
             // install mode


### PR DESCRIPTION
#### Summary
title

#### Purpose of change
i dont think you should need to be playing a guitar to be able to steal parts from cars etc

#### Describe the solution
removed an incorrect !

#### Describe alternatives you've considered
maybe im too grumpy and mechanics should always be playing music..?

#### Testing
in my mind

though something else is broken with it as on master:
- spawning a harmonica with holder
- wielding and playing it, seeing i now have the status effect
- trying to remove a car battery
still doesnt let me steal a car's battery, so i imagine it would just be dead code if this is merged until that is fixed

#### Additional context

mistake from https://github.com/Cataclysm-TLG/Cataclysm-TLG/commit/7cff8f7bf863298a7d99b83868f1a29de4b69dd1


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
