### PR TITLE
Fix tile rotation, fire, itemgroups, mantises

### DIFF
--- a/data/core/tips.json
+++ b/data/core/tips.json
@@ -102,7 +102,7 @@
       "Major blood loss?  Drink plenty, supplement iron, and rest to regenerate your red blood cells.",
       "Arterial bleeding from a gunshot?  A tourniquet can save you from death.",
       "No bandages nearby?  Empty your hands and let the time pass to apply pressure to the wound.",
-      "Adhesive bandages are much quicker to use, but not as effective.  Perfect for minor wounds.",
+      "Adhesive bandages are much quicker to use, but not as effective - perfect for minor wounds.",
       "The zone activity manager can make your life easier.  Do more in one go.",
       "Want less micro-management?  The zone manager can change your game.",
       "Every sensei was once a student.  NPCs can teach you and vice versa.",
@@ -174,9 +174,11 @@
       "Grenades create very fine shrapnel which isn't great against armor.  Pipebombs on the other hand…",
       "Use the fire, sludge, and acid some enemies spread to your advantage.",
       "Mutant meat isn't good for you, but if you're hungry, surely you can eat just a little…",
-      "NSAIDs are all the same type of drug and their effects don't stack, but they do with acetaminophen.",
+      "Aspirin and ibuprofen don't stack with each other, but most other pain medication does.",
       "Pain medication doesn't reduce pain, it is a buffer against it for the entirety of its duration.",
-      "Over the counter pain medication is weak, but it's not habit forming. It may keep you in the fight."
+      "Over the counter pain medication is weak, but it's not habit forming. It may keep you in the fight.",
+      "Construction can be a good way to gain your first rank of mechanics and electronics.",
+      "Injuries take longer to heal the worse they are.  Don't overdo it!"
     ]
   }
 ]

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -842,7 +842,72 @@
       { "item": "menstrual_cup", "prob": 1 },
       { "item": "toothbrush_plain", "count": [ 1, 3 ], "prob": 45 },
       { "item": "dentures", "count": [ 1, 2 ], "prob": 5 },
-      { "item": "toothbrush_electric", "count": [ 1, 3 ], "prob": 25 }
+      { "item": "toothbrush_electric", "count": [ 1, 3 ], "prob": 25 },
+      { "item": "bug_spray_can", "prob": 7, "charges": [ 1, 5 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bathroom_medicine_pills",
+    "subtype": "distribution",
+    "entries": [
+      {
+        "item": "aspirin",
+        "prob": 50,
+        "count": [ 1, 30 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "acetaminophen",
+        "prob": 70,
+        "count": [ 1, 30 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "ibuprofen",
+        "prob": 80,
+        "count": [ 1, 30 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "naproxen",
+        "prob": 20,
+        "count": [ 1, 30 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "codeine",
+        "prob": 10,
+        "count": [ 1, 15 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "tramadol",
+        "prob": 10,
+        "count": [ 1, 15 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "oxycodone",
+        "prob": 10,
+        "count": [ 1, 7 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_painkiller"
+      },
+      {
+        "item": "adderall",
+        "prob": 10,
+        "count": [ 1, 30 ],
+        "container-item": "null",
+        "entry-wrapper": "bottle_plastic_pill_prescription"
+      },
+      { "item": "bottle_plastic_pill_prescription", "prob": 5, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -852,53 +917,10 @@
     "//2": "This group is for the medicine cabinet.",
     "subtype": "collection",
     "entries": [
-      {
-        "distribution": [
-          {
-            "item": "aspirin",
-            "prob": 50,
-            "count": [ 1, 30 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          },
-          {
-            "item": "acetaminophen",
-            "prob": 70,
-            "count": [ 1, 30 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          },
-          {
-            "item": "ibuprofen",
-            "prob": 80,
-            "count": [ 1, 30 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          },
-          {
-            "item": "naproxen",
-            "prob": 20,
-            "count": [ 1, 30 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          },
-          {
-            "item": "codeine",
-            "prob": 10,
-            "count": [ 1, 15 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          },
-          {
-            "item": "tramadol",
-            "prob": 10,
-            "count": [ 1, 15 ],
-            "container-item": "null",
-            "entry-wrapper": "bottle_plastic_pill_painkiller"
-          }
-        ],
-        "prob": 65
-      },
+      { "group": "bathroom_medicine_pills", "prob": 65 },
+      { "group": "bathroom_medicine_pills", "prob": 20 },
+      { "group": "bathroom_medicine_pills", "prob": 5 },
+      { "group": "bathroom_medicine_pills", "prob": 1 },
       { "item": "comb_lice", "prob": 2 },
       { "item": "eyedrops", "prob": 15, "count": 10 },
       { "item": "pepto", "prob": 60, "charges": [ 1, -1 ], "container-item": "bottle_plastic_small" },
@@ -1105,7 +1127,8 @@
         "prob": 20
       },
       { "item": "toilet_paper", "prob": 80 },
-      { "item": "towel", "count": [ 1, 2 ], "prob": 75 }
+      { "item": "towel", "count": [ 1, 2 ], "prob": 75 },
+      { "item": "bug_spray_can", "prob": 2, "charges": [ 1, 5 ] }
     ]
   },
   {

--- a/data/json/monster_weakpoints/arthropod_weakpoints.json
+++ b/data/json/monster_weakpoints/arthropod_weakpoints.json
@@ -177,6 +177,209 @@
   },
   {
     "type": "weakpoint_set",
+    "id": "wps_arthropod_winged",
+    "//": "For stuff that uses its wings to leap but isn't constantly flying.",
+    "weakpoints": [
+      { "id": "abdomen", "name": "abdomen", "coverage": 25 },
+      {
+        "id": "leg",
+        "name": "a leg",
+        "difficulty": { "melee": 3, "ranged": 3 },
+        "damage_mult": { "all": 0.66 },
+        "crit_mult": { "all": 0.66 },
+        "coverage_mult": { "point": 0.75 },
+        "effects": [
+          { "effect": "staggered", "chance": 5, "message": "The %s is knocked off-balance!", "damage_required": [ 10, 30 ] },
+          {
+            "effect": "staggered",
+            "chance": 15,
+            "message": "The %s is knocked off-balance!",
+            "damage_required": [ 30, 100 ]
+          }
+        ],
+        "coverage": 10
+      },
+      {
+        "id": "leg_joint",
+        "name": "a joint",
+        "damage_mult": { "all": 0.66 },
+        "crit_mult": { "all": 0.66 },
+        "armor_mult": { "all": 0.5 },
+        "coverage_mult": { "point": 0.75 },
+        "effects": [
+          { "effect": "staggered", "chance": 25, "message": "The %s is knocked off-balance!", "damage_required": [ 5, 20 ] },
+          {
+            "effect": "staggered",
+            "chance": 40,
+            "message": "The %s is knocked off-balance!",
+            "damage_required": [ 21, 100 ]
+          },
+          {
+            "effect": "maimed_leg",
+            "chance": 10,
+            "duration": [ 5, 25 ],
+            "message": "The %s's leg falls limp!",
+            "damage_required": [ 1, 10 ]
+          },
+          {
+            "effect": "maimed_leg",
+            "chance": 25,
+            "duration": [ 15, 50 ],
+            "message": "The %s's leg falls limp!",
+            "damage_required": [ 11, 30 ]
+          },
+          {
+            "effect": "maimed_leg",
+            "chance": 25,
+            "duration": 86400,
+            "message": "The %s's leg is disabled!",
+            "damage_required": [ 31, 100 ]
+          }
+        ],
+        "coverage": 2
+      },
+      {
+        "id": "body_joint",
+        "name": "a gap in the exoskeleton",
+        "armor_mult": { "all": 0.5 },
+        "crit_mult": { "all": 1.25 },
+        "coverage_mult": { "broad": 0.25, "ranged": 0.5 },
+        "difficulty": { "melee": 4, "ranged": 7 },
+        "coverage": 5
+      },
+      {
+        "id": "armor_thick",
+        "name": "a thick part of the exoskeleton",
+        "is_good": false,
+        "armor_mult": { "all": 1.5 },
+        "crit_mult": { "all": 0.75 },
+        "coverage_mult": { "cut": 1.5 },
+        "coverage": 5
+      },
+      {
+        "id": "antenna",
+        "name": "the antennae",
+        "difficulty": { "melee": 4, "ranged": 8 },
+        "damage_mult": { "all": 0.5 },
+        "armor_mult": { "all": 0.5 },
+        "effects": [
+          {
+            "effect": "stunned",
+            "duration": [ 1, 3 ],
+            "chance": 25,
+            "message": "The %s is stunned!",
+            "damage_required": [ 0, 20 ]
+          },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 6 ],
+            "chance": 50,
+            "message": "The %s is stunned!",
+            "damage_required": [ 21, 100 ]
+          }
+        ],
+        "coverage": 3,
+        "coverage_mult": { "point": 0.5 }
+      },
+      {
+        "id": "head",
+        "name": "the head",
+        "is_head": true,
+        "damage_mult": { "all": 1.1 },
+        "crit_mult": { "all": 1.1 },
+        "armor_mult": { "physical": 0.75 },
+        "difficulty": { "melee": 3, "ranged": 5 },
+        "effects": [
+          { "effect": "stunned", "duration": 1, "chance": 5, "message": "The %s is stunned!", "damage_required": [ 30, 50 ] },
+          {
+            "effect": "stunned",
+            "duration": [ 1, 2 ],
+            "chance": 33,
+            "message": "The %s is stunned!",
+            "damage_required": [ 51, 100 ]
+          }
+        ],
+        "coverage": 3
+      },
+      {
+        "id": "eye",
+        "name": "the eye",
+        "is_head": true,
+        "armor_mult": { "physical": 0.4 },
+        "crit_mult": { "all": 1.25 },
+        "difficulty": { "ranged": 8, "melee": 6 },
+        "effects": [
+          {
+            "effect": "blind",
+            "duration": 86400,
+            "chance": 20,
+            "message": "The %s's eyes are obliterated!",
+            "damage_required": [ 35, 100 ]
+          }
+        ],
+        "coverage": 2
+      },
+      {
+        "id": "mandible",
+        "name": "the mandibles",
+        "is_head": true,
+        "crit_mult": { "all": 1.25 },
+        "difficulty": { "ranged": 5, "melee": 3 },
+        "effects": [
+          {
+            "effect": "maimed_mandible",
+            "chance": 25,
+            "duration": [ 1, 10 ],
+            "message": "The %s's mandibles are maimed!",
+            "damage_required": [ 1, 20 ]
+          },
+          {
+            "effect": "maimed_mandible",
+            "chance": 50,
+            "duration": [ 5, 25 ],
+            "message": "The %s's mandibles are maimed!",
+            "damage_required": [ 21, 40 ]
+          },
+          {
+            "effect": "maimed_mandible",
+            "chance": 50,
+            "duration": 86400,
+            "message": "The %s's mandibles are destroyed!",
+            "damage_required": [ 41, 100 ]
+          }
+        ],
+        "coverage": 2
+      },
+      {
+        "id": "wings_stagger",
+        "name": "the wings",
+        "damage_mult": { "all": 0.2 },
+        "crit_mult": { "all": 0.2 },
+        "armor_mult": { "physical": 0.2 },
+        "difficulty": { "ranged": 7, "melee": 2 },
+        "coverage_mult": { "point": 0.75 },
+        "effects": [
+          { "effect": "staggered", "chance": 25, "message": "The %s is knocked off-balance!", "damage_required": [ 0, 20 ] },
+          {
+            "effect": "staggered",
+            "chance": 50,
+            "message": "The %s is knocked off-balance!",
+            "damage_required": [ 21, 100 ]
+          },
+          {
+            "effect": "maimed_wings",
+            "duration": [ 5, 10 ],
+            "chance": 5,
+            "message": "The %s's wings flutter uselessly",
+            "damage_required": [ 21, 100 ]
+          }
+        ],
+        "coverage": 10
+      }
+    ]
+  },
+  {
+    "type": "weakpoint_set",
     "id": "wps_arthropod_centipede",
     "weakpoints": [
       {

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2814,24 +2814,35 @@
   {
     "id": "mon_mantis_small",
     "type": "MONSTER",
-    "name": { "str": "oversized praying mantis", "str_pl": "oversized praying mantises" },
-    "description": "A green mutant insect with sharp grappling spikes on its front legs.  It's a little smaller than an adult person.",
+    "name": { "str": "mutant mantis", "str_pl": "mutant mantises" },
+    "description": "A spindly insect a bit taller than a man.  Its front legs remain folded in front of its body in a posture reminiscent of prayer, but the jagged hooks lining their grasping edge leave little doubt as to their purpose.",
     "copy-from": "mon_mantis_giant",
-    "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.67, "melee_skill": 0.625 },
-    "volume": "60 L",
-    "weight": "80 kg",
+    "hp": 40,
+    "speed": 110,
+    "material": [ "iflesh" ],
+    "symbol": "M",
+    "color": "light_green",
+    "aggression": 20,
+    "morale": 16,
+    "melee_skill": 5,
+    "melee_dice": 1,
+    "melee_dice_sides": 6,
+    "dodge": 2,
+    "volume": "45 L",
+    "weight": "40 kg",
+    "weakpoint_sets": [ "wps_arthropod_winged" ],
     "melee_damage": [ { "damage_type": "cut", "amount": 8 } ],
     "dissect": "dissect_insect_sample_single",
     "extend": { "flags": [ "NO_BREED" ] },
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "upgrades": { "age_grow": 42, "into": "mon_mantis_giant" },
-    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 1, "acid": 2 }
+    "upgrades": { "half_life": 30, "into": "mon_mantis_giant" },
+    "armor": { "bash": 4, "cut": 7, "electric": 1, "acid": 2 }
   },
   {
     "id": "mon_mantis_giant",
     "type": "MONSTER",
     "name": { "str": "giant praying mantis", "str_pl": "giant praying mantises" },
-    "description": "An enormous green insect grown to about the size of a bear.  It moves in a weird, dance-like pattern and looks ready to chop your head off at any moment.",
+    "description": "A gigantic insect half-again the size of a man.  Its scythelike arms are covered in sawlike barbs and its complex mouthparts are always in motion, even when the rest of it remains deathly still.  The light reflects eerily off of its enormous eyes, so that no matter where you are, it appears to be looking directly at you.",
     "default_faction": "mantis",
     "bodytype": "insect",
     "species": [ "INSECT" ],
@@ -2849,7 +2860,7 @@
     "melee_dice_sides": 6,
     "melee_damage": [ { "damage_type": "cut", "amount": 10.0, "armor_penetration": 12 } ],
     "dodge": 3,
-    "weakpoint_sets": [ "wps_arthropod" ],
+    "weakpoint_sets": [ "wps_arthropod_winged" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug" ],
     "vision_day": 8,
     "vision_night": 4,
@@ -2869,12 +2880,12 @@
         "cooldown": 8,
         "max_range": 5,
         "allow_no_target": false,
-        "condition": { "not": { "u_has_effect": "maimed_leg" } }
+        "condition": { "and": [ { "not": { "u_has_effect": "maimed_wing" } }, { "not": { "u_has_effect": "maimed_leg" } } ] }
       }
     ],
-    "upgrades": { "age_grow": 42, "into": "mon_mantis_mega" },
+    "upgrades": { "half_life": 30, "into": "mon_mantis_mega" },
     "flags": [ "SEES", "HEARS", "CLIMBS", "PATH_AVOID_DANGER" ],
-    "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 2, "acid": 4 }
+    "armor": { "bash": 8, "cut": 16, "bullet": 4, "electric": 2, "acid": 4 }
   },
   {
     "id": "mon_mantis_nymph",
@@ -2883,7 +2894,7 @@
     "description": "A mantis nymph about the size of a dog.  Even though its far smaller than the adults, you have a feeling it wouldn't take kindly to you coming too close.",
     "copy-from": "mon_larva_abstract",
     "default_faction": "mantis",
-    "volume": "20 L",
+    "volume": "9 L",
     "weight": "10 kg",
     "hp": 25,
     "speed": 80,
@@ -2897,6 +2908,7 @@
     "dodge": 3,
     "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
     "vision_night": 4,
+    "weakpoint_sets": [ "wps_arthropod_winged" ],
     "dissect": "dissect_insect_sample_single",
     "upgrades": { "age_grow": 30, "into": "mon_mantis_giant" },
     "special_attacks": [
@@ -2905,12 +2917,12 @@
         "cooldown": 8,
         "max_range": 3,
         "allow_no_target": false,
-        "condition": { "not": { "u_has_effect": "maimed_leg" } }
+        "condition": { "and": [ { "not": { "u_has_effect": "maimed_wing" } }, { "not": { "u_has_effect": "maimed_leg" } } ] }
       }
     ],
     "anger_triggers": [ "PLAYER_CLOSE" ],
     "path_settings": { "max_dist": 10, "avoid_sharp": true, "avoid_dangerous_fields": true },
-    "armor": { "bash": 1, "cut": 2, "bullet": 1 }
+    "armor": { "bash": 1, "cut": 2 }
   },
   {
     "id": "mon_mantis_mega",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2140,9 +2140,11 @@ void activity_handlers::train_finish( player_activity *act, Character *you )
         int old_skill_level = you->get_knowledge_level( sk );
         // Teacher intelligence, subject matter knowledge, and social skill matters most.
         // Student intelligence and social skill is secondary.
-        int teacher_quality = ( teacher->get_int() + ( teacher->get_skill_level( skill_social ) + teacher->get_knowledge_level( sk ) ) ) * 4;
-        int student_quality = ( you->get_int() + (you->get_skill_level( skill_social ) * 2 ) ) * 4;
-        int teaching_effectiveness = std::min( 200, std::max( 10, ( teacher_quality * 2 + student_quality ) / 2 ) );
+        int teacher_quality = ( teacher->get_int() + ( teacher->get_skill_level(
+                                    skill_social ) + teacher->get_knowledge_level( sk ) ) ) * 4;
+        int student_quality = ( you->get_int() + ( you->get_skill_level( skill_social ) * 2 ) ) * 4;
+        int teaching_effectiveness = std::min( 200, std::max( 10,
+                                               ( teacher_quality * 2 + student_quality ) / 2 ) );
         you->practice( sk, teaching_effectiveness, old_skill_level + 2 );
         int new_skill_level = you->get_knowledge_level( sk );
         if( old_skill_level != new_skill_level ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2557,6 +2557,28 @@ void cata_tiles::set_disable_occlusion( const bool val )
     disable_occlusion = val;
 }
 
+std::string cata_tiles::get_multitile_base_id( const std::string &id,
+        TILE_CATEGORY category )
+{
+    if( category == TILE_CATEGORY::TERRAIN ) {
+        const ter_t &current = ter_str_id( id ).obj();
+
+        for( const ter_t &candidate : get_all_terrain_types() ) {
+            if( candidate.id == current.id ||
+                candidate.connect_groups != current.connect_groups ) {
+                continue;
+            }
+
+            const tile_type *tt = tileset_ptr->find_tile_type( candidate.id.str() );
+            if( tt && tt->multitile ) {
+                return candidate.id.str();
+            }
+        }
+    }
+
+    return id;
+}
+
 bool cata_tiles::draw_from_id_string_internal(
     const std::string &id,
     const tripoint_bub_ms &pos,
@@ -2886,14 +2908,16 @@ bool cata_tiles::draw_from_id_string_internal(
     // Seed PRNG for random tile selection
     unsigned int seed = 0;
     creature_tracker &creatures = get_creature_tracker();
-    bool creature = false;
+    bool creature = true;
     switch( category ) {
         case TILE_CATEGORY::TERRAIN:
         case TILE_CATEGORY::FIELD:
         case TILE_CATEGORY::LIGHTING:
+            creature = false;
             seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
             break;
         case TILE_CATEGORY::VEHICLE_PART: {
+            creature = false;
             const auto vp_override = vpart_override.find( tripoint_bub_ms( pos ) );
             const bool vp_overridden = vp_override != vpart_override.end();
             if( vp_overridden ) {
@@ -2908,6 +2932,7 @@ bool cata_tiles::draw_from_id_string_internal(
             break;
         }
         case TILE_CATEGORY::FURNITURE: {
+            creature = false;
             const furn_str_id fid( found_id );
             if( fid.is_valid() && !fid.obj().is_movable() ) {
                 seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
@@ -2918,6 +2943,7 @@ bool cata_tiles::draw_from_id_string_internal(
         case TILE_CATEGORY::OVERMAP_TERRAIN:
         case TILE_CATEGORY::OVERMAP_VISION_LEVEL:
         case TILE_CATEGORY::MAP_EXTRA:
+            creature = false;
             seed = simple_point_hash( here.get_abs( pos ).raw().xy() );
             break;
         case TILE_CATEGORY::NONE:
@@ -2931,25 +2957,24 @@ bool cata_tiles::draw_from_id_string_internal(
         case TILE_CATEGORY::TRAP:
         case TILE_CATEGORY::BULLET:
         case TILE_CATEGORY::HIT_ENTITY:
+            creature = false;
             break;
         case TILE_CATEGORY::WEATHER:
+            creature = false;
             seed = rng_bits();
             break;
         case TILE_CATEGORY::MONSTER:
             if( monster_override.find( tripoint_bub_ms( pos ) ) == monster_override.end() ) {
                 seed = reinterpret_cast<uintptr_t>( creatures.creature_at<monster>( tripoint_bub_ms( pos ) ) );
             }
-            creature = true;
             break;
         default:
             if( string_starts_with( found_id, "player_" ) ) {
                 seed = std::hash<std::string> {}( get_player_character().name );
-                creature = true;
             } else if( string_starts_with( found_id, "npc_" ) ) {
                 if( npc *const guy = creatures.creature_at<npc>( tripoint_bub_ms( pos ) ) ) {
                     seed = guy->getID().get_value();
                 }
-                creature = true;
             }
             break;
     }
@@ -3442,12 +3467,8 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
         }
         // draw the actual terrain if there's no override
         if( !neighborhood_overridden ) {
-
-
             draw_options opts{};
             opts.category = TILE_CATEGORY::TERRAIN;
-
-
             return memorize_only
                    ? false
                    : draw_from_id_string(
@@ -3487,7 +3508,6 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             const bool nv = !overridden;
             draw_options opts{};
             opts.category = TILE_CATEGORY::TERRAIN;
-
             return memorize_only
                    ? false
                    : draw_from_id_string(
@@ -3510,9 +3530,8 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             } else {
                 draw_options opts{};
                 opts.category = TILE_CATEGORY::TERRAIN;
-
                 return draw_from_id_string(
-                           mt.get_ter_id(),
+                           tname,
                            p,
                            mt.get_ter_subtile(),
                            mt.get_ter_rotation(),

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -727,6 +727,8 @@ class cata_tiles
 
         void set_disable_occlusion( bool val );
 
+        std::string get_multitile_base_id( const std::string &id, TILE_CATEGORY category );
+
         /**
          * Initialize the current tileset (load tile images, load mapping), using the current
          * tileset as it is set in the options.

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -602,6 +602,12 @@ void load_season_array( const JsonObject &jo, const std::string &key, const std:
     }
 }
 
+// Accessor for terrain_data.
+const std::vector<ter_t> &get_all_terrain_types()
+{
+    return terrain_data.get_all();
+}
+
 std::string map_data_common_t::name() const
 {
     return name_.translated();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -41,6 +41,7 @@ int_id<ter_t> string_id<ter_t>::id() const;
 // size of connect groups bitset; increase if needed
 const int NUM_TERCONN = 256;
 connect_group get_connect_group( const std::string &name );
+const std::vector<ter_t> &get_all_terrain_types();
 
 template <typename E> struct enum_traits;
 

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -861,11 +861,11 @@ struct sound_effect_handler {
         }
 
         unsigned int chunk_already_playing_count = 0;
-        for ( int ch = 0; ch <= 128; ch++ ) {
-            if ( Mix_Playing( ch ) ) {
+        for( int ch = 0; ch <= 128; ch++ ) {
+            if( Mix_Playing( ch ) ) {
                 const Mix_Chunk *chunk = Mix_GetChunk( ch );
                 chunk_already_playing_count += static_cast<unsigned int>( chunk == audio_src );
-                if ( chunk_already_playing_count == 2 ) {
+                if( chunk_already_playing_count == 2 ) {
                     return true;
                 }
             }


### PR DESCRIPTION
#### Summary
Fix tile rotation, fire, itemgroups, mantises

#### Purpose of change

#### Describe the solution
- Character hair no longer comes off when they rotate.
- [msx] Fire fits a bit more neatly in a fire ring.
- Start improving autotile connectivity code for connect groups (still not there yet)
- Mantises are no longer unstoppable death machines.
- Wasp queens don't spawn on radio towers in fall or winter.
- Fewer map_bincoular radio tower specials.
- Bathrooms can have more pills in them.
- More bug spray in bathrooms.
- Added some more tips to the title screen.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
