### PR TITLE
Fix construction xp level cap equality check

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -384,7 +384,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
                 int s_lvl = player_character.get_skill_level( pr.first );
                 if( s_lvl < pr.second ) {
                     col = c_red;
-                } else if( s_lvl < pr.second * 1.25 ) {
+                } else if( s_lvl <= pr.second * 1.25 ) {
                     col = c_light_blue;
                 }
             }
@@ -676,7 +676,7 @@ construction_id construction_menu( const bool blueprint )
                         int s_lvl = player_character.get_skill_level( skill.first );
                         if( s_lvl < skill.second ) {
                             col = c_red;
-                        } else if( s_lvl < skill.second * 1.25 ) {
+                        } else if( s_lvl <= skill.second * 1.25 ) {
                             col = c_light_blue;
                         } else {
                             col = c_green;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -384,7 +384,7 @@ static nc_color construction_color( const construction_group_str_id &group, bool
                 int s_lvl = player_character.get_skill_level( pr.first );
                 if( s_lvl < pr.second ) {
                     col = c_red;
-                } else if( s_lvl <= pr.second * 1.25 ) {
+                } else if( s_lvl <= pr.second * 1.25 && s_lvl < MAX_SKILL ) {
                     col = c_light_blue;
                 }
             }
@@ -676,7 +676,7 @@ construction_id construction_menu( const bool blueprint )
                         int s_lvl = player_character.get_skill_level( skill.first );
                         if( s_lvl < skill.second ) {
                             col = c_red;
-                        } else if( s_lvl <= skill.second * 1.25 ) {
+                        } else if( s_lvl <= skill.second * 1.25 && s_lvl < MAX_SKILL ) {
                             col = c_light_blue;
                         } else {
                             col = c_green;


### PR DESCRIPTION
#### Summary

Fixing construction menu color display to correctly calculate which constructions help level the skills.

#### Purpose of change

So I saw some items in the construction menu were blue, and then I figured out that it's telling me that those items would give me xp. Like, these items were blue when my fabrication skilllevel was 2.

<img width="173" height="270" alt="image" src="https://github.com/user-attachments/assets/f0a618e3-013e-4d0d-bb2d-c2ad977fc2cb" />

<img width="313" height="107" alt="image" src="https://github.com/user-attachments/assets/5caebdb3-16c0-460a-9fdf-e064cd41afa8" />

But then I was like, why wasn't the household fridge blue when I had electronics level 0?

<img width="294" height="71" alt="image" src="https://github.com/user-attachments/assets/cec6593e-00b0-4399-8348-73136f39697c" />

So I checked and found that in construction.cpp, the check is if the skill level is strictly less than the difficulty level * 1.25. So for skill level 2 and difficulty level 2, it would be 2 < 2.5, but for skill level 0 and difficulty level 0, it would be 0 < 0, which is false. And then for difficulty 4 skill level 5 it would probably also be 5 < 4 * 1.25 which would be false too, even though that should give xp. The same would apply for a difficulty 8 construction and a skill level 10 player, though on second thought since the max level is 10 that particular case should be unchanged.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/ff227dd854f7b6b2a4297022dc2d0d161849f785/src/construction.cpp#L384-L389

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/ff227dd854f7b6b2a4297022dc2d0d161849f785/src/construction.cpp#L676-L683

#### Describe the solution

Changing < 1.25 to <= 1.25 to be consistent with the xp gain formula (i.e. at level 5 you can get skill xp from a level 4 recipe). So at skill level 0 it would be easier to see that certain constructions contribute skill xp towards level 1.

<img width="294" height="71" alt="image" src="https://github.com/user-attachments/assets/84b62a63-b154-4213-ab0c-baa031491333" />

<img width="294" height="71" alt="image" src="https://github.com/user-attachments/assets/ceac20db-d906-446e-87d3-ef703ce0aa31" />

I also added require s_lvl < MAX_SKILL so things don't show blue at max skill level. For the below screenshots I had set all skills to max to test that it's no longer blue.

<img width="179" height="71" alt="image" src="https://github.com/user-attachments/assets/5418f110-adb5-42e4-9941-0ab065bca8aa" />

<img width="280" height="119" alt="image" src="https://github.com/user-attachments/assets/d5f1fbfc-2764-4040-877a-ada2b640d5af" />



#### Describe alternatives you've considered

#### Testing

To test the fix, what I did was spawn in a household fridge at electronics 0 and look at its color in the construction menu to verify it was blue for an electronics level 0 character. Though other testing would be something that requires skill level 4 when the player has skill level 5. Skill level can be set in the debug menu.

As for the max skill level case, I spawned the tools and materials for a safe, set my skill levels to max, and took a look in the construction menu to verify it was white in the list and green in the breakdown.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
