### PR TITLE
fix up Makefile with regaurds to version and prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1001,7 +1001,7 @@ endif
 
 LDFLAGS += -lz
 
-all: version prefix $(CHECKS) $(TARGET) $(L10N) $(ZZIP_BIN)
+all: $(CHECKS) $(TARGET) $(L10N) $(ZZIP_BIN)
 	@
 
 $(TARGET): $(OBJS)
@@ -1022,14 +1022,7 @@ $(PCH_P): $(PCH_H)
 $(BUILD_PREFIX)$(TARGET_NAME).a: $(OBJS)
 	$(AR) rcs $(BUILD_PREFIX)$(TARGET_NAME).a $(filter-out $(ODIR)/main.o $(ODIR)/messages.o,$(OBJS))
 
-.PHONY: version prefix
-version:
-	@( VERSION_STRING=$(VERSION) ; \
-            [ -e ".git" ] && GITVERSION=$$( git describe --tags --always --match "[0-9A-Z]*.[0-9A-Z]*" ) && DIRTYFLAG=$$( [ -z "$$(git diff --numstat | grep -v lang/po/)" ] || echo "-dirty") && VERSION_STRING=$$GITVERSION$$DIRTYFLAG ; \
-            [ -e "$(SRC_DIR)/version.h" ] && OLDVERSION=$$(grep VERSION $(SRC_DIR)/version.h|cut -d '"' -f2) ; \
-            if [ "x$$VERSION_STRING" != "x$$OLDVERSION" ]; then printf '// NOLINT(cata-header-guard)\n#define VERSION "%s"\n' "$$VERSION_STRING" | tee $(SRC_DIR)/version.h ; fi \
-         )
-
+.PHONY: prefix
 prefix:
 	@( PREFIX_STRING=$(PREFIX) ; \
             [ -e "$(SRC_DIR)/prefix.h" ] && OLDPREFIX=$$(grep PREFIX $(SRC_DIR)/prefix.h|cut -d '"' -f2) ; \
@@ -1055,6 +1048,7 @@ $(ODIR)/third-party/%.o: $(SRC_DIR)/third-party/%.cpp
 $(ODIR)/third-party/%.o: $(SRC_DIR)/third-party/%.c
 	$(CXX) -x c $(CPPFLAGS) $(DEFINES) $(CFLAGS) -w -MMD -MP $(MJFLAG) -c $< -o $@
 
+$(SRC_DIR)/main.cpp: prefix
 $(ODIR)/%.o: $(SRC_DIR)/%.cpp $(PCH_P)
 	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP $(PCHFLAGS) $(MJFLAG) -c $< -o $@
 
@@ -1062,10 +1056,6 @@ $(ODIR)/%.o: $(SRC_DIR)/%.rc
 	$(RC) $(RFLAGS) $< -o $@
 
 $(ODIR)/resource.o: data/cataicon.ico data/application_manifest.xml
-
-src/version.h: version
-
-src/version.cpp: src/version.h
 
 TEST_MO := data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo
 
@@ -1114,7 +1104,7 @@ DATA_PREFIX=$(DESTDIR)$(PREFIX)/share/cataclysm-tlg/
 BIN_PREFIX=$(DESTDIR)$(PREFIX)/bin
 LOCALE_DIR=$(DESTDIR)$(PREFIX)/share/locale
 SHARE_DIR=$(DESTDIR)$(PREFIX)/share
-install: version $(TARGET) $(ZZIP_BIN)
+install: $(TARGET) $(ZZIP_BIN)
 	mkdir -p $(DATA_PREFIX)
 	mkdir -p $(BIN_PREFIX)
 	install --mode=755 $(TARGET) $(BIN_PREFIX)
@@ -1150,7 +1140,7 @@ DATA_PREFIX=$(DESTDIR)$(PREFIX)/share/cataclysm-tlg/
 BIN_PREFIX=$(DESTDIR)$(PREFIX)/bin
 LOCALE_DIR=$(DESTDIR)$(PREFIX)/share/locale
 SHARE_DIR=$(DESTDIR)$(PREFIX)/share
-install: version $(TARGET)
+install: $(TARGET)
 	mkdir -p $(DATA_PREFIX)
 	mkdir -p $(BIN_PREFIX)
 	install --mode=755 $(TARGET) $(BIN_PREFIX)
@@ -1200,9 +1190,9 @@ build-data/osx/AppIcon.icns: build-data/osx/AppIcon.iconset
 	iconutil -c icns $<
 
 ifdef OSXCROSS
-app: appclean version $(APPTARGET) $(ZZIP_BIN)
+app: appclean $(APPTARGET) $(ZZIP_BIN)
 else
-app: appclean version build-data/osx/AppIcon.icns $(APPTARGET) $(ZZIP_BIN)
+app: appclean build-data/osx/AppIcon.icns $(APPTARGET) $(ZZIP_BIN)
 endif
 	mkdir -p $(APPTARGETDIR)/Contents
 	cp build-data/osx/Info.plist $(APPTARGETDIR)/Contents/
@@ -1267,7 +1257,7 @@ endif
 
 endif  # ifeq ($(NATIVE), osx)
 
-$(BINDIST): distclean version $(TARGET) $(ZZIP_BIN) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
+$(BINDIST): distclean $(TARGET) $(ZZIP_BIN) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
 	mkdir -p $(BINDIST_DIR)
 	cp -R $(TARGET) $(ZZIP_BIN) $(BINDIST_EXTRAS) $(BINDIST_DIR)
 	$(foreach lib,$(INSTALL_EXTRAS), install --strip $(lib) $(BINDIST_DIR))
@@ -1357,10 +1347,10 @@ $(ZZIP_BIN): $(ZZIP_SOURCES) $(BUILD_PREFIX)zstd.a
 python-check:
 	flake8
 
-object_creator: version $(BUILD_PREFIX)cataclysm.a
+object_creator: $(BUILD_PREFIX)cataclysm.a
 	$(MAKE) -C object_creator
 
-object_creator.exe: version $(BUILD_PREFIX)cataclysm.a
+object_creator.exe: $(BUILD_PREFIX)cataclysm.a
 	$(MAKE) -C object_creator object_creator.exe
 
 clean-object_creator:


### PR DESCRIPTION

#### Summary
Category "Brief description"
re prefix: if you do `make install`, prefix used to not get built, now it always gets built since main.cpp depends on it (it's the only file that refers to prefix.h. if that ever changes, this will maybe need to be adjusted)
re version: version.h is just never used so I removed the code to generate it. If that's not what you want, let me know and I can keep around the old version code and make version.cpp depend on it (and you have write access to this PR too if you want to do it yourself) 
#### Purpose of change
without this patch, you'd either first need to run the `all` target or the `prefix` target before you could run `make install` since otherwise prefix.h would be missing.
#### Describe the solution
I just make main.cpp depend on the prefix target.
#### Describe alternatives you've considered
there's a lot of ways to do it but this is probably the only one that makes sense. You could also just add `prefix` as a dependency of the `install` target but then that's technically faulty since make doesn't gaurentee the dependency resolution order. so I.e $(TARGET) could be resolved completely before the `prefix` step ever runs and fail since there's no prefix.h, it's just unlikely to ever happen in practice.
#### Testing
`make install PREFIX=...` and `make PREFIX=...` both compile successfully. 
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
