### PR TITLE
Nerf passive artifact effects

### DIFF
--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -135,62 +135,62 @@
       }
     ],
     "passive_add_procgen_values": [
-      { "weight": 100, "min_value": -3, "max_value": 4, "type": "STRENGTH", "increment": 1, "power_per_increment": 250 },
+      { "weight": 100, "min_value": -3, "max_value": 2, "type": "STRENGTH", "increment": 1, "power_per_increment": 500 },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "DEXTERITY",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "PERCEPTION",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "INTELLIGENCE",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -20,
-        "max_value": 20,
+        "max_value": 10,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 50,
-        "min_value": -20,
-        "max_value": 50,
+        "min_value": -10,
+        "max_value": 20,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": -150
+        "power_per_increment": -300
       },
       {
         "weight": 50,
         "min_value": -2500,
-        "max_value": 10000,
+        "max_value": 2000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 50
+        "power_per_increment": 100
       },
       {
         "weight": 50,
         "min_value": -20000,
-        "max_value": 20000,
+        "max_value": 10000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 25
+        "power_per_increment": 100
       },
       {
         "weight": 10,
@@ -198,7 +198,7 @@
         "max_value": 10,
         "type": "EFFECTIVE_HEALTH_MOD",
         "increment": 2,
-        "power_per_increment": 100
+        "power_per_increment": 200
       }
     ],
     "type_weights": [
@@ -358,62 +358,62 @@
       }
     ],
     "passive_add_procgen_values": [
-      { "weight": 100, "min_value": -3, "max_value": 4, "type": "STRENGTH", "increment": 1, "power_per_increment": 250 },
+      { "weight": 100, "min_value": -3, "max_value": 2, "type": "STRENGTH", "increment": 1, "power_per_increment": 500 },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "DEXTERITY",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "PERCEPTION",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "INTELLIGENCE",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -20,
-        "max_value": 20,
+        "max_value": 10,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 50,
-        "min_value": -20,
-        "max_value": 50,
+        "min_value": -10,
+        "max_value": 20,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": -150
+        "power_per_increment": -300
       },
       {
         "weight": 50,
         "min_value": -2500,
-        "max_value": 10000,
+        "max_value": 2000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 50
+        "power_per_increment": 100
       },
       {
         "weight": 50,
         "min_value": -20000,
-        "max_value": 20000,
+        "max_value": 10000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 25
+        "power_per_increment": 50
       },
       {
         "weight": 10,
@@ -421,7 +421,7 @@
         "max_value": 10,
         "type": "EFFECTIVE_HEALTH_MOD",
         "increment": 2,
-        "power_per_increment": 100
+        "power_per_increment": 200
       }
     ],
     "type_weights": [
@@ -585,62 +585,62 @@
       }
     ],
     "passive_add_procgen_values": [
-      { "weight": 100, "min_value": -3, "max_value": 4, "type": "STRENGTH", "increment": 1, "power_per_increment": 250 },
+      { "weight": 100, "min_value": -3, "max_value": 2, "type": "STRENGTH", "increment": 1, "power_per_increment": 500 },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "DEXTERITY",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "PERCEPTION",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -3,
-        "max_value": 4,
+        "max_value": 2,
         "type": "INTELLIGENCE",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
         "min_value": -20,
-        "max_value": 20,
+        "max_value": 10,
         "type": "SPEED",
         "increment": 5,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 50,
-        "min_value": -20,
-        "max_value": 50,
+        "min_value": -10,
+        "max_value": 20,
         "type": "ATTACK_SPEED",
         "increment": 5,
-        "power_per_increment": -150
+        "power_per_increment": -300
       },
       {
         "weight": 50,
         "min_value": -2500,
-        "max_value": 10000,
+        "max_value": 2000,
         "type": "MAX_STAMINA",
         "increment": 250,
-        "power_per_increment": 50
+        "power_per_increment": 100
       },
       {
         "weight": 50,
         "min_value": -20000,
-        "max_value": 20000,
+        "max_value": 10000,
         "type": "CARRY_WEIGHT",
         "increment": 1000,
-        "power_per_increment": 25
+        "power_per_increment": 50
       },
       {
         "weight": 10,
@@ -648,7 +648,7 @@
         "max_value": 10,
         "type": "EFFECTIVE_HEALTH_MOD",
         "increment": 2,
-        "power_per_increment": 100
+        "power_per_increment": 200
       }
     ],
     "type_weights": [
@@ -680,30 +680,30 @@
     "type": "relic_procgen_data",
     "id": "held_passive_bad",
     "passive_add_procgen_values": [
-      { "weight": 100, "min_value": 1, "max_value": 2, "type": "STRENGTH", "increment": 1, "power_per_increment": 250 },
+      { "weight": 100, "min_value": -3, "max_value": 2, "type": "STRENGTH", "increment": 1, "power_per_increment": 500 },
       {
         "weight": 100,
-        "min_value": 1,
+        "min_value": -3,
         "max_value": 2,
         "type": "DEXTERITY",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
-        "min_value": 1,
+        "min_value": -3,
         "max_value": 2,
         "type": "PERCEPTION",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       },
       {
         "weight": 100,
-        "min_value": 1,
+        "min_value": -3,
         "max_value": 2,
         "type": "INTELLIGENCE",
         "increment": 1,
-        "power_per_increment": 250
+        "power_per_increment": 500
       }
     ],
     "passive_mult_procgen_values": [

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1893,7 +1893,6 @@
     "max_intensity": 3,
     "resist_traits": [ "THRESH_URSINE" ],
     "base_mods": {
-      "str_mod": [ 1 ],
       "fatigue_min": [ 1 ],
       "fatigue_chance": [ 1100 ],
       "hurt_min": [ 1 ],

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1303,7 +1303,7 @@ void avatar::set_movement_mode( const move_mode_id &new_mode )
         // Enchantments based on move modes can stack inappropriately without a recalc here
         recalculate_enchantment_cache();
         // crouching affects visibility
-        //TODO: Replace with dirtying vision_transparency_cache
+        // TODO: Replace with dirtying vision_transparency_cache
         here.set_transparency_cache_dirty( pos_bub() );
         here.set_seen_cache_dirty( posz() );
         recoil = MAX_RECOIL;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10812,10 +10812,10 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
     }
 
     run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
-                         _( "Enchantments" ) );
+                         _( "Modifiers" ) );
     run_cost_effect_mul( std::max( 0.01,
                                    1.0 + enchantment_cache->get_value_multiply( enchant_vals::mod::MOVE_COST ) ),
-                         _( "Enchantments" ) );
+                         _( "Modifiers" ) );
 
     run_cost_effect_mul( 1.0 / get_modifier( character_modifier_stamina_move_cost_mod ),
                          _( "Stamina" ) );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -805,7 +805,7 @@ void DynamicDataLoader::finalize_loaded_data( loading_ui &ui )
             { _( "Field types" ), &field_types::finalize_all },
             { _( "Ammo effects" ), &ammo_effects::finalize_all },
             { _( "Emissions" ), &emit::finalize },
-            { _( "Enchantments" ), &enchantment::finalize_all },
+            { _( "Modifiers" ), &enchantment::finalize_all },
             { _( "Event Statistics" ), &event_statistic::finalize_all },
             { _( "Event Transformations" ), &event_transformation::finalize_all },
             { _( "Faults" ), &faults::finalize },

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -616,7 +616,7 @@ void enchant_cache::load( const JsonObject &jo, std::string_view,
                 }
             } catch( ... ) {
                 if( legacy_values.find( value_obj.get_string( "value", "" ) ) == legacy_values.end() ) {
-                    debugmsg( "A relic attempted to load invalid enchantment %s.", value_obj.get_string( "value",
+                    debugmsg( "A relic attempted to load invalid modifier %s.", value_obj.get_string( "value",
                               "" ) );
                 }
             }


### PR DESCRIPTION
#### Summary
Nerf passive artifact effects

#### Purpose of change
Artifacts are SUUUPER boring and tend to be put together without much rhyme or reason. Worse, their passives stack in ways that can be cheesed. This needs to be fixed in a more comprehensive way but for now we can do a bit to help.

#### Describe the solution
Cut all passive maxes in half and double their power cost. This only applies to flat bonuses/penalties for now.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
