### PR TITLE
Curses sound

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@
 #  make RELEASE=1
 # Tiles (uses SDL rather than ncurses)
 #  make TILES=1
-# Sound (requires SDL, so TILES must be enabled)
-#  make TILES=1 SOUND=1
+# Sound
+#  make SOUND=1
 # Disable gettext, on some platforms the dependencies are hard to wrangle.
 #  make LOCALIZE=0
 # Disable backtrace support, not available on all platforms
@@ -692,9 +692,7 @@ endif
 PKG_CONFIG = $(CROSS)pkg-config
 
 ifeq ($(SOUND), 1)
-  ifneq ($(TILES),1)
-    $(error "SOUND=1 only works with TILES=1")
-  endif
+  SDL = 1
   ifeq ($(NATIVE),osx)
     ifndef FRAMEWORK # libsdl build
       ifeq ($(MACPORTS), 1)
@@ -716,10 +714,6 @@ ifeq ($(SOUND), 1)
   endif
 
   CXXFLAGS += -DSDL_SOUND
-endif
-
-ifeq ($(SDL), 1)
-  TILES = 1
 endif
 
 ifeq ($(TILES), 1)

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -27,6 +27,10 @@
 #include <memory>
 #include <stdexcept>
 
+#ifdef SDL_SOUND
+#include <SDL2/SDL.h>
+#endif
+
 #include "cached_options.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -36,6 +40,9 @@
 #include "game_ui.h"
 #include "output.h"
 #include "ui_manager.h"
+#ifdef SDL_SOUND
+#include "sdlsound.h"
+#endif
 
 static void curses_check_result( const int result, const int expected, const char *const /*name*/ )
 {
@@ -194,6 +201,9 @@ void catacurses::erase()
 
 void catacurses::endwin()
 {
+#ifdef SDL_SOUND
+    shutdown_sound();
+#endif
     ui_manager::reset();
     return curses_check_result( ::endwin(), OK, "endwin" );
 }
@@ -307,6 +317,18 @@ void catacurses::resizeterm()
 // wincurse.cpp for Windows builds without SDL and sdltiles.cpp for SDL builds.
 void catacurses::init_interface()
 {
+#ifdef SDL_SOUND
+    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+        throw std::runtime_error( "SDL_Init failed" );
+    }
+    if (!init_sound()) {
+        throw std::runtime_error( "init_sound failed" );
+    }
+    if( atexit( SDL_Quit ) ) {
+        debugmsg( "atexit failed to register SDL_Quit" );
+    }
+    load_soundset();
+#endif
     // ::endwin will free the pointer returned by ::initscr
     stdscr = window( std::shared_ptr<void>( ::initscr(), []( void *const ) { } ) );
     if( !stdscr ) {

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -29,7 +29,9 @@
 #include "options.h"
 #include "path_info.h"
 #include "rng.h"
+#ifdef TILES
 #include "sdl_wrappers.h"
+#endif
 #include "sounds.h"
 #include "units.h"
 #include "avatar.h"


### PR DESCRIPTION
#### Summary
Category "Brief description"
This allows you to build the curses interface with sound
#### Purpose of change
There is no reason that sound should be limited to when SDL is used as a gui. SDL has a very flexible subsystem system so why not use it.
#### Describe the solution
All this does is initialize the sound system on init_interface for ncurses instead of only for sdltiles and edits the CMakeLists.txt and Makefile to allow for SOUND=1 with TILE=0.
 
#### Describe alternatives you've considered
N/A

#### Testing
This compiles and works as expected on my linux machine. I don't have access to a windows or macos machine to do any testing on that.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
