### PR TITLE
Being high blocks cravings

### DIFF
--- a/data/json/addictions.json
+++ b/data/json/addictions.json
@@ -5,8 +5,9 @@
     "name": "Craving Caffeine",
     "type_name": "caffeine",
     "description": "Life without caffeine is rough, but there are worse things to be hooked on.",
-    "sated": "4 hours",
+    "sated": "6 hours",
     "craving_morale": "morale_craving_caffeine",
+    "satisfying_effects": [ "caffeine_eff" ],
     "effect_on_condition": "EOC_CAFFEINE_ADDICTION"
   },
   {
@@ -15,8 +16,9 @@
     "name": "Craving Nicotine",
     "type_name": "nicotine",
     "description": "A cigarette, a vape, even the gum would be better than going without.",
-    "sated": "3 hours",
+    "sated": "4 hours",
     "craving_morale": "morale_craving_nicotine",
+    "satisfying_effects": [ "cig" ],
     "builtin": "nicotine_effect"
   },
   {
@@ -27,6 +29,7 @@
     "description": "A drink would make everything better.",
     "sated": "6 hours",
     "craving_morale": "morale_craving_alcohol",
+    "satisfying_effects": [ "drunk" ],
     "builtin": "alcohol_effect"
   },
   {
@@ -36,6 +39,7 @@
     "type_name": "sleeping pills",
     "description": "You will have a hard time sleeping without help.",
     "sated": "6 hours",
+    "satisfying_effects": [ "zolpidem", "took_antihistamine", "opioid_eff", "took_xanax", "valium" ],
     "effect_on_condition": "EOC_SLEEP_ADDICTION"
   },
   {
@@ -46,6 +50,7 @@
     "description": "You really need some painkillers.",
     "sated": "6 hours",
     "craving_morale": "morale_craving_opioid",
+    "satisfying_effects": [ "opioid_eff" ],
     "builtin": "opioid_effect"
   },
   {
@@ -56,6 +61,7 @@
     "description": "Everything is too much and too loud, and you can't keep up.",
     "sated": "6 hours",
     "craving_morale": "morale_craving_speed",
+    "satisfying_effects": [ "amphetamine_eff" ],
     "builtin": "amphetamine_effect"
   },
   {
@@ -64,8 +70,9 @@
     "name": "Craving Cocaine",
     "type_name": "cocaine",
     "description": "Just a bump would fix you.",
-    "sated": "2 hours",
+    "sated": "4 hours",
     "craving_morale": "morale_craving_cocaine",
+    "satisfying_effects": [ "cocaine" ],
     "builtin": "cocaine_effect"
   },
   {
@@ -76,6 +83,7 @@
     "description": "You could use some herb right now.",
     "sated": "8 hours",
     "craving_morale": "morale_craving_cannabis",
+    "satisfying_effects": [ "high" ],
     "builtin": "cannabis_effect"
   },
   {
@@ -86,6 +94,7 @@
     "description": "The world is way too much, you're freaking out.  You just need a chill pill, that's all.",
     "sated": "6 hours",
     "craving_morale": "morale_craving_diazepam",
+    "satisfying_effects": [ "valium", "took_xanax" ],
     "builtin": "diazepam_effect"
   },
   {

--- a/data/json/effects_on_condition/addictions_eocs.json
+++ b/data/json/effects_on_condition/addictions_eocs.json
@@ -10,7 +10,12 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CAFFEINE_ADDICTION",
-    "condition": { "math": [ "rand(2000)", "<=", "addiction_rational(2000, 20, u_addiction_intensity('caffeine'))" ] },
+    "condition": {
+      "and": [
+        { "not": { "u_has_effect": "caffeine_eff" } },
+        { "math": [ "rand(2000)", "<=", "addiction_rational(2000, 20, u_addiction_intensity('caffeine'))" ] }
+      ]
+    },
     "effect": [
       { "u_message": "You want some caffeine.", "type": "warning" },
       { "u_add_morale": "morale_craving_caffeine", "bonus": -5, "max_bonus": -25 },

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -28,11 +28,13 @@
 
 static const efftype_id effect_amphetamine_eff( "amphetamine_eff" );
 static const efftype_id effect_cig( "cig" );
+static const efftype_id effect_cocaine( "cocaine" );
 static const efftype_id effect_nausea( "nausea" );
 static const efftype_id effect_opioid_eff( "opioid_eff" );
 static const efftype_id effect_withdrawal_alcohol( "withdrawal_alcohol" );
 static const efftype_id effect_withdrawal_alcohol_detoxed( "withdrawal_alcohol_detoxed" );
 static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
+static const efftype_id effect_high( "high" );
 static const efftype_id effect_withdrawal_nicotine( "withdrawal_nicotine" );
 static const efftype_id effect_withdrawal_nicotine_detoxed( "withdrawal_nicotine_detoxed" );
 static const efftype_id effect_withdrawal_nicotine_timer( "withdrawal_nicotine_timer" );
@@ -41,6 +43,8 @@ static const efftype_id effect_withdrawal_opioid_detoxed( "withdrawal_opioid_det
 static const efftype_id effect_withdrawal_opioid_timer( "withdrawal_opioid_timer" );
 static const efftype_id effect_hallu( "hallu" );
 static const efftype_id effect_shakes( "shakes" );
+static const efftype_id effect_took_xanax( "took_xanax" );
+static const efftype_id effect_valium( "valium" );
 
 static const morale_type morale_craving_alcohol( "morale_craving_alcohol" );
 static const morale_type morale_craving_cannabis( "morale_craving_cannabis" );
@@ -49,6 +53,10 @@ static const morale_type morale_craving_diazepam( "morale_craving_diazepam" );
 static const morale_type morale_craving_nicotine( "morale_craving_nicotine" );
 static const morale_type morale_craving_opioid( "morale_craving_opioid" );
 static const morale_type morale_craving_speed( "morale_craving_speed" );
+
+
+static const trait_id trait_ADDICTIVE( "ADDICTIVE" );
+static const trait_id trait_NONADDICTIVE( "NONADDICTIVE" );
 
 namespace
 {
@@ -206,7 +214,13 @@ static bool cocaine_add( Character &u, int in )
 static bool nicotine_effect( Character &u, addiction &add )
 {
     if( u.has_effect( effect_cig ) ) {
-        add.sated = 0_turns;
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 140_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 220_minutes;
+        } else {
+            add.sated = 180_minutes;
+        }
         return false;
     }
     static time_point last_dream = calendar::turn_zero;
@@ -248,6 +262,16 @@ static bool nicotine_effect( Character &u, addiction &add )
 
 static bool cannabis_effect( Character &u, addiction &add )
 {
+    if( u.has_effect( effect_high ) ) {
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 7_hours;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 9_hours;
+        } else {
+            add.sated = 8_hours;
+        }
+        return false;
+    }
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
 
@@ -282,12 +306,32 @@ static bool cannabis_effect( Character &u, addiction &add )
 
 static bool alcohol_effect( Character &u, addiction &add )
 {
+    if( u.has_effect( effect_cig ) ) {
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 310_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 410_minutes;
+        } else {
+            add.sated = 360_minutes;
+        }
+        return false;
+    }
     const int in = std::min( 20, add.intensity );
     return alcohol_add( u, in );
 }
 
 static bool diazepam_effect( Character &u, addiction &add )
 {
+    if( u.has_effect( effect_valium ) || u.has_effect( effect_took_xanax ) ) {
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 310_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 410_minutes;
+        } else {
+            add.sated = 360_minutes;
+        }
+        return false;
+    }
     const int in = std::min( 20, add.intensity );
     return benzodiazepine_add( u, in );
 }
@@ -295,7 +339,13 @@ static bool diazepam_effect( Character &u, addiction &add )
 static bool opioid_effect( Character &u, addiction &add )
 {
     if( u.has_effect( effect_opioid_eff ) ) {
-        add.sated = 0_turns;
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 310_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 410_minutes;
+        } else {
+            add.sated = 360_minutes;
+        }
         u.remove_effect( effect_shakes );
         return false;
     }
@@ -350,7 +400,13 @@ static bool opioid_effect( Character &u, addiction &add )
 static bool amphetamine_effect( Character &u, addiction &add )
 {
     if( u.has_effect( effect_amphetamine_eff ) ) {
-        add.sated = 0_turns;
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 310_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 410_minutes;
+        } else {
+            add.sated = 360_minutes;
+        }
         return false;
     }
     static time_point last_dream = calendar::turn_zero;
@@ -396,6 +452,16 @@ static bool amphetamine_effect( Character &u, addiction &add )
 
 static bool cocaine_effect( Character &u, addiction &add )
 {
+    if( u.has_effect( effect_cocaine ) ) {
+        if( u.has_trait( trait_ADDICTIVE ) ) {
+            add.sated = 105_minutes;
+        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
+            add.sated = 135_minutes;
+        } else {
+            add.sated = 120_minutes;
+        }
+        return false;
+    }
     const int in = std::min( 20, add.intensity );
     return cocaine_add( u, in );
 }

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -34,7 +34,6 @@ static const efftype_id effect_opioid_eff( "opioid_eff" );
 static const efftype_id effect_withdrawal_alcohol( "withdrawal_alcohol" );
 static const efftype_id effect_withdrawal_alcohol_detoxed( "withdrawal_alcohol_detoxed" );
 static const efftype_id effect_withdrawal_alcohol_timer( "withdrawal_alcohol_timer" );
-static const efftype_id effect_high( "high" );
 static const efftype_id effect_withdrawal_nicotine( "withdrawal_nicotine" );
 static const efftype_id effect_withdrawal_nicotine_detoxed( "withdrawal_nicotine_detoxed" );
 static const efftype_id effect_withdrawal_nicotine_timer( "withdrawal_nicotine_timer" );
@@ -108,7 +107,12 @@ static bool alcohol_add( Character &u, int in )
     int timer_int = std::min( in / 3, 3 );
 
     bool ret = false;
-    if( x_in_y( in, 24 ) && !u.in_sleep_state() ) {
+    int strength_adjusted = u.enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                            u.get_str_base() );
+    // Since we got str_base and not get_str(), make sure we don't forget any strength penalties.
+    int strength_penalty = std::min( u.get_str_bonus(), 0 );
+    strength_adjusted += strength_penalty;
+    if( x_in_y( in, 18 + std::max( strength_adjusted, -17 ) ) && !u.in_sleep_state() ) {
         if( !u.has_effect( effect_withdrawal_alcohol_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_alcohol_timer ) ) ) {
             u.add_effect( effect_withdrawal_alcohol_timer, 24_hours * timer_int, false, timer_int );
@@ -213,22 +217,24 @@ static bool cocaine_add( Character &u, int in )
 
 static bool nicotine_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_cig ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 140_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 220_minutes;
-        } else {
-            add.sated = 180_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            return false;
         }
-        return false;
     }
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
     int timer_int = std::min( in / 3, 3 );
 
     bool ret = false;
-    if( x_in_y( in, 48 ) && !u.in_sleep_state() ) {
+    int strength_adjusted = u.enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                            u.get_str_base() );
+    // Since we got str_base and not get_str(), make sure we don't forget any strength penalties.
+    int strength_penalty = std::min( u.get_str_bonus(), 0 );
+    strength_adjusted += strength_penalty;
+    if( x_in_y( in, 38 + std::max( strength_adjusted, -37 ) ) && !u.in_sleep_state() ) {
         if( !u.has_effect( effect_withdrawal_nicotine_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_nicotine_timer ) ) ) {
             u.add_effect( effect_withdrawal_nicotine_timer, 32_hours * timer_int, false, timer_int );
@@ -262,15 +268,12 @@ static bool nicotine_effect( Character &u, addiction &add )
 
 static bool cannabis_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_high ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 7_hours;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 9_hours;
-        } else {
-            add.sated = 8_hours;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            return false;
         }
-        return false;
     }
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( 20, add.intensity );
@@ -306,15 +309,13 @@ static bool cannabis_effect( Character &u, addiction &add )
 
 static bool alcohol_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_cig ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 310_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 410_minutes;
-        } else {
-            add.sated = 360_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            u.remove_effect( effect_shakes );
+            return false;
         }
-        return false;
     }
     const int in = std::min( 20, add.intensity );
     return alcohol_add( u, in );
@@ -322,15 +323,13 @@ static bool alcohol_effect( Character &u, addiction &add )
 
 static bool diazepam_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_valium ) || u.has_effect( effect_took_xanax ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 310_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 410_minutes;
-        } else {
-            add.sated = 360_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            u.remove_effect( effect_shakes );
+            return false;
         }
-        return false;
     }
     const int in = std::min( 20, add.intensity );
     return benzodiazepine_add( u, in );
@@ -338,24 +337,25 @@ static bool diazepam_effect( Character &u, addiction &add )
 
 static bool opioid_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_opioid_eff ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 310_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 410_minutes;
-        } else {
-            add.sated = 360_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            u.remove_effect( effect_shakes );
+            return false;
         }
-        u.remove_effect( effect_shakes );
-        return false;
     }
 
     bool ret;
 
     const int in = std::min( 20, add.intensity );
     int timer_int = std::min( in / 3, 3 );
-
-    if( x_in_y( in, 24 ) && !u.in_sleep_state() ) {
+    int strength_adjusted = u.enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
+                            u.get_str_base() );
+    // Since we got str_base and not get_str(), make sure we don't forget any strength penalties.
+    int strength_penalty = std::min( u.get_str_bonus(), 0 );
+    strength_adjusted += strength_penalty;
+    if( x_in_y( in, 18 + std::max( strength_adjusted, -17 ) ) && !u.in_sleep_state() ) {
         if( !u.has_effect( effect_withdrawal_opioid_detoxed ) &&
             ( !u.has_effect( effect_withdrawal_opioid_timer ) ) ) {
             u.add_effect( effect_withdrawal_opioid_timer, 48_hours * timer_int, false, timer_int );
@@ -399,15 +399,12 @@ static bool opioid_effect( Character &u, addiction &add )
 
 static bool amphetamine_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_amphetamine_eff ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 310_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 410_minutes;
-        } else {
-            add.sated = 360_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            return false;
         }
-        return false;
     }
     static time_point last_dream = calendar::turn_zero;
     const int in = std::min( add.intensity, 20 );
@@ -452,15 +449,12 @@ static bool amphetamine_effect( Character &u, addiction &add )
 
 static bool cocaine_effect( Character &u, addiction &add )
 {
-    if( u.has_effect( effect_cocaine ) ) {
-        if( u.has_trait( trait_ADDICTIVE ) ) {
-            add.sated = 105_minutes;
-        } else if( u.has_trait( trait_NONADDICTIVE ) ) {
-            add.sated = 135_minutes;
-        } else {
-            add.sated = 120_minutes;
+    // We shouldn't be able to get here if we have the effect, but bail if we have.
+    for( const efftype_id &effect : add.type->get_satisfying_effects() ) {
+        if( u.has_effect( effect ) ) {
+            add.sated = add.type->get_default_sated();
+            return false;
         }
-        return false;
     }
     const int in = std::min( 20, add.intensity );
     return cocaine_add( u, in );
@@ -500,6 +494,7 @@ void add_type::load( const JsonObject &jo, std::string_view )
     mandatory( jo, was_loaded, "name", _name );
     mandatory( jo, was_loaded, "type_name", _type_name );
     mandatory( jo, was_loaded, "description", _desc );
+    optional( jo, false, "satisfying_effects", _satisfying_effects );
     optional( jo, false, "sated", _sated, 2_hours );
     optional( jo, was_loaded, "craving_morale", _craving_morale, morale_type::NULL_ID() );
     optional( jo, was_loaded, "effect_on_condition", _effect );

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -22,6 +22,7 @@ struct add_type {
         morale_type _craving_morale;
         effect_on_condition_id _effect;
         time_duration _sated = 2_hours;
+        std::vector<efftype_id> _satisfying_effects;
         std::string _builtin;
     public:
         addiction_id id;
@@ -52,6 +53,9 @@ struct add_type {
         const time_duration &get_default_sated() const {
             return _sated;
         }
+        const std::vector<efftype_id> &get_satisfying_effects() const {
+            return _satisfying_effects;
+        }
         const effect_on_condition_id &get_effect() const {
             return _effect;
         }
@@ -66,6 +70,7 @@ class addiction
         addiction_id type;
         int intensity = 0;
         time_duration sated = 2_hours;
+        std::vector<efftype_id> effects;
 
         addiction() = default;
         explicit addiction( const addiction_id &t, const int i = 1 )

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6741,7 +6741,7 @@ float Character::get_bmi_lean() const
 {
     int strength_adjusted = enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
                             get_str_base() );
-    //strength BMIs decrease to zero as you starve (muscle atrophy)
+    // Strength BMI adjustment decreases to zero as you starve (muscle atrophy).
     if( get_bmi_fat() < character_weight_category::normal ) {
         const stat_mod wpen = get_weight_penalty();
         return 12.0f + strength_adjusted - wpen.strength;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1264,6 +1264,7 @@ static std::string assemble_stat_details( avatar &u, int sel )
 {
     std::string description_str;
     switch( sel ) {
+        // Strength
         case 0: {
             u.recalc_hp();
             u.set_stored_kcal( u.get_healthy_kcal() );
@@ -1292,18 +1293,19 @@ static std::string assemble_stat_details( avatar &u, int sel )
                        "\n- Grappling and escaping grabs and pull attacks"
                        "\n- Speed and effectiveness of smashing corpses and terrain"
                        "\n- Speed and effectiveness of prying things open, chopping wood, and mining"
-                       "\n- Chance of breaking out of snares and bear traps"
-                       "\n- Power produced by muscle-powered vehicles"
+                       "\n- Chance of breaking out of snares, webs, and other bindings"
+                       "\n- Power produced by muscle-powered vehicles like bicycles"
                        "\n- Most aspects of melee combat"
                        "\n- Resistance to many diseases and poisons"
                        "\n- Ability to drag heavy objects"
                        "\n- Ability to wield heavy weapons with one hand"
-                       "\n- Ability to manage gun recoil"
-                       "\n- Duration of action of various drugs and alcohol" ),
+                       "\n- Ability to manage gun recoil and heavier firearms"
+                       "\n- Duration of action of various drugs and alcohol"
+                       "\n- Resistance to drug withdrawals" ),
                     c_green );
         }
         break;
-
+        // Dexterity
         case 1: {
             description_str =
                 string_format(
@@ -1327,25 +1329,25 @@ static std::string assemble_stat_details( avatar &u, int sel )
                 + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
                 + _( "\n\nAffects:" )
                 + colorize(
-                    _( "\n- Effectiveness of lockpicking"
-                       "\n- Chance of avoiding or escaping grabs and traps"
-                       "\n- Attack speed and accuracy in melee combat"
-                       "\n- Small bonus to melee critical hit chance"
-                       "\n- Chance of damaging melee weapon on attack"
-                       "\n- Effectiveness of disarming traps"
-                       "\n- Chance of success when manipulating with gun modifications"
-                       "\n- Effectiveness of repairing and modifying clothes and armor"
-                       "\n- Effectiveness of stealing"
-                       "\n- Throwing speed"
-                       "\n- Aiming speed"
-                       "\n- Speed and effectiveness of chopping wood with powered tools"
-                       "\n- Chance to get better results when butchering corpses or cutting items"
-                       "\n- Chance of losing control of vehicle when driving"
-                       "\n- Damage from falling" ),
+                    _(
+                        "\n- Attack speed and accuracy in melee and ranged combat"
+                        "\n- Aim and reload speed with ranged weapons"
+                        "\n- Small bonus to melee critical hit chance"
+                        "\n- Picking locks and disarming traps"
+                        "\n- Avoiding or escaping grabs and traps"
+                        "\n- Chance of preventing damage to weapons in melee combat"
+                        "\n- Chance of avoiding damage to items when making repairs"
+                        "\n- Bonus to success rate when modifying guns"
+                        "\n- Stealing success rate"
+                        "\n- Work speed when using powered tools"
+                        "\n- Chance to get better results when butchering corpses or cutting items"
+                        "\n- Maintaining control of vehicles while driving"
+                        "\n- Climbing success rate"
+                        "\n- Resisting fall damage" ),
                     c_green );
         }
         break;
-
+        // Intelligence
         case 2: {
             const int read_spd = u.read_speed();
             // It's actually a float, but we use a double here for legibility.
@@ -1370,8 +1372,8 @@ static std::string assemble_stat_details( avatar &u, int sel )
                             COL_STAT_BONUS )
                 + _( "\n\nAffects:" )
                 + colorize(
-                    _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
-                       "\n- Detection and disarming traps"
+                    _( "\n- Learning speed"
+                       "\n- Teaching ability"
                        "\n- Bandaging wounds and stopping blood loss"
                        "\n- Chance of success when installing bionics"
                        "\n- Chance of success when manipulating with gun modifications"
@@ -1380,11 +1382,12 @@ static std::string assemble_stat_details( avatar &u, int sel )
                        "\n- Chance of bypassing vehicle security system"
                        "\n- Chance to get better results when disassembling items"
                        "\n- Bash damage with whips and flails"
-                       "\n- Chance of being paralyzed by fear attack" ),
+                       "\n- Chance of being paralyzed by fear attack"
+                       "\n- Speed of recovery from addiction" ),
                     c_green );
         }
         break;
-
+        // Perception
         case 3: {
             description_str = string_format(
                                   _( "A measure of wits, proprioception, and acuity.  Perceptive characters excel at ranged accuracy, critical hits, and striking weakpoints.  Perception is broadly useful in combat, but most benefits stabbing weapons.\n\n" ) );
@@ -1402,19 +1405,16 @@ static std::string assemble_stat_details( avatar &u, int sel )
                 + string_format( _( "\nPersuasion: %1s \nDeception: %2s" ), u.persuade_skill(), u.lie_skill() )
                 + _( "\n\nAffects:" )
                 + colorize(
-                    _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
-                       "\n- Precision and reliability with ranged attacks"
+                    _( "\n- Precision and reliability with all ranged attacks"
                        "\n- Large bonus to melee critical hit chance"
-                       "\n- Reduces chance for stabbing weapons to get stuck"
+                       "\n- Spotting hidden creatures and hazards"
+                       "\n- Preventing stabbing weapons from getting stuck in enemies"
                        "\n- Sight distance on overmap"
-                       "\n- Effectiveness of stealing"
-                       "\n- Throwing accuracy"
-                       "\n- Disinfecting your own wounds and using first aid on others"
-                       "\n- Chance of losing control of vehicle when driving"
-                       "\n- Chance of spotting hidden creatures and traps"
+                       "\n- Stealing success rate"
+                       "\n- Providing medical care, especially to others"
+                       "\n- Maintaining control of vehicles when driving"
                        "\n- Speed and effectiveness of lockpicking and foraging"
-                       "\n- Morale bonus when playing a musical instrument"
-                       "\n- Effectiveness of repairing and modifying clothes and armor" ),
+                       "\n- Morale bonus when playing a musical instrument" ),
                     c_green );
         }
         break;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -441,13 +441,29 @@ void suffer::while_grabbed( Character &you )
 
 void suffer::from_addictions( Character &you )
 {
-    time_duration timer = -50_hours;
-    if( you.has_trait( trait_ADDICTIVE ) ) {
-        timer = -60_hours;
-    } else if( you.has_trait( trait_NONADDICTIVE ) ) {
-        timer = -40_hours;
+    // Early return if we don't have any addictions.
+    if( you.addictions.empty() ) {
+        return;
     }
+    time_duration recovery_threshold = -60_hours;
+    const bool addictive = you.has_trait( trait_ADDICTIVE );
+    const bool nonaddictive = you.has_trait( trait_NONADDICTIVE );
+    if( addictive ) {
+        recovery_threshold = -70_hours;
+    } else if( nonaddictive ) {
+        recovery_threshold = -50_hours;
+    }
+    // Intelligence isn't just book smarts, it's willpower, patience, and long-term thinking.
+    time_duration int_adjustment = 1_hours * ( std::clamp( you.get_int(), 1, 30 ) );
+    // Add rather than subtract because timer is negative.
+    recovery_threshold += int_adjustment;
     for( addiction &cur_addiction : you.addictions ) {
+        for( const efftype_id &effect : cur_addiction.type->get_satisfying_effects() ) {
+            if( you.has_effect( effect ) ) {
+                cur_addiction.sated = cur_addiction.type->get_default_sated();
+                break;
+            }
+        }
         if( cur_addiction.sated <= 0_turns && cur_addiction.intensity >= MIN_ADDICTION_LEVEL ) {
             cur_addiction.run_effect( you );
         }
@@ -456,8 +472,8 @@ void suffer::from_addictions( Character &you )
         if( rng( 1, 60 ) < cur_addiction.intensity ) {
             cur_addiction.sated -= 4_minutes;
         }
-        // Higher intensity addictions heal faster.
-        if( cur_addiction.sated - 10_minutes * cur_addiction.intensity < timer ) {
+        // Addiction recovery is faster at higher intensities, most people will trend to a midpoint.
+        if( cur_addiction.sated - 10_minutes * cur_addiction.intensity < recovery_threshold ) {
             if( cur_addiction.intensity <= 2 ) {
                 you.rem_addiction( cur_addiction.type );
                 break;


### PR DESCRIPTION
#### Summary
Being high blocks cravings

#### Purpose of change
Being high is supposed to block addiction cravings. I had assumed this was being handled in suffer::from_addictions(), however, it wasn't. This was due to me misunderstanding how the system works. addiction is our current character's instance of the addiction, add_type is the basic definition of said addiction.

#### Describe the solution
- Addiction jsons now define satisfying effects which when active skip all cravings and withdrawals.
- Intelligence now helps characters get over addictions faster. This is because int is not just IQ or book smarts, it's willpower, patience, long-term planning, etc. Addictive and Addiction-Reisistant count the same as +/- 10 intelligence.
- Strength now helps characters resist going into withdrawal. This is because strength is not just muscle, it's overall fortitude. This includes strength from mutations, but not strength from bionics.
- Fixed some of the stat descriptions in chargen.
- Upped the base satisfied timer for most substances. It's reduced by addiction intensity and got kind of obnoxious as it was.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
