### PR TITLE
Adding strength enchantment for permanent strength effects like mutations

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3962,7 +3962,12 @@
     "category": [ "SLIME" ],
     "enchantments": [
       {
-        "values": [ { "value": "MAX_HP", "add": 3 }, { "value": "STRENGTH", "add": -2 }, { "value": "DEXTERITY", "add": 3 } ]
+        "values": [
+          { "value": "MAX_HP", "add": 3 },
+          { "value": "STRENGTH", "add": -2 },
+          { "value": "STRENGTH_NATURAL", "add": -2 },
+          { "value": "DEXTERITY", "add": 3 }
+        ]
       }
     ]
   },
@@ -3984,7 +3989,12 @@
     "flags": [ "PSEUDOPOD_GRASP" ],
     "enchantments": [
       {
-        "values": [ { "value": "MAX_HP", "add": 6 }, { "value": "STRENGTH", "add": -4 }, { "value": "DEXTERITY", "add": 4 } ]
+        "values": [
+          { "value": "MAX_HP", "add": 6 },
+          { "value": "STRENGTH", "add": -4 },
+          { "value": "STRENGTH_NATURAL", "add": -4 },
+          { "value": "DEXTERITY", "add": 4 }
+        ]
       }
     ]
   },
@@ -3996,7 +4006,11 @@
     "visibility": 1,
     "description": "Your extremities have gained strength but lost fine motor skills.  -1 Dexterity +2 Strength.",
     "category": [ "GASTROPOD" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": -1 } ] } ]
+    "enchantments": [
+      {
+        "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "STRENGTH_NATURAL", "add": 2 }, { "value": "DEXTERITY", "add": -1 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -4331,7 +4345,11 @@
     "//": "Trading X for Y usually means reducing X to gain Y, so I switched the order.",
     "threshreq": [ "THRESH_TROGLOBITE" ],
     "category": [ "TROGLOBITE" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "DEXTERITY", "add": -2 } ] } ]
+    "enchantments": [
+      {
+        "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "STRENGTH_NATURAL", "add": 2 }, { "value": "DEXTERITY", "add": -2 } ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -5635,6 +5653,7 @@
       {
         "values": [
           { "value": "STRENGTH", "add": 2 },
+          { "value": "STRENGTH_NATURAL", "add": 2 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 },
           { "value": "CARRY_WEIGHT", "multiply": 0.05 }
         ]
@@ -5659,6 +5678,7 @@
       {
         "values": [
           { "value": "STRENGTH", "add": 2 },
+          { "value": "STRENGTH_NATURAL", "add": 2 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 0.5 },
           { "value": "CARRY_WEIGHT", "multiply": 0.05 }
         ]
@@ -5686,6 +5706,7 @@
         "values": [
           { "value": "MAX_HP", "add": -6 },
           { "value": "STRENGTH", "add": 4 },
+          { "value": "STRENGTH_NATURAL", "add": 4 },
           { "value": "FATIGUE_REGEN", "multiply": -0.15 },
           { "value": "FATIGUE", "multiply": 0.15 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
@@ -5715,6 +5736,7 @@
       {
         "values": [
           { "value": "STRENGTH", "add": 4 },
+          { "value": "STRENGTH_NATURAL", "add": 4 },
           { "value": "STOMACH_SIZE_MULTIPLIER", "multiply": 1 },
           { "value": "CARRY_WEIGHT", "multiply": 0.1 }
         ]
@@ -5745,7 +5767,7 @@
       "URSINE",
       "CRUSTACEAN"
     ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 1 }, { "value": "STRENGTH_NATURAL", "add": 1 } ] } ]
   },
   {
     "type": "mutation",
@@ -5757,7 +5779,7 @@
     "prereqs": [ "STR_UP" ],
     "changes_to": [ "STR_UP_3", "STR_ALPHA" ],
     "category": [ "LIZARD", "CATTLE", "PLANT", "ALPHA", "CHIMERA", "LUPINE", "TROGLOBITE", "BEAST", "URSINE", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 2 }, { "value": "STRENGTH_NATURAL", "add": 2 } ] } ]
   },
   {
     "type": "mutation",
@@ -5779,7 +5801,7 @@
       "THRESH_CATTLE",
       "THRESH_CRUSTACEAN"
     ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 4 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 4 }, { "value": "STRENGTH_NATURAL", "add": 4 } ] } ]
   },
   {
     "type": "mutation",
@@ -5793,7 +5815,7 @@
     "prereqs": [ "STR_UP_3" ],
     "threshreq": [ "THRESH_BEAST", "THRESH_URSINE", "THRESH_CRUSTACEAN" ],
     "category": [ "BEAST", "URSINE", "CRUSTACEAN" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 7 } ] } ]
+    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": 7 }, { "value": "STRENGTH_NATURAL", "add": 7 } ] } ]
   },
   {
     "type": "mutation",
@@ -5805,7 +5827,14 @@
     "prereqs": [ "STR_UP_2" ],
     "threshreq": [ "THRESH_ALPHA" ],
     "category": [ "ALPHA" ],
-    "enchantments": [ { "values": [ { "value": "STRENGTH", "add": { "math": [ "alpha_stat_bonus(u_val('strength_base'))" ] } } ] } ]
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": { "math": [ "alpha_stat_bonus(u_val('strength_base'))" ] } },
+          { "value": "STRENGTH_NATURAL", "add": { "math": [ "alpha_stat_bonus(u_val('strength_base'))" ] } }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -959,7 +959,7 @@ Character status value  | Description
 `STEALTH_MODIFIER`      | Amount to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
 `STOMACH_SIZE_MULTIPLIER`   | Changes how much food you can consume at once. `"add": 1000` adds 1 L to stomach size
 `STRENGTH`              | Affects the strength stat. Formula for all stat affecting enchantments are `(base_stat + enchantment_addition) * (enchantment_multiplier + 1)`. Str 8 with enchantment `add 2, multiply 1` result in `(8+2) * (1+1) = 10 * 2 =` 20 str
-`STRENGTH_NATURAL`      | Affects factors, such as max HP and muscle BMI, that are affected by base strength but are not affected by enchantments that raise strength through temporary or artifical means. Does not raise strength itself; should be used in addition.
+`STRENGTH_NATURAL`      | Affects factors, such as max HP and muscle BMI, that are affected by base strength but are not affected by enchantments that raise strength through temporary or artifical means. Does not raise strength itself; should be used in addition to the STRENGTH enchantment.
 `SWEAT_MULTIPLIER`      | Affects how much your body can sweat. Affects all bodyparts at once. Since it's a percent, using `multiply` is recommended.
 `THIRST`                | 
 `THROW_STR`             | Increases your strength for throwing purposes. Not limited by your throwing skill (you still throw it as precise as your skill allows you, just further). Only additive. Rule of thumb: one additional point of strength allow you to throw 113 g object 10 tiles further, or 1130 g object 1 tile further, limited by [ str * 3 + skill ]. Full calculations are in Character::throw_range

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -959,6 +959,7 @@ Character status value  | Description
 `STEALTH_MODIFIER`      | Amount to be subtracted from player's visibility range, capped to 60.  Negative values work, but are not very effective due to the way vision ranges are capped.
 `STOMACH_SIZE_MULTIPLIER`   | Changes how much food you can consume at once. `"add": 1000` adds 1 L to stomach size
 `STRENGTH`              | Affects the strength stat. Formula for all stat affecting enchantments are `(base_stat + enchantment_addition) * (enchantment_multiplier + 1)`. Str 8 with enchantment `add 2, multiply 1` result in `(8+2) * (1+1) = 10 * 2 =` 20 str
+`STRENGTH_NATURAL`      | Affects factors, such as max HP and muscle BMI, that are affected by base strength but are not affected by enchantments that raise strength through temporary or artifical means. Does not raise strength itself; should be used in addition.
 `SWEAT_MULTIPLIER`      | Affects how much your body can sweat. Affects all bodyparts at once. Since it's a percent, using `multiply` is recommended.
 `THIRST`                | 
 `THROW_STR`             | Increases your strength for throwing purposes. Not limited by your throwing skill (you still throw it as precise as your skill allows you, just further). Only additive. Rule of thumb: one additional point of strength allow you to throw 113 g object 10 tiles further, or 1130 g object 1 tile further, limited by [ str * 3 + skill ]. Full calculations are in Character::throw_range

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2840,7 +2840,9 @@ void Character::recalc_hp()
     float hp_mod = 1.0f + enchantment_cache->get_value_multiply( enchant_vals::mod::MAX_HP );
     float hp_adjustment = ( str_boost_val * 3 ) +
                           enchantment_cache->get_value_add( enchant_vals::mod::MAX_HP );
-    calc_all_parts_hp( hp_mod, hp_adjustment, get_str_base(), get_dex_base(), get_per_base(),
+    int strength_adjusted = enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                            get_str_base() );
+    calc_all_parts_hp( hp_mod, hp_adjustment, strength_adjusted, get_dex_base(), get_per_base(),
                        get_int_base(), get_lifestyle(), get_fat_to_hp() );
     cached_dead_state.reset();
 }
@@ -6655,12 +6657,14 @@ float Character::get_bmi() const
 
 float Character::get_bmi_lean() const
 {
+    int strength_adjusted = enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                            get_str_base() );
     //strength BMIs decrease to zero as you starve (muscle atrophy)
     if( get_bmi_fat() < character_weight_category::normal ) {
         const stat_mod wpen = get_weight_penalty();
-        return 12.0f + get_str_base() - wpen.strength;
+        return 12.0f + strength_adjusted - wpen.strength;
     }
-    return 12.0f + get_str_base();
+    return 12.0f + strength_adjusted;
 }
 
 float Character::get_bmi_fat() const

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1490,8 +1490,10 @@ void Character::modify_morale( item &food, const int nutr )
         if( has_trait( trait_PICKYEATER ) ) {
             nausea_chance += 5;
         }
-        if( get_str_base() > 10 ) {
-            nausea_chance -= ( std::min( get_str(), get_str_base() ) / 2 );
+        int strength_adjusted = enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                                get_str_base() );
+        if( strength_adjusted > 10 ) {
+            nausea_chance -= ( std::min( get_str(), strength_adjusted ) / 2 );
         }
     }
     if( nausea_chance > 0 && x_in_y( std::min( 100, nausea_chance ), 100 ) ) {

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -58,6 +58,7 @@ namespace io
         switch ( data ) {
             case enchant_vals::mod::ARTIFACT_RESONANCE: return "ARTIFACT_RESONANCE";
             case enchant_vals::mod::STRENGTH: return "STRENGTH";
+            case enchant_vals::mod::STRENGTH_NATURAL: return "STRENGTH_NATURAL";
             case enchant_vals::mod::DEXTERITY: return "DEXTERITY";
             case enchant_vals::mod::PERCEPTION: return "PERCEPTION";
             case enchant_vals::mod::INTELLIGENCE: return "INTELLIGENCE";

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -36,6 +36,7 @@ enum class mod : int {
     ARTIFACT_RESONANCE,
     // effects for the Character
     STRENGTH,
+    STRENGTH_NATURAL,
     DEXTERITY,
     PERCEPTION,
     INTELLIGENCE,


### PR DESCRIPTION
#### Summary
Fixing mutations that improve strength to improve things that base strength affects like max hp and BMI.


#### Purpose of change
An attempt to fix #190. When changing mutations that increased strength to use enchantments, it stopped affecting a couple values like health and max BMI, because the enchantment system is used to support effects like exo suits or magic potions or such where it isn't actually changing your body. But the mutations that affect strength are usually supposed to be changing the character's actual physical body, so the prior behavior was preferable. Or at least that was the explanation recall seeing in the stale issue CleverRaven/Cataclysm-DDA#72698 when I was looking into the CDDA issues.

#### Describe the solution

As suggested in #190, I created a new enchantment, which I decided to name STRENGTH_NATURAL, and plugged it into the three places I saw get_str_base being called where the other 3 stats weren't also being used, and then added it to the mutations with the STRENGTH enchantment where I thought it made sense. To clarify, this is in addition to STRENGTH. If STRENGTH_NATURAL is used without STRENGTH then it won't increase the strength calculations that are impacted by STRENGTH.

Btw the three new places where I added STRENGTH_NATURAL to the calculations were:
Lean BMI calculations in get_bmi_lean in character.cpp
The calculate hp code in recalc_hp in character.cpp
The part where strength affects nausea chance in modify_morale in consumption.cpp

As of making this fix, from what I could tell, weight_capacity in character.cpp uses get_str instead of get_str_base and thus does benefit from the STRENGTH enchantment.


#### Describe alternatives you've considered

I called the new enchantment STRENGTH_NATURAL based on my understanding of what it was supposed to represent. Feel free to suggest/change it to something else. A couple that came to my mind was STRENGTH_PERMANENT or STRENGTH_MUSCLE.

I saw that the base versus enchanted strength was used to in stat screens in such for whether the stats are colored green/red/yellow or such due to being buffed. If we'd rather that strength boosted from mutations is considered the natural state and then, say it being decreased by other factors should make it yellow/red even if it's at/above the character creation strength, then that would probably also involve updating the other 3 stats/mutations to behave similarly, is doable.

At first I considered adding STRENGTH_NATURAL as an alternative to STRENGTH (i.e. you don't need both), but it seemed less conventional to me to change activate_passive to modify strength with both enchantments in a way such that STRENGTH_NATURAL and STRENGTH stack like STRENGTH stacks with other STRENGTH enchantments, in the case that some mod or something used a multiplicative STRENGTH enchantment. Though I'd be willing to try.

It was a little unclear to me whether the Hyde trait's strength buff should count towards BMI/max hp as a physical enhancement, like whether it bulks them up physically, so I didn't add STRENGTH_PERMANENT to it yet.

#### Testing

1. Spawn a character with 10 strength.
2. Check the character's weight, like through a bathroom scale.
3. Check the character's max hp, like from character info.
4. Get the Insanely Strong mutation, bumping strength up to 17.
5. Check that the character's weight and max hp are now higher.
6. Verify you can now eat as much butter as you want until you're full, without getting nauseous, because the nausea chance of 8 is decreased by 17/2=8.

#### Additional context

Btw there were a couple of things that seemed odd to me about the nausea code, like how nausea chance was in the denominator so a lower nausea chance meant higher duration/intensity, or how the effect of strength on nausea chance jumps from -0% to -5% at 11, but I couldn't tell for certain whether those were intended or not.

Screenshots testing the fix:

Pre mutation:
<img width="655" height="448" alt="Screenshot from 2026-06-30 19-57-07" src="https://github.com/user-attachments/assets/f611b09b-619c-4a30-9876-d5b5dc56fa4b" />

<img width="125" height="52" alt="image" src="https://github.com/user-attachments/assets/efbee07b-130a-4aaa-8fdd-20faedd33717" />

Post mutation:

<img width="441" height="436" alt="image" src="https://github.com/user-attachments/assets/3e8b8ddd-697c-48b3-b718-74e41add88a1" />

<img width="106" height="49" alt="image" src="https://github.com/user-attachments/assets/c8b791e1-2e11-4191-b7a9-de1e72f2cb66" />




<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
