### PR TITLE
reduce inflatable decoration charges

### DIFF
--- a/data/json/items/items_holiday.json
+++ b/data/json/items/items_holiday.json
@@ -125,7 +125,7 @@
     "material": [ "plastic" ],
     "symbol": "P",
     "color": "light_red",
-    "charges_per_use": 100,
+    "charges_per_use": 56,
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {


### PR DESCRIPTION
#### Summary
Found out inflatable dragon is not usable because it required more charges than its compatible battery could provide

#### Purpose of change
Makes inflatable dragon, inflatable ghost and fog machine usable

#### Describe the solution
Reduce charges_per_use on inflatable_decoration to 56. This also affects the inflatable ghost and fog machine, but they also use the same battery so it's not an issue

#### Describe alternatives you've considered
Maybe define the battery pocket on the inflatable_decoration to make sure future items who copy it work. 

#### Testing
Spawned an inflatable dragon, reloaded with lithium battery, was able to activate

#### Additional context
Before:
<img width="352" height="174" alt="image" src="https://github.com/user-attachments/assets/dd526848-e04b-4715-a3ed-ebd8f04103a3" />

After:
<img width="1364" height="518" alt="image" src="https://github.com/user-attachments/assets/17353c5b-0572-4084-8222-310b65fcfaba" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
