### PR TITLE
Mission fixes for smokes and corrie

### DIFF
--- a/data/json/npcs/necc/godco_missions.json
+++ b/data/json/npcs/necc/godco_missions.json
@@ -727,14 +727,12 @@
     "id": "MISSION_GODCO_CORRIE_MACHINE1",
     "type": "mission_definition",
     "name": { "str": "Renewable Energy" },
-    "description": "Find a solar array or four solar panels for Corrie.",
+    "description": "Find two solar arrays for Corrie.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "u_has_items_sum": [
-        { "item": "ground_solar_panel", "amount": 1 },
-        { "item": "ground_solar_panel_v2", "amount": 1 },
-        { "item": "solar_panel", "amount": 4 },
-        { "item": "solar_panel_v2", "amount": 4 }
+        { "item": "ground_solar_panel", "amount": 2 },
+        { "item": "ground_solar_panel_v2", "amount": 2 }
       ]
     },
     "difficulty": 1,
@@ -744,12 +742,12 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "I have a plan…",
-      "offer": "Okay, great.  We're gonna create a charger and a generator all in one.  Here's the battle plan.  Zack could create the framework, you'll get me a solar array or four solar panels.  The rest I can craft or repurpose from the bus.  Helena's promised us a reward if this thing lives up to her standards.",
+      "offer": "Okay, great.  We're gonna create a charger and a generator all in one.  Here's the battle plan.  Zack could create the framework, you'll get me two solar arrays.  The rest I can craft or repurpose from the bus.  Helena's promised us a reward if this thing lives up to her standards.",
       "accepted": "With my brains and your brawn we'll make an excellent team.  A regular solar panel will do just fine.",
       "rejected": "No electricity for us then.",
-      "advice": "The best place to look is probably on rooftops.  You'll need a wrench, and maybe a stepladder to get up and down safely.",
-      "inquire": "Do you have the solar panels?",
-      "success": "The great work is now complete.  Are you good with words, by the way?  I was thinking, maybe you should be the one to negotiate with Helena.  But whatever you do, don't accept their icons.  Our work is worth a lot more than their valueless currency.",
+      "advice": "The best place to look is probably on rooftops, and remember: we need full arrays, not just the little panels or cells.  One array is made from four panels, got it?",
+      "inquire": "Do you have the solar arrays?",
+      "success": "Yes!  Are you good with words, by the way?  I was thinking, maybe you should be the one to negotiate with Helena.  But whatever you do, don't accept their icons.  Our work is worth a lot more than their valueless currency.",
       "success_lie": "Thanks for trying…  I guess.",
       "failure": "No electricity for us then."
     },
@@ -757,10 +755,8 @@
       "effect": [
         {
           "u_consume_item_sum": [
-            { "item": "ground_solar_panel", "amount": 1 },
-            { "item": "ground_solar_panel_v2", "amount": 1 },
-            { "item": "solar_panel", "amount": 4 },
-            { "item": "solar_panel_v2", "amount": 4 }
+            { "item": "ground_solar_panel", "amount": 2 },
+            { "item": "ground_solar_panel_v2", "amount": 2 }
           ]
         },
         { "u_add_var": "mission_completed_godco_corrie_machine", "value": "in-progress" },

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard1.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard1.json
@@ -110,7 +110,7 @@
   {
     "id": "MISSION_EVAC_SMOKER_GET_CIGARETTES",
     "type": "mission_definition",
-    "name": { "str": "Smokes, let's go." },
+    "name": { "str": "One hundred cigarettes." },
     "description": "Make a friend at the refugee center by handing over around five packs - 100 cigarettes.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 2,

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_missions.json
@@ -229,14 +229,16 @@
     "id": "MISSION_FREE_MERCHANTS_EVAC_4",
     "type": "mission_definition",
     "name": { "str": "Solar Power" },
-    "description": "Deliver 10 solar panel arrays to help the Free Merchants set up a renewable power grid, in exchange for a handsome reward.",
-    "goal": "MGOAL_FIND_ITEM",
-    "difficulty": 5,
-    "value": 400000,
+    "description": "Deliver 10 solar panel arrays to help the Free Merchants set up a renewable power grid in exchange for a handsome reward.",
+    "value": 0,
+    "goal": "MGOAL_CONDITION",
     "goal_condition": {
-      "u_has_items_sum": [ { "item": "ground_solar_panel", "amount": 10 }, { "item": "ground_solar_panel_v2", "amount": 10 } ]
+      "u_has_items_sum": [
+        { "item": "ground_solar_panel", "amount": 10 },
+        { "item": "ground_solar_panel_v2", "amount": 10 }
+      ]
     },
-    "count": 10,
+    "difficulty": 2,
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,
     "followup": "MISSION_FREE_MERCHANTS_EVAC_5",


### PR DESCRIPTION
#### Summary
Mission fixes for Smokes and Corrie

#### Purpose of change
Smokes and Corrie now ask for just solar arrays, not panels or arrays. Smokes's mission uses CONDITION instead of FIND_ITEM. The guard who wants cigarettes has a new name for their mission since the old one used the word "smokes" which is confusing when a guy named smokes is ten feet away.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
