### PR TITLE
Activating washboard or sponge opens washing menu

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -34,7 +34,8 @@
     "symbol": "/",
     "color": "light_gray",
     "flags": [ "BELT_CLIP", "WASH_HARD" ],
-    "melee_damage": { "bash": 1 }
+    "melee_damage": { "bash": 1 },
+    "use_action": [ "WASH_ALL_ITEMS" ]
   },
   {
     "id": "dish_towel",
@@ -51,7 +52,8 @@
     "material": [ "cotton" ],
     "flags": [ "TINDER", "WASH_HARD" ],
     "symbol": ",",
-    "color": "white"
+    "color": "white",
+    "use_action": [ "WASH_ALL_ITEMS" ]
   },
   {
     "id": "elec_hairtrimmer",
@@ -186,7 +188,8 @@
     "material": [ "plastic" ],
     "symbol": "s",
     "color": "yellow",
-    "flags": [ "NO_SALVAGE", "WASH_HARD" ]
+    "flags": [ "NO_SALVAGE", "WASH_HARD" ],
+    "use_action": [ "WASH_ALL_ITEMS" ]
   },
   {
     "id": "survivor_hairtrimmer",
@@ -242,7 +245,8 @@
     "material": [ "wood" ],
     "symbol": ";",
     "color": "white",
-    "flags": [ "ALLOWS_REMOTE_USE", "WASH_SOFT" ]
+    "flags": [ "ALLOWS_REMOTE_USE", "WASH_SOFT" ],
+    "use_action": [ "WASH_ALL_ITEMS" ]
   },
   {
     "id": "hair_dye_kit",


### PR DESCRIPTION
#### Summary
Activating washboard or sponge opens washing menu

#### Purpose of change

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
