### PR TITLE
Sound fixes

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -281,6 +281,14 @@
   },
   {
     "type": "effect_type",
+    "id": "sound_triggered",
+    "name": [ "Heard Sound" ],
+    "max_intensity": 400,
+    "max_duration": "10 s",
+    "desc": [ "AI tag used for monsters responding to sound.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
     "id": "worked_on",
     "name": [ "Worked On" ],
     "desc": [ "AI tag used for robots being disabled.  This is a bug if you have it." ]

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2309,7 +2309,7 @@ std::optional<int> iuse::radio_on( Character *, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::noise_emitter_on( Character *, item *, const tripoint_bub_ms &pos )
 {
-    sounds::sound( pos, 30, sounds::sound_t::alarm, _( "KXSHHHHRRCRKLKKK!" ), true, "tool",
+    sounds::sound( pos, 50, sounds::sound_t::alarm, _( "KXSHHHHRRCRKLKKK!" ), true, "tool",
                    "noise_emitter" );
     return 1;
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -130,6 +130,7 @@ static const efftype_id effect_run( "run" );
 static const efftype_id effect_slippery_terrain( "slippery_terrain" );
 static const efftype_id effect_smoke_eyes( "smoke_eyes" );
 static const efftype_id effect_smoke_lungs( "smoke_lungs" );
+static const efftype_id effect_sound_triggered( "sound_triggered" );
 static const efftype_id effect_spooked( "spooked" );
 static const efftype_id effect_spooked_recent( "spooked_recent" );
 static const efftype_id effect_stunned( "stunned" );
@@ -4093,7 +4094,9 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
         return;
     }
     // Only trigger this if the monster is not friendly or the source isn't us or the player.
-    if( source != pos_bub() && ( friendly == 0 || source != get_player_character().pos_bub() ) ) {
+    // Skip if the sound is quiet-ish, or we've already hear a louder sound recently.
+    if( source != pos_bub() && volume > 9 && ( friendly == 0 || source != get_player_character().pos_bub() ) && get_effect_int( effect_sound_triggered ) < volume ) {
+        add_effect( effect_sound_triggered, ( 1_seconds * rng( 2, 10 ) ), false, std::min( volume, 400 ) );
         process_trigger( mon_trigger::SOUND, volume );
     }
     provocative_sound = tmp_provocative;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4095,9 +4095,10 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
     }
     // Only trigger this if the monster is not friendly or the source isn't us or the player.
     // Skip if the sound is quiet-ish, or we've already hear a louder sound recently.
-    if( source != pos_bub() && volume > 9 && ( friendly == 0 || source != get_player_character().pos_bub() ) && get_effect_int( effect_sound_triggered ) < volume ) {
+    if( source != pos_bub() && volume > 15 && ( friendly == 0 || source != get_player_character().pos_bub() ) && get_effect_int( effect_sound_triggered ) < volume ) {
         add_effect( effect_sound_triggered, ( 1_seconds * rng( 2, 10 ) ), false, std::min( volume, 400 ) );
-        process_trigger( mon_trigger::SOUND, volume );
+        int trigger_strength = std::max( 0, volume - 15 );
+        process_trigger( mon_trigger::SOUND, trigger_strength );
     }
     provocative_sound = tmp_provocative;
     if( morale >= 0 && anger >= 10 ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -443,8 +443,8 @@ static std::vector<centroid> cluster_sounds(
 
 static int get_signal_for_hordes( const centroid &centr )
 {
-    //Volume in  tiles. Signal for hordes in submaps
-    //modify vol using weather vol.Weather can reduce monster hearing
+    //Volume in tiles. Signal for hordes in submaps
+    //modify vol using weather vol. Weather can reduce monster hearing.
     const int vol = centr.volume - get_weather().weather_id->sound_attn;
     const int min_vol_cap = 60; //Hordes can't hear volume lower than this
     const int underground_div = 2; //Coefficient for volume reduction underground
@@ -479,9 +479,13 @@ void sounds::process_sounds()
         const tripoint_bub_ms source = tripoint_bub_ms( this_centroid.x, this_centroid.y, this_centroid.z );
         // --- Monster sound handling here ---
         // Alert all hordes
-        int sig_power = get_signal_for_hordes( this_centroid );
-        if( sig_power > 0 ) {
 
+        int sig_power = get_signal_for_hordes( this_centroid );
+        bool outside = here.is_outside( source );
+        if( !outside ) {
+            sig_power *= 0.8;
+        }
+        if( sig_power > 0 ) {
             const point_abs_ms abs_ms = here.get_abs( source ).xy();
             const point_abs_sm abs_sm( coords::project_to<coords::sm>( abs_ms ) );
             const tripoint_abs_sm target( abs_sm, source.z() );
@@ -490,12 +494,14 @@ void sounds::process_sounds()
         // Alert all monsters (that can hear) to the sound.
         for( monster &critter : g->all_monsters() ) {
             // TODO: Generalize this to Creature::hear_sound
-            const int dist = sound_distance( source, critter.pos_bub() );
+            tripoint_bub_ms target_bub = critter.pos_bub();
+            const int dist = sound_distance( source, target_bub );
             if( vol * 2 > dist && critter.has_flag( mon_flag_HEARS ) && !critter.has_effect( effect_deaf ) ) {
                 // Exclude monsters that certainly won't hear the sound
                 critter.hear_sound( source, vol, dist, this_centroid.provocative );
                 if( raw_volume >= 150 && !critter.is_immune_effect( effect_deaf ) ) {
-                    const int felt_volume = raw_volume - dist;
+                    const bool both_inside = !outside && !here.is_outside( target_bub );
+                    const int felt_volume = ( raw_volume - dist * 2 ) * ( both_inside ? 100 : 80 ) / 100;
                     const bool is_sound_deafening = felt_volume >= 150;
                     if( is_sound_deafening ) {
                         // Reduced deafness for monsters (zombies adapt, animals have better ears, etc)


### PR DESCRIPTION
#### Summary
Sound fixes

#### Purpose of change
Noise emitters sucked, monster sound triggers sucked, deafness sucked

#### Describe the solution
- Noise emitters make 50 noise instead of 30
- When outdoors, sound is attenuated 20% for purposes of determining whether it deafens creatures. This includes the most common case, the player firing a gun and deafening themself.
- When indoors, sound is attenuated 20% for purposes of signaling hordes.
- Monsters who are frightened by sound now have a random 2-10 second cooldown on being frightened more. Louder sounds will override cooldowns caused by quieter ones.
- Sounds must be more than 15 volume to frighten a monster.
- Sounds reduce morale by volume - 15 instead of just volume. This curbs the impact of e.g. yelling through a mask without overly impacting things like gunfire.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
