### PR TITLE
Adjust tree-felling time and add ecology xp

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7682,11 +7682,11 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
             }
         }
     }
-
+    who.practice( skill_survival, 3, 3 );
     here.cut_down_tree( pos, direction.xy() );
 
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );
-    // sound of falling tree
+    // Sound of falling tree.
     here.collapse_at( pos, false, true, false );
     sfx::play_variant_sound( "misc", "timber",
                              sfx::get_heard_volume( here.get_bub( act.placement ) ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2632,8 +2632,12 @@ static int chop_moves( Character &you, item &it )
     const int attr = it.has_flag( flag_POWERED ) ? you.dex_cur : you.get_arm_str();
 
     // Ecology skill cuts chopping time.
-    int skill_modifier = std::clamp( 100 - static_cast<int>( ( you.get_skill_level(
-                                         skill_survival ) * 10.f ) ), 0, 100 );
+    int skill_modifier = 450 - std::clamp( static_cast<int>( ( you.get_skill_level(
+                                         skill_survival ) * 40.f ) ), 0, 400 );
+
+    if( it.has_flag( flag_POWERED ) ) {
+        skill_modifier = 50 + ( skill_modifier - 50 ) * 0.5f;
+    }
 
     int moves = to_moves<int>( time_duration::from_minutes( 60 - attr + skill_modifier ) / std::pow( 2,
                                quality - 1 ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2633,7 +2633,7 @@ static int chop_moves( Character &you, item &it )
 
     // Ecology skill cuts chopping time.
     int skill_modifier = 450 - std::clamp( static_cast<int>( ( you.get_skill_level(
-                                         skill_survival ) * 40.f ) ), 0, 400 );
+            skill_survival ) * 40.f ) ), 0, 400 );
 
     if( it.has_flag( flag_POWERED ) ) {
         skill_modifier = 50 + ( skill_modifier - 50 ) * 0.5f;

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -318,10 +318,10 @@ void catacurses::resizeterm()
 void catacurses::init_interface()
 {
 #ifdef SDL_SOUND
-    if (SDL_Init(SDL_INIT_AUDIO) != 0) {
+    if( SDL_Init( SDL_INIT_AUDIO ) != 0 ) {
         throw std::runtime_error( "SDL_Init failed" );
     }
-    if (!init_sound()) {
+    if( !init_sound() ) {
         throw std::runtime_error( "init_sound failed" );
     }
     if( atexit( SDL_Quit ) ) {


### PR DESCRIPTION
#### Summary
Adjust tree-felling time and add ecology xp

#### Purpose of change
Tree felling was a bit too generous and the ecology bonus scaled up too high. It also was working weird with chainsaws because of the std::( pow ) giving them a huge divisor.

#### Describe the solution
- Make the overall skill penalty way steeper and add a base amount.
- Fudge the skill penalty for powered items a bit. by using a 50% multiplier but keeping some of the base amount intact so it doesn't fall behind axes at high skill levels.
- Add 3 xp for a successful tree felling, up to 3 ranks of ecology. That isn't much but who told you to cut down trees to learn ecology?

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
