### PR TITLE
Better tire damage calculations

### DIFF
--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -136,10 +136,6 @@
     "info": "Keeps the rain out of the interior of the vehicle."
   },
   {
-    "id": "RESIST_RUNOVER_DAMAGE",
-    "type": "json_flag"
-  },
-  {
     "id": "SEAT",
     "type": "json_flag",
     "info": "You need to be in a seat or saddle to operate vehicle controls."

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -235,7 +235,7 @@
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
-    "damage_reduction": { "bash": 20 },
+    "damage_reduction": { "bash": 20, "cut": 12, "stab": 12, "bullet": 4 },
     "variants": [ { "symbols": "0", "symbols_broken": "x" } ]
   },
   {
@@ -247,7 +247,7 @@
     "wheel_offroad_rating": 0.2,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
     "contact_area": 180,
-    "damage_reduction": { "bash": 12 }
+    "damage_reduction": { "bash": 15, "cut": 7, "stab": 7, "bullet": 3 }
   },
   {
     "id": "wheel_armor",
@@ -259,8 +259,9 @@
     "categories": [ "movement" ],
     "color": "green",
     "durability": 800,
-    "description": "A very strong, armored metal wheel.",
+    "description": "A heavy-duty wheel with a reinforced run-flat tire.",
     "damage_modifier": 50,
+    "wheel_offroad_rating": 0.5,
     "breaks_into": [
       { "item": "steel_chunk", "count": [ 2, 3 ] },
       { "item": "steel_fragment", "count": [ 2, 3 ] },
@@ -274,8 +275,8 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "20 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_HEAVY", "RESIST_RUNOVER_DAMAGE" ],
-    "damage_reduction": { "all": 60, "cut": 30, "stab": 16 },
+    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_HEAVY" ],
+    "damage_reduction": { "bash": 60, "cut": 65, "stab": 65, "bullet": 16 },
     "variants": [ { "symbols": "0", "symbols_broken": "x" } ]
   },
   {
@@ -302,7 +303,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
-    "damage_reduction": { "bash": 10 },
+    "damage_reduction": { "bash": 13, "cut": 6, "stab": 6 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -332,7 +333,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
-    "damage_reduction": { "bash": 6 },
+    "damage_reduction": { "bash": 10, "cut": 8, "stab": 8, "bullet": 1 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
       { "id": "rear", "label": "Rear", "symbols": "|\\-/|\\-/", "symbols_broken": "x" }
@@ -346,6 +347,7 @@
     "item": "wheel_bicycle_or",
     "contact_area": 36,
     "wheel_offroad_rating": 0.7,
+    "damage_reduction": { "bash": 10, "cut": 8, "stab": 8, "bullet": 2 },
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
   },
   {
@@ -370,6 +372,7 @@
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "adhesive", 5 ] ] }
     },
+    "damage_reduction": { "bash": 4, "cut": 20, "stab": 20, "bullet": 2 },
     "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
@@ -390,6 +393,7 @@
     "wheel_offroad_rating": 0.4,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 6 ], "ROAD": [ 0, 3 ] },
     "contact_area": 12,
+    "damage_reduction": { "bash": 6, "cut": 25, "stab": 25, "bullet": 4 },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_1", 1 ] ] },
@@ -416,6 +420,7 @@
     "wheel_offroad_rating": 0.3,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 6 ], "ROAD": [ 0, 3 ] },
     "contact_area": 4,
+    "damage_reduction": { "bash": 4, "cut": 20, "stab": 20, "bullet": 2 },
     "requirements": {
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "1 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] },
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "1 m", "qualities": [ { "id": "WRENCH", "level": 2 } ] }
@@ -480,6 +485,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "NO_COVER" ],
+    "damage_reduction": { "bash": 6, "cut": 12, "stab": 12, "bullet": 3 },
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
@@ -509,7 +515,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
-    "damage_reduction": { "bash": 10 },
+    "damage_reduction": { "bash": 18, "cut": 12, "stab": 12, "bullet": 4 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "o", "symbols_broken": "x" },
       { "id": "rear", "label": "Rear", "symbols": "o", "symbols_broken": "x" }
@@ -524,7 +530,7 @@
     "contact_area": 60,
     "wheel_offroad_rating": 0.7,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
-    "damage_reduction": { "bash": 10, "cut": 8, "stab": 4 }
+    "damage_reduction": { "bash": 18, "cut": 14, "stab": 14, "bullet": 5 }
   },
   {
     "id": "wheel_small",
@@ -551,6 +557,7 @@
     },
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
     "variants_bases": [ { "id": "scooter", "label": "Scooter" } ],
+    "damage_reduction": { "bash": 14, "cut": 10, "stab": 10, "bullet": 2 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "o", "symbols_broken": "x" },
       { "id": "rear", "label": "Rear", "symbols": "o", "symbols_broken": "x" }
@@ -578,7 +585,7 @@
     "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 10,
     "flags": [ "STABLE", "STEERABLE", "WHEEL", "NEEDS_JACKING", "NO_COVER" ],
-    "damage_reduction": { "bash": 8 },
+    "damage_reduction": { "bash": 9, "cut": 6, "stab": 6, "bullet": 1 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
@@ -609,7 +616,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
-    "damage_reduction": { "bash": 8 },
+    "damage_reduction": { "bash": 9, "cut": 6, "stab": 6, "bullet": 1 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
@@ -640,7 +647,7 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "NEEDS_JACKING", "STABLE", "STEERABLE", "NEEDS_WHEEL_MOUNT_LIGHT", "NO_COVER" ],
-    "damage_reduction": { "bash": 6 },
+    "damage_reduction": { "bash": 9, "cut": 6, "stab": 6, "bullet": 1 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
@@ -670,7 +677,7 @@
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
     },
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
-    "damage_reduction": { "bash": 25 },
+    "damage_reduction": { "bash": 25, "cut": 10, "stab": 9, "bullet": 4 },
     "variants": [ { "symbols": "O", "symbols_broken": "x" } ]
   },
   {
@@ -682,7 +689,7 @@
     "wheel_offroad_rating": 0.7,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
     "contact_area": 320,
-    "damage_reduction": { "bash": 20, "cut": 15, "stab": 10 }
+    "damage_reduction": { "bash": 26, "cut": 13, "stab": 12, "bullet": 5 }
   },
   {
     "id": "wheel_wood",
@@ -707,7 +714,7 @@
     "wheel_terrain_modifiers": { "FLAT": [ 0, 6 ], "ROAD": [ 0, 3 ] },
     "contact_area": 60,
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
-    "damage_reduction": { "all": 14 },
+    "damage_reduction": { "bash": 16, "cut": 18, "stab": 18, "bullet": 6 },
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
@@ -723,7 +730,7 @@
     ],
     "rolling_resistance": 2.05,
     "proportional": { "durability": 2, "damage_modifier": 2 },
-    "damage_reduction": { "all": 20 }
+    "damage_reduction": { "bash": 16, "cut": 18, "stab": 18, "bullet": 6 }
   },
   {
     "type": "vehicle_part",
@@ -758,6 +765,7 @@
     "rolling_resistance": 1.5,
     "wheel_offroad_rating": 0.3,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
+    "damage_reduction": { "bash": 10, "cut": 8, "stab": 8, "bullet": 2 },
     "contact_area": 60,
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_CONCRETE_MIX", "NO_INSTALL_HIDDEN", "NO_COVER" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1163,10 +1163,11 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
             if( !hazard || ( vp_wheel.info().wheel_info->offroad_rating >= 0.6f && !extra_hazard ) ) {
                 continue;
             }
-
-            int chance = std::clamp( 250000 / velocity, 80, 200 );
+            // Turn this numerator down if you want to make procs more likely, up if you want less.
+            // Turn the big side of the clamp up if you want it safer for slow drivers.
+            int chance = std::clamp( 80000 / velocity, 25, 125 );
             if( extra_hazard ) {
-                chance = chance * 3 / 4;
+                chance = chance / 2;
             }
 
             add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Final chance to proc rough terrain: 1 / %d.", chance );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -47,6 +47,7 @@
 
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_cut( "cut" );
+static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_airborne( "airborne" );
 static const efftype_id effect_bleed( "bleed" );
@@ -1334,22 +1335,29 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
     // Wheels use the worst/softest possible value, the squishy parts. In other words, a wheel is damaged
     // if its rubber tire is punctured.
     double wheel_hardness = item_hardness_calc( vp_wheel.get_base() ).first;
-    if( vp_wheel.info().has_flag( "RESIST_RUNOVER_DAMAGE" ) ) {
-        // Wheels with the flag have double effective hardness due to their design, etc.
-        wheel_hardness = wheel_hardness * 2.0;
-    }
     // Items attempting to do damage use the best/hardest possible value, the pointy bits.
     double item_hardness = item_hardness_calc( it ).second;
+    // Stab armor protects wheels from damage. Wheels do not benefit from other armor on their tile, it checks the wheel itself.
+    // TODO: Make different items use different damage types.
+    double armor = std::clamp( vp_wheel.info().damage_reduction.at( damage_stab ) / 100.0, 0.0, 0.75 ) / rng_float( 1.0, 4.0 );
     // It is exponentially more difficult for soft items to damage wheels, even if you're hitting a lot of them.
-    const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ) / 10,
-                                    0.5 );
-    add_msg_debug( debugmode::DF_VEHICLE_MOVE,
-                   "Vehicle %s running over item %s."
-                   "\n Chance to damage: %f%%."
-                   "\n Item hardness: %f"
-                   "\n Wheel hardness: %f",
-                   disp_name(), it.tname(), chance_to_damage * 100.0, item_hardness,
-                   wheel_hardness );
+    const double base_chance = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ) / 10, 0.5 );
+    const double chance_to_damage = std::max( 0.0, base_chance - armor );
+    add_msg_debug(
+        debugmode::DF_VEHICLE_MOVE,
+        "Vehicle %s running over item %s."
+        "\n Item hardness: %f"
+        "\n Wheel hardness: %f"
+        "\n Base chance: %f%%"
+        "\n Armor reduction: %f%%"
+        "\n Final chance: %f%%",
+        disp_name(), it.tname(),
+        item_hardness,
+        wheel_hardness,
+        base_chance * 100.0,
+        armor * 100.0,
+        chance_to_damage * 100.0
+    );
     return chance_to_damage;
 }
 


### PR DESCRIPTION
#### Summary
Better tire damage calculations

#### Purpose of change
Tires didn't have much in the way of armor values. Now they do, and we can use those values to derive better rough terrain resistance.

#### Describe the solution
- Tires now have stab armor and use that to protect themselves from damage.
- It is now easier to proc rough terrain, since said terrain is less likely to deal damage through the tire's armor.
- Armored wheels are much better than they were before at resisting damage. All tires have a little bit of resistance. Wooden wheels are less fragile.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
