### PR TITLE
Dialogue error fix

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
@@ -92,6 +92,6 @@
       "I dunno, I wasn't there but I overheard some guy talking about it.",
       "You know how it is, people talk, I mean sure, there was one of those weird storms at the time but the helicopter story?  I don't believe it."
     ],
-    "responses": [ { "text": "<end_talking_bye>", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "I see.", "topic": "TALK_DONE" } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Dialogue error fix

#### Purpose of change
<end_talking_bye> was incorrectly being used in a side conversation related to the sunken helicopter quest. This is a DDA thing and an artifact of porting the quest.

#### Describe the solution
Just put normal words and not a variable string which does not exist.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
