### PR TITLE
Fix visibility check on invalid character

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -731,7 +731,6 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_characte
     if( std::abs( posz() - t.z() ) > fov_3d_z_range ) {
         return false;
     }
-
     const tripoint_bub_ms pos = pos_bub( here );
 
     // Check for adjacent high-concealment tiles that would block vision.
@@ -774,9 +773,9 @@ bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_characte
         }
         if( is_character ) {
             // Get character visibility from things like mutations.
-            Creature *ch = get_creature_tracker().creature_at( t );
+            Character *ch = get_creature_tracker().creature_at<Character>( t );
             if( ch != nullptr ) {
-                const float character_visibility_factor = ch->as_character()->visibility() / 100.0f;
+                const float character_visibility_factor = ch->visibility() / 100.0f;
                 int adj_range = std::floor( range * character_visibility_factor );
                 return adj_range >= wanted_range && here.sees( pos, t, range );
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1491,7 +1491,7 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( std::abs( v.pos.z() - zpos.z() ) > fov_3d_z_range ) {
             continue;
         }
-        if( rl_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
+        if( trig_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
             continue; // coarse distance filter, 40 = ~24 * sqrt(2) - rough max diameter of a vehicle
         }
         for( const vpart_reference &vpr : v.v->get_all_parts() ) {


### PR DESCRIPTION
#### Summary
Fix visibility check on invalid character

#### Purpose of change
It was possible for visibility() to be called by a monster on a character who hadn't yet been loaded in or was otherwise invalid, and additionally the check in creature::sees() was not safe.

#### Describe the solution
Ensure we're dealing with a character and ensure it's safe.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
