### PR TITLE
Remove all forms of "pepper meat"

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -269,18 +269,6 @@
     "flags": [ "EATEN_HOT" ]
   },
   {
-    "id": "pepperhuman",
-    "copy-from": "human_flesh",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "peppered human flesh" },
-    "description": "A cooked portion of human flesh seasoned with pepper and salt.",
-    "proportional": { "price": 1.5 },
-    "parasites": 0,
-    "fun": 2,
-    "flags": [ "EATEN_HOT" ]
-  },
-  {
     "id": "meat",
     "copy-from": "flesh",
     "type": "ITEM",
@@ -521,19 +509,6 @@
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
   },
   {
-    "id": "peppermutant_human",
-    "copy-from": "mutant_human_flesh",
-    "calories": 402,
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "cooked pepper cretin" },
-    "description": "Cooked meat from a heavily mutated humanoid.  Now that the worst bits have been picked out, it's probably digestible.  It has also been properly seasoned with black pepper and salt, giving it a better taste.  Still, it is somewhat gross, but hey, it's food!",
-    "proportional": { "price": 1.5 },
-    "parasites": 0,
-    "fun": 1,
-    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
-  },
-  {
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "meat_mutant_tainted",
@@ -615,24 +590,6 @@
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ]
   },
   {
-    "id": "peppermeat",
-    "copy-from": "flesh",
-    "weight": "275 g",
-    "volume": "250 ml",
-    "spoils_in": "1 day",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "cooked pepper meat" },
-    "description": "A piece of cooked meat, properly seasoned with black pepper and salt.  It's nutritious, yet basic seasoning adds a welcoming taste to this simple dish.",
-    "price": "8 USD",
-    "price_postapoc": "1 USD 50 cent",
-    "fun": 2,
-    "parasites": 0,
-    "calories": 402,
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 12 ], [ "meat_allergen", 1 ] ],
-    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ]
-  },
-  {
     "id": "meat_fatty_cooked",
     "copy-from": "flesh",
     "weight": "296 g",
@@ -652,24 +609,6 @@
     "flags": [ "EATEN_HOT" ]
   },
   {
-    "id": "pepperfat",
-    "copy-from": "flesh",
-    "weight": "275 g",
-    "volume": "250 ml",
-    "spoils_in": "1 day",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "cooked pepper fatty meat" },
-    "description": "A chunk of cooked fatty meat properly seasoned with black pepper and salt.  Although absent of vitamins, it is very filling, tasty and delightfully greasy.",
-    "calories": 1300,
-    "price": "9 USD 20 cent",
-    "price_postapoc": "3 USD 20 cent",
-    "fun": 3,
-    "parasites": 0,
-    "vitamins": [ [ "meat_allergen", 1 ] ],
-    "flags": [ "EATEN_HOT" ]
-  },
-  {
     "id": "meat_scrap_cooked",
     "copy-from": "meat_scrap",
     "type": "ITEM",
@@ -677,18 +616,6 @@
     "name": { "str": "cooked scrap of meat", "str_pl": "cooked scraps of meat" },
     "parasites": 0,
     "fun": 0,
-    "flags": [ "NUTRIENT_OVERRIDE" ],
-    "calories": 51
-  },
-  {
-    "id": "pepperscrap",
-    "copy-from": "meat_scrap",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "name": { "str": "cooked pepper scrap of meat", "str_pl": "cooked pepper scraps of meat" },
-    "description": "A cooked scrap of meat that has been properly seasoned with pepper and salt.  Yet small, they have a good taste.",
-    "parasites": 0,
-    "fun": 1,
     "flags": [ "NUTRIENT_OVERRIDE" ],
     "calories": 51
   },
@@ -707,20 +634,6 @@
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
   },
   {
-    "id": "peppermutant",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "copy-from": "mutant_meat",
-    "name": { "str_sp": "cooked pepper mutant meat" },
-    "snippet_category": "cooked_mutant_meat_desc",
-    "description": "A cooked chunk of meat from a mutated animal which has been properly seasoned with black pepper and salt, will keep your hunger away, but even seasoned, it has a weird taste.",
-    "looks_like": "meat_cooked",
-    "proportional": { "price": 1.5 },
-    "parasites": 0,
-    "fun": 0,
-    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
-  },
-  {
     "id": "mutant_meat_scrap_cooked",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
@@ -730,21 +643,8 @@
     "looks_like": "meat_scrap_cooked",
     "parasites": 0,
     "calories": 25,
-    "fun": 0,
-    "flags": [ "NUTRIENT_OVERRIDE" ]
-  },
-  {
-    "id": "pepperscrap_mutant",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "copy-from": "mutant_meat_scrap",
-    "name": { "str": "cooked pepper scrap of mutant meat", "str_pl": "cooked pepper scraps of mutant meat" },
-    "description": "A tiny scrap of cooked mutant meat properly seasoned with black pepper and salt.  It is small, and even though it has been seasoned, it has a weird taste.",
-    "looks_like": "meat_scrap_cooked",
-    "parasites": 0,
-    "calories": 25,
-    "fun": 1,
-    "flags": [ "NUTRIENT_OVERRIDE" ]
+    "fun": -1,
+    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
   },
   {
     "id": "cooked_marrow",
@@ -764,26 +664,6 @@
     "spoils_in": "1 day",
     "calories": 471,
     "fun": 5,
-    "vitamins": [ [ "iron", 17 ], [ "meat_allergen", 1 ] ]
-  },
-  {
-    "id": "pepperbone",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "comestible_type": "FOOD",
-    "name": { "str_sp": "peppered bone marrow" },
-    "conditional_names": [ { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "peppered human bone marrow" } } ],
-    "description": "Bone marrow, fully cooked to eliminate any parasites and properly seasoned with black pepper and salt.  Tasty!",
-    "symbol": "%",
-    "color": "red",
-    "weight": "55 g",
-    "volume": "50 ml",
-    "price": "5 USD",
-    "price_postapoc": "50 cent",
-    "material": [ "flesh" ],
-    "spoils_in": "1 day",
-    "calories": 471,
-    "fun": 6,
     "vitamins": [ [ "iron", 17 ], [ "meat_allergen", 1 ] ]
   },
   {

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -4132,5 +4132,45 @@
     "type": "MIGRATION",
     "id": "armor_faux_farmor_xs",
     "replace": "leather_armor_suit_xs"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "peppermeat",
+    "replace": "meat_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "pepperfat",
+    "replace": "meat_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "peppermutant",
+    "replace": "mutant_meat_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "pepperscrap",
+    "replace": "meat_scrap_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "pepperscrap_mutant",
+    "replace": "mutant_meat_scrap_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "pepperbone",
+    "replace": "cooked_marrow"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "pepperhuman",
+    "replace": "human_cooked"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "peppermutant_human",
+    "replace": "mutant_human_cooked"
   }
 ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -196,22 +196,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "peppermeat",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "time": "17 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "//": "20u energy to cook a meat chunk per standard",
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "meat", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "meat_fatty_cooked",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_MEAT",
@@ -292,21 +276,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "pepperbone",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "time": "22 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "qualities": [ { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "edible_bonemarrow", 1, "LIST" ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "bacon",
     "id_suffix": "hand_smoked",
     "category": "CC_FOOD",
@@ -355,17 +324,6 @@
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
-    "result": "pepperscrap",
-    "copy-from": "meat_cooked",
-    "time": "45 s",
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "//": "2u heat to cook 30g of flesh",
-    "components": [ [ [ "meat_scrap", 1 ], [ "human_meat_scrap", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "NO_EXERCISE",
     "result": "fish_scrap_cooked",
     "copy-from": "meat_cooked",
     "time": "45 s",
@@ -392,22 +350,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "peppermutant",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "time": "17 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "//": "20u heat to cook 300g of flesh",
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "mutant_meat", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
     "copy-from": "mutant_meat_cooked",
     "result": "meat_mutant_tainted_cooked",
     "qualities": [ { "id": "COOK", "level": 1 } ],
@@ -428,18 +370,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "result": "pepperscrap_mutant",
-    "copy-from": "mutant_meat_cooked",
-    "delete_flags": [ "BAD_TASTE" ],
-    "time": "47 s",
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "//": "2u heat to cook 30g of flesh",
-    "components": [ [ [ "mutant_meat_scrap", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "mutant_human_cooked",
     "category": "CC_FOOD",
@@ -453,22 +383,6 @@
     "//": "300g meat = 20u heat per usual",
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
     "components": [ [ [ "mutant_human_flesh", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "peppermutant_human",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "time": "17 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "//": "20u heat to cook 300g of flesh",
-    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "mutant_human_flesh", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -1759,22 +1673,6 @@
     "//": "as usual, 300g of meat = 20u surface_heat",
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_knife_skills" } ],
     "components": [ [ [ "human_flesh", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "pepperhuman",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_MEAT",
-    "skill_used": "cooking",
-    "time": "17 m",
-    "autolearn": true,
-    "batch_time_factors": [ 67, 5 ],
-    "qualities": [ { "id": "COOK", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "//": "20u heat to cook 300g of flesh",
-    "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_knife_skills" } ],
-    "components": [ [ [ "human_flesh", 1 ] ], [ [ "pepper", 1 ] ], [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Remove all forms of "pepper meat"

#### Purpose of change
"pepper meat" was an attempt by someone at DDA to make spices more useful, but it caused a ton of problems with messy copy-froms and inconsistencies and was not scalable.

#### Describe the solution
Remove.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
