### PR TITLE
Latex from triffids

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -2164,6 +2164,7 @@
       { "drop": "triffid_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "triffid_meat", "type": "offal", "mass_ratio": 0.05 },
       { "drop": "stick", "type": "bone", "mass_ratio": 0.05 },
+      { "drop": "latex", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "venom_paralytic", "type": "offal", "mass_ratio": 0.0075 }
     ]
   },
@@ -2201,6 +2202,7 @@
       { "drop": "stick_fiber", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "triffid_meat", "type": "flesh", "mass_ratio": 0.2 },
       { "drop": "triffid_meat", "type": "offal", "mass_ratio": 0.05 },
+      { "drop": "latex", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "venom_paralytic", "type": "offal", "mass_ratio": 0.02 }
     ]
   },

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -91,19 +91,20 @@
   {
     "type": "ITEM",
     "id": "fighter_sting",
-    "name": { "str": "fungal fighter stinger" },
-    "description": "A short dart from a fungal fighter.  Makes a poor melee weapon.",
+    "name": { "str": "triffid stinger" },
+    "description": "A short wooden dart grown from a mutated plant.",
     "weight": "270 g",
-    "to_hit": -1,
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "point", "balance": "neutral" },
     "color": "green",
     "symbol": ",",
-    "material": [ "vegetable" ],
+    "material": [ "wood" ],
     "volume": "250 ml",
-    "flags": [ "SPEAR", "SHEATH_KNIFE" ],
     "weapon_category": [ "SHIVS" ],
-    "price": "5 USD",
+    "flags": [ "NPC_THROWN" ],
+    "price": "0 USD",
     "price_postapoc": "0 cent",
-    "melee_damage": { "stab": 8 }
+    "thrown_damage": [ { "damage_type": "stab", "amount": 6 } ],
+    "melee_damage": { "stab": 7 }
   },
   {
     "id": "incendiary",


### PR DESCRIPTION
#### Summary
Latex from triffids

#### Purpose of change
I forgot we had latex. Triffids should be bleedable for that.

#### Describe the solution
Added it to the regular and queen triffid, not the others.

#### Describe alternatives you've considered

#### Testing
I was having trouble getting it, I think I was just failing my harvesting rolls though. If it continues to be an issue, reexamine.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
