### PR TITLE
Add kiting mode: autoattack key strikes once then retreats

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3014,6 +3014,12 @@
   },
   {
     "type": "keybinding",
+    "name": "Toggle kiting mode",
+    "category": "DEFAULTMODE",
+    "id": "toggle_autokite"
+  },
+  {
+    "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -290,6 +290,8 @@ std::string action_ident( action_id act )
             return "auto_travel_mode";
         case ACTION_TOGGLE_SAFEMODE:
             return "safemode";
+        case ACTION_TOGGLE_AUTOKITE:
+            return "toggle_autokite";
         case ACTION_TOGGLE_AUTOSAFE:
             return "autosafe";
         case ACTION_TOGGLE_THIEF_MODE:
@@ -973,6 +975,7 @@ action_id handle_action_menu( map &here )
             REGISTER_ACTION( ACTION_PICK_STYLE );
             REGISTER_ACTION( ACTION_TOGGLE_AUTO_TRAVEL_MODE );
             REGISTER_ACTION( ACTION_TOGGLE_SAFEMODE );
+            REGISTER_ACTION( ACTION_TOGGLE_AUTOKITE );
             REGISTER_ACTION( ACTION_TOGGLE_AUTOSAFE );
             REGISTER_ACTION( ACTION_IGNORE_ENEMY );
             REGISTER_ACTION( ACTION_TOGGLE_AUTO_FEATURES );

--- a/src/action.h
+++ b/src/action.h
@@ -227,6 +227,8 @@ enum action_id : int {
     ACTION_TOGGLE_AUTO_TRAVEL_MODE,
     /** Turn safemode on/off, while leaving autosafemode intact */
     ACTION_TOGGLE_SAFEMODE,
+    /** Toggle kiting mode: autoattack key retreats/strikes instead */
+    ACTION_TOGGLE_AUTOKITE,
     /** Turn automatic triggering of safemode on/off */
     ACTION_TOGGLE_AUTOSAFE,
     /** Toggle permanent attitude to stealing */

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -716,6 +716,90 @@ void avatar_action::autoattack( avatar &you, map &m )
     you.reach_attack( best.pos_bub() );
 }
 
+void avatar_action::autokite_step( avatar &you, map &m )
+{
+    // Strike only when something first comes into reach, then retreat.  The
+    // flag resets whenever the kite is broken off for a turn or more.
+    static time_point last_step = calendar::turn_zero;
+    static bool struck_last_step = false;
+    if( calendar::turn - last_step > 1_turns ) {
+        struck_last_step = false;
+    }
+    last_step = calendar::turn;
+
+    const std::vector<Creature *> hostiles = you.get_hostile_creatures( 20 );
+    if( hostiles.empty() ) {
+        add_msg( m_info, _( "No enemies in sight to kite." ) );
+        return;
+    }
+
+    if( !struck_last_step && !you.has_flag( json_flag_CANNOT_ATTACK ) ) {
+        const item_location weapon = you.get_wielded_item();
+        const int reach = weapon ? weapon->reach_range( you ) : std::max( 1,
+                          static_cast<int>( you.calculate_by_enchantment( 1,
+                                            enchant_vals::mod::MELEE_RANGE_MODIFIER ) ) );
+        std::vector<Creature *> critters = you.get_targetable_creatures( reach, true );
+        critters.erase( std::remove_if( critters.begin(), critters.end(), [&you,
+        reach]( const Creature * c ) {
+            if( reach == 1 && !you.is_adjacent( c, true ) ) {
+                return true;
+            }
+            if( !c->is_npc() ) {
+                return false;
+            }
+            return !dynamic_cast<const npc &>( *c ).is_enemy();
+        } ), critters.end() );
+        if( !critters.empty() ) {
+            Creature &best = **std::max_element( critters.begin(), critters.end(),
+            []( const Creature * l, const Creature * r ) {
+                return rate_critter( *l ) > rate_critter( *r );
+            } );
+            struck_last_step = true;
+            const tripoint_rel_ms diff = best.pos_bub() - you.pos_bub();
+            if( std::abs( diff.x() ) <= 1 && std::abs( diff.y() ) <= 1 && diff.z() == 0 ) {
+                move( you, m, tripoint_rel_ms( diff.xy(), 0 ) );
+            } else {
+                you.reach_attack( best.pos_bub() );
+            }
+            return;
+        }
+    }
+    struck_last_step = false;
+
+    const auto threat_distance = [&hostiles]( const tripoint_bub_ms & p ) {
+        int min_dist = INT_MAX;
+        for( const Creature *critter : hostiles ) {
+            min_dist = std::min( min_dist, rl_dist( p, critter->pos_bub() ) );
+        }
+        return min_dist;
+    };
+    const int here_threat = threat_distance( you.pos_bub() );
+    creature_tracker &creatures = get_creature_tracker();
+    tripoint_bub_ms best_tile = you.pos_bub();
+    int best_threat = here_threat;
+    for( const tripoint_bub_ms &p : m.points_in_radius( you.pos_bub(), 1 ) ) {
+        if( p == you.pos_bub() || p.z() != you.pos_bub().z() ) {
+            continue;
+        }
+        if( m.impassable( p ) || g->is_dangerous_tile( p ) ||
+            creatures.creature_at( p ) != nullptr ) {
+            continue;
+        }
+        const int threat = threat_distance( p );
+        if( threat > best_threat ) {
+            best_threat = threat;
+            best_tile = p;
+        }
+    }
+    if( best_threat > here_threat ) {
+        move( you, m, tripoint_rel_ms( ( best_tile - you.pos_bub() ).xy(), 0 ) );
+        return;
+    }
+    // No turn passes here: getting cornered must never quietly cost time.
+    add_msg( m_bad, _( "You are surrounded — nowhere better to retreat to!" ) );
+    popup( _( "You are surrounded — nowhere better to retreat to!" ) );
+}
+
 // TODO: Move data/functions related to targeting out of game class
 bool avatar_action::can_fire_weapon( avatar &you, const map &m, const item &weapon )
 {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -759,7 +759,46 @@ void avatar_action::autokite_step( avatar &you, map &m )
         return;
     }
 
-    if( !struck_last_step && !you.has_flag( json_flag_CANNOT_ATTACK ) ) {
+    // Retreat only ever follows a strike.
+    if( struck_last_step ) {
+        struck_last_step = false;
+        const auto threat_distance = [&hostiles]( const tripoint_bub_ms & p ) {
+            int min_dist = INT_MAX;
+            for( const Creature *critter : hostiles ) {
+                min_dist = std::min( min_dist, rl_dist( p, critter->pos_bub() ) );
+            }
+            return min_dist;
+        };
+        const int here_threat = threat_distance( you.pos_bub() );
+        creature_tracker &creatures = get_creature_tracker();
+        tripoint_bub_ms best_tile = you.pos_bub();
+        int best_threat = here_threat;
+        for( const tripoint_bub_ms &p : m.points_in_radius( you.pos_bub(), 1 ) ) {
+            if( p == you.pos_bub() || p.z() != you.pos_bub().z() ) {
+                continue;
+            }
+            if( m.impassable( p ) || g->is_dangerous_tile( p ) ||
+                creatures.creature_at( p ) != nullptr ) {
+                continue;
+            }
+            const int threat = threat_distance( p );
+            if( threat > best_threat ) {
+                best_threat = threat;
+                best_tile = p;
+            }
+        }
+        if( best_threat > here_threat ) {
+            move( you, m, tripoint_rel_ms( ( best_tile - you.pos_bub() ).xy(), 0 ) );
+            return;
+        }
+        // No turn passes here: getting cornered must never quietly cost time.
+        add_msg( m_bad, _( "You are surrounded — nowhere better to retreat to!" ) );
+        popup( _( "You are surrounded — nowhere better to retreat to!" ) );
+        return;
+    }
+
+    // Strike the first press something is in reach.
+    if( !you.has_flag( json_flag_CANNOT_ATTACK ) ) {
         const item_location weapon = you.get_wielded_item();
         const int reach = weapon ? weapon->reach_range( you ) : std::max( 1,
                           static_cast<int>( you.calculate_by_enchantment( 1,
@@ -790,40 +829,12 @@ void avatar_action::autokite_step( avatar &you, map &m )
             return;
         }
     }
-    struck_last_step = false;
 
-    const auto threat_distance = [&hostiles]( const tripoint_bub_ms & p ) {
-        int min_dist = INT_MAX;
-        for( const Creature *critter : hostiles ) {
-            min_dist = std::min( min_dist, rl_dist( p, critter->pos_bub() ) );
-        }
-        return min_dist;
-    };
-    const int here_threat = threat_distance( you.pos_bub() );
-    creature_tracker &creatures = get_creature_tracker();
-    tripoint_bub_ms best_tile = you.pos_bub();
-    int best_threat = here_threat;
-    for( const tripoint_bub_ms &p : m.points_in_radius( you.pos_bub(), 1 ) ) {
-        if( p == you.pos_bub() || p.z() != you.pos_bub().z() ) {
-            continue;
-        }
-        if( m.impassable( p ) || g->is_dangerous_tile( p ) ||
-            creatures.creature_at( p ) != nullptr ) {
-            continue;
-        }
-        const int threat = threat_distance( p );
-        if( threat > best_threat ) {
-            best_threat = threat;
-            best_tile = p;
-        }
+    // Nothing in reach and nothing to retreat from: hold position.
+    if( g->check_safe_mode_allowed() ) {
+        add_msg( m_info, _( "You hold your ground, waiting for them to come." ) );
+        you.pause();
     }
-    if( best_threat > here_threat ) {
-        move( you, m, tripoint_rel_ms( ( best_tile - you.pos_bub() ).xy(), 0 ) );
-        return;
-    }
-    // No turn passes here: getting cornered must never quietly cost time.
-    add_msg( m_bad, _( "You are surrounded — nowhere better to retreat to!" ) );
-    popup( _( "You are surrounded — nowhere better to retreat to!" ) );
 }
 
 // TODO: Move data/functions related to targeting out of game class

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -68,6 +68,7 @@ static const bionic_id bio_railgun( "bio_railgun" );
 static const character_modifier_id
 character_modifier_melee_stamina_cost_mod( "melee_stamina_cost_mod" );
 
+static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_grabbing( "grabbing" );
 static const efftype_id effect_grabbed( "grabbed" );
 static const efftype_id effect_harnessed( "harnessed" );
@@ -726,6 +727,31 @@ void avatar_action::autokite_step( avatar &you, map &m )
         struck_last_step = false;
     }
     last_step = calendar::turn;
+
+    // A kite only works while you can freely move and outpace the enemy.
+    // Anything that breaks that assumption must wake the player up with a
+    // blocking popup, never quietly fail.  No game time passes here.
+    const auto kite_broken = [&]( const std::string & why ) {
+        add_msg( m_bad, why );
+        popup( why );
+    };
+    if( you.has_effect( effect_grabbed ) ) {
+        kite_broken( _( "You are GRABBED!  The kite is broken — break free before anything else." ) );
+        return;
+    }
+    if( you.has_effect( effect_downed ) ) {
+        kite_broken( _( "You are KNOCKED DOWN!  The kite is broken — get up!" ) );
+        return;
+    }
+    if( you.has_effect( effect_stunned ) || you.has_effect( effect_psi_stunned ) ) {
+        kite_broken( _( "You are STUNNED!  The kite is broken — you cannot trust your feet." ) );
+        return;
+    }
+    if( you.has_effect( effect_winded ) ||
+        you.get_stamina() < you.get_stamina_max() / 4 ) {
+        kite_broken( _( "You are too WINDED to keep kiting — you can no longer outpace them." ) );
+        return;
+    }
 
     const std::vector<Creature *> hostiles = you.get_hostile_creatures( 20 );
     if( hostiles.empty() ) {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -777,6 +777,12 @@ void avatar_action::autokite_step( avatar &you, map &m )
             if( p == you.pos_bub() || p.z() != you.pos_bub().z() ) {
                 continue;
             }
+            // Axial steps only: diagonals cost more moves, which is exactly
+            // the margin that lets a pursuer catch up and grab you.
+            const tripoint_rel_ms d = p - you.pos_bub();
+            if( d.x() != 0 && d.y() != 0 ) {
+                continue;
+            }
             if( m.impassable( p ) || g->is_dangerous_tile( p ) ||
                 creatures.creature_at( p ) != nullptr ) {
                 continue;

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -38,6 +38,10 @@ void swim( map &m, avatar &you, const tripoint_bub_ms &p );
 
 void autoattack( avatar &you, map &m );
 
+/** One kite step: strike once when a hostile first comes into reach, otherwise
+ *  retreat to the adjacent tile farthest from all hostiles. */
+void autokite_step( avatar &you, map &m );
+
 void mend( avatar &you, item_location loc );
 
 /**

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2736,6 +2736,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "safemode" );
     ctxt.register_action( "autosafe" );
     ctxt.register_action( "autoattack" );
+    ctxt.register_action( "toggle_autokite" );
     ctxt.register_action( "ignore_enemy" );
     ctxt.register_action( "whitelist_enemy" );
     ctxt.register_action( "workout" );

--- a/src/game.h
+++ b/src/game.h
@@ -1209,6 +1209,9 @@ class game
         bool auto_travel_mode = false;
         bool queue_screenshot = false; // NOLINT(cata-serialize)
         safe_mode_type safe_mode;
+        // When true, the autoattack action performs a kite step
+        // (strike once when in reach, otherwise retreat) instead.
+        bool kiting_tab = false;
 
         // tracks time since last monster seen to allow automatically
         // reactivating safe mode.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3095,7 +3095,20 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_AUTOATTACK:
-            avatar_action::autoattack( player_character, here );
+            if( kiting_tab ) {
+                avatar_action::autokite_step( player_character, here );
+            } else {
+                avatar_action::autoattack( player_character, here );
+            }
+            break;
+
+        case ACTION_TOGGLE_AUTOKITE:
+            kiting_tab = !kiting_tab;
+            if( kiting_tab ) {
+                add_msg( m_info, _( "Kiting mode ON.  The autoattack key now strikes once and retreats." ) );
+            } else {
+                add_msg( m_info, _( "Kiting mode OFF." ) );
+            }
             break;
 
         default:


### PR DESCRIPTION
Kiting is simple but takes a lot of near-identical keypresses by hand. Two issues follow. The repeated input is a repetitive strain injury risk, and since kiting is precision rather than a decision, one mis-sequenced key makes you take damage for no real choice. This is an optional mode that repurposes the autoattack key (Tab by default) to do a whole kite step on one press, and warns you when the assumptions behind the kite no longer hold. It is off unless you turn it on, and turning it off returns Tab to normal autoattack. Behaviour is WIP, mostly posting to gauge interest.

#### Summary
Features "Kiting mode - an optional replacement for the autoattack key that performs one kite step per press"

#### Purpose of change

Kiting by hand is hundreds of repeated inputs. That is a repetitive strain injury risk, and because it is precision rather than judgement, one fumbled key costs HP for a non-decision.

#### Describe the solution

Adds a "Toggle kiting mode" keybinding. It is off by default. While on, the autoattack key (Tab by default) does one kite step per press instead of a normal autoattack.

- if you struck last press, retreat to the adjacent tile farthest from all enemies (orthogonal only, since diagonals cost more movement)
- otherwise, if an enemy is in weapon reach, strike once
- otherwise, hold and wait

If you are grabbed, knocked down, stunned, or winded, it shows a popup and does nothing. Cornered does the same. No game time passes on a popup. Hold the key to kite continuously, release to stop.

Toggle the mode off and the autoattack key behaves exactly as before.

#### Describe alternatives you've considered

- A self-driving kiting activity (activity_actor running until it stops itself). Built and scrapped, because it keeps its own state and keeps acting after the situation changes, so it could flail against a grab or walk into a fresh threat before an abort fired. The keypress version cannot, since the player is the loop.
- A JSON/EOC mod. It cannot add a keybinding or read movement-cost state, so it cannot express "retreat orthogonally when I struck last turn".

#### Testing

I played it and it works.