### PR TITLE
Add swimming proficiency

### DIFF
--- a/data/json/backgrounds.json
+++ b/data/json/backgrounds.json
@@ -276,6 +276,15 @@
     "missions": [ "MISSION_SKATES" ]
   },
   {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "swimming",
+    "name": "Swimming",
+    "description": "At some point in your life, you learned how to swim.  Whether you still can or not is a matter of your athletics skill and the overall shape you're in.",
+    "points": 1,
+    "proficiencies": [ "prof_swimming" ]
+  },
+  {
     "subtype": "hobby",
     "type": "profession",
     "name": "Tabletop Gaming",

--- a/data/json/furniture_and_terrain/terrain-bridges-docks.json
+++ b/data/json/furniture_and_terrain/terrain-bridges-docks.json
@@ -8,7 +8,7 @@
     "looks_like": "t_pavement",
     "color": "yellow",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "FLAT", "SWIM_UNDER" ],
+    "flags": [ "TRANSPARENT", "FLAT", "SWIM_UNDER", "INDOORS" ],
     "connect_groups": "WATER"
   },
   {

--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -378,7 +378,7 @@
     "color": "light_green",
     "move_cost": 6,
     "liquid_source": { "id": "water_sewage" },
-    "flags": [ "TRANSPARENT", "SWIMMABLE", "SHALLOW_WATER" ],
+    "flags": [ "TRANSPARENT", "SWIMMABLE", "SHALLOW_WATER", "INDOORS" ],
     "examine_action": "water_source"
   },
   {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1250,7 +1250,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_swimming"
     ],
     "skills": [
       { "level": 5, "name": "gun" },
@@ -1312,7 +1313,8 @@
       "prof_metalworking",
       "prof_welding_basic",
       "prof_welding",
-      "prof_gun_cleaning"
+      "prof_gun_cleaning",
+      "prof_swimming"
     ],
     "skills": [
       { "level": 5, "name": "mechanics" },
@@ -1365,7 +1367,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_swimming"
     ],
     "skills": [
       { "level": 6, "name": "swimming" },
@@ -1713,64 +1716,6 @@
   },
   {
     "type": "profession",
-    "id": "seal_sniper",
-    "name": "Navy SEAL Marksmen",
-    "description": "Recruited into the ranks of the US Navy's Special Warfare forces as a designated sniper, your training in precision marksmanship and maritime operations was extensive.  As a proficient soldier and combative in all respects, you provided overwatch and long-range elimination services in the line of duty.  Now, with naval command imploding and your spotter MIA, your skills with a rifle and covert operations are the only things standing between you and the Cataclysm.",
-    "npc_background": "BG_survival_story_SOLDIER",
-    "points": 7,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_spotting",
-      "prof_field_medic",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
-    ],
-    "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "rifle" },
-      { "level": 5, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "firstaid" },
-      { "level": 4, "name": "survival" },
-      { "level": 2, "name": "throw" },
-      { "level": 3, "name": "swimming" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "tank_top" },
-          { "item": "combat_shirt" },
-          { "item": "tac_fullhelmet" },
-          { "item": "mask_ski" },
-          { "item": "gloves_liner" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "diving_watch" },
-          { "item": "load_bearing_vest" },
-          { "item": "boots_combat" },
-          { "group": "loaded_webbing_belt" },
-          { "group": "charged_two_way_radio" },
-          { "group": "charged_powered_earmuffs" },
-          { "item": "pants_army" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_tac338" },
-          { "item": "knife_rm42", "container-item": "sheath" },
-          { "item": "p226_9mm", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
-          { "item": "p226mag_15rd_9x19mm", "ammo-item": "9mm", "charges": 15, "count": 2 },
-          { "item": "tac338", "ammo-item": "338lapua_fmjbt", "charges": 5, "contents-item": [ "shoulder_strap" ] }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "group": "female_underwear_top" }, { "item": "boxer_shorts" } ] }
-    },
-    "flags": [ "SCEN_ONLY" ]
-  },
-  {
-    "type": "profession",
     "id": "seal",
     "name": "Navy SEAL",
     "description": "You were a member of the SEALs; a key component of the US Navy's special forces and a proficient combatant in both maritime and ground operations.  'The only easy day was yesterday', and with the chain of command in ruins, you may fulfill your final mission in any way you see fit.",
@@ -1783,7 +1728,8 @@
       "prof_gun_cleaning",
       "prof_knives_familiar",
       "prof_auto_rifles_familiar",
-      "prof_auto_pistols_familiar"
+      "prof_auto_pistols_familiar",
+      "prof_swimming"
     ],
     "skills": [
       { "level": 7, "name": "gun" },
@@ -1832,62 +1778,6 @@
       "female": { "entries": [ { "group": "female_underwear_top" }, { "item": "boxer_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
-  },
-  {
-    "type": "profession",
-    "id": "specops",
-    "name": "Special Operator",
-    "description": "You were the best of the best, the military's finest.  That's why you're still alive, even after all your comrades fell to the undead.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
-    "npc_background": "BG_survival_story_SOLDIER",
-    "points": 7,
-    "proficiencies": [
-      "prof_gunsmithing_basic",
-      "prof_traps",
-      "prof_disarming",
-      "prof_spotting",
-      "prof_gun_cleaning",
-      "prof_knives_familiar",
-      "prof_auto_rifles_familiar"
-    ],
-    "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "smg" },
-      { "level": 7, "name": "rifle" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 4, "name": "traps" },
-      { "level": 2, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 4, "name": "swimming" },
-      { "level": 3, "name": "survival" }
-    ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "wetsuit" },
-          { "item": "pants_army" },
-          { "item": "wetsuit_hood" },
-          { "group": "tac_helmet_nvg" },
-          { "item": "wetsuit_gloves" },
-          { "item": "gloves_tactical" },
-          { "item": "socks" },
-          { "item": "boots_combat" },
-          { "item": "dive_bag" },
-          { "item": "diving_watch" },
-          { "item": "single_sling" },
-          { "group": "charged_two_way_radio" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "kukri", "container-item": "sheath" },
-          { "item": "chestrig", "contents-group": "army_mags_mp5" },
-          { "item": "hk_mp5", "ammo-item": "9mm", "charges": 30, "contents-item": [ "suppressor", "holo_sight" ] }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "group": "female_underwear_top" }, { "item": "boxer_shorts" } ] }
-    }
   },
   {
     "type": "profession",
@@ -2695,38 +2585,6 @@
       "male": { "entries": [ { "item": "boxer_shorts" } ] },
       "female": { "entries": [ { "group": "female_underwear_top" }, { "group": "female_underwear_bottom" } ] }
     }
-  },
-  {
-    "type": "profession",
-    "id": "modern_archer",
-    "name": "Modern Archer",
-    "description": "A great fan of the archers of old, but at the same time a follower of the latest trends in archery.  You always tried to keep up with the times, acquiring a takedown bow as well as several accessories to complement it.  You can only hope all the training you did with them can help you survive in this trying times.",
-    "npc_background": "BG_survival_story_SPORTS",
-    "points": 4,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "archery" }, { "level": 2, "name": "swimming" } ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "whistle" },
-          { "item": "socks" },
-          { "item": "boots_steel" },
-          { "item": "pants_cargo" },
-          { "item": "jacket_leather" },
-          { "item": "fancy_sunglasses" },
-          { "item": "hat_boonie" },
-          { "item": "diving_watch" },
-          { "item": "caff_gum" },
-          { "group": "charged_smart_phone" },
-          { "item": "rashguard" },
-          { "item": "takedown_recurbow", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "quiver_takedown_bow", "contents-group": "quiver_modern_archer" }
-        ]
-      },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "group": "female_underwear_top" }, { "item": "boxer_shorts" } ] }
-    },
-    "missions": [ "MISSION_HUNTER" ]
   },
   {
     "type": "profession",
@@ -3570,32 +3428,6 @@
           { "item": "fire_gauntlets" },
           { "item": "wristwatch" },
           { "item": "hammer" },
-          { "group": "charged_smart_phone" }
-        ]
-      },
-      "male": { "entries": [ { "group": "male_underwear_bottom" } ] },
-      "female": { "entries": [ { "group": "female_underwear_top" }, { "group": "female_underwear_bottom" } ] }
-    }
-  },
-  {
-    "type": "profession",
-    "id": "jeweler",
-    "name": "Jeweler",
-    "description": "You were an independent artisan, who made gorgeous rings and pendants for the people who afforded your services.  You doubt the market for your work has fared well after the end of the world, but perhaps your proficiency with fine tools and metals will come in handy somehow.",
-    "npc_background": "BG_survival_story_WORKER_COMMERCIAL",
-    "points": 2,
-    "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_metalworking", "prof_redsmithing", "prof_fine_metalsmithing", "prof_gem_setting" ],
-    "items": {
-      "both": {
-        "entries": [
-          { "item": "jeans" },
-          { "item": "socks" },
-          { "item": "boots" },
-          { "item": "longshirt" },
-          { "item": "wristwatch" },
-          { "item": "apron_leather" },
-          { "item": "chisel" },
           { "group": "charged_smart_phone" }
         ]
       },
@@ -4926,6 +4758,7 @@
     "description": "It was hard enough getting kids to run laps without having to worry about them trying to eat your brains.  Zombies won't even line up when you blow your whistle.",
     "npc_background": "BG_survival_story_WORKER_PUBLIC",
     "points": 2,
+    "proficiencies": [ "prof_swimming" ],
     "skills": [
       { "level": 3, "name": "swimming" },
       { "level": 3, "name": "speech" },
@@ -5634,8 +5467,9 @@
     "name": "Swimmer",
     "description": "You were looking forward to a nice, relaxing day at the beach.  You had to run when some lunatics tried to rip your head off and play beach volleyball with it, but at least you managed to grab your bag on the way out.",
     "npc_background": "BG_survival_story_TOURIST",
-    "points": 0,
-    "skills": [ { "level": 2, "name": "swimming" } ],
+    "points": 2,
+    "proficiencies": [ "prof_swimming" ],
+    "skills": [ { "level": 3, "name": "swimming" } ],
     "items": {
       "both": {
         "entries": [
@@ -5667,7 +5501,8 @@
     "name": "Diver",
     "description": "You were exploring below the waves close to shore when you noticed something weird on the nearby beach, you decided to swim away when you heard the screams.",
     "npc_background": "BG_survival_story_SPORTS",
-    "points": 2,
+    "points": 3,
+    "proficiencies": [ "prof_swimming" ],
     "skills": [ { "level": 5, "name": "swimming" } ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {

--- a/data/json/proficiencies/athletics.json
+++ b/data/json/proficiencies/athletics.json
@@ -16,5 +16,14 @@
     "description": "You suffer lower penalties to dodging and are less likely to fall down if hit in melee combat while riding a skateboard or wearing skates.",
     "can_learn": true,
     "time_to_learn": "8 h"
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_swimming",
+    "category": "prof_athletics",
+    "name": { "str": "Swimming" },
+    "description": "You are acquainted with the principles of swimming and staying afloat.  This does not necessarily mean you can always swim in all conditions, but it certainly helps.",
+    "can_learn": true,
+    "time_to_learn": "2 h"
   }
 ]

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -754,7 +754,6 @@
     "professions": [
       "rifleman",
       "recruit",
-      "specops",
       "national_guard",
       "politician",
       "hitman",
@@ -797,7 +796,6 @@
       "unemployed",
       "recruit",
       "rifleman",
-      "specops",
       "labtech",
       "surgeon",
       "mil_auto_rifleman",

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -51,6 +51,7 @@
 #include "pimpl.h"
 #include "popup.h"
 #include "point.h"
+#include "proficiency.h"
 #include "projectile.h"
 #include "ranged.h"
 #include "ret_val.h"
@@ -93,6 +94,8 @@ static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const json_character_flag json_flag_ITEM_WATERPROOFING( "ITEM_WATERPROOFING" );
 
 static const move_mode_id move_mode_prone( "prone" );
+
+static const proficiency_id proficiency_prof_swimming( "prof_swimming" );
 
 static const skill_id skill_swimming( "swimming" );
 static const skill_id skill_throw( "throw" );
@@ -602,6 +605,9 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
     g->water_affect_items( you );
 
     int movecost = you.swim_speed();
+    if( !you.has_proficiency( proficiency_prof_swimming ) ) {
+        you.practice_proficiency( proficiency_prof_swimming, 1_seconds );
+    }
     you.practice( skill_swimming, you.is_underwater() ? 2 : 1 );
     if( movecost >= 500 || you.has_effect( effect_winded ) ) {
         if( !you.is_underwater() &&

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -399,6 +399,7 @@ static const mtype_id mon_player_blob( "mon_player_blob" );
 static const proficiency_id proficiency_prof_parkour( "prof_parkour" );
 static const proficiency_id proficiency_prof_skating( "prof_skating" );
 static const proficiency_id proficiency_prof_spotting( "prof_spotting" );
+static const proficiency_id proficiency_prof_swimming( "prof_swimming" );
 static const proficiency_id proficiency_prof_traps( "prof_traps" );
 static const proficiency_id proficiency_prof_trapsetting( "prof_trapsetting" );
 static const proficiency_id proficiency_prof_field_medic( "prof_field_medic" );
@@ -1662,9 +1663,9 @@ int Character::swim_speed() const
     units::mass effective_weight = std::max( 0_gram,
                                    ( weight_carried() + bionics_weight() ) - ( str_cur * 1_kilogram ) );
     float swim_speed_mult = enchantment_cache->modify_value( enchant_vals::mod::MOVECOST_SWIM_MOD, 1 );
-    ret = ( 750 * swim_speed_mult ) +
-          effective_weight / ( 60_gram / swim_speed_mult ) -
-          50 * get_skill_level( skill_swimming );
+    // Swimming proficiency grants an effective +4 skill, capped at 10.
+    const int swim_skill = std::min( 10, static_cast<int>( std::round( get_skill_level( skill_swimming ) + ( has_proficiency( proficiency_prof_swimming ) ? 4.0f : 0.0f ) ) ) );
+    ret = ( 750 * swim_speed_mult ) + effective_weight / ( 60_gram / swim_speed_mult ) - 50 * swim_skill;
     /** @EFFECT_STR increases swim speed bonus from swim_fins */
     if( worn_with_flag( flag_FIN, body_part_foot_l ) ||
         worn_with_flag( flag_FIN, body_part_foot_r ) ) {
@@ -13432,9 +13433,9 @@ void Character::knock_back_to( const tripoint_bub_ms &to )
         if( !is_npc() ) {
             avatar_action::swim( here, get_avatar(), to );
         }
+        // FIXME: NPCs REALLY NEED TO BE ABLE TO SWIM!!
         // TODO: NPCs can't swim!
-    } else if( here.impassable( to ) ) { // Wait, it's a wall
-
+    } else if( here.impassable( to ) ) { // Wait, it's a wall.
         // It's some kind of wall.
         // TODO: who knocked us back? Maybe that creature should be the source of the damage?
         apply_damage( nullptr, bodypart_id( "torso" ), 3 );

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1738,8 +1738,8 @@ bool Character::can_estimate_rot() const
 bool Character::can_consume_as_is( const item &it ) const
 {
     if( it.is_comestible() ) {
-        return !it.has_flag( flag_FROZEN ) || it.has_flag( flag_EDIBLE_FROZEN ) ||
-               it.has_flag( flag_MELTS );
+        return !it.has_flag( flag_NO_INGEST ) && ( !it.has_flag( flag_FROZEN ) || it.has_flag( flag_EDIBLE_FROZEN ) ||
+               it.has_flag( flag_MELTS ) );
     }
     return false;
 }


### PR DESCRIPTION
#### Summary
Add swimming proficiency

#### Purpose of change
Swimming was too hard, and tying it strictly to skill was a little too simplistic.

#### Describe the solution
Adds a swimming proficiency, selectable in chargen for 1 point or trainable in-game by trying to swim, even if you fail. Also makes it impossible to drink sewage from the ground (it was already impossible otherwise) and flags sewer tiles as INDOORS. Adds swimming proficiency to a couple of professions and gets rid of some extraneous ones.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
