### PR TITLE
Sky Island - update monstergroups json following rename of mi-go slaver

### DIFF
--- a/data/mods/Sky_Island/monstergroups.json
+++ b/data/mods/Sky_Island/monstergroups.json
@@ -176,7 +176,7 @@
     "monsters": [
       { "monster": "mon_mi_go", "weight": 200 },
       { "monster": "mon_mi_go_scout", "weight": 25 },
-      { "monster": "mon_mi_go_slaver", "weight": 15 },
+      { "monster": "mon_mi_go_abductor", "weight": 15 },
       { "monster": "mon_mi_go_surgeon", "weight": 10 }
     ]
   },


### PR DESCRIPTION
#### Summary
Sky Island still had an entry referring to the mi-go slaver and threw json errors on load. This updates the file to refer to the slaver rename, abductor.

#### Purpose of change
json error in Sky Island from a renamed monster

#### Describe the solution
update the name of the monster

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
