### PR TITLE
No memory cards from smartphone disassembly

### DIFF
--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -1760,13 +1760,7 @@
     "difficulty": 1,
     "time": "3 m 30 s",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "scrap_aluminum", 1 ] ],
-      [ [ "medium_battery_cell", 1 ] ],
-      [ [ "small_lcd_screen", 1 ] ],
-      [ [ "memory_card", 1 ] ],
-      [ [ "processor", 1 ] ]
-    ]
+    "components": [ [ [ "scrap_aluminum", 1 ] ], [ [ "medium_battery_cell", 1 ] ], [ [ "small_lcd_screen", 1 ] ], [ [ "processor", 1 ] ] ]
   },
   {
     "result": "smart_phone_locked",
@@ -1776,13 +1770,7 @@
     "difficulty": 1,
     "time": "3 m 30 s",
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "scrap_aluminum", 1 ] ],
-      [ [ "medium_battery_cell", 1 ] ],
-      [ [ "small_lcd_screen", 1 ] ],
-      [ [ "memory_card", 1 ] ],
-      [ [ "processor", 1 ] ]
-    ]
+    "components": [ [ [ "scrap_aluminum", 1 ] ], [ [ "medium_battery_cell", 1 ] ], [ [ "small_lcd_screen", 1 ] ], [ [ "processor", 1 ] ] ]
   },
   {
     "result": "mp3",


### PR DESCRIPTION
#### Summary
No memory cards from smartphone disassembly

#### Purpose of change
People were getting around the intended challenge of smartphones being locked by disassembling them for their memory cards. That hurts my brain. What did they think locked means?!

Smartphones used to use removable SD cards in addtion to an integrated one, but they basically only use the integrated these days, and moreover these are encrypted in a way which pretty much requires the phone's hardware to use, even in non-Cataclysm times with all the power of the internet at our disposal.

#### Describe the solution
Smartphone disassembly no longer yields a memory card.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
