### PR TITLE
Fix endless painkiller

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4402,10 +4402,10 @@
     "id": "opioid_eff",
     "//": "Pain relief increases linearly. Vomit chance increases and then becomes impossible due to CNS depression. Sleep is mostly impossible but ramps up sharply at i4 toward 100% at i7.",
     "name": [
-      "Pain Relief",
-      "Painkillers",
-      "Heavy Opioid Euphoria",
+      "Opioid Painkillers",
+      "Opipid Buzz",
       "Opioid High",
+      "Heavy Opioid High",
       "Nodding Out",
       "Opioid Overdose",
       "Severe Opioid Overdose"
@@ -4422,7 +4422,7 @@
     "blood_analysis_description": "Opioids",
     "max_intensity": 7,
     "miss_messages": [ [ "You feel numb.", 1 ] ],
-    "chance_kill": [ [ -1, 1 ], [ -1, 1 ], [ -1, 1 ], [ -1, 1 ], [ 1, 250000 ], [ 1, 50000 ], [ 1, 5000 ] ],
+    "chance_kill": [ [ -1, 1 ], [ -1, 1 ], [ -1, 1 ], [ -1, 1 ], [ 1, 500000 ], [ 1, 100000 ], [ 1, 5000 ] ],
     "death_msg": "Your breathing grows weaker and weaker, and then you are gone.",
     "pkill_addict_reduces": true,
     "base_mods": {
@@ -4434,10 +4434,10 @@
       "fatigue_max_val": [ 150 ],
       "cough_chance": [ -1002 ],
       "sleep_chance": [ -584 ],
-      "sleep_chance_bot": [ 1000 ],
+      "sleep_chance_bot": [ 6000 ],
       "sleep_tick": [ 1800 ],
       "sleep_min": [ 5 ],
-      "sleep_max": [ 10 ],
+      "sleep_max": [ 50 ],
       "pkill_max_val": [ 15 ],
       "pkill_min": [ 1 ],
       "pkill_tick": [ 45 ]

--- a/data/json/mapgen/mansion_boarded.json
+++ b/data/json/mapgen/mansion_boarded.json
@@ -531,7 +531,7 @@
         "o": "t_window_enhanced"
       },
       "furniture": { ")": "f_speaker_cabinet" },
-      "place_loot": [ { "item": "stereo", "x": 18, "y": 0, "chance": 80} ],
+      "place_loot": [ { "item": "stereo", "x": 18, "y": 0, "chance": 80 } ],
       "items": {
         ".": { "item": "clutter_yard", "chance": 1 },
         " ": { "item": "clutter_mansion", "chance": 1 },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5588,14 +5588,8 @@ void Character::update_needs( int rate_multiplier )
         set_stim( std::max( current_stim - rate_multiplier, 0 ) );
     }
 
-    // Only spend painkiller to treat pain we actually feel.
-    if( get_painkiller() > 0 && get_perceived_pain() > 0 ) {
-        const int spend = std::min( {
-            get_painkiller(),
-            rate_multiplier,
-            get_perceived_pain()
-        } );
-        mod_painkiller( -spend );
+    if( get_painkiller() > 0 ) {
+        mod_painkiller( -std::min( get_painkiller(), rate_multiplier ) );
     }
 
     if( get_bp_effect_mod() > 0 ) {


### PR DESCRIPTION
#### Summary
Fix endless painkiller

#### Purpose of change
If pkill (a hidden parameter on characters) exceeded your pain amount, they could become permanent, This was because I didn't realize that there wasn't a way for them to decay anymore after #2400 . Whoops.

#### Describe the solution
Bring back the old decay. This probably has some issues, but in testing it works OK.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
