### PR TITLE
Fixing funnel remainder handling and int truncation

### DIFF
--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -324,9 +324,13 @@ double trap::funnel_turns_per_charge( double rain_depth_mm_per_hour ) const
 /**
  * Main routine for filling funnels from weather effects.
  */
-static void fill_funnels( int rain_depth_mm_per_hour, const trap &tr )
+static void fill_funnels( double rain_depth_mm_per_hour, const trap &tr )
 {
     const double turns_per_charge_d = tr.funnel_turns_per_charge( rain_depth_mm_per_hour );
+    if( turns_per_charge_d == 0.0 ) {
+        return;
+    }
+    const double charges_per_turn = 1.0 / turns_per_charge_d;
 
     map &here = get_map();
     // Give each funnel on the map a chance to collect the rain.
@@ -342,28 +346,11 @@ static void fill_funnels( int rain_depth_mm_per_hour, const trap &tr )
             }
         }
 
-        if( container != items.end() && turns_per_charge_d > 0.0 ) {
-            int whole = static_cast<int>( std::floor( turns_per_charge_d ) );
-            double frac = turns_per_charge_d - whole;
-
-            // If turns_per_charge < 1, always fill (multiple charges per turn possible)
-            if( turns_per_charge_d < 1.0 ) {
-                int count = static_cast<int>( std::ceil( 1.0 / turns_per_charge_d ) );
-                for( int i = 0; i < count; i++ ) {
-                    container->add_rain_to_container( 1 );
-                }
+        if( container != items.end() ) {
+            int charges = roll_remainder( charges_per_turn );
+            if( charges > 0 ) {
+                container->add_rain_to_container( charges );
                 container->set_age( 0_turns );
-            } else {
-                // Base chance: one charge every 'whole' turns
-                if( one_in( whole ) ) {
-                    container->add_rain_to_container( 1 );
-                    container->set_age( 0_turns );
-                }
-                // Fractional chance to add an *extra* charge
-                if( frac > 0.0 && x_in_y( frac, 1.0 ) ) {
-                    container->add_rain_to_container( 1 );
-                    container->set_age( 0_turns );
-                }
             }
         }
     }
@@ -373,7 +360,7 @@ static void fill_funnels( int rain_depth_mm_per_hour, const trap &tr )
  * Fill funnels and makeshift funnels from weather effects.
  * @see fill_funnels
  */
-static void fill_water_collectors( int mmPerHour )
+static void fill_water_collectors( double mmPerHour )
 {
     for( const trap * const &e : trap::get_funnels() ) {
         fill_funnels( mmPerHour, *e );


### PR DESCRIPTION
#### Summary
Fixing a bug where funnels weren't working inside the reality bubble for light drizzle, and one where they were filling containers way too fast for rain in the reality bubble.

#### Purpose of change
The first issue thing I noticed was that nearby funnels weren't filling containers in a light drizzle as I was doing other stuff. In the code, I saw that precip_mm_per_hour was a double, and was handled elsewhere as a double, but fill_water_collectors and fill_funnels treated the parameters as an int.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/7b831e8b4ee44ea61c9519f775825940d316597f/src/weather.cpp#L376

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/7b831e8b4ee44ea61c9519f775825940d316597f/src/weather.cpp#L327



During testing/investigating I noticed that the intended refill rates were documented in #2233, which also made me realize that the containers were filling way too fast in rain, like a 60L tank went from empty to almost full in two hours. I did test that the rate was much slower when the funnel/tank is outside the reality bubble (and that the prior error was also specific to within the reality bubble), so the issue is specific to fill_funnels and isn't in the out of reality bubble code. What I ended up figuring out was that whole was used to represent the int part of turns_per_charge_d, and frac was used to represent the remainder/decimals, but since frac is the decimal of the number of turns it takes to add a charge, and not the decimal of the number of charges added a turn, it doesn't make sense to have a frac chance of adding one water. Like if it takes 500.9 turns to add 1 water, then we don't want to have a 90% of adding a water each turn.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/7b831e8b4ee44ea61c9519f775825940d316597f/src/weather.cpp#L346-L347

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/7b831e8b4ee44ea61c9519f775825940d316597f/src/weather.cpp#L363-L366



#### Describe the solution

I changed fill_water_collectors and fill_funnels so the water rate is a double, and I changed the increase in charges to use roll_remainder on 1 / turns per charges (i.e. so charges per turns) instead of the prior conditional on <1 turn per charge and the whole/fraction split.

#### Describe alternatives you've considered

I guess if we really wanted the water rate thing to be an int, then we could have multiplied it by 2, like at when fill_water_collectors is called, and then divided it by 2 later in fill_funnels, but since precipitation was a double elsewhere I didn't think that keeping it as an int was necessary enough to warrant those hoops.

I'm getting the charge rate per turns by dividing 1 by the turns per charge from funnel_turns_per_charge, which is a bit weird since funnel_turns_per_charge divides 1 by  charges per turn, but funnel_turns_per_charge had non-trivial logic I was wary about duplicating, and also there's precedent in retroactively_fill_from_funnel which also divides 1 by turns per charge from funnel_turns_per_charge.

#### Testing

For testing you'd want a funnel, a container that works with the funnel, and modifying the weather via debug menu to light drizzle or rain. You should verify that on rain and such, if you place the tank and activate the funnel on it, and wait an hour or hours, the water increase is reasonable, as in line with out of reality bubble filling or what was mentioned in #2233. For light drizzle, it's normal for the water to not increase after a couple hours, so you may have to wait more like 6 hours, but water should eventually increase.

For stuff outside the reality bubble that's handled by different code that should be unchanged, though if you do want to test it I'd mention that 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
