### PR TITLE
Fix mp5sd mod slots

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -173,6 +173,17 @@
     "barrel_length": "146 mm",
     "price": "30000 USD",
     "price_postapoc": "140 USD",
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "brass catcher", 1 ],
+      [ "mechanism", 2 ],
+      [ "rail mount", 1 ],
+      [ "sights mount", 1 ],
+      [ "sling", 1 ],
+      [ "stock accessory", 1 ],
+      [ "stock", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
     "built_in_mods": [ "mp5sd_suppressor" ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix mp5sd mod slots

#### Purpose of change
The mp5sd has an integrated suppressor. It was using copy-from from the mp5, which has a muzzle slot. So you could install a suppressor on your suppressor. No.

#### Describe the solution
Add actual mod slots to the mp5sd and remove the muzzle one.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
