### PR TITLE
Fix the spawn rate of cooking oil and vinegar inside supermarkets

### DIFF
--- a/data/json/mapgen/supermarket.json
+++ b/data/json/mapgen/supermarket.json
@@ -456,7 +456,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "place_furniture": [ { "furn": "f_warehouse_shelf", "x": 0, "y": 0 } ],
-      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 148 } ]
+      "place_items": [ { "item": "SUS_shelf_commercial_oil_vinegar", "x": 0, "y": 0, "chance": 14 } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Change the chance of spawning for vinegar and cooking oil in supermarkets to be at "14%" instead of "148%".

#### Purpose of change
This caused an error every time I approached a supermarket, saying that some items could not be placed because of an "invalid chance".

#### Describe the solution
Put the chance back to 14%, matching most of the odds from other items.

#### Describe alternatives you've considered
Changing the chance to anything in between 0 and 100.

#### Testing
Before the change :  
- Reveal the Overmap.
- Teleport 2 overmap tiles away from a supermarket. 
- Walk towards the supermarket.
- Trigger the error when close enough for the loot to spawn.

After the change : 
- Repeat the first 3 points, but teleport to another supermarket not discovered.
- No error appearing when inside the supermarket.

#### Additional context
This is following the bug report I did on Discord : https://discord.com/channels/1341953719889170594/1530942667528208476
