### PR TITLE
Improve drunk text

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -255,7 +255,7 @@ class messages_impl
             }
 
             if( is_drunk ) {
-                const int intensity = p_char->get_effect_int( effect_drunk );
+                const int intensity = p_char->get_effect_int( effect_drunk ) - 1;
                 if( intensity > 0 ) {
                     // String length determines how many errors are added. Increase the divisor to reduce number of errors.
                     const float length_factor = static_cast<float>( msg.size() ) / 16.0f;
@@ -317,7 +317,6 @@ class messages_impl
                                 }
                                 continue;
                             }
-
                             // Exclude markup symbols and stuff they're attached to.
                             if( c == '_' || c == ' ' || c == '/' || c == '|' ) {
                                 if( start != std::string::npos ) {
@@ -355,6 +354,7 @@ class messages_impl
                         auto [rstart, rlen] = random_entry( usable );
                         int slurred_roll = rng( 0, intensity + 1 );
                         if( slurred_roll <= 1 ) {
+                            // Decapitalization.
                             size_t pos = rstart + rng( 0, rlen - 1 );
                             char &c = msg[pos];
                             if( !is_ascii_char( c ) || unsafe[pos] ) {
@@ -365,9 +365,17 @@ class messages_impl
                             } else {
                                 c = static_cast<char>( tolower( c ) );
                             }
+                        } else if( slurred_roll <= 2 ) {
+                            // Letter duplication.
+                            size_t pos = rstart + rng( 0, rlen - 1 );
+                            if( !is_ascii_char( msg[pos] ) || unsafe[pos] ) {
+                                continue;
+                            }
+                            char c = msg[pos];
+                            msg.insert( pos + 1, 1, c );
                         } else if( slurred_roll <= 3 && rlen >= 4 ) {
+                            // Letter swapping.
                             size_t pos = rstart + rng( 0, rlen - 2 );
-
                             if( !is_ascii_char( msg[pos] ) ||
                                 !is_ascii_char( msg[pos + 1] ) ||
                                 unsafe[pos] || unsafe[pos + 1] ) {
@@ -375,6 +383,7 @@ class messages_impl
                             }
                             std::swap( msg[pos], msg[pos + 1] );
                         } else {
+                            // Letter deletion.
                             size_t pos = rstart + rng( 0, rlen - 1 );
                             if( !is_ascii_char( msg[pos] ) || unsafe[pos] ) {
                                 continue;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -255,13 +255,14 @@ class messages_impl
             }
 
             if( is_drunk ) {
-                const int intensity = p_char->get_effect_int( effect_drunk ) - 1;
-                if( intensity > 0 ) {
+                const int intensity = p_char->get_effect_int( effect_drunk );
+                // Don't mangle text if we're only buzzed.
+                if( intensity > 1 ) {
                     // String length determines how many errors are added. Increase the divisor to reduce number of errors.
                     const float length_factor = static_cast<float>( msg.size() ) / 16.0f;
-                    // Insensity multiplier increases the amount of errors.
+                    // Insensity multiplier increases the frequency of errors.
                     const float expected = length_factor * ( 0.7f * intensity );
-                    // Expected multiplier makes it more chaotic.
+                    // Expected multiplier increases the randomness of errors.
                     int slurred_words = std::max( 0, static_cast<int>(
                                                       round( rng_normal( expected, expected * 0.75f ) )
                                                   ) );
@@ -270,7 +271,7 @@ class messages_impl
                         return static_cast<unsigned char>( c ) < 0x80;
                     };
                     std::vector<bool> unsafe( msg.size(), false );
-                    // Exclude up to 8 characters adjacent to these markup symbols.
+                    // Exclude up to 8 characters adjacent to these markup symbols to ensure we don't accidentally break formatting.
                     for( size_t i = 0; i < msg.size(); i++ ) {
                         if( msg[i] == '%' || msg[i] == '\\' || msg[i] == '$' ) {
                             for( int d = -8; d <= 8; d++ ) {
@@ -301,7 +302,7 @@ class messages_impl
                             if( in_tag ) {
                                 continue;
                             }
-                            // Ensure that we only mess up ASCII text.
+                            // Ensure that we only mess up ASCII text. Other text (e.g. cyrillic) is not bit-safe.
                             if( !is_ascii_char( c ) ) {
                                 if( start != std::string::npos ) {
                                     ranges.emplace_back( start, i - start );
@@ -317,7 +318,7 @@ class messages_impl
                                 }
                                 continue;
                             }
-                            // Exclude markup symbols and stuff they're attached to.
+                            // Exclude markup symbols and stuff they're attached to. I forget why we do this twice but there's probably a reason.
                             if( c == '_' || c == ' ' || c == '/' || c == '|' ) {
                                 if( start != std::string::npos ) {
                                     ranges.emplace_back( start, i - start );


### PR DESCRIPTION
#### Summary
Improve drunk text

#### Describe the solution
Drunk text now only happens when you're above "buzzed". Drunk text now also sometimes repeats letters in addition to deleting them, swapping them, or decapitalizing them.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
