### PR TITLE
fixed a curses compilation error

### DIFF
--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -1,4 +1,6 @@
 #if !(defined(TILES) || defined(_WIN32))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 
 // input.h must be include *before* the ncurses header. The latter has some macro
 // defines that clash with the constants defined in input.h (e.g. KEY_UP).
@@ -572,4 +574,5 @@ void set_title( const std::string & )
     // curses does not seem to have a portable way of setting the window title.
 }
 
+#pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
#### Summary
Category "Brief description"
Without this patch, compiling would fail since the Makefile sets both -Werror and -Wno-old-style-cast and several ncurses macros that are referenced use old style casts.

#### Purpose of change
To be able to compile curses builds on my machine, and hopefully help other people too.

#### Describe the solution
add a pragma to src/ncurses_def.cpp to tell gcc to ignore old-style-cast warnings in

#### Describe alternatives you've considered
I can't think of any other alternatives, except just disabling -Werror or -Wold-style-cast. Imo -Werror should never be the default since warnings are completely implementation defined and it makes it basically impossible to gaurentee the program compiles on all machines, but at the same time I'm sure -Werror is the default here for a reason and the solution is definitely not to just naively disable it.

#### Testing
I compiled it and it works on my machine whereas it did not compile before this patch. I think it depends on the version of the system ncurses so I'm not sure how to reproduce this. I'm using ncurses-6.5_p20251120 from the official gentoo repo.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
