### PR TITLE
Fix cigarettes more

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -835,7 +835,7 @@
     "max_intensity": 3,
     "int_dur_factor": "100 s",
     "show_in_info": true,
-    "base_mods": { "pain_min": [ 1 ], "pain_chance": [ -50 ], "pain_chance_bot": [ 1000 ] },
+    "base_mods": { "pain_min": [ 1 ], "pain_chance": [ -50 ], "pain_max_val": [ 15 ], "pain_chance_bot": [ 1000 ] },
     "scaling_mods": { "pain_max_val": [ 5 ], "pain_chance": [ 150 ] },
     "limb_score_mods": [ { "limb_score": "reaction", "modifier": 0.9, "scaling": -0.2 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
@@ -2855,7 +2855,19 @@
     "desc": [ "Your %s is uncomfortable.  Wearing something soft under your hard armor would help." ],
     "max_intensity": 1,
     "part_descs": true,
-    "base_mods": { "speed_mod": [ -2 ], "pain_min": [ 1 ], "pain_chance": [ 2 ], "pain_max_val": [ -1 ] }
+    "immune_bp_flags": [ "BIONIC_LIMB" ],
+    "base_mods": { "speed_mod": [ -4 ], "pain_min": [ 1 ], "pain_chance": [ 2 ], "pain_max_val": [ 15 ] },
+    "limb_score_mods": [
+      { "limb_score": "manip", "modifier": -0.05 },
+      { "limb_score": "grip", "modifier": -0.05 },
+      { "limb_score": "block", "modifier": -0.05 },
+      { "limb_score": "lift", "modifier": -0.05 },
+      { "limb_score": "move_speed", "modifier": -0.05 },
+      { "limb_score": "balance", "modifier": -0.05 },
+      { "limb_score": "swimming", "modifier": -0.05 },
+      { "limb_score": "crawl", "modifier": -0.05 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
   {
     "type": "effect_type",
@@ -2936,7 +2948,7 @@
     "desc": [ "Your %s is blistering from the intense heat." ],
     "main_parts_only": true,
     "part_descs": true,
-    "miss_messages": [ [ "Your blisters distract you", 1 ] ],
+    "miss_messages": [ [ "Your burns distract you.", 1 ] ],
     "immune_bp_flags": [ "BIONIC_LIMB" ],
     "base_mods": {
       "dex_mod": [ -1 ],
@@ -3422,7 +3434,8 @@
     "base_mods": {
       "focus_min": [ 1 ],
       "focus_max": [ 2 ],
-      "focus_max_val": [ 10 ],
+      "focus_max_val": [ 110 ],
+      "focus_min_val": [ 5 ],
       "focus_chance": [ 60 ],
       "int_mod": [ 1 ],
       "per_mod": [ 0.5 ],
@@ -3439,7 +3452,6 @@
     },
     "scaling_mods": {
       "focus_min": [ -1 ],
-      "focus_min_val": [ -10 ],
       "focus_max_val": [ 5 ],
       "speed_mod": [ 3 ],
       "str_mod": [ 0.5 ],
@@ -3470,7 +3482,8 @@
       "focus_min": [ 1 ],
       "focus_max": [ 2 ],
       "speed_mod": [ 3 ],
-      "focus_max_val": [ 6 ],
+      "focus_max_val": [ 106 ],
+      "focus_min_val": [ 20 ],
       "focus_chance": [ 40 ],
       "int_mod": [ 1 ],
       "per_mod": [ 0.5 ],
@@ -3515,35 +3528,34 @@
       "vomit_tick": [ 180 ],
       "focus_min": [ 1 ],
       "focus_max": [ 2 ],
-      "focus_chance": [ 10 ],
-      "focus_max_val": [ 8 ],
+      "focus_chance": [ 100 ],
+      "focus_max_val": [ 104 ],
+      "focus_min_val": [ 50 ],
       "fatigue_min": [ -1 ],
       "fatigue_max": [ -3 ],
       "fatigue_chance": [ 100 ],
-      "fatigue_max_val": [ -25 ]
+      "fatigue_min_val": [ 100 ]
     },
-    "scaling_mods": {
-      "focus_min_val": [ -8 ],
-      "focus_max_val": [ -8 ],
-      "focus_min": [ -1 ],
-      "vomit_chance": [ 21 ],
-      "int_mod": [ -1 ],
-      "per_mod": [ -1 ]
-    },
+    "scaling_mods": { "focus_min": [ -8 ], "focus_max": [ -4 ], "focus_min_val": [ -20 ], "vomit_chance": [ 21 ], "int_mod": [ -1 ], "per_mod": [ -1 ] },
     "blood_analysis_description": "Nicotine"
   },
   {
     "type": "effect_type",
     "id": "took_antihistamine",
     "rating": "good",
-    "base_mods": { "fatigue_min": [ 2 ], "fatigue_max": [ 10 ], "fatigue_chance": [ 60 ], "fatigue_max_val": [ 90 ] },
+    "base_mods": {
+      "fatigue_min": [ 0 ],
+      "fatigue_max": [ 5 ],
+      "fatigue_chance": [ 600 ],
+      "fatigue_max_val": [ 200 ]
+    },
     "blood_analysis_description": "Diphenhydramine"
   },
   {
     "type": "effect_type",
     "id": "zolpidem",
     "name": [ "Zolpidem" ],
-    "desc": [ "Medication is making you more drowsy by the minute" ],
+    "desc": [ "Medication is making you more drowsy by the minute." ],
     "rating": "good",
     "base_mods": {
       "int_mod": [ -1 ],
@@ -3551,7 +3563,7 @@
       "fatigue_min": [ 2 ],
       "fatigue_max": [ 60 ],
       "fatigue_chance": [ 60 ],
-      "fatigue_max_val": [ 350 ]
+      "fatigue_max_val": [ 500 ]
     },
     "blood_analysis_description": "Zolpidem"
   },
@@ -3582,7 +3594,7 @@
       "pkill_max_val": [ 7 ],
       "pkill_min": [ 1 ],
       "pkill_tick": [ 45 ],
-      "fatigue_max_val": [ 90 ],
+      "fatigue_max_val": [ 130 ],
       "fatigue_chance": [ 1000 ],
       "fatigue_min": [ 1 ]
     },
@@ -3735,6 +3747,7 @@
       "per_mod": [ -0.67 ],
       "dex_mod": [ -1.0 ],
       "int_mod": [ -1.67 ],
+      "pain_max_val": [ 15 ],
       "pain_chance": [ -500 ],
       "stamina_max": [ -500 ],
       "stamina_chance": [ -300 ],
@@ -3775,7 +3788,7 @@
     "miss_messages": [ [ "You feel horrible.", 1 ] ],
     "rating": "bad",
     "base_mods": {
-      "pain_max_val": [ 35 ],
+      "pain_max_val": [ 25 ],
       "pain_min": [ 1, 0 ],
       "pain_chance": [ 1800 ],
       "stamina_min": [ -100 ],
@@ -3783,6 +3796,7 @@
       "stamina_chance": [ 2400 ]
     },
     "scaling_mods": {
+      "pain_max_val": [ 15 ],
       "per_mod": [ -0.5 ],
       "dex_mod": [ -1.0 ],
       "int_mod": [ -1.0 ],
@@ -3844,6 +3858,7 @@
       "vomit_tick": [ 1800 ]
     },
     "scaling_mods": {
+      "pain_max_val": [ 15 ],
       "str_mod": [ -1.0 ],
       "per_mod": [ -0.67 ],
       "dex_mod": [ -1.34 ],
@@ -4398,8 +4413,23 @@
     "max_intensity": 150,
     "max_duration": "30 s",
     "int_add_val": 1,
-    "base_mods": { "pkill_max_val": [ 1 ], "pkill_min": [ 1 ], "pkill_max": [ 1 ], "pkill_tick": [ 1 ] },
-    "scaling_mods": { "pkill_max_val": [ 1 ], "per_mod": [ -0.03 ] }
+    "base_mods": {
+      "fatigue_min": [ 1 ],
+      "fatigue_max_val": [ 100 ],
+      "fatigue_chance": [ 190 ],
+      "pkill_max_val": [ 1 ],
+      "pkill_min": [ 1 ],
+      "pkill_max": [ 1 ],
+      "pkill_tick": [ 1 ]
+    },
+    "scaling_mods": {
+      "pkill_max_val": [ 1 ],
+      "per_mod": [ -0.03 ],
+      "dex_mod": [ -0.03 ],
+      "int_mod": [ -0.02 ],
+      "fatigue_max_val": [ 1 ],
+      "fatigue_chance": [ -1 ]
+    }
   },
   {
     "type": "effect_type",
@@ -4515,7 +4545,7 @@
       "focus_min": [ 1 ],
       "focus_max": [ 1 ],
       "focus_chance": [ 600 ],
-      "focus_max_val": [ 5 ],
+      "focus_max_val": [ 105 ],
       "fatigue_min": [ -1 ],
       "fatigue_max": [ -1 ],
       "fatigue_chance": [ 100 ],
@@ -4557,7 +4587,7 @@
   {
     "type": "effect_type",
     "id": "cough_suppress",
-    "base_mods": { "fatigue_min": [ 1 ], "fatigue_max": [ 6 ], "fatigue_chance": [ 60 ], "fatigue_max_val": [ 60 ] }
+    "base_mods": { "fatigue_min": [ 1 ], "fatigue_max": [ 6 ], "fatigue_chance": [ 60 ], "fatigue_max_val": [ 200 ] }
   },
   {
     "type": "effect_type",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -325,12 +325,7 @@
     "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED", "HURT" ],
     "fear_triggers": [ "FIRE", "PLAYER_CLOSE" ],
     "zombify_into": "mon_zpig_brute",
-    "special_attacks": [
-      { "id": "low_charge", "cooldown": 12 },
-      [ "EAT_FOOD", 20 ],
-      [ "EAT_CARRION", 60 ],
-      { "id": "impale" }
-    ],
+    "special_attacks": [ { "id": "low_charge", "cooldown": 12 }, [ "EAT_FOOD", 20 ], [ "EAT_CARRION", 60 ], { "id": "impale" } ],
     "flags": [
       "SEES",
       "HEARS",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -123,7 +123,7 @@
     "min": 0,
     "max": 10,
     "rate": "5 m",
-    "disease_excess": [ [ 1, 3 ], [ 4, 10 ] ]
+    "disease_excess": [ [ 1, 6 ], [ 7, 10 ] ]
   },
   {
     "id": "diphenhydramine",

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2611,13 +2611,13 @@ bool cata_tiles::draw_from_id_string_internal(
                                                   1.0f ) ) );
         }
 
-         if( prevent_occlusion_transp && retract > 0 && category != TILE_CATEGORY::OVERMAP_VISION_LEVEL ) {
-             res = find_tile_looks_like( id + "_transparent", category, variant );
-            
-             if( res ) {
-                 tt = &res->tile();
-             }
-         }
+        if( prevent_occlusion_transp && retract > 0 && category != TILE_CATEGORY::OVERMAP_VISION_LEVEL ) {
+            res = find_tile_looks_like( id + "_transparent", category, variant );
+
+            if( res ) {
+                tt = &res->tile();
+            }
+        }
     }
 
     // Intensity lookup.
@@ -3098,7 +3098,8 @@ bool cata_tiles::draw_sprite_at(
     float offset_y = 0.0f;
     // If we are scaling or rotating a character tile, we need to do some annoying math to make sure
     // that all the overlays line up even if they're different sizes from the tile itself.
-    if( creature && rota != 0 && rota != -1 && ( width != tileset_width || height != tileset_height ) ) {
+    if( creature && rota != 0 && rota != -1 && ( width != tileset_width ||
+            height != tileset_height ) ) {
         const float effective_scale_y = scale_y != 0 ? scale_y : 1.0f;
         const float scaled_height = height * effective_scale_y;
         const float scaled_tileset_height = tileset_height * effective_scale_y;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11571,7 +11571,8 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                     const int damage = rng( force, force * 2.0f ) / 6;
                     // zed_damage uses flvel because they take damage based on c's velocity, not their own size.
                     int zed_damage = rng( flvel, flvel * 2.0f ) / 6;
-                    add_msg_if_player_sees( pt, _( "%1s collides with %2s!" ), c->disp_name( false, true ), critter.disp_name() );
+                    add_msg_if_player_sees( pt, _( "%1s collides with %2s!" ), c->disp_name( false, true ),
+                                            critter.disp_name() );
                     c->impact( damage, pt );
                     zed_damage = std::max( 0, ( zed_damage - critter.get_armor_type( damage_bash,
                                                 bodypart_id( "torso" ) ) ) );
@@ -11591,7 +11592,8 @@ bool game::fling_creature( Creature *c, const units::angle &dir, float flvel, bo
                     const int damage = rng( force, force * 2.0f ) / 6;
                     // guy_damage uses flvel because they take damage based on c's velocity, not their own size.
                     int guy_damage = rng( flvel, flvel * 2.0f ) / 6;
-                    add_msg_if_player_sees( pt, _( "%1s collides with %2s!" ), c->disp_name( false, true ), guy.disp_name() );
+                    add_msg_if_player_sees( pt, _( "%1s collides with %2s!" ), c->disp_name( false, true ),
+                                            guy.disp_name() );
                     c->impact( damage, pt );
                     guy_damage = std::max( 0, ( guy_damage - guy.get_armor_type( damage_bash,
                                                 bodypart_id( "torso" ) ) ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14092,7 +14092,7 @@ bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoin
 bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms &pos )
 {
     // cig dies out
-    if( item_counter == 0 ) {
+    if( item_counter <= 0 ) {
         bool remove = false;
         if( carrier != nullptr ) {
             carrier->add_msg_if_player( m_neutral, _( "You finish your %s." ), type_name() );
@@ -14100,15 +14100,15 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
         if( type->transform_into ) {
             type->transform_into.value().transform( carrier, *this, true );
             if( !this->is_null() ) {
-                here.add_item_or_charges( carrier->pos_bub(), *this );
-                on_drop( carrier->pos_bub(), here );
+                here.add_item_or_charges( pos, *this );
+                on_drop( pos, here );
                 remove = true;
             }
         } else {
             type->invoke( carrier, *this, pos, "transform" );
             if( !this->is_null() ) {
-                here.add_item_or_charges( carrier->pos_bub(), *this );
-                on_drop( carrier->pos_bub(), here );
+                here.add_item_or_charges( pos, *this );
+                on_drop( pos, here );
                 remove = true;
             }
         }
@@ -14147,11 +14147,15 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
     }
     // if carried by someone:
     if( carrier != nullptr ) {
-        int puff_chance = 4;
+        int puff_chance = 24;
         if( has_flag( flag_TOBACCO ) ) {
-            // Try not to go over 3mg nicotine if we started at 0.
+            // Try not to go over 5mg nicotine if we started at 0.
             if( typeId() == itype_cigar_lit ) {
-                puff_chance = 14;
+                puff_chance = 36;
+            }
+            // Smokers reflexively puff more often if they need more nicotine.
+            if( carrier->vitamin_get( vitamin_nicotine ) < 5 ) {
+                puff_chance /= 6;
             }
             if( one_in( puff_chance ) ) {
                 carrier->vitamin_mod( vitamin_nicotine, 1 );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1461,7 +1461,7 @@ void monster::footsteps( const tripoint_bub_ms &p )
     } else if( has_flag( mon_flag_QUIETMOVES ) ) {
         volume -= 3;
     }
-    
+
     if( volume <= 0 ) {
         return;
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -556,16 +556,16 @@ static bool describe_sound( sounds::sound_t category, bool from_player_position 
         switch( category ) {
             case sounds::sound_t::background:
             case sounds::sound_t::weather:
-                return one_in( 80  );
+                return one_in( 80 );
             case sounds::sound_t::sensory:
                 return false;
             case sounds::sound_t::music:
-                return one_in( 80  );
+                return one_in( 80 );
             case sounds::sound_t::movement:
             case sounds::sound_t::activity:
-                return one_in( 50  );
+                return one_in( 50 );
             case sounds::sound_t::destructive_activity:
-                return one_in( 20  );
+                return one_in( 20 );
             case sounds::sound_t::speech:
             case sounds::sound_t::electronic_speech:
             case sounds::sound_t::alarm:
@@ -599,7 +599,7 @@ void sounds::process_sound_markers( Character *you )
         const int distance_to_sound = sound_distance( you_pos, pos );
         const int raw_volume = sound.volume;
         add_msg_debug( debugmode::DF_SOUND,
-            "sound vol %d dist %d", raw_volume, distance_to_sound );
+                       "sound vol %d dist %d", raw_volume, distance_to_sound );
         // The felt volume of a sound is not affected by negative multipliers, such as already
         // deafened players or players with sub-par hearing to begin with.
         int felt_volume = static_cast<int>( std::round( ( raw_volume * std::min( 1.0f,


### PR DESCRIPTION
#### Summary
Fix cigarettes more

#### Purpose of change
Cigarettes had incorrect values for the effect, the puff_chance was not tuning for nicotine amount, and it was just too easy to get a nic overdose.

#### Describe the solution
Fixed(?) the effect values. Puff_chance now flexes to how much nicotine you have in your system. Dropped cigs no longer crash the game.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
