### PR TITLE
Fix gum and sleep deprivation

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -296,9 +296,8 @@
     "symbol": "*",
     "color": "white",
     "fun": 1,
-    "flags": [ "NO_INGEST" ],
-    "vitamins": [ [ "caffeine", 90 ] ],
-    "use_action": [ "CHEW" ]
+    "flags": [ "NO_INGEST", "CHEW", "NO_TEMP" ],
+    "vitamins": [ [ "caffeine", 90 ] ]
   },
   {
     "id": "caffeine",
@@ -1378,8 +1377,7 @@
     "addiction_type": "nicotine",
     "addiction_potential": 25,
     "vitamins": [ [ "nicotine_slow", 3 ] ],
-    "flags": [ "NO_INGEST" ],
-    "use_action": [ "CHEW" ]
+    "flags": [ "NO_INGEST", "CHEW", "NO_TEMP" ]
   },
   {
     "id": "nicotine_patch",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -28,8 +28,7 @@
     "symbol": "*",
     "color": "pink",
     "fun": 2,
-    "flags": [ "NO_INGEST", "NO_TEMP" ],
-    "use_action": [ "CHEW" ]
+    "flags": [ "NO_INGEST", "NO_TEMP", "CHEW" ]
   },
   {
     "type": "ITEM",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5863,19 +5863,18 @@ void Character::check_needs_extremes()
             if( sleep_deprivation < SLEEP_DEPRIVATION_MINOR ) {
                 add_msg_if_player( m_warning,
                                    _( "It's been a while since you've slept well, it's fraying at your nerves." ) );
-                mod_fatigue( 5 );
+                mod_fatigue( 20 );
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_SERIOUS ) {
                 add_msg_if_player( m_bad,
                                    _( "Your mind feels foggy from a lack of good sleep, and your eyes keep trying to close against your will." ) );
-                mod_fatigue( 20 );
-
+                mod_fatigue( 50 );
                 if( one_in( 10 ) ) {
                     mod_daily_health( -1, -10 );
                 }
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_MAJOR ) {
                 add_msg_if_player( m_bad,
                                    _( "You feel dazed from lack of sleep." ) );
-                mod_fatigue( 35 );
+                mod_fatigue( 75 );
 
                 if( one_in( 5 ) ) {
                     mod_daily_health( -2, -10 );
@@ -5883,7 +5882,7 @@ void Character::check_needs_extremes()
             } else if( sleep_deprivation < SLEEP_DEPRIVATION_MASSIVE ) {
                 add_msg_if_player( m_bad,
                                    _( "You can't concentrate.  You need sleep." ) );
-                mod_fatigue( 50 );
+                mod_fatigue( 100 );
                 mod_daily_health( -5, -10 );
             }
             // Microsleeps are slightly worse if you're sleep deprived, but not by much. (chance: 1 in (75 + int_cur) at lethal sleep deprivation)

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -905,7 +905,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     }
 
     // Here's why PROBOSCIS is such a negative trait.
-    if( has_trait( trait_PROBOSCIS ) && !( drinkable || food.is_medication() ) ) {
+    if( has_trait( trait_PROBOSCIS ) && !( drinkable || food.is_medication() || food.has_flag( flag_CHEW ) ) ) {
         return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, _( "Ugh, you can't drink that!" ) );
     }
 
@@ -1743,7 +1743,7 @@ bool Character::can_consume_as_is( const item &it ) const
         return false;
     }
 
-    return ( !it.has_flag( flag_NO_INGEST ) || it.get_comestible()->comesttype == "MED" || it.type->can_use( "CHEW" ) ) &&
+    return ( !it.has_flag( flag_NO_INGEST ) || it.get_comestible()->comesttype == "MED" || it.has_flag( flag_CHEW ) ) &&
            ( !it.has_flag( flag_FROZEN ) || it.has_flag( flag_EDIBLE_FROZEN ) || it.has_flag( flag_MELTS ) );
 }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -905,7 +905,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
     }
 
     // Here's why PROBOSCIS is such a negative trait.
-    if( has_trait( trait_PROBOSCIS ) && !( drinkable || food.is_medication() || food.has_flag( flag_CHEW ) ) ) {
+    if( has_trait( trait_PROBOSCIS ) && !drinkable && ( !food.is_medication() || food.has_flag( flag_CHEW ) ) ) {
         return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, _( "Ugh, you can't drink that!" ) );
     }
 

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -66,6 +66,7 @@ const flag_id flag_CASING( "CASING" );
 const flag_id flag_CATTLE( "CATTLE" );
 const flag_id flag_CHALLENGE( "CHALLENGE" );
 const flag_id flag_CHARGEDIM( "CHARGEDIM" );
+const flag_id flag_CHEW( "CHEW" );
 const flag_id flag_CHOKE( "CHOKE" );
 const flag_id flag_CITY_START( "CITY_START" );
 const flag_id flag_COLD( "COLD" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -74,6 +74,7 @@ extern const flag_id flag_CASING;
 extern const flag_id flag_CATTLE;
 extern const flag_id flag_CHALLENGE;
 extern const flag_id flag_CHARGEDIM;
+extern const flag_id flag_CHEW;
 extern const flag_id flag_CHOKE;
 extern const flag_id flag_CITY_START;
 extern const flag_id flag_COLD;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1993,7 +1993,6 @@ void Item_factory::init()
     add_iuse( "DIRECTIONAL_HOLOGRAM", &iuse::directional_hologram );
     add_iuse( "CAPTURE_MONSTER_ACT", &iuse::capture_monster_act );
     add_iuse( "CAPTURE_MONSTER_VEH", &iuse::capture_monster_veh );
-    add_iuse( "CHEW", &iuse::chew );
     add_iuse( "RPGDIE", &iuse::rpgdie );
     add_iuse( "CHANGE_EYES", &iuse::change_eyes );
     add_iuse( "CHANGE_SKIN", &iuse::change_skin );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1073,13 +1073,6 @@ std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint_bub_
     }
 }
 
-std::optional<int> iuse::chew( Character *p, item *it, const tripoint_bub_ms & )
-{
-    // TODO: Add more effects?
-    p->add_msg_if_player( _( "You chew your %s." ), it->tname() );
-    return 1;
-}
-
 // Helper to handle the logic of removing some random mutations.
 static void do_purify( Character &p )
 {

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -37,7 +37,6 @@ std::optional<int> antifungal( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> antiparasitic( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> blech( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> blech_because_unclean( Character *, item *, const tripoint_bub_ms & );
-std::optional<int> chew( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> coke( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> datura( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> ecig( Character *, item *, const tripoint_bub_ms & );


### PR DESCRIPTION
#### Summary
Fix gum and sleep deprivation

#### Purpose of change
- Gum was being jammed up by a use action which literally didn't do anything.
- Sleep was still an issue for people who were using normal amounts of caffeine.

#### Describe the solution
- Removed the use_action and just made its behavior flag-dependent.
- Sleep deprivation now adds a lot more fatigue.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
