### PR TITLE
Implement part 1 of the ledge view fix

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -248,7 +248,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     }
     bool via_ramp = false;
     if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_UP_LOW, you_pos ) &&
-               m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
+        m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {
         return false;
     } else if( !m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, you_pos ) &&
                m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest_loc ) ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1753,7 +1753,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         inv_title += _( " which device" ) + used_device_name;
         select_one_edevice.set_title( inv_title );
         if( select_one_edevice.empty() ) {
-        std::string eligible_devices = ( _( "You have no eligible devices to " ) );
+            std::string eligible_devices = ( _( "You have no eligible devices to " ) );
             popup( std::string( _( eligible_devices + action_name + "." ) ), PF_GET_KEY );
             return drop_locations();
         }
@@ -1771,7 +1771,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
         inv_title += _( " which devices" ) + used_device_name;
         inv_s.set_title( inv_title );
         if( inv_s.empty() ) {
-        std::string eligible_devices = ( _( "You have no eligible devices to " ) );
+            std::string eligible_devices = ( _( "You have no eligible devices to " ) );
             popup( std::string( _( eligible_devices + action_name + "." ) ), PF_GET_KEY );
             return drop_locations();
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8652,9 +8652,8 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
     if( viewer_p.z() == target_p.z() ) {
         return 0;
     }
-
-    // Find ledge between viewer and target
-    // Only the first ledge found is calculated for performance reasons
+    // Find ledge between viewer and target.
+    // For performance reasons, only the first ledge found is calculated.
     tripoint_bub_ms high_p;
     tripoint_bub_ms low_p;
     if( viewer_p.z() > target_p.z() ) {
@@ -8673,23 +8672,23 @@ int map::ledge_concealment( const tripoint_bub_ms &viewer_p, const tripoint_bub_
         }
         return true;
     } );
-
     float dist_to_ledge_base = trig_dist_precise( viewer_p, tripoint_bub_ms( ledge_p.x(), ledge_p.y(),
                                viewer_p.z() ) );
-    // Adjustment to ledge distance because ledge is assumed to be between two grids
+    // Adjustment to ledge distance because ledge is assumed to be between two grids.
     dist_to_ledge_base *= ( viewer_p.z() < target_p.z() ) ? -2.0f : 2.0f;
     const float flat_dist = trig_dist_precise( viewer_p, tripoint_bub_ms( target_p.xy(),
                             viewer_p.z() ) );
-    // Similarly adjust relative Z comparisons.
-    const float adjusted_viewer_z = viewer_p.z() * 2;
-    // "Opposite" of the angle between the viewer level and ledge
-    const float adjusted_ledge_z_delta = ( ledge_p.z() ) - adjusted_viewer_z;
+    // "Opposite" of the angle between the viewer level and ledge.
+    const float adjusted_ledge_z_delta =
+        ( ledge_p.z() - viewer_p.z() ) * 2 - 1;
     const float tangent = adjusted_ledge_z_delta / dist_to_ledge_base;
-    // Absolute level concealed by ledge, anything below this point is invisible
-    const float covered_z = adjusted_viewer_z + ( tangent * flat_dist );
+    // Relative to the viewer's Z level.
+    const float covered_z = tangent * flat_dist;
     // Compare adjusted target Z to covered area. Multiply by 100 to compare to eye_level().
-    int ledge_concealment = static_cast<int>( std::round( 100 * ( covered_z -
-                            ( target_p.z() * 2 ) ) ) );
+    const float target_z_delta = ( target_p.z() - viewer_p.z() ) * 2;
+    int ledge_concealment = static_cast<int>(
+                                std::round( 100.f * ( covered_z - target_z_delta ) )
+                            );
     return std::max( ledge_concealment, 0 );
 }
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -936,8 +936,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
             const om_vision_level vision = overmap_buffer.seen( omp );
             const bool los = overmap_buffer.seen_more_than( omp, om_vision_level::details ) &&
-                               ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
-                                 you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
+                             ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
+                               you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
 
             // the full string from the ter_id including _north etc.
             std::string id;
@@ -983,19 +983,20 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                 }
             }
 
-             if( vision != om_vision_level::unseen ) {
-                 if( draw_overlays && uistate.overmap_debug_mongroup ) {
-                     std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes = overmap_buffer.hordes_at(
-                                 omp );
-                     if( !hordes.empty() ) {
-                         static const std::string empty_string;
-                         draw_from_id_string_om( "mon_zombie", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                     }
-                 }
-                 if( showhordes && los ) {
-                         static const std::string empty_string;
-                     const int horde_size = overmap_buffer.get_horde_size( omp, horde_map_flavors::active );
-                     if( horde_size >= HORDE_VISIBILITY_SIZE ) {
+            if( vision != om_vision_level::unseen ) {
+                if( draw_overlays && uistate.overmap_debug_mongroup ) {
+                    std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes = overmap_buffer.hordes_at(
+                                omp );
+                    if( !hordes.empty() ) {
+                        static const std::string empty_string;
+                        draw_from_id_string_om( "mon_zombie", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                    }
+                }
+                if( showhordes && los ) {
+                    static const std::string empty_string;
+                    const int horde_size = overmap_buffer.get_horde_size( omp, horde_map_flavors::active );
+                    if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                         // Scale down the range of horde population, which can be 1-576 to a range of 1-10.
                         static constexpr int horde_thresholds[] = {
                             5, 13, 27, 47, 73, 106, 147, 195, 251, 577
@@ -1008,38 +1009,44 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                         const std::string horde_id = string_format( "overmap_horde_%d", sprite_size );
                         if( find_tile_with_season( horde_id ) ) {
                             //NOLINTNEXTLINE(cata-translate-string-literal)
-                             draw_from_id_string_om( string_format( horde_id, sprite_size ),
-                                                  TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                            draw_from_id_string_om( string_format( horde_id, sprite_size ),
+                                                    TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
                         } else {
-                             // a little bit of hardcoded fallbacks for hordes for
-                             // tilesets that don't have overmap_horde_X sprites defined.
-                             switch( sprite_size ) {
-                                 case 1:
-                                     draw_from_id_string_om( "mon_zombie", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                                     break;
-                                 case 2:
-                                     draw_from_id_string_om( "mon_zombie_tough", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                                     break;
-                                 case 3:
-                                     draw_from_id_string_om( "mon_zombie_brute", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                                     break;
-                                 case 4:
-                                     draw_from_id_string_om( "mon_zombie_hulk", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                                     break;
-                                 case 5:
-                                     draw_from_id_string_om( "mon_zombie_necro", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                                     break;
-                                 case 6:
-                                 case 7:
-                                 case 8:
-                                 case 9:
-                                 case 10:
-                                     draw_from_id_string_om( "mon_zombie_master", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0, lit_level::LIT, false, height_3d, 1.0f, 1.0f );
-                             };
-                         }
-                     }
-                 }
-             }
+                            // a little bit of hardcoded fallbacks for hordes for
+                            // tilesets that don't have overmap_horde_X sprites defined.
+                            switch( sprite_size ) {
+                                case 1:
+                                    draw_from_id_string_om( "mon_zombie", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                    break;
+                                case 2:
+                                    draw_from_id_string_om( "mon_zombie_tough", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                    break;
+                                case 3:
+                                    draw_from_id_string_om( "mon_zombie_brute", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                    break;
+                                case 4:
+                                    draw_from_id_string_om( "mon_zombie_hulk", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                    break;
+                                case 5:
+                                    draw_from_id_string_om( "mon_zombie_necro", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                                    break;
+                                case 6:
+                                case 7:
+                                case 8:
+                                case 9:
+                                case 10:
+                                    draw_from_id_string_om( "mon_zombie_master", TILE_CATEGORY::MONSTER, empty_string, omp, 0, 0,
+                                                            lit_level::LIT, false, height_3d, 1.0f, 1.0f );
+                            };
+                        }
+                    }
+                }
+            }
             if( ( uistate.place_terrain || uistate.place_special ) &&
                 overmap_ui::is_generated_omt( omp.xy() ) ) {
                 // Highlight areas that already have been generated.


### PR DESCRIPTION
#### Summary
Implement part 1 of the ledge view fix

#### Purpose of change
The primary problem with ledge view was that it was inconsistent on different Z levels. That was a problem. This was because it was relying on multiplying the Z level, but the Z level can be zero, so instead we'll rely on the difference and then work with that number.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
