### PR TITLE
Fix Dakin's solution

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -954,6 +954,8 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "copy-from": "disinfectant",
+    "weight": "260 g",
+    "charges": 1,
     "description": "A makeshift antiseptic made from bleach and water.  The volatile chlorine compounds break down quickly, so it won't stay good for long.",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE", "DECAYS" ],
     "//": "Gentler but less effective than ethanol.",

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -165,6 +165,7 @@
     "book_learn": [ [ "atomic_survival", 1 ], [ "textbook_firstaid", 2 ], [ "emergency_book", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
     "time": "30 s",
+    "charges": 10,
     "components": [ [ [ "water_clean", 10 ] ], [ [ "bleach", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Fix Dakin's solution

#### Purpose of change
Dakin's solution still had weird portioning issues due to copy-from and charges being weird.

#### Describe the solution
- Dakin's solution now has the same weight and volume as salt water.
- The Dakin's solution recipe now makes ten charges.
- When Dakin's solution decays into salt water, it now appropriately becomes an equivalent amount, so it isn't magically making extra water.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
