### PR TITLE
Fix junk allergen name and add NUTRIENT_OVERRIDE to syrup

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1363,7 +1363,7 @@
     "id": "sugar_house_drum",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [ { "item": "syrup", "container-item": "55gal_drum", "charges": [ 2, 150 ] } ]
+    "entries": [ { "item": "syrup", "container-item": "55gal_drum", "charges": [ 2, 100 ] } ]
   },
   {
     "id": "petstore_misc",

--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -422,6 +422,7 @@
     "price": "6 USD",
     "price_postapoc": "7 USD 50 cent",
     "material": [ "junk" ],
+    "flags": [ "NUTRIENT_OVERRIDE" ],
     "volume": "250 ml",
     "phase": "liquid",
     "charges": 16,

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -648,7 +648,7 @@
     "//": "used so allergies and restrictions could be inherited in cooking process",
     "type": "vitamin",
     "vit_type": "counter",
-    "name": { "str": "vegetable" },
+    "name": { "str": "Vegetable" },
     "min": 0,
     "max": 1,
     "rate": "1 h"
@@ -688,7 +688,7 @@
     "//": "used so allergies and restrictions could be inherited in cooking process",
     "type": "vitamin",
     "vit_type": "counter",
-    "name": { "str": "Fruit" },
+    "name": { "str": "Junk Food" },
     "min": 0,
     "max": 1,
     "rate": "1 h"


### PR DESCRIPTION
#### Summary
Fix junk allergen name and add NUTRIENT_OVERRIDE to syrup

#### Purpose of change
Syrup was behaving strangely.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
