### PR TITLE
Fix json serialization

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4751,8 +4751,6 @@ void basecamp::serialize( JsonOut &json ) const
             json.end_object();
         }
         json.end_array();
-        json.start_array();
-        json.end_array();
         json.end_object();
 
     } else {


### PR DESCRIPTION
#### Summary
Fix json serialization

#### Purpose of change
An extra blank array was left in savegame_json.cpp

#### Describe the solution
domp eet

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
