### PR TITLE
Nerf more artifact stuff

### DIFF
--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -64,7 +64,7 @@
       {
         "weight": 100,
         "min_value": -0.5,
-        "max_value": 2,
+        "max_value": 1.5,
         "type": "MAX_HP",
         "increment": 0.1,
         "power_per_increment": 100
@@ -72,10 +72,10 @@
       {
         "weight": 100,
         "min_value": -0.5,
-        "max_value": 2,
+        "max_value": 1.5,
         "type": "REGEN_HP",
         "increment": 0.1,
-        "power_per_increment": 50
+        "power_per_increment": 100
       },
       {
         "weight": 100,

--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -112,10 +112,10 @@
       {
         "weight": 50,
         "min_value": -0.5,
-        "max_value": 1.0,
+        "max_value": 0.5,
         "type": "REGEN_STAMINA",
         "increment": 0.1,
-        "power_per_increment": 100
+        "power_per_increment": 200
       },
       {
         "weight": 25,
@@ -127,7 +127,7 @@
       },
       {
         "weight": 35,
-        "min_value": -0.75,
+        "min_value": -0.25,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
         "increment": 0.05,
@@ -310,15 +310,15 @@
       },
       {
         "weight": 50,
-        "min_value": -0.4,
-        "max_value": 0.2,
+        "min_value": -0.2,
+        "max_value": 0.4,
         "type": "MOVE_COST",
         "increment": 0.1,
         "power_per_increment": -250
       },
       {
         "weight": 100,
-        "min_value": -0.5,
+        "min_value": -0.2,
         "max_value": 0.5,
         "type": "ATTACK_SPEED",
         "increment": 0.1,
@@ -335,10 +335,10 @@
       {
         "weight": 50,
         "min_value": -0.5,
-        "max_value": 1.0,
+        "max_value": 0.5,
         "type": "REGEN_STAMINA",
         "increment": 0.1,
-        "power_per_increment": 100
+        "power_per_increment": 200
       },
       {
         "weight": 25,
@@ -350,7 +350,7 @@
       },
       {
         "weight": 35,
-        "min_value": -0.75,
+        "min_value": -0.25,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
         "increment": 0.05,
@@ -537,15 +537,15 @@
       },
       {
         "weight": 50,
-        "min_value": -0.4,
-        "max_value": 0.2,
+        "min_value": -0.2,
+        "max_value": 0.4,
         "type": "MOVE_COST",
         "increment": 0.1,
         "power_per_increment": -250
       },
       {
         "weight": 100,
-        "min_value": -0.5,
+        "min_value": -0.2,
         "max_value": 0.5,
         "type": "ATTACK_SPEED",
         "increment": 0.1,
@@ -562,10 +562,10 @@
       {
         "weight": 50,
         "min_value": -0.5,
-        "max_value": 1.0,
+        "max_value": 0.5,
         "type": "REGEN_STAMINA",
         "increment": 0.1,
-        "power_per_increment": 100
+        "power_per_increment": 200
       },
       {
         "weight": 25,
@@ -577,7 +577,7 @@
       },
       {
         "weight": 35,
-        "min_value": -0.75,
+        "min_value": -0.25,
         "max_value": 0.5,
         "type": "WEAPON_DISPERSION",
         "increment": 0.05,


### PR DESCRIPTION
#### Summary
Nerf more artifact stuff

#### Purpose of change
A bunch of the artifact multipliers had bonkers values, like double hp or a SEVENTY-FIVE PERCENT REDUCTION IN WEAPON DISPERSION???

#### Describe the solution
Bring these down to "reasonable" values. They still stack which sucks. The whole system needs an overhaul so that every artifact has an upside and a downside that both matter, and hopefully make sense together.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
