### PR TITLE
Restore platinum grille recipe

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -661,9 +661,7 @@
   {
     "id": "animal_decay",
     "type": "harvest",
-    "entries": [
-      { "drop": "bone", "type": "bone", "mass_ratio": 0.15 }
-    ]
+    "entries": [ { "drop": "bone", "type": "bone", "mass_ratio": 0.15 } ]
   },
   {
     "id": "animal_antler_decay",

--- a/data/json/itemgroups/electronics.json
+++ b/data/json/itemgroups/electronics.json
@@ -237,12 +237,7 @@
     "id": "civilian_phones_case",
     "container-item": "waterproof_smart_phone_case",
     "items": [
-      {
-        "group": "smart_phone_maybe_locked",
-        "prob": 17,
-        "charges": 0,
-        "contents-group": "civilian_smartphone_efiles"
-      },
+      { "group": "smart_phone_maybe_locked", "prob": 17, "charges": 0, "contents-group": "civilian_smartphone_efiles" },
       {
         "group": "smart_phone_maybe_locked",
         "prob": 83,

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2916,5 +2916,26 @@
     "autolearn": true,
     "components": [ [ [ "dry_seaweed", 20 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "platinum_grille",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "book_learn": [ [ "textbook_chemistry", 4 ], [ "textbook_fabrication", 4 ] ],
+    "time": "2 h",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_intro_chemistry" } ],
+    "qualities": [ { "id": "HAMMER", "level": 3 } ],
+    "tools": [ [ [ "electrolysis_kit", 10 ] ], [ [ "surface_heat", 10, "LIST" ] ] ],
+    "components": [
+      [ [ "steel_grille", 1 ] ],
+      [ [ "platinum_small", 1 ] ],
+      [ [ "water", 3 ], [ "water_clean", 3 ] ],
+      [ [ "any_strong_acid", 1, "LIST" ] ]
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
Restore platinum grille recipe

#### Purpose of change
This recipe was accidentally deleted when removing the jewelry bloat in #963 or #984 or somewhere.

fixes #2818 

#### Describe the solution
- Re-add it, credit everyone who touched the recipe in DDA as a collaborator (lol)

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
