### PR TITLE
Propane tanks at steel mill contain propane

### DIFF
--- a/data/json/itemgroups/shops_trades.json
+++ b/data/json/itemgroups/shops_trades.json
@@ -38,9 +38,9 @@
       [ "sandpaper", 75 ],
       { "item": "ear_plugs", "prob": 25, "count": [ 1, 3 ] },
       { "group": "charcoal_bag_part", "prob": 25 },
-      { "item": "small_propane_tank", "prob": 10, "count": [ 0, 2 ] },
-      { "item": "medium_propane_tank", "prob": 20, "count": [ 0, 2 ] },
-      { "item": "large_propane_tank", "prob": 15, "count": [ 0, 2 ] },
+      { "item": "small_propane_tank", "prob": 10, "count": [ 0, 2 ], "charges": [ 0, 3000 ] },
+      { "item": "medium_propane_tank", "prob": 20, "count": [ 0, 2 ], "charges": [ 0, 15000 ] },
+      { "item": "large_propane_tank", "prob": 15, "count": [ 0, 2 ], "charges": [ 0, 60000 ] },
       { "item": "steel_chunk", "prob": 5, "count": [ 1, 3 ] },
       { "item": "steel_fragment", "prob": 15, "count": [ 1, 5 ] },
       {


### PR DESCRIPTION
#### Summary
Propane tanks at steel mill contain propane

#### Purpose of change
The propane tanks didn't have propane in them. These aren't items to be recycled, they're tools that people use.

#### Describe the solution
Put propane

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
