### PR TITLE
Field monstergroups

### DIFF
--- a/data/json/monstergroups/wilderness.json
+++ b/data/json/monstergroups/wilderness.json
@@ -95,25 +95,21 @@
       {
         "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
         "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "starts": "12 days"
       },
       {
         "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
         "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "starts": "28 days"
       },
       {
         "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
         "weight": 20,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "starts": "112 days"
       },
       {
         "group": "GROUP_WILDERNESS_FOREST_ZOMBIE",
         "weight": 50,
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
         "starts": "360 days"
       },
       {
@@ -122,8 +118,10 @@
         "cost_multiplier": 5,
         "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
       },
-      { "monster": "mon_bullfrog", "weight": 10 },
-      { "monster": "mon_big_bullfrog", "weight": 7 }
+      { "monster": "mon_bullfrog", "weight": 10,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      { "monster": "mon_big_bullfrog", "weight": 7,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] }
     ]
   },
   {
@@ -233,18 +231,146 @@
     "is_animal": true,
     "monsters": [
       { "monster": "mon_fly_small", "weight": 1, "cost_multiplier": 0 },
+      { "monster": "mon_spider_jumping_small", "weight": 1, "cost_multiplier": 0 },
+      { "monster": "mon_spider_wolf_small", "weight": 3, "cost_multiplier": 0 },
+      { "monster": "mon_mantis_small", "weight": 3, "cost_multiplier": 10 },
+      { "monster": "mon_aphid", "weight": 1, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
+      { "monster": "mon_woodlouse", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_butterfly", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_moth", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_MAMMAL",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_bat", "weight": 2, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_dog", "weight": 3, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
+      { "group": "GROUP_BEARS", "weight": 1, "cost_multiplier": 15 },
+      { "monster": "mon_zombear", "weight": 1, "cost_multiplier": 15, "starts": "20 days" },
+      { "group": "GROUP_SHEEP", "weight": 1, "cost_multiplier": 4, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_zombie_sheep", "weight": 1, "cost_multiplier": 4, "pack_size": [ 1, 4 ], "starts": "10 days" },
+      { "group": "GROUP_STRAY_CATS", "weight": 10 },
+      { "group": "GROUP_STRAY_CATS", "weight": 3, "pack_size": [ 2, 8 ] },
+      { "group": "GROUP_STRAY_DOGS", "weight": 20, "cost_multiplier": 25, "pack_size": [ 1, 6 ] },
+      { "group": "GROUP_HORSES_STABLES", "weight": 1, "cost_multiplier": 35, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_groundhog", "weight": 30, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
+      { "monster": "mon_rabbit", "weight": 80, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_squirrel", "weight": 100, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_weasel", "weight": 5, "cost_multiplier": 5 },
+      { "monster": "mon_raccoon", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_opossum", "weight": 15, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_skunk", "weight": 12, "cost_multiplier": 0, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_rat", "weight": 55, "cost_multiplier": 0, "pack_size": [ 1, 5 ] },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER", "weight": 22 },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT", "weight": 1 },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT", "weight": 2, "starts": "30 days" },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT", "weight": 4, "starts": "90 days" },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT", "weight": 8, "starts": "120 days" },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT", "weight": 12, "starts": "240 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_BOARS", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 4 ] },
+      { "group": "GROUP_DEER", "weight": 1, "cost_multiplier": 2, "pack_size": [ 1, 5 ] },
+      { "monster": "mon_fox", "weight": 1, "cost_multiplier": 0 },
+      { "monster": "mon_coyote", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 8 ] },
+      { "group": "GROUP_MOOSE", "weight": 1, "cost_multiplier": 3, "pack_size": [ 1, 3 ] }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_MAMMAL_MUTANT",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_DEER_MUT_SPIDERS", "weight": 4, "cost_multiplier": 2, "pack_size": [ 1, 3 ] },
+      { "group": "GROUP_TUSKED_MOOSE", "weight": 1, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_bear_mutant_3headed", "weight": 1, "cost_multiplier": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_BIRD",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_bluejay", "weight": 1, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_crow", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 8 ] },
+      { "monster": "mon_crow_mutant_small", "weight": 5, "cost_multiplier": 0, "pack_size": [ 1, 6 ] },
+      { "monster": "mon_raven", "weight": 2, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_robin", "weight": 8, "cost_multiplier": 0, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_sparrow", "weight": 10, "cost_multiplier": 0, "pack_size": [ 1, 12 ] },
+      { "monster": "mon_pigeon", "weight": 4, "cost_multiplier": 0, "pack_size": [ 1, 6 ] },
+      { "monster": "mon_turkey", "weight": 3, "cost_multiplier": 2, "pack_size": [ 1, 6 ] },
+      {
+        "monster": "mon_duck",
+        "weight": 3,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "monster": "mon_goose",
+        "weight": 3,
+        "cost_multiplier": 5,
+        "pack_size": [ 1, 4 ],
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_INSECT_HARMLESS",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_fly_small", "weight": 2, "cost_multiplier": 0 },
+      { "monster": "mon_aphid", "weight": 3, "pack_size": [ 1, 5 ], "cost_multiplier": 0 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_INSECT",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_fly_small", "weight": 1, "cost_multiplier": 0 },
       { "monster": "mon_spider_jumping_small", "weight": 2, "cost_multiplier": 0 },
-      { "monster": "mon_spider_wolf_small", "weight": 4, "cost_multiplier": 0 },
-      { "monster": "mon_mantis_small", "weight": 2, "cost_multiplier": 10 },
+      { "monster": "mon_spider_wolf_small", "weight": 1, "cost_multiplier": 0 },
       { "monster": "mon_lady_bug", "weight": 1, "cost_multiplier": 10 },
       { "monster": "mon_aphid", "weight": 1, "pack_size": [ 1, 5 ], "cost_multiplier": 0 },
       { "monster": "mon_locust_small", "weight": 1, "pack_size": [ 3, 9 ], "cost_multiplier": 0 },
       { "monster": "mon_grasshopper_small", "weight": 1, "pack_size": [ 1, 3 ], "cost_multiplier": 0 },
-      { "monster": "mon_antlion_giant", "weight": 1, "cost_multiplier": 10 },
       { "monster": "mon_woodlouse", "weight": 1, "cost_multiplier": 3 },
       { "monster": "mon_butterfly", "weight": 1, "cost_multiplier": 3 },
-      { "monster": "mon_moth", "weight": 2, "cost_multiplier": 3 },
-      { "monster": "mon_cicada", "weight": 1, "cost_multiplier": 3 }
+      { "monster": "mon_antlion_giant", "weight": 2, "cost_multiplier": 5 },
+      { "group": "GROUP_WASP_FORAGER", "weight": 1, "cost_multiplier": 6 },
+      { "monster": "mon_moth", "weight": 2, "cost_multiplier": 3 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_WILDERNESS_FIELD_ZOMBIE",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 12, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_zeer", "weight": 6, "cost_multiplier": 12, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zeer_frail", "weight": 2, "cost_multiplier": 5 },
+      { "monster": "mon_zombear", "weight": 2, "cost_multiplier": 10 },
+      { "monster": "mon_zombie_dog", "weight": 2, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_horse", "weight": 1, "cost_multiplier": 19, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zombie_horse_lame", "weight": 1, "cost_multiplier": 8 },
+      { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10 }
     ]
   },
   {
@@ -253,14 +379,111 @@
     "default": "mon_null",
     "is_animal": true,
     "monsters": [
-      { "monster": "mon_zeer", "weight": 4, "cost_multiplier": 12, "pack_size": [ 1, 5 ] },
-      { "monster": "mon_zeer", "weight": 6, "cost_multiplier": 12, "pack_size": [ 1, 2 ] },
-      { "monster": "mon_zeer_frail", "weight": 2, "cost_multiplier": 5 },
-      { "monster": "mon_zombear", "weight": 2, "cost_multiplier": 10 },
-      { "monster": "mon_zombie_dog", "weight": 2, "cost_multiplier": 2 },
+      { "monster": "mon_zeer", "weight": 5, "cost_multiplier": 12, "pack_size": [ 1, 5 ] },
+      { "monster": "mon_zeer", "weight": 7, "cost_multiplier": 12, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_zeer_frail", "weight": 3, "cost_multiplier": 5 },
+      { "monster": "mon_zombear", "weight": 3, "cost_multiplier": 10 },
+      { "monster": "mon_zombie_dog", "weight": 3, "cost_multiplier": 2 },
       { "monster": "mon_zombie_horse", "weight": 1, "cost_multiplier": 19, "pack_size": [ 1, 2 ] },
       { "monster": "mon_zombie_horse_lame", "weight": 1, "cost_multiplier": 8 },
       { "monster": "mon_zoose", "weight": 1, "cost_multiplier": 10 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_FIELD",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL", "weight": 5, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL",
+        "weight": 5,
+        "ends": "28 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL",
+        "weight": 5,
+        "ends": "112 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL",
+        "weight": 5,
+        "ends": "360 days",
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "group": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER", "weight": 5, "conditions": [ "WINTER" ] },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER",
+        "weight": 5,
+        "ends": "12 days",
+        "conditions": [ "WINTER" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER",
+        "weight": 5,
+        "ends": "112 days",
+        "conditions": [ "WINTER" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_MAMMAL_WINTER",
+        "weight": 5,
+        "ends": "360 days",
+        "conditions": [ "WINTER" ]
+      },
+      { "group": "GROUP_WILDERNESS_FIELD_BIRD", "weight": 20 },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_INSECT_HARMLESS",
+        "weight": 4,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      { "group": "GROUP_WILDERNESS_FIELD_INSECT", "weight": 7, "conditions": [ "SPRING", "SUMMER", "AUTUMN" ] },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_INSECT",
+        "weight": 6,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "20 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_INSECT",
+        "weight": 5,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "180 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_INSECT",
+        "weight": 5,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "360 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_ZOMBIE",
+        "weight": 3,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_ZOMBIE",
+        "weight": 3,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "20 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_ZOMBIE",
+        "weight": 3,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "112 days"
+      },
+      {
+        "group": "GROUP_WILDERNESS_FIELD_ZOMBIE",
+        "weight": 3,
+        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ],
+        "starts": "360 days"
+      },
+      { "monster": "mon_zombie_dog", "weight": 1, "cost_multiplier": 3, "pack_size": [ 1, 3 ] },
+      { "group": "GROUP_ZOMBIE", "weight": 3, "cost_multiplier": 4, "pack_size": [ 1, 10 ] },
+      { "group": "GROUP_VANILLA_DORMANT", "weight": 3, "cost_multiplier": 4, "pack_size": [ 1, 4 ] }
     ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -676,7 +676,7 @@
     "sym": "+",
     "color": "light_green",
     "see_cost": "spaced_high",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "spawns": { "group": "GROUP_FIELD", "population": [ 1, 2 ], "chance": 12 },
     "flags": [ "RISK_LOW", "SOURCE_SAFETY", "SOURCE_FOOD" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -121,7 +121,7 @@
     "see_cost": "none",
     "extras": "agricultural",
     "looks_like": "farm_5",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 2 ], "chance": 15 }
+    "spawns": { "group": "GROUP_FIELD", "population": [ 0, 2 ], "chance": 15 }
   },
   {
     "type": "overmap_terrain",
@@ -133,7 +133,7 @@
     "see_cost": "none",
     "extras": "agricultural",
     "looks_like": "ranch_camp_76",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 2 ], "chance": 15 }
+    "spawns": { "group": "GROUP_FIELD", "population": [ 0, 2 ], "chance": 15 }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -21,7 +21,7 @@
     "vision_levels": "always_full",
     "see_cost": "none",
     "extras": "field",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "spawns": { "group": "GROUP_FIELD", "population": [ 0, 1 ], "chance": 13 },
     "travel_cost_type": "field",
     "flags": [ "NO_ROTATE" ]
   },
@@ -74,7 +74,7 @@
     "color": "dark_gray",
     "vision_levels": "open_land",
     "see_cost": "medium",
-    "spawns": { "group": "GROUP_STANDING_STONES", "population": [ 1, 4 ], "chance": 100 },
+    "spawns": { "group": "GROUP_STANDING_STONES", "population": [ 1, 4 ], "chance": 90 },
     "flags": [ "NO_ROTATE" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hill.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hill.json
@@ -29,7 +29,7 @@
     "sym": ",",
     "color": "brown",
     "travel_cost_type": "forest",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "spawns": { "group": "GROUP_FIELD", "population": [ 0, 1 ], "chance": 13 },
     "flags": [ "REQUIRES_PREDECESSOR" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_meadow.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_meadow.json
@@ -7,7 +7,7 @@
     "sym": ",",
     "color": "brown",
     "travel_cost_type": "forest",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "spawns": { "group": "GROUP_FIELD", "population": [ 1, 2 ], "chance": 13 },
     "flags": [ "REQUIRES_PREDECESSOR" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_special.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_special.json
@@ -43,7 +43,7 @@
     "color": "brown",
     "looks_like": "field",
     "see_cost": "none",
-    "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "spawns": { "group": "GROUP_FIELD", "population": [ 0, 1 ], "chance": 13 },
     "travel_cost_type": "field",
     "flags": [ "NO_ROTATE" ]
   },


### PR DESCRIPTION
#### Summary
Field monstergroups

#### Purpose of change
Fields were spawning forest monsters. This made the wildlife all feel kinda samey and led to weird stuff like mantises just standing out in the open instead of lurking among the trees.

#### Describe the solution
Split group_field from group_forest. They're similar, but forests are forestier now and fields can have more random bullshit you'd expect in a field like dog zombies and stray wasps and whatnot.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
