### PR TITLE
Aim speed and dispersion adjustments

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1074,7 +1074,7 @@ int Character::point_shooting_limit( const item &gun )const
 aim_mods_cache Character::gen_aim_mods_cache( const item &gun )const
 {
     parallax_cache parallaxes{ get_character_parallax( true ), get_character_parallax( false ) };
-    return { get_modifier( character_modifier_aim_speed_skill_mod, gun.gun_skill() ), get_modifier( character_modifier_aim_speed_dex_mod ), get_modifier( character_modifier_aim_speed_mod ), most_accurate_aiming_method_limit( gun ), aim_factor_from_volume( gun ), aim_factor_from_length( gun ), parallaxes };
+    return { get_modifier( character_modifier_aim_speed_skill_mod, gun.gun_skill() ), get_modifier( character_modifier_aim_speed_dex_mod ), get_modifier( character_modifier_aim_speed_mod ), most_accurate_aiming_method_limit( gun ), aim_factor_from_length( gun ), aim_factor_from_volume( gun ), parallaxes };
 }
 
 double Character::fastest_aiming_method_speed( const item &gun, double recoil,
@@ -1183,21 +1183,38 @@ int Character::most_accurate_aiming_method_limit( const item &gun ) const
 
 double Character::aim_factor_from_volume( const item &gun ) const
 {
-    skill_id gun_skill = gun.gun_skill();
+    if( !is_wielding( gun ) ) {
+        return 1.0;
+    }
     double wielded_volume = gun.volume() / 1_ml;
-    // this is only here for mod support
+    // This is only here for mod support.
     if( gun.has_flag( flag_COLLAPSIBLE_STOCK ) ) {
-        // use the unfolded volume
+        // Use the unfolded volume.
         wielded_volume += gun.collapsed_volume_delta() / 1_ml;
     }
-
-    double factor = gun_skill == skill_pistol ? 4 : 1;
-    double min_volume_without_debuff =  800;
-    if( wielded_volume > min_volume_without_debuff ) {
-        factor *= std::pow( min_volume_without_debuff / wielded_volume, 0.333333 );
+    // Thresholds are cheaper than std::pow(), otherwise we'd just use that.
+    constexpr double volume_thresholds[] = { 200.0, 400.0, 800.0, 1600.0, 3200.0 };
+    const double max_volume_without_slowdown = volume_thresholds[get_size() - 1];
+    double factor = 1.0;
+    if( wielded_volume > max_volume_without_slowdown ) {
+        factor = std::cbrt( max_volume_without_slowdown / wielded_volume );
     }
+    return std::max( factor, 0.2 );
+}
 
-    return std::max( factor, 0.2 ) ;
+double Character::aim_factor_from_weight( const item &gun ) const
+{
+    if( !is_wielding( gun ) ) {
+        return 1.0;
+    }
+    double wielded_weight = gun.weight() / 1_gram;
+    const double effective_strength = get_arm_str() * std::clamp( (static_cast<double>( get_stamina() ) / static_cast<double>( get_stamina_max() ) ), 0.4, 1.0 );
+    const double max_weight_without_slowdown = effective_strength * 100.0;
+    double factor = 1.0;
+    if( wielded_weight > max_weight_without_slowdown ) {
+        factor = std::cbrt( max_weight_without_slowdown / wielded_weight );
+    }
+    return std::max( factor, 0.2 );
 }
 
 static bool is_obstacle( tripoint_bub_ms pos )
@@ -1208,22 +1225,28 @@ static bool is_obstacle( tripoint_bub_ms pos )
 double Character::aim_factor_from_length( const item &gun ) const
 {
     tripoint_bub_ms cur_pos = pos_bub();
-    bool nw_to_se = is_obstacle( cur_pos + tripoint::south_east ) &&
-                    is_obstacle( cur_pos + tripoint::north_west );
-    bool w_to_e = is_obstacle( cur_pos + tripoint::west ) &&
-                  is_obstacle( cur_pos + tripoint::east );
-    bool sw_to_ne = is_obstacle( cur_pos + tripoint::south_west ) &&
-                    is_obstacle( cur_pos + tripoint::north_east );
-    bool n_to_s = is_obstacle( cur_pos + tripoint::north ) &&
-                  is_obstacle( cur_pos + tripoint::south );
-    double wielded_length = gun.length() / 1_mm;
-    double factor = 1.0;
-
-    if( nw_to_se || w_to_e || sw_to_ne || n_to_s ) {
-        factor = 1.0 - static_cast<float>( ( wielded_length - 300 ) / 1000 );
-        factor =  std::min( factor, 1.0 );
+    const int length = gun.length() / 1_mm;
+    if( length <= 200 ) {
+        return 1.0;
     }
-    return std::max( factor, 0.2 ) ;
+    const bool confined =
+        in_vehicle ||
+        ( is_obstacle( cur_pos + tripoint::south_east ) &&
+        is_obstacle( cur_pos + tripoint::north_west ) ) ||
+        ( is_obstacle( cur_pos + tripoint::west ) &&
+        is_obstacle( cur_pos + tripoint::east ) ) ||
+        ( is_obstacle( cur_pos + tripoint::south_west ) &&
+        is_obstacle( cur_pos + tripoint::north_east ) ) ||
+        ( is_obstacle( cur_pos + tripoint::north ) &&
+        is_obstacle( cur_pos + tripoint::south ) );
+
+    if( !confined ) {
+        return 1.0;
+    }
+    const double factor = std::clamp(
+        1.0 - ( length - 200.0 ) / 1125.0,
+        0.2, 1.0 );
+    return factor;
 }
 
 double Character::aim_per_move( const item &gun, double recoil,
@@ -1242,64 +1265,56 @@ double Character::aim_per_move( const item &gun, double recoil,
         // No suitable sights (already at maximum aim).
         return 0;
     }
-
     // Overall strategy for determining aim speed is to sum the factors that contribute to it,
     // then scale that speed by current recoil level.
     // Player capabilities make aiming faster, and aim speed slows down as it approaches 0.
     // Base speed is non-zero to prevent extreme rate changes as aim speed approaches 0.
     double aim_speed = 10.0;
-
     skill_id gun_skill = gun.gun_skill();
-
     aim_speed += sight_speed_modifier;
-
     if( !use_cache ) {
-        // Ranges [-1.5 - 3.5] for archery Ranges [0 - 2.5] for others
+        // Ranges [-1.5 - 3.5] for archery/throwing, ranges [0 - 2.5] for others.
         aim_speed += get_modifier( character_modifier_aim_speed_skill_mod, gun_skill );
 
         /** @EFFECT_DEX increases aiming speed */
-        // every DEX increases 0.5 aim_speed
+        // Every DEX above 9 adds 0.5 aim_speed.  This is hardcoded in character_modifiers.cpp.
         aim_speed += get_modifier( character_modifier_aim_speed_dex_mod );
 
         aim_speed *= get_modifier( character_modifier_aim_speed_mod );
     } else {
         aim_speed += aim_cache.value().get().aim_speed_skill_mod;
-
         aim_speed += aim_cache.value().get().aim_speed_dex_mod;
-
         aim_speed *= aim_cache.value().get().aim_speed_mod;
     }
-
-    // finally multiply everything by a harsh function that is eliminated by 7.5 gunskill
+    // Finally multiply everything by a harsh function that is eliminated by 7.5 weapon skill.
     aim_speed /= std::max( 1.0, 2.5 - 0.2 * get_skill_level( gun_skill ) );
     // Use a milder attenuation function to replace the previous logarithmic attenuation function when recoil is closed to 0.
     aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
-
-    // add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10
+    // Add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10.
     double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0,
                                 3.0 * get_skill_level( gun_skill ) );
     if( !use_cache ) {
-        // This upper limit usually only affects the first half of the aiming process
-        // Pistols have a much higher aiming speed limit
-        aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_volume( gun ) );
-
-        // When the character is in an open area, it will not be affected by the length of the weapon.
-        // This upper limit usually only affects the first half of the aiming process
-        // Weapons shorter than carbine are usually not affected by it
         aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_length( gun ) );
+        aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_volume( gun ) );
+        // aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_weight( gun ) );
     } else {
         aim_speed = std::min( aim_speed,
-                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_volume );
-
+                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_length ); 
         aim_speed = std::min( aim_speed,
-                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_length );
+                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_volume );                         
+        // aim_speed = std::min( aim_speed,
+                             // base_aim_speed_cap * aim_cache.value().get().aim_factor_from_weight );
+    }
+    int stamina = get_stamina();
+    int stamina_max = get_stamina_max();
+    if( stamina < stamina_max ) {
+        double stamina_mod = std::max( 0.6, stamina_max / stamina_mod );
+        aim_speed *= stamina_mod;
     }
     // Just a raw scaling factor.
     aim_speed *= 2.4;
-
     // Minimum improvement is 0.01MoA.  This is just to prevent data anomalies
     aim_speed = std::max( aim_speed, MIN_RECOIL_IMPROVEMENT );
-
     // Never improve by more than the currently used sights permit.
     return std::min( aim_speed, recoil - limit );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1291,7 +1291,6 @@ double Character::aim_per_move( const item &gun, double recoil,
     // Getting some aim bar is fast, but it slows as you build it.
     double recoil_factor = 
        std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
-
     recoil_factor = std::pow( recoil_factor, 1.05 );
     aim_speed *= recoil_factor;
     // Add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1288,8 +1288,12 @@ double Character::aim_per_move( const item &gun, double recoil,
     }
     // Finally multiply everything by a harsh function that is eliminated by 7.5 weapon skill.
     aim_speed /= std::max( 1.0, 2.5 - 0.2 * get_skill_level( gun_skill ) );
-    // Use a milder attenuation function to replace the previous logarithmic attenuation function when recoil is closed to 0.
-    aim_speed *= std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
+    // Getting some aim bar is fast, but it slows as you build it.
+    double recoil_factor = 
+       std::max( recoil / MAX_RECOIL, 1 - logarithmic_range( 0, MAX_RECOIL, recoil ) );
+
+    recoil_factor = std::pow( recoil_factor, 1.05 );
+    aim_speed *= recoil_factor;
     // Add 4 max aim speed per skill up to 5 skill, then 1 per skill for skill 5-10.
     double base_aim_speed_cap = 5.0 +  1.0 * get_skill_level( gun_skill ) + std::max( 10.0,
                                 3.0 * get_skill_level( gun_skill ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1074,7 +1074,7 @@ int Character::point_shooting_limit( const item &gun )const
 aim_mods_cache Character::gen_aim_mods_cache( const item &gun )const
 {
     parallax_cache parallaxes{ get_character_parallax( true ), get_character_parallax( false ) };
-    return { get_modifier( character_modifier_aim_speed_skill_mod, gun.gun_skill() ), get_modifier( character_modifier_aim_speed_dex_mod ), get_modifier( character_modifier_aim_speed_mod ), most_accurate_aiming_method_limit( gun ), aim_factor_from_length( gun ), aim_factor_from_volume( gun ), parallaxes };
+    return { get_modifier( character_modifier_aim_speed_skill_mod, gun.gun_skill() ), get_modifier( character_modifier_aim_speed_dex_mod ), get_modifier( character_modifier_aim_speed_mod ), most_accurate_aiming_method_limit( gun ), aim_factor_from_length( gun ), aim_factor_from_volume( gun ), aim_factor_from_weight( gun ), parallaxes };
 }
 
 double Character::fastest_aiming_method_speed( const item &gun, double recoil,
@@ -1296,20 +1296,14 @@ double Character::aim_per_move( const item &gun, double recoil,
     if( !use_cache ) {
         aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_length( gun ) );
         aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_volume( gun ) );
-        // aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_weight( gun ) );
+        aim_speed = std::min( aim_speed, base_aim_speed_cap * aim_factor_from_weight( gun ) );
     } else {
         aim_speed = std::min( aim_speed,
                               base_aim_speed_cap * aim_cache.value().get().aim_factor_from_length ); 
         aim_speed = std::min( aim_speed,
                               base_aim_speed_cap * aim_cache.value().get().aim_factor_from_volume );                         
-        // aim_speed = std::min( aim_speed,
-                             // base_aim_speed_cap * aim_cache.value().get().aim_factor_from_weight );
-    }
-    int stamina = get_stamina();
-    int stamina_max = get_stamina_max();
-    if( stamina < stamina_max ) {
-        double stamina_mod = std::max( 0.6, stamina_max / stamina_mod );
-        aim_speed *= stamina_mod;
+        aim_speed = std::min( aim_speed,
+                              base_aim_speed_cap * aim_cache.value().get().aim_factor_from_weight );
     }
     // Just a raw scaling factor.
     aim_speed *= 2.4;

--- a/src/character.h
+++ b/src/character.h
@@ -418,7 +418,7 @@ struct aim_mods_cache {
     int limit;
     double aim_factor_from_length;
     double aim_factor_from_volume;
-//    double aim_factor_from_weight;
+    double aim_factor_from_weight;
     parallax_cache parallaxes;
 };
 

--- a/src/character.h
+++ b/src/character.h
@@ -416,8 +416,9 @@ struct aim_mods_cache {
     float aim_speed_dex_mod;
     float aim_speed_mod;
     int limit;
-    double aim_factor_from_volume;
     double aim_factor_from_length;
+    double aim_factor_from_volume;
+//    double aim_factor_from_weight;
     parallax_cache parallaxes;
 };
 
@@ -860,8 +861,15 @@ class Character : public Creature, public visitable
                                             const Target_attributes &target_attributes = Target_attributes(),
                                             std::optional<std::reference_wrapper<const parallax_cache>> parallax_cache = std::nullopt ) const;
         int most_accurate_aiming_method_limit( const item &gun ) const;
-        double aim_factor_from_volume( const item &gun ) const;
+        /* Aim speed penalty from the general bulk of the weapon.
+           This scales with the shooter's size category. */
         double aim_factor_from_length( const item &gun ) const;
+        /* Length penalties to aim speed are only assessed when the shooter is in a vehicle or
+           against a wall. These do not scale with the shooter's height as it's more about gun
+           vs environment. Guns under 200mm (about 8 inches) are unaffected. */
+        double aim_factor_from_volume( const item &gun ) const;
+        // Heavier guns are slower to aim. This is checked against get_arm_str() and stamina.
+        double aim_factor_from_weight( const item &gun ) const;
         aim_mods_cache gen_aim_mods_cache( const item &gun )const;
 
         // Get the value of the specified character modifier.

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -32,6 +32,7 @@ static const limb_score_id limb_score_swim( "swim" );
 
 static const skill_id skill_archery( "archery" );
 static const skill_id skill_swimming( "swimming" );
+static const skill_id skill_throw( "throw" );
 
 namespace
 {
@@ -270,12 +271,11 @@ float Character::get_limb_score( const limb_score_id &score, const body_part_typ
 }
 
 // Modifiers
-
 static float aim_speed_skill_modifier( const Character &c, const skill_id &gun_skill )
 {
     float skill_mult = 0.25f;
     float base_modifier = 0.0f;
-    if( gun_skill == skill_archery ) {
+    if( gun_skill == skill_archery || gun_skill == skill_throw ) {
         skill_mult = 0.5f;
         base_modifier = -1.5f;
     }
@@ -285,7 +285,8 @@ static float aim_speed_skill_modifier( const Character &c, const skill_id &gun_s
 
 static float aim_speed_dex_modifier( const Character &c, const skill_id & )
 {
-    return ( c.get_dex() - 8 ) * 0.5f;
+    // 9-10 is average, so that's where the bonus starts.
+    return ( c.get_dex() - 9 ) * 0.5f;
 }
 
 static float move_mode_move_cost_modifier( const Character &c, const skill_id & )

--- a/src/creature.h
+++ b/src/creature.h
@@ -323,7 +323,7 @@ class Creature : public viewer
         void setpos( map &here, const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
-        // Convert size to int. TODO: use this everywhere instead of enuming every time.
+        // Convert size to int. Useful when working in classes like avatar so we don't have to jump through hoops.
         int enum_size() const;
         /** Checks if the creature fits into a given tile. Set the boolean argument to true if the creature would barely fit. */
         bool can_move_to_vehicle_tile( const tripoint_abs_ms &loc, bool &cramped ) const;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2934,6 +2934,7 @@ target_handler::trajectory target_ui::run()
     if( reentered ) {
         if( !try_reacquire_target( resume_critter, initial_dst ) ) {
             // Target lost
+            you->recoil = MAX_RECOIL;
             action.clear();
             attack_was_confirmed = false;
         }
@@ -2942,7 +2943,8 @@ target_handler::trajectory target_ui::run()
     }
     set_cursor_pos( initial_dst );
     if( dst != initial_dst ) {
-        // Our target moved out of range
+        // Our target moved out of range.
+        you->recoil = MAX_RECOIL;
         action.clear();
         attack_was_confirmed = false;
     }
@@ -2957,6 +2959,7 @@ target_handler::trajectory target_ui::run()
         if( !action.empty() && !prompt_friendlies_in_lof() ) {
             // A friendly creature moved into line of fire during aim-and-shoot,
             // and player decided to stop aiming
+            you->recoil = MAX_RECOIL;
             action.clear();
             attack_was_confirmed = false;
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2692,7 +2692,9 @@ dispersion_sources Character::get_tracking_dispersion( const item *obj, const Cr
     }
     tracking_dispersion *= distance_factor;
     if( rng ) {
-    tracking_dispersion *= rng_float( 0.25, 1.5 );
+        // Weight RNG by range so close firefights are more chaotic.
+        const double rng_max = 1.0 + ( 1.75 * distance_factor );
+        tracking_dispersion *= rng_float( 0.25, rng_max );
     }
     if( report ) {
     add_msg_debug( debugmode::DF_RANGED,


### PR DESCRIPTION
#### Summary
Aim speed and dispersion adjustments

#### Purpose of change
More fixes were needed

#### Describe the solution
- Aim speed now cares about your size compared to the volume of your gun, and your strength and stamina compared to the weight of your gun.
- Aim speed is now a bit slower the more full your aim bar is. This makes precise shots harder to get off, but doesn't change regular shots.
- Tracking dispersion now has much more RNG the closer you are, and less the farther away you are.
- Added a number of aim resets that appeared to be missing from the code, particularly when a creature you were aiming at left your weapon's max range or otherwise disappeared.
- Optimized and fixed up some aim speed code generally.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
