### PR TITLE
Dormant zombies revive when "Frozen"

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8787,7 +8787,7 @@ bool item::can_revive() const
            !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
               has_flag( flag_QUARTERED ) ||
               has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) || has_flag( flag_GIBBED ) ||
-              has_flag( flag_FROZEN ) );
+              ( has_flag( flag_FROZEN ) && !corpse->has_flag( mon_flag_DORMANT ) ) );
 }
 
 bool item::ready_to_revive( map &here, const tripoint_bub_ms &pos )


### PR DESCRIPTION
#### Summary
Dormant zombies revive when "Frozen"

#### Purpose of change
Frozen zombies don't revive, but dormant zombies were freezing and this was causing them not to get up, but the trap would go off, and everything would get weird.

#### Describe the solution
Dormant zombies still revive when frozen. They're not fully dead, so they're just covered in frost and I guess the characters assume they're frozen.

#### Describe alternatives you've considered
It'd be cool if thermal vision clued you in, but there's no real support for that right now.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
