### PR TITLE
Sleep deprivation makes you sleepy

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5863,11 +5863,11 @@ void Character::check_needs_extremes()
             if( sleep_deprivation < SLEEP_DEPRIVATION_MINOR ) {
                 add_msg_if_player( m_warning,
                                    _( "It's been a while since you've slept well, it's fraying at your nerves." ) );
-                mod_fatigue( 1 );
+                mod_fatigue( 5 );
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_SERIOUS ) {
                 add_msg_if_player( m_bad,
                                    _( "Your mind feels foggy from a lack of good sleep, and your eyes keep trying to close against your will." ) );
-                mod_fatigue( 5 );
+                mod_fatigue( 20 );
 
                 if( one_in( 10 ) ) {
                     mod_daily_health( -1, -10 );
@@ -5875,7 +5875,7 @@ void Character::check_needs_extremes()
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_MAJOR ) {
                 add_msg_if_player( m_bad,
                                    _( "You feel dazed from lack of sleep." ) );
-                mod_fatigue( 10 );
+                mod_fatigue( 35 );
 
                 if( one_in( 5 ) ) {
                     mod_daily_health( -2, -10 );
@@ -5883,7 +5883,7 @@ void Character::check_needs_extremes()
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_MASSIVE ) {
                 add_msg_if_player( m_bad,
                                    _( "You can't concentrate.  You need sleep." ) );
-                mod_fatigue( 40 );
+                mod_fatigue( 50 );
                 mod_daily_health( -5, -10 );
             }
             // Microsleeps are slightly worse if you're sleep deprived, but not by much. (chance: 1 in (75 + int_cur) at lethal sleep deprivation)


### PR DESCRIPTION
#### Summary
Sleep deprivation makes you sleepy

#### Purpose of change
Caffeine (currently) just reduces fatigue and you don't get it back when the caffeine wears off. This can lead to some issues where people aren't sleepy but are mega sleep deprived. To some extent that is intended, but it's a bit overtuned.

#### Describe the solution
Every hour, if you're sleep deprived, your fatigue will increase. It increases more the higher your sleep deprivation.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
