### PR TITLE
Fix limb dodge mod when limbs are broken

### DIFF
--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -363,8 +363,10 @@ float character_modifier::modifier( const Character &c, const skill_id &skill ) 
 
     // score == 0
     if( score < std::numeric_limits<float>::epsilon() ) {
-        return min_val > std::numeric_limits<float>::epsilon() ? min_val :
-               max_val > std::numeric_limits<float>::epsilon() ? max_val : 0.0f;
+        if( nominator > std::numeric_limits<float>::epsilon() ) {
+            return max_val > std::numeric_limits<float>::epsilon() ? max_val : 0.0f;
+        }
+        return min_val > std::numeric_limits<float>::epsilon() ? min_val : 0.0f;
     }
     if( nominator > std::numeric_limits<float>::epsilon() ) {
         score = ( nominator / denominator ) / score;


### PR DESCRIPTION
#### Summary
Fix limb dodge mod when limbs are broken

#### Purpose of change
A minor math error was making limb_dodge_mod flip to the max if the value got low enough.

#### Describe the solution
Fixed the check. It now goes to the min value.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
