### PR TITLE
Fix incorrect error_skipped_members error that happens sometimes

### DIFF
--- a/src/cata_bitset.cpp
+++ b/src/cata_bitset.cpp
@@ -16,28 +16,51 @@ void tiny_bitset::resize_heap( size_t requested_bits ) noexcept
 {
     size_t blocks_needed = bit_count_to_block_count( requested_bits );
 
+    const size_t old_size = size();
+
     // Round up to a multiple of the block allocation size.
     // The allocation size is stored by malloc so realloc() can be optimized if we keep resizing by small amounts.
+    // One extra block for prepending the capacity to the allocation, which is stored in the first block.
     blocks_needed = ( ( blocks_needed + ( kMinimumBlockPerAlloc - 1 ) ) / kMinimumBlockPerAlloc ) *
                     kMinimumBlockPerAlloc + 1;
 
+    block_t *data;
+
     if( is_inline() ) {
-        // Allocate an extra block for prepending the capacity to.
-        block_t *data = static_cast<block_t *>( malloc( sizeof( block_t ) * ( blocks_needed + 1 ) ) );
+        data = static_cast<block_t *>( malloc( sizeof( block_t ) * blocks_needed ) );
         cata_assert( data != nullptr );
+
         // Capacity goes at the front ahead of the actual bits.
         data[ 0 ] = requested_bits;
         // Copy inline bits to heap.
         data[ 1 ] = storage_ & ~kMetaMask;
-        set_storage( data + 1 );
     } else {
-        block_t *data = static_cast<block_t *>( realloc( real_heap_allocation(),
-                                                sizeof( block_t ) * ( blocks_needed + 1 ) ) );
-        if( data != real_heap_allocation() ) {
-            set_storage( data + 1 );
+        data = static_cast<block_t *>( realloc( real_heap_allocation(),
+                                                sizeof( block_t ) * blocks_needed ) );
+        cata_assert( data != nullptr );
+    }
+
+    if (requested_bits > old_size) {
+        size_t first_block = old_size / kBitsPerBlock;
+        const size_t first_bit = old_size % kBitsPerBlock;
+        block_t *new_storage = data + 1;
+
+        if (first_bit != 0) {
+            // Clear the bits in the first block that are beyond the old size.
+            block_t new_suffix = ( kLowBit << ( kBitsPerBlock - first_bit ) ) - 1;
+            new_storage[first_block] &= ~new_suffix;
+            ++first_block;
+        }
+
+        const size_t end_block = blocks_needed - 1;
+
+        if (first_block < end_block) {
+            // Clear all blocks between the first and last block.
+            memset( new_storage + first_block, 0, sizeof( block_t ) * ( end_block - first_block ) );
         }
     }
 
+    set_storage( data + 1 );
     set_size( requested_bits );
 }
 

--- a/src/cata_bitset.h
+++ b/src/cata_bitset.h
@@ -41,10 +41,13 @@ class tiny_bitset
         // In 64 bit this is 256 bits. Seems unlikely we'll need more than this.
         static constexpr size_t kMinimumBlockPerAlloc = 4;
 
+        static constexpr size_t blocks_needed( size_t bits ) noexcept {
+            return ( bits + kBitsPerBlock - 1 ) / kBitsPerBlock;
+        }
+
         tiny_bitset() noexcept : tiny_bitset( kMaxInlineBits ) { }
 
         explicit tiny_bitset( size_t initial_capacity ) noexcept {
-            storage_ = kStorageIsInlineMask;
             resize( initial_capacity );
         }
 
@@ -60,7 +63,7 @@ class tiny_bitset
                 storage_ = rhs.storage_;
             } else {
                 resize( rhs.capacity() );
-                memcpy( bits(), rhs.bits(), rhs.size() / kBitsPerBlock );
+                memcpy( bits(), rhs.bits(), blocks_needed( rhs.size() ) * sizeof( block_t ) );
             }
         }
 
@@ -76,7 +79,7 @@ class tiny_bitset
                 storage_ = rhs.storage_;
             } else {
                 resize( rhs.capacity() );
-                memcpy( bits(), rhs.bits(), rhs.size() / kBitsPerBlock );
+                memcpy( bits(), rhs.bits(), blocks_needed( rhs.size() ) * sizeof( block_t ) );
             }
             return *this;
         }
@@ -124,6 +127,18 @@ class tiny_bitset
 
         void resize( size_t requested_bits ) noexcept {
             if( is_inline() && requested_bits <= kMaxInlineBits ) {
+                const size_t old_size = size();
+                if (requested_bits > old_size) {
+                    // Initialize newly exposed bits, so they don't unexpectedly hold old data.
+                    if (old_size == 0) {
+                        storage_ &= kMetaMask;
+                    } else {
+                        storage_ &= ( 
+                            ~( ( kLowBit << ( kBitsPerBlock - old_size ) ) - 1) | 
+                            kMetaMask
+                        );
+                    }
+                }
                 set_size( requested_bits );
                 return;
             }
@@ -246,7 +261,7 @@ class tiny_bitset
         // the existing value in what is written.
         template<typename Op>
         void map( Op &&op ) {
-            size_t bits_used = size();
+            const size_t bits_used = size();
             if( bits_used == 0 ) {
                 return;
             }
@@ -256,40 +271,21 @@ class tiny_bitset
                 return;
             }
 
-            // The compiler auto vectorizer is too smart and inserts a bunch of code
-            // to handle various cases of how big the data is. We expect things to be
-            // small, so we can hand roll a loop which doesn't blow up code size or
-            // insert a huge number of conditionals into the hot path, and probably
-            // not measurably slower than the fully expanded vectorized code which handles
-            // 128 bytes (1,024 bits!) in one pass.
-            size_t used_blocks = bits_used / kBitsPerBlock;
-            // The final block requires special handling.
-            size_t used_bits_in_final_block = bits_used % kBitsPerBlock;
-            size_t used_whole_blocks = used_bits_in_final_block > 0 &&
-                                       used_blocks > 0 ? used_blocks - 1 : used_blocks;
+            const size_t whole_blocks = bits_used / kBitsPerBlock;
+            const size_t partial_bits = bits_used % kBitsPerBlock;            
 
-            // Process 4 at a time for some manual unrolling.
-            block_t *blocks = bits();
-            size_t i = 0;
-            for( size_t end = used_whole_blocks; i + 3 < end; i += 4 ) {
-                op( blocks[i + 0] );
-                op( blocks[i + 1] );
-                op( blocks[i + 2] );
-                op( blocks[i + 3] );
-            }
-            // final whole blocks that don't fit in unrolled loop.
-            for( ; i < used_whole_blocks; ++i ) {
+            block_t *const blocks = bits();
+            for(size_t i = 0 ; i < whole_blocks; ++i ) {
                 op( blocks[i] );
             }
             // final, partial block
-            block_t unused_mask;
-            if( used_bits_in_final_block != 0 ) {
+            if( partial_bits != 0 ) {
                 // Create mask which is all bits set for bits not used in capacity.
                 // If we used N bits, create a mask of the k - N least significant bits by
                 // shifting a 1 k-N times, into the k-N'th bit _index_ (or k-N+1'th bit) then
                 // subtracting one, setting k-N of the least significant bits to 1.
-                unused_mask = ( kLowBit << ( kBitsPerBlock - used_bits_in_final_block ) ) - 1;
-                op( blocks[i], unused_mask );
+                const block_t unused_mask = ( kLowBit << ( kBitsPerBlock - partial_bits ) ) - 1;
+                op( blocks[whole_blocks], unused_mask );
             }
         }
 
@@ -327,7 +323,7 @@ class tiny_bitset
         // way, have a nickel get yourself a better computer.
         // This could probably be some extremely complicated thing with a union and other
         // stuff but some constraints and assumptions make it work out simply.
-        uintptr_t storage_;
+        uintptr_t storage_ = kStorageIsInlineMask;
 
         static_assert( std::numeric_limits<uintptr_t>::radix == 2, "Non binary integers are forbidden" );
         static_assert( std::numeric_limits<uintptr_t>::digits > 0, "Must be > 0 bits are in uintptr_t" );

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -263,8 +263,11 @@ void JsonObject::report_unvisited() const
         skipped_members.reserve( visited_fields_bitset_.size() );
         tiny_bitset::block_t *bits = visited_fields_bitset_.bits();
         size_t block_idx = 0;
-        for( size_t last_whole_block = visited_fields_bitset_.size() / tiny_bitset::kBitsPerBlock;
-             block_idx < last_whole_block; ++block_idx ) {
+
+        const size_t whole_blocks = visited_fields_bitset_.size() / tiny_bitset::kBitsPerBlock;
+        const size_t partial_bits = visited_fields_bitset_.size() % tiny_bitset::kBitsPerBlock;
+
+        for(; block_idx < whole_blocks; ++block_idx ) {
             tiny_bitset::block_t block = bits[block_idx];
             tiny_bitset::block_t mask = tiny_bitset::kLowBit << ( tiny_bitset::kBitsPerBlock - 1 );
             for( size_t bit_idx = 0; bit_idx < tiny_bitset::kBitsPerBlock; ++bit_idx ) {
@@ -275,14 +278,16 @@ void JsonObject::report_unvisited() const
             }
         }
 
-        tiny_bitset::block_t block = bits[block_idx];
-        tiny_bitset::block_t mask = tiny_bitset::kLowBit << ( tiny_bitset::kBitsPerBlock - 1 );
-        for( size_t bit_idx = 0, end = visited_fields_bitset_.size() % tiny_bitset::kBitsPerBlock;
-             bit_idx < end; ++bit_idx ) {
-            if( !( block & mask ) ) {
-                skipped_members.emplace_back( block_idx * tiny_bitset::kBitsPerBlock + bit_idx );
+        if (partial_bits > 0) {
+            tiny_bitset::block_t block = bits[block_idx];
+            tiny_bitset::block_t mask = tiny_bitset::kLowBit << ( tiny_bitset::kBitsPerBlock - 1 );
+            for( size_t bit_idx = 0, end = visited_fields_bitset_.size() % tiny_bitset::kBitsPerBlock;
+                bit_idx < end; ++bit_idx ) {
+                if( !( block & mask ) ) {
+                    skipped_members.emplace_back( block_idx * tiny_bitset::kBitsPerBlock + bit_idx );
+                }
+                mask >>= 1;
             }
-            mask >>= 1;
         }
 
         // Don't error on skipped comments.


### PR DESCRIPTION
#### Summary

Sometimes, especially when quitting and loading games repeatedly without closing the game, a json error will appear complaining about random json objects having unread keys despite being untrue and otherwise loading fine.  It's a harmless error, but annoying, and makes times when it's legitimate easier to miss.

#### Purpose of change

I tracked this down to a few potential issues in tiny_bitset's handling of its memory, along with how it was mapping index to bit locations.  In many cases, its data was left uninitialized, or left unchanged from resizing, which could easily mean a random bit was incorrectly flagged as true despite never actually being touched.  In its mapping function, whenever it had a block that was partially allocated for use, it was also excluding its last full-use block.  The two issues compounded to mean that, very randomly, a json object that was being loaded could have had an entry that was in a partial-use block, was populated with uninitialized or old data, and couldn't be properly written to.  When the error checker iterated over it, the bit wasn't set, so the error gets displayed.

#### Describe the solution

Fix up tiny_bitset's memory initialization to always set newly allocated/available bits to 0, and always start with zeroed data.  Fix tiny_bitset's copy constructor and operator to actually copy the entirety of its active blocks in the heap case.  Fix tiny_bitset's map function to not exclude the last block when it has partial blocks.  Fix tiny_bitset's resizing function not zeroing newly exposed bits.  Fix flexbuffer_json's method for reading the tiny_bitset to avoid potentially reading a block that is out-of-bounds.

#### Describe alternatives you've considered

Just leaving it.  I imagine most won't even encounter it, since I've only ever seen it when saving and loading games a bunch without exiting the game.  That's probably just developers and mod developers?

#### Testing

Spammed loading several different worlds with different mods, no json loading errors.  It's intermittent, so I can't guarantee it was actually fixed, but I also can't make it error with these fixes.  Edited a few json objects to include unread keys, and the unread keys did produce errors correctly, so these changes didn't break that functionality.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
