### PR TITLE
Hides from tiny dogs and no fat from rabbits

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -617,9 +617,7 @@
       { "drop": "brain", "type": "flesh", "mass_ratio": 0.005 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
       { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "fat", "type": "flesh", "mass_ratio": 0.07 }
+      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 }
     ]
   },
   {
@@ -635,9 +633,7 @@
       { "drop": "mutant_liver", "type": "offal", "mass_ratio": 0.01 },
       { "drop": "mutant_brain", "type": "offal", "mass_ratio": 0.005 },
       { "drop": "bone", "type": "bone", "mass_ratio": 0.15 },
-      { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 },
-      { "drop": "mutant_fat", "type": "flesh", "mass_ratio": 0.07 }
+      { "drop": "raw_fur", "type": "skin", "mass_ratio": 0.02 }
     ]
   },
   {
@@ -2649,7 +2645,8 @@
     "entries": [
       { "drop": "skull_canis_small", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
       { "drop": "meat_scrap", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 }
+      { "drop": "animal_blood", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "raw_leather", "type": "skin", "mass_ratio": 0.02 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Hides from tiny dogs and no fat from rabbits

#### Purpose of change
It was impossible to skin a tiny dog because their harvest listed no skin. Rabbits were harvestable for fat, which is not how rabbits work.

#### Describe the solution
- Rabbits no longer give fat or sinew on harvest.
- Tiny dogs now give hides.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
