### PR TITLE
Backport 87581 - Craftable Luty SMGs

### DIFF
--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -156,7 +156,6 @@
     "subtypes": [ "GUN" ],
     "name": { "str_sp": "Luty SMG" },
     "description": "A Luty pattern makeshift smoothbore SMG crudely constructed out of various steel parts using advanced powered hand tools; likely one of the most complex guns that is feasible to make outside of a machine shop, but still very unreliable.  This one is chambered for .40 S&W cartridges and accepts custom-made makeshift magazines.",
-    "//": "Crafting recipe must make use of angle grinder, bench grinder, set square and vise, which don't yet exist in game. No factory mags until UMP40, mp5/40, or other straight .40 mags are implemented.",
     "weight": "3520 g",
     "volume": "1110 ml",
     "longest_side": "538 mm",

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -284,7 +284,6 @@
     "subtypes": [ "GUN" ],
     "name": { "str": "Luty SMG" },
     "description": "A Luty pattern makeshift smoothbore SMG crudely constructed out of various steel parts using advanced powered hand tools; likely one of the most complex guns that is feasible to make outside of a machine shop, but still very unreliable.  This one is chambered for .45 ACP cartridges and accepts MAC-10 compatible magazines.",
-    "//": "Crafting recipe must make use of angle grinder, bench grinder, set square and vise, which don't yet exist in game.",
     "weight": "3520 g",
     "volume": "1110 ml",
     "longest_side": "538 mm",

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -648,7 +648,6 @@
     "subtypes": [ "GUN" ],
     "name": { "str": "Luty SMG" },
     "description": "A Luty pattern makeshift smoothbore SMG crudely constructed out of various steel parts using advanced powered hand tools; likely one of the most complex guns that is feasible to make outside of a machine shop, but still very unreliable.  This one is chambered for 9x19mm cartridges and accepts STEN-compatible magazines.",
-    "//": "Crafting recipe must make use of angle grinder, bench grinder, set square and vise, which don't yet exist in game.",
     "weight": "3520 g",
     "volume": "1110 ml",
     "longest_side": "538 mm",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -546,6 +546,93 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_9mm",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_40",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "smg_45",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "fabrication",
+    "skills_required": [ [ "gun", 2 ] ],
+    "difficulty": 5,
+    "time": "16 h",
+    "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
+    "qualities": [ { "id": "DRILL", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "HAMMER", "level": 3 } ],
+    "tools": [
+      [ [ "metal_file", -1 ] ],
+      [ [ "angle_grinder", 100 ] ],
+      [ [ "belt_grinder", 100 ] ],
+      [ [ "pin_reamer", -1 ] ],
+      [ [ "bench_vise", -1 ] ]
+    ],
+    "proficiencies": [ { "proficiency": "prof_gunsmithing_improv" }, { "proficiency": "prof_gunsmithing_basic" } ],
+    "components": [
+      [ [ "pipe", 2 ] ],
+      [ [ "sheet_metal", 5 ] ],
+      [ [ "nuts_bolts", 15 ] ],
+      [ [ "scrap", 33 ] ],
+      [ [ "qt_wire", 1 ] ],
+      [ [ "spring_medium", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "briefcase_smg",
     "category": "CC_WEAPON",

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -551,7 +551,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "fabrication",
-    "skills_required": [ [ "gun", 2 ] ],
+    "skills_required": [ [ "devices", 3 ], [ "mechanics", 2 ], [ "gun", 2 ]  ],
     "difficulty": 5,
     "time": "16 h",
     "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
@@ -569,8 +569,8 @@
       [ [ "sheet_metal", 5 ] ],
       [ [ "nuts_bolts", 15 ] ],
       [ [ "scrap", 33 ] ],
-      [ [ "qt_wire", 1 ] ],
-      [ [ "spring_medium", 1 ] ]
+      [ [ "wire", 1 ] ],
+      [ [ "spring", 1 ] ]
     ]
   },
   {
@@ -580,7 +580,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "fabrication",
-    "skills_required": [ [ "gun", 2 ] ],
+    "skills_required": [ [ "devices", 3 ], [ "mechanics", 2 ], [ "gun", 2 ]  ],
     "difficulty": 5,
     "time": "16 h",
     "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
@@ -598,8 +598,8 @@
       [ [ "sheet_metal", 5 ] ],
       [ [ "nuts_bolts", 15 ] ],
       [ [ "scrap", 33 ] ],
-      [ [ "qt_wire", 1 ] ],
-      [ [ "spring_medium", 1 ] ]
+      [ [ "wire", 1 ] ],
+      [ [ "spring", 1 ] ]
     ]
   },
   {
@@ -609,7 +609,7 @@
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_RANGED",
     "skill_used": "fabrication",
-    "skills_required": [ [ "gun", 2 ] ],
+    "skills_required": [ [ "devices", 3 ], [ "mechanics", 2 ], [ "gun", 2 ]  ],
     "difficulty": 5,
     "time": "16 h",
     "book_learn": [ [ "text_gunsmith", 3 ], [ "textbook_anarch", 4 ], [ "manual_smg", 4 ] ],
@@ -627,8 +627,8 @@
       [ [ "sheet_metal", 5 ] ],
       [ [ "nuts_bolts", 15 ] ],
       [ [ "scrap", 33 ] ],
-      [ [ "qt_wire", 1 ] ],
-      [ [ "spring_medium", 1 ] ]
+      [ [ "wire", 1 ] ],
+      [ [ "spring", 1 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Backport 87581 - Craftable Luty SMGs

#### Purpose of change
DDA has had these for a minute, let's get em too.

#### Describe the solution
Backport. Change the recipes a bit to reflect our expanded devices/mechanics skills.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
