### PR TITLE
Don't catch rotten fish

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3818,7 +3818,7 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
         chosen_fish->fish_population -= 1;
         if( chosen_fish->fish_population <= 0 ) {
             Character *who_ptr = &who;
-            g->catch_a_monster( chosen_fish, who.pos_bub(), who_ptr, 50_hours );
+            g->catch_a_monster( chosen_fish, who.pos_bub(), who_ptr );
         } else {
             if( chosen_fish->type != nullptr ) {
                 caught_corpse( who, here, *( chosen_fish->type ) );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3797,8 +3797,7 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
     map &here = get_map();
     constexpr auto caught_corpse = []( Character & who, map & here, const mtype & corpse_type ) {
         item corpse = item::make_corpse( corpse_type.id,
-                                         calendar::turn + rng( 0_turns,
-                                                 3_hours ) );
+                                         calendar::turn );
         corpse.set_var( "activity_var", who.name );
         item_location loc = here.add_item_or_charges_ret_loc( who.pos_bub(), corpse );
         if( who.is_avatar() ) {
@@ -3808,7 +3807,7 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
             who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
     };
-    //if the vector is empty (no fish around) the player is still given a small chance to get a (let us say it was hidden) fish
+    // If the vector is empty (no fish around) the player is still given a small chance to get a (let us say it was hidden) fish.
     if( fishables.empty() ) {
         const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                     GROUP_FISH, true );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1574,18 +1574,16 @@ void game::set_driving_view_offset( const point_rel_ms &p )
         driving_view_offset.raw(); // TODO: Implement -= etc. for relative coordinates.
 }
 
-void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character *p,
-                            const time_duration &catch_duration ) // catching function
+void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character *p )
 {
     map &here = get_map();
 
-    //spawn the corpse, rotten by a part of the duration
-    here.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
-                              catch_duration ) ) );
+    // Apawn the corpse, rotten by a part of the duration.
+    here.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn ) );
     if( u.sees( here, pos ) ) {
         u.add_msg_if_player( m_good, _( "You caught a %s." ), fish->type->nname() );
     }
-    //quietly kill the caught
+    // Quietly kill whatever we caught.
     fish->no_corpse_quiet = true;
     fish->die( &here, p );
 }

--- a/src/game.h
+++ b/src/game.h
@@ -614,8 +614,7 @@ class game
         /** validate camps to ensure they are on the overmap list */
         void validate_camps();
         /** Picks and spawns a random fish from the remaining fish list when a fish is caught. */
-        void catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character *p,
-                              const time_duration &catch_duration );
+        void catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character *p );
         /**
          * Get the contiguous fishable locations starting at fish_pos, out to the specified distance.
          * @param distance Distance around the fish_pos to examine for contiguous fishable locations.

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1802,14 +1802,13 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
             player.practice( skill_survival, rng( 3, 10 ) );
             if( !fishables.empty() ) {
                 monster *chosen_fish = random_entry( fishables );
-                // reduce the abstract fish_population marker of that fish
+                // Reduce the abstract fish_population marker of that fish.
                 chosen_fish->fish_population -= 1;
                 if( chosen_fish->fish_population <= 0 ) {
-                    g->catch_a_monster( chosen_fish, pos, p, 300_hours ); //catch the fish!
+                    g->catch_a_monster( chosen_fish, pos, p ); // Catch the fish!
                 } else {
                     here.add_item_or_charges( pos, item::make_corpse( chosen_fish->type->id,
-                                              calendar::turn + rng( 0_turns,
-                                                      3_hours ) ) );
+                                              calendar::turn ) );
                 }
             } else {
                 //there will always be a chance that the player will get lucky and catch a fish
@@ -1824,8 +1823,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
                     //but it's not as comfortable as if you just put fishes in the same tile with the trap.
                     //Also: corpses and comestibles do not rot in containers like this, but on the ground they will rot.
                     //we don't know when it was caught so use a random turn
-                    here.add_item_or_charges( pos, item::make_corpse( fish_mon, it->birthday() + rng( 0_turns,
-                                              3_hours ) ) );
+                    here.add_item_or_charges( pos, item::make_corpse( fish_mon, calendar::turn ) );
                     break; //this can happen only once
                 }
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1794,7 +1794,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
             return 0;
         }
 
-        //get the fishables around the trap's spot
+        // Get the fishables around the trap's spot.
         std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub(
                     MAX_VIEW_DISTANCE, pos );
         std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
@@ -1811,20 +1811,14 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
                                               calendar::turn ) );
                 }
             } else {
-                //there will always be a chance that the player will get lucky and catch a fish
-                //not existing in the fishables vector. (maybe it was in range, but wandered off)
-                //lets say it is a 5% chance per fish to catch
+                // There will always be a chance that the player will get lucky and catch a fish
+                // not existing in the fishables vector, as fish can always be hiding or whatever.
                 if( one_in( 20 ) ) {
                     const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                                 GROUP_FISH, true );
                     const mtype_id &fish_mon = random_entry_ref( fish_group );
-                    //Yes, we can put fishes in the trap like knives in the boot,
-                    //and then get fishes via activation of the item,
-                    //but it's not as comfortable as if you just put fishes in the same tile with the trap.
-                    //Also: corpses and comestibles do not rot in containers like this, but on the ground they will rot.
-                    //we don't know when it was caught so use a random turn
                     here.add_item_or_charges( pos, item::make_corpse( fish_mon, calendar::turn ) );
-                    break; //this can happen only once
+                    break;
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Don't catch rotten fish

#### Purpose of change
For some reason, the code for catching fish was aging them for 0-3 hours and then again for 0-50 hours, or 0-300 hours for fish traps. ????? what??? The fish is alive when you catch it, that's how you caught it!

#### Describe the solution
Remove the extra age added to the fish corpse for seemingly no reason.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
