### PR TITLE
Fix house25 floor and add fireplace pokers

### DIFF
--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -425,7 +425,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 4,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 6,
@@ -452,7 +452,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 8,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 3,
@@ -479,7 +479,7 @@
     "symbol": ",",
     "color": "dark_gray",
     "material_thickness": 6,
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE"  ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "NO_SALVAGE", "NO_REPAIR", "PREFIX_XL", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 3,
@@ -567,7 +567,7 @@
     "material": [ "steel" ],
     "symbol": ",",
     "color": "dark_gray",
-    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "PREFIX_XL", "OVERSIZE"  ],
+    "flags": [ "ABLATIVE_LARGE_XL", "CANT_WEAR", "PREFIX_XL", "OVERSIZE" ],
     "armor": [
       {
         "material": [

--- a/data/json/mapgen/house/2storymodern01.json
+++ b/data/json/mapgen/house/2storymodern01.json
@@ -222,7 +222,7 @@
       },
       "furniture": { "!": "f_region_flower_decorative", "$": "f_table" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
-      "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 } ],
+      "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 }, { "item": "fire_poker", "x": 16, "y": 12, "chance": 20 } ],
       "place_vehicles": [ { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 } ],
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 3 } ],
       "rotation": [ 2 ]
@@ -286,6 +286,7 @@
       },
       "furniture": { "$": "f_table", ",": "f_chair" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
+      "place_loot": [ { "item": "fire_poker", "x": 16, "y": 12, "chance": 20 } ],
       "place_vehicles": [ { "vehicle": "bicycle", "x": 21, "y": 3, "chance": 30, "status": 100, "rotation": 180 } ],
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 3 } ],
       "rotation": [ 2 ]
@@ -337,6 +338,7 @@
       },
       "furniture": { "$": "f_table", ",": "f_chair", "(": "f_piano", "[": "f_region_flower_decorative" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
+      "place_loot": [ { "item": "fire_poker", "x": 16, "y": 12, "chance": 20 } ],
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 17, "y": 3 } ],
       "rotation": [ 2 ]
     }

--- a/data/json/mapgen/house/bungalow11.json
+++ b/data/json/mapgen/house/bungalow11.json
@@ -60,6 +60,7 @@
         { "chunks": [ [ "null", 80 ], [ "carcrash_10x10_rand", 20 ] ], "x": 10, "y": 0 }
       ],
       "place_loot": [
+        { "item": "fire_poker", "x": 14, "y": 8, "chance": 15 },
         { "item": "television", "x": 18, "y": 5, "chance": 90 },
         { "group": "child_items", "x": [ 2, 6 ], "y": [ 7, 8 ], "chance": 60, "repeat": [ 3, 4 ] }
       ]

--- a/data/json/mapgen/house/bungalow15.json
+++ b/data/json/mapgen/house/bungalow15.json
@@ -63,7 +63,11 @@
         "}": { "item": "jackets", "chance": 50, "repeat": [ 2, 3 ] },
         "$": { "item": "clothing_outdoor_shoes", "chance": 100, "repeat": [ 1, 3 ] }
       },
-      "place_loot": [ { "item": "lawnmower", "x": 3, "y": 21, "chance": 25 }, { "item": "television", "x": 10, "y": 9, "chance": 90 } ],
+      "place_loot": [
+        { "item": "lawnmower", "x": 3, "y": 21, "chance": 25 },
+        { "item": "television", "x": 10, "y": 9, "chance": 90 },
+        { "item": "fire_poker", "x": 8, "y": 11, "chance": 15 }
+      ],
       "place_vehicles": [ { "vehicle": "car", "x": 3, "y": 4, "chance": 30, "fuel": 80, "rotation": 90 } ],
       "place_nested": [
         { "chunks": [ "rolling_trash_can_1x1" ], "x": 23, "y": 1 },

--- a/data/json/mapgen/house/bungalow17.json
+++ b/data/json/mapgen/house/bungalow17.json
@@ -45,6 +45,7 @@
         "Q": "t_floor_waxed"
       },
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 5, "y": 0 } ],
+      "place_loot": [ { "item": "fire_poker", "x": 11, "y": 19, "chance": 15 } ],
       "furniture": { "&": "f_boulder_large", "/": [ [ "f_null", 4 ], "f_ladder" ] }
     }
   },

--- a/data/json/mapgen/house/house25.json
+++ b/data/json/mapgen/house/house25.json
@@ -32,9 +32,10 @@
         "........................"
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_landscaping_palette", "parametrized_carpets_palette" ],
-      "terrain": { "~": { "param": "carpet_color_type", "fallback": "t_carpet_yellow" }, ",": "t_thconc_floor" },
+      "terrain": { "~": { "param": "carpet_color_type", "fallback": "t_carpet_yellow" }, ",": "t_thconc_floor", "%": "t_floor" },
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 12, "y": 1 } ],
       "furniture": { "%": "f_safe_o" },
+      "place_loot": [ { "item": "fire_poker", "x": 5, "y": 8, "chance": 15 } ],
       "place_items": [
         { "chance": 10, "item": "ammo_rifle_common", "x": 9, "y": 17 },
         { "chance": 20, "item": "camping", "x": 13, "y": 19 },

--- a/data/json/mapgen/house/house_detatched4.json
+++ b/data/json/mapgen/house/house_detatched4.json
@@ -65,6 +65,7 @@
       "place_nested": [ { "chunks": [ "rolling_trash_can_1x1" ], "x": 1, "y": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 5, "y": 3 } ],
+      "place_loot": [ { "item": "fire_poker", "x": 21, "y": 10, "chance": 20 } ],
       "place_items": [
         { "chance": 10, "item": "stoner", "x": 7, "y": 4 },
         { "chance": 25, "item": "pool_side", "x": 14, "y": 21 },


### PR DESCRIPTION
#### Summary
Fix house25 floor and add fireplace pokers

#### Purpose of change
- house25 had a mapgen issue where it was placing a shrub under the safe instead of the normal floor.
- fireplace pokers weren't really spawning anywhere.

#### Describe the solution
- Add a low-ish chance for fireplace pokers to appear in a bunch of houses with fireplaces. There are probably more places it could be added, but
- fix the floor

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
