### PR TITLE
Workbenches can be taken down

### DIFF
--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -171,6 +171,7 @@
       ]
     },
     "examine_action": "workbench",
+    "deployed_item": "workbench",
     "workbench": { "multiplier": 1.2, "mass": "500000 g", "volume": "200 L" }
   },
   {


### PR DESCRIPTION
#### Summary
Workbenches can be taken down

#### Purpose of change

fixes #2925 

#### Describe the solution
I am not sure how the attached issue came about, but f_workbench was missing deployed_item: "workbench" so I added it and now it works.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
