### PR TITLE
Further sleep fixes, photos train ecology, fix shouting

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -7739,7 +7739,7 @@
     "name": { "str": "Hissing Voice" },
     "mixed_effect": true,
     "points": 0,
-    "description": "You hiss when speaking.  Persuading people will be more difficult, but lying to or threatening them will be easier.",
+    "description": "You hiss when speaking, and your voice is a bit quieter.  Persuading people will be more difficult, but lying to or threatening them will be easier.",
     "types": [ "VOICE_TONE" ],
     "category": [ "LIZARD", "RAPTOR" ],
     "enchantments": [ { "values": [ { "value": "SHOUT_NOISE", "add": -2 } ] } ],

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -881,8 +881,8 @@ static hack_result hack_attempt( Character &who, item_location &tool )
         who.practice( skill_computer, 20 );
     }
 
-    // only skilled supergenius never cause short circuits, but the odds are low for people
-    // with moderate skills
+    // Only skilled supergeniuses never cause short circuits, but the odds are low for people
+    // with moderate skills.
     const int hack_stddev = 5;
     int success = std::ceil( normal_roll( hack_level( who, tool ), hack_stddev ) );
     if( success < 0 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -507,6 +507,7 @@ static const trait_id trait_ROOTS2( "ROOTS2" );
 static const trait_id trait_ROOTS3( "ROOTS3" );
 static const trait_id trait_SAPIOVORE( "SAPIOVORE" );
 static const trait_id trait_SAVANT( "SAVANT" );
+static const trait_id trait_SCREECH( "SCREECH" );
 static const trait_id trait_SHELL2( "SHELL2" );
 static const trait_id trait_SHELL3( "SHELL3" );
 static const trait_id trait_SHOUT2( "SHOUT2" );
@@ -7746,87 +7747,63 @@ void Character::wake_up()
 
 int Character::get_shout_volume() const
 {
-    int base = 10;
+    int base = 1 + get_size() * 3;
     int shout_multiplier = 2;
-
     base = enchantment_cache->modify_value( enchant_vals::mod::SHOUT_NOISE, base );
     shout_multiplier = enchantment_cache->modify_value( enchant_vals::mod::SHOUT_NOISE_STR_MULT,
                        shout_multiplier );
-
-    // Masks and such dampen the sound
-    // Balanced around whisper for wearing bondage mask
-    // and noise ~= 10 (door smashing) for wearing dust mask for character with strength = 8
-    /** @EFFECT_STR increases shouting volume */
     int noise = ( base + str_cur * shout_multiplier ) * get_limb_score( limb_score_breathing );
-
     // Minimum noise volume possible after all reductions.
     // Volume 1 can't be heard even by player
     constexpr int minimum_noise = 2;
-
     if( noise <= base ) {
         noise = std::max( minimum_noise, noise );
     }
-
-    // Screaming underwater is not good for oxygen and harder to do overall
+    // Screaming underwater is much quieter.
     if( underwater ) {
-        noise = std::max( minimum_noise, noise / 2 );
+        noise = std::max( minimum_noise, noise / 4 );
     }
     return noise;
 }
 
 void Character::shout( std::string msg, bool order )
 {
-    int base = 10;
-    std::string shout;
-
-    // Mutations make shouting louder, they also define the default message
+    std::string shout = "shout";
+    // Mutations make shouting louder or quieter, they also define the default message.
     if( has_trait( trait_SHOUT3 ) ) {
-        base = 20;
         if( msg.empty() ) {
             msg = is_avatar() ? _( "yourself let out a piercing howl!" ) : _( "a piercing howl!" );
             shout = "howl";
         }
     } else if( has_trait( trait_SHOUT2 ) ) {
-        base = 15;
         if( msg.empty() ) {
             msg = is_avatar() ? _( "yourself scream loudly!" ) : _( "a loud scream!" );
             shout = "scream";
         }
-    }
-
-    if( msg.empty() ) {
-        msg = is_avatar() ? _( "yourself shout loudly!" ) : _( "a loud shout!" );
-        shout = "default";
+    } else if( has_trait( trait_SCREECH ) ) {
+        if( msg.empty() ) {
+            msg = is_avatar() ? _( "yourself screech loudly!" ) : _( "a loud screech!" );
+            shout = "screech";
+        }
     }
     int noise = get_shout_volume();
-
-    // Minimum noise volume possible after all reductions.
-    // Volume 1 can't be heard even by player
-    constexpr int minimum_noise = 2;
-
-    if( noise <= base ) {
-        std::wstring wstr( utf8_to_wstr( msg ) );
-        std::transform( wstr.begin(), wstr.end(), wstr.begin(), towlower );
-        msg = wstr_to_utf8( wstr );
-    }
-
-    // Screaming underwater is not good for oxygen and harder to do overall
+    // Screaming underwater is a bad idea.  Volume was handled in get_shout_volume().
     if( underwater ) {
         if( !has_trait( trait_GILLS ) && !has_trait( trait_GILLS_CEPH ) ) {
             mod_stat( "oxygen", -noise );
         }
     }
-
-    // TODO: indistinct noise descriptions should be handled in the sounds code
-    if( noise <= minimum_noise ) {
-        add_msg_if_player( m_warning,
-                           _( "The sound of your voice is almost completely muffled!" ) );
-        msg = is_avatar() ? _( "your muffled shout" ) : _( "an indistinct voice" );
-    } else if( get_limb_score( limb_score_breathing ) < 0.5f ) {
+    if( underwater || get_limb_score( limb_score_breathing ) < 0.5f ) {
         // The shout's volume is 1/2 or lower of what it would be without the penalty
-        add_msg_if_player( m_warning, _( "The sound of your voice is significantly muffled!" ) );
+        add_msg_if_player( m_warning, _( "Your %s is significantly muffled!" ), shout );
     }
-
+    if( noise <= 2 ) {
+        add_msg_if_player( m_warning, _( "Your %s is barely audible!" ), shout );
+        msg = is_avatar() ? _( "your faint voice." ) : _( "an indistinct voice." );
+    }
+    if( msg.empty() ) {
+        msg = is_avatar() ? _( "yourself shout loudly!" ) : _( "a loud shout!" );
+    }
     sounds::sound( pos_bub(), noise, order ? sounds::sound_t::order : sounds::sound_t::alert, msg,
                    false,
                    "shout", shout );
@@ -9423,7 +9400,9 @@ void Character::set_knows_creature_type( const Creature *c )
 
 void Character::set_knows_creature_type( const mtype_id &c )
 {
-    known_monsters.emplace( c );
+    if( known_monsters.emplace( c ).second ) {
+        practice( skill_survival, 10 );
+    }
 }
 
 void Character::assign_activity( const activity_id &type, int moves, int index, int pos,

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -1039,7 +1039,7 @@ void faction_manager::display() const
 
     avatar &player_character = get_avatar();
     while( true ) {
-        // create a list of NPCs, visible and the ones on overmapbuffer
+        // Create a list of NPCs, visible and the ones on overmapbuffer.
         followers.clear();
         for( const character_id &elem : g->get_follower_list() ) {
             shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
@@ -1062,7 +1062,7 @@ void faction_manager::display() const
         interactable = false;
         radio_interactable = false;
         camp = nullptr;
-        // create a list of faction camps
+        // Create a list of faction camps.
         camps.clear();
         for( tripoint_abs_omt elem : player_character.camps ) {
             std::optional<basecamp *> p = overmap_buffer.find_camp( elem.xy() );
@@ -1071,7 +1071,7 @@ void faction_manager::display() const
             }
             basecamp *temp_camp = *p;
             if( temp_camp->get_owner() != player_character.get_faction()->id ) {
-                // Don't display NPC camps as ours
+                // Don't display NPC camps as ours.
                 continue;
             }
             camps.push_back( temp_camp );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -6185,20 +6185,16 @@ static void item_save_monsters( Character &p, item &it, const std::vector<monste
     if( monster_photos.empty() ) {
         monster_photos = ",";
     }
-
     for( monster * const &monster_p : monster_vec ) {
         const std::string mtype = monster_p->type->id.str();
         const std::string name = monster_p->name();
-
-        // position of <monster type string>
+        // Position of <monster type string>
         const size_t mon_str_pos = monster_photos.find( "," + mtype + "," );
-
-        // monster gets recorded by the character, add to known types
+        // Monster gets recorded by the character, add to known types.
         p.set_knows_creature_type( monster_p->type->id );
-
-        if( mon_str_pos == std::string::npos ) { // new monster
+        if( mon_str_pos == std::string::npos ) { // New monster.
             monster_photos += string_format( "%s,%d,", mtype, photo_quality );
-        } else { // replace quality character, if new photo is better
+        } else { // Replace quality character, if new photo is better.
             const size_t quality_num_pos = mon_str_pos + mtype.size() + 2;
             const size_t next_comma = monster_photos.find( ',', quality_num_pos );
             const int old_quality =
@@ -6369,7 +6365,6 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
         tripoint_bub_ms aim_point{ *aim_point_ };
         bool incorrect_focus = false;
         tripoint_range<tripoint_bub_ms> aim_bounds = here.points_in_radius( aim_point, 2 );
-
         std::vector<tripoint_bub_ms> trajectory = line_to( p->pos_bub(), aim_point, 0, 0 );
         trajectory.push_back( aim_point );
 
@@ -6395,8 +6390,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
             monster *const mon = creatures.creature_at<monster>( trajectory_point, true );
             Character *const guy = creatures.creature_at<Character>( trajectory_point );
             if( mon || guy || trajectory_point == aim_point ) {
-                int dist = rl_dist( p->pos_bub(), trajectory_point );
-
+                int dist = trig_dist( p->pos_bub(), trajectory_point );
                 int camera_bonus = it->has_flag( flag_CAMERA_PRO ) ? 10 : 0;
                 int photo_quality = 20 - rng( dist, dist * 2 ) * 2 + rng( camera_bonus / 2, camera_bonus );
                 if( photo_quality > 5 ) {
@@ -6408,10 +6402,8 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
                 if( p->is_blind() ) {
                     photo_quality /= 2;
                 }
-
                 if( mon ) {
                     monster &z = *mon;
-
                     // shoot past small monsters and hallucinations
                     if( trajectory_point != aim_point && ( z.type->size <= creature_size::small ||
                                                            z.is_hallucination() ||
@@ -6425,7 +6417,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
                     } else if( trajectory_point != aim_point ) { // shoot past mon that will be in photo anyway
                         continue;
                     }
-                    // get a special message if the target is a hallucination
+                    // Get a special message if the target is a hallucination.
                     if( trajectory_point == aim_point && ( z.is_hallucination() ||
                                                            z.type->in_species( species_HALLUCINATION ) ) ) {
                         p->add_msg_if_player( _( "Strange… there's nothing in the center of this picture?" ) );
@@ -6434,10 +6426,10 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
                     if( trajectory_point == aim_point && guy->is_hallucination() ) {
                         p->add_msg_if_player( _( "Strange… %s isn't visible on the picture?" ), guy->get_name() );
                     } else if( !aim_bounds.is_point_inside( trajectory_point ) ) {
-                        // take a photo of the monster that's in the way
+                        // Take a photo of the monster that's in the way.
                         p->add_msg_if_player( m_warning, _( "%s got in the way of your photo." ), guy->get_name() );
                         incorrect_focus = true;
-                    } else if( trajectory_point != aim_point ) {  // shoot past guy that will be in photo anyway
+                    } else if( trajectory_point != aim_point ) {  // Shoot past guy that will be in photo anyway.
                         continue;
                     }
                 }
@@ -6462,7 +6454,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
                 }
 
                 const bool selfie = std::find( character_vec.begin(), character_vec.end(),
-                                               p ) != character_vec.end();
+                                p ) != character_vec.end();
 
                 if( selfie ) {
                     p->add_msg_if_player( _( "You took a selfie." ) );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -149,6 +149,8 @@ static const efftype_id effect_worked_on( "worked_on" );
 static const emit_id emit_emit_shock_cloud( "emit_shock_cloud" );
 static const emit_id emit_emit_shock_cloud_big( "emit_shock_cloud_big" );
 
+static const faction_id faction_your_followers( "your_followers" );
+
 static const flag_id json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const flag_id json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
 static const flag_id json_flag_DISABLE_FLIGHT( "DISABLE_FLIGHT" );
@@ -562,6 +564,14 @@ void monster::try_reproduce()
     if( !reproduces ) {
         return;
     }
+    // Don't lay eggs if you're at Tacoma or something, the people who work there took them.
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( pos_abs_omt().xy() );
+    if( bcp ) {
+        basecamp *actual_camp = *bcp;
+        if( actual_camp->get_owner() != get_player_character().get_faction()->id ) {
+            return;
+        }
+    }
     // This can happen if the monster type has changed (from reproducing to non-reproducing monster).
     if( !type->baby_timer ) {
         return;
@@ -638,6 +648,14 @@ void monster::refill_udders()
     if( type->starting_ammo.empty() ) {
         debugmsg( "monster %s has no starting ammo to refill udders", get_name() );
         return;
+    }
+    // Don't produce milk if you're at Tacoma or something, the people who work there took it.
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( pos_abs_omt().xy() );
+    if( bcp ) {
+        basecamp *actual_camp = *bcp;
+        if( actual_camp->get_owner() != get_player_character().get_faction()->id ) {
+            return;
+        }
     }
     if( ammo.empty() ) {
         // Legacy animals got empty ammo map, fill them up now if needed.
@@ -3546,51 +3564,53 @@ void monster::process_effects()
     }
 
     Character &player_character = get_player_character();
-    //If this monster has the ability to heal in combat, do it now.
-    int regeneration_amount = type->regenerates;
-    //Apply effect-triggered regeneartion modifiers
-    for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
-        if( has_effect( regeneration_modifier.first ) ) {
-            regeneration_amount += regeneration_modifier.second;
+    // If this monster is below full health and can regenerate, do it now.
+    if( hp < type->hp ) {
+        int regeneration_amount = type->regenerates;
+        //Apply effect-triggered regeneartion modifiers
+        for( const auto &regeneration_modifier : type->regeneration_modifiers ) {
+            if( has_effect( regeneration_modifier.first ) ) {
+                regeneration_amount += regeneration_modifier.second;
+            }
+        }
+        // Apply enchantment modifiers.
+        regeneration_amount = calculate_by_enchantment( regeneration_amount, enchant_vals::mod::REGEN_HP,
+                            true );
+        // Prevent negative regeneration.
+        if( regeneration_amount < 0 ) {
+            regeneration_amount = 0;
+        }
+        const int healed_amount = heal( regeneration_amount );
+        if( healed_amount > 0 && one_in( 2 ) ) {
+            std::string healing_format_string;
+            if( healed_amount >= 30 ) {
+                healing_format_string = _( "The %s is visibly regenerating!" );
+            } else if( healed_amount >= 10 ) {
+                healing_format_string = _( "The %s seems a little healthier." );
+            } else {
+                healing_format_string = _( "The %s is healing slowly." );
+            }
+            add_msg_if_player_sees( *this, m_warning, healing_format_string, name() );
+        }
+
+        if( type->regenerates_in_dark && !g->is_in_sunlight( pos_bub() ) ) {
+            const float light = here.ambient_light_at( pos_bub() );
+            const int dark_regen_amount = static_cast<int>( std::round( 30.f * std::clamp( 600.f - light, 0.f, 600.f ) / 600.f ) );
+            if( heal( dark_regen_amount ) > 20 && one_in( 31 - dark_regen_amount ) ) {
+                add_msg_if_player_sees( *this, m_warning, _( "The %s uses the darkness to regenerate." ), name() );
+            } else if( heal( dark_regen_amount ) > 0 && one_in( 31 - dark_regen_amount ) ) {
+                add_msg_if_player_sees( *this, m_warning, _( "The light seems to be slowing %s regeneration." ), disp_name( true ) );
+            }
+        }
+
+        if( has_effect( effect_critter_well_fed ) && one_in( 90 ) ) {
+            heal( 1 );
         }
     }
-    //Apply enchantment modifiers
-    regeneration_amount = calculate_by_enchantment( regeneration_amount, enchant_vals::mod::REGEN_HP,
-                          true );
-    //Prevent negative regeneration
-    if( regeneration_amount < 0 ) {
-        regeneration_amount = 0;
-    }
-    const int healed_amount = heal( regeneration_amount );
-    if( healed_amount > 0 && one_in( 2 ) ) {
-        std::string healing_format_string;
-        if( healed_amount >= 50 ) {
-            healing_format_string = _( "The %s is visibly regenerating!" );
-        } else if( healed_amount >= 10 ) {
-            healing_format_string = _( "The %s seems a little healthier." );
-        } else {
-            healing_format_string = _( "The %s is healing slowly." );
-        }
-        add_msg_if_player_sees( *this, m_warning, healing_format_string, name() );
-    }
 
-    if( type->regenerates_in_dark && !g->is_in_sunlight( pos_bub() ) ) {
-        const float light = here.ambient_light_at( pos_bub() );
-        // Magic number 10000 was chosen so that a floodlight prevents regeneration in a range of 20 tiles
-        // TODO: Fix this horseshit
-        const int dHP = std::clamp( static_cast<int>( 30.0 * std::exp( - light * light / 10000 ) ), 0, 30 );
-        if( heal( dHP ) > 0 && one_in( 31 - dHP ) ) {
-            add_msg_if_player_sees( *this, m_warning, _( "The %s uses the darkness to regenerate." ), name() );
-        }
-    }
-
-    if( has_effect( effect_critter_well_fed ) && one_in( 90 ) ) {
-        heal( 1 );
-    }
-
-    //We already check these timers on_load, but adding a random chance for them to go off here
-    //will make it so that the player needn't leave the area and return for critters to poop,
-    //become hungry, evolve, have babies, or refill udders.
+    // We already check these timers on_load, but adding a random chance for them to go off here
+    // will make it so that the player needn't leave the area and return for critters to poop,
+    // become hungry, evolve, have babies, or refill udders.
     if( one_in( 30000 ) ) {
         try_upgrade( false );
         try_reproduce();

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1082,17 +1082,15 @@ static void eff_fun_sleep( Character &u, effect &it )
     } else if( intense < 24 ) {
         it.mod_intensity( 1 );
     }
-
-    if( u.has_effect( effect_narcosis ) && u.get_fatigue() <= 25 ) {
-        u.set_fatigue( 25 ); //Prevent us from waking up naturally while under anesthesia
+    int current_fatigue = u.get_fatigue();
+    const bool anesthetized = u.has_effect( effect_narcosis );
+    if( anesthetized ) {
+        if( current_fatigue <= 25 ) {
+            u.set_fatigue( 25 ); // Prevent us from waking up while under anesthesia.
+            current_fatigue = 25;
+        }
     }
-
-    if( u.get_fatigue() < -25 && it.get_duration() > 3_minutes && !u.has_effect( effect_narcosis ) ) {
-        it.set_duration( 1_turns * dice( 3, 10 ) );
-    }
-
-    if( u.get_fatigue() <= 0 && u.get_fatigue() > -20 && !u.has_effect( effect_narcosis ) ) {
-        u.mod_fatigue( -25 );
+    if( !anesthetized && current_fatigue < 5 ) {
         if( u.get_sleep_deprivation() < SLEEP_DEPRIVATION_HARMLESS ) {
             u.add_msg_if_player( m_good, _( "You feel well rested." ) );
         } else {
@@ -1104,7 +1102,7 @@ static void eff_fun_sleep( Character &u, effect &it )
 
     // Check mutation category strengths to see if we're mutated enough to get a dream
     // If we've crossed a threshold, always show dreams for that category
-    // Otherwise, check for the category that we have the most vitamins in our blood for
+    // Otherwise, check for the category that we have the most mutagen in our blood for.
     mutation_category_id cat = u.get_threshold_category();
     weighted_int_list<mutation_category_id> cat_list = u.get_vitamin_weighted_categories();
     if( cat.is_null() && cat_list.get_weight() > 0 ) {
@@ -1112,89 +1110,81 @@ static void eff_fun_sleep( Character &u, effect &it )
     }
     int cat_strength = u.mutation_category_level[cat];
 
-    // Determine the strength of effects or dreams based upon category strength
-    int strength = 0; // Category too weak for any effect or dream
-    if( u.crossed_threshold() ) {
-        strength = 4; // Post-human.
-    } else if( cat_strength >= 15 && cat_strength < 22 ) {
-        strength = 1; // Low strength
-    } else if( cat_strength >= 22 && cat_strength < 30 ) {
-        strength = 2; // Medium strength
-    } else if( cat_strength >= 30 ) {
-        strength = 3; // High strength
-    }
+    if( cat_strength > 14 ) {
+        // Determine the strength of effects or dreams based upon category strength
+        int strength = 0; // Category too weak for any effect or dream
+        if( u.crossed_threshold() ) {
+            strength = 4; // Post-human.
+        } else if( cat_strength >= 15 && cat_strength < 22 ) {
+            strength = 1; // Low strength
+        } else if( cat_strength >= 22 && cat_strength < 30 ) {
+            strength = 2; // Medium strength
+        } else if( cat_strength >= 30 ) {
+            strength = 3; // High strength
+        }
 
-    // Get a dream if category strength is high enough.
-    if( strength != 0 ) {
-        //Once every 6 / 3 / 2 hours, with a bit of randomness
-        if( calendar::once_every( 6_hours / strength ) && one_in( 3 ) ) {
-            // Select a dream
-            std::string dream = u.get_category_dream( cat, strength );
-            if( !dream.empty() ) {
-                u.add_msg_if_player( dream );
-            }
-            // Mycus folks upgrade in their sleep.
-            if( u.has_trait( trait_THRESH_MYCUS ) ) {
-                if( one_in( 8 ) ) {
-                    u.mutate_category( mutation_category_MYCUS, false, true );
-                    u.mod_stored_kcal( -87 );
-                    u.mod_thirst( 10 );
-                    u.mod_fatigue( 5 );
+        // Get a dream if category strength is high enough.
+        if( strength != 0 ) {
+            //Once every 6 / 3 / 2 hours, with a bit of randomness.
+            if( calendar::once_every( 6_hours / strength ) && one_in( 6 ) ) {
+                // Select a dream.
+                std::string dream = u.get_category_dream( cat, strength );
+                if( !dream.empty() ) {
+                    u.add_msg_if_player( dream );
+                }
+                // Mycus folks upgrade in their sleep.
+                if( u.has_trait( trait_THRESH_MYCUS ) ) {
+                    if( one_in( 8 ) ) {
+                        u.mutate_category( mutation_category_MYCUS, false, true );
+                        u.mod_stored_kcal( -87 );
+                        u.mod_thirst( 10 );
+                        u.mod_fatigue( 5 );
+                        current_fatigue += 5;
+                    }
                 }
             }
         }
     }
 
     bool woke_up = false;
-    int tirednessVal = rng( 5, 200 ) + rng( 0, std::abs( u.get_fatigue() * 2 * 5 ) );
-    if( !u.is_blind() && !u.has_effect( effect_narcosis ) &&
-        !u.has_active_mutation( trait_CHLOROMORPH ) && !u.has_active_bionic( bio_sleep_shutdown ) ) {
-        // People who can see while sleeping are acclimated to the light.
-        if( !u.has_flag( json_flag_SEESLEEP ) ) {
-            if( u.has_trait( trait_HEAVYSLEEPER2 ) && !u.has_trait( trait_HIBERNATE ) ) {
+    if( !anesthetized ) {
+        // Slightly wonky once_every() time so this isn't obviously every ten minutes.
+        if( calendar::once_every( 465_seconds ) && !u.is_blind() && !u.has_active_mutation( trait_CHLOROMORPH ) && !u.has_active_bionic( bio_sleep_shutdown ) ) {
+            // People who can see while sleeping are acclimated to the light.
+            if( !u.has_flag( json_flag_SEESLEEP ) ) {
+                int divisor = 5;
+                if( u.has_trait( trait_HEAVYSLEEPER2 ) || u.has_trait( trait_HIBERNATE ) ) {
+                    divisor = 4;
+                } else if( u.has_trait( trait_HEAVYSLEEPER ) ) {
+                    divisor = 3;
+                }
                 // So you can too sleep through noon.
-                if( ( tirednessVal * 1.25 ) < here.ambient_light_at( u.pos_bub() ) && ( u.get_fatigue() < 10 ||
-                        one_in( u.get_fatigue() / 2 ) ) ) {
+                int wake_chance = current_fatigue / divisor;
+                if( wake_chance <= here.ambient_light_at( u.pos_bub() ) || one_in( 1 + wake_chance ) ) {
                     u.add_msg_if_player( _( "It's too bright to sleep." ) );
-                    // Set ourselves up for removal
                     it.set_duration( 0_turns );
                     woke_up = true;
                 }
-                // Ursine hibernators would likely do so indoors.  Plants, though, might be in the sun.
-            } else if( u.has_trait( trait_HIBERNATE ) ) {
-                if( ( tirednessVal * 5 ) < here.ambient_light_at( u.pos_bub() ) && ( u.get_fatigue() < 10 ||
-                        one_in( u.get_fatigue() / 2 ) ) ) {
-                    u.add_msg_if_player( _( "It's too bright to sleep." ) );
-                    // Set ourselves up for removal
+            } else if( u.has_flag( json_flag_SEESLEEP ) ) {
+                Creature *hostile_critter = g->is_hostile_very_close();
+                if( hostile_critter != nullptr ) {
+                    u.add_msg_if_player( _( "You see %s approaching!" ),
+                                        hostile_critter->disp_name() );
                     it.set_duration( 0_turns );
                     woke_up = true;
                 }
-            } else if( tirednessVal < here.ambient_light_at( u.pos_bub() ) && ( u.get_fatigue() < 10 ||
-                       one_in( u.get_fatigue() / 2 ) ) ) {
-                u.add_msg_if_player( _( "It's too bright to sleep." ) );
-                // Set ourselves up for removal
-                it.set_duration( 0_turns );
-                woke_up = true;
-            }
-        } else if( u.has_flag( json_flag_SEESLEEP ) ) {
-            Creature *hostile_critter = g->is_hostile_very_close();
-            if( hostile_critter != nullptr ) {
-                u.add_msg_if_player( _( "You see %s approaching!" ),
-                                     hostile_critter->disp_name() );
-                it.set_duration( 0_turns );
-                woke_up = true;
             }
         }
     }
 
     // Have we already woken up?
-    if( !woke_up && !u.has_effect( effect_narcosis ) ) {
+    if( !woke_up && !anesthetized ) {
         // Cold or heat may wake you up.
         // Player will sleep through cold or heat if fatigued enough
         for( const bodypart_id &bp : u.get_all_body_parts() ) {
             const units::temperature curr_temp = u.get_part_temp_cur( bp );
             const units::temperature_delta fatigue_modifier = units::from_celsius_delta(
-                        u.get_fatigue() / 1000.0 );
+                        current_fatigue / 1000.0 );
             if( curr_temp < BODYTEMP_VERY_COLD - fatigue_modifier ) {
                 if( one_in( 30000 ) ) {
                     u.add_msg_if_player( _( "You toss and turn trying to keep warm." ) );
@@ -1225,7 +1215,7 @@ static void eff_fun_sleep( Character &u, effect &it )
 
     // A bit of a hack: check if we are about to wake up for any reason, including regular
     // timing out of sleep
-    if( it.get_duration() == 1_turns || woke_up ) {
+    if( it.get_duration() <= 1_turns || woke_up ) {
         u.wake_up();
     }
 }


### PR DESCRIPTION
#### Summary
Further sleep fixes, photos train ecology, fix shouting

#### Purpose of change
Did a bunch of stuff at once. Mostly a followup to #2928 

#### Describe the solution
While fixing some stuff that relied on negative fatigue for its logic, I realized there were optimizations to be made to sleep. Then I scrolled past shout code and it was bad. Then for some reason within this very PR I added ecology training for photographing a monster for the first time.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
