### PR TITLE
Fix lightmap transparency bug

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -473,7 +473,7 @@ void map::generate_lightmap( const int zlev )
                     const tripoint_bub_ms p( p2, zlev );
                     // Project light into any openings into buildings.
                     if( !outside_cache[p.x()][p.y()] || ( !top_floor && prev_floor_cache[p.x()][p.y()] ) ||
-                        cur_submap->get_ter( { smx, smy } ).obj().has_flag( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR ) ) {
+                        cur_submap->get_ter( { sx, sy } ).obj().has_flag( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR ) ) {
                         // Apply light sources for external/internal divide
                         for( int i = 0; i < 4; ++i ) {
                             point_bub_ms neighbour = p.xy() + point( dir_x[i], dir_y[i] );


### PR DESCRIPTION
#### Summary
Fix lightmap transparency bug

#### Purpose of change
Some new code was accidentally looking at smx smy instead of sx sy, which was possibly causing an out of bounds check.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
