### PR TITLE
Fix slow melee message

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -643,19 +643,25 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         add_msg( m_bad, _( "This weapon is too unwieldy to attack with!" ) );
         return false;
     }
+    std::string weapon_string;
+    if( !cur_weap.is_null() ) {
+        weapon_string = string_format(
+            _( "<color_light_red>Attacking your %s will take a long time. Are you sure you want to continue?</color>" ),
+            cur_weap.display_name()
+        );
+    } else {
+        weapon_string = _( "<color_light_red>Attacking unarmed will take a long time. Are you sure you want to continue?</color>" );
+    }
 
-    if( is_avatar() && move_cost > 400 && calendar::turn > melee_warning_turn ) {
+    if( is_avatar() && move_cost >= 500 && calendar::turn > melee_warning_turn ) {
         const std::string &action = query_popup()
                                     .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
-                                    .message( _( "<color_light_red>Attacking with your %1$s will take a long time.  "
-                                              "Are you sure you want to continue?</color>" ),
-                                              cur_weap.display_name() )
+                                    .message( "%s", weapon_string )
                                     .option( "YES" )
                                     .option( "NO" )
                                     .option( "IGNORE" )
                                     .query()
                                     .action;
-
         if( action == "NO" ) {
             return false;
         }


### PR DESCRIPTION
#### Summary
Fix slow melee message

#### Purpose of change
The slow attack warning was popping up at 4 seconds, which was still within the range a healthy ectotherm or something might reach. Let's bump it up to 5 seconds just to be sure people aren't getting into the habit of ignoring it.

The message also made no provision for unarmed attacks. Now it does.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
