### PR TITLE
Fewer efiles on phones

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -666,7 +666,7 @@
     ]
   },
   {
-    "id": "animal_decay",
+    "id": "animal_antler_decay",
     "type": "harvest",
     "entries": [
       { "drop": "antler", "type": "bone", "base_num": [ 0, 2 ], "max": 2 },

--- a/data/json/itemgroups/efiles.json
+++ b/data/json/itemgroups/efiles.json
@@ -107,8 +107,8 @@
     "subtype": "collection",
     "entries": [
       { "item": "efile_lore", "prob": 20 },
-      { "group": "novels", "prob": 50 },
-      { "group": "literature", "prob": 50 },
+      { "group": "novels", "prob": 10 },
+      { "group": "literature", "prob": 10 },
       { "item": "photo_album", "prob": 25, "count": [ 1, 5 ] },
       { "item": "efile_recipes", "prob": 25 },
       { "group": "efiles_contraband", "prob": 1 },
@@ -120,11 +120,12 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "item": "efile_map", "prob": 75 },
-      { "item": "efile_lore", "prob": 50 },
-      { "group": "novels", "prob": 50, "count": [ 1, 3 ] },
-      { "group": "literature", "prob": 50, "count": [ 1, 3 ] },
-      { "item": "efile_recipes", "prob": 25 },
+      { "item": "efile_map", "prob": 35 },
+      { "item": "efile_lore", "prob": 20 },
+      { "group": "novels", "prob": 10, "count": [ 1, 3 ] },
+      { "group": "literature", "prob": 10, "count": [ 1, 3 ] },
+      { "item": "photo_album", "prob": 25, "count": [ 1, 5 ] },
+      { "item": "efile_recipes", "prob": 15 },
       { "group": "efiles_contraband", "prob": 1 }
     ]
   },
@@ -134,10 +135,11 @@
     "subtype": "collection",
     "entries": [
       { "item": "efile_map", "prob": 20 },
-      { "item": "efile_lore", "prob": 60 },
-      { "group": "novels", "prob": 50, "count": [ 1, 3 ] },
-      { "group": "literature", "prob": 50, "count": [ 1, 3 ] },
-      { "item": "efile_recipes", "prob": 40 },
+      { "item": "efile_lore", "prob": 30 },
+      { "group": "novels", "prob": 20, "count": [ 1, 3 ] },
+      { "group": "literature", "prob": 10, "count": [ 1, 3 ] },
+      { "item": "photo_album", "prob": 25, "count": [ 1, 5 ] },
+      { "item": "efile_recipes", "prob": 30 },
       { "item": "software_useless", "prob": 20 },
       { "group": "efiles_contraband", "prob": 2 },
       { "item": "software_robotics", "prob": 1 }
@@ -150,8 +152,8 @@
     "entries": [
       { "item": "efile_map", "prob": 20 },
       { "item": "efile_lore", "prob": 20 },
-      { "group": "novels", "prob": 50, "count": [ 1, 3 ] },
-      { "group": "literature", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "novels", "prob": 40, "count": [ 1, 3 ] },
+      { "group": "literature", "prob": 40, "count": [ 1, 3 ] },
       { "item": "efile_recipes", "prob": 15 }
     ]
   }

--- a/data/json/itemgroups/electronics.json
+++ b/data/json/itemgroups/electronics.json
@@ -240,13 +240,13 @@
       {
         "group": "smart_phone_maybe_locked",
         "prob": 17,
-        "charges": [ 0, 15 ],
+        "charges": 0,
         "contents-group": "civilian_smartphone_efiles"
       },
       {
         "group": "smart_phone_maybe_locked",
-        "prob": 1,
-        "charges": 100,
+        "prob": 83,
+        "charges": [ 0, 100 ],
         "contents-group": "civilian_smartphone_efiles"
       }
     ]
@@ -261,13 +261,13 @@
       {
         "group": "smart_phone_maybe_locked",
         "prob": 17,
-        "charges": [ 0, 15 ],
+        "charges": 0,
         "contents-group": "civilian_smartphone_efiles"
       },
       {
         "group": "smart_phone_maybe_locked",
-        "prob": 1,
-        "charges": 100,
+        "prob": 83,
+        "charges": [ 0, 100 ],
         "contents-group": "civilian_smartphone_efiles"
       }
     ]
@@ -276,8 +276,8 @@
     "type": "item_group",
     "id": "smart_phone_maybe_locked",
     "items": [
-      { "item": "smart_phone", "prob": 15, "charges": [ 0, 24 ] },
-      { "item": "smart_phone_locked", "prob": 85, "charges": [ 0, 24 ] }
+      { "item": "smart_phone", "prob": 17, "charges": [ 0, 100 ] },
+      { "item": "smart_phone_locked", "prob": 83, "charges": [ 0, 100 ] }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Fewer efiles on phones

#### Purpose of change
Phones were way too full of stuff. There were like 3 books on every other phone. Chill!

#### Describe the solution
- Phones now have much less stuff than before. They're still worth breaking into if you need books and recipes.
- Phones are much more likely to be at a very low charge. When was the last time the zombie plugged the thing in?

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
