### PR TITLE
Fix bmr and remove imperial

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1617,163 +1617,194 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                             std::string temp_str;
                             if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
                                 temp_str = string_format( "%.0f", celsius_temp_value );
-                            } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
-                                temp_str = string_format( "%.0f", units::to_kelvin( temp_value ) );
                             } else {
                                 temp_str = string_format( "%.0f", units::to_fahrenheit( temp_value ) );
                             }
-                            here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ),
-                                                                formatted_text( temp_str, color,
-                                                                        text_alignment::left ) );
+                        here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ),
+                                                            formatted_text( temp_str, color,
+                                                                    text_alignment::left ) );
+                    }
+
+                    if( g->display_overlay_state( ACTION_DISPLAY_SNOW_DEPTH ) && !invisible[0] ) {
+                        const double snow_mm = get_weather().get_snow_depth_mm(
+                                                   project_to<coords::omt>( here.get_abs( pos ) ) );
+                        short color;
+                        const short bold = 8;
+                        if( snow_mm >= 500 ) {
+                            color = catacurses::white + bold;
+                        } else if( snow_mm >= 250 ) {
+                            color = catacurses::cyan + bold;
+                        } else if( snow_mm >= 100 ) {
+                            color = catacurses::blue + bold;
+                        } else if( snow_mm >= 1 ) {
+                            color = catacurses::green + bold;
+                        } else {
+                            color = catacurses::dark_gray;
                         }
 
-                        if( g->display_overlay_state( ACTION_DISPLAY_SNOW_DEPTH ) && !invisible[0] ) {
-                            const double snow_mm = get_weather().get_snow_depth_mm(
-                                                       project_to<coords::omt>( here.get_abs( pos ) ) );
-                            short color;
-                            const short bold = 8;
-                            if( snow_mm >= 500 ) {
-                                color = catacurses::white + bold;
-                            } else if( snow_mm >= 250 ) {
-                                color = catacurses::cyan + bold;
-                            } else if( snow_mm >= 100 ) {
-                                color = catacurses::blue + bold;
-                            } else if( snow_mm >= 1 ) {
-                                color = catacurses::green + bold;
-                            } else {
-                                color = catacurses::dark_gray;
-                            }
+                        std::string snow_str = string_format( "%.0f", snow_mm );
+                        here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ),
+                                                            formatted_text( snow_str, color,
+                                                                    text_alignment::left ) );
+                    }
 
-                            std::string snow_str = string_format( "%.0f", snow_mm );
-                            here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ),
-                                                                formatted_text( snow_str, color,
-                                                                        text_alignment::left ) );
+                    if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
+                        g->displaying_visibility_creature && !invisible[0] ) {
+                        const bool visibility = g->displaying_visibility_creature->sees( here, pos );
+
+                        // color overlay.
+                        SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
+                                                SDL_Color{ 192, 192, 192, 255 };
+                        block_color.a = 100;
+                        here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
+                        here.color_blocks_cache.second.emplace( player_to_screen( point_bub_ms( x, y ) ), block_color );
+
+                        // overlay string
+                        std::string visibility_str = visibility ? "+" : "-";
+                        here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + quarter_tile,
+                                                            formatted_text( visibility_str, catacurses::black,
+                                                                    direction::NORTH ) );
+                    }
+
+                    static std::vector<SDL_Color> lighting_colors;
+                    // color hue in the range of [0..10], 0 being white,  10 being blue
+                    auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
+                        if( lighting_colors.empty() ) {
+                            SDL_Color white = { 255, 255, 255, 255 };
+                            SDL_Color blue = { 0, 0, 255, 255 };
+                            lighting_colors = color_linear_interpolate( white, blue, 9 );
                         }
+                        point tile_pos = player_to_screen( point_bub_ms( x, y ) );
 
-                        if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
-                            g->displaying_visibility_creature && !invisible[0] ) {
-                            const bool visibility = g->displaying_visibility_creature->sees( here, pos );
+                        // color overlay
+                        SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
+                        color.a = 100;
+                        here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
+                        here.color_blocks_cache.second.emplace( tile_pos, color );
 
-                            // color overlay.
-                            SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
-                                                    SDL_Color{ 192, 192, 192, 255 };
-                            block_color.a = 100;
-                            here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
-                            here.color_blocks_cache.second.emplace( player_to_screen( point_bub_ms( x, y ) ), block_color );
+                        // string overlay
+                        here.overlay_strings_cache.emplace(
+                            tile_pos + quarter_tile,
+                            formatted_text( text, catacurses::black, direction::NORTH ) );
+                    };
 
-                            // overlay string
-                            std::string visibility_str = visibility ? "+" : "-";
-                            here.overlay_strings_cache.emplace( player_to_screen( point_bub_ms( x, y ) ) + quarter_tile,
-                                                                formatted_text( visibility_str, catacurses::black,
-                                                                        direction::NORTH ) );
-                        }
-
-                        static std::vector<SDL_Color> lighting_colors;
-                        // color hue in the range of [0..10], 0 being white,  10 being blue
-                        auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
-                            if( lighting_colors.empty() ) {
-                                SDL_Color white = { 255, 255, 255, 255 };
-                                SDL_Color blue = { 0, 0, 255, 255 };
-                                lighting_colors = color_linear_interpolate( white, blue, 9 );
-                            }
-                            point tile_pos = player_to_screen( point_bub_ms( x, y ) );
-
-                            // color overlay
-                            SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
-                            color.a = 100;
-                            here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
-                            here.color_blocks_cache.second.emplace( tile_pos, color );
-
-                            // string overlay
-                            here.overlay_strings_cache.emplace(
-                                tile_pos + quarter_tile,
-                                formatted_text( text, catacurses::black, direction::NORTH ) );
-                        };
-
-                        if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
-                            if( g->displaying_lighting_condition == 0 ) {
-                                const float light = here.ambient_light_at( {x, y, center.z()} );
-                                // note: lighting will be constrained in the [1.0, 11.0] range.
-                                int intensity =
-                                    static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
-                                draw_debug_tile( intensity, string_format( "%.1f", light ) );
-                            }
-                        }
-
-                        if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
-                            const float tr = here.light_transparency( tripoint_bub_ms{x, y, center.z()} );
-                            int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
-                                             ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
-                            draw_debug_tile( intensity, string_format( "%.2f", tr ) );
+                    if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
+                        if( g->displaying_lighting_condition == 0 ) {
+                            const float light = here.ambient_light_at( {x, y, center.z()} );
+                            // note: lighting will be constrained in the [1.0, 11.0] range.
+                            int intensity =
+                                static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
+                            draw_debug_tile( intensity, string_format( "%.1f", light ) );
                         }
                     }
 
-                    if( !invisible[0] ) {
-                        const visibility_type vis_type = here.get_visibility( ll, cache );
-                        if( would_apply_vision_effects( vis_type ) ) {
-                            const Creature *critter = creatures.creature_at( pos, true );
-                            if( has_draw_override( pos ) || you.has_memory_at( pos_global ) ||
-                                ( critter &&
-                                  ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
-                                    || you.sees_with_specials( *critter ) ) ) ) {
-                                invisible[0] = true;
-                            } else {
-                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
-                                        tile_render_info::vision_effect{ vis_type } );
-                                break;
-                            }
+                    if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
+                        const float tr = here.light_transparency( tripoint_bub_ms{x, y, center.z()} );
+                        int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
+                                         ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
+                        draw_debug_tile( intensity, string_format( "%.2f", tr ) );
+                    }
+                }
+
+                if( !invisible[0] ) {
+                    const visibility_type vis_type = here.get_visibility( ll, cache );
+                    if( would_apply_vision_effects( vis_type ) ) {
+                        const Creature *critter = creatures.creature_at( pos, true );
+                        if( has_draw_override( pos ) || you.has_memory_at( pos_global ) ||
+                            ( critter &&
+                              ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
+                                || you.sees_with_specials( *critter ) ) ) ) {
+                            invisible[0] = true;
+                        } else {
+                            here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
+                                    tile_render_info::vision_effect{ vis_type } );
+                            break;
                         }
                     }
-                    for( int i = 0; i < 4; i++ ) {
-                        const tripoint_bub_ms np = pos + neighborhood[i];
-                        invisible[1 + i] = apply_visible( np, ch2, here );
-                    }
+                }
+                for( int i = 0; i < 4; i++ ) {
+                    const tripoint_bub_ms np = pos + neighborhood[i];
+                    invisible[1 + i] = apply_visible( np, ch2, here );
+                }
 
-                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
-                            tile_render_info::sprite{ ll, invisible } );
-                    // Stop building draw points below when floor reached
-                    if( here.dont_draw_lower_floor( pos ) ) {
-                        break;
-                    }
+                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0},
+                        tile_render_info::sprite{ ll, invisible } );
+                // Stop building draw points below when floor reached
+                if( here.dont_draw_lower_floor( pos ) ) {
+                    break;
                 }
             }
         }
     }
-    overlay_strings = here.overlay_strings_cache;
-    color_blocks = here.color_blocks_cache;
+}
+overlay_strings = here.overlay_strings_cache;
+color_blocks = here.color_blocks_cache;
 
-    // List all layers for a single z-level
-    const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
-            &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
-            &cata_tiles::draw_field_or_item,
-            &cata_tiles::draw_vpart_no_roof, &cata_tiles::draw_vpart_roof,
-            &cata_tiles::draw_critter_at, &cata_tiles::draw_zone_mark,
-            &cata_tiles::draw_zombie_revival_indicators
-        }
-    };
-
-    // Legacy code to use when vertical vision range is 0
-    const std::array<decltype( &cata_tiles::draw_furniture ), 14> drawing_layers_legacy = {{
-            &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
-            &cata_tiles::draw_field_or_item, &cata_tiles::draw_vpart_below,
-            &cata_tiles::draw_critter_at_below, &cata_tiles::draw_terrain_below,
-            &cata_tiles::draw_vpart_no_roof, &cata_tiles::draw_vpart_roof,
-            &cata_tiles::draw_critter_at, &cata_tiles::draw_zone_mark,
-            &cata_tiles::draw_zombie_revival_indicators
-        }
-    };
-
-    // Skip drawing shadow of critters above if there is no shadow sprite
-    bool do_draw_shadow = false;
-    if( find_tile_looks_like( "shadow", TILE_CATEGORY::NONE, "" ) ) {
-        do_draw_shadow = true;
+// List all layers for a single z-level
+const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
+        &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
+        &cata_tiles::draw_field_or_item,
+        &cata_tiles::draw_vpart_no_roof, &cata_tiles::draw_vpart_roof,
+        &cata_tiles::draw_critter_at, &cata_tiles::draw_zone_mark,
+        &cata_tiles::draw_zombie_revival_indicators
     }
+};
 
-    if( max_draw_depth <= 0 ) {
-        // Legacy draw mode
-        for( int row = min_row; row < max_row; row ++ ) {
-            for( auto f : drawing_layers_legacy ) {
-                for( tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
+// Legacy code to use when vertical vision range is 0
+const std::array<decltype( &cata_tiles::draw_furniture ), 14> drawing_layers_legacy = {{
+        &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
+        &cata_tiles::draw_field_or_item, &cata_tiles::draw_vpart_below,
+        &cata_tiles::draw_critter_at_below, &cata_tiles::draw_terrain_below,
+        &cata_tiles::draw_vpart_no_roof, &cata_tiles::draw_vpart_roof,
+        &cata_tiles::draw_critter_at, &cata_tiles::draw_zone_mark,
+        &cata_tiles::draw_zombie_revival_indicators
+    }
+};
+
+// Skip drawing shadow of critters above if there is no shadow sprite
+bool do_draw_shadow = false;
+if( find_tile_looks_like( "shadow", TILE_CATEGORY::NONE, "" ) )
+{
+    do_draw_shadow = true;
+}
+
+if( max_draw_depth <= 0 )
+{
+    // Legacy draw mode
+    for( int row = min_row; row < max_row; row ++ ) {
+        for( auto f : drawing_layers_legacy ) {
+            for( tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
+                if( const tile_render_info::vision_effect * const
+                    var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
+                    if( f == &cata_tiles::draw_terrain ) {
+                        apply_vision_effects( p.com.pos, var->vis, p.com.height_3d );
+                    }
+                } else if( const tile_render_info::sprite * const
+                           var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
+                    ( this->*f )( p.com.pos, var->ll, p.com.height_3d, var->invisible, false );
+                }
+            }
+        }
+    }
+} else
+{
+    // Multi z-level draw mode
+    // Start drawing from the lowest visible z-level (some off-screen tiles
+    // are considered visible here to simplify the logic.)
+    int cur_zlevel = draw_min_z;
+    while( cur_zlevel <= center.z() ) {
+        const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
+                ? z_any_tile_range[center.z() - cur_zlevel] : top_any_tile_range;
+        // For each row
+        for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
+            // Set base height for each tile
+            for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
+                p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
+            }
+            // For each layer
+            for( auto f : drawing_layers ) {
+                // For each tile
+                for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
                     if( const tile_render_info::vision_effect * const
                         var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                         if( f == &cata_tiles::draw_terrain ) {
@@ -1781,199 +1812,190 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                         }
                     } else if( const tile_render_info::sprite * const
                                var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
-                        ( this->*f )( p.com.pos, var->ll, p.com.height_3d, var->invisible, false );
-                    }
-                }
-            }
-        }
-    } else {
-        // Multi z-level draw mode
-        // Start drawing from the lowest visible z-level (some off-screen tiles
-        // are considered visible here to simplify the logic.)
-        int cur_zlevel = draw_min_z;
-        while( cur_zlevel <= center.z() ) {
-            const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
-                    ? z_any_tile_range[center.z() - cur_zlevel] : top_any_tile_range;
-            // For each row
-            for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
-                // Set base height for each tile
-                for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
-                    p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
-                }
-                // For each layer
-                for( auto f : drawing_layers ) {
-                    // For each tile
-                    for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
-                        if( const tile_render_info::vision_effect * const
-                            var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
-                            if( f == &cata_tiles::draw_terrain ) {
-                                apply_vision_effects( p.com.pos, var->vis, p.com.height_3d );
-                            }
-                        } else if( const tile_render_info::sprite * const
-                                   var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
 
-                            // Get visibility variables
-                            lit_level ll = var->ll;
-                            std::array<bool, 5> invisible = var->invisible;
+                        // Get visibility variables
+                        lit_level ll = var->ll;
+                        std::array<bool, 5> invisible = var->invisible;
 
-                            if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
-                                int temp_height_3d = p.com.height_3d;
-                                // Reset height_3d to base when drawing vehicles
-                                p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
-                                // Draw
-                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) ) {
-                                    // If no vpart drawn, revert height_3d changes
-                                    p.com.height_3d = temp_height_3d;
-                                }
-                            } else if( f == &cata_tiles::draw_critter_at ) {
-                                // Draw
-                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow &&
-                                    here.dont_draw_lower_floor( p.com.pos ) ) {
-                                    // Draw shadow of flying critters on bottom-most tile if no other critter drawn
-                                    draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
-                                }
-                            } else {
-                                // Draw
-                                ( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false );
+                        if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
+                            int temp_height_3d = p.com.height_3d;
+                            // Reset height_3d to base when drawing vehicles
+                            p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
+                            // Draw
+                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) ) {
+                                // If no vpart drawn, revert height_3d changes
+                                p.com.height_3d = temp_height_3d;
                             }
+                        } else if( f == &cata_tiles::draw_critter_at ) {
+                            // Draw
+                            if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow &&
+                                here.dont_draw_lower_floor( p.com.pos ) ) {
+                                // Draw shadow of flying critters on bottom-most tile if no other critter drawn
+                                draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
+                            }
+                        } else {
+                            // Draw
+                            ( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false );
                         }
                     }
                 }
             }
-            cur_zlevel += 1;
         }
+        cur_zlevel += 1;
     }
+}
 
-    // display number of monsters to spawn in mapgen preview
-    for( int row = top_any_tile_range.p_min.y; row < top_any_tile_range.p_max.y; row ++ ) {
-        for( const tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
-            const tile_render_info::sprite *const
-            var = std::get_if<tile_render_info::sprite>( &p.var );
-            if( !var ) {
-                continue;
-            }
-            const auto mon_override = monster_override.find( p.com.pos );
-            if( mon_override != monster_override.end() ) {
-                const int count = std::get<1>( mon_override->second );
-                const bool more = std::get<2>( mon_override->second );
-                if( count > 1 || more ) {
-                    std::string text = "x" + std::to_string( count );
-                    if( more ) {
-                        text += "+";
-                    }
-                    overlay_strings.emplace( player_to_screen( p.com.pos.xy() ) + half_tile,
-                                             formatted_text( text, catacurses::red,
-                                                     direction::NORTH ) );
+// display number of monsters to spawn in mapgen preview
+for( int row = top_any_tile_range.p_min.y; row < top_any_tile_range.p_max.y; row ++ )
+{
+    for( const tile_render_info &p : here.draw_points_cache[center.z()][row] ) {
+        const tile_render_info::sprite *const
+        var = std::get_if<tile_render_info::sprite>( &p.var );
+        if( !var ) {
+            continue;
+        }
+        const auto mon_override = monster_override.find( p.com.pos );
+        if( mon_override != monster_override.end() ) {
+            const int count = std::get<1>( mon_override->second );
+            const bool more = std::get<2>( mon_override->second );
+            if( count > 1 || more ) {
+                std::string text = "x" + std::to_string( count );
+                if( more ) {
+                    text += "+";
                 }
+                overlay_strings.emplace( player_to_screen( p.com.pos.xy() ) + half_tile,
+                                         formatted_text( text, catacurses::red,
+                                                 direction::NORTH ) );
             }
-            if( !var->invisible[0] ) {
-                here.memory_cache_ter_set_dirty( p.com.pos, false );
-            }
+        }
+        if( !var->invisible[0] ) {
+            here.memory_cache_ter_set_dirty( p.com.pos, false );
         }
     }
-    // tile overrides are already drawn in the previous code
-    void_radiation_override();
-    void_terrain_override();
-    void_furniture_override();
-    void_graffiti_override();
-    void_trap_override();
-    void_field_override();
-    void_item_override();
-    void_vpart_override();
-    void_draw_below_override();
-    void_monster_override();
+}
+// tile overrides are already drawn in the previous code
+void_radiation_override();
+void_terrain_override();
+void_furniture_override();
+void_graffiti_override();
+void_trap_override();
+void_field_override();
+void_item_override();
+void_vpart_override();
+void_draw_below_override();
+void_monster_override();
 
-    //Memorize everything the character just saw even if it wasn't displayed.
-    for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ ) {
-        for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
-            const point colrow = player_to_tile( { mem_x, mem_y } );
-            if( is_isometric() && top_any_tile_range.contains( colrow ) ) {
-                continue;
-            }
-            const tripoint_bub_ms p( mem_x, mem_y, center.z() );
-            lit_level lighting = ch.visibility_cache[p.x()][p.y()];
-            // `apply_vision_effects` does not memorize anything so we only need
-            // to call `would_apply_vision_effects` here.
-            if( would_apply_vision_effects( here.get_visibility( lighting, cache ) ) ) {
-                continue;
-            }
-            int height_3d = 0;
-            std::array<bool, 5> invisible;
-            invisible[0] = false;
-            for( int i = 0; i < 4; i++ ) {
-                const tripoint_bub_ms np = p + neighborhood[i];
-                invisible[1 + i] = apply_visible( np, ch, here );
-            }
-            //calling draw to memorize (and only memorize) everything.
-            //bypass cache check in case we learn something new about the terrain's connections
-            draw_terrain( p, lighting, height_3d, invisible, true );
-            if( here.memory_cache_dec_is_dirty( p ) ) {
-                you.memorize_clear_decoration( here.get_abs( p ), "" );
-                draw_furniture( p, lighting, height_3d, invisible, true );
-                draw_trap( p, lighting, height_3d, invisible, true );
-                draw_part_con( p, lighting, height_3d, invisible, true );
-                draw_vpart_no_roof( p, lighting, height_3d, invisible, true );
-                draw_vpart_roof( p, lighting, height_3d, invisible, true );
-                here.memory_cache_dec_set_dirty( p, false );
-            }
+//Memorize everything the character just saw even if it wasn't displayed.
+for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ )
+{
+    for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
+        const point colrow = player_to_tile( { mem_x, mem_y } );
+        if( is_isometric() && top_any_tile_range.contains( colrow ) ) {
+            continue;
+        }
+        const tripoint_bub_ms p( mem_x, mem_y, center.z() );
+        lit_level lighting = ch.visibility_cache[p.x()][p.y()];
+        // `apply_vision_effects` does not memorize anything so we only need
+        // to call `would_apply_vision_effects` here.
+        if( would_apply_vision_effects( here.get_visibility( lighting, cache ) ) ) {
+            continue;
+        }
+        int height_3d = 0;
+        std::array<bool, 5> invisible;
+        invisible[0] = false;
+        for( int i = 0; i < 4; i++ ) {
+            const tripoint_bub_ms np = p + neighborhood[i];
+            invisible[1 + i] = apply_visible( np, ch, here );
+        }
+        //calling draw to memorize (and only memorize) everything.
+        //bypass cache check in case we learn something new about the terrain's connections
+        draw_terrain( p, lighting, height_3d, invisible, true );
+        if( here.memory_cache_dec_is_dirty( p ) ) {
+            you.memorize_clear_decoration( here.get_abs( p ), "" );
+            draw_furniture( p, lighting, height_3d, invisible, true );
+            draw_trap( p, lighting, height_3d, invisible, true );
+            draw_part_con( p, lighting, height_3d, invisible, true );
+            draw_vpart_no_roof( p, lighting, height_3d, invisible, true );
+            draw_vpart_roof( p, lighting, height_3d, invisible, true );
+            here.memory_cache_dec_set_dirty( p, false );
         }
     }
+}
 
-    in_animation = do_draw_explosion || do_draw_custom_explosion ||
-                   do_draw_bullet || do_draw_hit || do_draw_line ||
-                   do_draw_cursor || do_draw_highlight || do_draw_weather ||
-                   do_draw_sct || do_draw_zones || do_draw_async_anim;
+in_animation = do_draw_explosion || do_draw_custom_explosion ||
+               do_draw_bullet || do_draw_hit || do_draw_line ||
+               do_draw_cursor || do_draw_highlight || do_draw_weather ||
+               do_draw_sct || do_draw_zones || do_draw_async_anim;
 
-    draw_footsteps_frame( center );
-    if( in_animation ) {
-        if( do_draw_explosion ) {
-            draw_explosion_frame();
-        }
-        if( do_draw_custom_explosion ) {
-            draw_custom_explosion_frame();
-        }
-        if( do_draw_bullet ) {
-            draw_bullet_frame();
-        }
-        if( do_draw_hit ) {
-            draw_hit_frame();
-            void_hit();
-        }
-        if( do_draw_line ) {
-            draw_line();
-            void_line();
-        }
-        if( do_draw_weather ) {
-            draw_weather_frame();
-            void_weather();
-        }
-        if( do_draw_sct ) {
-            draw_sct_frame( overlay_strings );
-            void_sct();
-        }
-        if( do_draw_zones ) {
-            draw_zones_frame();
-            void_zones();
-        }
-        if( do_draw_cursor ) {
-            draw_cursor();
-            void_cursor();
-        }
-        if( do_draw_highlight ) {
-            draw_highlight();
-            void_highlight();
-        }
-        if( do_draw_async_anim ) {
-            draw_async_anim();
-        }
-    } else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle ) {
-        // check to see if player is located at ter
+draw_footsteps_frame( center );
+if( in_animation )
+{
+    if( do_draw_explosion ) {
+        draw_explosion_frame();
+    }
+    if( do_draw_custom_explosion ) {
+        draw_custom_explosion_frame();
+    }
+    if( do_draw_bullet ) {
+        draw_bullet_frame();
+    }
+    if( do_draw_hit ) {
+        draw_hit_frame();
+        void_hit();
+    }
+    if( do_draw_line ) {
+        draw_line();
+        void_line();
+    }
+    if( do_draw_weather ) {
+        draw_weather_frame();
+        void_weather();
+    }
+    if( do_draw_sct ) {
+        draw_sct_frame( overlay_strings );
+        void_sct();
+    }
+    if( do_draw_zones ) {
+        draw_zones_frame();
+        void_zones();
+    }
+    if( do_draw_cursor ) {
+        draw_cursor();
+        void_cursor();
+    }
+    if( do_draw_highlight ) {
+        draw_highlight();
+        void_highlight();
+    }
+    if( do_draw_async_anim ) {
+        draw_async_anim();
+    }
+} else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle )
+{
+    // check to see if player is located at ter
+    draw_options opts{};
+    opts.category = TILE_CATEGORY::NONE;
+    int height_3d = 0;
+    draw_from_id_string(
+        "cursor",
+        tripoint_bub_ms( g->ter_view_p.xy(), center.z() ),
+        0, 0,
+        lit_level::LIT,
+        false,
+        height_3d,
+        opts
+    );
+}
+if( you.controlling_vehicle )
+{
+    std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );
+    if( indicator_offset ) {
         draw_options opts{};
         opts.category = TILE_CATEGORY::NONE;
         int height_3d = 0;
         draw_from_id_string(
             "cursor",
-            tripoint_bub_ms( g->ter_view_p.xy(), center.z() ),
+            tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
             0, 0,
             lit_level::LIT,
             false,
@@ -1981,26 +2003,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             opts
         );
     }
-    if( you.controlling_vehicle ) {
-        std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );
-        if( indicator_offset ) {
-            draw_options opts{};
-            opts.category = TILE_CATEGORY::NONE;
-            int height_3d = 0;
-            draw_from_id_string(
-                "cursor",
-                tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
-                0, 0,
-                lit_level::LIT,
-                false,
-                height_3d,
-                opts
-            );
-        }
-    }
+}
 
-    printErrorIf( SDL_RenderSetClipRect( renderer.get(), nullptr ) != 0,
-                  "SDL_RenderSetClipRect failed" );
+printErrorIf( SDL_RenderSetClipRect( renderer.get(), nullptr ) != 0,
+              "SDL_RenderSetClipRect failed" );
 }
 
 void cata_tiles::set_draw_cache_dirty()

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -211,15 +211,11 @@ int bound_mod_to_vals( int val, int mod, int max, int min )
 
 const char *velocity_units( const units_type vel_units )
 {
-    if( get_option<std::string>( "UNIT_SYSTEM" ) == "imperial" ) {
-        return _( "mph" );
-    } else {
-        switch( vel_units ) {
-            case VU_VEHICLE:
-                return _( "km/h" );
-            case VU_WIND:
-                return _( "m/s" );
-        }
+    switch( vel_units ) {
+        case VU_VEHICLE:
+            return _( "km/h" );
+        case VU_WIND:
+            return _( "m/s" );
     }
     return "error: unknown units!";
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6863,17 +6863,8 @@ void Character::mod_base_height( int mod )
 
 std::string Character::height_string() const
 {
-    const bool metric = get_option<std::string>( "UNIT_SYSTEM" ) == "metric";
-
-    if( metric ) {
-        std::string metric_string = _( "%d cm" );
-        return string_format( metric_string, height() );
-    }
-
-    int total_inches = std::round( height() / 2.54 );
-    int feet = std::floor( total_inches / 12 );
-    int remainder_inches = total_inches % 12;
-    return string_format( "%d\'%d\"", feet, remainder_inches );
+    std::string metric_string = _( "%d cm" );
+    return string_format( metric_string, height() );
 }
 
 int Character::height() const
@@ -6888,12 +6879,24 @@ int Character::height() const
 int Character::base_bmr() const
 {
     /**
-    Values are for males, and average!
+      The Mifflin–St Jeor equation would use +5 as equation_constant for men and -161 for women.
+      These are not magical sex-based constants, they're just general tendencies based on the
+      average differences in lean body mass between the sexes which are not otherwise accounted
+      for by body weight and height. We already track this via strength's effect on BMR elsewhere
+      in the code, so we use -78 to more accurately represent a midpoint which is later modified
+      by strength.
     */
-    const int equation_constant = 5;
+    const int equation_constant = -78;
     const int weight_factor = units::to_gram<int>( bodyweight() / 100.0 );
     const int height_factor = 6.25 * height();
-    const int age_factor = 5 * age();
+    /**
+      Age is clamped between 18 and 90 to avoid weird ages distorting the model. Younger characters
+      would be unduly penalized if it wasn't, and characters who somehow had their age set very high
+      would completely break the model. It might be more appropriate to use a different model for kids,
+      but clamping to 18 should be close enough that it doesn't really matter.
+    */
+    const int effective_age = std::clamp( age(), 18, 90 );
+    const int age_factor = 5 * effective_age;
     return metabolic_rate_base() * ( weight_factor + height_factor - age_factor + equation_constant );
 }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3313,14 +3313,6 @@ static void debug_menu_force_temperature()
             if( ret ) {
                 forced_temp = units::from_celsius( *ret );
             }
-        } else if( option == "kelvin" ) {
-            if( forced_temp ) {
-                current = units::to_kelvin( *forced_temp );
-            }
-            std::optional<float> ret = ask( "K", current );
-            if( ret ) {
-                forced_temp = units::from_kelvin( *ret );
-            }
         } else {
             if( forced_temp ) {
                 current = units::to_fahrenheit( *forced_temp );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -905,7 +905,7 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
     if( veh ) {
         int target = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
         int current = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-        const std::string units = get_option<std::string>( "UNIT_SYSTEM" ) == "metric" ? "km/h" : "mph";
+        const std::string units = _("km/h" );
         vel_text = string_format( "%d < %d %s", target, current, units );
 
         const float strain = veh->strain( here );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -905,7 +905,7 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
     if( veh ) {
         int target = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
         int current = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
-        const std::string units = _("km/h" );
+        const std::string units = _( "km/h" );
         vel_text = string_format( "%d < %d %s", target, current, units );
 
         const float strain = veh->strain( here );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1789,17 +1789,9 @@ void options_manager::add_options_interface()
     add_option_group( "interface", Group( "measurement_unit", to_translation( "Measurement Units" ),
                                           to_translation( "Options regarding measurement units." ) ),
     [&]( const std::string & page_id ) {
-        add( "UNIT_SYSTEM", page_id, to_translation( "Unit System" ),
-             to_translation( "Switch between metric and imperial units for speed, weight, volume, and distance." ),
-        {
-            { "imperial", to_translation( "Imperial (mph, lbs, quarts)" ) },
-            { "metric", to_translation( "Metric (km/h, kg, liters)" ) }
-        },
-        ( SystemLocale::UseMetricSystem().value_or( false ) ? "metric" : "imperial" ) );
-
         add( "USE_CELSIUS", page_id, to_translation( "Temperature units" ),
              to_translation( "Switch between Fahrenheit, Celsius, and Kelvin." ),
-        { { "fahrenheit", to_translation( "Fahrenheit" ) }, { "celsius", to_translation( "Celsius" ) }, { "kelvin", to_translation( "Kelvin" ) } },
+        { { "fahrenheit", to_translation( "Fahrenheit" ) }, { "celsius", to_translation( "Celsius" ) } },
         "fahrenheit"
            );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1790,7 +1790,7 @@ void options_manager::add_options_interface()
                                           to_translation( "Options regarding measurement units." ) ),
     [&]( const std::string & page_id ) {
         add( "USE_CELSIUS", page_id, to_translation( "Temperature units" ),
-             to_translation( "Switch between Fahrenheit, Celsius, and Kelvin." ),
+             to_translation( "Switch between Fahrenheit and Celsius." ),
         { { "fahrenheit", to_translation( "Fahrenheit" ) }, { "celsius", to_translation( "Celsius" ) } },
         "fahrenheit"
            );

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -865,7 +865,7 @@ struct sound_effect_handler {
             if( Mix_Playing( ch ) ) {
                 const Mix_Chunk *chunk = Mix_GetChunk( ch );
                 chunk_already_playing_count += static_cast<unsigned int>( chunk == audio_src );
-                if ( chunk_already_playing_count == 2 ) {
+                if( chunk_already_playing_count == 2 ) {
                     return false;
                 }
             }

--- a/src/system_locale.cpp
+++ b/src/system_locale.cpp
@@ -160,32 +160,4 @@ std::optional<std::string> Language()
 #endif
 }
 
-std::optional<bool> UseMetricSystem()
-{
-#if defined(_WIN32)
-    // https://docs.microsoft.com/en-us/globalization/locale/units-of-measurement
-    DWORD measurementUnit;
-    if( GetLocaleInfo( LOCALE_USER_DEFAULT, LOCALE_IMEASURE | LOCALE_RETURN_NUMBER,
-                       reinterpret_cast<LPSTR>( &measurementUnit ),
-                       sizeof( measurementUnit ) / sizeof( TCHAR ) ) == 0 ) {
-        return std::nullopt;
-    }
-    // measurementUnit == 0 => Metric System
-    // measurementUnit == 1 => Imperial System
-    return measurementUnit == 0;
-#elif defined(__APPLE__)
-    CFLocaleRef localeRef = CFLocaleCopyCurrent();
-    CFTypeRef useMetricSystem = CFLocaleGetValue( localeRef, kCFLocaleUsesMetricSystem );
-    return static_cast<bool>( CFBooleanGetValue( static_cast<CFBooleanRef>( useMetricSystem ) ) );
-#elif defined(__linux__) && defined(_NL_MEASUREMENT_MEASUREMENT)
-    std::string const measurement( nl_langinfo( _NL_MEASUREMENT_MEASUREMENT ) );
-    if( !measurement.empty() ) {
-        return measurement.front() == 1;
-    }
-    return std::nullopt;
-#else
-    return std::nullopt;
-#endif
-}
-
 } // namespace SystemLocale

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -90,52 +90,33 @@ int angle_to_dir8( const units::angle direction )
 
 const char *weight_units()
 {
-    return get_option<std::string>( "UNIT_SYSTEM" ) == "imperial" ? _( "pounds" ) : _( "kg" );
+    return _( "kg" );
 }
 
 const char *volume_units_abbr()
 {
-    const std::string vol_units = get_option<std::string>( "UNIT_SYSTEM" );
-    if( vol_units == "imperial" ) {
-        return pgettext( "Volume unit", "c" );
-    } else if( vol_units == "metric" ) {
-        return pgettext( "Volume unit", "L" );
-    } else {
-        return pgettext( "Volume unit", "qt" );
-    }
+    return pgettext( "Volume unit", "L" );
 }
 
 const char *volume_units_long()
 {
-    const std::string vol_units = get_option<std::string>( "UNIT_SYSTEM" );
-    if( vol_units == "imperial" ) {
-        return _( "cup" );
-    } else if( vol_units == "metric" ) {
-        return _( "liter" );
-    } else {
-        return _( "quart" );
-    }
+
+    return _( "liter" );
 }
 
 double convert_velocity( int velocity, const units_type vel_units )
 {
-    const std::string type = get_option<std::string>( "UNIT_SYSTEM" );
     // internal units to mph conversion
     double ret = static_cast<double>( velocity ) / 100;
-
-    if( type == "metric" ) {
-        switch( vel_units ) {
-            case VU_VEHICLE:
-                // mph to km/h conversion
-                ret *= 1.609f;
-                break;
-            case VU_WIND:
-                // mph to m/s conversion
-                ret *= 0.447f;
-                break;
-        }
-    } else if( type == "t/t" ) {
-        ret /= 4;
+    switch( vel_units ) {
+        case VU_VEHICLE:
+            // mph to km/h conversion
+            ret *= 1.609f;
+            break;
+        case VU_WIND:
+            // mph to m/s conversion
+            ret *= 0.447f;
+            break;
     }
 
     return ret;
@@ -143,55 +124,29 @@ double convert_velocity( int velocity, const units_type vel_units )
 double convert_weight( const units::mass &weight )
 {
     double ret = to_gram( weight );
-    if( get_option<std::string>( "UNIT_SYSTEM" ) == "metric" ) {
         ret /= 1000;
-    } else {
-        ret /= 453.6;
-    }
     return ret;
 }
 
-double convert_length_cm_in( const units::length &length )
+double convert_length_cm( const units::length &length )
 {
-
     double ret = to_millimeter( length );
-    const bool metric = get_option<std::string>( "UNIT_SYSTEM" ) == "metric";
-    if( metric ) {
-        ret /= 10;
-    } else {
-        // imperial's a doozy, we can only try to approximate
-        // so first we convert it to inches which are the smallest unit
-        ret /= 25.4;
-    }
+    ret /= 10;
     return ret;
 }
 
 int convert_length( const units::length &length )
 {
     int ret = to_millimeter( length );
-    const bool metric = get_option<std::string>( "UNIT_SYSTEM" ) == "metric";
-    if( metric ) {
-        if( ret % 1000000 == 0 ) {
-            // kilometers
-            ret /= 1000000;
-        } else if( ret % 1000 == 0 ) {
-            // meters
-            ret /= 1000;
-        } else if( ret % 10 == 0 ) {
-            // centimeters
-            ret /= 10;
-        }
-    } else {
-        // imperial's a doozy, we can only try to approximate
-        // so first we convert it to inches which are the smallest unit
-        ret /= 25.4;
-        if( ret % 63360 == 0 ) {
-            ret /= 63360;
-        } else if( ret % 36 == 0 ) {
-            ret /= 36;
-        } else if( ret % 12 == 0 ) {
-            ret /= 12;
-        }
+    if( ret % 1000000 == 0 ) {
+        // kilometers
+        ret /= 1000000;
+    } else if( ret % 1000 == 0 ) {
+        // meters
+        ret /= 1000;
+    } else if( ret % 10 == 0 ) {
+        // centimeters
+        ret /= 10;
     }
     return ret;
 }
@@ -199,42 +154,18 @@ int convert_length( const units::length &length )
 std::string length_units( const units::length &length )
 {
     int length_mm = to_millimeter( length );
-    const bool metric = get_option<std::string>( "UNIT_SYSTEM" ) == "metric";
-    if( metric ) {
-        if( length_mm % 1000000 == 0 ) {
-            //~ kilometers
-            return _( "km" );
-        } else if( length_mm % 1000 == 0 ) {
-            //~ meters
-            return _( "m" );
-        } else if( length_mm % 10 == 0 ) {
-            //~ centimeters
-            return _( "cm" );
-        } else {
-            //~ millimeters
-            return _( "mm" );
-        }
+    if( length_mm % 1000000 == 0 ) {
+        //~ kilometers
+        return _( "km" );
+    } else if( length_mm % 1000 == 0 ) {
+        //~ meters
+        return _( "m" );
+    } else if( length_mm % 10 == 0 ) {
+        //~ centimeters
+        return _( "cm" );
     } else {
-        // imperial's a doozy, we can only try to approximate
-        // so first we convert it to inches which are the smallest unit
-        length_mm /= 25.4;
-        if( length_mm == 0 ) {
-            //~ inches
-            return _( "in." );
-        }
-        if( length_mm % 63360 == 0 ) {
-            //~ miles
-            return _( "mi" );
-        } else if( length_mm % 36 == 0 ) {
-            //~ yards (length)
-            return _( "yd" );
-        } else if( length_mm % 12 == 0 ) {
-            //~ feet (length)
-            return _( "ft" );
-        } else {
-            //~ inches
-            return _( "in." );
-        }
+        //~ millimeters
+        return _( "mm" );
     }
 }
 
@@ -281,17 +212,8 @@ double convert_volume( int volume, int *out_scale )
 {
     double ret = volume;
     int scale = 0;
-    const std::string vol_units = get_option<std::string>( "UNIT_SYSTEM" );
-    if( vol_units == "imperial" ) {
-        ret *= 0.004;
-        scale = 1;
-    } else if( vol_units == "metric" ) {
         ret *= 0.001;
         scale = 2;
-    } else {
-        ret *= 0.00105669;
-        scale = 2;
-    }
     if( out_scale != nullptr ) {
         *out_scale = scale;
     }

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -124,7 +124,7 @@ double convert_velocity( int velocity, const units_type vel_units )
 double convert_weight( const units::mass &weight )
 {
     double ret = to_gram( weight );
-        ret /= 1000;
+    ret /= 1000;
     return ret;
 }
 
@@ -212,8 +212,8 @@ double convert_volume( int volume, int *out_scale )
 {
     double ret = volume;
     int scale = 0;
-        ret *= 0.001;
-        scale = 2;
+    ret *= 0.001;
+    scale = 2;
     if( out_scale != nullptr ) {
         *out_scale = scale;
     }

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -92,14 +92,13 @@ double convert_weight( const units::mass &weight );
  * converts length to largest unit available
  * 1000 mm = 1 meter for example
  * assumed to be used in conjunction with unit string functions
- * also works for imperial units
  */
 int convert_length( const units::length &length );
 std::string length_units( const units::length &length );
 std::string length_to_string( const units::length &length, bool compact = false );
 
-/** Convert length to inches or cm. Used in pickup UI */
-double convert_length_cm_in( const units::length &length );
+/** Convert length to cm. Used in pickup UI */
+double convert_length_cm( const units::length &length );
 
 /** convert a mass unit to a string readable by a human */
 std::string weight_to_string( const units::mass &weight, bool compact = false,

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -492,7 +492,7 @@ void vehicle::print_speed_gauge( map &here, const catacurses::window &win, const
                  static_cast<int>( std::log10( static_cast<double>( std::abs( value ) ) ) ) + 1 :
                  static_cast<int>( std::log10( static_cast<double>( std::abs( value ) ) ) ) + 2 );
     };
-    const std::string type = get_option<std::string>( "UNIT_SYSTEM" ) == "metric" ? "km/h" : "mph";
+    const std::string type = _( "km/h" );
     int t_offset = ndigits( t_speed );
     int c_offset = ndigits( c_speed );
 


### PR DESCRIPTION
#### Summary
Fix BMR and remove imperial

#### Purpose of change
- BMR was always using the male numbers in the Mifflin–St Jeor equation to account for presumed differences in lean mass, but those are already dynamically accounted for by the strength stat. So instead let's use the average.
- Imperial volume, length, and weight measurements were straight up lying to players about the size and weight of items because imperial measurement sucks and lacks any real precision. This was causing a lot of issues with players not understanding why things couldn't fit in containers, and there's no reason to support people measuring their inventory in fucking cups because these numbers are all describing things in internally consistent ways.

#### Describe the solution
- Remove the option to switch from metric to imperial.
- Remove all imperial calculations and functions from the game.
- Remove the option to display temperatures in Kelvin. No one does that!
- Switch the constant in BMR from +5 to -78. The overall effect of this is that your BMR will go down by about 100 kcal/day, depending on your other characteristics. More if you've got fast metabolism.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
