### PR TITLE
Tacoma fixes

### DIFF
--- a/data/json/mapgen/ranch_camp.json
+++ b/data/json/mapgen/ranch_camp.json
@@ -230,7 +230,8 @@
         "..%....................................................................."
       ],
       "palettes": [ "ranch_camp" ],
-      "place_monsters": [ { "monster": "GROUP_DOMESTIC", "x": [ 10, 23 ], "y": [ 3, 23 ], "repeat": [ 4, 6 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_DOMESTIC_SAFE", "x": [ 10, 19 ], "y": [ 3, 19 ], "repeat": [ 3, 5 ], "density": 0.1 } ],
+      "place_monster": [ { "monster": "mon_woodlouse", "x": 22, "y": 22, "name": "Durst", "chance": 100 } ]
     },
     "om_terrain": [ [ "ranch_camp_19", "ranch_camp_20", "ranch_camp_21" ], [ "ranch_camp_28", "ranch_camp_29", "ranch_camp_30" ] ],
     "type": "mapgen",
@@ -467,7 +468,7 @@
         "........xxxxxxx.................................x.............x........."
       ],
       "palettes": [ "ranch_camp" ],
-      "place_monsters": [ { "monster": "GROUP_DOMESTIC", "x": [ 3, 23 ], "y": [ 3, 23 ], "repeat": [ 4, 6 ], "density": 0.1 } ]
+      "place_monsters": [ { "monster": "GROUP_DOMESTIC_SAFE", "x": [ 3, 23 ], "y": [ 3, 23 ], "repeat": [ 4, 6 ], "density": 0.1 } ]
     },
     "om_terrain": [ [ "ranch_camp_40", "ranch_camp_41", "ranch_camp_42" ], [ "ranch_camp_49", "ranch_camp_50", "ranch_camp_51" ] ],
     "type": "mapgen",
@@ -620,14 +621,14 @@
         }
       ],
       "place_monster": [
-        { "monster": "mon_horse", "x": [ 42, 43 ], "y": [ 25, 47 ], "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_cow", "x": [ 67, 68 ], "y": [ 25, 47 ], "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_pig", "x": [ 52, 58 ], "y": [ 26, 28 ], "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_pig", "x": [ 52, 58 ], "y": [ 26, 28 ], "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_sheep", "x": [ 52, 58 ], "y": 36, "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_sheep", "x": [ 52, 58 ], "y": 36, "repeat": [ 1, 4 ], "chance": 8 },
-        { "monster": "mon_chicken", "x": [ 52, 58 ], "y": [ 44, 46 ], "repeat": [ 1, 6 ], "chance": 8 },
-        { "monster": "mon_chicken", "x": [ 52, 58 ], "y": [ 44, 46 ], "repeat": [ 1, 6 ], "chance": 8 }
+        { "monster": "mon_horse", "x": [ 42, 43 ], "y": [ 25, 47 ], "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_cow", "x": [ 67, 68 ], "y": [ 25, 47 ], "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_pig", "x": [ 52, 58 ], "y": [ 26, 28 ], "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_pig", "x": [ 52, 58 ], "y": [ 26, 28 ], "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_sheep", "x": [ 52, 58 ], "y": 36, "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_sheep", "x": [ 52, 58 ], "y": 36, "repeat": [ 1, 3 ], "chance": 8 },
+        { "monster": "mon_chicken", "x": [ 52, 58 ], "y": [ 44, 46 ], "repeat": [ 1, 5 ], "chance": 8 },
+        { "monster": "mon_chicken", "x": [ 52, 58 ], "y": [ 44, 46 ], "repeat": [ 1, 5 ], "chance": 8 }
       ]
     },
     "om_terrain": [ [ "ranch_camp_55", "ranch_camp_56", "ranch_camp_57" ], [ "ranch_camp_64", "ranch_camp_65", "ranch_camp_66" ] ],
@@ -675,7 +676,7 @@
         "../#################/............../..............%.....................",
         "..///////////////////............../..............%.....................",
         "../#################/............../....|||||+||4.%.....................",
-        "../#################/...........sssssss.|t B- ±|..%.....................",
+        "../#################/....?......sssssss.|t B- ±|..%.....................",
         "..///////////////////...|ƃ|.....sssssss.|Ŧ B- ±|..%.....................",
         "......WWWWWWWWWwwWWWW...|||www||||w+w||||-+----|..%.....................",
         "......W;;;rrr;;;;;;rW...|  hnh  -‡      -  @@  |..%.....................",
@@ -693,7 +694,14 @@
       ],
       "palettes": [ "ranch_camp" ],
       "place_npcs": [ { "class": "ranch_foreman", "x": 16, "y": 38 }, { "class": "ranch_construction_1", "x": 9, "y": 40 } ],
-      "terrain": { "r": "t_dirtfloor", ";": "t_dirtfloor", "ƃ": "t_ramp_down_low", "|": "t_brick_wall", "-": "t_wall_w" },
+      "terrain": {
+        "r": "t_dirtfloor",
+        ";": "t_dirtfloor",
+        "?": "t_earth_ramp_down_high",
+        "ƃ": "t_earth_ramp_down_low",
+        "|": "t_brick_wall",
+        "-": "t_wall_w"
+      },
       "furniture": { "±": "f_rack_wood" },
       "items": {
         "d": [
@@ -1058,10 +1066,10 @@
         "                        ",
         "                        ",
         "                        ",
-        "                        ",
         "|||                     ",
+        "|?|                     ",
         "|ƃ|                     ",
-        "|.|||||||               ",
+        "|+|||||||               ",
         "|......X|               ",
         "|..a.r.H|               ",
         "|..a.r.b|               ",
@@ -1076,7 +1084,7 @@
         "                        "
       ],
       "palettes": [ "standard_domestic_basement_palette" ],
-      "terrain": { "ƃ": "t_ramp_up_high", ".": "t_dirtfloor", "|": "t_brick_wall" },
+      "terrain": { "ƃ": "t_earth_ramp_up_low", "?": "t_earth_ramp_up_high", ".": "t_dirtfloor", "|": "t_brick_wall" },
       "furniture": {
         "a": "f_rack_wood",
         "r": "f_rack_wood",

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -277,6 +277,33 @@
   },
   {
     "type": "monstergroup",
+    "name": "GROUP_DOMESTIC_SAFE",
+    "default": "mon_dog",
+    "is_animal": true,
+    "is_safe": true,
+    "monsters": [
+      { "group": "GROUP_PET_CATS", "weight": 100 },
+      { "group": "GROUP_PET_CATS", "weight": 20, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
+      { "group": "GROUP_PET_DOGS", "weight": 100, "cost_multiplier": 25 },
+      { "group": "GROUP_PET_DOGS", "weight": 20, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_chicken", "weight": 50, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_duck", "weight": 10, "cost_multiplier": 10, "pack_size": [ 1, 3 ] },
+      { "group": "GROUP_COWS", "weight": 2, "cost_multiplier": 25, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_horse", "weight": 2, "cost_multiplier": 50, "pack_size": [ 1, 2 ] },
+      { "group": "GROUP_PIGS", "weight": 10, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
+      { "group": "GROUP_SHEEP", "weight": 2, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_goat", "weight": 3, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_llama", "weight": 1, "cost_multiplier": 25, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_rabbit_domestic", "weight": 5, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_pigeon", "weight": 5, "pack_size": [ 1, 3 ] },
+      { "monster": "mon_reindeer", "weight": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_turkey", "weight": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_pheasant", "weight": 1, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_ferret", "weight": 5 }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_SAFE",
     "is_safe": true,
     "is_animal": true,


### PR DESCRIPTION
#### Summary
Tacoma fixes

#### Purpose of change
Tacoma Ranch had some map problems. GROUP_DOMESTIC, intended to spawn some random farm-appropriate animals, had mutants and zombies in it, so there would often be some kind of brawl going on in the field.

The ramp down to the basement no longer worked after some recent updates. It has been replaced with a proper two-tile earth ramp. I've also added an unlocked door down there because basements have doors.

I also gave them a pet rolly polly named Durst. It's not tame or anything, it just wandered into the field and started eating fodder and they left it there.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
