### PR TITLE
Port 75916 - add item spellcasting

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1801,6 +1801,17 @@ int spell::heal( const tripoint_bub_ms &target, Creature &caster ) const
     return -1;
 }
 
+void spell::cast_spell_effect( const tripoint_bub_ms &target ) const
+{
+    map &here = get_map();
+    avatar fake_avatar;
+    fake_avatar.setpos( here, target );
+    get_event_bus().send<event_type::character_casts_spell>( character_id( -1 ),
+            this->id(), this->spell_class(),
+            0, 0, 0, this->damage( fake_avatar ) );
+    type->effect( *this, fake_avatar, target );
+}
+
 void spell::cast_spell_effect( Creature &source, const tripoint_bub_ms &target ) const
 {
     Character *caster = source.as_character();
@@ -1813,6 +1824,36 @@ void spell::cast_spell_effect( Creature &source, const tripoint_bub_ms &target )
     }
 
     type->effect( *this, source, target );
+}
+
+void spell::cast_all_effects( const tripoint_bub_ms &target ) const
+{
+    map &here = get_map();
+    avatar fake_avatar;
+    fake_avatar.setpos( here, target );
+    if( has_flag( spell_flag::WONDER ) ) {
+        const auto iter = type->additional_spells.begin();
+        for( int num_spells = std::abs( damage( fake_avatar ) ); num_spells > 0; num_spells-- ) {
+            if( type->additional_spells.empty() ) {
+                debugmsg( "ERROR: %s has WONDER flag but no spells to choose from!", type->id.c_str() );
+                return;
+            }
+            const int rand_spell = rng( 0, type->additional_spells.size() - 1 );
+            spell sp = ( iter + rand_spell )->get_spell( fake_avatar, get_effective_level() );
+            // This spell flag makes it so the message of the spell that's cast using this spell will be sent.
+            // if a message is added to the casting spell, it will be sent as well.
+            add_msg( sp.message() );
+            sp.cast_all_effects( target );
+        }
+    } else {
+        if( has_flag( spell_flag::EXTRA_EFFECTS_FIRST ) ) {
+            cast_extra_spell_effects( target );
+            cast_spell_effect( target );
+        } else {
+            cast_spell_effect( target );
+            cast_extra_spell_effects( target );
+        }
+    }
 }
 
 void spell::cast_all_effects( Creature &source, const tripoint_bub_ms &target ) const
@@ -1853,6 +1894,17 @@ void spell::cast_all_effects( Creature &source, const tripoint_bub_ms &target ) 
             cast_spell_effect( source, target );
             cast_extra_spell_effects( source, target );
         }
+    }
+}
+
+void spell::cast_extra_spell_effects( const tripoint_bub_ms &target ) const
+{
+    map &here = get_map();
+    avatar fake_avatar;
+    fake_avatar.setpos( here, target );
+    for( const fake_spell &extra_spell : type->additional_spells ) {
+        spell sp = extra_spell.get_spell( fake_avatar, get_effective_level() );
+        sp.cast_all_effects( target );
     }
 }
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -48,8 +48,8 @@ class event;
 template <typename E> struct enum_traits;
 
 enum class spell_flag : int {
-    AIRBORNE,
-    CHARM_PET, // Applies the pet friendliness adjustment to a monster when charming them
+    AIRBORNE, // This dash effect will treat the caster as airborne until they reach their destination.
+    CHARM_PET, // Applies the pet friendliness adjustment to a monster when charming them.
     CONCENTRATE, // Focus affects spell fail %.
     DODGEABLE, // The target can dodge this attack completely if they succeed on a dodge roll against its spell level. Implies NO_DODGE_MITIGATION.
     EXTRA_EFFECTS_FIRST, // The extra effects are cast before the main spell.
@@ -696,11 +696,17 @@ class spell
         // heals the critter at the location, returns amount healed (Character heals each body part)
         int heal( const tripoint_bub_ms &target, Creature &caster ) const;
 
-        // casts the spell effect. returns true if successful
+        // Casts the spell effect from an item.  Less functionality compared to creature casting.
+        void cast_spell_effect( const tripoint_bub_ms &target ) const;
+        // Casts the spell effect. returns true if successful
         void cast_spell_effect( Creature &source, const tripoint_bub_ms &target ) const;
-        // goes through the spell effect and all of its internal spells
+        // Goes through all effects when casting from an item.
+        void cast_all_effects( const tripoint_bub_ms &target ) const;
+        // Goes through the spell effect and all of its internal spells.
         void cast_all_effects( Creature &source, const tripoint_bub_ms &target ) const;
-        // goes through the spell effect and all of its internal spells
+        // Casts extra_effects when casting from an item (labeled as additional_spells internally)
+        void cast_extra_spell_effects( const tripoint_bub_ms &target ) const;
+        // Casts extra_effects (labeled as additional_spells internally)
         void cast_extra_spell_effects( Creature &source, const tripoint_bub_ms &target ) const;
         // uses up the components in @guy's inventory
         void use_components( Character &guy ) const;


### PR DESCRIPTION
#### Summary
Port 75916 - add item spellcasting

#### Purpose of change
Item spellcasting wasn't ever ported. This ports it.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
