### PR TITLE
Domestic rabbits in pet supply stores and animal shelters

### DIFF
--- a/data/json/mapgen/animalshelter.json
+++ b/data/json/mapgen/animalshelter.json
@@ -93,7 +93,7 @@
       { "monster": "mon_null", "weight": 5 },
       { "monster": "mon_ferret", "weight": 2, "cost_multiplier": 0 },
       { "monster": "mon_chicken", "weight": 1, "cost_multiplier": 0 },
-      { "monster": "mon_rabbit", "weight": 3, "cost_multiplier": 0 }
+      { "monster": "mon_rabbit_domestic", "weight": 3, "cost_multiplier": 0 }
     ]
   },
   {

--- a/data/json/mapgen/petstore.json
+++ b/data/json/mapgen/petstore.json
@@ -168,8 +168,8 @@
       },
       "place_monster": [
         { "group": "GROUP_PET_CATS", "x": 2, "y": 3 },
-        { "monster": "mon_rabbit", "x": 2, "y": 7 },
-        { "monster": "mon_rabbit", "x": 3, "y": 7 },
+        { "monster": "mon_rabbit_domestic", "x": 2, "y": 7 },
+        { "monster": "mon_rabbit_domestic", "x": 3, "y": 7 },
         { "monster": "mon_dog_zombie_rot", "x": 2, "y": 9 },
         { "group": "GROUP_PET_DOGS", "x": 2, "y": 13 },
         { "group": "GROUP_PET_DOGS", "x": 2, "y": 15 },


### PR DESCRIPTION
#### Summary
Changes rabbit spawns in pet supply stores and animal shelters from the wild to the domestic kind.

#### Purpose of change
The rabbits in pet supply stores and animal shelters were the wild, untameable kind. It makes more sense for these to be the tameable kind kept as pets.

#### Describe the solution
Changes "mon_rabbit" to "mon_rabbit_domestic" in "petstore.json", and "animalshelter.json".

#### Describe alternatives you've considered
Keeping them wild. Making the change but lowering the number that spawn.

#### Testing

#### Additional context
Noticed the rabbits in a pet supply store were the wild kind, thought this was strange.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
