### PR TITLE
Clean up dissection snippets

### DIFF
--- a/data/json/snippets/zombie_anatomy.json
+++ b/data/json/snippets/zombie_anatomy.json
@@ -13,7 +13,7 @@
       },
       {
         "id": "tainted_innards_3",
-        "text": "A clump of rotten entrails.  The sallow membranes that link these lobes of flesh together are lined with blackened veins and capillaries.  A caul of slime coats them all in a greasy sheen.  You should not put this anywhere near your mouth."
+        "text": "A clump of rotten entrails.  The sallow membranes that link these lobes of flesh together are lined with veins and capillaries.  A caul of slime coats them all in a greasy sheen.  You should not put this anywhere near your mouth."
       },
       {
         "id": "tainted_innards_4",
@@ -114,7 +114,7 @@
       "The tissue is rotting before your eyes, muscle turning to jelly and fat to a clear, reeking slime.  It's as if time is catching up with the carcass now that it's no longer animated.",
       "The overbearing sweet smell of decay emanating from the carcass forces you to take short breaks during your work to not puke.",
       "As you cut through the muscle, it tenses up in reaction.",
-      "You spot a few flies and maggots in the corpse, their chosen carcass not seeming to be very good for them, as most seem moribund.",
+      "You spot a few flies and maggots in the corpse.  Most are dead, but a few seem to be able to handle eating zombie flesh.",
       "Random cavities in its body make you think it was at least partially feeding on its own tissues to keep functioning.",
       "The corpse twitches as you begin.  It didn't feel like rigor mortis.",
       "The body stirs as you open it up, suggesting it's still trying to attack, and reminding you to be cautious.",
@@ -127,74 +127,59 @@
     "text": [
       "The majority of the digestive tract seems to have reshaped into a singular stomach.",
       "Some organs have atrophied or outright dissolved entirely.",
-      "The heart is overtaken by a mass of fistulas and other growths.",
+      "The heart is overtaken by a mass of fistulas and other growths.  Healthy-looking arteries still spiderweb out of the tumorous mass.",
       "The thing's innards resemble one giant tumor more than the body of a human being.",
       "The thing's feet are entirely calloused and the smaller toes are completely vestigal, simply a bump with a dead nail on them.",
-      "This person had a tattoo on their arm - said tattoo has reappeared in multiple spots along the inner tissues and the walls of organs.",
       "The front part of the brain is completely missing, with spongy, half-formed bone in its place.",
       "While its individual fingers appear to be losing their dexterity, the zombie's flexor muscles are tense and swollen.",
-      "This person had an artificial hip, but it's completely overgrown with bone now.",
       "Organs in the lower abdomen, mainly the kidneys and the reproductive organs, are absent.",
       "The heart makes an odd, swallowing sound on occasion as you work around it.",
       "You try pulling out some teeth to better analyze them, only to find they've fused with the jawbone.",
-      "Inside the chest is some unfamiliar organ, a Frankenstein of nearby tissues and black veins.",
+      "The inside of the torso is stuffed with hair, fingers, and a distorted face, as if the zombie was growing a twin inside of itself.",
       "Inside the chest is some unfamiliar organ, fatty and wrinkled like brain tissue.",
-      "Your search nets you no explanation as to how the creature's black blood still circulates through it, and you come to the disturbing conclusion it moves on its own.",
-      "The vestibular organs seem to be nonfunctional, but your question of how the creature balances itself is answered by an odd mass in the center of the brain, that you liken to a gyroscope.",
-      "While some parts of the blackened brain have lost their wrinkles, in others the wrinkles are surprisingly uniform.",
-      "You find a clump of malformed tissue leading deeper inwards, at the center of which is a bullet.",
+      "While some parts of the brain have turned to mush, others appear healthy and pink.",
       "Its tissue has significant trouble separating from the bone in some spots.",
       "The skin is loose on the muscle in some places and melded with it in others.",
       "The thing's innards churn slightly even as you dig through them.",
-      "As you finish up, you notice your earliest cuts seem to be the tiniest bit smaller.",
-      "To your \"delight,\" you find a tapeworm in its gut, turgid but seemingly dead.",
-      "As you cut into its stomach, the insane fragmentary remains of some creature it devoured, which appears to have melded with its own tissues, attempt to claw at your hand before you bludgeon them until they cease moving."
+      "As you finish up, you notice your earliest cuts seem to be the tiniest bit smaller."
     ]
   },
   {
     "type": "snippet",
     "category": "<zombie_humanoid_harvest_headless_deeper>",
     "text": [
-      "The majority of the digestive tract seems to have reshaped into a singular stomach.",
+      "The brain stem is swollen and packed with what looks like new growth bulging along the cervical vertebrae.",
+      "The intestines have pushed their way up into the thoracic cavity.  Lined with teeth, they stretch up toward the throat like a swarm of eels.",
       "Some organs have atrophied or outright dissolved entirely.",
       "The heart is overtaken by a mass of fistulas and other growths.",
       "The thing's innards resemble one giant tumor more than the body of a human being.",
       "The thing's feet are entirely calloused and the smaller toes are completely vestigal, simply a bump with a dead nail on them.",
-      "This person had a tattoo on their arm - said tattoo has reappeared in multiple spots along the inner tissues and the walls of organs.",
       "While its individual fingers appear to be losing their dexterity, the zombie's flexor muscles are tense and swollen.",
       "This person had an artificial hip, but it's completely overgrown with bone now.",
       "Organs in the lower abdomen, mainly the kidneys and the reproductive organs, are absent.",
       "The heart makes an odd, swallowing sound on occasion as you work around it.",
-      "Inside the chest is some unfamiliar organ, a Frankenstein of nearby tissues and black veins.",
       "Inside the chest is some unfamiliar organ, fatty and wrinkled like brain tissue.",
-      "Your search nets you no explanation as to how the creature's black blood still circulates through it, and you come to the disturbing conclusion it moves on its own.",
-      "You find a clump of malformed tissue leading deeper inwards, at the center of which is a bullet.",
       "Its tissue has significant trouble separating from the bone in some spots.",
       "The skin is loose on the muscle in some places and melded with it in others.",
       "The thing's innards churn slightly even as you dig through them.",
-      "As you finish up, you notice your earliest cuts seem to be the tiniest bit smaller.",
-      "To your \"delight,\" you find a tapeworm in its gut, turgid but seemingly dead.",
-      "As you cut into its stomach, the insane fragmentary remains of some creature it devoured, which appears to have melded with its own tissues, attempt to claw at your hand before you bludgeon them until they cease moving."
+      "As you finish up, you notice your earliest cuts seem to be the tiniest bit smaller."
     ]
   },
   {
     "type": "snippet",
     "category": "<zombie_animal_harvest_general_deeper>",
     "text": [
-      "The majority of the digestive tract seems to have reshaped into a singular stomach.",
       "Some organs have atrophied or outright dissolved entirely.",
-      "The heart is overtaken by a mass of fistulas and other growths.",
+      "The heart is overtaken by a mass of fistulas and other growths.  Healthy-looking arteries still spiderweb out of the tumorous mass.",
       "The thing's innards resemble one giant tumor more than the body of a living being.",
       "The thing has extra teeth leading all the way down into the stomach.",
       "Organs in the lower abdomen, mainly the kidneys and the reproductive organs, are absent.",
       "The heart makes an odd, swallowing sound on occasion as you work around it.",
       "You try pulling out some teeth to better analyze them, only to find they've fused with the jawbone.",
-      "Inside the chest is some unfamiliar organ, a Frankenstein of nearby tissues and black veins.",
+      "Inside the chest is some unfamiliar organ, a hideous amalgam of disparate tissues and veins.",
       "Inside the chest is some unfamiliar organ, fatty and wrinkled like brain tissue.",
-      "Your search nets you no explanation as to how the creature's black blood still circulates through it, and you come to the disturbing conclusion it moves on its own.",
       "The vestibular organs seem to be nonfunctional, but your question of how the creature balances itself is answered by an odd mass in the center of the brain, that you liken to a gyroscope.",
-      "While some parts of the blackened brain have lost their wrinkles, in others the wrinkles are surprisingly uniform.",
-      "You find a clump of malformed tissue leading deeper inwards, at the center of which is a bullet.",
+      "While some parts of the brain have turned to mush, others appear pink and almost healthy.",
       "Its tissue has significant trouble separating from the bone in some spots.",
       "The skin is loose on the muscle in some places and melded with it in others.",
       "The thing's innards churn slightly even as you dig through them.",
@@ -219,7 +204,7 @@
     "category": "<zombie_humanoid_harvest_bone_general>",
     "text": [
       "Removing its bone plates proves more arduous than you would have thought, requiring you to almost put your entire weight on your tool to pry them off.",
-      "Black liquid bubbles in the places where you managed to remove its skeletal growths.",
+      "Putrefied blood bubbles like tar in the places where you managed to remove its skeletal growths.",
       "This one's armor falls off surprisingly easily, almost as if whatever puppets it wishes for it to lose the extra weight.",
       "The layout and segmentation of its bony carapace disturbingly resembles what you want to call plate mail, but it's closer to the armor of an arthropod.",
       "These plates are almost impossible to remove until you realize they are linked to the internal skeleton with calcified pillars you must break before removing its armor."
@@ -230,7 +215,7 @@
     "category": "<zombie_animal_harvest_bone_general>",
     "text": [
       "Removing its bone plates proves more arduous than you would have thought, requiring you to almost put your entire weight on your tool to pry them off.",
-      "Black liquid bubbles in the places where you managed to remove its skeletal growths.",
+      "Putrefied blood bubbles like tar in the places where you managed to remove its skeletal growths.",
       "This one's armor falls off surprisingly easily, almost as if whatever puppets it wishes for it to lose the extra weight.",
       "The layout and segmentation of its bony carapace disturbingly resembles what you want to call plate mail, but it's closer to the armor of an arthropod.",
       "These plates are almost impossible to remove until you realize they are linked to the internal skeleton with calcified pillars you must break before removing its armor."
@@ -253,7 +238,7 @@
     "text": [
       "The sheer pungent acrid odor of the carcass makes you temporarily recoil and reconsider the safety of delving into its entrails.",
       "The sputters of acid on your gear you earned by digging into this corpse could maybe warrant the use of some water to douse.",
-      "Most cavities in its anatomy seem to have been filled with an acidic solution mixed with a foul black liquid and pieces of its slowly melting tissues.",
+      "Most cavities in its anatomy seem to have been filled with an acidic solution mixed with putrefied fat and pieces of its slowly melting tissues.",
       "You are almost certain that its flesh should not be able to contain such a virulently aggressive liquid, yet, it does.",
       "Pressed against the liver is a swollen gland the size of a golfball, still somewhat functioning, pumping out acrid fluids.",
       "You have to step back as a gland you inadvertently cut into seems to perform a neutralization reaction between its contents and the rest of its fluids."
@@ -319,7 +304,7 @@
     "text": [
       "The sheer remaining tension in each of the muscles of its arms and shoulders makes them unwind with a sonorous thwang each time you cut one off the supporting bones.",
       "The tremendous growth of its upper body's muscle mass must have rendered the creature almost incapable of efficiently surveying its surroundings.",
-      "You realize the muscles of the zombie's arms are hollow, their marrow replaced by a thick oily black liquid.  You wonder if the ridiculous muscle mass surrounding them is the other half of a strange hydraulic system.",
+      "You realize the muscles of the zombie's arms are hollow, their marrow replaced by a thick reddish liquid.  You wonder if the ridiculous muscle mass surrounding them is the other half of a strange hydraulic system.",
       "You cut into the arms of the creature and realize that instead of what you would expect from what you know of normal human anatomy, its muscles wind around the bones in what looks like a tight spring.",
       "While you are cutting into it, the creature suddenly moves and grabs one of your limbs.  Despite considerable effort, you are unable to pry open the creature's iron grip and resign yourself to chop off the hand instead."
     ]
@@ -339,12 +324,10 @@
     "type": "snippet",
     "category": "<zombie_harvest_electric_general>",
     "text": [
-      "You find strange tubular glands across the creature contained alternating layers of two alien tissue types soaked in a black liquid, its smell putrid but saltier than usual for a zombie.",
       "Uncomfortable static forces you to ground yourself multiple times during your work.",
       "A roaming insect attracted by the carcass gets fried after landing on an organ glowing a faint blue, making you decide to avoid it with the utmost care.",
-      "The creature's heart seems to still be beating, but rather than pumping blood, it strangely reminds you of some sort of biological dynamo.",
       "There are bundles of nerves snaking all throughout the tissues, still channeling small amounts of electricity.",
-      "The blackened veins of the creature seem strangely rigid, and you see faint crackles of electricity course across them."
+      "The putrid veins of the creature seem strangely rigid, and you see faint crackles of electricity course across them."
     ]
   },
   {
@@ -353,7 +336,6 @@
     "text": [
       "Despite the carcass lying still, you still notice churning while investigating its entrails, as if whatever was originally animating this corpse is wrestling with the mycelium fibers to retake control.",
       "Under the stomach you notice a wrinkled fruit that you can't help but think somewhat appetizing despite where you found it.",
-      "The skin feels absolutely turgid, oozing water mixed in with traces of a black liquid where you make your incisions.",
       "Fungal stalks still sway gently despite the lack of movement of the formerly shambling corpse.",
       "The putrefied blood that leaks from your incisions is visibly saturated with spores."
     ]
@@ -364,7 +346,6 @@
     "text": [
       "Despite the carcass lying still, you still notice churning while investigating its entrails, as if whatever was originally animating this corpse is wrestling with the mycelium fibers to retake control.",
       "Under the stomach you notice a wrinkled fruit that you can't help but think somewhat appetizing despite where you found it.",
-      "The skin feels absolutely turgid, oozing water mixed in with traces of a black liquid where you make your incisions.",
       "Fungal stalks still sway gently despite the lack of movement of the formerly shambling corpse.",
       "The putrefied blood that leaks from your incisions is visibly saturated with spores."
     ]


### PR DESCRIPTION
#### Summary
Clean up dissection snippets

#### Purpose of change
A bunch of these still referenced black fluids and black brains. There were also some that didn't make sense like tattoos on children, or bullets in people who might never have been shot, or blood moving all on its own (it doesn't)

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
