### PR TITLE
Improve NPC weapon eval

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -406,7 +406,7 @@
         "effect": { "toggle_npc_rule": "use_guns" }
       },
       {
-        "truefalsetext": { "condition": { "npc_rule": "use_silent" }, "true": "Don't worry about noise.", "false": "Use only silent weapons." },
+        "truefalsetext": { "condition": { "npc_rule": "use_silent" }, "true": "Don't worry about noise.", "false": "Don't use loud weapons." },
         "topic": "TALK_COMBAT_COMMANDS",
         "effect": { "toggle_npc_rule": "use_silent" }
       },

--- a/src/character.h
+++ b/src/character.h
@@ -1265,7 +1265,7 @@ class Character : public Creature, public visitable
         bool sees_with_echolocation() const;
 
         /** NPC-related item rating functions */
-        double weapon_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a weapon
+        double weapon_value( const item &weap, int ammo = 10, bool prompt = false ) const; // Evaluates item as a weapon
         double gun_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a gun
         double melee_value( const item &weap ) const; // As above, but only as melee
         double unarmed_value() const; // Evaluate yourself!

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10055,7 +10055,7 @@ int item::get_reload_time() const
 
 bool item::is_silent() const
 {
-    return gun_noise().volume < 5;
+    return gun_noise().volume < 16;
 }
 
 bool item::is_gunmod() const

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2896,22 +2896,26 @@ int Character::attack_speed( const item &weap ) const
     return std::round( move_cost );
 }
 
-double Character::weapon_value( const item &weap, int ammo ) const
+double Character::weapon_value( const item &weap, int ammo, bool prompt ) const
 {
-    if( is_wielding( weap ) || ( !get_wielded_item() && weap.is_null() ) ) {
-        auto cached_value = cached_info.find( "weapon_value" );
-        if( cached_value != cached_info.end() ) {
-            return cached_value->second;
+    if( !prompt ) {
+        if( is_wielding( weap ) || ( !get_wielded_item() && weap.is_null() ) ) {
+            auto cached_value = cached_info.find( "weapon_value" );
+            if( cached_value != cached_info.end() ) {
+            add_msg_debug( debugmode::DF_NPC_ITEMAI,
+                        "<color_magenta>weapon_value</color>%s returned cached weapon value of <color_light_cyan>%1.2f</color>.",
+                        disp_name( true ), cached_value->second );
+                return cached_value->second;
+            }
         }
     }
     double val_gun = gun_value( weap, ammo );
     val_gun = val_gun /
-              5.0f; // This is an emergency patch to get melee and ranged in approximate parity.
+              4.0; // This is an emergency patch to get melee and ranged in approximate parity.
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "<color_magenta>weapon_value</color>%s %s valued at <color_light_cyan>%1.2f as a ranged weapon</color>.",
                    disp_name( true ), weap.type->get_id().str(), val_gun );
     double val_melee = melee_value( weap );
-    val_melee *= val_melee; // Same emergency patch.
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a melee weapon</color>.", disp_name( true ),
                    weap.type->get_id().str(), val_melee );
@@ -2920,7 +2924,7 @@ double Character::weapon_value( const item &weap, int ammo ) const
 
     // A small bonus for guns you can also use to hit stuff with (bayonets etc.)
     const double my_val = more + ( less / 2.0 );
-    add_msg_debug( debugmode::DF_MELEE, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(),
+    add_msg_debug( debugmode::DF_NPC_ITEMAI, "%s (%ld ammo) sum value: %.1f", weap.type->get_id().str(),
                    ammo, my_val );
     if( is_wielding( weap ) || ( !get_wielded_item() && weap.is_null() ) ) {
         cached_info.emplace( "weapon_value", my_val );
@@ -2945,8 +2949,14 @@ double Character::melee_value( const item &weap ) const
         }
         my_value += total;
         my_value += weap.type->m_to_hit * 2;
+        if( weap.has_technique( WBLOCK_2 ) ) {
+            my_value += 6.0;
+        } else if( weap.has_technique( WBLOCK_1 ) ) {
+            my_value += 4.0;
+        }
+        // TODO: Smarter scaling here. But it's a start!
         if( weap.weight() > 0_gram ) {
-            my_value *= 1.0 / ( 1.0 + ( weap.weight() / 3000_gram ) );
+            my_value *= 1.0 / ( 1.0 + ( weap.weight() / ( get_str() * 400_gram ) ) );
         }
         float reach = weap.reach_range( *this );
         if( reach > 1.0f ) {
@@ -2964,11 +2974,7 @@ double Character::melee_value( const item &weap ) const
         if( !martial_arts_data->enumerate_known_styles( weap.type->get_id() ).empty() ) {
             my_value *= 1.2;
         }
-        if( weap.type != nullptr ) {
-            add_msg_debug( debugmode::DF_MELEE, "%s as melee: %.1f", weap.type->get_id().str(), my_value );
-        } else {
-            add_msg_debug( debugmode::DF_MELEE, "Unarmed as melee: 0.0" );
-        }
+        add_msg_debug( debugmode::DF_MELEE, "%s as melee: %.1f", weap.type->get_id().str(), my_value );
         return std::max( 0.0, my_value );
     } else {
         return unarmed_value();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2663,6 +2663,10 @@ double Character::gun_value( const item &weap, int ammo ) const
 {
     // TODO: Mods
     // TODO: Allow using a specified type of ammo rather than default or current
+    if( weap.is_null() ) {
+        return 0.0;
+    }
+
     if( !weap.type->gun ) {
         return 0.0;
     }
@@ -2707,7 +2711,6 @@ double Character::gun_value( const item &weap, int ammo ) const
 
     int move_cost = time_to_attack( *this, *weap.type );
     if( gun.clip != 0 && gun.clip < 10 ) {
-        // TODO: RELOAD_ONE should get a penalty here
         int reload_cost = gun.reload_time + encumb( bodypart_id( "hand_l" ) ) + encumb(
                               bodypart_id( "hand_r" ) );
         reload_cost /= gun.clip;
@@ -2715,7 +2718,7 @@ double Character::gun_value( const item &weap, int ammo ) const
     }
 
     // "Medium range" below means 9 tiles, "short range" means 4
-    // Those are guarantees (assuming maximum time spent aiming)
+    // These are merely estimates and are impacted by RNG, limb scores, and perception.
     static const std::vector<std::pair<float, float>> dispersion_thresholds = {{
             // Headshots all the time
             { 0.0f, 5.0f },
@@ -2731,18 +2734,19 @@ double Character::gun_value( const item &weap, int ammo ) const
             { 700.0f, 1.5f },
             // Glances at medium, criticals at point blank
             { 1000.0f, 1.0f },
+            // Iffy
+            { 1500.0f, 0.75f },
             // Nothing guaranteed, pure gamble
             { 2000.0f, 0.1f },
         }
     };
 
     static const std::vector<std::pair<float, float>> move_cost_thresholds = {{
-            { 10.0f, 4.0f },
-            { 25.0f, 3.0f },
-            { 100.0f, 1.0f },
-            { 500.0f, 0.5f },
-        }
-    };
+        { 10.0f, 2.0f },
+        { 25.0f, 1.75f },
+        { 100.0f, 1.0f },
+        { 500.0f, 0.8f },
+    }};
 
     float move_cost_factor = multi_lerp( move_cost_thresholds, move_cost );
 
@@ -2756,21 +2760,24 @@ double Character::gun_value( const item &weap, int ammo ) const
 
     float dispersion_factor = multi_lerp( dispersion_thresholds, total_dispersion );
 
+    // Some consideration for perception here.
+    dispersion_factor *= 1.f * std::clamp( 0.75f, 2.f, ( static_cast<float>(get_per() ) / 10.f ) );
+
     float damage_and_accuracy = damage_factor * dispersion_factor;
 
-    // TODO: Some better approximation of the ability to keep on shooting
+    // TODO: Some better approximation of the ability to keep on shooting.
     static const std::vector<std::pair<float, float>> capacity_thresholds = {{
-            { 1.0f, 0.5f },
+            { 1.0f, 0.75f },
             { 5.0f, 1.0f },
-            { 10.0f, 1.5f },
-            { 20.0f, 2.0f },
-            { 50.0f, 3.0f },
+            { 10.0f, 1.25f },
+            { 20.0f, 1.75f },
+            { 50.0f, 2.5f },
         }
     };
 
-    // How much until reload
+    // How much until reload?
     float capacity = gun.clip > 0 ? std::min<float>( gun.clip, ammo ) : ammo;
-    // How much until dry and a new weapon is needed
+    // How much until dry and a new weapon is needed?
     capacity += std::min<float>( 1.0, ammo / 20.0 );
     double capacity_factor = multi_lerp( capacity_thresholds, capacity );
 

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -398,15 +398,23 @@ std::string talker_npc::give_item_to( const bool to_use )
     bool taken = false;
     std::string reason = me_npc->chat_snippets().snip_give_nope.translated();
     const item_location weapon = me_npc->get_wielded_item();
-    int our_ammo = me_npc->ammo_count_for( weapon );
-    int new_ammo = me_npc->ammo_count_for( loc );
-    const double new_weapon_value = me_npc->weapon_value( given, new_ammo );
     const item &weap = weapon ? *weapon : null_item_reference();
-    const double cur_weapon_value = me_npc->weapon_value( weap, our_ammo );
-    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates own %s (%d ammo): %0.1f",
-                   weap.typeId().str(), our_ammo, cur_weapon_value );
-    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates your %s (%d ammo): %0.1f",
-                   given.typeId().str(), new_ammo, new_weapon_value );
+    double new_weapon_value = 0.0;
+    double cur_weapon_value = 0.0;
+    int new_ammo = 0;
+    int our_ammo = 0;
+    if( weap.type->gun ) {
+        our_ammo = me_npc->ammo_count_for( weapon );
+    }
+    if( given.type->gun ) {
+        new_ammo = me_npc->ammo_count_for( loc );
+    }
+    new_weapon_value = me_npc->weapon_value( given, new_ammo, true );
+    cur_weapon_value = me_npc->weapon_value( weap, our_ammo, true );
+    add_msg_debug( debugmode::DF_NPC_ITEMAI, "NPC evaluates own %s (%d ammo): %0.1f",
+                weap.typeId().str(), our_ammo, cur_weapon_value );
+    add_msg_debug( debugmode::DF_NPC_ITEMAI, "NPC evaluates your %s (%d ammo): %0.1f",
+                given.typeId().str(), new_ammo, new_weapon_value );
     if( to_use ) {
         // Eating first, to avoid evaluating bread as a weapon
         const consumption_result consume_res = try_consume( *me_npc, given, reason );
@@ -440,10 +448,18 @@ std::string talker_npc::give_item_to( const bool to_use )
                 }
             }
         } else {
-            add_msg_debug( debugmode::DF_TALKER, "New weapon value %.1f is lower than current value %.1f",
+            add_msg_debug( debugmode::DF_NPC_ITEMAI, "New weapon value %.1f is lower than current value %.1f",
                            new_weapon_value, cur_weapon_value );
-            if( query_yn( _( "I think my %1s is better, do you really want me to use the %2s?" ), weap.tname(),
-                          given.tname() ) ) {
+            std::string weapon_query = string_format(
+                _( "I think I might be better off barehanded, do you really want me to use the %s?" ),
+                given.tname() );
+            if( !weap.is_null() ) {
+                weapon_query = string_format(
+                    _( "I think my %s is better, do you really want me to use the %s?" ),
+                    weap.tname(),
+                    given.tname() );
+            }
+            if( query_yn( weapon_query ) ) {
                 me_npc->wield( given );
                 reason = me_npc->chat_snippets().snip_give_wield.translated();
                 taken = true;


### PR DESCRIPTION
#### Summary
Improve NPC weapon eval

#### Purpose of change
NPC weapon evaluation was (and still is, but less so!) a mess. NPCs were massively overvaluing their bare hands and the text was a bit odd in several places. There were also some worrying invalid integers being accessed.

#### Describe the solution
- Add a couple more parameters for both ranged and melee evaluation, remove the ^2 on melee scores. Cut ranged scores from /5 to /4. Clean up the code, initialize all integers before assuming they exist.
- NPCs consider anything <16 loudness to be "quiet".
- The rule is now "don't use loud weapons" instead of "silent".

#### Describe alternatives you've considered

#### Testing
NPC preferred a light crossbow over fists, but just barely. NPC preferred an uzi over a katana, but just barely. NPC preferred a pocket knife over a can of cola.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
