### PR TITLE
remove the standalone zzip executable from the game

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,15 +235,6 @@ ifneq (,$(findstring mingw32,$(CROSS)))
   JSON_FORMATTER_BIN=tools/format/json_formatter.exe
 endif
 
-# Determine zzip compression tool name
-ZZIP_BIN=zzip
-ifeq ($(MSYS2), 1)
-  ZZIP_BIN=zzip.exe
-endif
-ifneq (,$(findstring mingw32,$(CROSS)))
-  ZZIP_BIN=zzip.exe
-endif
-
 # Enable backtrace by default
 ifndef BACKTRACE
   # ...except not on native Windows builds, because the relevant headers are
@@ -907,7 +898,6 @@ TESTSRC := $(wildcard tests/*.cpp)
 TESTHDR := $(wildcard tests/*.h)
 JSON_FORMATTER_SOURCES := $(wildcard tools/format/*.cpp) src/wcwidth.cpp src/json.cpp src/string_id.cpp
 JSON_FORMATTER_HEADERS := $(wildcard tools/format/*.h)
-ZZIP_SOURCES := tools/save/zzip_main.cpp
 CHKJSON_SOURCES := $(wildcard src/chkjson/*.cpp) src/wcwidth.cpp src/json.cpp
 CLANG_TIDY_PLUGIN_SOURCES := \
   $(wildcard tools/clang-tidy-plugin/*.cpp tools/clang-tidy-plugin/*/*.cpp)
@@ -923,7 +913,6 @@ ASTYLE_SOURCES := $(sort \
   $(TESTHDR) \
   $(JSON_FORMATTER_SOURCES) \
   $(JSON_FORMATTER_HEADERS) \
-  $(ZZIP_SOURCES) \
   $(CHKJSON_SOURCES) \
   $(CLANG_TIDY_PLUGIN_SOURCES) \
   $(CLANG_TIDY_PLUGIN_HEADERS))
@@ -1001,7 +990,7 @@ endif
 
 LDFLAGS += -lz
 
-all: $(CHECKS) $(TARGET) $(L10N) $(ZZIP_BIN)
+all: $(CHECKS) $(TARGET) $(L10N)
 	@
 
 $(TARGET): $(OBJS)
@@ -1104,11 +1093,10 @@ DATA_PREFIX=$(DESTDIR)$(PREFIX)/share/cataclysm-tlg/
 BIN_PREFIX=$(DESTDIR)$(PREFIX)/bin
 LOCALE_DIR=$(DESTDIR)$(PREFIX)/share/locale
 SHARE_DIR=$(DESTDIR)$(PREFIX)/share
-install: $(TARGET) $(ZZIP_BIN)
+install: $(TARGET)
 	mkdir -p $(DATA_PREFIX)
 	mkdir -p $(BIN_PREFIX)
 	install --mode=755 $(TARGET) $(BIN_PREFIX)
-	install --mode=755 $(ZZIP_BIN) $(BIN_PREFIX)
 	cp -R --no-preserve=ownership data/core $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/font $(DATA_PREFIX)
 	cp -R --no-preserve=ownership data/json $(DATA_PREFIX)
@@ -1190,9 +1178,9 @@ build-data/osx/AppIcon.icns: build-data/osx/AppIcon.iconset
 	iconutil -c icns $<
 
 ifdef OSXCROSS
-app: appclean $(APPTARGET) $(ZZIP_BIN)
+app: appclean $(APPTARGET)
 else
-app: appclean build-data/osx/AppIcon.icns $(APPTARGET) $(ZZIP_BIN)
+app: appclean build-data/osx/AppIcon.icns $(APPTARGET)
 endif
 	mkdir -p $(APPTARGETDIR)/Contents
 	cp build-data/osx/Info.plist $(APPTARGETDIR)/Contents/
@@ -1200,7 +1188,6 @@ endif
 	cp build-data/osx/Cataclysm.sh $(APPTARGETDIR)/Contents/MacOS/
 	mkdir -p $(APPRESOURCESDIR)
 	cp $(APPTARGET) $(APPRESOURCESDIR)/
-	cp $(ZZIP_BIN) $(APPRESOURCESDIR)/
 	cp build-data/osx/AppIcon.icns $(APPRESOURCESDIR)/
 	mkdir -p $(APPDATADIR)
 	cp data/fontdata.json $(APPDATADIR)
@@ -1257,9 +1244,9 @@ endif
 
 endif  # ifeq ($(NATIVE), osx)
 
-$(BINDIST): distclean $(TARGET) $(ZZIP_BIN) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
+$(BINDIST): distclean $(TARGET) $(L10N) $(BINDIST_EXTRAS) $(BINDIST_LOCALE)
 	mkdir -p $(BINDIST_DIR)
-	cp -R $(TARGET) $(ZZIP_BIN) $(BINDIST_EXTRAS) $(BINDIST_DIR)
+	cp -R $(TARGET) $(BINDIST_EXTRAS) $(BINDIST_DIR)
 	$(foreach lib,$(INSTALL_EXTRAS), install --strip $(lib) $(BINDIST_DIR))
 ifdef LANGUAGES
 	cp -R --parents lang/mo $(BINDIST_DIR)
@@ -1340,9 +1327,6 @@ $(JSON_FORMATTER_BIN): $(JSON_FORMATTER_SOURCES)
 
 $(BUILD_PREFIX)zstd.a: $(filter $(ODIR)/third-party/zstd/%.o,$(OBJS))
 	$(AR) rcs $(AR_FLAGS) $(BUILD_PREFIX)zstd.a $^
-
-$(ZZIP_BIN): $(ZZIP_SOURCES) $(BUILD_PREFIX)zstd.a
-	$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP $(ZZIP_SOURCES) $(BUILD_PREFIX)zstd.a -isystem src/third-party -o $(ZZIP_BIN)
 
 python-check:
 	flake8

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#include "zzip_main.h"
 #if defined(MACOSX) || defined(__CYGWIN__)
 #   include <unistd.h> // getpid()
 #endif
@@ -622,6 +623,9 @@ extern "C" int SDL_main( int argc, char **argv ) {
 int main( int argc, const char *argv[] )
 {
 #endif
+    if (argc > 1 && std::string(argv[1]) == "zzip") {
+        return zzip_main(argc - 1, argv + 1);
+    }
     ordered_static_globals();
     init_crash_handlers();
     reset_floating_point_mode();

--- a/src/zzip_main.cpp
+++ b/src/zzip_main.cpp
@@ -14,6 +14,8 @@
 #include <zstd/common/mem.h>
 #include <zstd/common/xxhash.h>
 
+#include "zzip_main.h"
+
 // This is a c++ utility written like a oneshot python script.
 // Do not consider code here to exemplify best practices.
 
@@ -663,8 +665,7 @@ static int handle_file_contextual( std::filesystem::path const &input_file )
                         dict );
 }
 
-int main( int argc, char **argv )
-{
+int zzip_main( int argc, const char **argv ) {
     if( argc == 2 ) {
         // If there's exactly one argument, it's 'something' that we need to deal with.
         // For example someone drag and dropping something onto the binary.

--- a/src/zzip_main.h
+++ b/src/zzip_main.h
@@ -1,0 +1,2 @@
+// no need to header gaurd since it's only ever sensical to include in main.cpp
+int zzip_main( int, const char **);


### PR DESCRIPTION
it can now be accessed via `cataclysm-tlg zzip` instead.

#### Summary
Category "Brief description"
Cataclysm comes with a tool called "zzip" which is not used internally. As far as I can tell, the only point of it being seperately installed is to allow people to decompress cataclysm saves without having the game installed, which isn't very sensical in my opinion.
#### Purpose of change
Instead of installing cataclysm-tlg *and* zzip, we now just install cataclysm-tlg which has a zzip entrypoint
running cataclysm-tlg opens cataclysm-tlg as normal, but running `cataclysm-tlg zzip` now redirects you to zzip's main() function
#### Describe the solution
We move tools/save/zzip_main.cpp into src/, rename main() to zzip_main(), and then do a quick check in the main.cpp main() that redirects you to zzip_main() if argv[1] is "zzip". 
#### Describe alternatives you've considered
I was originally just going to remove zzip entirely since cataclysm-tlg doesn't use it, but someone might want this for save editing purposes. The quality of the code and user experience is pretty attrocious and I can't imagine anyone actually uses zzip though, it doesn't even have a --help command, you can only learn how to use it by reading the main() function. I still think it'd be better to delete it personally.
#### Testing
I loaded a game, saved it, and loaded it, and all of it worked as expected.
#### Additional context

I was also going to expose a way to build it as a standalone executable with SEPERATE_ZZIP=1, but it turned out to be too annoying to modify the Makefile to allow for conditionally installing a binary so I didn't bother. If you want me to do that I can give it another try, I just assumed it wouldn't be something anyone would miss to be honest lol

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
