### PR TITLE
Fix ramps

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -247,10 +247,10 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         return true;
     }
     bool via_ramp = false;
-    if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
+    if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you_pos ) && m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
         dest_loc.z() += 1;
         via_ramp = true;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest_loc ) ) {
+    } else if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, you_pos ) && m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest_loc ) ) {
         dest_loc.z() -= 1;
         via_ramp = true;
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11720,12 +11720,12 @@ void Character::stagger()
 
     preferred_stumbles.reserve( 11 );
     valid_stumbles.reserve( 11 );
-
-    for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1 ) ) {
+    tripoint_bub_ms pos = pos_bub();
+    for( const tripoint_bub_ms &dest : here.points_in_radius( pos, 1 ) ) {
         if( dest != pos_bub() ) {
-            if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
+            if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, pos ) && here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
                 valid_stumbles.emplace_back( dest + tripoint::below );
-            } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
+            } else if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, pos ) && here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
                 valid_stumbles.emplace_back( dest + tripoint::above );
             } else {
                 valid_stumbles.push_back( dest );


### PR DESCRIPTION
#### Summary
Fix ramps

#### Purpose of change
Fix that annoying sideways ramp movement issue

#### Describe the solution
When on a bridge or other wide ramp, stepping sideways along the lower or upper tiles will no longer move you to the upper end. You have to actually go UP the ramp.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
