### PR TITLE
Health fix

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -260,6 +260,15 @@ enum sleep_deprivation_levels {
     SLEEP_DEPRIVATION_MASSIVE = 14 * 24 * 60
 };
 
+/** @brief thresholds of morale at which health is impacted
+    @details If the player reaches low morale at some point in a day, their lifestyle score
+    is decreased.
+*/
+enum morale_levels {
+    MORALE_UNHEALTHY_LOW = -25,
+    MORALE_UNHEALTHY_VERY_LOW = -50
+};
+
 enum class blood_type {
     blood_O,
     blood_A,

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -276,11 +276,13 @@ void Character::update_body( const time_point &from, const time_point &to )
         needs_rates tmp_rates;
         calc_sleep_recovery_rate( tmp_rates );
         const float fatigue_regen_rate = tmp_rates.recovery;
-        const int turns = to_turns<int>( to - from );
-        const time_duration effective_time_slept = time_duration::from_turns(
-                    roll_remainder( turns * fatigue_regen_rate ) );
-        mod_daily_sleep( effective_time_slept );
-        mod_continuous_sleep( effective_time_slept );
+        if( fatigue_regen_rate > 0.0f ) {
+            const int turns = to_turns<int>( to - from );
+            const time_duration effective_time_slept = time_duration::from_turns(
+                        roll_remainder( turns * fatigue_regen_rate ) );
+            mod_daily_sleep( effective_time_slept );
+            mod_continuous_sleep( effective_time_slept );
+        }
     }
     if( was_sleeping && !in_sleep_state() ) {
         if( get_continuous_sleep() >= 6_hours ) {

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -342,13 +342,18 @@ void Character::update_body( const time_point &from, const time_point &to )
             mod_daily_health( 1, 200 );
         }
 
+        // Low morale flags last a day, unless their morale still meets the threshold throughout days.
         if( !get_value( "got_to_low_morale" ).is_empty() ) {
             mod_daily_health( -1, -100 );
-            remove_value( "got_to_low_morale" );
+            if( get_morale_level() > MORALE_UNHEALTHY_LOW ) {
+                remove_value( "got_to_low_morale" );
+            }
         }
         if( !get_value( "got_to_very_low_morale" ).is_empty() ) {
             mod_daily_health( -2, -200 );
-            remove_value( "got_to_very_low_morale" );
+            if( get_morale_level() > MORALE_UNHEALTHY_VERY_LOW ) {
+                remove_value( "got_to_very_low_morale" );
+            }
         }
 
         // Being badly injured is not healthy, though your immune system might be able to handle it.

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -275,8 +275,10 @@ void Character::update_body( const time_point &from, const time_point &to )
     if( in_sleep_state() && was_sleeping ) {
         needs_rates tmp_rates;
         calc_sleep_recovery_rate( tmp_rates );
-        const int fatigue_regen_rate = tmp_rates.recovery;
-        const time_duration effective_time_slept = ( to - from ) * fatigue_regen_rate;
+        const float fatigue_regen_rate = tmp_rates.recovery;
+        const int turns = to_turns<int>( to - from );
+        const time_duration effective_time_slept = time_duration::from_turns(
+                    roll_remainder( turns * fatigue_regen_rate ) );
         mod_daily_sleep( effective_time_slept );
         mod_continuous_sleep( effective_time_slept );
     }
@@ -340,19 +342,17 @@ void Character::update_body( const time_point &from, const time_point &to )
 
         if( !get_value( "got_to_low_morale" ).is_empty() ) {
             mod_daily_health( -1, -100 );
-        } else {
             remove_value( "got_to_low_morale" );
         }
         if( !get_value( "got_to_very_low_morale" ).is_empty() ) {
             mod_daily_health( -2, -200 );
-        } else {
             remove_value( "got_to_very_low_morale" );
         }
 
         // Being badly injured is not healthy, though your immune system might be able to handle it.
         bool wounded = false;
         for( const bodypart_id &bp : get_all_body_parts( get_body_part_flags::only_main ) ) {
-            if( get_part_hp_cur( bp ) < ( get_part_hp_cur( bp ) / 2 ) ) {
+            if( get_part_hp_cur( bp ) < ( get_part_hp_max( bp ) / 2 ) ) {
                 wounded = true;
             }
         }
@@ -409,7 +409,7 @@ void Character::update_body( const time_point &from, const time_point &to )
                 // "RDA" for our character and roll a chance to get a penalty tied to how much we ate.
                 if( ( toxin_RDA > 0 ) && ( rng( 1, 115 ) <= std::min( toxin_RDA, 100 ) ) ) {
                     int toxin_malus = static_cast<int>( std::ceil( toxin_RDA / 10.0 ) );
-                    mod_daily_health( std::max( -5, toxin_malus ), -200 );
+                    mod_daily_health( std::max( -5, -toxin_malus ), -200 );
                 }
             }
 

--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -94,11 +94,11 @@ void Character::add_morale( const morale_type &type, int bonus, int max_bonus,
                             bool capped, const itype *item_type )
 {
     morale->add( type, bonus, max_bonus, duration, decay_start, capped, item_type );
-    if( get_morale_level() <= -25 ) {
+    if( get_morale_level() <= MORALE_UNHEALTHY_LOW ) {
         // These two values are used to ding your lifestyle score. Stress is bad for you!
         set_value( "got_to_low_morale", "true" );
     }
-    if( get_morale_level() <= -50 ) {
+    if( get_morale_level() <= MORALE_UNHEALTHY_VERY_LOW ) {
         // These two values are used to ding your lifestyle score. Stress is bad for you!
         set_value( "got_to_very_low_morale", "true" );
     }


### PR DESCRIPTION
#### Summary

Fix some health value logic seemingly being calculated incorrectly.

#### Purpose of change

So while I was looking into whether current hp% affected health regen yet in the character.cpp regen code, I noticed it does have an impact through its impact on health in the case that current hp is less than half of current hp, which seems like something that wouldn't happen while hp is positive.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/a4651547f7d4d6e1179cc5fb8ca1053ff48b3c27/src/character_body.cpp#L353-L358

I figured that while I was there, I'd read through the rest of the health code.

The toxin malus was positive the more toxins the player had, and was then maxed with a negative number, that's then added to health, so toxins wouldn't affect health.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/a4651547f7d4d6e1179cc5fb8ca1053ff48b3c27/src/character_body.cpp#L405-L414

Also, fatigue_regen_rate was cast from a float to an int even though it was a supposed to be a rate multiplier that seemed to range from 0.0 to 2.0.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/a4651547f7d4d6e1179cc5fb8ca1053ff48b3c27/src/character_body.cpp#L277-L281

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/a4651547f7d4d6e1179cc5fb8ca1053ff48b3c27/src/character.cpp#L5675-L5687

Also, if the player was not missing (i.e. did have) a low morale flag, then morale gets decreased, while otherwise, if they don't have the flag then it gets removed. It seemed to me it was probably intended that if they did have the flag then it should get removed, rather than if they have the flag then it doesn't get removed and just stays around.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/a4651547f7d4d6e1179cc5fb8ca1053ff48b3c27/src/character_body.cpp#L341-L350

#### Describe the solution

1. Change the wounded text from current hp < current hp / 2, to current hp < max hp / 2.
2. Change the toxin malus part to negative.
3. Change fatigue_regen_rate to a float, cast to - from to int (though I think this is currently called every turn), calculate roll_remainder( turns * fatigue_regen_rate ) ) so that 0.5 regen rate means that on average they get half of their turns to count rather than 0.5 rounding down to 0, and hten casting back to time_duration.
4. If they have the low morale flags, they lose health and also the flag, rather than the flag persisting. Unless their morale is low enough when that's calculated that they still meet the thresholds for low morale.

#### Describe alternatives you've considered

Btw in testing I noticed that in_sleep_state also includes when the player is trying to sleep, not just actual sleeping. Dunno whether that's supposed to count. Also I wasn't sure whether or not tmp_rates.recovery is allowed to be negative, like reverse sleep progress or something, though in the other place using .recovery for sleep stuff in character.cpp it seemed to have a >0 guard so I ended up going with that here too.

For morale, it made sense to me that if they still had low morale for the duration of the check, like when the new time period starts, the low morale flag remains, such as in the case where they have some long-lasting negative morale effect.

#### Testing

The player's health value can be seen with debug mode, though considering how many things affect it I just added logging for myself for the specific conditionals and values I was testing. The test is if low hp, high toxins, and a bunch of negative morale affect health, and if the health sleep calculations handle the fatigue recovery for decimal values rather than just truncating to 0/1. The hp/toxins/morale can be set in the debug menu.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
