### PR TITLE
Fix skipped update_vitamins() in vitamin_mod()

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5598,7 +5598,6 @@ void Character::update_needs( int rate_multiplier )
                     recovered *= .5;
                 }
                 mod_fatigue( -recovered );
-
                 // Sleeping on the ground, no bionic = 1x rest_modifier
                 // Sleeping on a bed, no bionic      = 2x rest_modifier
                 // Sleeping on a comfy bed, no bionic= 3x rest_modifier
@@ -5619,7 +5618,6 @@ void Character::update_needs( int rate_multiplier )
                 } else if( comfort >= comfort_data::COMFORT_SLIGHTLY_COMFORTABLE ) {
                     rest_modifier *= 2;
                 }
-
                 // If we're just tired, we'll get a decent boost to our sleep quality.
                 // The opposite is true for very tired characters.
                 if( get_fatigue() < fatigue_levels::DEAD_TIRED ) {
@@ -5629,7 +5627,6 @@ void Character::update_needs( int rate_multiplier )
                 }
                 // Recovered is multiplied by 2 as well, since we spend 1/3 of the day sleeping
                 mod_sleep_deprivation( -rest_modifier * ( recovered * 2 ) );
-
             }
         }
         map &here = get_map();
@@ -9092,13 +9089,8 @@ void Character::blossoms()
 
 void Character::update_vitamins( const vitamin_id &vit )
 {
-    if( !needs_food() ) {
-        return; // NPCs can only develop vitamin diseases if their needs are enabled
-    }
-
     efftype_id def = vit.obj().deficiency();
     efftype_id exc = vit.obj().excess();
-
     int lvl = vit.obj().severity( vitamin_get( vit ) );
     if( lvl <= 0 ) {
         remove_effect( def );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -88,8 +88,6 @@ static const efftype_id effect_narcosis( "narcosis" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_wet( "wet" );
 
-
-
 static const json_character_flag json_flag_BARKY( "BARKY" );
 static const json_character_flag json_flag_CANNOT_CHANGE_TEMPERATURE( "CANNOT_CHANGE_TEMPERATURE" );
 static const json_character_flag json_flag_COLDBLOOD( "COLDBLOOD" );
@@ -128,6 +126,9 @@ static const trait_id trait_SLIMY( "SLIMY" );
 static const trait_id trait_URSINE_FUR( "URSINE_FUR" );
 
 static const vitamin_id vitamin_blood( "blood" );
+static const vitamin_id vitamin_calcium( "calcium" );
+static const vitamin_id vitamin_iron( "iron" );
+static const vitamin_id vitamin_vitC( "vitC" );
 
 void Character::update_body_wetness( const w_point &weather )
 {
@@ -262,7 +263,6 @@ void Character::update_body( const time_point &from, const time_point &to )
     const int five_mins = ticks_between( from, to, 5_minutes );
     if( five_mins > 0 ) {
         activity_history.try_reduce_weariness( base_bmr() );
-
         check_needs_extremes();
         update_needs( five_mins );
         regen( five_mins );
@@ -270,6 +270,17 @@ void Character::update_body( const time_point &from, const time_point &to )
         // TODO: change @ref mend to take time_duration
         mend( five_mins * to_turns<int>( 5_minutes ) );
         activity_history.reset_activity_level();
+        // Ensure that NPCs outside the player faction don't die of scurvy.
+        if( !needs_food() ) {
+            vitamin_set( vitamin_vitC, 0 );
+            vitamin_set( vitamin_iron, 0 );
+            vitamin_set( vitamin_calcium, 0 );
+        }
+        /* This is called in vitamin_mod, but we call it again here as a fallback so
+           hypovolemia etc don't get stuck on a character who should have recovered by now. */
+        for( const auto &v : vitamin::all() ) {
+            update_vitamins( v.first );
+        }
     }
     bool was_sleeping = get_value( "was_sleeping" ).str() == "true";
     if( in_sleep_state() && was_sleeping ) {
@@ -1110,7 +1121,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
             mod_stored_calories( -std::floor( five_mins * kcal_per_time * 1000 ) );
         }
     }
-    // if foodless no need to calc hunger, and set hunger_effect
+    // If foodless, no need to calc hunger, and set hunger_effect.
     if( foodless ) {
         return;
     }

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -682,7 +682,6 @@ int Character::vitamin_mod( const vitamin_id &vit, int qty )
     // (Okay, technically it returns a pair<iterator, bool>, the iterator is what we want)
     auto it = vitamin_levels.emplace( vit, 0 ).first;
     const vitamin &v = *it->first;
-
     if( qty > 0 ) {
         it->second = std::min( it->second + qty, v.max() );
         // update the daily trackers too while here
@@ -693,7 +692,6 @@ int Character::vitamin_mod( const vitamin_id &vit, int qty )
         } else {
             daily_vitamins[vit].second = daily_vitamins_max;
         }
-
     } else if( qty < 0 ) {
         it->second = std::max( it->second + qty, v.min() );
         update_vitamins( vit );
@@ -703,7 +701,8 @@ int Character::vitamin_mod( const vitamin_id &vit, int qty )
             }
         }
     }
-
+    // We must always call update_vitamins() because effects must be both applied and removed.
+    update_vitamins( vit );
     return it->second;
 }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1587,8 +1587,7 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
     int total_damage = 0;
     int total_base_damage = 0;
     int total_pain = 0;
-    damage_instance d = dam; // copy, since we will mutate in absorb_hit
-
+    damage_instance d = dam; // Copy, since we will mutate in absorb_hit.
     dealt_damage_instance dealt_dams;
     weakpoint_attack attack_copy = attack;
     if( attack.accuracy == -1.0 ) {
@@ -1598,8 +1597,7 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
     }
     const weakpoint *wkpt = absorb_hit( attack_copy, bp, d, wp );
     dealt_dams.wp_hit = wkpt == nullptr ? "" : wkpt->get_name();
-
-    // Add up all the damage units dealt
+    // Add up all the damage units dealt.
     for( const damage_unit &it : d.damage_units ) {
         int cur_damage = 0;
         deal_damage_handle_type( effect_source( source ), it, bp, cur_damage, total_pain );
@@ -1609,9 +1607,8 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
             total_damage += cur_damage;
         }
     }
-    // get eocs for all damage effects
+    // Get eocs for all damage effects.
     d.ondamage_effects( source, this, dam, bp.id() );
-
     if( total_base_damage < total_damage ) {
         // Only deal more HP than remains if damage not including crit multipliers is higher.
         total_damage = clamp( get_hp( bp ), total_base_damage, total_damage );
@@ -1619,15 +1616,13 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
     if( !bp->has_flag( json_flag_BIONIC_LIMB ) ) {
         mod_pain( total_pain );
     }
-
     apply_damage( source, bp, total_damage );
-
     if( wkpt != nullptr ) {
         wkpt->apply_effects( *this, total_damage, attack );
     }
-
     return dealt_dams;
 }
+
 void Creature::deal_damage_handle_type( const effect_source &source, const damage_unit &du,
                                         bodypart_id bp, int &damage, int &pain )
 {


### PR DESCRIPTION
#### Summary
Fix skipped update_vitamins() in vitamin_mod()

#### Purpose of change
Players were reporting that hypovolemia was getting stuck, and a couple instances showed up of people only losing it when they started bleeding. After some investigation, it was discovered that update_vitamins() (which clears such effects when appropriate) was only being called in vitamin_mod when a vitamin _decreased_. This bug was missed because in most cases, vitamins are always decreasing over time. Blood volume is the one exception. Most characters lose blood pretty often, so it was only exposed when players had long at-home recovery periods and weren't getting better.

#### Describe the solution
- Run update_vitamins() in vitamin_mod() irrespective of whether vitamin levels went up or down.
- Run update_vitamins() every 5 minutes no matter what.
- Add a failsafe for !needs_food() NPCs which sets their vitC, calcium, and iron to 0 every 5 minutes no matter what.
- Remove a thing that skipped deficiency checks for !needs_food() NPCs, which was preventing them from being affected by hypovolemia. In english: bandits can now bleed out.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
