### PR TITLE
Re-add weeds to forest clutter

### DIFF
--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -194,10 +194,7 @@
     "id": "digging_topsoil_loam_50L",
     "type": "item_group",
     "subtype": "collection",
-    "items": [
-      { "group": "digging_soil_loam_50L", "count": 1 },
-      { "item": "earthworm", "count": [ 0, 16 ], "prob": 75 }
-    ]
+    "items": [ { "group": "digging_soil_loam_50L", "count": 1 }, { "item": "earthworm", "count": [ 0, 16 ], "prob": 75 } ]
   },
   {
     "id": "mining_rock",

--- a/data/json/recipes/basecamps/recipe_groups.json
+++ b/data/json/recipes/basecamps/recipe_groups.json
@@ -328,9 +328,7 @@
     "type": "recipe_group",
     "id": "saltworks_recipes_1",
     "building_type": "COOK",
-    "recipes": [
-      { "id": "salt_from_salt_water", "description": " Craft: Salt from salt water" }
-    ]
+    "recipes": [ { "id": "salt_from_salt_water", "description": " Craft: Salt from salt water" } ]
   },
   {
     "type": "recipe_group",

--- a/data/json/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/regional_map_settings.json
@@ -248,14 +248,15 @@
     "sequence": 2,
     "chance": 80,
     "types": [
-      [ "t_trunk", 128 ],
-      [ "t_dirtmound", 128 ],
-      [ "f_boulder_small", 128 ],
-      [ "f_rubble_rock", 32 ],
-      [ "f_boulder_medium", 8 ],
-      [ "f_boulder_large", 1 ],
-      [ "t_pit", 1 ],
-      [ "t_pit_shallow", 1 ]
+      [ "t_trunk", 256 ],
+      [ "t_dirtmound", 256 ],
+      [ "f_boulder_small", 256 ],
+      [ "f_rubble_rock", 64 ],
+      [ "f_boulder_medium", 16 ],
+      [ "f_boulder_large", 2 ],
+      [ "t_pit", 2 ],
+      [ "t_pit_shallow", 2 ],
+      [ "f_region_forest", 3 ]
     ]
   },
   {
@@ -285,14 +286,15 @@
     "copy-from": "clutter_forest",
     "chance": 64,
     "types": [
-      [ "t_trunk", 64 ],
-      [ "t_dirtmound", 64 ],
-      [ "f_boulder_small", 32 ],
-      [ "f_rubble_rock", 32 ],
-      [ "f_boulder_medium", 16 ],
-      [ "f_boulder_large", 4 ],
-      [ "t_pit", 1 ],
-      [ "t_pit_shallow", 1 ]
+      [ "t_trunk", 128 ],
+      [ "t_dirtmound", 128 ],
+      [ "f_boulder_small", 64 ],
+      [ "f_rubble_rock", 64 ],
+      [ "f_boulder_medium", 32 ],
+      [ "f_boulder_large", 8 ],
+      [ "t_pit", 2 ],
+      [ "t_pit_shallow", 2 ],
+      [ "f_region_forest_dense", 3 ]
     ]
   },
   {
@@ -352,7 +354,7 @@
     "id": "clutter_forest_water",
     "copy-from": "clutter_forest",
     "chance": 75,
-    "types": [ [ "t_trunk", 1 ], [ "f_boulder_small", 2 ], [ "f_boulder_medium", 1 ] ]
+    "types": [ [ "t_trunk", 50 ], [ "f_boulder_small", 100 ], [ "f_boulder_medium", 50 ], [ "f_region_forest_water", 2 ] ]
   },
   {
     "type": "forest_biome_component",
@@ -1691,7 +1693,13 @@
     "type": "region_terrain_furniture",
     "id": "default_f_region_forest_water",
     "furn_id": "f_region_forest_water",
-    "replace_with_furniture": [ [ "f_burdock", 4 ], [ "f_purple_loosestrife", 3 ], [ "f_japanese_knotweed", 2 ], [ "f_lily", 1 ] ]
+    "replace_with_furniture": [
+      [ "f_burdock", 40 ],
+      [ "f_purple_loosestrife", 30 ],
+      [ "f_japanese_knotweed", 20 ],
+      [ "f_lily", 10 ],
+      [ "f_plant_dead", 1 ]
+    ]
   },
   {
     "type": "region_terrain_furniture",


### PR DESCRIPTION
#### Summary
Re-add weeds to forest clutter

#### Purpose of change
Forests didn't have random plants spawning in them, just the basic shrub terrains. Definitions existed for randomized forest weeds, but they weren't used anywhere.

#### Describe the solution
Add them to clutter. Now you will sometimes spot burdock or whatever as you travel around in the woods, though swamps are going to be far better for that sort of thing, at least in spring.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
