### PR TITLE
Fix string extraction for translation in a few spots

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1753,7 +1753,8 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         inv_title += _( " which device" ) + used_device_name;
         select_one_edevice.set_title( inv_title );
         if( select_one_edevice.empty() ) {
-            popup( std::string( _( "You have no eligible devices to " + action_name + "." ) ), PF_GET_KEY );
+        std::string eligible_devices = ( _( "You have no eligible devices to " ) );
+            popup( std::string( _( eligible_devices + action_name + "." ) ), PF_GET_KEY );
             return drop_locations();
         }
         drop_locations returned_device;
@@ -1763,13 +1764,15 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         }
         return returned_device;
     } else {
-        inventory_multiselector inv_s( who, preset, _( "Select devices to " + action_name ) );
+        std::string select_devices = ( _( "Select devices to " ) );
+        inventory_multiselector inv_s( who, preset, _( select_devices + action_name ) );
         inv_s.add_character_items( who );
         inv_s.add_nearby_items( PICKUP_RANGE );
         inv_title += _( " which devices" ) + used_device_name;
         inv_s.set_title( inv_title );
         if( inv_s.empty() ) {
-            popup( std::string( _( "You have no eligible devices to " + action_name + "." ) ), PF_GET_KEY );
+        std::string eligible_devices = ( _( "You have no eligible devices to " ) );
+            popup( std::string( _( eligible_devices + action_name + "." ) ), PF_GET_KEY );
             return drop_locations();
         }
         return inv_s.execute();


### PR DESCRIPTION
#### Summary
Fix string extraction for translation in a few spots

#### Purpose of change
Some of the edevices stuff appears to not be getting extracted. It uses _( ) but I think it's doing it in a way that doesn't actually work.

#### Describe the solution
define a few strings as std::string and display those in the message as variables.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
