### PR TITLE
Add caution mode: toggleable warnings for fighting while impaired

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -16,6 +16,7 @@
 #include "action.h"
 #include "activity_actor_definitions.h"
 #include "avatar.h"
+#include "caution.h"
 #include "bionics.h"
 #include "body_part_set.h"
 #include "calendar.h"
@@ -401,6 +402,9 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                     return false;
                 }
             }
+            if( !caution::confirm_attack( you ) ) {
+                return false;
+            }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {
                 critter.die( &m, &you );
@@ -429,6 +433,9 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             return false;
         }
 
+        if( !caution::confirm_attack( you ) ) {
+            return false;
+        }
         you.melee_attack( np, true );
         np.make_angry();
         return false;

--- a/src/caution.cpp
+++ b/src/caution.cpp
@@ -1,0 +1,252 @@
+#include "caution.h"
+
+#include <algorithm>
+#include <string>
+
+#include "bodypart.h"
+#include "calendar.h"
+#include "character.h"
+#include "messages.h"
+#include "options.h"
+#include "output.h"
+#include "string_formatter.h"
+#include "translations.h"
+#include "type_id.h"
+
+static const efftype_id effect_bite( "bite" );
+static const efftype_id effect_bleed( "bleed" );
+static const efftype_id effect_grabbed( "grabbed" );
+static const efftype_id effect_infected( "infected" );
+
+namespace
+{
+
+// Transient per-session state.  Deliberately not serialized: after loading a
+// save the worst case is one repeated warning.
+struct caution_state {
+    time_point next_speed_warn = calendar::turn_zero;
+    time_point next_hurt_warn = calendar::turn_zero;
+    time_point next_bleed_warn = calendar::turn_zero;
+    time_point next_bite_warn = calendar::turn_zero;
+    time_point next_infect_warn = calendar::turn_zero;
+    time_point next_surround_warn = calendar::turn_zero;
+    time_point attack_confirmed_until = calendar::turn_zero;
+    time_point danger_since = calendar::turn_zero;
+    bool in_danger = false;
+    bool grab_warned = false;
+    bool stamina_warned = false;
+    bool torso_warned = false;
+    bool head_warned = false;
+    int pain_tier_seen = 0;
+    time_point last_check = calendar::turn_zero;
+
+    void reset() {
+        *this = caution_state();
+    }
+};
+
+caution_state state;
+
+bool alert_enabled( const std::string &toggle )
+{
+    return get_option<bool>( "CAUTION_MODE" ) && get_option<bool>( toggle );
+}
+
+bool speed_impaired( const Character &you )
+{
+    return you.get_speed() < get_option<int>( "CAUTION_SPEED_THRESHOLD" );
+}
+
+void yell( const std::string &msg )
+{
+    add_msg( m_bad, msg );
+    popup( msg );
+}
+
+int pain_tier( const Character &you )
+{
+    const int pain = you.get_perceived_pain();
+    if( pain >= 60 ) {
+        return 3;
+    } else if( pain >= 40 ) {
+        return 2;
+    } else if( pain >= 20 ) {
+        return 1;
+    }
+    return 0;
+}
+
+} // namespace
+
+namespace caution
+{
+
+void check_turn( const Character &you )
+{
+    if( !get_option<bool>( "CAUTION_MODE" ) ) {
+        return;
+    }
+
+    const time_point now = calendar::turn;
+    // Time moved backwards: a new game or an older save was loaded.
+    if( now < state.last_check ) {
+        state.reset();
+    }
+    state.last_check = now;
+
+    const int hostiles_near = static_cast<int>( you.get_hostile_creatures( 15 ).size() );
+
+    if( alert_enabled( "CAUTION_SPEED_WARN" ) && hostiles_near > 0 &&
+        speed_impaired( you ) && now >= state.next_speed_warn ) {
+        yell( string_format(
+                  _( "SLOW DOWN!  Your speed is %d and there are enemies nearby.  Stop autopiloting and reassess." ),
+                  you.get_speed() ) );
+        const int cooldown = std::max( 3, get_option<int>( "CAUTION_WARN_COOLDOWN" ) -
+                                       hostiles_near * 2 );
+        state.next_speed_warn = now + time_duration::from_seconds( cooldown );
+    }
+
+    if( alert_enabled( "CAUTION_GRAB_WARN" ) ) {
+        if( you.has_effect( effect_grabbed ) ) {
+            if( !state.grab_warned ) {
+                state.grab_warned = true;
+                yell( _( "You were just grabbed!  Slow down!  There is no rush." ) );
+            }
+        } else {
+            state.grab_warned = false;
+        }
+    }
+
+    if( alert_enabled( "CAUTION_STAMINA_WARN" ) ) {
+        const int pct = get_option<int>( "CAUTION_STAMINA_PCT" );
+        const int stamina_pct = 100 * you.get_stamina() / std::max( 1, you.get_stamina_max() );
+        if( hostiles_near > 0 && stamina_pct < pct && !state.stamina_warned ) {
+            state.stamina_warned = true;
+            yell( _( "You're winded — you swing slower and dodge worse.  Disengage now, don't try to finish the fight." ) );
+        } else if( stamina_pct > pct + 10 ) {
+            state.stamina_warned = false;
+        }
+    }
+
+    if( alert_enabled( "CAUTION_BLEED_WARN" ) ) {
+        if( you.has_effect( effect_bleed ) ) {
+            if( now >= state.next_bleed_warn ) {
+                yell( _( "You are bleeding.  Stop and bandage it — ten seconds and a rag beat bleeding out." ) );
+                state.next_bleed_warn = now + 20_seconds;
+            }
+        } else {
+            state.next_bleed_warn = now;
+        }
+    }
+
+    if( alert_enabled( "CAUTION_BITE_WARN" ) ) {
+        if( you.has_effect( effect_bite ) ) {
+            if( now >= state.next_bite_warn ) {
+                yell( _( "You've been bitten!  Clean and dress that wound — you have hours, not days, before it infects." ) );
+                state.next_bite_warn = now + 5_minutes;
+            }
+        } else {
+            state.next_bite_warn = now;
+        }
+        if( you.has_effect( effect_infected ) ) {
+            if( now >= state.next_infect_warn ) {
+                yell( _( "The wound is INFECTED.  Antibiotics or antiseptic, now.  This kills in about a day." ) );
+                state.next_infect_warn = now + 1_minutes;
+            }
+        } else {
+            state.next_infect_warn = now;
+        }
+    }
+
+    if( alert_enabled( "CAUTION_SURROUND_WARN" ) && now >= state.next_surround_warn &&
+        you.get_hostile_creatures( 4 ).size() >= 3 ) {
+        yell( _( "You're being flanked — get to a chokepoint or run.  Full health means nothing when you're surrounded." ) );
+        state.next_surround_warn = now + 10_seconds;
+    }
+
+    if( alert_enabled( "CAUTION_PAIN_WARN" ) ) {
+        const int tier = pain_tier( you );
+        if( tier > state.pain_tier_seen ) {
+            if( tier == 1 ) {
+                yell( _( "Pain is creeping in — your speed and stats are starting to suffer." ) );
+            } else if( tier == 2 ) {
+                yell( _( "You are in serious pain — reflexes and speed are dulled.  Painkillers, then reconsider this fight." ) );
+            } else {
+                yell( _( "You are in agony and badly impaired.  Whatever you're doing, it can wait.  Get safe and rest." ) );
+            }
+        }
+        state.pain_tier_seen = tier;
+    }
+
+    if( alert_enabled( "CAUTION_LIMB_WARN" ) ) {
+        const int pct = get_option<int>( "CAUTION_LIMB_PCT" );
+        const bodypart_id torso( "torso" );
+        const bodypart_id head( "head" );
+        const int torso_pct = 100 * you.get_part_hp_cur( torso ) /
+                              std::max( 1, you.get_part_hp_max( torso ) );
+        const int head_pct = 100 * you.get_part_hp_cur( head ) /
+                             std::max( 1, you.get_part_hp_max( head ) );
+        if( torso_pct < pct && !state.torso_warned ) {
+            state.torso_warned = true;
+            yell( _( "Your torso is wrecked — one bad hit ends this.  Why are you still here?" ) );
+        } else if( torso_pct > pct + 10 ) {
+            state.torso_warned = false;
+        }
+        if( head_pct < pct && !state.head_warned ) {
+            state.head_warned = true;
+            yell( _( "Your head is badly hurt — the next hit could be the last.  Disengage." ) );
+        } else if( head_pct > pct + 10 ) {
+            state.head_warned = false;
+        }
+    }
+
+    if( alert_enabled( "CAUTION_FIGHT_WARN" ) ) {
+        if( hostiles_near > 0 ) {
+            if( !state.in_danger ) {
+                state.in_danger = true;
+                state.danger_since = now;
+            }
+            const time_duration limit =
+                time_duration::from_seconds( get_option<int>( "CAUTION_FIGHT_SECONDS" ) );
+            if( now - state.danger_since >= limit ) {
+                yell( _( "You've been in danger a long time — check your HP, your stamina, your exits.  Is this still worth it?" ) );
+                // Re-warn two minutes later if the danger persists.
+                state.danger_since = now - limit + 2_minutes;
+            }
+        } else {
+            state.in_danger = false;
+        }
+    }
+}
+
+bool confirm_attack( const Character &you )
+{
+    if( !alert_enabled( "CAUTION_ATTACK_CONFIRM" ) || !speed_impaired( you ) ) {
+        return true;
+    }
+    const time_point now = calendar::turn;
+    if( now < state.attack_confirmed_until ) {
+        return true;
+    }
+    if( query_yn( _( "Your speed is %d — you are in no shape to trade blows.  Attack anyway?" ),
+                  you.get_speed() ) ) {
+        state.attack_confirmed_until = now + 20_seconds;
+        return true;
+    }
+    return false;
+}
+
+void on_avatar_hurt( const Character &you )
+{
+    if( !alert_enabled( "CAUTION_HURT_WARN" ) || !speed_impaired( you ) ) {
+        return;
+    }
+    const time_point now = calendar::turn;
+    if( now < state.next_hurt_warn ) {
+        return;
+    }
+    state.next_hurt_warn = now + 5_seconds;
+    yell( _( "You were hurt, are you sure you want to keep fighting?" ) );
+}
+
+} // namespace caution

--- a/src/caution.h
+++ b/src/caution.h
@@ -1,0 +1,26 @@
+#pragma once
+#ifndef CATA_SRC_CAUTION_H
+#define CATA_SRC_CAUTION_H
+
+class Character;
+
+// Caution mode: optional warnings and confirmations that interrupt the player
+// when they keep acting while impaired.  See the "Caution Mode Options" group
+// in the options menu; everything is toggleable there.
+namespace caution
+{
+
+// Run the per-turn checks (speed, stamina, bleeding, bites, surrounded, pain,
+// critical limbs, prolonged danger).  Call once per game turn for the avatar.
+void check_turn( const Character &you );
+
+// Ask for confirmation before a melee attack while impaired.  Returns false
+// if the player backs out of the attack.
+bool confirm_attack( const Character &you );
+
+// Warn after the avatar takes damage while impaired.
+void on_avatar_hurt( const Character &you );
+
+} // namespace caution
+
+#endif // CATA_SRC_CAUTION_H

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -27,6 +27,7 @@
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "caution.h"
 #include "character_attire.h"
 #include "character_martial_arts.h"
 #include "city.h"
@@ -8987,6 +8988,9 @@ void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
             } else {
                 g->cancel_activity_or_ignore_query( distraction_type::attacked, _( "You were hurt!" ) );
             }
+        }
+        if( is_avatar() && !is_dead_state() ) {
+            caution::on_avatar_hurt( *this );
         }
     }
 

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -23,6 +23,7 @@
 #include "bionics.h"
 #include "cached_options.h"
 #include "calendar.h"
+#include "caution.h"
 #include "cata_variant.h"
 #include "clzones.h"
 #include "coordinates.h"
@@ -679,6 +680,7 @@ bool do_turn()
     }
     g->mon_info_update();
     u.process_turn();
+    caution::check_turn( u );
     if( u.get_moves() < 0 && get_option<bool>( "FORCE_REDRAW" ) ) {
         ui_manager::redraw();
         refresh_display();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1657,6 +1657,129 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
+    add_option_group( "general", Group( "caution_mode_opts", to_translation( "Caution Mode Options" ),
+                                        to_translation( "Options regarding caution mode, which warns you when you fight or keep moving while impaired." ) ),
+    [&]( const std::string & page_id ) {
+        add( "CAUTION_MODE", page_id, to_translation( "Caution mode" ),
+             to_translation( "If true, enables caution mode: warning popups and confirmations when you are impaired, hurt, grabbed, or surrounded.  Each warning can be toggled individually below." ),
+             false
+           );
+
+        add( "CAUTION_SPEED_THRESHOLD", page_id, to_translation( "Caution: speed threshold" ),
+             to_translation( "Your speed is considered impaired when below this value.  Base speed is 100.  Used by the speed warning, the attack confirmation, and the hurt warning." ),
+             10, 300, 90
+           );
+
+        get_option( "CAUTION_SPEED_THRESHOLD" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_WARN_COOLDOWN", page_id, to_translation( "Caution: seconds between warnings" ),
+             to_translation( "Base number of seconds between repeated speed warnings.  More hostiles nearby shortens the interval." ),
+             3, 300, 15
+           );
+
+        get_option( "CAUTION_WARN_COOLDOWN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_SPEED_WARN", page_id, to_translation( "Caution: warn when slowed near enemies" ),
+             to_translation( "If true, shows a warning popup when your speed is below the threshold while hostiles are nearby." ),
+             true
+           );
+
+        get_option( "CAUTION_SPEED_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_ATTACK_CONFIRM", page_id, to_translation( "Caution: confirm attacks while slowed" ),
+             to_translation( "If true, asks for confirmation before you melee attack while your speed is below the threshold." ),
+             true
+           );
+
+        get_option( "CAUTION_ATTACK_CONFIRM" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_HURT_WARN", page_id, to_translation( "Caution: warn when hurt while slowed" ),
+             to_translation( "If true, shows a warning popup when you take damage while your speed is below the threshold." ),
+             true
+           );
+
+        get_option( "CAUTION_HURT_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_GRAB_WARN", page_id, to_translation( "Caution: warn when grabbed" ),
+             to_translation( "If true, shows a warning popup the moment something grabs you." ),
+             true
+           );
+
+        get_option( "CAUTION_GRAB_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_STAMINA_WARN", page_id, to_translation( "Caution: warn when winded near enemies" ),
+             to_translation( "If true, shows a warning popup when your stamina drops below the stamina threshold while hostiles are nearby." ),
+             true
+           );
+
+        get_option( "CAUTION_STAMINA_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_STAMINA_PCT", page_id, to_translation( "Caution: stamina threshold percent" ),
+             to_translation( "Stamina is considered dangerously low when below this percentage of your maximum." ),
+             5, 95, 25
+           );
+
+        get_option( "CAUTION_STAMINA_PCT" ).setPrerequisite( "CAUTION_STAMINA_WARN" );
+
+        add( "CAUTION_BLEED_WARN", page_id, to_translation( "Caution: nag while bleeding" ),
+             to_translation( "If true, shows a repeating warning popup while you are bleeding." ),
+             true
+           );
+
+        get_option( "CAUTION_BLEED_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_BITE_WARN", page_id, to_translation( "Caution: warn on bites and infection" ),
+             to_translation( "If true, warns you when you receive a bite wound, and nags aggressively while a wound is infected." ),
+             true
+           );
+
+        get_option( "CAUTION_BITE_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_SURROUND_WARN", page_id, to_translation( "Caution: warn when surrounded" ),
+             to_translation( "If true, shows a warning popup when three or more hostiles are within four tiles of you." ),
+             true
+           );
+
+        get_option( "CAUTION_SURROUND_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_PAIN_WARN", page_id, to_translation( "Caution: warn on rising pain" ),
+             to_translation( "If true, shows a warning popup each time your pain climbs past 20, 40, and 60." ),
+             true
+           );
+
+        get_option( "CAUTION_PAIN_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_LIMB_WARN", page_id, to_translation( "Caution: warn on critical torso or head" ),
+             to_translation( "If true, shows a warning popup when your torso or head HP falls below the limb threshold." ),
+             true
+           );
+
+        get_option( "CAUTION_LIMB_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_LIMB_PCT", page_id, to_translation( "Caution: limb threshold percent" ),
+             to_translation( "Torso or head HP is considered critical when below this percentage of its maximum." ),
+             10, 90, 30
+           );
+
+        get_option( "CAUTION_LIMB_PCT" ).setPrerequisite( "CAUTION_LIMB_WARN" );
+
+        add( "CAUTION_FIGHT_WARN", page_id, to_translation( "Caution: warn after prolonged danger" ),
+             to_translation( "If true, shows a warning popup after hostiles have been continuously nearby for the configured time, reminding you to reassess." ),
+             true
+           );
+
+        get_option( "CAUTION_FIGHT_WARN" ).setPrerequisite( "CAUTION_MODE" );
+
+        add( "CAUTION_FIGHT_SECONDS", page_id, to_translation( "Caution: prolonged danger seconds" ),
+             to_translation( "Number of consecutive seconds with hostiles nearby before the prolonged danger warning fires." ),
+             60, 3600, 300
+           );
+
+        get_option( "CAUTION_FIGHT_SECONDS" ).setPrerequisite( "CAUTION_FIGHT_WARN" );
+    } );
+
+    add_empty_line();
+
     add_option_group( "general", Group( "auto_save_opts", to_translation( "Autosave Options" ),
                                         to_translation( "Options regarding autosave." ) ),
     [&]( const std::string & page_id ) {


### PR DESCRIPTION
I use this in my personal game but I believe it has wider utility as a way to guard against road hypnosis - which often gets people killed. The exact text and thresholds are a work in progress and this PR is mainly to gauge interest in adding this feature at all.

#### Summary
Features "Caution mode: optional warnings when you keep fighting while impaired"

#### Purpose of change

Players die by continuing to fight while slowed, hurt, or surrounded without noticing. Safe mode warns when a threat appears. Nothing warns when you keep going in a bad state.

#### Describe the solution

Adds a caution mode section to the options, next to safe mode. It is off by default. Each warning can be toggled on its own.

It warns you when:

- your speed is low and enemies are near
- you attack while slowed (asks for confirmation first)
- you take damage while slowed
- you get grabbed
- you are winded near enemies
- you are bleeding
- you have a bite or infection
- you are surrounded
- your pain is rising
- your torso or head is badly hurt
- you have been in danger a long time

Warnings are popups, so they stop you mid-keypress. Thresholds are configurable.

#### Describe alternatives you've considered

A JSON mod. It cannot add real options or stop an attack before it happens.

#### Testing

I played it and it works. Tuning the experience is pending affirmative interest in merging the concept.