### PR TITLE
makes the survivorcoat use the proper sprite

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_overcoats.json
+++ b/data/json/items/armor/bespoke_armor/custom_overcoats.json
@@ -13,7 +13,7 @@
     "to_hit": -1,
     "material": [ "soft_rubber", "nylon", "kevlar" ],
     "symbol": "[",
-    "looks_like": "longcoat_leather",
+    "looks_like": "longcoat_survivor",
     "color": "brown",
     "armor": [
       {


### PR DESCRIPTION
#### Summary
makes the survivorcoat use the proper sprite

#### Purpose of change
Drip
#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
