### PR TITLE
Allow tunnel runners to wear dog armor.

### DIFF
--- a/data/json/items/armor/pets_dog_armor.json
+++ b/data/json/items/armor/pets_dog_armor.json
@@ -17,39 +17,9 @@
     "flags": [ "IS_PET_ARMOR" ],
     "material_thickness": 2.0,
     "max_pet_vol": "60 L",
-    "min_pet_vol": "25000 ml",
+    "min_pet_vol": "15000 ml",
     "pet_bodytype": "dog",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "5 L",
-        "max_contains_weight": "10 kg",
-        "max_item_length": "60 cm",
-        "moves": 200
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "5 L",
-        "max_contains_weight": "10 kg",
-        "max_item_length": "60 cm",
-        "moves": 200
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "20 cm",
-        "moves": 200
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "20 cm",
-        "moves": 200
-      }
-    ],
-    "melee_damage": { "bash": 5 }
+    "environmental_protection": 4
   },
   {
     "type": "ITEM",
@@ -63,7 +33,7 @@
     "price_postapoc": "25 USD",
     "material": [ "acidchitin" ],
     "weight": "5362 g",
-    "environmental_protection": 7
+    "environmental_protection": 1
   },
   {
     "type": "ITEM",
@@ -75,7 +45,7 @@
     "price": "350 USD",
     "price_postapoc": "20 USD",
     "material": [ "chitin" ],
-    "environmental_protection": 4
+    "environmental_protection": 1
   },
   {
     "type": "ITEM",
@@ -130,8 +100,8 @@
     "material": [ "neoprene", "plastic", "rubber" ],
     "weight": "1960 g",
     "material_thickness": 0.1,
-    "environmental_protection": 10,
-    "min_pet_vol": "15000 ml",
+    "environmental_protection": 8,
+    "min_pet_vol": "10000 ml",
     "extend": { "flags": [ "NO_SALVAGE" ] }
   }
 ]

--- a/data/json/monsters/mi-go.json
+++ b/data/json/monsters/mi-go.json
@@ -112,7 +112,7 @@
   {
     "id": "mon_mi_go_surgeon",
     "type": "MONSTER",
-    "name": { "str": "mi-go surgeon" },
+    "name": { "str": "mi-go vivisector" },
     "description": "This mi-go has a slender body with snaking carapace along it, and even more paired clawed appendages.  Its claws are smaller and more delicate looking, but that does not make them less unnerving.",
     "default_faction": "mi-go",
     "bodytype": "migo",
@@ -164,7 +164,7 @@
   {
     "id": "mon_mi_go_guard",
     "type": "MONSTER",
-    "name": { "str": "mi-go guard" },
+    "name": { "str": "mi-go defender" },
     "description": "A more heavily armored version of the common mi-go.  Its trunk is a shapeless mass of strange flesh encased in an iridescent carapace, from which sprout several appendages terminating in what appear to be devices of some sort.  Its pyramidal head is encrusted in barnacle-like armor, aside from the bristling antennae that serve as its - you assume - sensory devices and mouth.",
     "default_faction": "mi-go",
     "bodytype": "migo",
@@ -226,7 +226,7 @@
   {
     "id": "mon_mi_go_myrmidon",
     "type": "MONSTER",
-    "name": { "str": "mi-go myrmidon" },
+    "name": { "str": "giant mi-go" },
     "description": "This creature resembles the smaller mi-go like a grizzly bear resembles a human.  Its enormous, thick body is covered in an iridescent segmented carapace, like a scarab crossed with an isopod.  It boasts several pairs of deadly looking claws and other appendages, and it moves with a strange, slow grace, like an otherworldly dancer.  It appears to be carrying weaponry.",
     "default_faction": "mi-go",
     "bodytype": "migo",
@@ -288,7 +288,7 @@
   {
     "id": "mon_mi_go_captured",
     "type": "MONSTER",
-    "name": { "str": "partially harvested mi-go" },
+    "name": { "str": "vivisected mi-go" },
     "description": "This creature resembles the smaller mi-go like a grizzly bear resembles a human.  Its enormous, thick body is covered in an iridescent segmented carapace, like a scarab crossed with an isopod.  It has been mostly pulled apart and is stuck to a surgical table that seems to be keeping it alive.",
     "default_faction": "mi-go",
     "bodytype": "migo",

--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -54,6 +54,7 @@
     "copy-from": "mon_big_rat",
     "volume": "20 L",
     "weight": "35 kg",
+    "bodytype": "dog",
     "hp": 45,
     "speed": 80,
     "attack_cost": 80,
@@ -67,7 +68,7 @@
     "upgrades": { "half_life": 120, "into_group": "GROUP_RATKIN_EVOLVED" },
     "path_settings": { "max_dist": 50, "avoid_traps": true, "avoid_sharp": true },
     "special_attacks": [
-      { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 17, "armor_multiplier": 0.8 } ] },
+      { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 14 } ] },
       {
         "type": "bite",
         "cooldown": 3,
@@ -91,7 +92,6 @@
     "name": { "str": "pack rat" },
     "description": "This mutated rodent stands on two legs, as tall as a man.  It has a habit of shoving shiny objects into its cheek pouches, and eyes its surroundings with too-human eyes that sparkle with greed, but not intellect.",
     "default_faction": "ratkin",
-    "//": "Ratty enough to fit in with mutant rats, though it didn't evolve from one.",
     "copy-from": "mon_big_rat",
     "volume": "75000 ml",
     "weight": "74000 g",


### PR DESCRIPTION
#### Summary
Allow tunnel runners to wear dog armor.

#### Purpose of change
Tunnel runners couldn't wear dog armor. Now they can.

Renamed mi-go surgeon to mi-go vivisector, mi-go guard to mi-go defender, and mi-go myrmidon to giant mi-go. This helps get rid of the association with ants (they aren't eusocial) and makes the surgeon sound a little more menacing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
