### PR TITLE
Reduce welding supplies and a few other big piles of goodies

### DIFF
--- a/data/json/itemgroups/SUS/garage.json
+++ b/data/json/itemgroups/SUS/garage.json
@@ -10,14 +10,14 @@
         "distribution": [
           {
             "collection": [
-              { "item": "oxy_torch" },
-              { "item": "weldtank", "count": [ 1, 3 ], "prob": 95 },
-              { "item": "tinyweldtank", "count": [ 1, 3 ], "prob": 95 },
-              { "item": "oxygen_cylinder", "count": [ 1, 2 ], "prob": 95 },
+              { "item": "oxy_torch", "prob": 80 },
+              { "item": "weldtank", "prob": 66 },
+              { "item": "tinyweldtank", "count": [ 1, 3 ], "prob": 80 },
+              { "item": "oxygen_cylinder", "count": [ 1, 2 ], "prob": 80 },
               {
                 "distribution": [
-                  { "item": "brazing_rod_bronze", "prob": 100, "charges": [ 1000, 2000 ] },
-                  { "item": "brazing_rod_alloy", "prob": 70, "charges": [ 500, 1500 ] }
+                  { "item": "brazing_rod_bronze", "prob": 80, "charges": [ 300, 2000 ] },
+                  { "item": "brazing_rod_alloy", "prob": 70, "charges": [ 300, 1500 ] }
                 ]
               }
             ],
@@ -29,12 +29,12 @@
       { "distribution": [ { "item": "welding_mask", "prob": 70 }, { "item": "goggles_welding", "prob": 70 } ] },
       {
         "distribution": [
-          { "item": "welding_rod_steel", "prob": 90, "charges": [ 1000, 1600 ] },
-          { "item": "welding_rod_alloy", "prob": 40, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_steel", "prob": 90, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_alloy", "prob": 40, "charges": [ 1000, 1600 ] },
-          { "item": "brazing_rod_bronze", "prob": 80, "charges": [ 500, 1500 ] },
-          { "item": "brazing_rod_alloy", "prob": 30, "charges": [ 400, 1200 ] },
+          { "item": "welding_rod_steel", "prob": 80, "charges": [ 300, 1600 ] },
+          { "item": "welding_rod_alloy", "prob": 40, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_steel", "prob": 80, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_alloy", "prob": 40, "charges": [ 300, 1600 ] },
+          { "item": "brazing_rod_bronze", "prob": 80, "charges": [ 300, 1500 ] },
+          { "item": "brazing_rod_alloy", "prob": 30, "charges": [ 300, 1200 ] },
           { "item": "welding_blanket", "prob": 20, "count": [ 0, 1 ] }
         ]
       }

--- a/data/json/itemgroups/shops_trades.json
+++ b/data/json/itemgroups/shops_trades.json
@@ -45,10 +45,10 @@
       { "item": "steel_fragment", "prob": 15, "count": [ 1, 5 ] },
       {
         "collection": [
-          { "item": "oxy_torch", "prob": 100 },
+          { "item": "oxy_torch", "prob": 90 },
           {
-            "distribution": [ { "item": "weldtank", "prob": 100, "count": [ 1, 2 ] }, { "item": "tinyweldtank", "prob": 100, "count": [ 1, 3 ] } ],
-            "prob": 100
+            "distribution": [ { "item": "weldtank", "prob": 100 }, { "item": "tinyweldtank", "prob": 100, "count": [ 1, 3 ] } ],
+            "prob": 80
           },
           {
             "distribution": [
@@ -57,10 +57,10 @@
             ]
           }
         ],
-        "prob": 6
+        "prob": 5
       },
       [ "oxy_torch", 5 ],
-      { "item": "weldtank", "prob": 3, "count": [ 1, 2 ] },
+      { "item": "weldtank", "prob": 3 },
       { "item": "tinyweldtank", "prob": 4, "count": [ 1, 3 ] },
       { "item": "oxygen_cylinder", "prob": 10, "count": [ 1, 2 ] },
       { "item": "polisher", "prob": 1, "charges": [ 0, 100 ] },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -408,9 +408,9 @@
     "//2": "Stuff you might find in a jobsite, a hardware store, or a home workshop.",
     "items": [
       { "item": "nuts_bolts", "prob": 80, "charges": 500, "container-item": "box_small" },
-      { "item": "brazing_rod_bronze", "prob": 15, "charges": 1500 },
-      { "item": "welding_rod_steel", "prob": 20, "charges": 1500 },
-      { "item": "welding_wire_steel", "prob": 20, "charges": 1500 },
+      { "item": "brazing_rod_bronze", "prob": 15, "charges": [ 300, 1000 ] },
+      { "item": "welding_rod_steel", "prob": 20, "charges": [ 300, 1000 ] },
+      { "item": "welding_wire_steel", "prob": 20, "charges": [ 300, 1000 ] },
       { "item": "pipe_cleaner", "prob": 10 },
       { "group": "concrete_bag", "prob": 40 },
       { "group": "cement_bag", "prob": 50 },

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -779,6 +779,15 @@
     ]
   },
   {
+    "id": "racing_tire_used",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "tire_medium_slick", "prob": 50, "damage": [ 0, 5 ] },
+      { "item": "tire_medium", "prob": 50, "damage": [ 0, 5 ] }
+    ]
+  },
+  {
     "id": "supplies_spares_vehicle",
     "type": "item_group",
     "//": "Spare parts for crafting or mending vehicle parts",

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -384,8 +384,8 @@
           },
           {
             "distribution": [
-              { "item": "brazing_rod_bronze", "prob": 75, "charges": [ 500, 1500 ] },
-              { "item": "brazing_rod_alloy", "prob": 50, "charges": [ 500, 1500 ] }
+              { "item": "brazing_rod_bronze", "prob": 75, "charges": [ 300, 1500 ] },
+              { "item": "brazing_rod_alloy", "prob": 50, "charges": [ 300, 1500 ] }
             ]
           }
         ],
@@ -398,18 +398,18 @@
       { "item": "angle_grinder", "prob": 5, "charges": [ 0, 500 ] },
       { "item": "grinder_cutoff_disc", "prob": 2 },
       { "item": "welder", "prob": 10 },
-      { "item": "small_propane_tank", "prob": 10, "count": [ 0, 3 ], "charges": [ 1000, 3000 ] },
-      { "item": "medium_propane_tank", "prob": 20, "count": [ 0, 3 ], "charges": [ 5000, 15000 ] },
-      { "item": "large_propane_tank", "prob": 15, "count": [ 0, 2 ], "charges": [ 20000, 60000 ] },
+      { "item": "small_propane_tank", "prob": 8, "count": [ 1, 3 ], "charges": [ 1000, 3000 ] },
+      { "item": "medium_propane_tank", "prob": 15, "count": [ 1, 3 ], "charges": [ 5000, 15000 ] },
+      { "item": "large_propane_tank", "prob": 12, "count": [ 1, 2 ], "charges": [ 20000, 60000 ] },
       { "item": "welding_blanket", "prob": 20, "count": [ 0, 1 ] },
       {
         "distribution": [
-          { "item": "welding_rod_steel", "prob": 20, "charges": [ 1000, 1600 ] },
-          { "item": "welding_rod_alloy", "prob": 10, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_steel", "prob": 15, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_alloy", "prob": 5, "charges": [ 1000, 1600 ] },
-          { "item": "brazing_rod_bronze", "prob": 7, "charges": [ 500, 1500 ] },
-          { "item": "brazing_rod_alloy", "prob": 5, "charges": [ 400, 1200 ] }
+          { "item": "welding_rod_steel", "prob": 20, "charges": [ 300, 1600 ] },
+          { "item": "welding_rod_alloy", "prob": 10, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_steel", "prob": 15, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_alloy", "prob": 5, "charges": [ 300, 1600 ] },
+          { "item": "brazing_rod_bronze", "prob": 7, "charges": [ 300, 1500 ] },
+          { "item": "brazing_rod_alloy", "prob": 5, "charges": [ 300, 1200 ] }
         ]
       },
       [ "clamp", 10 ],
@@ -831,12 +831,12 @@
       { "item": "welding_blanket", "prob": 10, "count": [ 0, 1 ] },
       {
         "distribution": [
-          { "item": "welding_rod_steel", "prob": 10, "charges": [ 1000, 1600 ] },
-          { "item": "welding_rod_alloy", "prob": 5, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_steel", "prob": 20, "charges": [ 1000, 1600 ] },
-          { "item": "welding_wire_alloy", "prob": 20, "charges": [ 1000, 1600 ] },
-          { "item": "brazing_rod_bronze", "prob": 3, "charges": [ 500, 1500 ] },
-          { "item": "brazing_rod_alloy", "prob": 2, "charges": [ 400, 1200 ] }
+          { "item": "welding_rod_steel", "prob": 10, "charges": [ 300, 1600 ] },
+          { "item": "welding_rod_alloy", "prob": 5, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_steel", "prob": 20, "charges": [ 300, 1600 ] },
+          { "item": "welding_wire_alloy", "prob": 20, "charges": [ 300, 1600 ] },
+          { "item": "brazing_rod_bronze", "prob": 3, "charges": [ 300, 1500 ] },
+          { "item": "brazing_rod_alloy", "prob": 2, "charges": [ 300, 1200 ] }
         ]
       },
       { "item": "soldering_iron", "prob": 8 },

--- a/data/json/mapgen/airport/s_airport_runway_private.json
+++ b/data/json/mapgen/airport/s_airport_runway_private.json
@@ -67,7 +67,7 @@
         "_______________________s"
       ],
       "terrain": { "_": "t_pavement", "b": "t_pavement_y", "s": "t_sidewalk" },
-      "place_vehicles": [ { "vehicle": "helicopters_no_wreck", "x": 12, "y": 10, "chance": 50, "rotation": 270 } ]
+      "place_vehicles": [ { "vehicle": "helicopters_no_wreck", "x": 12, "y": 10, "chance": 60, "rotation": 270 } ]
     }
   }
 ]

--- a/data/json/mapgen/regional_airport.json
+++ b/data/json/mapgen/regional_airport.json
@@ -345,7 +345,7 @@
       "F": { "item": "SUS_office_filing_cabinet", "chance": 50 },
       "l": { "item": "clothing_work_set", "chance": 70 },
       "r": { "item": "mechanics", "chance": 30, "repeat": [ 1, 2 ] },
-      "k": { "item": "mechanics", "chance": 40, "repeat": [ 1, 3 ] },
+      "k": { "item": "mechanics", "chance": 40, "repeat": [ 1, 2 ] },
       "D": { "item": "trash", "chance": 70, "repeat": [ 3, 6 ] },
       "O": [
         { "item": "supplies_electronics", "chance": 20, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/speedway.json
+++ b/data/json/mapgen/speedway.json
@@ -65,7 +65,7 @@
       "0": "f_manual_tire_changer",
       "8": "f_gas_tank"
     },
-    "item": { "X": { "item": "tire_wide_or", "repeat": [ 2, 3 ] } },
+    "item": { "X": { "group": "racing_tire_used", "repeat": [ 1, 3 ] } },
     "items": {
       "b": [
         { "item": "softdrinks_canned", "chance": 1, "repeat": [ 0, 2 ] },
@@ -445,7 +445,7 @@
       ],
       "palettes": [ "speedway_palette" ],
       "items": { "R": { "item": "mechanics", "chance": 40, "repeat": [ 1, 6 ] }, "n": { "item": "SUS_welding_gear", "chance": 20 } },
-      "place_vehicles": [ { "vehicle": "rara_x", "x": 36, "y": 55, "rotation": 90, "chance": 5 } ],
+      "place_vehicles": [ { "vehicle": "rara_x", "x": 36, "y": 55, "rotation": 90, "chance": 1 } ],
       "place_loot": [
         { "item": "tire_medium_slick", "x": [ 36, 38 ], "y": 50, "repeat": [ 0, 6 ] },
         { "item": "tire_medium_slick", "x": [ 41, 43 ], "y": 74, "repeat": [ 0, 6 ] },

--- a/data/json/mapgen/speedway.json
+++ b/data/json/mapgen/speedway.json
@@ -65,7 +65,7 @@
       "0": "f_manual_tire_changer",
       "8": "f_gas_tank"
     },
-    "item": { "X": { "group": "racing_tire_used", "repeat": [ 1, 3 ] } },
+    "item": { "X": { "item": "racing_tire_used", "repeat": [ 1, 3 ] } },
     "items": {
       "b": [
         { "item": "softdrinks_canned", "chance": 1, "repeat": [ 0, 2 ] },

--- a/data/json/mapgen/speedway.json
+++ b/data/json/mapgen/speedway.json
@@ -65,8 +65,8 @@
       "0": "f_manual_tire_changer",
       "8": "f_gas_tank"
     },
-    "item": { "X": { "item": "racing_tire_used", "repeat": [ 1, 3 ] } },
     "items": {
+      "X": { "item": "racing_tire_used", "repeat": [ 1, 3 ] },
       "b": [
         { "item": "softdrinks_canned", "chance": 1, "repeat": [ 0, 2 ] },
         { "item": "snacks", "chance": 1, "repeat": [ 0, 2 ] },

--- a/data/json/mapgen_palettes/roof_palette.json
+++ b/data/json/mapgen_palettes/roof_palette.json
@@ -73,7 +73,7 @@
           [ "null", 440 ]
         ]
       },
-      "2": { "chunks": [ [ "industrial_1x1_solar", 4 ], [ "industrial_1x1_solar_v2", 1 ] ] },
+      "2": { "chunks": [ [ "industrial_1x1_solar", 4 ], [ "industrial_1x1_solar_v2", 1 ], [ "null", 3 ] ] },
       "3": {
         "chunks": [
           [ "null", 15 ],

--- a/data/json/mapgen_palettes/welding_store.json
+++ b/data/json/mapgen_palettes/welding_store.json
@@ -53,16 +53,16 @@
       "S": "f_rack"
     },
     "item": {
-      "f": { "item": "weldtank", "chance": 45, "repeat": [ 0, 2 ] },
-      "F": { "item": "weldtank", "chance": 40, "repeat": [ 0, 2 ] }
+      "f": { "item": "tinyweldtank", "chance": 25, "repeat": [ 1, 2 ] },
+      "F": { "item": "weldtank", "chance": 20, "repeat": [ 1, 2 ] }
     },
     "items": {
       "H": { "item": "cash_register_random" },
-      "s": { "item": "SUS_welding_gear", "chance": 40, "repeat": [ 0, 2 ] },
-      "C": { "item": "SUS_welding_gear", "chance": 35, "repeat": [ 0, 2 ] },
-      "r": { "item": "SUS_welding_gear", "chance": 35, "repeat": [ 0, 2 ] },
-      "S": { "item": "tools_common_small", "chance": 45, "repeat": [ 0, 2 ] },
-      "l": { "item": "clothing_work_set", "chance": 45, "repeat": [ 0, 1 ] }
+      "s": { "item": "SUS_welding_gear", "chance": 20, "repeat": [ 1, 2 ] },
+      "C": { "item": "SUS_welding_gear", "chance": 20, "repeat": [ 1, 2 ] },
+      "r": { "item": "SUS_welding_gear", "chance": 15, "repeat": [ 1, 2 ] },
+      "S": { "item": "tools_common_small", "chance": 30, "repeat": [ 1, 2 ] },
+      "l": { "item": "clothing_work_set", "chance": 35 }
     },
     "vehicles": {
       "=": { "vehicle": "welding_cart", "chance": 35, "rotation": 0 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
@@ -59,7 +59,7 @@
     "type": "item_group",
     "id": "REFUGEE_Fatima_carried",
     "subtype": "collection",
-    "entries": [ { "item": "weldtank" } ]
+    "entries": [ { "item": "tinyweldtank" } ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
#### Summary
Reduce welding supplies and a few other big piles of goodies

#### Purpose of change
- Speedways now have the types of tires used at the actual speedway instead of huge heaps of wide offroad tires (???). These are now medium slicks and normal tires, and they're generally quite damaged from sitting out in the sun and snow for months on end and having been used and probably discarded in the first place. But not always!
- Welding tanks were spawning too generously because of this weird nested itemgroup.
- Welding wires were spawning too generously because their maximum and minimum amounts were both high, I have turned down the minimum.
- The roof of the irradiation plant accidentally always had 8 solar panels instead of "some" solar panels.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
