### PR TITLE
Add BELLYUP flag to a bunch of monsters

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -165,7 +165,8 @@
       "PUSH_MON",
       "CORNERED_FIGHTER",
       "EATS",
-      "CLIMBS"
+      "CLIMBS",
+      "BELLYUP"
     ],
     "armor": { "bash": 7, "cut": 8, "bullet": 7, "electric": 1 }
   },
@@ -200,7 +201,7 @@
     "zombify_into": "mon_zombeaver",
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "special_attacks": [ { "type": "bite", "cooldown": 15 } ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "WATER_CAMOUFLAGE" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "WATER_CAMOUFLAGE", "BELLYUP" ]
   },
   {
     "id": "mon_lab_rat",
@@ -252,7 +253,8 @@
       "PATH_AVOID_DANGER",
       "CAN_BE_CULLED",
       "EATS",
-      "SMALL_HIDER"
+      "SMALL_HIDER",
+      "BELLYUP"
     ]
   },
   {
@@ -288,7 +290,7 @@
     "upgrades": { "age_grow": 38, "into": "mon_boar_wild" },
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_FOOD", 40 ], [ "EAT_CARRION", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_boar_wild",
@@ -336,7 +338,8 @@
       "WARM",
       "KEENNOSE",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 5, "bullet": 2, "electric": 1 }
   },
@@ -381,7 +384,8 @@
       "HIT_AND_RUN",
       "SMALL_HIDER",
       "CORNERED_FIGHTER",
-      "CLIMBS"
+      "CLIMBS",
+      "BELLYUP"
     ]
   },
   {
@@ -437,7 +441,8 @@
       "HIT_AND_RUN",
       "CORNERED_FIGHTER",
       "SMALL_HIDER",
-      "CAN_BE_CULLED"
+      "CAN_BE_CULLED",
+      "BELLYUP"
     ],
     "armor": { "cold": 2 }
   },
@@ -488,7 +493,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "ANIMAL", "PATH_AVOID_DANGER", "SMALL_HIDER" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "ANIMAL", "PATH_AVOID_DANGER", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_tiger",
@@ -535,7 +540,18 @@
     "dissect": "dissect_feline_sample_small",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "KEENNOSE" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "HIT_AND_RUN",
+      "KEENNOSE",
+      "BELLYUP"
+    ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   },
   {
@@ -585,7 +601,8 @@
       "CANPLAY",
       "PET_WONT_FOLLOW",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 2 }
   },
@@ -651,7 +668,8 @@
       "MILKABLE",
       "CAN_BE_CULLED",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 3, "cut": 3, "electric": 1 }
   },
@@ -686,7 +704,7 @@
     "harvest": "mammal_fur_canis",
     "dissect": "dissect_canine_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "KEENNOSE", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "KEENNOSE", "EATS", "BELLYUP" ],
     "armor": { "bash": 2, "cut": 3, "bullet": 3, "electric": 1 }
   },
   {
@@ -720,7 +738,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "upgrades": { "age_grow": 330, "into": "mon_deer" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "BELLYUP" ]
   },
   {
     "id": "mon_deer",
@@ -759,7 +777,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 12 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS", "BELLYUP" ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2, "electric": 1 }
   },
   {
@@ -796,7 +814,7 @@
     "fear_triggers": [ "SOUND", "FIRE" ],
     "zombify_into": "mon_zeer_frail",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 12 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "BELLYUP" ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2, "electric": 1 }
   },
   {
@@ -858,7 +876,8 @@
       "SWARMS",
       "WARM",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2, "electric": 1 }
   },
@@ -1016,7 +1035,8 @@
       "WARM",
       "EATS",
       "SMALL_HIDER",
-      "CORNERED_FIGHTER"
+      "CORNERED_FIGHTER",
+      "BELLYUP"
     ]
   },
   {
@@ -1064,7 +1084,19 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "KEENNOSE", "CLIMBS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "HIT_AND_RUN",
+      "KEENNOSE",
+      "CLIMBS",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_groundhog",
@@ -1095,7 +1127,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "special_attacks": [ [ "GRAZE", 100 ] ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS", "SMALL_HIDER" ]
+    "flags": [ "SEES", "HEARS", "GOODHEARING", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_horse_foal",
@@ -1144,7 +1176,8 @@
       "WARM",
       "NO_BREED",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 2, "electric": 1 }
   },
@@ -1200,7 +1233,8 @@
       "WARM",
       "MILKABLE",
       "EATS",
-      "CORNERED_FIGHTER"
+      "CORNERED_FIGHTER",
+      "BELLYUP"
     ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   },
@@ -1234,7 +1268,7 @@
     "dissect": "dissect_cattle_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "zombify_into": "mon_zombie_horse_lame",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "IMMOBILE", "CORNERED_FIGHTER" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "IMMOBILE", "CORNERED_FIGHTER", "BELLYUP" ],
     "armor": { "bash": 2, "cut": 4, "bullet": 5, "electric": 1 }
   },
   {
@@ -1274,7 +1308,7 @@
     "special_attacks": [ [ "GRAZE", 50 ] ],
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER", "EATS" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER", "EATS", "BELLYUP" ]
   },
   {
     "id": "mon_mink",
@@ -1303,7 +1337,19 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "KEENNOSE", "SWIMS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "HIT_AND_RUN",
+      "KEENNOSE",
+      "SWIMS",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_moose",
@@ -1354,7 +1400,18 @@
       [ "EAT_CROP", 60 ],
       [ "GRAZE", 50 ]
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "PET_MOUNTABLE",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "CORNERED_FIGHTER",
+      "EATS",
+      "BELLYUP"
+    ],
     "armor": { "bash": 5, "cut": 6, "bullet": 8, "electric": 1 }
   },
   {
@@ -1392,7 +1449,7 @@
     "upgrades": { "age_grow": 180, "into": "mon_moose" },
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 50 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "EATS", "BELLYUP" ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   },
   {
@@ -1441,7 +1498,7 @@
     "dissect": "dissect_cattle_sample_large",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS", "BELLYUP" ],
     "armor": { "bash": 8, "cut": 10, "bullet": 12, "electric": 1 }
   },
   {
@@ -1479,7 +1536,7 @@
     "upgrades": { "age_grow": 120, "into": "mon_tusked_moose" },
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 50 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "PET_WONT_FOLLOW", "EATS", "BELLYUP" ],
     "armor": { "bash": 5, "cut": 7, "bullet": 8, "electric": 1 }
   },
   {
@@ -1510,7 +1567,7 @@
     "dissect": "dissect_rat_sample_single",
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER", "SMALL_HIDER" ]
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_opossum",
@@ -1542,7 +1599,19 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
     "fear_triggers": [ "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "CLIMBS",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "KEENNOSE",
+      "EATS",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_skunk",
@@ -1596,7 +1665,8 @@
       "GOODHEARING",
       "EATS",
       "CORNERED_FIGHTER",
-      "SMALL_HIDER"
+      "SMALL_HIDER",
+      "BELLYUP"
     ]
   },
   {
@@ -1625,7 +1695,18 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "WATER_CAMOUFLAGE", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "SWIMS",
+      "WARM",
+      "WATER_CAMOUFLAGE",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_pig_piglet",
@@ -1671,7 +1752,8 @@
       "KEENNOSE",
       "CAN_BE_CULLED",
       "EATS",
-      "SMALL_HIDER"
+      "SMALL_HIDER",
+      "BELLYUP"
     ]
   },
   {
@@ -1721,7 +1803,8 @@
       "KEENNOSE",
       "CAN_BE_CULLED",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ]
   },
   {
@@ -1764,7 +1847,8 @@
       "CAN_BE_CULLED",
       "GOODHEARING",
       "EATS",
-      "SMALL_HIDER"
+      "SMALL_HIDER",
+      "BELLYUP"
     ]
   },
   {
@@ -1833,7 +1917,19 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "special_attacks": [ [ "EAT_FOOD", 60 ], [ "BROWSE", 50 ], [ "EAT_CARRION", 60 ] ],
     "anger_triggers": [ "FRIEND_ATTACKED", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CLIMBS", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "CLIMBS",
+      "PATH_AVOID_DANGER",
+      "WARM",
+      "KEENNOSE",
+      "EATS",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_rat",
@@ -1869,7 +1965,19 @@
     "upgrades": { "half_life": 70, "into_group": "GROUP_RATKIN_EVOLVED" },
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED", "FRIEND_DIED" ],
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "SWIMS", "ANIMAL", "PATH_AVOID_DANGER", "STUMBLES", "EATS", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "SMELLS",
+      "HEARS",
+      "WARM",
+      "SWIMS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "STUMBLES",
+      "EATS",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_sheep_lamb",
@@ -1906,7 +2014,7 @@
     "//": "Puberty reached in 6-9 months.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CAN_BE_CULLED", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CAN_BE_CULLED", "EATS", "BELLYUP" ]
   },
   {
     "id": "mon_sheep",
@@ -1956,7 +2064,8 @@
       "PET_WONT_FOLLOW",
       "MILKABLE",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ]
   },
   {
@@ -2004,7 +2113,8 @@
       "MILKABLE",
       "CLIMBS",
       "CAN_BE_CULLED",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 2, "cut": 3, "bullet": 3, "electric": 1 }
   },
@@ -2037,7 +2147,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "special_attacks": [ [ "BROWSE", 120 ] ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "STUMBLES", "WARM", "EATS", "SMALL_HIDER" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "STUMBLES", "WARM", "EATS", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_weasel",
@@ -2065,7 +2175,7 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "SMALL_HIDER" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "SMALL_HIDER", "BELLYUP" ]
   },
   {
     "id": "mon_wolf",
@@ -2100,7 +2210,7 @@
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
     "anger_triggers": [ "STALK", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_WEAK", "PLAYER_CLOSE", "PLAYER_NEAR_BABY" ],
     "zombify_into": "mon_zolf",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "CORNERED_FIGHTER" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "CORNERED_FIGHTER", "BELLYUP" ],
     "armor": { "bash": 3, "cut": 6, "bullet": 5, "electric": 1 }
   },
   {
@@ -2167,7 +2277,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 12 },
     "baby_flags": [ "WINTER", "AUTUMN" ],
     "special_attacks": [ { "id": "smash", "throw_strength": 37 }, [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "CORNERED_FIGHTER", "EATS", "BELLYUP" ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   },
   {
@@ -2227,7 +2337,7 @@
     "//": "Puberty reached in 6-9 months, copied from lamb but it probably applies the same on llamas.",
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 7 },
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS", "BELLYUP" ]
   },
   {
     "id": "mon_llama",
@@ -2277,7 +2387,8 @@
       "MILKABLE",
       "CAN_BE_CULLED",
       "CORNERED_FIGHTER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   },
@@ -2314,7 +2425,19 @@
     "families": [ "prof_intro_biology", "prof_physiology" ],
     "reproduction": { "baby_monster": "mon_ferret_kit", "baby_count": 5, "baby_timer": 100 },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "CANPLAY", "CAN_BE_CULLED", "SMALL_HIDER" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "SWIMS",
+      "WARM",
+      "CANPLAY",
+      "CAN_BE_CULLED",
+      "SMALL_HIDER",
+      "BELLYUP"
+    ]
   },
   {
     "id": "mon_ferret_kit",
@@ -2329,7 +2452,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "dodge": 9,
     "path_settings": { "max_dist": 10, "avoid_dangerous_fields": true, "avoid_sharp": true },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CANPLAY", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "NO_BREED" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "CANPLAY", "PATH_AVOID_DANGER", "WARM", "HIT_AND_RUN", "NO_BREED", "BELLYUP" ],
     "upgrades": { "age_grow": 90, "into": "mon_ferret" },
     "armor": { "cold": 0 }
   }

--- a/data/json/monsters/mutant.json
+++ b/data/json/monsters/mutant.json
@@ -192,7 +192,8 @@
       "GROUP_BASH",
       "HIT_AND_RUN",
       "PATH_AVOID_DANGER",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 10, "cut": 11, "stab": 8, "bullet": 5, "electric": 2 }
   },

--- a/data/json/monsters/mutant_mammal.json
+++ b/data/json/monsters/mutant_mammal.json
@@ -72,7 +72,8 @@
       "PUSH_MON",
       "STUMBLES",
       "KEENNOSE",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 8, "cut": 12, "electric": 1 }
   },
@@ -114,7 +115,7 @@
       }
     ],
     "fear_triggers": [ "SOUND" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "BELLYUP" ],
     "armor": { "cut": 4 }
   },
   {
@@ -155,7 +156,7 @@
         "damage_max_instance": [ { "damage_type": "stab", "amount": 8, "armor_penetration": 2 } ]
       }
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "SWIMS", "WARM", "BELLYUP" ]
   },
   {
     "id": "mon_coyote_mutant_shark",
@@ -198,7 +199,7 @@
     "path_settings": { "max_dist": 7 },
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK" ],
     "fear_triggers": [ "SOUND" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "GROUP_MORALE", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "GROUP_MORALE", "EATS", "BELLYUP" ],
     "armor": { "bash": 1 }
   },
   {
@@ -244,7 +245,8 @@
       "KEENNOSE",
       "BADVENOM",
       "GROUP_MORALE",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 1 }
   },
@@ -303,7 +305,7 @@
       { "id": "bite_grab_required" }
     ],
     "anger_triggers": [ "STALK", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_WEAK", "PLAYER_CLOSE" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "KEENNOSE", "EATS", "BELLYUP" ],
     "armor": { "bash": 8, "cut": 10, "electric": 1 }
   },
   {
@@ -341,7 +343,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 12 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "special_attacks": [ [ "EAT_CROP", 60 ], [ "GRAZE", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "EATS", "BELLYUP" ]
   },
   {
     "id": "mon_deer_mutant_spider_fawn",
@@ -374,7 +376,7 @@
     "path_settings": { "max_dist": 10 },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "upgrades": { "age_grow": 330, "into": "mon_deer_mutant_spider" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "STUMBLES" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER", "WARM", "STUMBLES", "BELLYUP" ]
   },
   {
     "id": "mon_dog_mutant_mongrel",
@@ -433,7 +435,8 @@
       "SMELLS",
       "SWARMS",
       "WARM",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ]
   },
   {
@@ -494,7 +497,8 @@
       "SWARMS",
       "WARM",
       "CLIMBS",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "cut": 1 }
   },
@@ -591,7 +595,8 @@
       "SMELLS",
       "SWARMS",
       "WARM",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ]
   },
   {
@@ -685,7 +690,8 @@
       "SWARMS",
       "CAN_DIG",
       "WARM",
-      "EATS"
+      "EATS",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "cut": 1 }
   },
@@ -794,7 +800,8 @@
       "EATS",
       "CORNERED_FIGHTER",
       "COMBAT_MOUNT",
-      "NO_BREED"
+      "NO_BREED",
+      "BELLYUP"
     ],
     "armor": { "bash": 5, "cut": 6, "bullet": 8, "electric": 1 }
   }

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -346,7 +346,8 @@
       "ACID_BLOOD",
       "NO_BREATHE",
       "REVIVES",
-      "PUSH_MON"
+      "PUSH_MON",
+      "BELLYUP"
     ]
   },
   {
@@ -440,7 +441,8 @@
       "REVIVES",
       "PUSH_MON",
       "PUSH_VEH",
-      "FILTHY"
+      "FILTHY",
+      "BELLYUP"
     ],
     "armor": { "electric": 2, "bash": 10, "cut": 10, "bullet": 8 }
   },
@@ -480,7 +482,8 @@
       "FILTHY",
       "PATH_AVOID_FIRE",
       "PATH_AVOID_FALL",
-      "PARALYZEVENOM"
+      "PARALYZEVENOM",
+      "BELLYUP"
     ],
     "armor": { "electric": 2, "bash": 8, "cut": 8, "bullet": 6 }
   }

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -31,7 +31,7 @@
     "special_attacks": [ { "id": "bite_grab", "attack_upper": false, "cooldown": 5 }, { "id": "scratch_grab_required", "max_mul": 1.5 } ],
     "death_drops": "mon_dog_death_drops",
     "upgrades": { "half_life": 168, "into": "mon_dog_skeleton_brute" },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "WARM", "REVIVES", "POISON", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "WARM", "REVIVES", "POISON", "FILTHY", "BASHES", "BELLYUP" ],
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 12, "electric": 1 }
   },
   {
@@ -107,7 +107,7 @@
       { "id": "scratch_grab_required" },
       { "id": "bite_grab_required" }
     ],
-    "extend": { "flags": [ "DESTROYS" ] },
+    "extend": { "flags": [ "DESTROYS", "GROUP_BASH", "PUSH_VEH" ] },
     "armor": { "bash": 8, "cut": 10, "bullet": 10, "electric": 4 }
   },
   {
@@ -211,7 +211,7 @@
     "vision_night": 3,
     "harvest": "puppy_bones",
     "upgrades": { "half_life": 168, "into": "mon_dog_skeleton_brute" },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "WARM", "POISON", "FILTHY", "BASHES" ],
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "REVIVES", "WARM", "POISON", "FILTHY", "BASHES", "BELLYUP" ],
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 12, "electric": 3 }
   },
   {

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -39,7 +39,19 @@
       { "id": "bite_grab_required" }
     ],
     "harvest": "zombie_leather",
-    "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "AQUATIC", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "WATER_CAMOUFLAGE" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "SWIMS",
+      "AQUATIC",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "WATER_CAMOUFLAGE",
+      "BELLYUP"
+    ],
     "armor": { "bash": 6, "cut": 2, "bullet": 2 }
   },
   {
@@ -82,7 +94,19 @@
       { "id": "bite_grab_required" }
     ],
     "harvest": "zombie_leather",
-    "flags": [ "SEES", "HEARS", "SMELLS", "SWIMS", "AQUATIC", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "WATER_CAMOUFLAGE" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "SWIMS",
+      "AQUATIC",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "WATER_CAMOUFLAGE",
+      "BELLYUP"
+    ],
     "armor": { "bash": 8, "cut": 2, "bullet": 2 }
   },
   {
@@ -346,7 +370,8 @@
       "REVIVES",
       "PUSH_MON",
       "FILTHY",
-      "KEENNOSE"
+      "KEENNOSE",
+      "BELLYUP"
     ],
     "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 2 }
   },
@@ -382,7 +407,20 @@
     "special_attacks": [ { "id": "low_charge", "cooldown": 12 }, { "type": "bite", "attack_upper": false, "cooldown": 2 } ],
     "anger_triggers": [ "PLAYER_WEAK", "PLAYER_CLOSE" ],
     "upgrades": { "half_life": 200, "into_group": "GROUP_ZOMBIE_PIG_UPGRADE" },
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "KEENNOSE", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "STUMBLES",
+      "WARM",
+      "KEENNOSE",
+      "BASHES",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "BELLYUP"
+    ],
     "//": "1d8->2d5, minor bonus over 1d9",
     "armor": { "electric": 1 }
   },
@@ -415,7 +453,20 @@
     "vision_night": 5,
     "harvest": "zombie_fur",
     "anger_triggers": [ "PLAYER_CLOSE", "HURT" ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "SWIMS" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "STUMBLES",
+      "WARM",
+      "BASHES",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "SWIMS",
+      "BELLYUP"
+    ],
     "armor": { "electric": 1 }
   },
   {
@@ -457,7 +508,7 @@
         "cooldown": 45
       }
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "BELLYUP" ],
     "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 2 }
   },
   {
@@ -490,7 +541,7 @@
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
     "upgrades": { "half_life": 188, "into_group": "GROUP_ZOMBIE_HORSE_UPGRADE" },
     "fungalize_into": "mon_zombie_horse_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "GOODHEARING" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "GOODHEARING", "BELLYUP" ],
     "armor": { "bash": 5, "cut": 1, "electric": 2 }
   },
   {
@@ -550,7 +601,8 @@
       "POISON",
       "NO_BREATHE",
       "REVIVES",
-      "FILTHY"
+      "FILTHY",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "electric": 2 }
   },
@@ -582,7 +634,7 @@
     "vision_night": 3,
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
     "harvest": "zombie_fur",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "BELLYUP" ],
     "armor": { "bash": 4, "cut": 1, "electric": 3 }
   },
   {
@@ -615,7 +667,7 @@
     "vision_night": 3,
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
     "harvest": "zombie_fur",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "NO_BREATHE", "REVIVES", "FILTHY", "BELLYUP" ],
     "armor": { "bash": 1, "cut": 2, "electric": 1 }
   },
   {
@@ -656,7 +708,7 @@
     "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK" ],
     "death_drops": { "subtype": "collection", "groups": [ [ "cow", 25 ] ], "//": "25% chance of an item from group cow" },
     "harvest": "zombie_leather",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "BELLYUP" ],
     "armor": { "bash": 3, "cut": 3, "electric": 3 }
   },
   {
@@ -708,7 +760,8 @@
       "REVIVES",
       "FILTHY",
       "PUSH_MON",
-      "PUSH_VEH"
+      "PUSH_VEH",
+      "BELLYUP"
     ],
     "armor": { "bash": 6, "cut": 4, "bullet": 3, "electric": 4 }
   },
@@ -756,7 +809,7 @@
       },
       [ "ACID_BARF", 5 ]
     ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "POISON", "NO_BREATHE", "REVIVES", "FILTHY", "BELLYUP" ]
   },
   {
     "id": "mon_zeer",
@@ -799,7 +852,8 @@
       "BASHES",
       "FILTHY",
       "KEENNOSE",
-      "GOODHEARING"
+      "GOODHEARING",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2, "electric": 1 }
   },
@@ -844,7 +898,8 @@
       "BASHES",
       "FILTHY",
       "KEENNOSE",
-      "GOODHEARING"
+      "GOODHEARING",
+      "BELLYUP"
     ],
     "armor": { "bash": 1, "cut": 3, "bullet": 2, "electric": 1 }
   },
@@ -889,7 +944,8 @@
       "FILTHY",
       "BASHES",
       "KEENNOSE",
-      "GOODHEARING"
+      "GOODHEARING",
+      "BELLYUP"
     ],
     "armor": { "bash": 3, "cut": 5, "bullet": 6, "electric": 1 }
   }

--- a/data/json/monsters/zed-animal.json
+++ b/data/json/monsters/zed-animal.json
@@ -117,7 +117,20 @@
     "death_drops": "mon_dog_death_drops",
     "upgrades": { "half_life": 112, "into_group": "GROUP_ZOMBIE_DOG_UPGRADE" },
     "fungalize_into": "mon_zombie_dog_fungus",
-    "flags": [ "SEES", "HEARS", "SMELLS", "GRABS", "STUMBLES", "WARM", "BASHES", "POISON", "NO_BREATHE", "REVIVES", "FILTHY" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "GRABS",
+      "STUMBLES",
+      "WARM",
+      "BASHES",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "FILTHY",
+      "BELLYUP"
+    ],
     "armor": { "electric": 1 }
   },
   {
@@ -165,7 +178,8 @@
       "REVIVES",
       "PUSH_MON",
       "FILTHY",
-      "KEENNOSE"
+      "KEENNOSE",
+      "BELLYUP"
     ],
     "armor": { "bash": 6, "cut": 6, "bullet": 5, "electric": 1 }
   },
@@ -214,7 +228,8 @@
       "NO_BREATHE",
       "REVIVES",
       "PUSH_MON",
-      "FILTHY"
+      "FILTHY",
+      "BELLYUP"
     ],
     "armor": { "electric": 1 }
   },

--- a/data/json/monsters/zed_acid.json
+++ b/data/json/monsters/zed_acid.json
@@ -323,7 +323,8 @@
       "REVIVES",
       "FILTHY",
       "ACIDPROOF",
-      "ACID_BLOOD"
+      "ACID_BLOOD",
+      "BELLYUP"
     ],
     "armor": { "electric": 1 }
   },

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -983,7 +983,8 @@
       "PUSH_MON",
       "FILTHY",
       "PATH_AVOID_FIRE",
-      "PATH_AVOID_FALL"
+      "PATH_AVOID_FALL",
+      "BELLYUP"
     ],
     "armor": { "electric": 1 }
   },
@@ -1335,7 +1336,8 @@
       "CLIMBS",
       "FILTHY",
       "PATH_AVOID_FIRE",
-      "PATH_AVOID_FALL"
+      "PATH_AVOID_FALL",
+      "BELLYUP"
     ],
     "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 1 }
   },

--- a/data/mods/Gun_Control/exclusions.json
+++ b/data/mods/Gun_Control/exclusions.json
@@ -2,14 +2,7 @@
   {
     "type": "SCENARIO_BLACKLIST",
     "subtype": "blacklist",
-    "scenarios": [
-      "heli_crash",
-      "overrun",
-      "lab_cargo_staff_1",
-      "lab_chal",
-      "lab_staff",
-      "overrun"
-    ]
+    "scenarios": [ "heli_crash", "overrun", "lab_cargo_staff_1", "lab_chal", "lab_staff", "overrun" ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/Gun_Control/itemgroups.json
+++ b/data/mods/Gun_Control/itemgroups.json
@@ -350,8 +350,12 @@
     "type": "item_group",
     "id": "guns_pistol_collectible",
     "//": "Highly rare or collectable factory-made pistols that are possible for civilians to own; only likely to show up in gun collections, museums or similar.  Pistols that are of historic or collectors value and which fall under NFA regulations, i.e. pistols which are integrally supressed, have a burst or fully-automatic capability, or have a non-detachable buttstock, can be placed within this item group.  These weapons are always unloaded.",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "mauser_c96", "prob": 50 }, { "item": "colt_navy", "prob": 40 }, { "item": "colt_army", "prob": 40 } ]
+    "items": [
+      { "item": "null", "prob": 4000 },
+      { "item": "mauser_c96", "prob": 50 },
+      { "item": "colt_navy", "prob": 40 },
+      { "item": "colt_army", "prob": 40 }
+    ]
   },
   {
     "type": "item_group",
@@ -369,8 +373,11 @@
     "id": "guns_smg_common",
     "//": "Semi-auto civilian SMGs owned by citizens and found in many locations.",
     "//2": "Making the assumption any loaded gun will have additional ammo and mags with it.",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "group": "nested_mp40semi", "prob": 10 }, { "group": "nested_hk_mp5_semi_pistol", "prob": 70 } ]
+    "items": [
+      { "item": "null", "prob": 4000 },
+      { "group": "nested_mp40semi", "prob": 10 },
+      { "group": "nested_hk_mp5_semi_pistol", "prob": 70 }
+    ]
   },
   {
     "type": "item_group",
@@ -388,8 +395,12 @@
     "subtype": "distribution",
     "id": "guns_smg_common_display",
     "//": "Empty Semi-auto civilian SMGs owned by citizens and found in many locations.",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "mp40semi", "prob": 10 }, { "item": "hk_mp5_semi_pistol", "prob": 70 }, { "item": "TDI_10", "prob": 70 } ]
+    "items": [
+      { "item": "null", "prob": 4000 },
+      { "item": "mp40semi", "prob": 10 },
+      { "item": "hk_mp5_semi_pistol", "prob": 70 },
+      { "item": "TDI_10", "prob": 70 }
+    ]
   },
   {
     "type": "item_group",
@@ -486,8 +497,7 @@
     "type": "item_group",
     "id": "guns_smg_collectible",
     "//": "Extremely rare factory-made submachine guns that are possible for civilians to own; only likely to show up in gun collections, museums or similar.  Always unloaded.",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "mp18", "variant": "mp18", "prob": 3 } ]
+    "items": [ { "item": "null", "prob": 4000 }, { "item": "mp18", "variant": "mp18", "prob": 3 } ]
   },
   {
     "type": "item_group",
@@ -883,8 +893,12 @@
     "type": "item_group",
     "id": "guns_rifle_improvised",
     "//": "Makeshift or otherwise poor quality rifles.",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "rifle_22", "prob": 60 }, { "item": "rifle_38", "prob": 30 }, { "item": "rifle_44", "prob": 5 } ]
+    "items": [
+      { "item": "null", "prob": 4000 },
+      { "item": "rifle_22", "prob": 60 },
+      { "item": "rifle_38", "prob": 30 },
+      { "item": "rifle_44", "prob": 5 }
+    ]
   },
   {
     "type": "item_group",
@@ -1094,8 +1108,7 @@
     "type": "item_group",
     "id": "guns_launcher_flame",
     "//": "Factory manufactured incendiary liquid projectors (excludes improvised weapons)",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "flamethrower", "prob": 50, "charges": [ 100, 8000 ] } ]
+    "items": [ { "item": "null", "prob": 4000 }, { "item": "flamethrower", "prob": 50, "charges": [ 100, 8000 ] } ]
   },
   {
     "type": "item_group",
@@ -1151,8 +1164,11 @@
     "type": "item_group",
     "id": "guns_launcher_improvised",
     "//": "Makeshift or otherwise poor quality grenade and rocket launchers",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "item": "launcher_simple", "prob": 100 }, { "item": "triple_launcher_simple", "prob": 15, "charges": [ 0, 3 ] } ]
+    "items": [
+      { "item": "null", "prob": 4000 },
+      { "item": "launcher_simple", "prob": 100 },
+      { "item": "triple_launcher_simple", "prob": 15, "charges": [ 0, 3 ] }
+    ]
   },
   {
     "type": "item_group",
@@ -1268,7 +1284,13 @@
     "subtype": "distribution",
     "items": [
       { "item": "null", "prob": 4000 },
-      { "group": "ar15_223medium", "ammo-item": "223", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "prob": 90 },
+      {
+        "group": "ar15_223medium",
+        "ammo-item": "223",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 90
+      },
       {
         "group": "ar15_223short",
         "ammo-item": "223",
@@ -2051,8 +2073,7 @@
     "type": "item_group",
     "id": "guns_cop",
     "//": "Police issue weapons of all types",
-    "items": [ 
-      { "item": "null", "prob": 4000 },{ "group": "longguns_cop", "prob": 20 }, { "group": "sidearms_cop", "prob": 80 } ]
+    "items": [ { "item": "null", "prob": 4000 }, { "group": "longguns_cop", "prob": 20 }, { "group": "sidearms_cop", "prob": 80 } ]
   },
   {
     "type": "item_group",
@@ -2073,7 +2094,9 @@
     "type": "item_group",
     "id": "longguns_operator",
     "items": [
-      { "item": "null", "prob": 4000 }, { "group": "modular_ar15", "prob": 20, "charges": [ 0, 30 ], "contents-item": "shoulder_strap_front" } ]
+      { "item": "null", "prob": 4000 },
+      { "group": "modular_ar15", "prob": 20, "charges": [ 0, 30 ], "contents-item": "shoulder_strap_front" }
+    ]
   },
   {
     "type": "item_group",

--- a/data/mods/Gun_Control/vehicle_groups.json
+++ b/data/mods/Gun_Control/vehicle_groups.json
@@ -629,10 +629,7 @@
   {
     "type": "vehicle_group",
     "id": "military_vehicles",
-    "vehicles": [
-      [ "military_cargo_truck", 1000 ],
-      [ "military_cargo_truck_b", 1000 ]
-    ]
+    "vehicles": [ [ "military_cargo_truck", 1000 ], [ "military_cargo_truck_b", 1000 ] ]
   },
   {
     "type": "vehicle_group",


### PR DESCRIPTION
#### Summary
Add BELLYUP flag to a bunch of monsters

#### Purpose of change
Stuff that crawls on all fours shouldn't be tipped 90 degrees when downed, invert it instead.

#### Describe the solution
All zombie animals, upgraded zombie animals, and some lab mutants and mutant animals.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
