### PR TITLE
Fix house_43 terrain

### DIFF
--- a/data/json/mapgen/house/house43.json
+++ b/data/json/mapgen/house/house43.json
@@ -31,7 +31,7 @@
         "........................"
       ],
       "palettes": [ "parametrized_linoleum_palette", "domestic_general_and_variant_palette" ],
-      "terrain": { "$": "t_thconc_floor", "º": "t_water_pool" },
+      "terrain": { "$": "t_thconc_floor_no_roof", "º": "t_water_pool" },
       "place_monster": [ { "group": "GROUP_ZOMBIE_POOL", "x": 16, "y": 18, "chance": 50 } ],
       "place_loot": [
         { "item": "television", "x": 9, "y": 13 },


### PR DESCRIPTION
#### Summary
Fix house_43 terrain

#### Purpose of change
house_43 has a pool deck, which is unroofed, but it was using thconc_floor and not thconc_floor_no_roof.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
