### PR TITLE
Fix ddotd

### DIFF
--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -10,6 +10,7 @@
     "melee_skill": 0,
     "harvest": "zombie_pupating",
     "extend": { "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ] },
+    "delete": { "categories": [ "CLASSIC" ] },
     "upgrades": { "half_life": 4, "into": "mon_zombie_crawler_pupa" },
     "armor": { "electric": 1, "bash": 7, "cut": 5, "bullet": 5 }
   },


### PR DESCRIPTION
#### Summary
Fix ddotd

#### Purpose of change
One of the pupating zombies was incorrectly inheriting the CLASSIC category and so appearing in ddotd, which led to problems when it tried to spawn flesh raptors which are blacklisted in that mod.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
