### PR TITLE
Disallow non-allied NPC temp tracking and battery modding invalid items

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3838,6 +3838,16 @@ void fish_activity_actor::do_turn( player_activity &, Character &who )
 
     float fish_chance = 1.0f;
     float survival_skill = who.get_skill_level( skill_survival );
+    // Recover from an invalid item_location, which can occur after NPC unload/reload.
+    if( !fishing_rod ) {
+        const item_location &wielded = who.get_wielded_item();
+        if( wielded && wielded->has_quality( qual_FISHING_ROD ) ) {
+            fishing_rod = wielded;
+        } else {
+            who.cancel_activity();
+            return;
+        }
+    }
     switch( fishing_rod->get_quality( qual_FISHING_ROD ) ) {
         case 1:
             survival_skill += dice( 1, 6 );
@@ -3856,13 +3866,13 @@ void fish_activity_actor::do_turn( player_activity &, Character &who )
     if( fishables.empty() ) {
         fish_chance += survival_skill / 2;
     } else {
-        // if they are visible however, it implies a larger population
+        // If they are visible however, it implies a larger population.
         for( monster *elem : fishables ) {
             fish_chance += elem->fish_population;
         }
         fish_chance += survival_skill;
     }
-    // no matter the population of fish, your skill and tool limits the ease of catching.
+    // No matter the population of fish, your skill and tool limits the ease of catching.
     fish_chance = std::min( survival_skill * 10, fish_chance );
     if( x_in_y( fish_chance, 500000 ) ) {
         who.add_msg_if_player( m_good, _( "You feel a tug on your line!" ) );
@@ -6870,7 +6880,6 @@ time_duration prying_activity_actor::prying_time( const activity_data_common &da
 void prying_activity_actor::start( player_activity &act, Character &who )
 {
     const map &here = get_map();
-
     if( here.has_furn( target ) ) {
         const furn_id &furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
@@ -6917,9 +6926,11 @@ void prying_activity_actor::start( player_activity &act, Character &who )
 void prying_activity_actor::do_turn( player_activity &/*act*/, Character &who )
 {
     map &here = get_map();
-
+    if( !tool ) {
+        who.cancel_activity();
+        return;
+    }
     std::string method = "CROWBAR";
-
     if( tool->ammo_sufficient( &who, method ) ) {
         int ammo_consumed = tool->ammo_required();
         std::map<std::string, int>::const_iterator iter = tool->type->ammo_scale.find( method );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -494,7 +494,9 @@ std::map<bodypart_id, temp_warning_record> last_temp_warnings;
 
 void Character::update_bodytemp()
 {
-    if( has_trait( trait_DEBUG_NOTEMP ) ) {
+    npc *n = as_npc();
+    if( has_trait( trait_DEBUG_NOTEMP ) ||
+        ( !is_avatar() && n && !n->is_player_ally() ) ) {
         set_all_parts_temp_conv( BODYTEMP_NORM );
         set_all_parts_temp_cur( BODYTEMP_NORM );
         return;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5094,19 +5094,22 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_
     }
 
     auto filter = [&it]( const item & e ) {
-        // don't allow ups or bionic battery mods on a UPS or UPS-powered/bionic-powered tools
+        // Don't allow ups or bionic battery mods on a UPS or UPS-powered/bionic-powered tools.
         if( ( it->has_flag( flag_USE_UPS ) || it->has_flag( flag_USES_BIONIC_POWER ) ) &&
             ( e.has_flag( flag_IS_UPS ) || e.has_flag( flag_USE_UPS ) ||
               e.has_flag( flag_USES_BIONIC_POWER ) ) ) {
             return false;
         }
-
-        // can't mod non-tool, or a tool with existing mods, or a battery currently installed
+        // FIXME: Make internal batteries compatible with toolmods.
+        if( e.can_link_up() && e.link().charge_rate > 0 ) {
+            return false;
+        }
+        // Can't mod non-tool, or a tool with existing mods, or a battery currently installed.
         if( !e.is_tool() || !e.toolmods().empty() || e.magazine_current() ) {
             return false;
         }
 
-        // can't mod integrated tools
+        // Can't mod integrated tools
         if( e.has_flag( flag_INTEGRATED ) ) {
             return false;
         }


### PR DESCRIPTION
#### Summary
Disallow non-allied NPC temp tracking and battery modding invalid items

#### Purpose of change
- Neutral NPCs were freezing to death in winter. They should not be tracking temperature at all.
- Battery mods were usable on items with internal batteries. This should logically work, but currently breaks things, so we have to disallow it.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
