### PR TITLE
Fix possibly reading/writing invalid data while processing cigarettes.

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14111,6 +14111,7 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
 {
     // cig dies out
     if( item_counter == 0 ) {
+        bool remove = false;
         if( carrier != nullptr ) {
             carrier->add_msg_if_player( m_neutral, _( "You finish your %s." ), type_name() );
         }
@@ -14119,14 +14120,14 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
             if( !this->is_null() ) {
                 here.add_item_or_charges( carrier->pos_bub(), *this );
                 on_drop( carrier->pos_bub(), here );
-                carrier->i_rem( this );
+                remove = true;
             }
         } else {
             type->invoke( carrier, *this, pos, "transform" );
             if( !this->is_null() ) {
                 here.add_item_or_charges( carrier->pos_bub(), *this );
                 on_drop( carrier->pos_bub(), here );
-                carrier->i_rem( this );
+                remove = true;
             }
         }
         if( typeId() == itype_joint_lit && carrier != nullptr ) {
@@ -14135,7 +14136,7 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
             weed_msg( *carrier );
         }
         active = false;
-        return false;
+        return remove;
     }
 
     if( carrier != nullptr ) {


### PR DESCRIPTION
#### Summary

Hopefully fix an intermittent crash, or at least avoid unintended behaviour, while smoking cigarettes.

#### Purpose of change

Lit cigarette processing was removing itself in the middle of its processing and always returning false, which let the rest of item processing run on an object that's no longer valid.  That could be the reason some people are crashing while smoking.

#### Describe the solution

Just return true and let item processing handle the item's removal like it does for all other items.  Cigarettes didn't need to handle it themselves, and were unique in doing so.

#### Describe alternatives you've considered

Just leaving it.

#### Testing

Made a test character smoke a bunch of cigarettes and joints.  They all properly turned into dropped butts/roaches when finished.  I can't really confirm that this will fix the intermittent crashing, since I can't reproduce it, but it doesn't alter cigarette's behaviour and doesn't risk accessing invalid data.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
