### PR TITLE
Nerf nanobots, fatigue can't be negative

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1001,7 +1001,7 @@
     "id": "bio_nanobots",
     "type": "bionic",
     "name": { "str": "Repair Nanobots" },
-    "description": "Inside your body is a fleet of tiny dormant robots.  While activated they will flit about your body, repairing damage at 1 HP per minute and stopping bleeding at the cost of extra power and stored calories.  No power is consumed if there is nothing to heal.",
+    "description": "Inside your body is a fleet of tiny dormant robots.  While activated they will flit about your body, slowly repairing damage stopping bleeding at the cost of extra power and stored calories.  Excessive use of this CBM can depress the immune system.  No power is consumed if there is nothing to heal.",
     "occupied_bodyparts": [ [ "torso", 12 ] ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE", "BIONIC_SLEEP_FRIENDLY" ],
     "act_cost": "80 J",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -715,7 +715,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Repair Nanobots CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A fleet of tiny, dormant robots.  While activated, they will flit about the user's body, repairing damage and stopping bleeding at the cost of power.",
+    "description": "A fleet of tiny, dormant robots.  While activated, they will flit about the user's body, repairing damage and stopping bleeding at the cost of power.  Excessive use of this CBM can depress the immune system.",
     "price": "9500 USD",
     "price_postapoc": "100 USD",
     "weight": "200 g",

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1809,12 +1809,12 @@ void Character::process_bionic( bionic &bio )
             }
         }
         if( damaged_hp_parts.empty() && bleeding_bp_parts.empty() ) {
-            // Nothing to heal. Return the consumed power and exit early
+            // Nothing to heal. Return the consumed power and exit early.
             mod_power_level( cost );
             return;
         }
         for( const bodypart_id &i : bleeding_bp_parts ) {
-            // effectively reduces by 1 intensity level
+            // Effectively reduces by 1 intensity level.
             if( get_stored_kcal() >= 15 ) {
                 get_effect( effect_bleed, i ).mod_duration( -get_effect( effect_bleed, i ).get_int_dur_factor() );
                 mod_stored_kcal( -15 );
@@ -1823,11 +1823,14 @@ void Character::process_bionic( bionic &bio )
                 break;
             }
         }
-        if( calendar::once_every( 60_turns ) ) {
+        if( calendar::once_every( 5_minutes ) ) {
             if( get_stored_kcal() >= 5 && !damaged_hp_parts.empty() ) {
                 const bodypart_id part_to_heal = damaged_hp_parts[ rng( 0, damaged_hp_parts.size() - 1 ) ];
                 heal( part_to_heal, 1 );
-                mod_stored_kcal( -5 );
+                mod_stored_kcal( -10 );
+                if( one_in( 5 ) ) {
+                    mod_lifestyle( -1 );
+                }
             }
         }
     } else if( bio.id == bio_painkiller ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5131,7 +5131,7 @@ void Character::mod_sleep_deprivation( int nsleep_deprivation )
 
 void Character::set_fatigue( int nfatigue )
 {
-    nfatigue = std::max( nfatigue, -1000 );
+    nfatigue = std::max( nfatigue, 0 );
     if( fatigue != nfatigue ) {
         fatigue = nfatigue;
         on_stat_change( "fatigue", fatigue );


### PR DESCRIPTION
#### Summary
Nerf nanobots, fatigue can't be negative

#### Purpose of change
- Fatigue for some reason was capped at -1000. You need about 192 to be drowsy, why in God's name would -1000 be OK?
- Repair nanobots were stupidly good. They're going to change when surgery changes, but I don't want to just remove them because bionic patient is an interesting start.

#### Describe the solution
- Cap fatigue at 0. You can't be more awake than wide awake.
- Repair nanobots now heal 1 hp/5 minutes instead of 1 hp/minute, and every time they heal 1 hp, they have a 1 in 5 chance of reducing your lifestyle by 1. This is not a big deal unless you use them a lot, in which case lmao.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
