### PR TITLE
Car doors lock (sorta), monster drowning/swimming fixes, monster hitchhiking is harder.

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -397,7 +397,6 @@
   {
     "type": "terrain",
     "id": "t_water_cube",
-    "//": "for eventual use with water z levels.  Currently non-functional.",
     "name": "submersed water",
     "description": "You are submerged below the surface of the water, your feet can't touch the ground.  With a watertight container, you could gather fresh water from here.  Not safe to drink as is.",
     "symbol": "~",
@@ -426,7 +425,6 @@
   {
     "type": "terrain",
     "id": "t_lake_bed",
-    "//": "for eventual use with water z levels.  Currently non-functional.",
     "name": "lake bed",
     "description": "You are standing at the bottom of a body of fresh water.  With a watertight container, you could gather fresh water from here.  Not safe to drink as is.",
     "symbol": "~",
@@ -442,7 +440,6 @@
   {
     "type": "terrain",
     "id": "t_ocean_bed",
-    "//": "for eventual use with water z levels.  Currently non-functional.",
     "name": "ocean bed",
     "description": "You are standing at the bottom of a body of salt water.  With a watertight container, you could gather salt water from here.  Not safe to drink as is.",
     "symbol": "~",
@@ -458,7 +455,6 @@
   {
     "type": "terrain",
     "id": "t_bulkhead_roof",
-    "//": "for eventual use with water z levels.  Currently non-functional.  Roof for submerged structures.",
     "name": "bulkhead",
     "description": "The top of a submerged structure.  With a watertight container, you could gather fresh water from here.  Not safe to drink as is.",
     "symbol": "#",
@@ -474,7 +470,6 @@
   {
     "type": "terrain",
     "id": "t_bulkhead_floor",
-    "//": "for eventual use with water z levels.  Currently non-functional.  Floor for submerged structures.",
     "name": "bulkhead",
     "description": "The bottom of a submerged structure.",
     "symbol": "#",
@@ -499,7 +494,6 @@
   {
     "type": "terrain",
     "id": "t_lake_bed_concrete",
-    "//": "for eventual use with water z levels.  Currently non-functional.  Cement on the lake floor.",
     "name": "submerged concrete",
     "description": "You are standing at the bottom of a body of fresh water on a pad of concrete.  With a watertight container, you could gather fresh water from here.  Not safe to drink as is.",
     "symbol": "~",
@@ -522,7 +516,6 @@
   {
     "type": "terrain",
     "id": "t_lake_bed_concrete_yellow",
-    "//": "for eventual use with water z levels.  Currently non-functional.  Cement on the lake floor.",
     "name": "submerged concrete",
     "description": "You are standing at the bottom of a body of fresh water on a pad of yellow-painted concrete.  With a watertight container, you could gather fresh water from here.  Not safe to drink as is.",
     "symbol": "#",

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -425,7 +425,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 4,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL" ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
     "armor": [
       {
         "encumbrance": 6,
@@ -452,7 +452,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 8,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL" ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
     "armor": [
       {
         "encumbrance": 3,
@@ -479,7 +479,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 6,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL" ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
     "armor": [
       {
         "encumbrance": 3,
@@ -567,7 +567,7 @@
     "material": [ "steel" ],
     "symbol": ",",
     "color": "dark_gray",
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "PREFIX_XL" ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "PREFIX_XL", "OVERSIZE"  ],
     "armor": [
       {
         "material": [
@@ -599,7 +599,7 @@
     "repairs_with": [ "steel" ],
     "symbol": ",",
     "color": "dark_gray",
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "STURDY", "NO_SALVAGE", "PREFIX_XL" ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "STURDY", "NO_SALVAGE", "PREFIX_XL", "OVERSIZE" ],
     "armor": [
       {
         "material": [

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1117,7 +1117,17 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "RANGED_ATTACKER", "IMMOBILE", "NOHEAD", "STUN_IMMUNE", "ACIDPROOF" ]
+    "flags": [
+      "FLIES",
+      "NO_BREATHE",
+      "SEES",
+      "BIOLOGICALPROOF",
+      "RANGED_ATTACKER",
+      "IMMOBILE",
+      "NOHEAD",
+      "STUN_IMMUNE",
+      "ACIDPROOF"
+    ]
   },
   {
     "id": "mon_memory",

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -101,12 +101,11 @@ static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_electric( "electric" );
 static const damage_type_id damage_heat( "heat" );
 
-static const efftype_id effect_all_fours( "all_fours" );
+static const efftype_id effect_airborne( "airborne" );
 static const efftype_id effect_blind( "blind" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_foamcrete_slow( "foamcrete_slow" );
 static const efftype_id effect_invisibility( "invisibility" );
-static const efftype_id effect_knockdown( "knockdown" );
 static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_monster_dodged( "monster_dodged" );
 static const efftype_id effect_no_sight( "no_sight" );
@@ -282,6 +281,23 @@ bool Creature::can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramp
     const monster *mon = as_monster();
 
     vehicle &veh = vp_there->vehicle();
+
+    int vehicle_speed = vp_there->vehicle().velocity;
+
+    // You simply cannot purposefully enter a vehicle when it is going extremely fast, unless you can fly.
+    if( get_speed() * 35 < vehicle_speed ) {
+        if( !here.veh_at( pos_bub() ) ) {
+            if( mon ) {
+                if( !mon->flies() && !mon->has_effect( effect_airborne ) ) {
+                    return false;
+                }
+            } else {
+                if( !has_effect( effect_airborne ) ) {
+                    return false;
+                }
+            }
+        }
+    }
 
     std::vector<vehicle_part *> cargo_parts;
     cargo_parts = veh.get_parts_at( loc, "CARGO", part_status_flag::any );
@@ -641,11 +657,10 @@ bool Creature::sees( const map &here, const Creature &critter ) const
         return false;
     }
 
-    if( has_water_camouflage && target_range > this->spot_check() ) {
-        if( is_underwater ||
-            here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ) ||
-            ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub( here ) ) &&
-              critter.get_size() < creature_size::medium ) ) {
+    if( is_underwater || here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ) ||
+        ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub( here ) ) &&
+          critter.get_size() < creature_size::medium ) ) {
+        if( has_water_camouflage && target_range > this->spot_check() ) {
             return false;
         }
     }
@@ -1971,8 +1986,8 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
     if( !force && is_immune_effect( eff_id ) ) {
         return;
     }
-    if( eff_id == effect_knockdown && ( has_effect( effect_ridden ) ||
-                                        has_effect( effect_riding ) ) ) {
+    if( eff_id == effect_downed && ( has_effect( effect_ridden ) ||
+                                     has_effect( effect_riding ) ) ) {
         monster *mons = dynamic_cast<monster *>( this );
         if( mons && mons->mounted_player ) {
             mons->mounted_player->forced_dismount();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5049,10 +5049,10 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             if( !here.has_flag( ter_furn_flag::TFLAG_LIQUID, targ_pos ) &&
                 targ->has_flag( mon_flag_AQUATIC ) &&
                 !targ->is_dead() ) {
-                targ->die( &here, nullptr );
                 if( u.sees( here, *targ ) ) {
-                    add_msg( _( "The %s flops around and dies!" ), targ->name() );
+                    add_msg( _( "The %s flops around in a vain attempt to return to the water." ), targ->name() );
                 }
+                targ->die( &here, nullptr );
             }
             tp = traj[i];
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5649,53 +5649,50 @@ bool map::open_door( Creature const &u, const tripoint_bub_ms &p, const bool ins
         if( has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, p ) && !inside ) {
             return false;
         }
-
         if( !check_only ) {
             sounds::sound( p, 6, sounds::sound_t::movement, _( "swish" ), true,
                            "open_door", ter.id.str() );
             ter_set( p, ter.open );
-
             if( u.has_trait( trait_SCHIZOPHRENIC ) && u.is_avatar() &&
                 one_in( 50 ) && !ter.has_flag( ter_furn_flag::TFLAG_TRANSPARENT ) ) {
                 tripoint_bub_ms mp = p + point_rel_ms( -2 * u.pos_bub().xy().raw() ) + tripoint_rel_ms{ 2 * p.x(), 2 * p.y(), p.z() };
                 g->spawn_hallucination( mp );
             }
         }
-
         return true;
     } else if( furn.open ) {
         if( has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE, p ) && !inside ) {
             return false;
         }
-
         if( !check_only ) {
             sounds::sound( p, 6, sounds::sound_t::movement, _( "swish" ), true,
                            "open_door", furn.id.str() );
             furn_set( p, furn.open );
         }
-
         return true;
-    } else if( const optional_vpart_position vp = veh_at( p ) ) {
-        const optional_vpart_position creature_veh = veh_at( u.pos_bub() );
-        const bool creature_outside = !creature_veh.has_value() ||
-                                      &creature_veh->vehicle() != &veh_at( p )->vehicle();
-
-        const int openable = vp->vehicle().next_part_to_open( vp->part_index(), creature_outside );
-        if( openable >= 0 ) {
-            if( !check_only ) {
-                if( ( u.is_npc() || u.is_avatar() ) &&
-                    !vp->vehicle().handle_potential_theft( *u.as_character() ) ) {
-                    return false;
-                }
-                vp->vehicle().open_all_at( *this, openable );
+        } else if( const optional_vpart_position vp = veh_at( p ) ) {
+            const optional_vpart_position creature_veh = veh_at( u.pos_bub() );
+            const bool creature_outside =
+                !creature_veh.has_value() ||
+                &creature_veh->vehicle() != &vp->vehicle();
+            const bool player_can_lock = u.is_monster() && vp->vehicle().player_is_driving_this_veh( this );
+            if( player_can_lock ) {
+                return false;
             }
-
-            return true;
-        }
-
+            const int openable =
+                vp->vehicle().next_part_to_open( vp->part_index(), creature_outside );
+            if( openable >= 0 ) {
+                if( !check_only ) {
+                    if( ( u.is_npc() || u.is_avatar() ) &&
+                        !vp->vehicle().handle_potential_theft( *u.as_character() ) ) {
+                        return false;
+                    }
+                    vp->vehicle().open_all_at( *this, openable );
+                }
+                return true;
+            }
         return false;
     }
-
     return false;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5675,7 +5675,7 @@ bool map::open_door( Creature const &u, const tripoint_bub_ms &p, const bool ins
             const bool creature_outside =
                 !creature_veh.has_value() ||
                 &creature_veh->vehicle() != &vp->vehicle();
-            const bool player_can_lock = u.is_monster() && vp->vehicle().player_is_driving_this_veh( this );
+            const bool player_can_lock = u.attitude_to( get_player_character() ) != Creature::Attitude::FRIENDLY && vp->vehicle().player_is_driving_this_veh( this );
             if( player_can_lock ) {
                 return false;
             }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -929,6 +929,15 @@ void monster::move()
         return;
     }
 
+    // If the monster is aquatic and not a zombie, it will soon die out of water.
+    if( !here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub() ) &&
+        !here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, pos_bub() ) &&
+        !here.has_flag( ter_furn_flag::TFLAG_LIQUID, pos_bub() )
+        && has_flag( mon_flag_AQUATIC ) && !has_flag( mon_flag_NO_BREATHE ) && one_in( 20 ) ) {
+        add_msg_if_player_sees( *this, _( "The %s flops around in a vain attempt to return to the water." ), name() );
+        die( &here, nullptr );
+    }
+
     if( moves < 0 ) {
         return;
     }
@@ -962,7 +971,7 @@ void monster::move()
     const std::optional<vpart_reference> vp_boardable = ovp.part_with_feature( "BOARDABLE", true );
     if( vp_boardable && friendly != 0 ) {
         const vehicle &veh = vp_boardable->vehicle();
-        if( veh.is_moving() && veh.get_monster( here,  vp_boardable->part_index() ) ) {
+        if( veh.is_moving() && veh.get_monster( here, vp_boardable->part_index() ) ) {
             moves = 0;
             return; // don't move if friendly and passenger in a moving vehicle
         }
@@ -2387,11 +2396,13 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
     // If we're still in the function at this point, we're actually moving a tile!
     // die_if_drowning will kill the monster if necessary, but if the deep water
     // tile is on a vehicle, we should check for swimmers out of water
-    if( !die_if_drowning( to ) && has_flag( mon_flag_AQUATIC ) ) {
+    if( !here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub() ) &&
+        !here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, pos_bub() ) &&
+        !here.has_flag( ter_furn_flag::TFLAG_LIQUID, pos_bub() )
+        && has_flag( mon_flag_AQUATIC ) && !has_flag( mon_flag_NO_BREATHE ) && one_in( 20 ) ) {
+        add_msg_if_player_sees( *this, _( "The %s flops around in a vain attempt to return to the water." ),
+                                name() );
         die( &here, nullptr );
-        if( u_see ) {
-            add_msg( _( "The %s flops around and dies!" ), name() );
-        }
     }
 
     // It's some kind of wall.


### PR DESCRIPTION
#### Summary
Car doors lock (sorta), monster drowning/swimming fixes, monster hitchhiking is harder.

#### Purpose of change
Monsters calmly opening the door of a Ferrari traveling 72mph and stepping effortlessly into the vehicle is kinda dumb.

#### Describe the solution
- Hostiles (npc or monster) can no longer open doors to a vehicle you are currently driving. You have to be actively driving the thing for this to work, you can't just be sitting in the driver's seat. This is a bit of a kludge until doors can properly lock, but there's no reason not to have it this way.
- Creatures cannot enter a vehicle which is moving faster than ( 35 times their speed ) / 100 mph. This means that a human can't get in a car that's going ~35mph or faster. Flying or airborne creatures are exempt.
- WATER_CAMOUFLAGE no longer works on dry land.
- Live fish will eventually suffocate if they're on dry land. Zombie fish don't need to breathe so they'll just sit there being sad.
- Fixed a bug that was preventing the game from unmounting you if you or your mount were downed.
- Fixed the flags on XL ballistic plates.
- Fixed some flags for impossible shapes.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
