### PR TITLE
Dormant zeds have random damage, fix corpses

### DIFF
--- a/data/json/mapgen/map_extras/dormants.json
+++ b/data/json/mapgen/map_extras/dormants.json
@@ -3,5 +3,10 @@
     "type": "mapgen",
     "update_mapgen_id": "mx_dormant",
     "object": { "monsters": { " ": { "monster": "GROUP_VANILLA_DORMANT", "chance": 10, "density": 0.02 } } }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "mx_dormant_few",
+    "object": { "monsters": { " ": { "monster": "GROUP_VANILLA_DORMANT", "chance": 10, "density": 0.01 } } }
   }
 ]

--- a/data/json/mapgen/nested/road_nested.json
+++ b/data/json/mapgen/nested/road_nested.json
@@ -1320,7 +1320,12 @@
       "rotation": [ 0 ],
       "place_nested": [
         {
-          "chunks": [ [ "24x24_road_zombies_placement", 40 ], [ "24x24_road_zombies_dormant_placement", 5 ], [ "null", 55 ] ],
+          "chunks": [
+            [ "24x24_road_zombies_placement", 40 ],
+            [ "24x24_road_zombies_dormant_placement", 3 ],
+            [ "24x24_road_zombies_dormant_few_placement", 2 ],
+            [ "null", 55 ]
+          ],
           "x": 0,
           "y": 0,
           "flags_any": {
@@ -1353,6 +1358,15 @@
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
       "place_monsters": [ { "monster": "GROUP_VANILLA_DORMANT", "x": [ 0, 23 ], "y": [ 0, 23 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "24x24_road_zombies_dormant_few_placement",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rotation": [ 0 ],
+      "place_monsters": [ { "monster": "GROUP_VANILLA_DORMANT", "x": [ 0, 23 ], "y": [ 0, 23 ], "density": 0.3 } ]
     }
   }
 ]

--- a/data/json/monsters/zed_dormant.json
+++ b/data/json/monsters/zed_dormant.json
@@ -6,11 +6,11 @@
     "description": "You should not see this.  Kills pseudo zombie to turn it into a corpse for revival.",
     "valid_targets": [ "self" ],
     "max_level": 1,
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "PERCENTAGE_DAMAGE", "NO_FAIL" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "PERCENTAGE_DAMAGE", "RANDOM_DAMAGE", "NO_FAIL" ],
     "base_casting_time": 1,
     "shape": "blast",
     "min_damage": 100,
-    "max_damage": 100,
+    "max_damage": 150,
     "min_aoe": 1,
     "max_aoe": 1,
     "message": "",
@@ -42,7 +42,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie",
     "special_attacks": [
       {
@@ -63,7 +63,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_rot",
     "special_attacks": [
       {
@@ -84,7 +84,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_fat",
     "special_attacks": [
       {
@@ -105,7 +105,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_tough",
     "special_attacks": [
       {
@@ -126,7 +126,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_child",
     "special_attacks": [
       {
@@ -147,7 +147,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_crawler",
     "special_attacks": [
       {
@@ -168,7 +168,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_brainless",
     "special_attacks": [
       {
@@ -189,7 +189,7 @@
     "copy-from": "mon_zombie",
     "looks_like": "corpse_mon_zombie",
     "speed": 1,
-    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "AQUATIC", "WATER_CAMOUFLAGE" ],
+    "flags": [ "FILTHY", "REVIVES", "DORMANT", "QUIETDEATH", "AQUATIC", "WATER_CAMOUFLAGE", "REVIVES_HEALTHY" ],
     "zombify_into": "mon_zombie_swimmer_base",
     "special_attacks": [
       {
@@ -233,9 +233,9 @@
     "sound_id": "melee_attack",
     "sound_variant": "monster_melee_hit",
     "sound_description": "a zombie moaning!",
-    "min_damage": 42,
-    "max_damage": 90,
-    "//": "volume is damage/3, so 14 to 30"
+    "min_damage": 24,
+    "max_damage": 65,
+    "//": "volume is damage/3, so 8 to 20"
   },
   {
     "type": "SPELL",

--- a/data/json/obsoletion_and_migration/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration/obsolete_overmap_special.json
@@ -29,7 +29,7 @@
     "id": "Hunting Lodge - Normal",
     "new_id": "Hunting Lodge"
   },
-    {
+  {
     "type": "overmap_special_migration",
     "id": "Occupied Scrap Yard",
     "new_id": "Scrapyard 1"

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -38,9 +38,21 @@
   {
     "id": "mx_dormant",
     "type": "map_extra",
-    "name": { "str": "Corpses" },
+    "name": { "str": "Many Corpses" },
     "description": "There are a lot of corpses here.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_dormant" },
+    "min_max_zlevel": [ -7, 7 ],
+    "sym": "d",
+    "color": "light_red",
+    "autonote": false,
+    "flags": [ "MAN_MADE", "CLASSIC" ]
+  },
+  {
+    "id": "mx_dormant_few",
+    "type": "map_extra",
+    "name": { "str": "Corpses" },
+    "description": "There are a few of corpses here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_dormant_few" },
     "min_max_zlevel": [ -7, 7 ],
     "sym": "d",
     "color": "light_red",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -486,9 +486,7 @@
   {
     "type": "overmap_special",
     "id": "Scrapyard 1",
-    "overmaps": [
-      { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_north" }
-    ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_north" } ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest", "field" ],
     "city_distance": [ 30, -1 ],

--- a/data/json/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/regional_map_settings.json
@@ -1078,7 +1078,8 @@
       [ "mx_military", 5 ],
       [ "mx_science", 7 ],
       [ "mx_collegekids", 15 ],
-      [ "mx_dormant", 30 ],
+      [ "mx_dormant", 20 ],
+      [ "mx_dormant_few", 10 ],
       [ "mx_portal", 5 ],
       [ "mx_crater", 60 ],
       [ "mx_portal_in", 3 ],
@@ -1106,7 +1107,8 @@
       [ "mx_crater", 180 ],
       [ "mx_portal_in", 30 ],
       [ "mx_casings", 30 ],
-      [ "mx_dormant", 30 ]
+      [ "mx_dormant", 20 ],
+      [ "mx_dormant_few", 10 ]
     ]
   },
   {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -464,8 +464,7 @@ void activity_handlers::butcher_do_turn( player_activity *act, Character * )
     }
     item &corpse_item = *target;
     if( action == butcher_type::DISSECT && ( corpse_item.has_flag( flag_QUARTERED ) ||
-            corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ||
-            corpse_item.has_flag( flag_GIBBED ) ) ) {
+            corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ) ) {
         add_msg( m_bad, _( "You back off from the ruined corpse, unable to continue." ) );
         act->set_to_null();
         return;
@@ -603,8 +602,7 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
     }
 
     if( action == butcher_type::DISSECT && ( corpse_item.has_flag( flag_QUARTERED ) ||
-            corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ||
-            corpse_item.has_flag( flag_GIBBED ) ) ) {
+            corpse_item.has_flag( flag_FIELD_DRESS_FAILED ) || corpse_item.has_flag( flag_PULPED ) ) ) {
         you.add_msg_if_player( m_info,
                                _( "It would be futile to dissect this badly damaged corpse." ) );
         act.targets.pop_back();
@@ -619,8 +617,7 @@ static void set_up_butchery( player_activity &act, Character &you, butcher_type 
     }
 
     if( action == butcher_type::SKIN && ( corpse_item.has_flag( flag_SKINNED ) ||
-                                          corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) ||
-                                          corpse_item.has_flag( flag_GIBBED ) ) ) {
+                                          corpse_item.has_flag( flag_QUARTERED ) || corpse_item.has_flag( flag_PULPED ) ) ) {
         you.add_msg_if_player( m_info, _( "The corpse no longer has a salvageable skin." ) );
         act.targets.pop_back();
         return;
@@ -1015,7 +1012,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( corpse_item->has_flag( flag_QUARTERED ) ) {
         monster_weight *= 0.95;
     }
-    if( corpse_item->has_flag( flag_GIBBED ) || corpse_item->has_flag( flag_PULPED ) ||
+    if( corpse_item->has_flag( flag_PULPED ) ||
         corpse_item->damage() >= corpse_item->max_damage() ) {
         monster_weight = std::round( 0.4 * monster_weight );
         if( action != butcher_type::FIELD_DRESS ) {
@@ -1032,7 +1029,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
         }
     }
     if( corpse_item->has_flag( flag_SKINNED ) ) {
-        monster_weight = std::round( 0.85 * monster_weight );
+        monster_weight = std::round( 0.95 * monster_weight );
     }
     const int entry_count = ( action == butcher_type::DISSECT &&
                               !mt.dissect.is_empty() ) ? mt.dissect->get_all().size() : mt.harvest->get_all().size();
@@ -1105,13 +1102,9 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             roll = 0;
         }
 
-        // Check if monster was gibbed, starving, or skinned and handle accordingly
-        if( corpse_item->has_flag( flag_GIBBED ) && ( entry.type == harvest_drop_flesh ||
-                entry.type == harvest_drop_bone ) ) {
-            roll /= 2;
-        }
+        // Check if monster was starving, or skinned and handle accordingly
         if( corpse_item->has_flag( flag_UNDERFED ) && ( entry.type == harvest_drop_flesh ) ) {
-            roll /= 1.6;
+            roll *= 0.6;
         }
         if( corpse_item->has_flag( flag_SKINNED ) && entry.type == harvest_drop_skin ) {
             roll = 0;
@@ -1314,7 +1307,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 monster_weight_remaining -= ( monster_weight - ( monster_weight * 3 / 4 / 4 ) );
             }
             if( corpse_item->has_flag( flag_SKINNED ) ) {
-                monster_weight_remaining -= monster_weight * 0.15;
+                monster_weight_remaining -= monster_weight * 0.5;
             }
         }
         const itype_id &leftover_id = mt.harvest->leftovers;

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -148,7 +148,6 @@ const flag_id flag_FROZEN( "FROZEN" );
 const flag_id flag_FUNGAL_VECTOR( "FUNGAL_VECTOR" );
 const flag_id flag_GAS_DISCOUNT( "GAS_DISCOUNT" );
 const flag_id flag_GAS_PROOF( "GAS_PROOF" );
-const flag_id flag_GIBBED( "GIBBED" );
 const flag_id flag_GNV_EFFECT( "GNV_EFFECT" );
 const flag_id flag_HARD( "HARD" );
 const flag_id flag_HEAT_IMMUNE( "HEAT_IMMUNE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -155,7 +155,6 @@ extern const flag_id flag_FROZEN;
 extern const flag_id flag_FUNGAL_VECTOR;
 extern const flag_id flag_GAS_DISCOUNT;
 extern const flag_id flag_GAS_PROOF;
-extern const flag_id flag_GIBBED;
 extern const flag_id flag_GNV_EFFECT;
 extern const flag_id flag_HARVEST_SEEDS;
 extern const flag_id flag_HEAT_IMMUNE;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9065,21 +9065,20 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
             for( const harvest_entry &entry : dead_mon->harvest.obj() ) {
                 if( entry.type == harvest_drop_skin && !( corpses[index]->has_flag( flag_SKINNED ) ||
                         corpses[index]->damage() >= corpses[index]->max_damage() ||
-                        ( corpses[index]->has_flag( flag_QUARTERED ) ) || ( corpses[index]->has_flag( flag_PULPED ) ) ||
-                        ( corpses[index]->has_flag( flag_GIBBED ) ) ) ) {
+                        ( corpses[index]->has_flag( flag_QUARTERED ) ) || corpses[index]->has_flag( flag_PULPED ) ) ) {
                     has_skin = true;
                 }
                 if( entry.type == harvest_drop_offal && !( corpses[index]->has_flag( flag_QUARTERED ) ||
                         corpses[index]->has_flag( flag_FIELD_DRESS ) ||
                         corpses[index]->has_flag( flag_FIELD_DRESS_FAILED ) ||
-                        ( corpses[index]->has_flag( flag_PULPED ) ) || ( corpses[index]->has_flag( flag_GIBBED ) ) ) ) {
+                        corpses[index]->has_flag( flag_PULPED ) ) ) {
                     has_organs = true;
                 }
                 if( entry.type == harvest_drop_blood && dead_mon->bleed_rate > 0 &&
                     !( corpses[index]->has_flag( flag_QUARTERED ) ||
                        corpses[index]->has_flag( flag_FIELD_DRESS ) ||
                        corpses[index]->has_flag( flag_FIELD_DRESS_FAILED ) || corpses[index]->has_flag( flag_BLED ) ||
-                       ( corpses[index]->has_flag( flag_PULPED ) ) || ( corpses[index]->has_flag( flag_GIBBED ) ) ) ) {
+                       corpses[index]->has_flag( flag_PULPED ) ) ) {
                     has_blood = true;
                 }
                 /*
@@ -9094,8 +9093,7 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
                        corpses[index]->damage() >= corpses[index]->max_damage() ||
                        corpses[index]->has_flag( flag_FIELD_DRESS ) ||
                        corpses[index]->has_flag( flag_FIELD_DRESS_FAILED ) ||
-                       ( corpses[index]->has_flag( flag_SKINNED ) ) || ( corpses[index]->has_flag( flag_PULPED ) ) ||
-                       ( corpses[index]->has_flag( flag_GIBBED ) ) ) ) {
+                       corpses[index]->has_flag( flag_SKINNED ) || corpses[index]->has_flag( flag_PULPED ) ) ) {
                     intact = true;
                 }
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7033,11 +7033,11 @@ units::mass item::weight( bool include_contents, bool integral ) const
         if( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ) {
             ret_mul *= 0.75;
         }
-        if( has_flag( flag_GIBBED ) ) {
+        if( has_flag( flag_PULPED ) ) {
             ret_mul *= 0.85;
         }
         if( has_flag( flag_SKINNED ) ) {
-            ret_mul *= 0.85;
+            ret_mul *= 0.95;
         }
         if( has_flag( flag_QUARTERED ) ) {
             ret_mul *= 0.25;
@@ -7214,11 +7214,11 @@ units::volume item::corpse_volume( const mtype *corpse ) const
     if( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ) {
         corpse_volume *= 0.75;
     }
-    if( has_flag( flag_GIBBED ) ) {
+    if( has_flag( flag_PULPED ) ) {
         corpse_volume *= 0.85;
     }
     if( has_flag( flag_SKINNED ) ) {
-        corpse_volume *= 0.85;
+        corpse_volume *= 0.95;
     }
     if( corpse_volume > MAX_ITEM_VOLUME ) {
         // Silently set volume so the corpse can still spawn but a mtype can have a volume > MAX_ITEM_VOLUME
@@ -8729,7 +8729,7 @@ bool item::pulpable() const
            damage() < max_damage() &&
            !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
               has_flag( flag_QUARTERED ) ||
-              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) || has_flag( flag_GIBBED ) );
+              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) );
 }
 
 bool item::can_revive() const
@@ -8738,7 +8738,7 @@ bool item::can_revive() const
            damage() < max_damage() &&
            !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
               has_flag( flag_QUARTERED ) ||
-              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) || has_flag( flag_GIBBED ) ||
+              has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) ||
               ( has_flag( flag_FROZEN ) && !corpse->has_flag( mon_flag_DORMANT ) ) );
 }
 
@@ -9634,6 +9634,8 @@ std::string item::durability_indicator( bool include_intact ) const
                     return pgettext( "damage adjective", "damaged " );
                 case 3:
                     return pgettext( "damage adjective", "mangled " );
+                case 4:
+                    return pgettext( "damage adjective", "mutilated " );
                 default:
                     return pgettext( "damage adjective", "pulped " );
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3343,10 +3343,11 @@ static bool damage_item( Character &pl, item_location &fix )
     const std::string startdurability = fix->durability_indicator( true );
     const bool destroyed = fix->inc_damage();
     const std::string resultdurability = fix->durability_indicator( true );
-    pl.add_msg_if_player( m_bad, _( "You damage your %s!  ( %s-> %s)" ), fix->tname( 1, false ),
+    std::string iname = fix->tname( 1, false );
+    pl.add_msg_if_player( m_bad, _( "You damage your %s!  ( %s-> %s)" ), iname,
                           startdurability, resultdurability );
     if( destroyed ) {
-        pl.add_msg_if_player( m_bad, _( "You destroy it!" ) );
+        pl.add_msg_if_player( m_bad, _( "Your %s is destroyed!" ), iname );
         if( fix.where() == item_location::type::character ) {
             pl.i_rem_keep_contents( fix.get_item() );
         } else {

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -633,13 +633,13 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
             }
         }
 
-        //50% chance to spawn a blood trail of wounded soldier trying to escape,
-        //but eventually died out of blood loss and wounds and got devoured by zombies
+        // 50% chance to spawn a blood trail of wounded soldier trying to escape,
+        // but eventually died out of blood loss and wounds.
         if( one_in( 2 ) ) {
             m.add_splatter_trail( fd_blood, { 9, 15, abs_sub.z()}, {11, 18, abs_sub.z()} );
             m.add_splatter_trail( fd_blood, { 11, 18, abs_sub.z()}, {11, 21, abs_sub.z()} );
             for( const tripoint_omt_ms &loc : m.points_in_radius( tripoint_omt_ms{ 11, 21, abs_sub.z()}, 1 ) ) {
-                //50% chance to spawn gibs in every tile around corpse in 1-tile radius
+                // 50% chance to spawn gibs in every tile around corpse in 1-tile radius.
                 if( one_in( 2 ) ) {
                     m.add_field( { loc.xy(), abs_sub.z()}, fd_gibs_flesh, rng( 1, 3 ) );
                 }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -157,7 +157,7 @@ item_location mdeath::splatter( map *here, monster &z )
 
     const int max_hp = std::max( z.get_hp_max(), 1 );
     const float overflow_damage = std::max( -z.get_hp(), 0 );
-    const float corpse_damage = 2.5 * overflow_damage / max_hp;
+    const float corpse_damage = rng_float( 2.0, 4.0 ) * overflow_damage / max_hp;
 
     const field_type_id type_blood = z.bloodType();
     const field_type_id type_gib = z.gibType();
@@ -208,14 +208,13 @@ item_location mdeath::splatter( map *here, monster &z )
             scatter_chunks( here, leftover_id, chunk_amount, z, gib_distance,
                             chunk_amount / ( gib_distance + 1 ) );
         }
-        // add corpse with gib flag
+        // Add pulped corpse.
         item corpse = item::make_corpse( z.type->id, calendar::turn, z.unique_name, z.get_upgrade_time() );
         if( corpse.is_null() ) {
             return {};
         }
-        // Set corpse to damage that aligns with being pulped
         corpse.set_damage( 4000 );
-        corpse.set_flag( STATIC( flag_id( "GIBBED" ) ) );
+        corpse.set_flag( STATIC( flag_id( "PULPED" ) ) );
         if( z.has_effect( effect_no_ammo ) ) {
             corpse.set_var( "no_ammo", "no_ammo" );
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2336,7 +2336,8 @@ void monster::apply_damage( Creature *source, bodypart_id /*bp*/, int dam,
     }
 
     if( hp < 1 ) {
-        set_killer( source );
+        map &here = get_map();
+        die( &here, source );
     } else if( dam > 0 ) {
         process_trigger( mon_trigger::HURT, 1 + static_cast<int>( dam / 3 ) );
         // Get angry at characters if hurt by one
@@ -3114,7 +3115,7 @@ void monster::die( map *here, Creature *nkiller )
     }
 
     if( type->mdeath_effect.eoc.has_value() ) {
-        //Not a hallucination, go process the death effects.
+        // Not a hallucination, go process the death effects.
         if( type->mdeath_effect.eoc.value().is_valid() ) {
             dialogue d( get_talker_for( *this ), nullptr );
             type->mdeath_effect.eoc.value()->activate( d );
@@ -3877,14 +3878,13 @@ bool monster::is_nemesis() const
 void monster::init_from_item( item &itm )
 {
     if( itm.is_corpse() ) {
-        set_speed_base( get_speed_base() * 0.8 );
+        set_speed_base( get_speed_base() );
         const int burnt_penalty = itm.burnt;
-        hp = static_cast<int>( hp * 0.7 );
         if( itm.damage_level() > 0 ) {
             if( itm.damage_level() > 1 ) {
-                set_speed_base( speed_base / 2 );
+                set_speed_base( speed_base * ( itm.damage_level() / 10.0 ) );
             }
-            hp /= itm.damage_level() + 1;
+            hp -= hp * ( rng_float( 0.5, 1.8 ) * itm.damage_level() / 10.0 );
         }
 
         hp -= burnt_penalty;
@@ -3938,7 +3938,7 @@ item monster::to_item() const
     int percent_damage = std::max( 0, ( max_dmg + 1 ) - damfac );
 
     // Throwing a rock shouldn't gib a rabbit. Let's gate damage for sanity's sake.
-    int allowed_damage = std::clamp( -hp / 5, 0, 5 );
+    int allowed_damage = std::clamp( -hp / std::max( 5, ( type->hp / 10 ) ), 0, 5 );
     int final_damage = std::min( percent_damage, allowed_damage );
     result.set_damage( final_damage );
     return result;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -495,9 +495,7 @@ mtype MonsterGenerator::generate_fake_pseudo_dormant_monster( const mtype &mon )
     //        "description" : "Fake zombie used for spawning dormant zombies.  If you see this, open an issue on github.",
     //        "copy-from" : "mon_zombie",
     //        "looks_like" : "corpse_mon_zombie",
-    //        "hp" : 5,
-    //        "speed" : 1,
-    //        "flags" : ["FILTHY", "REVIVES", "DORMANT", "QUIETDEATH"] ,
+    //        "flags" : ["FILTHY", "REVIVES", "DORMANT", "QUIETDEATH" ],
     //        "zombify_into" : "mon_zombie",
     //        "special_attacks" : [
     //    {


### PR DESCRIPTION
#### Summary
Dormant zeds have random damage, fix corpses

#### Purpose of change
Dormant zombies never had any damage to the corpse item, making it easy to spot them. They also spawned in easily noticeable big groups, and they weren't coming back at full HP.

The revive code was also really weird. Corpses came back with barely any HP and a ton of slowdown, making them easy to just kill again. 

#### Describe the solution
- Dormant zombies have REVIVES_HEALTHY
- Dormant zombies randomly have some damage to their "corpses"
- Added a new damage level descriptor for corpses, "mutilated". This is above "mangled" but below "pulped." Previously, corpses at damage level 4 were described as "pulped" even though no they were not.
- Overkill is now a little less aggressive about applying damage to corpses with larger HP values.
- When you do enough damage to pulp a corpse, the game is a little more generous with splashing gibs around, because this is funny.
- Skinning a creature removes only 5% of its weight and volume, not 15%.
- Zombies revive with less of a speed and HP penalty. Previously they were frequently coming back with barely any HP and extremely reduced speed. It still scales with damage to the corpse.
- Dormant zombies can spawn in smaller groups.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
