### PR TITLE
Monsters can see down ledges

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -723,7 +723,7 @@ int Creature::eye_level() const
     }
 }
 
-bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_character,
                      int range_mod ) const
 {
     if( std::abs( posz() - t.z() ) > fov_3d_z_range ) {
@@ -770,18 +770,19 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
         if( range_mod > 0 ) {
             range = std::min( range, range_mod );
         }
-        if( is_avatar ) {
-            // Special case monster -> player visibility, forcing it to be symmetric with player vision.
-            const float player_visibility_factor = get_player_character().visibility() / 100.0f;
-            int adj_range = std::floor( range * player_visibility_factor );
-            return adj_range >= wanted_range &&
-                   here.get_cache_ref( posz() ).seen_cache[pos.x()][pos.y()] > LIGHT_TRANSPARENCY_SOLID;
+        if( is_character ) {
+            // Get character visibility from things like mutations.
+            Creature *ch = get_creature_tracker().creature_at( t );
+            if( ch != nullptr ) {
+                const float character_visibility_factor = ch->as_character()->visibility() / 100.0f;
+                int adj_range = std::floor( range * character_visibility_factor );
+                return adj_range >= wanted_range && here.sees( pos, t, range );
+            }
         } else {
             return here.sees( pos, t, range );
         }
-    } else {
-        return false;
     }
+    return false;
 }
 
 // Helper function to check if potential area of effect of a weapon overlaps vehicle

--- a/src/creature.h
+++ b/src/creature.h
@@ -404,7 +404,8 @@ class Creature : public viewer
          */
         /*@{*/
         bool sees( const map &here, const Creature &critter ) const override;
-        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+        // is_character means that the thing we are trying to see is a character, not that the viewer is one.
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_character = false,
                    int range_mod = 0 ) const override;
         /*@}*/
 


### PR DESCRIPTION
#### Summary
Monsters can see down ledges

#### Purpose of change
Monsters were unable to see down ledges. #2880 attempted to fix this, but I misunderstood how the function was working (it had some kind of a kludge that I think predated the "monsters can see you if you're on a roof" thing) and caused some problems. Now I have seemingly come up with an easier and better solution.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
