### PR TITLE
renamed social to socializing

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -69,7 +69,7 @@
   {
     "type": "skill",
     "id": "speech",
-    "name": { "str": "social" },
+    "name": { "str": "socializing" },
     "description": "Your skill in speaking to other people.  Covers ability in boasting, flattery, threats, persuasion, lies, bartering, and other facets of interpersonal communication.  Works best in conjunction with a high level of intelligence.",
     "companion_survival_rank_factor": 1,
     "display_category": "display_interaction",


### PR DESCRIPTION
#### Summary
Category "Brief description"
This edits skills.json to have the speech skill be called socializing instead of social for the purposes of learning the skill from the book. This might affect other things too but as far as I can tell, the only code that uses these names from the json is the book reading code.
#### Purpose of change
currently when reading a book that trains speech, the game says "You learn a bit about social!" which makes no sense.
"You learn a bit about socializing!" is still a bit weird but it makes grammatical sense.
#### Describe the solution
I edited skills.json,
#### Describe alternatives you've considered
I would have preferred "You learn a bit about being social" but since in the same file there's already a "tailor" -> "tailoring" transformation, I thought this would be appropriate.

#### Testing
I loaded the game with the new data directory, spawned a Car Buyer's Guide and the text printed as expected.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
