### PR TITLE
Uncraft for wooden door

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -114,7 +114,10 @@
   {
     "id": "cattails_winter_harv",
     "type": "harvest",
-    "entries": [ { "drop": "cattail_rhizome", "base_num": [ 0, 2 ], "difficulty": 8 }, { "drop": "withered", "base_num": [ 1, 5 ], "difficulty": 3 } ]
+    "entries": [
+      { "drop": "cattail_rhizome", "base_num": [ 0, 2 ], "difficulty": 8 },
+      { "drop": "withered", "base_num": [ 1, 5 ], "difficulty": 3 }
+    ]
   },
   {
     "id": "cattails_summer_harv",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -6021,5 +6021,15 @@
     "time": "4 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "carpet_scrap", 10 ] ] ]
+  },
+  {
+    "result": "wood_door",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "fabrication",
+    "time": "10 m",
+    "autolearn": true,
+    "qualities": [ { "id": "SCREW", "level": 1 } ],
+    "components": [ [ [ "wood_panel", 1 ] ], [ [ "hinge", 2 ] ], [ [ "scrap", 6 ] ] ]
   }
 ]

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -2413,7 +2413,6 @@ units::angle map::shake_vehicle( vehicle &veh, const int velocity_before,
         if( psg && veh.player_in_control( here, *psg ) ) {
             const int lose_ctrl_roll = rng( 0, d_vel );
             ///\EFFECT_DEX reduces chance of losing control of vehicle when shaken
-
             ///\EFFECT_DRIVING reduces chance of losing control of vehicle when shaken
             if( lose_ctrl_roll > psg->dex_cur * 2 + psg->get_skill_level( skill_driving ) * 3 ) {
                 psg->add_msg_player_or_npc( m_warning,


### PR DESCRIPTION
#### Summary
Uncraft for wooden door

#### Purpose of change
There was no way to reclaim hinges from a wooden door item.

#### Describe the solution
Add an uncraft so you can get them back. Nails and bolts are lost because I was nice enough to let you use either.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
