### PR TITLE
Make intelligence actually affect focus

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10482,7 +10482,7 @@ float Character::adjust_for_focus( float amount ) const
     float effective_focus = get_focus();
     effective_focus = enchantment_cache->modify_value( enchant_vals::mod::LEARNING_FOCUS,
                       effective_focus );
-    effective_focus = effective_focus * 1.0 + ( 0.01f * ( get_int() - 8 ) * 5 );
+    effective_focus = effective_focus * 1.0f + ( ( get_int() - 10.f ) * 2.5f );
     effective_focus = std::max( effective_focus, 1.f );
     return amount * ( effective_focus / 100.0f );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10480,10 +10480,12 @@ std::unordered_set<trait_id> Character::get_opposite_traits( const trait_id &fla
 float Character::adjust_for_focus( float amount ) const
 {
     float effective_focus = get_focus();
-    effective_focus = enchantment_cache->modify_value( enchant_vals::mod::LEARNING_FOCUS,
-                      effective_focus );
-    effective_focus = effective_focus * 1.0f + ( ( get_int() - 10.f ) * 2.5f );
-    effective_focus = std::max( effective_focus, 1.f );
+    // Scale bonus down as base focus decreases, because a flat bonus would create an
+    // artificially high floor and sufficiently bonused characters would never reach ~0 focus.
+    float bonus = ( get_int() - 10.0f ) * 2.5f;
+    bonus = enchantment_cache->modify_value( enchant_vals::mod::LEARNING_FOCUS, bonus );
+    effective_focus += bonus * ( effective_focus / 100.0f );
+    effective_focus = std::max( effective_focus, 1.0f );
     return amount * ( effective_focus / 100.0f );
 }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1342,12 +1342,21 @@ static std::string assemble_stat_details( avatar &u, int sel )
 
         case 2: {
             const int read_spd = u.read_speed();
+            // It's actually a float, but we use a double here for legibility.
+            const double effective_focus = ( u.get_int() - 10.0 ) * 2.5;
             description_str =
                 colorize( string_format( _( "%s\n" ), u.as_character()->get_stat_descriptor( u.get_int() ) ),
                           c_light_blue )
+
                 + colorize( string_format( _( "\nRead times: %d%%" ), read_spd ),
                             ( read_spd == 100 ? COL_STAT_NEUTRAL :
-                              ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
+                                            ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
+                + colorize(
+                    string_format( _( "\nFocus modifier: %+g%%" ), effective_focus ),
+                    effective_focus == 0.0 ? COL_STAT_NEUTRAL :
+                    effective_focus > 0.0 ? COL_STAT_BONUS :
+                    COL_STAT_PENALTY
+                )
                 + string_format( _( "\nPersuasion: %1s \nDeception: %2s" ), u.persuade_skill(), u.lie_skill() )
                 + colorize( string_format( _( "\nCrafting bonus: %2d%%" ), u.get_int() ),
                             COL_STAT_BONUS )


### PR DESCRIPTION
#### Summary
Make intelligence actually effect foucs

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/66834 - this PR severely nerfed intelligence's relationship to focus. This was previously adjustable via an external option which has since been removed (at least in TLG). In any event, the core issue the PR wanted to address was still a problem: sufficiently bonused characters could pretty much ignore the focus system and would always learn, because focus was a flat modifier.

#### Describe the solution
- Intelligence now bonuses or penalizes effective focus at a rate of 2.5 for every point above or below 10. 
- This bonus scales linearly with base focus. So at 100 base focus, it's 2.5 per, but at 10 focus, it's .25 per. This solves the issue outlined in DDA 66834.
- Added a note to the intelligence listing in chargen.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
