### PR TITLE
fix supermarket permanent marker charges

### DIFF
--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -624,7 +624,7 @@
       { "item": "stapler", "prob": 1 },
       { "item": "office_holepunch", "prob": 1 },
       { "item": "scissors", "prob": 1 },
-      { "group": "writing_utensils", "count": [ 6, 20 ], "prob": 80, "charges": 100 }
+      { "group": "writing_utensils", "count": [ 6, 20 ], "prob": 80, "charges": 500 }
     ]
   },
   {


### PR DESCRIPTION
Permanent markers spawned with 100/500 charges, it seemed odd considering the location and how the pens and pencils have full charges. Now they spawn with 500/500 charges, pens and pencils still spawn with 100/100 charges.

Pens and pencils can't write on terrain which is the only way to deplete writing utensils as far as I know, meaning I can't test if they actually have 500/100 charges despite showing 100/100.

A more proper fix might be creating a whole new 'writing_utensils_unused' group in the supplies.json that properly sets the charges to max for each item and change the supermarket to use that group, but changing the 1 to a 5 was my first idea to fix it and I think it would be weird to have a group just for one location, also I don't want to go through all the locations I can think of that might have new pens, pencils, and markers stocked and add the new item group to the spawn lists for certain tiles. Maybe when I'm full of manic energy I'll do that, or not.