### PR TITLE
Fix weariness exertion issues

### DIFF
--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -138,6 +138,7 @@ void activity_tracker::new_turn( bool sleeping )
     float base_activity_level = sleeping ? SLEEP_EXERCISE : NO_EXERCISE;
 
     if( activity_reset ) {
+        process_activity_weariness_penalty();
         activity_reset = false;
         previous_turn_activity = current_activity;
         current_activity = base_activity_level;
@@ -175,29 +176,42 @@ void activity_tracker::new_turn( bool sleeping )
             //
             if( brisk_activity > brisk_activity_new ) {
                 brisk_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
-                tracker += std::max( 0.0f, ( brisk_activity - brisk_activity_new ) * 12.5f );
-                brisk_activity_new = brisk_activity;
             }
             if( active_activity > active_activity_new ) {
                 active_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
-                tracker += std::max( 0.0f, ( active_activity - active_activity_new ) * 25.0f );
-                active_activity_new = active_activity;
             }
             if( extra_activity > extra_activity_new ) {
                 extra_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
-                tracker += std::max( 0.0f, ( extra_activity - extra_activity_new ) * 50.0f );
-                extra_activity_new = extra_activity;
             }
             if( explosive_activity > explosive_activity_new ) {
                 explosive_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
-                tracker += std::max( 0.0f, ( explosive_activity - explosive_activity_new ) * 120.0f );
-                explosive_activity_new = explosive_activity;
             }
             num_events += num_turns - 1;
+            process_activity_weariness_penalty();
         }
         previous_turn_activity = current_activity;
         current_activity = base_activity_level;
         num_events++;
+    }
+}
+
+void activity_tracker::process_activity_weariness_penalty()
+{
+    if( brisk_activity > brisk_activity_new ) {
+        tracker += std::max( 0.0f, ( brisk_activity - brisk_activity_new ) * 12.5f );
+        brisk_activity_new = brisk_activity;
+    }
+    if( active_activity > active_activity_new ) {
+        tracker += std::max( 0.0f, ( active_activity - active_activity_new ) * 25.0f );
+        active_activity_new = active_activity;
+    }
+    if( extra_activity > extra_activity_new ) {
+        tracker += std::max( 0.0f, ( extra_activity - extra_activity_new ) * 50.0f );
+        extra_activity_new = extra_activity;
+    }
+    if( explosive_activity > explosive_activity_new ) {
+        tracker += std::max( 0.0f, ( explosive_activity - explosive_activity_new ) * 120.0f );
+        explosive_activity_new = explosive_activity;
     }
 }
 

--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -172,19 +172,21 @@ void activity_tracker::new_turn( bool sleeping )
         // Then handle the interventing turns that had no activity logged.
         int num_turns = to_turns<int>( calendar::turn - current_turn );
         if( num_turns > 1 ) {
+            // accumulated_activity is updated on the assumption that the past num_turns turns were at activity level NO_EXERCISE.
             accumulated_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
-            //
+
+            // For high activity weariness, it is assumed that the past num_turns were at the activity level in current_activity.
             if( brisk_activity > brisk_activity_new ) {
-                brisk_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
+                brisk_activity += ( num_turns - 1 ) * current_activity;
             }
             if( active_activity > active_activity_new ) {
-                active_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
+                active_activity += ( num_turns - 1 ) * current_activity;
             }
             if( extra_activity > extra_activity_new ) {
-                extra_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
+                extra_activity += ( num_turns - 1 ) * current_activity;
             }
             if( explosive_activity > explosive_activity_new ) {
-                explosive_activity += ( num_turns - 1 ) * std::min( NO_EXERCISE, current_activity );
+                explosive_activity += ( num_turns - 1 ) * current_activity;
             }
             num_events += num_turns - 1;
             process_activity_weariness_penalty();

--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -157,17 +157,16 @@ void activity_tracker::new_turn( bool sleeping )
         // High-impact activity is less efficient in terms of weariness over time.
         // Because the system is just kcal spent = weariness, we need to track strenous
         // activity separately and apply a malus to weariness later in suffer.cpp.
-        if( current_activity == BRISK_EXERCISE ) {
-            brisk_activity += current_activity;
-        }
-        if( current_activity == ACTIVE_EXERCISE ) {
-            active_activity += current_activity;
-        }
-        if( current_activity == EXTRA_EXERCISE ) {
-            extra_activity += current_activity;
-        }
-        if( current_activity == EXPLOSIVE_EXERCISE ) {
-            explosive_activity += current_activity;
+        if( current_activity > MODERATE_EXERCISE ) {
+            if( current_activity <= BRISK_EXERCISE ) {
+                brisk_activity += current_activity;
+            } else if( current_activity <= ACTIVE_EXERCISE ) {
+                active_activity += current_activity;
+            } else if( current_activity <= EXTRA_EXERCISE ) {
+                extra_activity += current_activity;
+            } else if( current_activity <= EXPLOSIVE_EXERCISE ) {
+                explosive_activity += current_activity;
+            }
         }
         // Then handle the interventing turns that had no activity logged.
         int num_turns = to_turns<int>( calendar::turn - current_turn );

--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -165,7 +165,7 @@ void activity_tracker::new_turn( bool sleeping )
                 active_activity += current_activity;
             } else if( current_activity <= EXTRA_EXERCISE ) {
                 extra_activity += current_activity;
-            } else if( current_activity <= EXPLOSIVE_EXERCISE ) {
+            } else {
                 explosive_activity += current_activity;
             }
         }

--- a/src/activity_tracker.h
+++ b/src/activity_tracker.h
@@ -40,6 +40,8 @@ class activity_tracker
         void log_activity( float new_level );
         // Informs the tracker that a new turn has started.
         void new_turn( bool sleeping = false );
+        // Processes the weariness penalty from high activity levels.
+        void process_activity_weariness_penalty();
         // Resets accumulated activity level.
         void reset_activity_level();
         // Outputs player activity level to a printable string.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5424,7 +5424,7 @@ float Character::maximum_exertion_level() const
 {
     switch( weariness_level() ) {
         case 0:
-            return EXTRA_EXERCISE;
+            return EXPLOSIVE_EXERCISE;
         case 1:
             return ACTIVE_EXERCISE;
         case 2:
@@ -5447,7 +5447,8 @@ float Character::exertion_adjusted_move_multiplier( float level ) const
     if( level <= 0 ) {
         level = activity_history.activity( in_sleep_state() );
     }
-    const float max = maximum_exertion_level();
+    // Exertion levels are calculated out of 10, not 12. max is 10 for explosive activity.
+    const float max = std::min( 10.0f, maximum_exertion_level() );
     if( level < max ) {
         return 1.0f;
     }


### PR DESCRIPTION
#### Summary
Trying to fix some inconsistent activity level and weariness handling

#### Purpose of change

A.

First I noticed I was getting messages about tiring out and slowing down when I wasn't even close to lightly weary and had no weariness penalty. I looked into it and it seemed that activity level was greater than the maximum exertion level in maximum_exertion_level, which for a character with no weariness and no penalties is extra exercise, below explosive exercise.

I found that maximum_exertion_level was also used in some other places, some of which seemed to already be correct and a couple of which seemed to be incorrect. One place it's used in is as a clamp get_bmr, which seemed wrong since calorie consumption and the associated weariness is one of the main things affected by the activity level multiplier so treating it as 10 instead of 12 seemed to defeat the point.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/suffer.cpp#L1557-L1570

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/character.cpp#L5423-L5427



B.

The second thing was that when looking at how activity was tracked in activity_tracker, it seems that it was expected that current_activity would be exactly equal to a defined activity constant, which wouldn't detect non-standard activity levels like archery which uses a ratio of strength to bow required strength to calculate an activity level. Iirc throwing might do something similar with the object's weight.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/activity_tracker.cpp#L160-L171

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/ranged.cpp#L1704-L1707



C.

Every five minutes some activity tracker data is cleared, but the extra weariness effect of 12.5/25/50/120 doesn't get applied every turn, but rather only when there's a turn with no activity logged. So when I tested that by adding logging to the activity reset code to compare *_activity_new with *_activity, and then did a continuous activity like athletics exercise which is brisk and takes time, I'd see that there was activity that wasn't processed at the time it got reset.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/activity_tracker.cpp#L140-L154



D.

There was an inconsistency in how the *_activity variables were incremented. In the normal per turn code they were incremented by current_activity each turn (i.e. +12.0 for a turn of explosive activity), but in the num_turns > 1 case that handled intervening turns, while accumulated_activity is augmented by the number of passed turns * at most the no_exercise activity level of 1, the *_activity variable for that turn's activity level still gets incremented, but by the value of the no_exercise activity level (i.e. turns * 1 instead of * 6/8/10/12 for brisk/active/extra/explosive).

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/0c1222441b609e3018e17e5c8a6ae2991396bd6e/src/activity_tracker.cpp#L173-L198



#### Describe the solution

A.

For maximum_exertion_level, I changed the 0 weariness level case from EXTRA_EXERCISE to EXPLOSIVE_EXERCISE

https://github.com/aattss/Cataclysm-TLG/blob/4ea1bb32d7bd124468a45d20967453a150b6084c/src/character.cpp#L5425-L5427

Affected callers:

debug_weary_info has a log message that includes the maximum exertion level, so now it would display explosive exercise rather than extra exercise for a weariness 0 character.
activity_level
get_bmr used maximum_exertion_level as a clamp, so it was clamped to 10 even for a wariness level 0 character. Now it's not clamped to 10. Though since get_bmr is used to calculate average activity over a period of five minutes, for explosive activities that don't take an extended period of time, this is usually not a noticeable difference.
from_exertion in suffer.cpp was, as mentioned, giving messages at weariness 0 during explosive activity about tiring out and slowing down, and now should not.

Unaffected callers:

activity_level in character.cpp to determine the chance of making some noises I think, where it uses the max of 10-activity level, and 1, so the max of 1 and 10-12 is the same as the max if 1 and 10-10

https://github.com/aattss/Cataclysm-TLG/blob/b31f6f9ba9adcd14745b82d73590e1bbd6094a1f/src/game.cpp#L10372-L10376


For exertion_adjusted_move_multiplier, I saw code regarding applying min 10 to the activity level, from a prior fix, so I decided to add code to apply min 10 to the output of maximum exertion level such that this change does not affect it.

https://github.com/aattss/Cataclysm-TLG/blob/b31f6f9ba9adcd14745b82d73590e1bbd6094a1f/src/character.cpp#L5450-L5451

B.

Updating the buckets for activities should now accept values between the defined constants rather than expecting exact equality, so activity levels like 6.8 or 9.1 should be able to cause the extra weariness gain rather than just the calorie weariness gain.

https://github.com/aattss/Cataclysm-TLG/blob/b280bd739a07989ba106db988e7d2c75eaf1db18/src/activity_tracker.cpp#L161-L171

C.

I refactored the extra weariness processing to a function that is now calculated at the beginning of activity data being reset (i.e. every 5 minutes).

https://github.com/aattss/Cataclysm-TLG/blob/b31f6f9ba9adcd14745b82d73590e1bbd6094a1f/src/activity_tracker.cpp#L200-L218
https://github.com/aattss/Cataclysm-TLG/blob/b31f6f9ba9adcd14745b82d73590e1bbd6094a1f/src/activity_tracker.cpp#L140-L141

D. 

I was unsure as to whether the *_activity variables were intended to be incremented by 1 or by the activity level value, or by whether for num_turns we were assuming that those turns had activity level NO_EXERCISE or the current activity's activity level. I tried to resolve some of the contradiction while minimizing changes by just changing the values by which the high activity *_activity variables were incremented to be consistent to if they're incremented by the normal process before it i.e. current_activity.

https://github.com/aattss/Cataclysm-TLG/blob/b31f6f9ba9adcd14745b82d73590e1bbd6094a1f/src/activity_tracker.cpp#L174-L193


#### Describe alternatives you've considered

A.

For maximum exertion level, not changing maximum_exertion_level and instead changing the callers that seemed to have the wrong behavior, like, to ignore it if weariness is 0. That seemed like it would require more and more different changes. Another idea was to add a second function that returned a different value at weariness level 0 but was otherwise the same, or add the parameter that determined what's actually returned for level 0, but I wasn't sure whether splitting that behavior was warranted or not. I also considered if the calorie consumption and the move speed debuff were supposed to be linked i.e. you work x% slower so you consume x% less calories, but I was unsure and since that would be a balancing change I decided to leave it as is.

B.

For the getting the activity buckets to accept non-constants, I first went with using the first bucket for the smallest activity level was greater than the constant, but then I noticed that activity_level_str had logic for bucketing activity levels that went with more the biggest activity level that was smaller than the constant (i.e. bucketing 6.5 to Active instead of Brisk).

C.

For activity trackers getting reset without getting processed in new_turn, I considered having the extra weariness be processed every turn instead of being conditional on num_turns > 1, but I was worried the original intent was to process it in batches instead of every turn and that such a change would make that logic get calculated significantly more often than before. My first attempts also involved moving the num_turns > 1 block before the activity_reset block to calculate it, but that would have a greater impact on the order in which numbers are calculated/updated and seemed riskier.

D.

For how the higher activity _activity variables get updated, I considered changing the increment from current_activity to 1, or changing the assumption for how the num_turns > 1 case is handled to assume throughout that the activity level was either NO_EXERCISE or current_activity, but as I wasn't sure what the intended behavior/balance was I didn't want to minimize the change, though I'd be totally fine with doing something else with it instead.

#### Testing

For the maximum exertion level, aside form the message that has a random chance of popping up for a wariness level 0 character doing explosive activity, I found I was able to see the metabolic rate in the debug info when checking the game state, in the logs. Though that metabolic rate is a five-minute average. So I'd check it before I do anything, give my character debug stamina so they don't run out of stamina mid-testing, and then smash things for over 5 minutes, and see if the metabolic rate can go over 10* my initial no-action metabolic rate, or if it's capped at about 10*.

For which activities the activities has tracked or processed, the game has values for weariness and such, but since the math is a bit complicated, like including calorie-based weariness and some of the things are averages over periods of time rather than a direct count of turns for each activity, I just put logging in the activity_tracker code, like just before the reset or just before the code where tracker is getting updated with the extra 12.5/25/50/120 bonuses.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
