### PR TITLE
Fix wretched hatchery somewhat

### DIFF
--- a/data/json/monsters/zed_children.json
+++ b/data/json/monsters/zed_children.json
@@ -289,7 +289,7 @@
     "id": "mon_zombie_wretch",
     "type": "MONSTER",
     "name": { "str": "wretched hatchery", "str_pl": "wretched hatcheries" },
-    "description": "Lethargically resting on its back, this hideous mass of sagging flesh and writhing organs, which used to be a child, twitches feebly as its midsection churns.  Almost bursting from its skin, the child's ribcage has arched outward, forming a hive-like construct covered by severely stretched epidermis.  Through the wretched organism's taut abdominal flesh, you witness small forms swarming within its ribcage—its guts roiling as new beings are sculpted from pilfered flesh and bone.  The creature's limbs rest haphazardly on the ground, contorted in ways that suggest the absence of bones or any interior construct.",
+    "description": "Once a child, this hideous mass of sagging flesh and writhing organs twitches feebly as its midsection churns.  The ribcage has arched outward, forming a hive-like construct covered by severely stretched epidermis.  Bulging through the taut abdominal flesh, something squirms as if trying to break free.",
     "default_faction": "zombie",
     "bodytype": "blob",
     "species": [ "ZOMBIE", "HUMAN" ],
@@ -324,7 +324,7 @@
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_children_clothes", 100 ], [ "child_items_pockets", 65 ] ] },
     "burn_into": "mon_zombie_child_scorched",
     "fungalize_into": "mon_fungal_wretch",
-    "flags": [ "SEES", "HEARS", "SMELLS", "IMMOBILE", "WARM", "POISON", "NO_BREATHE", "FILTHY" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "IMMOBILE", "WARM", "POISON", "NO_BREATHE", "FILTHY", "BELLYUP" ],
     "armor": { "electric": 1 }
   }
 ]


### PR DESCRIPTION
#### Summary
Fix wretched hatchery somewhat

#### Purpose of change
The wretched hatchery is often cited as an example of the game being too edgy. I agree, the description is trying a bit too hard.

#### Describe the solution
- Improve the wretched hatchery's description by jettisoning the bits that repeatedly attempt to force a reaction on the reader. The thing is obviously repulsive, you don't need to keep saying that it's gross.
- Give the wretched hatchery the BELLYUP flag. Somehow it was getting downed (it's meant to be immune, I can't figure out why it isn't) and its tile was looking weird. The flag at least fixes the visual issue.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
