### PR TITLE
Fix rare case of mission failure killing the player

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -55,7 +55,7 @@
       ]
     },
     "end": { "effect": [ { "u_sell_item": "inhaler" }, "stop_guard", { "set_npc_rule": "investigate_noises" }, "npc_thankful" ] },
-    "fail": { "effect": "npc_die" }
+    "fail": { "effect": { "if": "has_beta", "then": "npc_die" } }
   },
   {
     "id": "MISSION_GET_ANTIBIOTICS",
@@ -107,7 +107,7 @@
         "npc_thankful"
       ]
     },
-    "fail": { "effect": "npc_die" }
+    "fail": { "effect": { "if": "has_beta", "then": "npc_die" } }
   },
   {
     "id": "MISSION_GET_BLACK_BOX",

--- a/data/mods/innawood/npcs/missiondef.json
+++ b/data/mods/innawood/npcs/missiondef.json
@@ -32,7 +32,7 @@
     "end": {
       "effect": [ "stop_guard", { "set_npc_rule": "investigate_noises" }, { "u_sell_item": "spurge_tea" }, "npc_thankful" ]
     },
-    "fail": { "effect": "npc_die" }
+    "fail": { "effect": { "if": "has_beta", "then": "npc_die" } }
   },
   {
     "id": "MISSION_GET_ANTIBIOTICS",
@@ -67,7 +67,7 @@
     "end": {
       "effect": [ { "npc_lose_effect": "infection" }, "stop_guard", { "set_npc_rule": "investigate_noises" }, "npc_thankful" ]
     },
-    "fail": { "effect": "npc_die" }
+    "fail": { "effect": { "if": "has_beta", "then": "npc_die" } }
   },
   {
     "id": "MISSION_GET_FLAG",


### PR DESCRIPTION
#### Summary

Fixes the rare case of mission failure incorrectly killing the player character.

#### Purpose of change

If an NPC is somehow removed without cleaning up its associated mission, and that mission happens to be one of the ones that kills them on failure (like finding antibiotics), then when the mission's failure eoc runs npc_die, that npc beta talker is invalid.  To avoid crashing, the code for selecting a talker will select the alpha talker if a beta talker isn't present.  That means, npc_die will effectively become u_die when there isn't a beta talker.  

#### Describe the solution

Just put a guard rail on the missions that makes sure there's actually an npc to kill before trying to kill it.

#### Describe alternatives you've considered

Diving deeper and finding situations where NPCs can be removed without cleaning up their missions.  I did take a look briefly, and most cases seem to be handled fine.  I figure adding the check is the safer option for now anyway.

#### Testing

Edited a save to remove the associated NPC on a fetch antibiotics mission. Let the mission time out, and confirmed that it killed the player.  Repeated the process with the changes added, and the mission simply failed without killing the player.

#### Additional context

