### PR TITLE
Nerf regenerate_in_darkness a bit

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3578,8 +3578,8 @@ void monster::process_effects()
         const float light = here.ambient_light_at( pos_bub() );
         // Magic number 10000 was chosen so that a floodlight prevents regeneration in a range of 20 tiles
         // TODO: Fix this horseshit
-        const float dHP = 50.0 * std::exp( - light * light / 10000 );
-        if( heal( static_cast<int>( dHP ) ) > 0 && one_in( 2 ) ) {
+        const int dHP = std::clamp( static_cast<int>( 30.0 * std::exp( - light * light / 10000 ) ), 0, 30 );
+        if( heal( dHP ) > 0 && one_in( 31 - dHP ) ) {
             add_msg_if_player_sees( *this, m_warning, _( "The %s uses the darkness to regenerate." ), name() );
         }
     }


### PR DESCRIPTION
#### Summary
Nerf regenerate_in_darkness a bit

#### Purpose of change
Because of how ambient_light works, it is hard for there to be much of a difference between a tile that's lit by a little flashlight and one that's in full sun. Because of this, regenerate_in_darkness is kind of horseshit, as it is 40 hp per turn with a scaling penalty according to how lit the tile is. Reducing the light level requirement for fully blocking the regen (floodlight or sunlight) breaks the whole thing.

I plan to just trash the function and make the unseen hunter do something else, but for now it can at least be playable.

#### Describe the solution
40hp/turn -> 30hp/turn. The "X uses the darkness to regenerate" message now has a chance to proc that scales with how fast the creature is actually regenerating, so players who are using something like a heavy-duty flashlight should have some hopefully intuitive feedback that their light is doing _something_.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
