### PR TITLE
Fix invalid limb blocks

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1681,8 +1681,9 @@
     "description": "A secret martial art used only by developers and cheaters.",
     "initiate": [ "You get ready pwn some zeds!", "%s prepares to cheat at martial arts!" ],
     "priority": 1,
-    "arm_block": 99,
-    "leg_block": 99,
+    "arm_block": 0,
+    "leg_block": 0,
+    "nonstandard_block": 0,
     "static_buffs": [
       {
         "id": "debug_elem_resist",

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -281,8 +281,8 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
             block_score *= u->worn_with_flag( flag_BLOCK_WHILE_WORN, bp ) ? 5 : 1;
         }
 
-        // Filter out nonblocking / broken limbs
-        if( block_score == 0 ) {
+        // Filter out nonblocking / broken limbs. Avoid weird float remainders by checking <= 0.001f.
+        if( block_score <= 0.0001f ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no blocking score",
                            body_part_name( bp ) );
             continue;
@@ -297,19 +297,19 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
         }
 
         // Can we block with our normal boring arm?
-        if( bp->limbtypes.count( body_part_type::type::arm ) == 0 &&
+        if( bp->limbtypes.count( body_part_type::type::arm ) > 0 &&
             !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) &&
             !arm ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no arm blocks allowed",
                            body_part_name( bp ) );
             continue;
-            // Can we block with our normal boring legs?
-        } else if( bp->limbtypes.count( body_part_type::type::leg ) == 0 &&
+        // Can we block with our normal boring legs?
+        } else if( bp->limbtypes.count( body_part_type::type::leg ) > 0 &&
                    !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) && !leg ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no leg blocks allowed",
                            body_part_name( bp ) );
             continue;
-            // Can we block with our non-normal non-arms/non-legs?
+        // Can we block with our non-normal non-arms/non-legs?
         } else if( bp->has_flag( json_flag_NONSTANDARD_BLOCK ) && !nonstandard ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no nonstandard blocks allowed",
                            body_part_name( bp ) );
@@ -326,7 +326,7 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
 
     const bodypart_id *ret = block_scores.pick();
     if( ret == nullptr ) {
-        debugmsg( "Attempted to select body part from empty anatomy %s", id.c_str() );
+        add_msg_debug( debugmode::DF_MELEE, "No intact body parts available for blocking. Aborting block." );
         return bodypart_str_id::NULL_ID().id();
     }
 

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -303,13 +303,13 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no arm blocks allowed",
                            body_part_name( bp ) );
             continue;
-        // Can we block with our normal boring legs?
+            // Can we block with our normal boring legs?
         } else if( bp->limbtypes.count( body_part_type::type::leg ) > 0 &&
                    !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) && !leg ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no leg blocks allowed",
                            body_part_name( bp ) );
             continue;
-        // Can we block with our non-normal non-arms/non-legs?
+            // Can we block with our non-normal non-arms/non-legs?
         } else if( bp->has_flag( json_flag_NONSTANDARD_BLOCK ) && !nonstandard ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no nonstandard blocks allowed",
                            body_part_name( bp ) );
@@ -326,7 +326,8 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
 
     const bodypart_id *ret = block_scores.pick();
     if( ret == nullptr ) {
-        add_msg_debug( debugmode::DF_MELEE, "No intact body parts available for blocking. Aborting block." );
+        add_msg_debug( debugmode::DF_MELEE,
+                       "No intact body parts available for blocking. Aborting block." );
         return bodypart_str_id::NULL_ID().id();
     }
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -507,9 +507,9 @@ void martialart::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "force_unarmed", force_unarmed, false );
     optional( jo, was_loaded, "prevent_weapon_blocking", prevent_weapon_blocking, false );
 
-    optional( jo, was_loaded, "leg_block", leg_block, 99 );
-    optional( jo, was_loaded, "arm_block", arm_block, 99 );
-    optional( jo, was_loaded, "nonstandard_block", nonstandard_block, 99 );
+    optional( jo, was_loaded, "leg_block", leg_block, -1 );
+    optional( jo, was_loaded, "arm_block", arm_block, -1 );
+    optional( jo, was_loaded, "nonstandard_block", nonstandard_block, -1 );
 
     optional( jo, was_loaded, "arm_block_with_bio_armor_arms", arm_block_with_bio_armor_arms, false );
     optional( jo, was_loaded, "leg_block_with_bio_armor_legs", leg_block_with_bio_armor_legs, false );
@@ -1169,6 +1169,7 @@ martialart::martialart()
 {
     leg_block = -1;
     arm_block = -1;
+    nonstandard_block = -1;
 }
 
 // simultaneously check and add all buffs. this is so that buffs that have
@@ -1705,11 +1706,11 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
     const int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                                   skill_unarmed );
 
-    // Before we check our legs, can you block at all?
-    const bool block_with_skill = unarmed_skill >= ma.leg_block;
+    // Before we check our legs, can we leg block at all?
+    const bool block_with_skill = ma.leg_block >= 0 && unarmed_skill >= ma.leg_block;
     const bool block_with_bio_armor = ma.leg_block_with_bio_armor_legs &&
                                       owner.has_bionic( bio_armor_legs );
-    if( !( block_with_skill || block_with_bio_armor ) ) {
+    if( !block_with_skill && !block_with_bio_armor ) {
         return false;
     }
 
@@ -1740,16 +1741,16 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
     const int unarmed_skill = owner.has_active_bionic( bio_cqb ) ? 5 : owner.get_skill_level(
                                   skill_unarmed );
 
-    // before we check our arms, can you block at all?
-    const bool block_with_skill = unarmed_skill >= ma.arm_block;
+    // Before we check our arms, can we block at all?
+    const bool block_with_skill = ma.arm_block >= 0 && unarmed_skill >= ma.arm_block;
     const bool block_with_bio_armor = ma.arm_block_with_bio_armor_arms &&
                                       owner.has_bionic( bio_armor_arms );
-    if( !( block_with_skill || block_with_bio_armor ) ) {
+    if( !block_with_skill && !block_with_bio_armor ) {
         return false;
     }
 
     // Success conditions.
-    // Do we have boring human anatomy? Use the basic calculation
+    // Do we have boring human anatomy? Use the basic calculation.
     if( !owner.has_flag( json_flag_NONSTANDARD_BLOCK ) ) {
         return owner.get_limb_score( limb_score_block, body_part_type::type::arm ) >= 0.5f;
     } else {
@@ -2277,36 +2278,23 @@ bool ma_style_callback::key( const input_context &ctxt, const input_event &event
 
         buffer += "--\n";
 
-        if( ma.arm_block_with_bio_armor_arms || ma.arm_block != 99 ||
-            ma.leg_block_with_bio_armor_legs || ma.leg_block != 99  ||
-            ma.nonstandard_block != 99 ) {
-            Character &u = get_player_character();
-            int unarmed_skill =  u.get_skill_level( skill_unarmed );
-            if( u.has_active_bionic( bio_cqb ) ) {
-                unarmed_skill = BIO_CQB_LEVEL;
-            }
+        if( ma.arm_block_with_bio_armor_arms || ma.arm_block >= 0 ||
+            ma.leg_block_with_bio_armor_legs || ma.leg_block >= 0 ) {
             if( ma.arm_block_with_bio_armor_arms ) {
                 buffer += _( "You can <info>arm block</info> by installing the <info>Arms Alloy Plating CBM</info>" );
                 buffer += "\n";
-            } else if( ma.arm_block != 99 ) {
+            } else if( ma.arm_block >= 0 ) {
                 buffer += string_format(
-                              _( "You can <info>arm block</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                              unarmed_skill, ma.arm_block ) + "\n";
+                              _( "You can <info>arm block</info> at <info>unarmed rank:</info> <stat>%s</stat>" ),
+                              ma.arm_block ) + "\n";
             }
-
             if( ma.leg_block_with_bio_armor_legs ) {
                 buffer += _( "You can <info>leg block</info> by installing the <info>Legs Alloy Plating CBM</info>" );
                 buffer += "\n";
-            } else if( ma.leg_block != 99 ) {
+            } else if( ma.leg_block >= 0 ) {
                 buffer += string_format(
-                              _( "You can <info>leg block</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                              unarmed_skill, ma.leg_block );
-                buffer += "\n";
-            }
-            if( ma.nonstandard_block != 99 ) {
-                buffer += string_format(
-                              _( "You can <info>block with mutated limbs</info> at <info>unarmed combat:</info> <stat>%s</stat>/<stat>%s</stat>" ),
-                              unarmed_skill, ma.nonstandard_block );
+                              _( "You can <info>leg block</info> at <info>unarmed rank:</info> <stat>%s</stat>" ),
+                              ma.leg_block );
                 buffer += "\n";
             }
             buffer += "--\n";

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -415,9 +415,9 @@ class martialart
         skill_id primary_skill;
         bool teachable = true;
         int learn_difficulty = 0;
-        int arm_block = 0;
-        int leg_block = 0;
-        int nonstandard_block = 0;
+        int arm_block = -1;
+        int leg_block = -1;
+        int nonstandard_block = -1;
         bool arm_block_with_bio_armor_arms = false;
         bool leg_block_with_bio_armor_legs = false;
         std::set<matec_id> techniques; // all available techniques

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2272,6 +2272,10 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     // Get the rest of our block modifiers to tally up a final score.
     if( can_block_unarmed ) {
         bp_hit = select_blocking_part( arm_block, leg_block, nonstandard_block );
+        // Bail out if all our blocking parts are unavailable.
+        if( bp_hit == bodypart_str_id::NULL_ID().id() ) {
+            return false;
+        }
         body_block_score *= get_part( bp_hit )->get_limb_score( limb_score_block );
         add_msg_debug( debugmode::DF_MELEE, "Body block score after limb score multiplier: %d",
                        body_block_score );


### PR DESCRIPTION
#### Summary
Fix invalid limb blocks

#### Purpose of change
Some iffy math was messing up limb block checks, resulting in characters blocking with the wrong parts or with nothing at all.

#### Describe the solution
Fix the math.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
