### PR TITLE
Backport 86684 - add belt grinder

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -15,7 +15,8 @@
       [ "metalworking_tongs", 90 ],
       [ "hammer", 80 ],
       [ "sandpaper", 80 ],
-      [ "bench_vise", 30 ]
+      [ "bench_vise", 30 ],
+      [ "belt_grinder", 50 ]
     ]
   },
   {
@@ -200,6 +201,7 @@
       [ "lug_wrench", 20 ],
       [ "jerrycan", 10 ],
       [ "jerrycan_big", 10 ],
+      [ "belt_grinder", 20 ],
       { "item": "char_smoker", "prob": 5, "charges": [ 0, 300 ] },
       { "item": "dehydrator", "prob": 5 },
       [ "tongs", 1 ],
@@ -912,7 +914,8 @@
       { "item": "grinder_metal_grinding_disc", "prob": 10 },
       { "item": "masonrysaw_off", "prob": 50, "charges": [ 0, 450 ] },
       { "item": "heavy_masonrysaw_off", "prob": 50, "charges": [ 0, 450 ] },
-      { "item": "electric_masonrysaw_off", "prob": 50, "charges": [ 0, 495 ] }
+      { "item": "electric_masonrysaw_off", "prob": 50, "charges": [ 0, 495 ] },
+      { "item": "belt_grinder", "prob": 20 }
     ]
   },
   {

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -313,6 +313,28 @@
     "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ]
   },
   {
+    "id": "belt_grinder",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "belt grinder" },
+    "looks_like": "pedal_grindstone",
+    "description": "A power tool used for grinding and shaping metal or even wood.  It consists of a motorized abrasive belt that spins at high speeds, allowing you to quickly polish, flatten, or overall remove material from surfaces.",
+    "weight": "55 kg",
+    "volume": "70 L",
+    "longest_side": "80 cm",
+    "price": "1500 USD",
+    "price_postapoc": "30 USD",
+    "material": [ "steel", "plastic" ],
+    "symbol": "B",
+    "color": "light_gray",
+    "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
+    "charged_qualities": [ { "id": "GRIND", "level": 2, "speed": 0.4 }, { "id": "FILE", "level": 3, "speed": 0.3 } ],
+    "charges_per_use": 25,
+    "use_action": [ { "type": "link_up", "cable_length": 10, "charge_rate": "1600 W" } ],
+    "tool_ammo": [ "battery" ]
+  },
+  {
     "id": "link_sheet",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -328,7 +328,6 @@
     "symbol": "B",
     "color": "light_gray",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
-    "faults": [ { "fault_group": "electronic_general" } ],
     "charged_qualities": [ { "id": "GRIND", "level": 2, "speed": 0.4 }, { "id": "FILE", "level": 3, "speed": 0.3 } ],
     "charges_per_use": 25,
     "use_action": [ { "type": "link_up", "cable_length": 10, "charge_rate": "1600 W" } ],

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -549,7 +549,7 @@
   {
     "id": "metal_file_any",
     "type": "requirement",
-    "tools": [ [ [ "metal_file", -1 ], [ "bronze_file", -1 ] ] ]
+    "tools": [ [ [ "metal_file", -1 ], [ "bronze_file", -1 ], [ "belt_grinder", 25 ] ] ]
   },
   {
     "id": "nm_teeth_removal",


### PR DESCRIPTION
#### Summary
Backport 86684 - add belt grinder

#### Purpose of change
Was needed for the luty

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
