### PR TITLE
Lifestyle message fixes and small healing nerf.

### DIFF
--- a/data/json/effects_on_condition/dream_eocs.json
+++ b/data/json/effects_on_condition/dream_eocs.json
@@ -51,7 +51,7 @@
           { "case": -100, "effect": { "u_message": "health_horrible", "snippet": true, "type": "bad" } },
           { "case": -50, "effect": { "u_message": "health_very_bad", "snippet": true, "type": "bad" } },
           { "case": -10, "effect": { "u_message": "health_bad", "snippet": true, "type": "bad" } },
-          { "case": 10, "effect": { "u_message": "" } },
+          { "case": 25, "effect": { "u_message": "" } },
           { "case": 50, "effect": { "u_message": "health_good", "snippet": true, "type": "good" } },
           { "case": 100, "effect": { "u_message": "health_very_good", "snippet": true, "type": "good" } },
           { "case": 200, "effect": { "u_message": "health_great", "snippet": true, "type": "good" } }

--- a/data/json/effects_on_condition/dream_eocs.json
+++ b/data/json/effects_on_condition/dream_eocs.json
@@ -7,10 +7,18 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_RESET_LIFESTYLE_MESSAGE_COUNTER",
+    "//": "used to prevent multiple dreams at the same sleep",
+    "recurrence": [ "24 hours", "72 hours" ],
+    "condition": { "and": [ { "math": [ "lifestyle_message_counter != 0" ] } ] },
+    "effect": [ { "math": [ "lifestyle_message_counter = 0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_GIVE_NIGHTMARES",
     "eoc_type": "EVENT",
     "required_event": "character_wakes_up",
-    "condition": { "and": [ { "u_has_effect": "nightmares" }, { "math": [ "dream_counter", "==", "0" ] } ] },
+    "condition": { "and": [ { "u_has_effect": "nightmares" }, { "math": [ "dream_counter == 0" ] } ] },
     "effect": [
       { "u_message": "nightmares", "snippet": true, "type": "bad" },
       { "u_add_morale": "morale_nightmare", "bonus": [ -15, -30 ], "max_bonus": -30 },
@@ -33,7 +41,7 @@
             { "not": { "u_has_effect": "flu" } }
           ]
         },
-        { "math": [ "dream_counter", "==", "0" ] }
+        { "math": [ "lifestyle_message_counter == 0" ] }
       ]
     },
     "effect": [
@@ -49,8 +57,7 @@
           { "case": 200, "effect": { "u_message": "health_great", "snippet": true, "type": "good" } }
         ]
       },
-      { "math": [ "dream_counter = 1" ] },
-      { "run_eocs": "EOC_RESET_DREAM_COUNTER", "time_in_future": 1 }
+      { "math": [ "lifestyle_message_counter = 1" ] }
     ]
   }
 ]

--- a/data/json/snippets/health_msgs.json
+++ b/data/json/snippets/health_msgs.json
@@ -52,14 +52,12 @@
     "category": "health_bad",
     "text": [
       "You feel cruddy.  Maybe you should consider eating a bit healthier.",
-      "You get up with a bit of a scratch in your throat.",
       "You stretch, but your muscles don't seem to be doing so good today.",
-      "You wake up congested and bleary-eyed.",
+      "You wake up bleary-eyed and lethargic.",
       "It's harder to get up today.",
       "You wake up feeling grouchy and foggy-headed.",
-      "Your body feels sluggish, making every movement an effort.",
-      "There's a nagging discomfort in your body, making it hard to focus on anything else.",
-      "You feel a general sense of malaise."
+      "Do you really need to get up yet?",
+      "You feel stiff and a little out of it."
     ]
   },
   {
@@ -68,7 +66,7 @@
     "text": [
       "Getting out of bed only comes with great difficulty, and your muscles resist the movement.",
       "Getting up seems like it should be easy, but all you want to do is lie there.",
-      "You feel like crap today.",
+      "You wake up feeling like crap. Maybe you should take better care of yourself.",
       "Alertness seems flighty today, and your body argues when you move towards it.",
       "You're up, but your body seems like it would rather stay in bed.",
       "You wake up feeling logy and your stomach is sour.",
@@ -88,9 +86,7 @@
       "Bleary-eyed and half-asleep, you consider why you are doing this to yourself.",
       "Awareness seems to only come with a battle… and your body seems to be on its side.",
       "You wake up feeling like you've been hit by a truck, every part of your body protesting.",
-      "You're so congested it's a wonder you didn't choke to death in your sleep.",
       "Your stomach feels sour, a sensation you can almost taste on the back of your tongue.",
-      "You feel a persistent ache in your body, as if you were fighting off a severe illness.",
       "Every joint and muscle screams in protest as you try to get up."
     ]
   },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6638,11 +6638,6 @@ float Character::healing_rate_medicine( float at_rest_quality, const bodypart_id
     // Sufficiently negative rest quality can completely eliminate your healing, but never turn it negative.
     rate_medicine *= 1.0f + std::max( at_rest_quality, -1.0f );
 
-    // increase healing if character has both effects
-    if( has_effect( effect_bandaged, bp ) && has_effect( effect_disinfected, bp ) ) {
-        rate_medicine *= 1.1;
-    }
-
     if( get_lifestyle() > 0.0f ) {
         rate_medicine *= 1.0f + get_lifestyle() / 220.0f;
     } else {
@@ -11590,13 +11585,13 @@ void Character::process_effects()
         !has_trait( trait_COMPOUND_EYES ) && !has_effect( effect_pre_conjunctivitis_bacterial ) &&
         !has_effect( effect_pre_conjunctivitis_viral ) && !has_effect( effect_conjunctivitis_bacterial ) &&
         !has_effect( effect_conjunctivitis_viral ) ) {
-        //Washing your eyes out in time may save you from getting pinkeye.
+        // Washing your eyes out in time may save you from getting pinkeye.
         float checked_health = get_lifestyle() + 200.0;
-        //Some animal eyes are more vulnerable to infection.
+        // Some animal eyes are more vulnerable to infection.
         if( has_trait_flag( json_flag_EYE_MEMBRANE ) ) {
             checked_health -= 50;
         }
-        //Ditto for contact lenses.
+        // Ditto for contact lenses.
         if( has_effect( effect_contacts ) || has_effect( effect_transition_contacts ) ) {
             checked_health -= 50;
         }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -883,16 +883,13 @@ void Character::update_bodytemp()
         // Otherwise, if any other body part is BODYTEMP_VERY_COLD, or 31C
         // AND you have frostbite, then that also prevents you from sleeping
         if( in_sleep_state() && !has_effect( effect_narcosis ) ) {
-            if( bp == body_part_torso && temp_after <= BODYTEMP_COLD && calendar::once_every( 1_hours ) ) {
-                add_msg( m_warning, _( "You feel cold and shiver." ) );
-            }
             if( temp_after <= BODYTEMP_VERY_COLD &&
                 get_fatigue() <= fatigue_levels::DEAD_TIRED && !has_bionic( bio_sleep_shutdown ) ) {
                 if( bp == body_part_torso ) {
-                    add_msg( m_warning, _( "Your shivering prevents you from sleeping." ) );
+                    add_msg( m_warning, _( "You are too cold to sleep." ) );
                     wake_up();
                 } else if( has_effect( effect_frostbite ) ) {
-                    add_msg( m_warning, _( "You are too cold.  Your frostbite prevents you from sleeping." ) );
+                    add_msg( m_warning, _( "You are too cold.  If you sleep now, you might never wake up." ) );
                     wake_up();
                 }
             }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -137,6 +137,7 @@ static void eff_fun_onfire( Character &u, effect &it )
     u.deal_damage( nullptr, it.get_bp(), damage_instance( STATIC( damage_type_id( "heat" ) ),
                    rng( 1, intense * 2 ) ) );
 }
+
 static void eff_fun_spores( Character &u, effect &it )
 {
     // Equivalent to X in 150000 + health * 100
@@ -146,6 +147,7 @@ static void eff_fun_spores( Character &u, effect &it )
         u.add_effect( effect_fungus, 1_turns, true );
     }
 }
+
 static void eff_fun_antifungal( Character &u, effect & )
 {
     // antifungal drugs are deadly poison for Marloss people
@@ -161,6 +163,7 @@ static void eff_fun_antifungal( Character &u, effect & )
         u.apply_damage( nullptr, random_bpart, 1 );
     }
 }
+
 static void eff_fun_fake_common_cold( Character &u, effect & )
 {
     if( calendar::once_every( time_duration::from_seconds( rng( 30, 300 ) ) ) && one_in( 2 ) ) {
@@ -172,6 +175,7 @@ static void eff_fun_fake_common_cold( Character &u, effect & )
         you.get_sick( false );
     }
 }
+
 static void eff_fun_fake_flu( Character &u, effect & )
 {
     if( calendar::once_every( time_duration::from_seconds( rng( 30, 300 ) ) ) && one_in( 2 ) ) {
@@ -183,6 +187,7 @@ static void eff_fun_fake_flu( Character &u, effect & )
         you.get_sick( true );
     }
 }
+
 static void eff_fun_fungus( Character &u, effect &it )
 {
     const int intense = it.get_intensity();
@@ -207,7 +212,7 @@ static void eff_fun_fungus( Character &u, effect &it )
                 u.add_msg_if_player( m_warning, _( "You feel nauseous." ) );
             }
             if( one_in( 600 + bonus * 6 ) ) {
-                u.add_msg_if_player( m_warning, _( "You smell and taste mushrooms." ) );
+                u.add_msg_if_player( m_warning, _( "The back of your throat is filled with a musty smell that you can almost taste." ) );
             }
             break;
         case 2:
@@ -283,6 +288,7 @@ static void eff_fun_fungus( Character &u, effect &it )
             break;
     }
 }
+
 static void eff_fun_rat( Character &u, effect &it )
 {
     const int dur = to_turns<int>( it.get_duration() );
@@ -305,6 +311,7 @@ static void eff_fun_rat( Character &u, effect &it )
         }
     }
 }
+
 static void eff_fun_bleed( Character &u, effect &it )
 {
     map &here = get_map();
@@ -387,6 +394,7 @@ static void eff_fun_bleed( Character &u, effect &it )
         }
     }
 }
+
 static void eff_fun_hallu( Character &u, effect &it )
 {
     // TODO: Redo this to allow for variable durations
@@ -1106,7 +1114,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         // People who can see while sleeping are acclimated to the light.
         if( !u.has_flag( json_flag_SEESLEEP ) ) {
             if( u.has_trait( trait_HEAVYSLEEPER2 ) && !u.has_trait( trait_HIBERNATE ) ) {
-                // So you can too sleep through noon
+                // So you can too sleep through noon.
                 if( ( tirednessVal * 1.25 ) < here.ambient_light_at( u.pos_bub() ) && ( u.get_fatigue() < 10 ||
                         one_in( u.get_fatigue() / 2 ) ) ) {
                     u.add_msg_if_player( _( "It's too bright to sleep." ) );
@@ -1156,7 +1164,7 @@ static void eff_fun_sleep( Character &u, effect &it )
                 if( curr_temp < BODYTEMP_FREEZING - fatigue_modifier ||
                     one_in( units::to_celsius( curr_temp ) * 3000 + 16500 ) ) {
                     u.add_msg_if_player( m_bad, _( "It's too cold to sleep." ) );
-                    // Set ourselves up for removal
+                    // Set ourselves up for removal.
                     it.set_duration( 0_turns );
                     woke_up = true;
                     break;
@@ -1168,7 +1176,7 @@ static void eff_fun_sleep( Character &u, effect &it )
                 if( curr_temp > BODYTEMP_SCORCHING + fatigue_modifier ||
                     one_in( 76500 - units::to_celsius( curr_temp ) * 500 ) ) {
                     u.add_msg_if_player( m_bad, _( "It's too hot to sleep." ) );
-                    // Set ourselves up for removal
+                    // Set ourselves up for removal.
                     it.set_duration( 0_turns );
                     woke_up = true;
                     break;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -647,9 +647,9 @@ void sounds::process_sound_markers( Character *you )
             you->volume = std::max( you->volume, noise );
         }
 
-        // Secure the flag before wake_up() clears the effect
+        // Secure the flag before wake_up() clears the effect.
         bool slept_through = you->has_effect( effect_slept_through_alarm );
-        // See if we need to wake someone up
+        // See if we need to wake someone up.
         if( you->in_sleep_state() ) {
             if( ( ( !( you->has_trait( trait_HEAVYSLEEPER ) ||
                        you->has_trait( trait_HEAVYSLEEPER2 ) ) && dice( 2, 15 ) < heard_volume ) ||
@@ -657,7 +657,7 @@ void sounds::process_sound_markers( Character *you )
                   ( you->has_trait( trait_HEAVYSLEEPER2 ) && dice( 6, 15 ) < heard_volume ) ) &&
                 !you->has_effect( effect_narcosis ) &&
                 !you->has_bionic( bio_sleep_shutdown ) ) {
-                //Not kidding about sleep-through-firefight
+                // Not kidding about sleep-through-firefight.
                 you->wake_up();
                 you->add_msg_if_player( m_warning, _( "Something is making noise." ) );
             } else {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1139,7 +1139,7 @@ void suffer::from_sunburn( Character &you, bool severe )
     auto warn_and_wake_up = [ &you, &all_parts_list]
     ( const char *message, game_message_type type ) {
         you.add_msg_if_player( type, message, all_parts_list );
-        // Wake up from skin irritation/burning
+        // Wake up from skin irritation/burning.
         if( you.has_effect( effect_sleep ) ) {
             you.wake_up();
         }


### PR DESCRIPTION
#### Summary
Lifestyle message fixes

#### Purpose of change
Lifestyle messages were using the dream timer, which resets every time you wake up. This meant you'd always get a lifestyle message any time you woke up if your lifestyle was anything other than smack dab in the middle of normal. This was especially noticeable if you were nodding out from heroin or something, it would spam the hell out of you.

#### Describe the solution
- You only get a lifestyle message once every 1-3 days. Also cleaned up a bit of text here and there.
- Removed the 10% healing speed buff you got from having both antiseptic and bandages. You already get a bonus from having antiseptic and bandages, it's called the bonus you get from having antiseptic and bandages.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
