### PR TITLE
Fix typo and faction display

### DIFF
--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -56,8 +56,8 @@
     "id": "robofac",
     "name": "Hub 01",
     "mon_faction": "robofac",
-    "likes_u": -200,
-    "respects_u": 0,
+    "likes_u": 15,
+    "respects_u": 15,
     "known_by_u": false,
     "size": 100,
     "power": 100,
@@ -114,7 +114,7 @@
       { "power_min": 0, "power_max": 149, "id": "epilogue_faction_robofac_0" },
       { "power_min": 150, "power_max": 299, "id": "epilogue_faction_robofac_150" }
     ],
-    "description": "The surviving staff of Hub 01, a pre-Cataclysm research lab.  They rarely leave their lab, if at all, and rely on their robots and advanced technology to survive."
+    "description": "A mysterious voice on the other end of an intercom."
   },
   {
     "type": "faction",
@@ -152,7 +152,6 @@
     "known_by_u": false,
     "size": 100,
     "power": 100,
-    "//": "FIXME: No camp! One character spawns at the refugee center but can't eat out of their stores",
     "fac_food_supply": [ [ 0, { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } } ] ],
     "wealth": 100000000,
     "relations": {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -347,7 +347,7 @@
       "offer": "I probably shouldn't be prescribing things, but there's a ton of people needing help with sleep in here.  If you could get us some antidepressants, Rhyzaea and I can probably make sure they're doled out appropriately without people having to starve to pay for them.  Three month's worth - about 6 bottles - would last us a little while.",
       "accepted": "Thanks so much.  It's a small thing but it'd be really helpful.",
       "rejected": "That's okay.  I'm sure we'll make do somehow.",
-      "advice": "Antidepressant was really common.  You can probably find it in most medicine cabinets and pharmacies.",
+      "advice": "Antidepressants were really common.  You can probably find them in medicine cabinets and pharmacies.",
       "inquire": "How is the search going?",
       "success": "Thanks so much.  Listen, I told some of the others what you were up to for us and we pooled our cash to thank you.  You've done a lot to help us out.",
       "success_lie": "What good does this do us?",


### PR DESCRIPTION
#### Summary
Fix typo and faction display

#### Purpose of change
Uyen tran had some wonky dialogue, Hub-01 was still showing as a mortal enemy to the player.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
