### PR TITLE
Buff teaching

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -376,7 +376,7 @@
   {
     "id": "ACT_TRAIN_TEACHER",
     "type": "activity_type",
-    "activity_level": "ACTIVE_EXERCISE",
+    "activity_level": "BRISK_EXERCISE",
     "verb": "teaching",
     "based_on": "speed",
     "can_resume": false

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -231,6 +231,7 @@ static const quality_id qual_FISHING_ROD( "FISHING_ROD" );
 
 static const skill_id skill_computer( "computer" );
 static const skill_id skill_firstaid( "firstaid" );
+static const skill_id skill_social( "social" );
 static const skill_id skill_survival( "survival" );
 
 static const species_id species_FERAL( "FERAL" );
@@ -2137,7 +2138,12 @@ void activity_handlers::train_finish( player_activity *act, Character *you )
         const Skill &skill = sk.obj();
         std::string skill_name = skill.name();
         int old_skill_level = you->get_knowledge_level( sk );
-        you->practice( sk, 100, old_skill_level + 2 );
+        // Teacher intelligence, subject matter knowledge, and social skill matters most.
+        // Student intelligence and social skill is secondary.
+        int teacher_quality = ( teacher->get_int() + ( teacher->get_skill_level( skill_social ) + teacher->get_knowledge_level( sk ) ) ) * 4;
+        int student_quality = ( you->get_int() + (you->get_skill_level( skill_social ) * 2 ) ) * 4;
+        int teaching_effectiveness = std::min( 200, std::max( 10, ( teacher_quality * 2 + student_quality ) / 2 ) );
+        you->practice( sk, teaching_effectiveness, old_skill_level + 2 );
         int new_skill_level = you->get_knowledge_level( sk );
         if( old_skill_level != new_skill_level ) {
             if( you->is_avatar() ) {


### PR DESCRIPTION
#### Summary
Buff teaching

#### Purpose of change
- Teaching was almost never worth doing, as it was active exercise and raised skill very little for the investment.

#### Describe the solution
- Teaching now benefits from the social skill and intelligence of teacher and student, as well as the teacher's knowledge (not rank!) of the subject skill. A session can teach up to 2x what it did before, but teachers and students who lack the skills and stats may have some trouble.
- Teaching is now brisk exercise, instead of active. This means it takes fewer kcal and causes less weariness.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
