### PR TITLE
Fix ledge view

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -556,10 +556,9 @@ static bool majority_rule( const bool a_vote, const bool b_vote, const bool c_vo
 bool Creature::sees( const map &here, const Creature &critter ) const
 {
     const Character *ch = critter.as_character();
-
+    bool critter_is_monster = critter.is_monster();
     const tripoint_bub_ms pos = pos_bub( here );
     const tripoint_bub_ms critter_pos = critter.pos_bub( here );
-
     // Creatures always see themselves (simplifies drawing).
     if( &critter == this ) {
         return true;
@@ -597,7 +596,6 @@ bool Creature::sees( const map &here, const Creature &critter ) const
         here.has_field_at( critter_pos, field_fd_last_known ) && critter.is_avatar() ) {
         return true;
     }
-
     // This check is ridiculously expensive so defer it to after everything else.
     // REVIEW: Is this really expensive, or an old comment?
     auto visible = []( const Character * ch ) {
@@ -618,8 +616,8 @@ bool Creature::sees( const map &here, const Creature &critter ) const
         return false;
     }
 
-    // If we cannot see without any of the penalties below, bail now.
-    if( !sees( here, critter_pos, critter.is_avatar() ) ) {
+    // Do some geometry checks and also look at visibility from mutations and stuff.
+    if( !sees( here, critter_pos, !critter_is_monster ) ) {
         return false;
     }
 
@@ -632,12 +630,10 @@ bool Creature::sees( const map &here, const Creature &critter ) const
     if( posz() != critter.posz() ) {
         different_levels = true;
     }
-
     bool has_camouflage = false;
     bool has_water_camouflage = false;
     bool has_night_invisibility = false;
-
-    if( critter.is_monster() ) {
+    if( critter_is_monster ) {
         has_camouflage = critter.has_flag( mon_flag_CAMOUFLAGE );
         has_water_camouflage = critter.has_flag( mon_flag_WATER_CAMOUFLAGE ) ||
                                ( critter.get_size() < creature_size::large && critter.has_flag( mon_flag_NO_BREATHE ) );
@@ -645,18 +641,15 @@ bool Creature::sees( const map &here, const Creature &critter ) const
     }
     bool is_underwater = critter.is_likely_underwater( here );
     bool is_invisible = critter.has_effect( effect_invisibility );
-
     // Check if creature is digging and the tile is diggable
     if( target_range > 2 && critter.digging() &&
         here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos_bub( here ) ) ) {
         return false;
     }
-
     // Camouflage or Water Camouflage checks
     if( has_camouflage && target_range > this->spot_check() ) {
         return false;
     }
-
     if( is_underwater || here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ) ||
         ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub( here ) ) &&
           critter.get_size() < creature_size::medium ) ) {
@@ -664,17 +657,14 @@ bool Creature::sees( const map &here, const Creature &critter ) const
             return false;
         }
     }
-
     // Night Invisibility check
     if( has_night_invisibility && here.light_at( critter.pos_bub( here ) ) <= lit_level::LOW ) {
         return false;
     }
-
     // Invisible effect
     if( is_invisible ) {
         return false;
     }
-
     // Underwater visibility check with majority rule
     if( !is_likely_underwater( here ) && is_underwater &&
         majority_rule( critter.has_flag( mon_flag_WATER_CAMOUFLAGE ),
@@ -682,17 +672,14 @@ bool Creature::sees( const map &here, const Creature &critter ) const
                        different_levels ) ) {
         return false;
     }
-
     if( ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub( here ) ) ) &&
         critter.get_size() < creature_size::large ) {
         return false;
     }
-
     if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SMALL_HIDE, critter.pos_bub( here ) ) &&
         critter.has_flag( mon_flag_SMALL_HIDER ) ) {
         return false;
     }
-
     int ledge_concealment = 0;
     if( different_levels ) {
         ledge_concealment = ( here.ledge_concealment( pos_bub( here ), critter.pos_bub( here ) ) );
@@ -700,7 +687,7 @@ bool Creature::sees( const map &here, const Creature &critter ) const
     visibility_result vis = here.sees_full( pos_bub( here ), critter.pos_bub( here ), target_range,
                                             true, false );
     const int concealment = std::max( vis.concealment, ledge_concealment );
-    if( ch != nullptr ) {
+    if( !critter_is_monster ) {
         if( concealment > critter.eye_level() ) {
             return false;
         } else {
@@ -723,7 +710,7 @@ int Creature::eye_level() const
     }
 }
 
-bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_character,
                      int range_mod ) const
 {
     if( std::abs( posz() - t.z() ) > fov_3d_z_range ) {
@@ -733,28 +720,25 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
     const tripoint_bub_ms pos = pos_bub( here );
 
     // Check for adjacent high-concealment tiles that would block vision.
-    if( rl_dist( pos, t ) > 2 ) {
+    // > 2 because any viewer can see over adjacent concealment.
+    if( square_dist( pos, t ) > 2 ) {
         // Get the direction to the target.
         const int dx = t.x() - pos.x();
         const int dy = t.y() - pos.y();
-
         const int adj_x = pos.x() + ( dx > 0 ? 1 : ( dx < 0 ? -1 : 0 ) );
         const int adj_y = pos.y() + ( dy > 0 ? 1 : ( dy < 0 ? -1 : 0 ) );
         const tripoint_bub_ms adjacent( adj_x, adj_y, pos.z() );
-
         if( adjacent != pos && here.inbounds( adjacent ) &&
             eye_level() < here.concealment( adjacent ) ) {
             return false;
         }
     }
-
     const int range_cur = sight_range( here.ambient_light_at( t ) );
     const int range_day = sight_range( default_daylight_level() );
     const int range_night = sight_range( 0 );
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );
     const int wanted_range = rl_dist( pos, t );
-
     if( wanted_range <= range_min ||
         ( wanted_range <= range_max &&
           here.ambient_light_at( t ) > here.get_cache_ref( t.z() ).natural_light_level_cache ) ) {
@@ -770,12 +754,16 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
         if( range_mod > 0 ) {
             range = std::min( range, range_mod );
         }
-        if( is_avatar ) {
-            // Special case monster -> player visibility, forcing it to be symmetric with player vision.
-            const float player_visibility_factor = get_player_character().visibility() / 100.0f;
-            int adj_range = std::floor( range * player_visibility_factor );
+        if( is_character ) {
+            // Special case monster -> character visibility, forcing it to be symmetric with player vision.
+            Creature *guy = get_creature_tracker().creature_at( t );
+            int adj_range = range;
+            if( guy != nullptr && !guy->is_monster() ) {
+                const float character_visibility_factor = guy->as_character()->visibility() / 100.0f;
+                adj_range = std::floor( range * character_visibility_factor );
+            }
             return adj_range >= wanted_range &&
-                   here.get_cache_ref( posz() ).seen_cache[pos.x()][pos.y()] > LIGHT_TRANSPARENCY_SOLID;
+                   here.get_cache_ref( t.z() ).seen_cache[ t.x()][t.y()] > LIGHT_TRANSPARENCY_SOLID;
         } else {
             return here.sees( pos, t, range );
         }

--- a/src/creature.h
+++ b/src/creature.h
@@ -404,7 +404,8 @@ class Creature : public viewer
          */
         /*@{*/
         bool sees( const map &here, const Creature &critter ) const override;
-        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+        // is_character is used if the target is a character, not the viewer.
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_character = false,
                    int range_mod = 0 ) const override;
         /*@}*/
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4188,7 +4188,6 @@ int map::collapse_check( const tripoint_bub_ms &p ) const
         // is deemed not to be sufficient either.
         return 0;
     }
-
     int num_supports = p.z() == OVERMAP_DEPTH ? 0 : -5;
     // if there's support below, things are less likely to collapse
     if( p.z() > -OVERMAP_DEPTH ) {
@@ -8652,9 +8651,8 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
     if( viewer_p.z() == target_p.z() ) {
         return 0;
     }
-
-    // Find ledge between viewer and target
-    // Only the first ledge found is calculated for performance reasons
+    // Find ledge between viewer and target.
+    // Only the first ledge found is calculated for performance reasons.
     tripoint_bub_ms high_p;
     tripoint_bub_ms low_p;
     if( viewer_p.z() > target_p.z() ) {
@@ -8683,7 +8681,7 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
     // Similarly adjust relative Z comparisons.
     const float adjusted_viewer_z = viewer_p.z() * 2;
     // "Opposite" of the angle between the viewer level and ledge
-    const float adjusted_ledge_z_delta = ( ledge_p.z() ) - adjusted_viewer_z;
+    const float adjusted_ledge_z_delta = ( ledge_p.z() * 2 ) - adjusted_viewer_z - 1;
     const float tangent = adjusted_ledge_z_delta / dist_to_ledge_base;
     // Absolute level concealed by ledge, anything below this point is invisible
     const float covered_z = adjusted_viewer_z + ( tangent * flat_dist );


### PR DESCRIPTION
#### Summary
Fix ledge view

#### Purpose of change
- Ledges concealment was behaving inconsistently because of a bad assumption about how the math between Z levels would work out. Since z can be 0, this meant that at z0, you couldn't see down into craters and other pits very well. This has been fixed.
- Monsters could not see down over ledges like at all. This was because of a very old bit of code in creature::sees() which was accidentally checking the light level at the target's z and the monster's xy. This was almost always going to be inside of a wall or a closed-up building, so the light level for monsters was always 0 and the function would return false. This has been fixed, and now monsters on roofs or crater edges can see you. An issue still remains where monsters on the ground can see you when you're on a roof edge, but the inverse is not true. That's next on the list.
- Fixed some code that was making character visibility from mutations only work for the player.


#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
