### PR TITLE
Nerf five-point harness

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1546,7 +1546,7 @@
     "durability": 100,
     "description": "A series of straps attached to the seat, intended to fasten together after going over your shoulders and hips and between your legs.",
     "folded_volume": "1 L",
-    "bonus": 25,
+    "bonus": 15,
     "item": "five-point_harness",
     "location": "on_seat",
     "requirements": {


### PR DESCRIPTION
#### Summary
Nerf five-point harness

#### Purpose of change
The five-point harness was protecting from 25 bash damage on impact, making you impervious to most car crashes. In reality, a three-point harness (a standard seatbelt) is already extremely effective at this and the five-point harness is just a mild improvement to the chance you won't be thrown from the vehicle.

#### Describe the solution
Reduce to 15

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
