### PR TITLE
Fix worldgen UI

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -247,10 +247,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         return true;
     }
     bool via_ramp = false;
-    if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you_pos ) && m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
+    if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you_pos ) &&
+        m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
         dest_loc.z() += 1;
         via_ramp = true;
-    } else if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, you_pos ) && m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest_loc ) ) {
+    } else if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, you_pos ) &&
+               m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest_loc ) ) {
         dest_loc.z() -= 1;
         via_ramp = true;
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11726,9 +11726,11 @@ void Character::stagger()
     tripoint_bub_ms pos = pos_bub();
     for( const tripoint_bub_ms &dest : here.points_in_radius( pos, 1 ) ) {
         if( dest != pos_bub() ) {
-            if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, pos ) && here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
+            if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, pos ) &&
+                here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
                 valid_stumbles.emplace_back( dest + tripoint::below );
-            } else if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, pos ) && here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
+            } else if( !here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, pos ) &&
+                       here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
                 valid_stumbles.emplace_back( dest + tripoint::above );
             } else {
                 valid_stumbles.push_back( dest );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5670,27 +5670,28 @@ bool map::open_door( Creature const &u, const tripoint_bub_ms &p, const bool ins
             furn_set( p, furn.open );
         }
         return true;
-        } else if( const optional_vpart_position vp = veh_at( p ) ) {
-            const optional_vpart_position creature_veh = veh_at( u.pos_bub() );
-            const bool creature_outside =
-                !creature_veh.has_value() ||
-                &creature_veh->vehicle() != &vp->vehicle();
-            const bool player_can_lock = u.attitude_to( get_player_character() ) != Creature::Attitude::FRIENDLY && vp->vehicle().player_is_driving_this_veh( this );
-            if( player_can_lock ) {
-                return false;
-            }
-            const int openable =
-                vp->vehicle().next_part_to_open( vp->part_index(), creature_outside );
-            if( openable >= 0 ) {
-                if( !check_only ) {
-                    if( ( u.is_npc() || u.is_avatar() ) &&
-                        !vp->vehicle().handle_potential_theft( *u.as_character() ) ) {
-                        return false;
-                    }
-                    vp->vehicle().open_all_at( *this, openable );
+    } else if( const optional_vpart_position vp = veh_at( p ) ) {
+        const optional_vpart_position creature_veh = veh_at( u.pos_bub() );
+        const bool creature_outside =
+            !creature_veh.has_value() ||
+            &creature_veh->vehicle() != &vp->vehicle();
+        const bool player_can_lock = u.attitude_to( get_player_character() ) != Creature::Attitude::FRIENDLY
+                                     && vp->vehicle().player_is_driving_this_veh( this );
+        if( player_can_lock ) {
+            return false;
+        }
+        const int openable =
+            vp->vehicle().next_part_to_open( vp->part_index(), creature_outside );
+        if( openable >= 0 ) {
+            if( !check_only ) {
+                if( ( u.is_npc() || u.is_avatar() ) &&
+                    !vp->vehicle().handle_potential_theft( *u.as_character() ) ) {
+                    return false;
                 }
-                return true;
+                vp->vehicle().open_all_at( *this, openable );
             }
+            return true;
+        }
         return false;
     }
     return false;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -934,7 +934,8 @@ void monster::move()
         !here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, pos_bub() ) &&
         !here.has_flag( ter_furn_flag::TFLAG_LIQUID, pos_bub() )
         && has_flag( mon_flag_AQUATIC ) && !has_flag( mon_flag_NO_BREATHE ) && one_in( 20 ) ) {
-        add_msg_if_player_sees( *this, _( "The %s flops around in a vain attempt to return to the water." ), name() );
+        add_msg_if_player_sees( *this, _( "The %s flops around in a vain attempt to return to the water." ),
+                                name() );
         die( &here, nullptr );
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4095,7 +4095,9 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
     }
     // Only trigger this if the monster is not friendly or the source isn't us or the player.
     // Skip if the sound is quiet-ish, or we've already hear a louder sound recently.
-    if( source != pos_bub() && volume > 15 && ( friendly == 0 || source != get_player_character().pos_bub() ) && get_effect_int( effect_sound_triggered ) < volume ) {
+    if( source != pos_bub() && volume > 15 && ( friendly == 0 ||
+            source != get_player_character().pos_bub() ) &&
+        get_effect_int( effect_sound_triggered ) < volume ) {
         add_effect( effect_sound_triggered, ( 1_seconds * rng( 2, 10 ) ), false, std::min( volume, 400 ) );
         int trigger_strength = std::max( 0, volume - 15 );
         process_trigger( mon_trigger::SOUND, trigger_strength );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1350,7 +1350,7 @@ static std::string assemble_stat_details( avatar &u, int sel )
 
                 + colorize( string_format( _( "\nRead times: %d%%" ), read_spd ),
                             ( read_spd == 100 ? COL_STAT_NEUTRAL :
-                                            ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
+                              ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
                 + colorize(
                     string_format( _( "\nFocus modifier: %+g%%" ), effective_focus ),
                     effective_focus == 0.0 ? COL_STAT_NEUTRAL :

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1719,7 +1719,7 @@ void Character::hardcoded_effects( effect &it )
                             translate_marker( "arm" ), translate_marker( "hand" ), translate_marker( "leg" )
                         } );
                         add_msg_if_player( m_bad, string_format(
-                                            _( "Your %s suddenly jerks in an unexpected direction!" ), _( limb ) ) );
+                                               _( "Your %s suddenly jerks in an unexpected direction!" ), _( limb ) ) );
                         if( limb == "arm" ) {
                             mod_dex_bonus( -8 );
                             release_grapple();
@@ -1732,7 +1732,7 @@ void Character::hardcoded_effects( effect &it )
                                     put_into_vehicle_or_drop( *this, item_drop_reason::tumbling, { remove_weapon() } );
                                 } else {
                                     add_msg_if_player( m_neutral, _( "You manage to keep hold of your %s." ),
-                                                    get_wielded_item()->tname() );
+                                                       get_wielded_item()->tname() );
                                 }
                             }
                         } else if( limb == "leg" && !is_on_ground() ) {
@@ -1747,7 +1747,7 @@ void Character::hardcoded_effects( effect &it )
                     if( one_turn_in( 2_days / mod ) && !has_effect( effect_valium ) &&
                         !has_effect( effect_took_xanax ) ) {
                         add_msg_if_player( m_bad,
-                                        _( "Your strength suddenly fails you, you can't even support your own weight!" ) );
+                                           _( "Your strength suddenly fails you, you can't even support your own weight!" ) );
                         schedule_effect( effect_motor_seizure, rng( 1_seconds, 2_seconds ) );
                         if( !is_on_ground() ) {
                             schedule_effect( effect_downed, rng( 5_seconds, 10_seconds ) );
@@ -1764,7 +1764,7 @@ void Character::hardcoded_effects( effect &it )
                         mod_pain( 12 );
                     }
                 }
-            break;
+                break;
         }
     }
 }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1365,7 +1365,8 @@ void suffer::from_radiation( Character &you )
         // 200 rads = 100 / 10000 = 1 / 100
         // 1000 rads = 900 / 10000 = 9 / 100 = 10% !!!
         // 2000 rads = 2000 / 10000 = 1 / 5 = 20% !!!
-        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) || !one_in( 3 ) ) {
+        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) ||
+            !one_in( 3 ) ) {
             if( rng( 100, 10000 ) < you.get_rad() ) {
                 get_event_bus().send<event_type::character_radioactively_mutates>( you.getID() );
             }
@@ -1379,7 +1380,8 @@ void suffer::from_radiation( Character &you )
 
     const bool radiogenic = you.has_trait( trait_RADIOGENIC );
     if( radiogenic && calendar::once_every( 30_minutes ) && you.get_rad() > 0 ) {
-        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) || !one_in( 3 ) ) {
+        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) ||
+            !one_in( 3 ) ) {
             // At 200 radioactivity, we heal about 48 hp/day.
             if( x_in_y( you.get_rad(), 400 ) ) {
                 you.healall( 1 );
@@ -1393,7 +1395,8 @@ void suffer::from_radiation( Character &you )
     }
 
     if( calendar::once_every( 1_days ) ) {
-        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) || !one_in( 3 ) ) {
+        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) ||
+            !one_in( 3 ) ) {
             int lifestyle_modifier = you.get_rad();
             if( lifestyle_modifier > 0 ) {
                 if( you.has_trait( trait_RADIOGENIC ) ) {
@@ -1406,7 +1409,8 @@ void suffer::from_radiation( Character &you )
     }
 
     if( you.get_rad() > 200 && calendar::once_every( 10_minutes ) && x_in_y( you.get_rad(), 1000 ) ) {
-        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) || !one_in( 3 ) ) {
+        if( ( !you.has_trait( trait_CHITIN2 ) && !you.has_trait( trait_CRUSTACEAN_CARAPACE ) ) ||
+            !one_in( 3 ) ) {
             you.hurtall( 1, nullptr, true, false );
         }
         you.mod_rad( -5 );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1444,35 +1444,6 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
     return tab_output;
 }
 
-static std::string get_opt_slider( int width, int current, int max, bool no_color,
-                                   bool no_selector = false )
-{
-    int new_cur = clamp<int>( std::round( ( width * current ) / static_cast<float>( max ) ),
-                              0, width - 1 );
-    if( no_selector ) {
-        new_cur = -2;
-    }
-
-    std::string ret;
-    for( int i = 0; i < width; i++ ) {
-        char ch = '-';
-        if( i == new_cur - 1 ) {
-            ch = '<';
-        } else if( i == new_cur + 1 ) {
-            ch = '>';
-        } else if( i == new_cur ) {
-            ch = '|';
-        }
-        if( !no_color && ch != '-' ) {
-            ret.append( colorize( std::string( 1, ch ), c_yellow ) );
-        } else {
-            ret.append( 1, ch );
-        }
-    }
-
-    return ret;
-}
-
 int worldfactory::show_worldgen_basic( WORLD *world )
 {
     catacurses::window w_confirmation;
@@ -1499,7 +1470,7 @@ int worldfactory::show_worldgen_basic( WORLD *world )
     ctxt.register_action( "MOUSE_MOVE" );
 
     int win_height = 0;
-    int content_height = 0; // buttons & sliders
+    int content_height = 0;
     bool recalc_startpos = false;
     const auto init_windows = [&]( ui_adaptor & ui ) {
         recalc_startpos = true;
@@ -1517,36 +1488,17 @@ int worldfactory::show_worldgen_basic( WORLD *world )
     ui.on_screen_resize( init_windows );
 
     bool noname = false;
-    bool custom_opts = false;
 
     std::map<int, inclusive_rectangle<point>> btn_map;
-    std::map<int, inclusive_rectangle<point>> slider_inc_map;
-    std::vector<option_slider_id> wg_sliders; // option sliders
-    std::vector<int> wg_slevels; // current slider levels
     std::string worldname = world->world_name;
     int sel_opt = 0;
     int top_opt = 0;
 
-    for( const option_slider &osl : option_slider::get_all() ) {
-        if( osl.context() == "WORLDGEN" ) {
-            wg_sliders.emplace_back( osl.id );
-            wg_slevels.emplace_back( osl.default_level() );
-        }
-    }
-    const std::vector<int> wg_slvl_default = wg_slevels; // save default slider levels
-
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        slider_inc_map.clear();
         btn_map.clear();
         const int win_width = getmaxx( w_confirmation ) - 2;
 
         int start = top_opt == 0 ? 0 : ( 2 + ( top_opt - 1 ) * 3 );
-        int sel_y = sel_opt == 0 ? 0 :
-                    ( sel_opt <= static_cast<int>( wg_sliders.size() ) ?
-                      ( 2 + ( sel_opt - 1 ) * 3 ) : ( 2 + wg_sliders.size() * 3 ) );
-        if( recalc_startpos ) {
-            calcStartPos( start, sel_y, content_height, wg_sliders.size() * 3 + 4 );
-        }
         top_opt = start < 2 ? 0 : start / 3 + 1;
 
         werase( w_confirmation );
@@ -1571,80 +1523,11 @@ int worldfactory::show_worldgen_basic( WORLD *world )
                              namebar_pos + point( name_txt_width, 0 ) ) );
         }
 
-        // Slider options
-        int y = namebar_pos.y + ( top_opt == 0 ? 2 : 0 );
-        bool all_sliders_drawn = false;
-        for( int i = top_opt == 0 ? 0 : top_opt - 1;
-             i < static_cast<int>( wg_sliders.size() ) && y < content_height - 2; i++, y++ ) {
-            std::string sl_txt = get_opt_slider( win_width / 2 - 2, wg_slevels[i],
-                                                 wg_sliders[i]->count() - 1,
-                                                 i == sel_opt - 1, custom_opts );
-            trim_and_print( w_confirmation, point( 3, y++ ), win_width,
-                            c_white, wg_sliders[i]->name().translated() );
-            trim_and_print( w_confirmation, point( 3, y ), win_width,
-                            i == sel_opt - 1 ? hilite( c_white ) : c_white, sl_txt );
-            if( i == sel_opt - 1 ) {
-                mvwputch( w_confirmation, point( 1, y ), hilite( c_yellow ), '<' );
-                mvwputch( w_confirmation, point( 2 + win_width / 2, y ), hilite( c_yellow ), '>' );
-            }
-            slider_inc_map.emplace( i * 2, inclusive_rectangle<point>( point( 1, y ), point( 1, y ) ) );
-            slider_inc_map.emplace( i * 2 + 1, inclusive_rectangle<point>( point( 2 + win_width / 2, y ),
-                                    point( 2 + win_width / 2, y ) ) );
-            mvwprintz( w_confirmation, point( 5 + win_width / 2, y++ ), c_white,
-                       custom_opts ? _( "Custom" ) : wg_sliders[i]->level_name( wg_slevels[i] ).translated() );
-            btn_map.emplace( 1 + i,
-                             inclusive_rectangle<point>( point( 1, y - 1 ), point( 2 + win_width / 2, y - 1 ) ) );
-            if( i == static_cast<int>( wg_sliders.size() ) - 1 ) {
-                all_sliders_drawn = true;
-            }
-        }
-
-        auto get_clr = []( const nc_color & base, bool hi ) {
-            return hi ? hilite( base ) : base;
-        };
-
-        if( all_sliders_drawn && y <= content_height ) {
-            // Finish button
-            nc_color acc_clr = get_clr( c_yellow, sel_opt == static_cast<int>( wg_sliders.size() + 1 ) );
-            nc_color acc_clr2 = get_clr( c_light_green, sel_opt == static_cast<int>( wg_sliders.size() + 1 ) );
-            nc_color base_clr = get_clr( c_white, sel_opt == static_cast<int>( wg_sliders.size() + 1 ) );
-            std::string btn_txt = string_format( "%s%s%s %s %s", colorize( "[", acc_clr ),
-                                                 colorize( ctxt.get_desc( "FINALIZE", 1U ), acc_clr2 ),
-                                                 colorize( "][", acc_clr ), _( "Finish" ), colorize( "]", acc_clr ) );
-            const point finish_pos( win_width / 4 - utf8_width( btn_txt, true ) / 2, y );
-            print_colored_text( w_confirmation, finish_pos, base_clr, base_clr, btn_txt );
-            btn_map.emplace( static_cast<int>( wg_sliders.size() + 1 ),
-                             inclusive_rectangle<point>( finish_pos, finish_pos + point( utf8_width( btn_txt, true ), 0 ) ) );
-            // Reset button
-            acc_clr = get_clr( c_yellow, sel_opt == static_cast<int>( wg_sliders.size() + 2 ) );
-            acc_clr2 = get_clr( c_light_green, sel_opt == static_cast<int>( wg_sliders.size() + 2 ) );
-            base_clr = get_clr( c_white, sel_opt == static_cast<int>( wg_sliders.size() + 2 ) );
-            btn_txt = string_format( "%s%s%s %s %s", colorize( "[", acc_clr ),
-                                     colorize( ctxt.get_desc( "RESET", 1U ), acc_clr2 ),
-                                     colorize( "][", acc_clr ), _( "Reset" ), colorize( "]", acc_clr ) );
-            const point reset_pos( win_width / 2 - utf8_width( btn_txt, true ) / 2, y );
-            print_colored_text( w_confirmation, reset_pos, base_clr, base_clr, btn_txt );
-            btn_map.emplace( static_cast<int>( wg_sliders.size() + 2 ),
-                             inclusive_rectangle<point>( reset_pos, reset_pos + point( utf8_width( btn_txt, true ), 0 ) ) );
-            // Randomize button
-            acc_clr = get_clr( c_yellow, sel_opt == static_cast<int>( wg_sliders.size() + 3 ) );
-            acc_clr2 = get_clr( c_light_green, sel_opt == static_cast<int>( wg_sliders.size() + 3 ) );
-            base_clr = get_clr( c_white, sel_opt == static_cast<int>( wg_sliders.size() + 3 ) );
-            btn_txt = string_format( "%s%s%s %s %s", colorize( "[", acc_clr ),
-                                     colorize( ctxt.get_desc( "RANDOMIZE", 1U ), acc_clr2 ),
-                                     colorize( "][", acc_clr ), _( "Randomize" ), colorize( "]", acc_clr ) );
-            const point rand_pos( ( win_width * 3 ) / 4 - utf8_width( btn_txt, true ) / 2, y++ );
-            print_colored_text( w_confirmation, rand_pos, base_clr, base_clr, btn_txt );
-            btn_map.emplace( static_cast<int>( wg_sliders.size() + 3 ),
-                             inclusive_rectangle<point>( rand_pos, rand_pos + point( utf8_width( btn_txt, true ), 0 ) ) );
-        }
-
         // Content scrollbar
         scrollbar()
         .border_color( BORDER_COLOR )
         .offset_x( 0 )
         .offset_y( 1 )
-        .content_size( wg_sliders.size() * 3 + 3 )
         .viewport_pos( top_opt * 3 )
         .viewport_size( content_height )
         .apply( w_confirmation );
@@ -1657,36 +1540,34 @@ int worldfactory::show_worldgen_basic( WORLD *world )
         wattroff( w_confirmation, BORDER_COLOR );
 
         // Hint text
-        std::string hint_txt =
-            string_format( _( "Press [<color_yellow>%s</color>] to pick a random name for your world.\n"
-                              "Navigate options with [<color_yellow>directional keys</color>] "
-                              "and confirm with [<color_yellow>%s</color>].\n"
-                              "Press [<color_yellow>%s</color>] to see additional control information." ),
-                           ctxt.get_desc( "PICK_RANDOM_WORLDNAME", 1U ), ctxt.get_desc( "CONFIRM", 1U ),
+        nc_color dummy = c_light_gray;
+        std::string finalize_txt =
+            string_format( _( "Press [<color_yellow>%s</color>] to finalize your world." ),
+                           ctxt.get_desc( "FINALIZE", 1U ) );
+
+        print_colored_text( w_confirmation, point( 2, win_height - 9 ), dummy, c_light_gray, finalize_txt );
+
+        std::string randomize_txt =
+            string_format( _( "Press [<color_yellow>%s</color>] to pick a random name for your world." ),
+                           ctxt.get_desc( "PICK_RANDOM_WORLDNAME", 1U ) );
+
+        print_colored_text( w_confirmation, point( 2, win_height - 8 ), dummy, c_light_gray,
+                            randomize_txt );
+
+        std::string keybind_txt =
+            string_format( _( "Press [<color_yellow>%s</color>] to see additional control information." ),
                            ctxt.get_desc( "HELP_KEYBINDINGS", 1U ) );
-        if( !custom_opts && sel_opt > 0 && sel_opt <= static_cast<int>( wg_sliders.size() ) ) {
-            hint_txt = wg_sliders[sel_opt - 1]->level_desc( wg_slevels[sel_opt - 1] ).translated();
-        }
-        y += fold_and_print( w_confirmation, point( 2, win_height - 9 ),
-                             win_width - 1, c_light_gray, hint_txt ) + 1;
+
+        print_colored_text( w_confirmation, point( 2, win_height - 7 ), dummy, c_light_gray, keybind_txt );
 
         // Advanced settings legend
-        nc_color dummy = c_light_gray;
         std::string sctxt = string_format( _( "[<color_yellow>%s</color>] - Advanced options" ),
                                            ctxt.get_desc( "ADVANCED_SETTINGS", 1U ) );
         mvwprintz( w_confirmation, point( 2, win_height - 4 ), c_light_gray, _( "Advanced settings:" ) );
         print_colored_text( w_confirmation, point( 2, win_height - 3 ), dummy, c_light_gray, sctxt );
-        btn_map.emplace( static_cast<int>( wg_sliders.size() + 4 ),
-                         inclusive_rectangle<point>(
-                             point( 2, win_height - 3 ),
-                             point( 2 + utf8_width( sctxt, true ), win_height - 3 ) ) );
         sctxt = string_format( _( "[<color_yellow>%s</color>] - Open mod manager" ),
                                ctxt.get_desc( "PICK_MODS", 1U ) );
         print_colored_text( w_confirmation, point( 2, win_height - 2 ), dummy, c_light_gray, sctxt );
-        btn_map.emplace( static_cast<int>( wg_sliders.size() + 5 ),
-                         inclusive_rectangle<point>(
-                             point( 2, win_height - 2 ),
-                             point( 2 + utf8_width( sctxt, true ), win_height - 2 ) ) );
         wnoutrefresh( w_confirmation );
     } );
 
@@ -1695,44 +1576,32 @@ int worldfactory::show_worldgen_basic( WORLD *world )
 
         recalc_startpos = false;
         std::string action = ctxt.handle_input();
-        // Handle mouse input
-        if( action == "MOUSE_MOVE" || action == "SELECT" ) {
-            std::optional<point> coord = ctxt.get_coordinates_text( w_confirmation );
-            if( !!coord ) {
-                int orig_opt = sel_opt;
-                bool found = run_for_point_in<int, point>( btn_map, *coord,
-                [&sel_opt]( const std::pair<int, inclusive_rectangle<point>> &p ) {
-                    sel_opt = p.first;
-                } ) > 0;
-                if( found && action == "SELECT" ) {
-                    if( sel_opt == static_cast<int>( wg_sliders.size() + 4 ) ) {
-                        action = "ADVANCED_SETTINGS";
-                    } else if( sel_opt == static_cast<int>( wg_sliders.size() + 5 ) ) {
-                        action = "PICK_MODS";
-                    } else {
-                        action = "CONFIRM";
-                        run_for_point_in<int, point>( slider_inc_map, *coord,
-                        [&action]( const std::pair<int, inclusive_rectangle<point>> &p ) {
-                            action = p.first % 2 == 0 ? "LEFT" : "RIGHT";
-                        } );
-                    }
-                }
-                if( sel_opt > static_cast<int>( wg_sliders.size() + 3 ) ) {
-                    sel_opt = orig_opt;
-                }
-            }
-        }
 
         // Button shortcuts
         if( action == "FINALIZE" ) {
-            action = "CONFIRM";
-            sel_opt = wg_sliders.size() + 1;
+            if( worldname.empty() ) {
+                noname = true;
+                ui.invalidate_ui();
+                if( !query_yn( _( "Are you sure you're finished?  World name will be randomly generated." ) ) ) {
+                    noname = false;
+                    continue;
+                } else {
+                    noname = false;
+                    world->world_name = pick_random_name();
+                    if( !valid_worldname( world->world_name ) ) {
+                        continue;
+                    }
+                    return 1;
+                }
+            } else if( valid_worldname( worldname ) && query_yn( _( "Are you sure you're finished?" ) ) ) {
+                world->world_name = worldname;
+                return 1;
+            }
         } else if( action == "RESET" ) {
-            action = "CONFIRM";
-            sel_opt = wg_sliders.size() + 2;
+            world->active_mod_order = world_generator->get_mod_manager().get_default_mods();
+            world->world_name = worldname = pick_random_name();
         } else if( action == "RANDOMIZE" ) {
-            action = "CONFIRM";
-            sel_opt = wg_sliders.size() + 3;
+            world->world_name = worldname = pick_random_name();
         }
 
         // Handle other inputs
@@ -1743,62 +1612,6 @@ int worldfactory::show_worldgen_basic( WORLD *world )
                 if( !ret.value_or( "" ).empty() ) {
                     world->world_name = worldname = ret.value();
                 }
-            } else if( sel_opt == static_cast<int>( wg_sliders.size() + 1 ) ) {
-                // finish
-                if( worldname.empty() ) {
-                    noname = true;
-                    ui.invalidate_ui();
-                    if( !query_yn( _( "Are you SURE you're finished?  World name will be randomly generated." ) ) ) {
-                        noname = false;
-                        continue;
-                    } else {
-                        noname = false;
-                        world->world_name = pick_random_name();
-                        if( !valid_worldname( world->world_name ) ) {
-                            continue;
-                        }
-                        return 1;
-                    }
-                } else if( valid_worldname( worldname ) && query_yn( _( "Are you SURE you're finished?" ) ) ) {
-                    world->world_name = worldname;
-                    return 1;
-                }
-            } else if( sel_opt == static_cast<int>( wg_sliders.size() + 2 ) &&
-                       query_yn( _( "Are you sure you want to reset this world?" ) ) ) {
-                // reset
-                world->WORLD_OPTIONS = get_options().get_world_defaults();
-                world->world_saves.clear();
-                world->active_mod_order = world_generator->get_mod_manager().get_default_mods();
-                wg_slevels = wg_slvl_default;
-                custom_opts = false;
-            } else if( sel_opt == static_cast<int>( wg_sliders.size() + 3 ) ) {
-                // randomize
-                for( int i = 0; i < static_cast<int>( wg_sliders.size() ); i++ ) {
-                    wg_slevels[i] = wg_sliders[i]->random_level();
-                }
-            }
-        } else if( navigate_ui_list( action, sel_opt, 1, wg_sliders.size() + 2, true ) ) {
-            recalc_startpos = true;
-        } else if( action == "LEFT" || action == "RIGHT" ) {
-            if( sel_opt > 0 && sel_opt <= static_cast<int>( wg_sliders.size() ) ) {
-                if( custom_opts && query_yn( _( "Currently using customized advanced options.  "
-                                                "Reset world options to defaults?" ) ) ) {
-                    world->WORLD_OPTIONS = get_options().get_world_defaults();
-                    wg_slevels = wg_slvl_default;
-                    custom_opts = false;
-                    continue;
-                } else if( custom_opts ) {
-                    continue;
-                }
-                int lvl = wg_slevels[sel_opt - 1] + ( action == "LEFT" ? -1 : 1 );
-                wg_slevels[sel_opt - 1] = clamp<int>( lvl, 0, wg_sliders[sel_opt - 1]->count() - 1 );
-                wg_sliders[sel_opt - 1]->apply_opts( wg_slevels[sel_opt - 1], world->WORLD_OPTIONS );
-            } else if( sel_opt > static_cast<int>( wg_sliders.size() ) ) {
-                if( action == "LEFT" && sel_opt > static_cast<int>( wg_sliders.size() + 1 ) ) {
-                    sel_opt--;
-                } else if( action == "RIGHT" && sel_opt < static_cast<int>( wg_sliders.size() + 3 ) ) {
-                    sel_opt++;
-                }
             }
         } else if( action == "PICK_MODS" ) {
             show_worldgen_tab_modselection( w_confirmation, world, false );
@@ -1807,7 +1620,6 @@ int worldfactory::show_worldgen_basic( WORLD *world )
             show_worldgen_tab_options( w_confirmation, world, false );
             for( auto &iter : WOPTIONS_OLD ) {
                 if( iter.second != world->WORLD_OPTIONS[iter.first] ) {
-                    custom_opts = true;
                     break;
                 }
             }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -1476,12 +1476,9 @@ int worldfactory::show_worldgen_basic( WORLD *world )
         recalc_startpos = true;
         const int iMinScreenWidth = std::max( FULL_SCREEN_WIDTH, TERMX / 2 );
         const int iOffsetX = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - iMinScreenWidth ) / 2 : 0;
-
         w_confirmation = catacurses::newwin( TERMY, iMinScreenWidth, point( iOffsetX, 0 ) );
-
         win_height = getmaxy( w_confirmation );
         content_height = win_height - namebar_pos.y - 10;
-
         ui.position_from_window( w_confirmation );
     };
     init_windows( ui );


### PR DESCRIPTION
#### Summary
Fix worldgen UI

#### Purpose of change
Following the last of the sliders being removed (they're still in options accessible via the s key) the worldgen UI was missing a button prompt. I didn't notice becuause the button still worked and so did my muscle memory.

#### Describe the solution
Rip out the rest of the slider code and fix the prompt.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
