### PR TITLE
Fix gum, smokes, and liquid soap menu actions

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2102,9 +2102,10 @@
   },
   {
     "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
+    "subtypes": [ "AMMO" ],
     "id": "liquid_soap",
     "name": { "str_sp": "liquid soap" },
+    "ammo_type": "components",
     "category": "chems",
     "weight": "46 g",
     "//": "Density of around 0.92 g/ml",
@@ -2119,8 +2120,7 @@
     "phase": "liquid",
     "flags": [ "DETERGENT" ],
     "use_action": [ "WASH_ALL_ITEMS" ],
-    "comestible_type": "INVALID",
-    "charges": 5
+    "count": 5
   },
   {
     "id": "pine_resin",

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1739,12 +1739,12 @@ bool Character::can_estimate_rot() const
 
 bool Character::can_consume_as_is( const item &it ) const
 {
-    if( it.is_comestible() ) {
-        return !it.has_flag( flag_NO_INGEST ) && ( !it.has_flag( flag_FROZEN ) ||
-                it.has_flag( flag_EDIBLE_FROZEN ) ||
-                it.has_flag( flag_MELTS ) );
+    if( !it.is_comestible() ) {
+        return false;
     }
-    return false;
+
+    return ( !it.has_flag( flag_NO_INGEST ) || it.get_comestible()->comesttype == "MED" || it.type->can_use( "CHEW" ) ) &&
+           ( !it.has_flag( flag_FROZEN ) || it.has_flag( flag_EDIBLE_FROZEN ) || it.has_flag( flag_MELTS ) );
 }
 
 bool Character::can_consume_rot() const


### PR DESCRIPTION
#### Summary
Fix gum, smokes, and liquid soap menu actions

#### Purpose of change
- Liquid soap wasn't appearing in the activate menu.
- Cigarettes weren't appearing in the consumption menu.
- Gum wasn't appearing in the consumption menu.

#### Describe the solution
Make liquid soap into an ammo instead of a comestible. Add an exception to can_consume_as_is which specifically lets the "CHEW" iuse in and anything that's flagged as a med even if it isn't ingestible.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
