### PR TITLE
Possibly fix the evac center computer

### DIFF
--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -322,7 +322,9 @@ void mission_start::reveal_refugee_center( mission *miss )
             get_player_character().pos_abs_omt(), "road",
             3, false );
     const tripoint_abs_omt dest_road = overmap_buffer.find_closest( *target_pos, "road", 3, false );
-
+    avatar &player_character = get_avatar();
+    const tripoint_abs_omt target = player_character.get_active_mission_target();
+    const bool has_target = !target.is_invalid();
     if( overmap_buffer.reveal_route( source_road, dest_road, 1, true ) ) {
         //reset the mission target to the refugee center entrance and reveal path from the road
         t.overmap_terrain = "refctr_S3e";
@@ -333,8 +335,10 @@ void mission_start::reveal_refugee_center( mission *miss )
         overmap_buffer.reveal_route( dest_road, dest_refugee_center, 1, false );
 
         add_msg( _( "You mark the refugee center and the road that leads to it…" ) );
-    } else {
+    } else if( has_target ) {
         add_msg( _( "You mark the refugee center, but you have no idea how to get there by road…" ) );
+    } else {
+        add_msg( _( "You don't recognize this address.  It's surely out there somewhere, but it must be quite far away." ) );
     }
 }
 


### PR DESCRIPTION
#### Summary
Possibly fix the evac center computer

#### Purpose of change
- People have been reporting the refugee center computer sometimes failing to find the refugee center, but also failing to find coords for it.
- I cannot reproduce this on my end. Maybe my computer is too good?
- There's supposed to be a failsafe for this, but it doesn't work.

#### Describe the solution
- Attempt to check if there's a destination, and if one is not found, print a different message.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
