### PR TITLE
Buff chain link fences, nerf laminated glass

### DIFF
--- a/data/json/furniture_and_terrain/terrain-doors.json
+++ b/data/json/furniture_and_terrain/terrain-doors.json
@@ -17,8 +17,8 @@
     "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "BLOCK_WIND", "SUPPORTS_ROOF" ],
     "open": "t_laminated_door_glass_o",
     "bash": {
-      "str_min": 20,
-      "str_max": 60,
+      "str_min": 12,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -44,8 +44,8 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
     "close": "t_laminated_door_glass_c",
     "bash": {
-      "str_min": 20,
-      "str_max": 60,
+      "str_min": 12,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -72,8 +72,8 @@
     "flags": [ "TRANSPARENT", "DOOR", "NOITEM", "MINEABLE", "BLOCK_WIND", "SUPPORTS_ROOF" ],
     "open": "t_ballistic_door_glass_o",
     "bash": {
-      "str_min": 200,
-      "str_max": 400,
+      "str_min": 25,
+      "str_max": 100,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -104,8 +104,8 @@
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "MINEABLE", "SUPPORTS_ROOF" ],
     "close": "t_ballistic_door_glass_c",
     "bash": {
-      "str_min": 200,
-      "str_max": 400,
+      "str_min": 25,
+      "str_max": 100,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,

--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -98,9 +98,9 @@
       "byproducts": [ { "item": "pipe", "count": 6 }, { "item": "wire", "count": [ 4, 20 ] } ]
     },
     "bash": {
-      "str_min": 7,
+      "str_min": 8,
       "str_max": 30,
-      "str_min_blocked": 7,
+      "str_min_blocked": 8,
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -134,9 +134,9 @@
       "byproducts": [ { "item": "pipe", "count": 6 }, { "item": "wire", "count": [ 4, 20 ] } ]
     },
     "bash": {
-      "str_min": 7,
+      "str_min": 8,
       "str_max": 30,
-      "str_min_blocked": 7,
+      "str_min_blocked": 8,
       "str_max_blocked": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -173,7 +173,7 @@
       "byproducts": [ { "item": "pipe", "count": 6 }, { "item": "wire", "count": [ 4, 20 ] } ]
     },
     "bash": {
-      "str_min": 7,
+      "str_min": 8,
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
@@ -639,7 +639,7 @@
       "byproducts": [ { "item": "pipe", "count": 6 }, { "item": "wire", "count": [ 4, 16 ] } ]
     },
     "bash": {
-      "str_min": 7,
+      "str_min": 8,
       "str_max": 30,
       "sound": "metal screeching!",
       "sound_fail": "clang!",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1509,8 +1509,8 @@
     "looks_like": "t_laminated_glass",
     "description": "A barrier made of laminated safety glass.  It's a lot tougher than regular glass, and is designed to break into fragments that are nowhere near as sharp.",
     "bash": {
-      "str_min": 20,
-      "str_max": 60,
+      "str_min": 12,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -1525,8 +1525,8 @@
     "id": "t_laminated_glass_lab",
     "copy-from": "t_laminated_glass",
     "bash": {
-      "str_min": 20,
-      "str_max": 60,
+      "str_min": 13,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -1545,7 +1545,7 @@
     "description": "A ballistic glass barrier, consisting of layers of laminated glass.  Its heavyweight construction is tough enough that even bullets that get through are unlikely to fully shatter it.",
     "bash": {
       "str_min": 25,
-      "str_max": 90,
+      "str_max": 100,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -1577,8 +1577,8 @@
     "flags": [ "NOITEM", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "OPENCLOSE_INSIDE", "MINEABLE", "BLOCK_WIND" ],
     "open": "t_laminated_glass_shutter_open",
     "bash": {
-      "str_min": 60,
-      "str_max": 210,
+      "str_min": 30,
+      "str_max": 100,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,
@@ -1620,8 +1620,8 @@
     ],
     "close": "t_laminated_glass_shutter",
     "bash": {
-      "str_min": 20,
-      "str_max": 60,
+      "str_min": 12,
+      "str_max": 50,
       "sound": "glass breaking!",
       "sound_fail": "whack!",
       "sound_vol": 20,


### PR DESCRIPTION
#### Summary
Buff chain link fences, nerf laminated glass

#### Describe the solution
- Laminated glass can be broken by a small group of regular zombies.
- Chain link fences are now slightly tougher and slightly larger characters can climb it.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
