### PR TITLE
Fix a lot of bracers and greaves

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -91,7 +91,7 @@
           { "type": "plastic", "covered_by_mat": 60, "thickness": 0.3 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 8,
+        "encumbrance": 9,
         "coverage": 90,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
       }
@@ -369,7 +369,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 10,
+        "encumbrance": 9,
         "coverage": 80,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
@@ -446,11 +446,11 @@
       {
         "material": [
           { "type": "steel", "covered_by_mat": 70, "thickness": 0.9 },
-          { "type": "leather", "covered_by_mat": 100, "thickness": 1.0 }
+          { "type": "leather", "covered_by_mat": 100, "thickness": 3.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
         "encumbrance": 8,
-        "coverage": 75,
+        "coverage": 95,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ],
         "rigid_layer_only": true
       }
@@ -1034,7 +1034,7 @@
     "armor": [
       {
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 8,
+        "encumbrance": 6,
         "coverage": 95,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
       }

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -57,7 +57,7 @@
           { "type": "plastic", "covered_by_mat": 60, "thickness": 0.3 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 16,
+        "encumbrance": 14,
         "coverage": 90,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l", "leg_upper_r", "leg_upper_l" ]
       }
@@ -91,7 +91,7 @@
           { "type": "plastic", "covered_by_mat": 60, "thickness": 0.3 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 8,
+        "encumbrance": 7,
         "coverage": 90,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ]
       }
@@ -1141,7 +1141,7 @@
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 4,
+        "encumbrance": 5,
         "coverage": 80,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
         "rigid_layer_only": true
@@ -1171,7 +1171,7 @@
     "armor": [
       {
         "covers": [ "leg_l", "leg_r" ],
-        "encumbrance": 12,
+        "encumbrance": 6,
         "coverage": 80,
         "specifically_covers": [ "leg_lower_r", "leg_lower_l" ],
         "rigid_layer_only": true


### PR DESCRIPTION
#### Summary
Fix a lot of bracers and greaves

#### Purpose of change
A lot of these items had too much encumbrance to ever be considered. The sheet metal bracers were also 1/3 as thick as the regular leather vambraces despite being made out of them. This is probably because they were envisioned as being the kind of thing you'd buy at hot topic, but since you can basically only get them by crafting them out of the 3mm vambraces, that doesn't make sense.

#### Describe the solution
- Reduce encumbrance on a ton of greaves and bracers.
- Sheet metal bracers are now 3mm leather and 95 coverage for the lower arms.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
