### PR TITLE
Fix line of sight bug

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8481,6 +8481,12 @@ visibility_result map::sees_full( const tripoint_bub_ms &F, const tripoint_bub_m
             }
 
             tripoint_bub_ms tp( new_point.x(), new_point.y(), T.z() );
+            // Inbounds check because monsters are using this too, and their view range can be OOB.
+            if( !inbounds( tp ) ) {
+                visible = false;
+                return false;
+            }
+
             point_bub_ms T_point( T.x(), T.y() );
             point_bub_ms F_point( F.x(), F.y() );
             // Concealment check only for tiles adjacent to target.
@@ -8541,6 +8547,11 @@ visibility_result map::sees_full( const tripoint_bub_ms &F, const tripoint_bub_m
             }
             // Exit before checking the last square only if it's not a vertical transition.
             if( new_point == T && last_point.z() == T.z() ) {
+                return false;
+            }
+            // Inbounds check because monster view can be OOB.
+            if( !inbounds( new_point ) ) {
+                visible = false;
                 return false;
             }
             // Concealment check only for tiles adjacent to target.


### PR DESCRIPTION
#### Summary
Fix line of sight bug

#### Purpose of change
Monsters running sees_full() were tripping an out of bounds bug in generate_transparency_cache() because a get_ter() check was added to the latter function which never crashed for the player (since their vision is always inbounds) but would rarely crash when a lot of monsters were flying around near the edge of the reality bubble and there were treetops below them

#### Describe the solution
Check for inbounds in sees_full, both the 2d and 3d paths.

#### Describe alternatives you've considered
check inbounds in is_transparent(), but it would be redundant and that's a hot path so let's add as little overhead as possible.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
