### PR TITLE
Fix alt map key

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain.json
+++ b/data/mods/alt_map_key/overmap_terrain.json
@@ -5292,14 +5292,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "smallscrapyard_ocu" ],
-    "copy-from": "smallscrapyard_ocu",
-    "name": "scrap yard",
-    "sym": "s",
-    "color": "light_gray"
-  },
-  {
-    "type": "overmap_terrain",
     "id": "music_venue",
     "copy-from": "music_venue",
     "name": "music venue",


### PR DESCRIPTION
#### Summary
Fix alt map key

#### Purpose of change
Submitted by Dingus Khan on discord. Fixes the error message for players using the alternate map key mod.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
