### PR TITLE
Remove mostly dead vehicle blood code

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13040,7 +13040,6 @@ bool item::allow_crafting_component() const
         return true;
     }
 
-    // fixes #18886 - turret installation may require items with irremovable mods
     if( is_gun() ) {
         bool valid = true;
         visit_items( [&]( const item * it, item * ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4118,10 +4118,6 @@ bool map::terrain_moppable( const tripoint_bub_ms &p )
         vehicle *const veh = &ovp->vehicle();
         for( const int elem : veh->parts_at_relative( ovp->mount_pos(), true ) ) {
             const vehicle_part &vp = veh->part( elem );
-            if( vp.blood > 0 ) {
-                return true;
-            }
-
             const vehicle_stack items = veh->get_items( vp );
             auto found = std::find_if( items.begin(), items.end(), []( const item & it ) {
                 return it.made_of( phase_id::LIQUID );
@@ -4163,11 +4159,7 @@ bool map::mop_spills( const tripoint_bub_ms &p )
         vehicle *const veh = &ovp->vehicle();
         for( const int elem : veh->parts_at_relative( ovp->mount_pos(), true ) ) {
             vehicle_part &vp = veh->part( elem );
-            if( vp.blood > 0 ) {
-                vp.blood = 0;
-                retval = true;
-            }
-            //remove any liquids that somehow didn't fall through to the ground
+            // Remove any liquids that somehow didn't fall through to the ground.
             vehicle_stack here = veh->get_items( vp );
             auto new_end = std::remove_if( here.begin(), here.end(), []( const item & it ) {
                 return it.made_of( phase_id::LIQUID );
@@ -7693,17 +7685,6 @@ void map::add_splatter( const field_type_id &type, const tripoint_bub_ms &where,
 {
     if( intensity <= 0 ) {
         return;
-    }
-    if( type.obj().is_splattering ) {
-        if( const optional_vpart_position vp = veh_at( where ) ) {
-            vehicle *const veh = &vp->vehicle();
-            // Might be -1 if all the vehicle's parts at where are marked for removal
-            const int part = veh->part_displayed_at( vp->mount_pos(), true );
-            if( part != -1 ) {
-                veh->part( part ).blood += 200 * std::min( intensity, 3 ) / 3;
-                return;
-            }
-        }
     }
     mod_field_intensity( where, type, intensity );
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3599,7 +3599,6 @@ void vehicle_part::deserialize( const JsonObject &data )
     int direction_int;
     data.read( "direction", direction_int );
     direction = units::from_degrees( direction_int );
-    data.read( "blood", blood );
     data.read( "enabled", enabled );
     data.read( "flags", flags );
     data.read( "passenger_id", passenger_id );
@@ -3655,7 +3654,6 @@ void vehicle_part::serialize( JsonOut &json ) const
     json.member( "mount_dy", mount.y() );
     json.member( "open", open );
     json.member( "direction", std::lround( to_degrees( direction ) ) );
-    json.member( "blood", blood );
     json.member( "enabled", enabled );
     json.member( "flags", flags );
     if( !carried_stack.empty() ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -342,8 +342,6 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
     bool destroyTank = false;
     bool destroyEngine = false;
     bool destroyTires = false;
-    bool blood_covered = false;
-    bool blood_inside = false;
     bool has_no_key = false;
     bool destroyAlarm = false;
 
@@ -465,14 +463,6 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             }
         }
 
-        if( one_in( 10 ) ) {
-            blood_covered = true;
-        }
-
-        if( one_in( 8 ) ) {
-            blood_inside = true;
-        }
-
         for( const vpart_reference &vp : get_parts_including_carried( "FRIDGE" ) ) {
             vp.part().enabled = true;
         }
@@ -486,7 +476,6 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
         }
     }
 
-    std::optional<point_rel_ms> blood_inside_pos;
     for( const vpart_reference &vp : get_all_parts() ) {
         const size_t p = vp.part_index();
         vehicle_part &pt = vp.part();
@@ -560,35 +549,6 @@ void vehicle::init_state( map &placed_on, int init_veh_fuel, int init_veh_status
             //Solar panels have 25% of being destroyed
             if( vp.has_feature( "SOLAR_PANEL" ) && one_in( 4 ) && init_veh_status != 2 ) {
                 set_hp( pt, 0, false );
-            }
-
-            /* Bloodsplatter the front-end parts. Assume anything with x > 0 is
-            * the "front" of the vehicle (since the driver's seat is at (0, 0).
-            * We'll be generous with the blood, since some may disappear before
-            * the player gets a chance to see the vehicle. */
-            if( blood_covered && vp.mount_pos().x() > 0 ) {
-                if( one_in( 3 ) ) {
-                    //Loads of blood. (200 = completely red vehicle part)
-                    pt.blood = rng( 200, 600 );
-                } else {
-                    //Some blood
-                    pt.blood = rng( 50, 200 );
-                }
-            }
-
-            if( blood_inside ) {
-                // blood is splattered around (blood_inside_pos),
-                // coordinates relative to mount point; the center is always a seat
-                if( blood_inside_pos ) {
-                    const int distSq = std::pow( blood_inside_pos->x() - vp.mount_pos().x(), 2 ) +
-                                       std::pow( blood_inside_pos->y() - vp.mount_pos().y(), 2 );
-                    if( distSq <= 1 ) {
-                        pt.blood = rng( 200, 400 ) - distSq * 100;
-                    }
-                } else if( vp.has_feature( "SEAT" ) ) {
-                    // Set the center of the bloody mess inside
-                    blood_inside_pos.emplace( vp.mount_pos() );
-                }
             }
         }
         //sets the vehicle to locked, if there is no key and an alarm part exists
@@ -4447,25 +4407,6 @@ int vehicle::safe_velocity( map &here, const bool fueled ) const
     }
 }
 
-bool vehicle::do_environmental_effects( map &here ) const
-{
-    bool needed = false;
-    // check for smoking parts
-    for( const vpart_reference &vp : get_all_parts() ) {
-        /* Only lower blood level if:
-         * - The part is outside.
-         * - The weather is any effect that would cause the player to be wet. */
-        if( vp.part().blood > 0 && here.is_outside( vp.pos_bub( here ) ) ) {
-            needed = true;
-            if( get_weather().weather_id->rains &&
-                get_weather().weather_id->precip != precip_class::very_light ) {
-                vp.part().blood--;
-            }
-        }
-    }
-    return needed;
-}
-
 void vehicle::spew_field( map &here, double joules, int part, field_type_id type,
                           int intensity ) const
 {
@@ -6651,10 +6592,6 @@ void vehicle::gain_moves( map &here )
         get_connected_vehicles( here, vehs );
     }
 
-    if( check_environmental_effects ) {
-        check_environmental_effects = do_environmental_effects( here );
-    }
-
     // turrets which are enabled will try to reload and then automatically fire
     // Turrets which are disabled but have targets set are a special case
     for( vehicle_part *e : turrets() ) {
@@ -6945,7 +6882,6 @@ void vehicle::refresh()
 
     // NB: using the _old_ pivot point, don't recalc here, we only do that when moving!
     precalc_mounts( 0, pivot_rotation[0], pivot_anchor[0] );
-    check_environmental_effects = true;
     insides_dirty = true;
     zones_dirty = true;
     coeff_air_dirty = true;
@@ -8396,8 +8332,6 @@ void vehicle::update_time( map &here, const time_point &update_to )
     time_duration elapsed = update_to - last_update;
     last_update = update_to;
 
-    // Weather stuff, only for z-levels >= 0
-    // TODO: Have it wash cars from blood?
     if( funnels.empty() && solar_panels.empty() && wind_turbines.empty() && water_wheels.empty() ) {
         return;
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -508,9 +508,6 @@ struct vehicle_part {
         npc &get_targeting_npc( vehicle &veh );
         /*@}*/
 
-        /** how much blood covers part (in turns). */
-        int blood = 0;
-
         /**
          * if tile provides cover.
          * WARNING: do not read it directly, use vpart_position::is_inside() instead
@@ -846,9 +843,6 @@ class vehicle
 
         // convert watts over time to battery energy (kJ)
         int power_to_energy_bat( units::power power, const time_duration &d ) const;
-
-        // Do stuff like clean up blood and produce smoke from broken parts. Returns false if nothing needs doing.
-        bool do_environmental_effects( map &here ) const;
 
         // Vehicle fuel indicator (by fuel)
         // TODO: Figure out what coordinate system "point" is in and type it.
@@ -2494,8 +2488,6 @@ class vehicle
         bool precollision_on = true;
         // skidding mode
         bool skidding = false;
-        // has bloody or smoking parts
-        bool check_environmental_effects = false; // NOLINT(cata-serialize)
         // "inside" flags are outdated and need refreshing
         bool insides_dirty = true; // NOLINT(cata-serialize)
         // Is the vehicle hanging in the air and expected to fall down in the next turn?

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -115,13 +115,6 @@ vpart_display vehicle::get_display_of_tile( const point_rel_ms &dp, bool rotate,
         }
     }
 
-    // blood color override
-    if( vp.blood > 200 ) {
-        ret.color = c_red;
-    } else if( vp.blood > 0 ) {
-        ret.color = c_light_red;
-    }
-
     // if cargo has items color is inverted
     const int cargo_part = part_with_feature( dp, VPFLAG_CARGO, true );
     if( cargo_part >= 0 && !get_items( part( cargo_part ) ).empty() ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1143,18 +1143,6 @@ veh_collision vehicle::part_collision( map &here, int part, const tripoint_abs_m
             // We know critter is set for this type.  Assert to inform static
             // analysis.
             cata_assert( critter );
-
-            // No blood from hallucinations
-            if( !critter->is_hallucination() ) {
-                if( vpi.has_flag( "SHARP" ) ) {
-                    vp.blood += 100 + 5 * dam;
-                } else if( dam > rng( 10, 30 ) ) {
-                    vp.blood += 50 + dam * 5 / 2;
-                }
-
-                check_environmental_effects = true;
-            }
-
             time_stunned = time_duration::from_turns( ( rng( 0, dam ) > 10 ) + ( rng( 0, dam ) > 40 ) );
             if( time_stunned > 0_turns ) {
                 critter->add_effect( effect_stunned, time_stunned );


### PR DESCRIPTION
#### Summary
Remove mostly dead vehicle blood code

#### Purpose of change
Did you know there was code for how much blood is on a vehicle? It didn't do anything unless you were playing in ascii, where it would recolor your vehicle tiles. As far as I know, tilesets never supported this feature.

#### Describe the solution
Remove it. A case could be made, but blood is not the only liquid you're getting spilled on your deathmobile, so whatever.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
