### PR TITLE
Add an impossible shape teleglow result

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3550,7 +3550,8 @@
   },
   {
     "type": "effect_type",
-    "id": "teleglow"
+    "id": "teleglow",
+    "max_duration": "960 m"
   },
   {
     "type": "effect_type",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1482,7 +1482,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",
-    "name": { "str": "zolpidem" },
+    "name": { "str_sp": "zolpidem" },
     "description": "A prescription-strength sedative with a variety of psychoactive side effects.  Used in the treatment of insomnia.",
     "weight": "1 g",
     "volume": "1 ml",

--- a/data/json/monstergroups/nether.json
+++ b/data/json/monstergroups/nether.json
@@ -10,6 +10,11 @@
     "monsters": [ { "monster": "mon_dark_wyrm" } ]
   },
   {
+    "name": "GROUP_IMPOSSIBLE_SHAPE",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_impossible_shape" } ]
+  },
+  {
     "type": "monstergroup",
     "name": "GROUP_NETHER_FATIGUE_FIELD",
     "default": "mon_blank",

--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -305,7 +305,12 @@
         "pack_size": [ 1, 4 ],
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      { "monster": "mon_pseudo_dormant_zombie_swimmer_base", "weight": 1, "cost_multiplier": 3, "pack_size": [ 1, 8 ] },
+      {
+        "monster": "mon_pseudo_dormant_zombie_swimmer_base",
+        "weight": 1,
+        "cost_multiplier": 3,
+        "pack_size": [ 1, 8 ]
+      },
       { "monster": "mon_zhark", "weight": 1, "cost_multiplier": 25, "starts": "12 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_zhark", "weight": 2, "cost_multiplier": 25, "starts": "112 days", "pack_size": [ 1, 3 ] },
       { "monster": "mon_fish_eel", "weight": 6, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1117,7 +1117,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "RANGED_ATTACKER", "IMMOBILE" ]
+    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "RANGED_ATTACKER", "IMMOBILE", "NOHEAD", "STUN_IMMUNE", "ACIDPROOF" ]
   },
   {
     "id": "mon_memory",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1107,7 +1107,7 @@ std::string monster::extended_description() const
     describe_properties( _( "It can %s." ), {
         {swims(), pgettext( "Swim as an action", "swim" )},
         {flies(), pgettext( "Fly as an action", "fly" )},
-        {can_dig(), pgettext( "Dig as an action", "dig" )},
+        {can_dig(), pgettext( "Burrow as an action", "burrow" )},
         {climbs(), pgettext( "Climb as an action", "climb" )}
     } );
 
@@ -1116,10 +1116,6 @@ std::string monster::extended_description() const
         {mon_flag_VENOM, pgettext( "Poison as an action", "poison" )},
         {mon_flag_PARALYZEVENOM, pgettext( "Paralyze as an action", "paralyze" )}
     } );
-
-    if( !type->has_flag( mon_flag_NOHEAD ) ) {
-        ss += std::string( _( "It has a head." ) ) + "\n";
-    }
 
     if( debug_mode ) {
         ss += "--\n";

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -112,6 +112,8 @@ static const json_character_flag json_flag_SEESLEEP( "SEESLEEP" );
 
 static const mongroup_id GROUP_NETHER( "GROUP_NETHER" );
 
+static const mtype_id mon_impossible_shape( "mon_impossible_shape" );
+
 static const mutation_category_id mutation_category_MYCUS( "MYCUS" );
 static const mutation_category_id mutation_category_RAT( "RAT" );
 static const mutation_category_id mutation_category_TROGLOBITE( "TROGLOBITE" );
@@ -630,12 +632,48 @@ static void eff_fun_teleglow( Character &u, effect &it )
             }
         }
     }
-    if( one_in( 7200 - ( dur - 360_minutes ) / 4_turns ) ) {
-        //Spawn a tindalos rift via effect_tindrift rather than it being hard-coded to teleglow
+    if( one_in( 7000 - ( dur - 360_minutes ) / 4_turns ) ) {
+        creature_tracker &creatures = get_creature_tracker();
+        tripoint_bub_ms dest( 0, 0, pos.z() );
+        int &x = dest.x();
+        int &y = dest.y();
+        int tries = 0;
+        do {
+            x = pos.x() + rng( -4, 4 );
+            y = pos.y() + rng( -4, 4 );
+            tries++;
+            if( tries >= 5 ) {
+                break;
+            }
+        } while( creatures.creature_at( dest ) );
+        if( tries < 5 ) {
+            if( !here.impassable( dest ) ) {
+                g->place_critter_at( mon_impossible_shape, dest );
+                if( uistate.distraction_hostile_spotted && player_character.sees( here, dest ) ) {
+                    g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
+                                                        _( "A monster appears nearby!" ) );
+                    add_msg( m_warning, _( "Space folds impossibly around itself!" ) );
+                }
+            }
+            if( one_in( 6 ) ) {
+                // Set ourselves up for removal
+                it.set_duration( 0_turns );
+            }
+        }
+    }
+    if( one_in( 21000 - ( dur - 360_minutes ) / 4_turns ) ) {
+        u.add_msg_if_player( m_bad, _( "You shudder suddenly." ) );
+        u.mutate();
+        if( one_in( 4 ) ) {
+            // Set ourselves up for removal.
+            it.set_duration( 0_turns );
+        }
+    }
+    if( one_in( 8000 - ( dur - 360_minutes ) / 4_turns ) ) {
+        // Spawn a tindalos rift via effect_tindrift rather than it being hard-coded to teleglow.
         u.add_effect( effect_tindrift, 5_turns );
-
         if( one_in( 2 ) ) {
-            // Set ourselves up for removal
+            // Set ourselves up for removal.
             it.set_duration( 0_turns );
         }
     }
@@ -643,7 +681,7 @@ static void eff_fun_teleglow( Character &u, effect &it )
         u.add_msg_if_player( m_bad, _( "You pass out." ) );
         u.fall_asleep( 2_hours );
         if( one_in( 6 ) ) {
-            // Set ourselves up for removal
+            // Set ourselves up for removal.
             it.set_duration( 0_turns );
         }
     }
@@ -725,8 +763,6 @@ static void eff_fun_teleglow( Character &u, effect &it )
     if( one_in( 10000 ) ) {
         if( !u.has_trait( trait_M_IMMUNE ) ) {
             u.add_effect( effect_fungus, 1_turns, true );
-        } else {
-            u.add_msg_if_player( m_info, _( "We have many colonists awaiting passage." ) );
         }
         // Set ourselves up for removal
         it.set_duration( 0_turns );


### PR DESCRIPTION
#### Summary
Add an impossible shape teleglow result

#### Purpose of change
Impossible shapes weren't being used. They seem like a natural consequence of teleporting, so let's add a teleglow event that summons some.

#### Describe the solution
- Caps teleglow duration for code safety.
- Adds a teleglow event which summons a handful of them.
- Make Hounds slightly less common.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
