### PR TITLE
Slightly reduce tire damage offroad

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1164,12 +1164,12 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                 continue;
             }
 
-            int chance = std::clamp( 250000 / velocity, 100, 200 );
+            int chance = std::clamp( 250000 / velocity, 80, 200 );
             if( extra_hazard ) {
                 chance = chance * 3 / 4;
             }
 
-            add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %d.", chance );
+            add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to proc rough terrain: 1 / %d.", chance );
 
             if( !one_in( chance ) ) {
                 continue;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1153,20 +1153,20 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             }
             const int velocity = std::max( std::abs( veh.velocity ), 1 );
             const bool extra_hazard = has_flag( ter_furn_flag::TFLAG_TIRE_DAMAGE, wheel_p ) ||
-                                      has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p );
+                                    has_flag( ter_furn_flag::TFLAG_SHARP, wheel_p );
 
-            const bool hazard = extra_hazard || ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
-                                                  !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
-                                                  !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
+            const bool hazard = extra_hazard ||
+                                ( has_flag( ter_furn_flag::TFLAG_DIGGABLE, wheel_p ) &&
+                                !has_flag( ter_furn_flag::TFLAG_ROAD, wheel_p ) &&
+                                !has_flag( ter_furn_flag::TFLAG_TIRE_SAFE, wheel_p ) );
 
             if( !hazard || ( vp_wheel.info().wheel_info->offroad_rating >= 0.6f && !extra_hazard ) ) {
                 continue;
             }
 
-            int chance = std::clamp( 250000 / velocity, 50, 150 );
-
+            int chance = std::clamp( 250000 / velocity, 100, 200 );
             if( extra_hazard ) {
-                chance *= 0.75;
+                chance = chance * 3 / 4;
             }
 
             add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to damage: 1 / %d.", chance );


### PR DESCRIPTION
#### Summary
Slightly reduce tire damage offroad

#### Purpose of change
Tire damage was a little more punishing offroad than intended. It's still supposed to be a big issue but I was seeing people frequently proc it when driving around e.g. a wrecked car or something.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
