### PR TITLE
Snow also slows monster movement

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1632,6 +1632,14 @@ int monster::calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t )
         movecost /= 2;
     } else {
         movecost = ( ( 50 * source_cost ) + ( 50 * dest_cost ) ) / 2.0;
+        // Snow depth movement penalty (outdoor, unroofed tiles only)
+        if( here.is_outside( pos_bub() ) && !here.is_roofed( pos_bub() ) ) {
+            const double snow_mm = get_weather().get_snow_depth_mm( pos_abs_omt() );
+            if( snow_mm >= 100 ) {
+                const int penalty = snow_mm >= 500 ? 100 : ( snow_mm >= 250 ? 50 : 20 );
+                movecost += penalty;
+            }
+        }
     }
 
     return movecost;


### PR DESCRIPTION
#### Summary
Snow also slows monster movement

#### Purpose of change
Characters were getting hit with up to +100 movecost for traveling through snow, and monsters were not.

#### Describe the solution
Now they are. There are probably some monsters who should not care, or who should be worse off, and probably huge or tiny creatures ought to care less, but this is fine for now.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
