### PR TITLE
Made hiding/unhiding wires a bit nicer

### DIFF
--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -541,11 +541,22 @@ void veh_app_interact::plug( map &here )
     }
 }
 
-void veh_app_interact::hide()
+void veh_app_interact::toggle_hide_wiring( map &here )
 {
     const int part_idx = veh->part_at( veh->coord_translate( a_point ) );
     vehicle_part &vp = veh->part( part_idx );
-    vp.hidden = !vp.hidden;
+    const bool should_hide = !vp.hidden;
+    vp.hidden = should_hide;
+    if ( query_yn( string_format( "Also %s all the wiring on this floor?", should_hide ? "hide" : "unhide" ) ) ) {
+        for ( const tripoint_bub_ms &target : here.points_on_zlevel() ) {
+            if ( auto target_vpart_position = here.veh_at( target ) ) {
+                if ( auto target_vpart_reference = target_vpart_position.part_with_feature( flag_WIRING, false ) ) {
+                    vehicle_part &target_vp = target_vpart_reference->part();
+                    target_vp.hidden = should_hide;
+                }
+            }
+        }
+    }
 }
 
 void veh_app_interact::populate_app_actions( map &here )
@@ -599,10 +610,10 @@ void veh_app_interact::populate_app_actions( map &here )
 #if defined(TILES)
     // Hide
     if( use_tiles && vp->info().has_flag( flag_WIRING ) ) {
-        app_actions.emplace_back( [this]() {
-            hide();
+        app_actions.emplace_back( [&here, this]() {
+            toggle_hide_wiring( here );
         } );
-        imenu.addentry( -1, true, 0, "Hide/Unhide wiring" );
+        imenu.addentry( -1, true, 0, string_format( _( "%s wiring" ), vp->hidden ? "Unhide" : "Hide" ) );
     }
 #endif
 

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -143,7 +143,7 @@ class veh_app_interact
         * Function associated with the "HIDE" action.
         * Hides the selected tiles sprite.
         */
-        void hide();
+        void toggle_hide_wiring( map &here );
         /**
          * The main loop of the appliance UI. Redraws windows, checks for input, and
          * performs selected actions. The loop exits once an activity is assigned


### PR DESCRIPTION
#### Summary
Category "Brief description"
pressing `e` on a wall with revealed wiring will show an action to "hide/unhide wiring"
This PR makes the name dependent on if the wiring is hidden or not right now, this gives the bare minimum feedback for you to know that you actually did something by pressing the button (and it makes the name less clunky)
It now also mimics the behavior of "Reveal wall wiring" in the construction menu in that it asks the user if they want to hide or unhide all the wiring on the floor.
#### Purpose of change
Currently, you'd need to go over to each piece of revealed wiring and manually hide it or unhide it, which is very unfortunate if youre dealing with an entire floor where each tile on the wall is probably wired.
#### Describe the solution
the action is named "Hide wall wiring" if it is unhidden and "Unhide wall wiring" if it is hidden
to hide or unhide all wiring on the floor, we get a list of points in the Z level, iterate them and check if any of them are a vehicle that has a part with flag_WIRING, then set vehicle_part::hidden to the right value.
#### Describe alternatives you've considered

#### Testing
I loaded a new world, went into the evac shelter, revealed the wiring, and it all worked as expected.
#### Additional context
I also wanted to change the prompt in "Reveal wall wiring" from "Also reveal nearby wall wiring" to "Also reveal all wall wiring on this floor" since that's what it actually does, but I didn't want to undo the translation work people have done for something so minor. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
