### PR TITLE
Fix hauling error message

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2418,8 +2418,15 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
             }
 
             if( overflow ) {
-                add_msg( m_warning,
-                         _( "You lose track of some hauled items as they didn't fit on the current tile." ) );
+                std::vector<item_location> &haul_list = who.haul_list;
+                int haul_qty = haul_list.size();
+                if( haul_qty < 1 ) {
+                add_msg( m_warning, _( "You have lost track of what you were hauling." ) );
+                who.stop_hauling();
+                } else {
+                    add_msg( m_warning,
+                             _( "You lose track of some items as there isn't room to haul them along." ) );
+                }
             }
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -851,7 +851,9 @@ static void haul()
 
     if( hauling && !autohaul ) {
         if( haul_qty == 0 ) {
-            debugmsg( "Invalid hauling state: hauling enabled, nothing is being hauled, autohaul is off." );
+            add_msg( _( "You have lost track of what you were hauling." ) );
+            player_character.stop_hauling();
+            return;
         } else {
             status_header = string_format( _( "You are currently hauling %d items.\nAutohaul is disabled." ),
                                            haul_qty );


### PR DESCRIPTION
#### Summary
Fix hauling error message

#### Purpose of change
fixes #2701 

#### Describe the solution
Added a check when hauled items are displaced. If the haul list is empty, print a non-error message and cancel hauling.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
