### PR TITLE
Make modular guns work on turrets

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -58,16 +58,8 @@
     "copy-from": "rifle_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "small game rifle" },
-    "description": "A venerable .22 caliber lever-action rifle, with a 19-round tube magazine and a classic design that dates back over a century.  Generally used for the hunting of small game like rabbits, the strict taxonomic classification of zombies as 'small game' is debatable, but this decades-old weapon can still be counted upon to help manage the undead population.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "marlin_9a",
-        "name": { "str": "Marlin 39A rifle" },
-        "description": "The oldest and longest-produced shoulder firearm in the world.  Though it fires the weak .22 round, it is highly accurate and damaging, and has essentially no recoil."
-      }
-    ],
+    "name": { "str": "Marlin 39A rifle" },
+    "description": "The oldest and longest-produced shoulder gun in the world.  Though the .22 is not a powerful round, this lever-action rifle is highly accurate and has essentially no recoil.",
     "weight": "2948 g",
     "volume": "2180 ml",
     "longest_side": "1029 mm",
@@ -75,7 +67,7 @@
     "price": "230 USD",
     "price_postapoc": "20 USD",
     "to_hit": -1,
-    "material": [ "iron", "wood" ],
+    "material": [ "steel", "wood" ],
     "symbol": "(",
     "color": "brown",
     "range": 11,
@@ -113,16 +105,8 @@
     "copy-from": "pistol_base",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": ".22 derringer pistol" },
-    "description": "A four barreled, adorably tiny pocket pistol, firing the equally minuscule .22 LR cartridge.  Produced in the early 20th century for trappers, its combat effectiveness is questionable to say the least.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "moss_brownie",
-        "name": { "str": "Mossberg Brownie pistol" },
-        "description": "The first gun produced by O.F. Mossberg & Sons, the Brownie is a small pocket pistol marketed to trappers during the early 20th century.  Its four barrels can accept .22 Short and .22 LR cartridges."
-      }
-    ],
+    "name": { "str": "Mossberg Brownie pistol" },
+    "description": "A four barreled pocket pistol that fires the minuscule .22 LR cartridge.  Produced in the early 20th century for trappers, its combat effectiveness is questionable to say the least.",
     "weight": "286 g",
     "volume": "100 ml",
     "longest_side": "129 mm",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -439,7 +439,7 @@
     "subtypes": [ "GUN" ],
     "copy-from": "rifle_auto",
     "name": { "str": "M4 carbine" },
-    "description": "A popular carbine, long used by the US military.  Though accurate, small, and lightweight, it is infamous for its unreliability when not properly maintained.  It is chambered in 5.56x45mm and accepts STANAG magazines.",
+    "description": "A popular carbine, long used by the US military.  Though accurate, small, and lightweight, it is infamous for its unreliability when not properly maintained.",
     "weight": "880 g",
     "volume": "1760 ml",
     "longest_side": "470 mm",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -31,8 +31,7 @@
       [ "stock accessory", 1 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "NO_TURRET", "FIRE_TWOHAND" ],
-    "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND" ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -101,16 +100,8 @@
     "looks_like": "oa93",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "Rifle caliber pistol" },
+    "name": { "str": "Kel-Tec PLR16 pistol" },
     "description": "This is a semi-automatic pistol chambered in 5.56x45, using a gas piston to reduce length and a frame constructed from reinforced polymer to make it both durable and light-weight.  This one comes with a plastic handguard.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "plr16",
-        "name": { "str": "Kel-Tec PLR16 pistol" },
-        "description": "This is a semi-automatic pistol chambered in 5.56 NATO, using a gas piston to reduce length and a frame constructed from reinforced polymer to make it both durable and light-weight.  This one comes with a plastic handguard."
-      }
-    ],
     "weight": "1800 g",
     "volume": "1665 ml",
     "longest_side": "485 mm",
@@ -258,8 +249,7 @@
       [ "stock", 1 ]
     ],
     "melee_damage": { "bash": 12 },
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
-    "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow."
+    "flags": [ "FIRE_TWOHAND" ]
   },
   {
     "id": "scar_l",
@@ -489,8 +479,7 @@
       [ "stock accessory", 1 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
-    "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND" ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -532,8 +521,7 @@
       [ "stock accessory", 1 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
-    "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND" ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -558,8 +546,7 @@
       }
     ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
-    "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow."
+    "flags": [ "FIRE_TWOHAND" ]
   },
   {
     "id": "m231pfw",
@@ -982,8 +969,7 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET" ],
-    "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -1124,8 +1110,7 @@
       [ "stock accessory", 2 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "NO_TURRET", "EASY_CLEAN" ],
-    "//2": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN" ],
     "melee_damage": { "bash": 10 }
   },
   {

--- a/data/json/items/gun/338lapua.json
+++ b/data/json/items/gun/338lapua.json
@@ -145,16 +145,8 @@
     "looks_like": "modular_ar15",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": "modular sniper rifle" },
+    "name": { "str": "Accuracy International AXMC rifle" },
     "description": "A weapon platform that prides itself on modularity and customizability, this highly accurate precision rifle may be configured with various caliber conversion kits that can allow it to fire either the .338 Lapua, .300 Win Mag, or .308 Winchester cartridges.  The rifle's size prevents it from being a particularly mobile piece of equipment, but the weapon's folding buttstock aids in portability.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "axmc",
-        "name": { "str": "Accuracy International AXMC rifle" },
-        "description": "Produced by the British precision rifle company Accuracy International, the AX Modular Caliber Weapon System is a highly-accurate combat sniper rifle offered to military, law enforcement, and civilian precision marksmen.  The rifle is compatible with a wide range of aftermarket components, including caliber conversion kits, and is built upon a base aluminum chassis, into which the weapon's parts may be installed or removed at the user's discretion."
-      }
-    ],
     "weight": "5420 g",
     "//": "Weight of gun plus muzzle break and empty 10-round magazine is 6.8 kg. Weights of these latter two have been deducted, as has the weight of a standard barrel.",
     "volume": "6050 ml",
@@ -180,8 +172,7 @@
       [ "underbarrel", 1 ],
       [ "stock", 1 ]
     ],
-    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN", "NO_TURRET" ],
-    "//3": "This should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
+    "flags": [ "FIRE_TWOHAND", "EASY_CLEAN" ],
     "melee_damage": { "bash": 12 }
   }
 ]

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -35,8 +35,6 @@
     "dispersion": 480,
     "durability": 7,
     "min_cycle_recoil": 1413,
-    "flags": [ "NO_TURRET" ],
-    "//2": "NO_TURRET should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "mechanism", 2 ], [ "rail mount", 1 ], [ "stock mount", 1 ] ],
     "faults": [

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -83,8 +83,6 @@
     "dispersion": 240,
     "durability": 8,
     "min_cycle_recoil": 540,
-    "flags": [ "NO_TURRET" ],
-    "//2": "NO_TURRET should be removed once vehicle turrets are capable of mounting guns with mods attached. As it stands, trying to mount this style of weapon would require the player to remove the conversion kit, thus rendering it unusable anyhow.",
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [
       [ "barrel", 1 ],

--- a/data/json/items/gun/500.json
+++ b/data/json/items/gun/500.json
@@ -5,16 +5,8 @@
     "looks_like": "modular_ar15",
     "type": "ITEM",
     "subtypes": [ "GUN" ],
-    "name": { "str": ".500 Magnum lever gun" },
-    "description": "A finely put together rifle, constructed in the image of old west lever-guns, this weapon features an impressive chambering of .500 Magnum.  Less unmanageable and impractical than within a handgun platform, the power potential of the huge round is nevertheless preserved within this rifle sized package.  Capable of taking down most forms of game, including deer, boars, and small dinosaurs, this is a respectable weapon for only the most enthusiastic of large-calibre shooters.",
-    "variant_type": "gun",
-    "variants": [
-      {
-        "id": "bh_m89",
-        "name": { "str": "Big Horn Model 89 rifle" },
-        "description": "Built in the image of the venerable Winchester Model 1886, Big Horn Armory's Model 89 rifle packs all the power of the .500 S&W Magnum cartridge into a package less likely to break one's wrist."
-      }
-    ],
+    "name": { "str": "Big Horn Model 89 rifle" },
+    "description": "Built in the image of the venerable Winchester Model 1886, Big Horn Armory's Model 89 rifle packs all the power of the .500 S&W Magnum cartridge into a package less likely to break one's wrist.",
     "weight": "3742 g",
     "volume": "1995 ml",
     "longest_side": "953 mm",
@@ -24,8 +16,7 @@
     "to_hit": -1,
     "material": [ "steel", "wood" ],
     "color": "dark_gray",
-    "range": 11,
-    "//range": "Given that .700 NX enjoys MUCH better range at 42 tiles, maybe give this a bit more range at some point, too?",
+    "range": 14,
     "ammo": [ "500" ],
     "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 180,

--- a/src/character.h
+++ b/src/character.h
@@ -3820,16 +3820,16 @@ class Character : public Creature, public visitable
                                bool npc_query = false, const recipe *rec = nullptr );
         std::list<item> consume_items( const comp_selection<item_comp> &is, int batch,
                                        const std::function<bool( const item & )> &filter = return_true<item>, bool select_ind = false,
-                                       bool disable_preference = false );
+                                       bool disable_preference = false, bool keep_receiver = false );
         std::list<item> consume_items( map &m, const comp_selection<item_comp> &is, int batch,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::vector<tripoint_bub_ms> &reachable_pts = {}, bool select_ind = false,
-                                       bool disable_preference = false );
+                                       bool disable_preference = false, bool keep_receiver = false );
         // Selects one entry in components using select_item_component and consumes those items.
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
                                        const std::function<bool( const itype_id & )> &select_ind = return_false<itype_id>,
-                                       bool can_cancel = false, bool disable_preference = false );
+                                       bool can_cancel = false, bool disable_preference = false, bool keep_receiver = false );
         bool consume_software_container( const itype_id &software_id );
         comp_selection<tool_comp>
         select_tool_component( const std::vector<tool_comp> &tools, int batch, read_only_visitable &map_inv,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -3080,7 +3080,7 @@ static void empty_buckets( Character &p )
 }
 
 std::list<item> Character::consume_items( const comp_selection<item_comp> &is, int batch,
-        const std::function<bool( const item & )> &filter, bool select_ind, bool disable_preference )
+        const std::function<bool( const item & )> &filter, bool select_ind, bool disable_preference, bool keep_receiver )
 {
     map &m = get_map();
     std::list<item> ret;
@@ -3091,13 +3091,13 @@ std::list<item> Character::consume_items( const comp_selection<item_comp> &is, i
     // populate a grid of spots that can be reached
     const std::vector<tripoint_bub_ms> &reachable_pts = m.reachable_flood_steps( pos_bub(),
             PICKUP_RANGE, 1, 100 );
-    return consume_items( m, is, batch, filter, reachable_pts, select_ind, disable_preference );
+    return consume_items( m, is, batch, filter, reachable_pts, select_ind, disable_preference, keep_receiver );
 }
 
 std::list<item> Character::consume_items( map &m, const comp_selection<item_comp> &is, int batch,
         const std::function<bool( const item & )> &filter,
         const std::vector<tripoint_bub_ms> &reachable_pts,
-        bool select_ind, bool disable_preference )
+        bool select_ind, bool disable_preference, bool keep_receiver )
 {
     std::function<bool( const item & )> active_preferred_filter = [&filter]( const item & it ) {
         return filter( it ) && is_preferred_component( it );
@@ -3127,7 +3127,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
         } else {
             std::list<item> tmp = m.use_amount( reachable_pts, selected_comp.type, real_count, preferred_filter,
                                                 select_ind );
-            remove_ammo( tmp, *this );
+            remove_ammo( tmp, *this, keep_receiver );
             ret.splice( ret.end(), tmp );
         }
     }
@@ -3142,7 +3142,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
         } else {
             std::list<item> tmp = use_amount( selected_comp.type, real_count, preferred_filter, select_ind );
             real_count -= tmp.size();  // The use_amount operation above doesn't deduct what's been used...
-            remove_ammo( tmp, *this );
+            remove_ammo( tmp, *this, keep_receiver );
             ret.splice( ret.end(), tmp );
         }
     }
@@ -3155,7 +3155,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
             } else {
                 std::list<item> tmp = m.use_amount( reachable_pts, selected_comp.type, real_count, filter,
                                                     select_ind );
-                remove_ammo( tmp, *this );
+                remove_ammo( tmp, *this, keep_receiver );
                 ret.splice( ret.end(), tmp );
             }
         }
@@ -3167,7 +3167,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
             } else {
                 std::list<item> tmp = use_amount( selected_comp.type, real_count, filter, select_ind );
                 // The use_amount operation above doesn't deduct what's been used, but we're not going to use real_count again.
-                remove_ammo( tmp, *this );
+                remove_ammo( tmp, *this, keep_receiver );
                 ret.splice( ret.end(), tmp );
             }
         }
@@ -3203,13 +3203,13 @@ to consume_items */
 std::list<item> Character::consume_items( const std::vector<item_comp> &components, int batch,
         const std::function<bool( const item & )> &filter,
         const std::function<bool( const itype_id & )> &select_ind,
-        const bool can_cancel, const bool disable_preference )
+        const bool can_cancel, const bool disable_preference, bool keep_receiver )
 {
     inventory map_inv;
     map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
     comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, can_cancel,
                                     filter );
-    return consume_items( sel, batch, filter, select_ind( sel.comp.type ), disable_preference );
+    return consume_items( sel, batch, filter, select_ind( sel.comp.type ), disable_preference, keep_receiver );
 }
 
 bool Character::consume_software_container( const itype_id &software_id )
@@ -4353,10 +4353,10 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
     }
 }
 
-void remove_ammo( std::list<item> &dis_items, Character &p, bool receiver = true )
+void remove_ammo( std::list<item> &dis_items, Character &p, bool keep_receiver )
 {
     for( item &dis_item : dis_items ) {
-        remove_ammo( dis_item, p, receiver );
+        remove_ammo( dis_item, p, keep_receiver );
     }
 }
 
@@ -4374,11 +4374,11 @@ void drop_or_handle( const item &newit, Character &p )
     }
 }
 
-void remove_ammo( item &dis_item, Character &p, bool receiver = true )
+void remove_ammo( item &dis_item, Character &p, bool keep_receiver )
 {
-    dis_item.remove_items_with( [&p, receiver]( const item &it ) {
+    dis_item.remove_items_with( [&p, keep_receiver]( const item & it ) {
         if( it.is_irremovable() ||
-            ( !receiver && it.is_gunmod() && it.type->gunmod->location.name() == "bore" ) ||
+            ( keep_receiver && it.is_gunmod() && it.type->gunmod->location.name() == "bore" ) ||
             !( it.is_gunmod() || it.is_toolmod() ||
                ( it.is_magazine() && !it.is_tool() ) ) ) {
             return false;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -4353,10 +4353,10 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
     }
 }
 
-void remove_ammo( std::list<item> &dis_items, Character &p )
+void remove_ammo( std::list<item> &dis_items, Character &p, bool receiver = true )
 {
     for( item &dis_item : dis_items ) {
-        remove_ammo( dis_item, p );
+        remove_ammo( dis_item, p, receiver );
     }
 }
 
@@ -4374,11 +4374,13 @@ void drop_or_handle( const item &newit, Character &p )
     }
 }
 
-void remove_ammo( item &dis_item, Character &p )
+void remove_ammo( item &dis_item, Character &p, bool receiver = true )
 {
-    dis_item.remove_items_with( [&p]( const item & it ) {
-        if( it.is_irremovable() || !( it.is_gunmod() || it.is_toolmod() || ( it.is_magazine() &&
-                                      !it.is_tool() ) ) ) {
+    dis_item.remove_items_with( [&p, receiver]( const item &it ) {
+        if( it.is_irremovable() ||
+            ( !receiver && it.is_gunmod() && it.type->gunmod->location.name() == "bore" ) ||
+            !( it.is_gunmod() || it.is_toolmod() ||
+               ( it.is_magazine() && !it.is_tool() ) ) ) {
             return false;
         }
         drop_or_handle( it, p );

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -29,9 +29,9 @@ struct enum_traits<craft_flags> {
 
 // removes any (removable) ammo from the item and stores it in the
 // players inventory.
-void remove_ammo( item &dis_item, Character &p );
+void remove_ammo( item &dis_item, Character &p, bool receiver );
 // same as above but for each item in the list
-void remove_ammo( std::list<item> &dis_items, Character &p );
+void remove_ammo( std::list<item> &dis_items, Character &p, bool receiver );
 
 void drop_or_handle( const item &newit, Character &p );
 

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -27,11 +27,11 @@ struct enum_traits<craft_flags> {
     static constexpr bool is_flag_enum = true;
 };
 
-// removes any (removable) ammo from the item and stores it in the
-// players inventory.
-void remove_ammo( item &dis_item, Character &p, bool receiver );
-// same as above but for each item in the list
-void remove_ammo( std::list<item> &dis_items, Character &p, bool receiver );
+// Removes any (removable) ammo from the item and stores it in p's inventory.
+// keep_receiver will leave any "bore" gunmods attached to the gun, if applicable.
+void remove_ammo( item &dis_item, Character &p, bool keep_receiver = false );
+// Same as above but for each item in the list.
+void remove_ammo( std::list<item> &dis_items, Character &p, bool keep_receiver = false );
 
 void drop_or_handle( const item &newit, Character &p );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -777,7 +777,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
         return *this;
     }
 
-    // check ammo is valid for the item
+    // Check whether ammo is valid for the item.
     std::set<itype_id> mags = magazine_compatible();
     if( ammo_types().count( ammo_type ) == 0 && !( magazine_current() &&
             magazine_current()->ammo_types().count( ammo_type ) ) &&
@@ -3013,12 +3013,12 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
                 insert_separation_line( info );
                 if( default_bore_type_id != itype_id::NULL_ID() ) {
                     info.emplace_back( "GUN",
-                                       _( "Weapon is <bad>not attached a bore mod</bad>, so stats below assume the default bore mod: " ),
+                                       _( "Weapon <bad>has no receiver</bad>, so stats below assume the default: " ),
                                        string_format( "<stat>%s</stat>",
                                                       default_bore_type_id->nname( 1 ) ) );
                 } else {
                     info.emplace_back( "GUN",
-                                       _( "Weapon is <bad>not attached a bore mod</bad>. " ) );
+                                       _( "Weapon <bad>has no receiver and cannot be fired</bad>. " ) );
                     return;
                 }
 
@@ -13039,14 +13039,20 @@ bool item::allow_crafting_component() const
     if( is_magazine() && ammo_types().count( ammo_battery ) ) {
         return true;
     }
-
     if( is_gun() ) {
+        // Ensure that this is a gun that can actually be fired.
+        if( ammo_types().size() == 1 &&
+            *ammo_types().begin() == ammotype::NULL_ID() ) {
+            return false;
+        }
         bool valid = true;
-        visit_items( [&]( const item * it, item * ) {
+        visit_items( [&]( const item *it, item * ) {
             if( this == it ) {
                 return VisitResponse::NEXT;
             }
-            if( !( it->is_magazine() || ( it->is_gunmod() && it->is_irremovable() ) ) ) {
+            // Disallow all gun mods except "bore" (receivers) and integrated (irremovable) parts.
+            if( !( it->is_magazine() || ( it->is_gunmod() && ( it->is_irremovable() ||
+                    it->type->gunmod->location.name() == "bore" ) ) ) ) {
                 valid = false;
                 return VisitResponse::ABORT;
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13046,13 +13046,13 @@ bool item::allow_crafting_component() const
             return false;
         }
         bool valid = true;
-        visit_items( [&]( const item *it, item * ) {
+        visit_items( [&]( const item * it, item * ) {
             if( this == it ) {
                 return VisitResponse::NEXT;
             }
             // Disallow all gun mods except "bore" (receivers) and integrated (irremovable) parts.
             if( !( it->is_magazine() || ( it->is_gunmod() && ( it->is_irremovable() ||
-                    it->type->gunmod->location.name() == "bore" ) ) ) ) {
+                                          it->type->gunmod->location.name() == "bore" ) ) ) ) {
                 valid = false;
                 return VisitResponse::ABORT;
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1966,7 +1966,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
     const bool filthy = cut.get_item()->is_filthy();
 
     // Clean up before removing the item.
-    remove_ammo( *cut.get_item(), p );
+    remove_ammo( *cut.get_item(), p, false );
     // Original item has been consumed.
     cut.remove_item();
     // Force an encumbrance update in case they were wearing that item.

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -923,7 +923,6 @@ bool veh_interact::update_part_requirements( map &here )
     }
 
     sel_vpart_info->format_description( nmsg, c_light_gray, getmaxx( w_msg ) - 4 );
-
     msg = colorize( nmsg, c_light_gray );
     return ok || player_character.has_trait( trait_DEBUG_HS );
 }
@@ -3128,7 +3127,7 @@ void veh_interact::complete_vehicle( map &here, Character &you )
             for( const std::vector<item_comp> &e : reqs.get_components() ) {
                 for( item &obj : you.consume_items( e, 1, is_crafting_component, [&vpinfo]( const itype_id & itm ) {
                 return itm == vpinfo.base_item;
-            }, false, true ) ) {
+            }, false, true, true ) ) {
                     if( obj.typeId() == vpinfo.base_item ) {
                         base = obj;
                     } else {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1041,9 +1041,6 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
                 base.put_in( tmp_mag, pocket_type::MAGAZINE_WELL );
             }
         }
-        long_descrip += string_format( _( "\nRange: %1$5d     Damage: %2$5.0f" ),
-                                       base.gun_range( true ),
-                                       base.gun_damage().total_damage() );
     }
 
     if( !get_pseudo_tools().empty() ) {


### PR DESCRIPTION
#### Summary
Make modular guns work on turrets

#### Purpose of change
Vehicle turrets are great, but they have a problem: Modular guns do not work on them. Given that many of the most common guns are shifting over to being modular, that is no good!

#### Describe the solution
- [x] Allow weapons with modded receivers (the badly named bore slot) to be installed.
- [x] Prevent the receiver from being uninstalled and returned to the character's inventory when the gun is installed.
- [x] Store the receiver in the vehicle part like the gun (base_item).
- [x] Remove buggy/false range+damage readout on the vpart description.
- [x] Ensure that it fires properly.
- [x] When the gun is uninstalled, make sure it removes both base_item and the receiver.
- [x] Make sure the gun is returned to the player with the receiver still installed.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
