### PR TITLE
Necromancer critfails and revive damage

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2562,7 +2562,6 @@ std::string cata_tiles::get_multitile_base_id( const std::string &id,
 {
     if( category == TILE_CATEGORY::TERRAIN ) {
         const ter_t &current = ter_str_id( id ).obj();
-
         for( const ter_t &candidate : get_all_terrain_types() ) {
             if( candidate.id == current.id ||
                 candidate.connect_groups != current.connect_groups ) {
@@ -2575,7 +2574,6 @@ std::string cata_tiles::get_multitile_base_id( const std::string &id,
             }
         }
     }
-
     return id;
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -67,6 +67,7 @@
 #include "mondefense.h"
 #include "monfaction.h"
 #include "monster.h"
+#include "mondeath.h"
 #include "mtype.h"
 #include "npc.h"
 #include "output.h"
@@ -237,6 +238,9 @@ static const trait_id trait_MARLOSS_BLUE( "MARLOSS_BLUE" );
 static const trait_id trait_PARAIMMUNE( "PARAIMMUNE" );
 static const trait_id trait_THRESH_MARLOSS( "THRESH_MARLOSS" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
+
+static const harvest_drop_type_id harvest_drop_bone( "bone" );
+static const harvest_drop_type_id harvest_drop_flesh( "flesh" );
 
 // shared utility functions
 static bool within_visual_range( monster *z, int max_range )
@@ -1325,6 +1329,49 @@ bool mattack::resurrect( monster *z )
     // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
     float corpse_damage = raised.second->damage_level();
     creature_tracker &creatures = get_creature_tracker();
+    // Check is probably unnecessary, but let's be sure to limit critfails to actual attempts.
+    if( found_eligible_corpse ) {
+        // Sometimes we screw up.
+        if( one_in( 100 - ( corpse_damage * 2 ) ) ) {
+            add_msg_if_player_sees( raised.first, _( "The %s bursts apart in a shower of gore!" ),
+                                    raised.second->tname() );
+            // limit gibbing to 15%
+            int gibbed_weight = to_gram( raised.second->weight() * ( 15.0 / 100.0 ) );
+            int gib_distance = std::round( rng( 2, 4 ) );
+            const mtype *mt = raised.second->get_mtype();
+            units::mass corpse_weight = raised.second->weight();
+            if( mt ) {
+                for( const harvest_entry &entry : mt->harvest->entries() ) {
+                    // only flesh and bones survive.
+                    if( entry.type == harvest_drop_flesh || entry.type == harvest_drop_bone ) {
+                        // the larger the overflow damage, the less you get
+                        const int chunk_amt =
+                            entry.mass_ratio / 2.0f / 10.0 *
+                            corpse_weight / item::find_type( itype_id( entry.drop ) )->weight;
+                        mdeath::scatter_chunks( &here, itype_id( entry.drop ), chunk_amt, *mt, raised.first, gib_distance,
+                                                chunk_amt / ( gib_distance - 1 ) );
+                        gibbed_weight -= entry.mass_ratio / 2.0 / 20 * to_gram( corpse_weight );
+                    }
+                }
+                if( gibbed_weight > 0 ) {
+                    const itype_id &leftover_id = mt->harvest->leftovers;
+                    const int chunk_amount =
+                        gibbed_weight / to_gram( item::find_type( leftover_id )->weight );
+                    mdeath::scatter_chunks( &here, leftover_id, chunk_amount, *mt, raised.first, gib_distance,
+                                            chunk_amount / ( gib_distance + 1 ) );
+                }
+            }
+            raised.second->set_damage( 4000 );
+            return false;
+        }
+        // Sometimes we REALLY screw up.
+        if( one_in( 200 ) ) {
+            add_msg_if_player_sees( *z, _( "The %s bursts apart in a shower of gore!" ),
+                                    z->disp_name() );
+            z->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_bash, 400 ) );
+            return false;
+        }
+    }
     // Did we successfully raise something?
     if( g->revive_corpse( raised.first, *raised.second ) ) {
         here.i_rem( raised.first, raised.second );
@@ -1347,16 +1394,14 @@ bool mattack::resurrect( monster *z )
             debugmsg( "Misplaced or failed to revive a zombie corpse" );
             return true;
         }
-
         zed->make_ally( *z );
         if( player_character.sees( here, *zed ) ) {
-            add_msg( m_warning, _( "A nearby %s rises from the dead!" ), zed->name() );
+            add_msg( m_warning, _( "A %s rises from the dead!" ), zed->name() );
         } else if( sees_necromancer ) {
             // We saw the necromancer but not the revival
             add_msg( m_info, _( "But nothing seems to happen." ) );
         }
     }
-
     return true;
 }
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -88,9 +88,9 @@ item_location mdeath::normal( map *here, monster &z )
     return {};
 }
 
-static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt, monster &z,
-                            int distance,
-                            int pile_size = 1 )
+void mdeath::scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt,
+                             const mtype &z, const tripoint_bub_ms &pos,
+                             int distance, int pile_size )
 {
     // can't have less than one item in a pile or it would cause an infinite loop
     pile_size = std::max( pile_size, 1 );
@@ -101,11 +101,11 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( z.pos_bub( *here ) + point( rng( -distance, distance ),
-                              rng( -distance,
-                                   distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( *here ), tarp );
-        tripoint_bub_ms prev_point = z.pos_bub();
+        tripoint_bub_ms tarp( pos + point( rng( -distance, distance ),
+                                           rng( -distance,
+                                                distance ) ) );
+        const std::vector<tripoint_bub_ms> traj = line_to( pos, tarp );
+        tripoint_bub_ms prev_point = pos;
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
             bool obstructed = false;
@@ -184,7 +184,7 @@ item_location mdeath::splatter( map *here, monster &z )
                                             ( overflow_damage / max_hp + 1 ) ) );
     const int z_weight = to_gram( z.get_weight() );
     // limit gibbing to 15%
-    gibbed_weight = std::min( gibbed_weight, z_weight * 15 / 100 );
+    gibbed_weight = std::min( gibbed_weight, static_cast<int>( round( z_weight * 15.0 / 100.0 ) ) );
 
     if( gibbable ) {
         float overflow_ratio = overflow_damage / max_hp + 1.0f;
@@ -196,8 +196,8 @@ item_location mdeath::splatter( map *here, monster &z )
                 const int chunk_amt =
                     entry.mass_ratio / overflow_ratio / 10 *
                     z.get_weight() / item::find_type( itype_id( entry.drop ) )->weight;
-                scatter_chunks( here, itype_id( entry.drop ), chunk_amt, z, gib_distance,
-                                chunk_amt / ( gib_distance - 1 ) );
+                scatter_chunks( here, itype_id( entry.drop ), chunk_amt, *z.type, z.pos_bub(),
+                                gib_distance, chunk_amt / ( gib_distance - 1 ) );
                 gibbed_weight -= entry.mass_ratio / overflow_ratio / 20 * to_gram( z.get_weight() );
             }
         }
@@ -205,7 +205,7 @@ item_location mdeath::splatter( map *here, monster &z )
             const itype_id &leftover_id = z.type->id->harvest->leftovers;
             const int chunk_amount =
                 gibbed_weight / to_gram( item::find_type( leftover_id )->weight );
-            scatter_chunks( here, leftover_id, chunk_amount, z, gib_distance,
+            scatter_chunks( here, leftover_id, chunk_amount, *z.type, z.pos_bub(), gib_distance,
                             chunk_amount / ( gib_distance + 1 ) );
         }
         // Add pulped corpse.

--- a/src/mondeath.h
+++ b/src/mondeath.h
@@ -13,6 +13,11 @@ namespace mdeath
 item_location normal( map *here, monster &z );
 // Overkill splatter (also part of normal under conditions)
 item_location splatter( map *here, monster &z );
+
+void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt,
+                     const mtype &z, const tripoint_bub_ms &pos,
+                     int distance, int pile_size = 1 );
+
 // Hallucination disappears
 void disappear( monster &z );
 // Broken robot drop

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3884,7 +3884,8 @@ void monster::init_from_item( item &itm )
             if( itm.damage_level() > 1 ) {
                 set_speed_base( speed_base * ( itm.damage_level() / 10.0 ) );
             }
-            hp -= hp * ( rng_float( 0.5, 1.8 ) * itm.damage_level() / 10.0 );
+            hp -= static_cast<int>( std::max( 1.0, hp * ( ( ( rng_float( 0.5,
+                                              1.9 ) * itm.damage_level() + 1.0 ) / 10.0 ) ) ) );
         }
 
         hp -= burnt_penalty;


### PR DESCRIPTION
#### Summary
Necromancer critfails and revive damage

#### Purpose of change
Necromancers were potentially abusable. I wanted to get out ahead of that. They now have a low chance of accidentally gibbing corpses instead of reviving them, and a very low chance of accidentally gibbing themselves.

Corpses were coming back a bit too healthy, so the RNG on their HP now tends to make them come back a bit weaker.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
