### PR TITLE
Item location fixes

### DIFF
--- a/data/json/species.json
+++ b/data/json/species.json
@@ -44,7 +44,7 @@
   {
     "type": "SPECIES",
     "id": "KRAKEN",
-    "description": "a squid-like mutant",
+    "description": "a cephalopod",
     "footsteps": "slithering.",
     "fear_triggers": [ "HURT", "FRIEND_ATTACKED" ],
     "bleeds": "fd_blood"
@@ -57,34 +57,29 @@
   {
     "type": "SPECIES",
     "id": "NETHER",
-    "description": "a nether creature",
     "flags": [ "DRACULIN_IMMUNE" ]
   },
   {
     "type": "SPECIES",
     "id": "NETHER_BURROWING",
-    "description": "a nether creature",
     "footsteps": "rustling",
     "flags": [ "DRACULIN_IMMUNE" ]
   },
   {
     "type": "SPECIES",
     "id": "NETHER_EMANATION",
-    "description": "a reflection of another dimension",
     "fear_triggers": [ "HURT" ],
     "flags": [ "DRACULIN_IMMUNE" ]
   },
   {
     "type": "SPECIES",
     "id": "MIGO",
-    "description": "a creature from the mi-go homeworld",
     "fear_triggers": [ "HURT" ],
     "flags": [ "DRACULIN_IMMUNE" ]
   },
   {
     "type": "SPECIES",
     "id": "SLIME",
-    "description": "a slime",
     "footsteps": "plop.",
     "bleeds": "fd_slime",
     "flags": [ "DRACULIN_IMMUNE" ]
@@ -92,7 +87,6 @@
   {
     "type": "SPECIES",
     "id": "FUNGUS",
-    "description": "a fungus",
     "fear_triggers": [ "HURT", "FIRE" ],
     "flags": [ "DRACULIN_IMMUNE" ]
   },
@@ -167,7 +161,6 @@
   {
     "type": "SPECIES",
     "id": "FERAL",
-    "description": "a feral",
     "footsteps": "shuffling.",
     "bleeds": "fd_blood"
   },
@@ -188,18 +181,15 @@
   },
   {
     "type": "SPECIES",
-    "id": "HORROR",
-    "description": "a horror"
+    "id": "HORROR"
   },
   {
     "type": "SPECIES",
-    "id": "ABERRATION",
-    "description": "an aberration"
+    "id": "ABERRATION"
   },
   {
     "type": "SPECIES",
-    "id": "HALLUCINATION",
-    "description": "your imagination"
+    "id": "HALLUCINATION"
   },
   {
     "type": "SPECIES",
@@ -209,7 +199,6 @@
   },
   {
     "type": "SPECIES",
-    "id": "UNKNOWN",
-    "description": "a bug"
+    "id": "UNKNOWN"
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3159,6 +3159,10 @@ void efile_activity_actor::start( player_activity &act, Character &who )
         }
     }
     for( item_location &i : target_edevices ) {
+        if( i->is_null() ) {
+            who.cancel_activity();
+            return;
+        }
         if( !i->has_pocket_type( pocket_type::E_FILE_STORAGE ) ) {
             debugmsg( "invalid item %s provided to efile activity; must have \"E_FILE_STORAGE\" pocket",
                       i->tname() );
@@ -3539,6 +3543,10 @@ void efile_activity_actor::combo_next_activity( Character &who )
 
     if( combo_type == COMBO_MOVE_ONTO_BROWSE ) {
         for( item_location &edevice : target_edevices_copy ) {
+            if( edevice->is_null() ) {
+                who.cancel_activity();
+                return;
+            }
             for( item *efile : edevice->efiles() ) {
                 all_updated_files.emplace_back( edevice, efile );
             }
@@ -3546,6 +3554,10 @@ void efile_activity_actor::combo_next_activity( Character &who )
 
         units::ememory total_ememory;
         for( item_location &edevice : target_edevices_copy ) {
+            if( edevice->is_null() ) {
+                who.cancel_activity();
+                return;
+            }
             if( edevice->is_browsed() ) {
                 for( item *efile : edevice->efiles() ) {
                     total_ememory += efile->ememory_size();
@@ -3754,6 +3766,9 @@ bool efile_activity_actor::efile_action_is_from( efile_action action_type )
 bool efile_activity_actor::efile_skip_copy( const efile_transfer &transfer, const item &efile )
 {
     auto check_for_file = [&efile]( const item_location & edevice ) {
+        if( edevice->is_null() ) {
+            return true;
+        }
         for( const item *i : edevice->efiles() ) {
             if( i->typeId() == efile.typeId() ) {
                 return true;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1605,7 +1605,7 @@ bool npc::wield( item &it )
     if( has_wield_conflicts( it ) && !get_wielded_item()->has_item( it ) ) {
         stow_item( *get_wielded_item() );
     }
-    if( !Character::wield( it ) ) {
+    if( !Character::wield( it, true ) ) {
         return false;
     }
     if( get_wielded_item() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1597,23 +1597,26 @@ void npc::stow_item( item &it )
 
 bool npc::wield( item &it )
 {
-    // dont unwield if you already wield the item
     if( is_wielding( it ) ) {
         return true;
     }
-    // instead of unwield(), call stow_item, allowing to wear it and check it is not inside wielded itm
-    if( has_wield_conflicts( it ) && !get_wielded_item()->has_item( it ) ) {
-        stow_item( *get_wielded_item() );
+    item * const held_item = get_wielded_item().get_item();
+    const bool stow =
+        has_wield_conflicts( it ) && held_item && held_item->has_item( it );
+    if( stow && held_item ) {
+        stow_item( *held_item );
     }
-    if( !Character::wield( it, true ) ) {
+    if( !Character::wield( it ) ) {
         return false;
     }
-    if( get_wielded_item() ) {
-        // add_msg_if_player_sees does no internal npc name replacement
-        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
-                                get_wielded_item()->tname() );
+    item * const new_item = get_wielded_item().get_item();
+    if( new_item ) {
+        add_msg_if_player_sees(
+            *this, m_info,
+            replace_with_npc_name( _( "<npcname> wields a %s." ) ),
+            new_item->tname()
+        );
     }
-
 
     invalidate_range_cache();
     return true;


### PR DESCRIPTION
#### Summary
Item location fixes

#### Purpose of change
Attempt to fix a crash while managing edevices and an infinite loop when an NPC tries to use a weapon under specific circumstances.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
