### PR TITLE
Remove "extremely long" hair

### DIFF
--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -508,84 +508,10 @@
   },
   {
     "type": "mutation",
-    "id": "hair_extremely_long",
-    "name": { "str": "Hair: extremely long" },
-    "points": 0,
-    "description": "You have extremely long hair, which goes down to your knees.",
-    "starting_trait": true,
-    "valid": false,
-    "purifiable": false,
-    "player_display": true,
-    "variants": [
-      {
-        "id": "black",
-        "name": { "str": "Hair: black, extremely long" },
-        "description": "You have extremely long black hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "blond",
-        "name": { "str": "Hair: blond, extremely long" },
-        "description": "You have extremely long blond hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "blue",
-        "name": { "str": "Hair: blue, extremely long" },
-        "description": "You have extremely long blue hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "brown",
-        "name": { "str": "Hair: brown, extremely long" },
-        "description": "You have extremely long brown hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "gray",
-        "name": { "str": "Hair: gray, extremely long" },
-        "description": "You have extremely long gray hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "green",
-        "name": { "str": "Hair: green, extremely long" },
-        "description": "You have extremely long green hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "pink",
-        "name": { "str": "Hair: pink, extremely long" },
-        "description": "You have extremely long pink hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "purple",
-        "name": { "str": "Hair: purple, extremely long" },
-        "description": "You have extremely long purple hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "red",
-        "name": { "str": "Hair: red, extremely long" },
-        "description": "You have extremely long red hair, which goes down to your knees.",
-        "weight": 1
-      },
-      {
-        "id": "white",
-        "name": { "str": "Hair: white, extremely long" },
-        "description": "You have extremely long white hair, which goes down to your knees.",
-        "weight": 1
-      }
-    ],
-    "types": [ "hair_style" ]
-  },
-  {
-    "type": "mutation",
     "id": "hair_body_length",
-    "name": { "str": "Hair: body-length" },
+    "name": { "str": "Hair: floor-length" },
     "points": 0,
-    "description": "Your hair is now so long that it reaches the floor.",
+    "description": "Your hair is so long that it reaches the floor.",
     "starting_trait": true,
     "valid": false,
     "purifiable": false,
@@ -594,61 +520,61 @@
       {
         "id": "black",
         "name": { "str": "Hair: black, body-length" },
-        "description": "Your black hair is now so long that it reaches the floor.",
+        "description": "Your black hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "blond",
-        "name": { "str": "Hair: blond, body-length" },
-        "description": "Your blond hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: blond, floor-length" },
+        "description": "Your blond hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "blue",
-        "name": { "str": "Hair: blue, body-length" },
-        "description": "Your blue hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: blue, floor-length" },
+        "description": "Your blue hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "brown",
-        "name": { "str": "Hair: brown, body-length" },
-        "description": "Your brown hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: brown, floor-length" },
+        "description": "Your brown hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "gray",
-        "name": { "str": "Hair: gray, body-length" },
-        "description": "Your gray hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: gray, floor-length" },
+        "description": "Your gray hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "green",
-        "name": { "str": "Hair: green, body-length" },
-        "description": "Your green hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: green, floor-length" },
+        "description": "Your green hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "pink",
-        "name": { "str": "Hair: pink, body-length" },
-        "description": "Your pink hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: pink, floor-length" },
+        "description": "Your pink hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "purple",
-        "name": { "str": "Hair: purple, body-length" },
-        "description": "Your purple hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: purple, floor-length" },
+        "description": "Your purple hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "red",
-        "name": { "str": "Hair: red, body-length" },
-        "description": "Your red hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: red, floor-length" },
+        "description": "Your red hair is so long that it reaches the floor.",
         "weight": 1
       },
       {
         "id": "white",
-        "name": { "str": "Hair: white, body-length" },
-        "description": "Your white hair is now so long that it reaches the floor.",
+        "name": { "str": "Hair: white, floor-length" },
+        "description": "Your white hair is so long that it reaches the floor.",
         "weight": 1
       }
     ],

--- a/data/json/npcs/EOC_talkers/haircutting.json
+++ b/data/json/npcs/EOC_talkers/haircutting.json
@@ -857,22 +857,6 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Get an extremely long cut.",
-        "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, { "or": [ { "u_has_trait": "hair_body_length" } ] } ] },
-        "effect": [
-          { "run_eocs": "reset_all_hair_types" },
-          {
-            "u_add_morale": "morale_haircut",
-            "bonus": 3,
-            "max_bonus": 5,
-            "duration": "30 minutes",
-            "decay_start": "30 minutes"
-          },
-          { "run_eocs": "reset_natural_hair_color", "variables": { "trait_id": "hair_extremely_long" } }
-        ],
-        "topic": "TALK_DONE"
-      },
-      {
         "text": "Get a buzzcut.",
         "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
         "effect": [

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -1163,5 +1163,15 @@
     "description": "Obsoleted trait.",
     "random_at_chargen": false,
     "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "hair_extremely_long",
+    "name": { "str": "Hair: obsoleted" },
+    "points": 0,
+    "description": "Obsoleted hairstyle.",
+    "valid": false,
+    "purifiable": false,
+    "player_display": false
   }
 ]


### PR DESCRIPTION
#### Summary
Remove "extremely long" hair

#### Purpose of change
We didn't need 10 impossibly long and voluminous hairstyles, and this was the worst offender. It's gone. The others are going to be edited later but OUFGHUH

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
