### PR TITLE
Making tracking dispersion affect dispersion

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1122,7 +1122,7 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
         // Add dispersion for shooting in close range.
         const Creature *victim = get_creature_tracker().creature_at( target, true );
         if( victim != nullptr ) {
-            get_tracking_dispersion( &gun, victim, true );
+            dispersion.add_range( get_tracking_dispersion( &gun, victim, true ).max() );
         }
         dealt_projectile_attack shot;
         projectile_attack( shot, proj, &here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );


### PR DESCRIPTION
#### Summary

Tracking dispersion didn't seem to be used in the gun firing code.

#### Purpose of change

I noticed that get_tracking_dispersion was called but not doing anything in fire_gun. As far as I can tell references aren't passed in.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/355e7e856376a39afa59d5b7d0d4011e7ae4546c/src/ranged.cpp#L1124-L1126

It seems that it was only used in a way that had an effect in calculate_ranged_changes, which was used for the UI/debug logging I think.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/355e7e856376a39afa59d5b7d0d4011e7ae4546c/src/ranged.cpp#L1919

#### Describe the solution

I put the return from get_tracking_disperesion into dispersion.add_range

            dispersion.add_range( get_tracking_dispersion( &gun, victim, true ).max() );

#### Describe alternatives you've considered

get_tracking_dispersion had rng logic within itself to modify tracking_dispersion, a double, and then did add_range( tracking_dispersion ) and returned that, so I figured it was trying to add the add_range( tracking_dispersion ) to the total dispersion and that the code in get_tracking_dispersion was itself correct.

#### Testing

Adding debug logging around the get_tracking_dispersion call in fire_gun might help? It's what I tested. Otherwise testing would probably involve a big gun against a close enemy.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
