### PR TITLE
Fix addiction sleepy sign and some incorrect withdrawal effect names

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11834,6 +11834,7 @@ bool Character::can_sleep()
     if( has_effect( effect_withdrawal_opioid_timer ) ) {
         addiction_mod -= get_effect_int( effect_withdrawal_opioid_timer );
     }
+    // The lower adiction_mod is, the more it decreases sleepy.
     sleepy += std::max( addiction_mod, -5 );
     sleepy = enchantment_cache->modify_value( enchant_vals::mod::SLEEPY, sleepy );
     if( get_fatigue() < fatigue_levels::TIRED + 1 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11834,7 +11834,7 @@ bool Character::can_sleep()
     if( has_effect( effect_withdrawal_timer_opioid ) ) {
         addiction_mod -= get_effect_int( effect_withdrawal_timer_opioid );
     }
-    sleepy -= std::min( addiction_mod, -5 );
+    sleepy += std::max( addiction_mod, -5 );
     sleepy = enchantment_cache->modify_value( enchant_vals::mod::SLEEPY, sleepy );
     if( get_fatigue() < fatigue_levels::TIRED + 1 ) {
         sleepy -= int( ( fatigue_levels::TIRED + 1 - get_fatigue() ) / 4 );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -280,9 +280,9 @@ static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 static const efftype_id effect_weed_high( "weed_high" );
 static const efftype_id effect_winded( "winded" );
-static const efftype_id effect_withdrawal_timer_alcohol( "withdrawal_alcohol_timer" );
-static const efftype_id effect_withdrawal_timer_nicotine( "withdrawal_nicotine_timer" );
-static const efftype_id effect_withdrawal_timer_opioid( "withdrawal_opioid_timer" );
+static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
+static const efftype_id effect_withdrawal_nicotine_timer( "withdrawal_nicotine_timer" );
+static const efftype_id effect_withdrawal_opioid_timer( "withdrawal_opioid_timer" );
 
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
@@ -11825,14 +11825,14 @@ bool Character::can_sleep()
     if( addiction_level( addiction_cannabis ) > 5 && !has_effect( effect_weed_high ) ) {
         addiction_mod -= 1;
     }
-    if( has_effect( effect_withdrawal_timer_alcohol ) ) {
-        addiction_mod -= get_effect_int( effect_withdrawal_timer_alcohol );
+    if( has_effect( effect_withdrawal_alcohol_timer ) ) {
+        addiction_mod -= get_effect_int( effect_withdrawal_alcohol_timer );
     }
-    if( has_effect( effect_withdrawal_timer_nicotine ) ) {
-        addiction_mod -= get_effect_int( effect_withdrawal_timer_nicotine );
+    if( has_effect( effect_withdrawal_nicotine_timer ) ) {
+        addiction_mod -= get_effect_int( effect_withdrawal_nicotine_timer );
     }
-    if( has_effect( effect_withdrawal_timer_opioid ) ) {
-        addiction_mod -= get_effect_int( effect_withdrawal_timer_opioid );
+    if( has_effect( effect_withdrawal_opioid_timer ) ) {
+        addiction_mod -= get_effect_int( effect_withdrawal_opioid_timer );
     }
     sleepy += std::max( addiction_mod, -5 );
     sleepy = enchantment_cache->modify_value( enchant_vals::mod::SLEEPY, sleepy );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -280,9 +280,9 @@ static const efftype_id effect_tied( "tied" );
 static const efftype_id effect_transition_contacts( "transition_contacts" );
 static const efftype_id effect_weed_high( "weed_high" );
 static const efftype_id effect_winded( "winded" );
-static const efftype_id effect_withdrawal_timer_alcohol( "withdrawal_timer_alcohol" );
-static const efftype_id effect_withdrawal_timer_nicotine( "withdrawal_timer_nicotine" );
-static const efftype_id effect_withdrawal_timer_opioid( "withdrawal_timer_opioid" );
+static const efftype_id effect_withdrawal_timer_alcohol( "withdrawal_alcohol_timer" );
+static const efftype_id effect_withdrawal_timer_nicotine( "withdrawal_nicotine_timer" );
+static const efftype_id effect_withdrawal_timer_opioid( "withdrawal_opioid_timer" );
 
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 


### PR DESCRIPTION
#### Summary
Fixing sleepiness addiction code to make addictions/withdrawal make it harder instead of easier to sleep.

Prior behavior:
Player is addicted to sleeping pills, alcohol, cannabis, and going through moderate nicotine withdrawal
Addiction_mod = -4 (sleeping pill) -1 (alcohol) -1 (cannabis) -0 (withdrawal) = -6
Min(-6, -5)=-6
sleepy -= -6

Fixed behavior:
Player has same addictions/withdrawal
Addiction_mod = -4-1-1-2 (nicotine withdrawal)=-8
Max(-8,-5)=-5
sleepy += -5

#### Purpose of change
When looking into what determines how a player could fall asleep, I noticed that is decreased by addictions and withdrawal. And then the negative value is subtracted from sleepy, which raises sleepy, which makes it easier to fall asleep. I tried finding when this change happened, and it seemed that before #2539, values were subtracted from sleepy, making it harder to sleep, but then after that commit the values were subtracted from addiction_mod instead to put a cap on the modifier from addictions, and addiction_mod was itself subtracted from sleepy.

Btw I also noticed the comment said it had a floor of -5, but it was std::min with -5, so values higher than -5 would be pulled down to -5, while values lower than -5 would be unaffected. So the prior behavior was making addiction_mod -5 or lower. So players without addictions/withdrawals would effectively have an addiction_mod of -5, which in combination with the sign thing would make it a little easier for them to sleep.

While testing with some debug messages, I also noticed that after the fixing the previous 2, when the player was having just nicotine withdrawal, addiction_mod was 0. When I searched, it seems that there was no effect called withdrawal_timer_nicotine, but there was one called withdrawal_nicotine_timer. And the other two withdrawal timers seemed to have a similar thing going on.

#### Describe the solution

I changed it from sleepy -= min(addiction mod, -5) to sleepy += min(addiction mod, -5). So addiction mod is still a negative number as before, and now addictions should make it harder to sleep up to a cap of decreasing sleepy by 5, as opposed to before where it was subtracting a negative number and thus adding 5/6 to it.

I also modified the withdrawal timer variable names in character.cpp to be consistent with the names in effect.json, so now those withdrawals should make it harder to sleep whereas before they weren't working.

#### Describe alternatives you've considered
Alternatively we could make addiction_mod a positive number that is higher than more addictions and is subtracted from sleepy. I just felt that this change was a little more consistent with the previous code.

#### Testing
For a character with a bunch of addictions/withdrawal, this fix would change the sleepiness addiction modifier from ~+5 to  up to -5. Which is smaller than the rng factor, so you would need to test multiple times to get the odds. Or just add logging to the code to get addiction_mod or the pre-rng sleepy factor with greater certainty.

I did test a character with sleeping pill/alcohol/cannabis addictions, sleeping on the floor at fatigue 210, and they seemed to successfully fall asleep more often pre-fix than post-fix with the same addictions.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
