### PR TITLE
Hallucinations don't bleed

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -416,7 +416,9 @@ void Creature::reset()
 
 void Creature::bleed( map &here ) const
 {
-    here.add_splatter( bloodType(), pos_bub( here ) );
+    if( !is_hallucination() ) {
+        here.add_splatter( bloodType(), pos_bub( here ) );
+    }
 }
 
 void Creature::reset_bonuses()

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -420,9 +420,8 @@ bool mtype::same_species( const mtype &other ) const
 
 field_type_id mtype::bloodType() const
 {
-    if( has_flag( mon_flag_ACID_BLOOD ) )
-        //A monster that has the death effect "ACID" does not need to have acid blood.
-    {
+    //A monster that has the death effect "ACID" does not need to have acid blood.
+    if( has_flag( mon_flag_ACID_BLOOD ) ) {
         return fd_acid;
     }
     if( has_flag( mon_flag_BILE_BLOOD ) ) {


### PR DESCRIPTION
#### Summary
Hallucinations don't bleed

#### Purpose of change
Someone shot a hallucinated character and they left a real bloodstain on the floor. That's no bueno!

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
