### PR TITLE
Maybe fix double fall for good

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -11772,9 +11772,11 @@ bool map::try_fall( const tripoint_bub_ms &p, Creature *c )
     }
 
     if( you->is_avatar() ) {
-        add_msg( m_bad, n_gettext( "You fall down %d story!", "You fall down %d stories!", height ),
-                 height );
-        g->vertical_move( -height, true );
+        if( ter( you->pos_bub() )->has_flag( "EMPTY_SPACE" ) ) {
+            add_msg( m_bad, n_gettext( "You fall down %d story!", "You fall down %d stories!", height ),
+                    height );
+            g->vertical_move( -height, true );
+        }
     } else {
         you->setpos( *this, where );
     }


### PR DESCRIPTION
#### Summary
Maybe fix double fall for good

#### Purpose of change
Someone fell off a roof and got grab-dragged by a grappler in the same turn. This was a rare case where it was still possible to fall twice and wind up underground.

#### Describe the solution
Add a check in try_fall that makes sure we're actually in empty space before vertical_moving

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
