### PR TITLE
An alternative fix for the sound stacking problem

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -860,6 +860,17 @@ struct sound_effect_handler {
             channels_to_end_mutex.unlock();
         }
 
+        unsigned int chunk_already_playing_count = 0;
+        for ( int ch = 0; ch <= 128; ch++ ) {
+            if ( Mix_Playing( ch ) ) {
+                const Mix_Chunk *chunk = Mix_GetChunk( ch );
+                chunk_already_playing_count += static_cast<unsigned int>( chunk == audio_src );
+                if ( chunk_already_playing_count == 2 ) {
+                    return true;
+                }
+            }
+        }
+
         sound_effect_handler *handler = new sound_effect_handler();
         handler->active = true;
         handler->audio_src = audio_src;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -738,10 +738,9 @@ void sounds::process_sound_markers( Character *you )
         const std::string &sfx_id = sound.id;
         const std::string &sfx_variant = sound.variant;
         const std::string &sfx_season = sound.season;
+        const bool indoors = !is_creature_outside( get_player_character() );
         const bool night = is_night( calendar::turn );
-        Character &player_character = get_player_character();
-        const bool indoors = !is_creature_outside( player_character );
-        if( !sfx_id.empty() && !player_character.activity ) {
+        if( !sfx_id.empty() ) {
             sfx::play_variant_sound( sfx_id, sfx_variant, sfx_season, indoors, night,
                                      sfx::get_heard_volume( pos ) );
         }
@@ -1479,20 +1478,11 @@ void sfx::sound_thread::operator()() const
     std::this_thread::sleep_for( std::chrono::milliseconds( rng( 1, 2 ) ) );
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-
-
-    Character &player_character = get_player_character();
-    const bool indoors = !is_creature_outside( player_character );
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
 
     std::string skill_variant;
     std::string weapon_variant = weapon_id.str();
-
-
-    if( !player_character.activity ) {
-        return;
-    }
-
 
     if( weapon_skill == skill_bashing ) {
         skill_variant = ( weapon_volume > 8 ) ? "big_bash" : "small_bash";
@@ -1584,15 +1574,9 @@ void sfx::do_player_death_hurt( const Character &target, bool death )
         return;
     }
 
-    Character &player_character = get_player_character();
-
-    if( !player_character.activity ) {
-        return;
-    }
-
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    const bool indoors = !is_creature_outside( player_character );
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
     int heard_volume = get_heard_volume( target.pos_bub() );
     if( heard_volume < 1 ) {
@@ -1741,10 +1725,9 @@ void sfx::do_hearing_loss( int turns )
         return;
     }
 
-    Character &player_character = get_player_character();
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    const bool indoors = !is_creature_outside( player_character );
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
     g_sfx_volume_multiplier = .1;
     fade_audio_group( group::weather, 50 );
@@ -1752,11 +1735,6 @@ void sfx::do_hearing_loss( int turns )
     // Negative duration is just insuring we stay in sync with player condition,
     // don't play any of the sound effects for going deaf.
     if( turns == -1 ) {
-        return;
-    }
-
-
-    if( !player_character.activity ) {
         return;
     }
     play_variant_sound( "environment", "deafness_shock", seas_str, indoors, night, 100 );
@@ -2016,13 +1994,8 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    Character &player_character = get_player_character();
-    const bool indoors = !is_creature_outside( player_character );
-    if( player_character.activity ) {
-        return;
-    }
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
-
     play_variant_sound( id, variant, seas_str, indoors, night, volume );
 }
 
@@ -2031,11 +2004,7 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    Character &player_character = get_player_character();
-    const bool indoors = !is_creature_outside( player_character );
-    if( player_character.activity ) {
-        return;
-    }
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
     play_variant_sound( id, variant, seas_str, indoors, night,
                         volume, angle, pitch_min, pitch_max );
@@ -2046,11 +2015,7 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
 {
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
-    Character &player_character = get_player_character();
-    const bool indoors = !is_creature_outside( player_character );
-    if( player_character.activity ) {
-        return;
-    }
+    const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
     play_ambient_variant_sound( id, variant, seas_str, indoors, night,
                                 volume, channel, fade_in_duration, pitch, loops );


### PR DESCRIPTION
#### Summary
Category "Brief description"

#### Purpose of change
The solution of disabling sounds during activities works but it's not great. The problem from what I can tell is not that sound is happening but that the sound stacks and becomes really loud. Instead of disabling sounds, this ensures that a sound effect can only ever be playing twice at the same time. So for example, reading when zombies are trying to smash down your car doors will still make a lot of clanking noises, but it won't ever produce the giant boom that would happen before.
#### Describe the solution
**NOTE: this reverts the original fix since it is now not necessary**
When adding a sound via make_audio, we loop over all playing channels and check if the sound is already playing twice. If so, we return early and never play the requested sound. This means a sound can only ever be stacked twice.
This means that you wlill get a lot of clanks while reading, they just won't be loud.
#### Describe alternatives you've considered
The original solution (just not playing sounds during activities)
#### Testing
I spawned a car and a ton of zombies and read a book. There was clanking but it was way quieter than before this patch.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
