### PR TITLE
Add Light Sleeper trait and optimize hearing

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1384,6 +1384,15 @@
   },
   {
     "type": "mutation",
+    "id": "LIGHTSLEEPER",
+    "name": { "str": "Light Sleeper" },
+    "points": -1,
+    "description": "Noise, light, and other disturbances wake you up easily.  It used to be annoying, but now it might just save your life.",
+    "starting_trait": true,
+    "category": [ "MOUSE", "FELINE", "BOVOID", "LAGOMORPH" ]
+  },
+  {
+    "type": "mutation",
     "id": "SLEEPY",
     "name": { "str": "Sleepy" },
     "points": -1,
@@ -1530,7 +1539,7 @@
   {
     "type": "mutation",
     "id": "HATES_BOOKS",
-    "name": { "str": "Hates Books" },
+    "name": { "str": "Hates Reading" },
     "points": -1,
     "description": "Reading is for nerds!  Boring books are more boring, and you can't have fun by reading books.",
     "valid": false,
@@ -6980,6 +6989,7 @@
     "types": [ "SUNLIGHT" ],
     "changes_to": [ "TROGLO2" ],
     "cancels": [ "SEASONAL_AFFECTIVE" ],
+    "flags": [ "LIGHT_SENSITIVE" ],
     "category": [ "BEAST", "INSECT", "SLIME", "SPIDER", "BATRACHIAN", "RAT", "TROGLOBITE", "CHIROPTERAN" ]
   },
   {
@@ -6991,6 +7001,7 @@
     "types": [ "SUNLIGHT" ],
     "prereqs": [ "TROGLO" ],
     "changes_to": [ "TROGLO3" ],
+    "flags": [ "LIGHT_SENSITIVE" ],
     "category": [ "RAT", "TROGLOBITE" ]
   },
   {
@@ -7001,6 +7012,7 @@
     "description": "Sunlight makes you extremely uncomfortable, resulting in large penalties to all stats.",
     "types": [ "SUNLIGHT" ],
     "prereqs": [ "TROGLO2" ],
+    "flags": [ "LIGHT_SENSITIVE" ],
     "category": [ "TROGLOBITE" ]
   },
   {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2239,7 +2239,7 @@ void activity_handlers::hand_crank_do_turn( player_activity *act, Character *you
             add_msg( m_info, _( "You've charged the battery completely." ) );
         }
     }
-    if( you->get_fatigue() >= fatigue_levels::DEAD_TIRED ) {
+    if( you->get_fatigue() >= fatigue_levels::DEAD_TIRED || you->weariness_level() >= 4 ) {
         act->moves_left = 0;
         add_msg( m_info, _( "You're too exhausted to keep cranking." ) );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -485,6 +485,7 @@ static const trait_id trait_INFRESIST( "INFRESIST" );
 static const trait_id trait_INSOMNIA( "INSOMNIA" );
 static const trait_id trait_LEG_TENT_BRACE( "LEG_TENT_BRACE" );
 static const trait_id trait_LIGHTSTEP( "LIGHTSTEP" );
+static const trait_id trait_LIGHTSLEEPER( "LIGHTSLEEPER" );
 static const trait_id trait_LOVES_BOOKS( "LOVES_BOOKS" );
 static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_MUCUS_SECRETION( "MUCUS_SECRETION" );
@@ -1680,15 +1681,15 @@ void Character::react_to_felt_pain( int intensity )
     }
     // Only a large pain burst will actually wake people while sleeping.
     if( has_effect( effect_sleep ) && get_effect( effect_sleep ).get_duration() > 0_turns &&
-        !has_effect( effect_narcosis ) ) {
+        !has_effect( effect_narcosis ) && !has_active_bionic( bio_sleep_shutdown ) ) {
         int pain_thresh = rng( 3, 5 );
 
-        if( has_active_bionic( bio_sleep_shutdown ) ) {
-            pain_thresh += 999;
-        } else if( has_trait( trait_HEAVYSLEEPER ) ) {
+        if( has_trait( trait_HEAVYSLEEPER ) ) {
             pain_thresh += 2;
-        } else if( has_trait( trait_HEAVYSLEEPER2 ) ) {
+        } else if( has_trait( trait_HEAVYSLEEPER2 ) || has_trait( trait_HIBERNATE ) ) {
             pain_thresh += 5;
+        } else if( has_trait( trait_LIGHTSLEEPER ) ) {
+            pain_thresh -= 1;
         }
 
         if( intensity >= pain_thresh ) {
@@ -5458,7 +5459,6 @@ int Character::weariness_level() const
             ++level;
         }
     }
-
     return level;
 }
 

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -43,6 +43,10 @@
 
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 
+static const addiction_id addiction_alcohol( "alcohol" );
+static const addiction_id addiction_caffeine( "caffeine" );
+static const addiction_id addiction_sleeping_pill( "sleeping pill" );
+
 static const bionic_id bio_sleep_shutdown( "bio_sleep_shutdown" );
 
 static const efftype_id effect_adrenaline( "adrenaline" );
@@ -107,6 +111,7 @@ static const json_character_flag json_flag_BIONIC_LIMB( "BIONIC_LIMB" );
 static const json_character_flag json_flag_BLEEDSLOW( "BLEEDSLOW" );
 static const json_character_flag json_flag_BLEEDSLOW2( "BLEEDSLOW2" );
 static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMAGE" );
+static const json_character_flag json_flag_LIGHT_SENSITIVE( "LIGHT_SENSITIVE" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_SEESLEEP( "SEESLEEP" );
 
@@ -127,6 +132,7 @@ static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
 static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
 static const trait_id trait_HIBERNATE( "HIBERNATE" );
 static const trait_id trait_INFRESIST( "INFRESIST" );
+static const trait_id trait_LIGHTSLEEPER( "LIGHTSLEEPER" );
 static const trait_id trait_M_IMMUNE( "M_IMMUNE" );
 static const trait_id trait_POISRESIST( "POISRESIST" );
 static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
@@ -1090,18 +1096,19 @@ static void eff_fun_sleep( Character &u, effect &it )
             current_fatigue = 25;
         }
     }
-    // If our sleep duration is almost up and we don't need any more rest, set duration to 3-5 minutes.
-    if( !anesthetized && current_fatigue <= 15 && it.get_duration() > 10_minutes ) {
-        if( u.get_sleep_deprivation() < SLEEP_DEPRIVATION_HARMLESS ) {
-            u.add_msg_if_player( m_good, _( "You feel well rested." ) );
+    // If our sleep duration is almost up and we don't need any more rest, set a wakeup timer.
+    if( !anesthetized && current_fatigue <= 15 && it.get_duration() > 30_minutes ) {
+        int timer;
+        if( u.has_trait( trait_LIGHTSLEEPER ) ) {
+            timer = rng( 30, 180 );
+        // Some people have a hard time getting up in the morning.
+        } else if( u.get_lifestyle() < 10 || u.get_sleep_deprivation() > SLEEP_DEPRIVATION_HARMLESS || u.has_addiction( addiction_sleeping_pill ) || u.has_addiction( addiction_caffeine ) || u.has_addiction( addiction_alcohol ) || u.has_trait( trait_HEAVYSLEEPER ) || u.has_trait( trait_HEAVYSLEEPER2 ) || u.has_trait( trait_HIBERNATE ) ) {
+            timer = rng( 300, 1680 );
         } else {
-            u.add_msg_if_player( m_warning,
-                                 _( "You feel physically rested, but you haven't been able to catch up on your missed sleep yet." ) );
+            timer = rng( 60, 600 );
         }
-        // This sets a wakeup timer.
-        it.set_duration( 1_turns * dice( 3, 100 ) );
+        it.set_duration( 1_turns * timer );
     }
-
     // Check mutation category strengths to see if we're mutated enough to get a dream
     // If we've crossed a threshold, always show dreams for that category
     // Otherwise, check for the category that we have the most mutagen in our blood for.
@@ -1154,8 +1161,10 @@ static void eff_fun_sleep( Character &u, effect &it )
         if( calendar::once_every( 465_seconds ) && current_fatigue < fatigue_levels::MASSIVE_FATIGUE && !u.is_blind() && !u.has_active_mutation( trait_CHLOROMORPH ) && !u.has_active_bionic( bio_sleep_shutdown ) ) {
             // People who can see while sleeping are acclimated to the light.
             if( !u.has_flag( json_flag_SEESLEEP ) ) {
+                bool lightsleeper = u.has_trait( trait_LIGHTSLEEPER ) || u.has_flag( json_flag_LIGHT_SENSITIVE );
                 int light = here.ambient_light_at( u.pos_bub() );
-                if( light > 29 ) {
+                // >= 3.5 is dimly lit. >= 15 is "bright". 300 is a flashlight. 500 is a heavy-duty flashlight.
+                if( light > 14 || ( lightsleeper && light > 3 ) ) {
                     int divisor = 4;
                     if( u.has_trait( trait_HEAVYSLEEPER2 ) || u.has_trait( trait_HIBERNATE ) ) {
                         divisor = 2;
@@ -1166,7 +1175,11 @@ static void eff_fun_sleep( Character &u, effect &it )
                     // Below that threshold, we sleep. Above it, we have a small chance to wake every time
                     // the check is run. Brightness is only a threshold, it doesn't influence wake_chance.
                     int wake_chance = current_fatigue * 2 / divisor;
-                    if( wake_chance <= light && one_in( ( 6 - divisor ) + wake_chance ) ) {
+                    int penalty = 0;
+                    if( lightsleeper ) {
+                        penalty = 10;
+                    }
+                    if( wake_chance <= light && one_in( std::max( 3, ( 6 - divisor ) + wake_chance ) - penalty ) ) {
                         u.add_msg_if_player( _( "It's too bright to sleep." ) );
                         it.set_duration( 0_turns );
                         woke_up = true;
@@ -1185,7 +1198,7 @@ static void eff_fun_sleep( Character &u, effect &it )
     }
 
     // Have we already woken up?
-    if( !woke_up && !anesthetized && calendar::once_every( 20_seconds ) ) {
+    if( !woke_up && !anesthetized && calendar::once_every( 20_seconds ) && !u.has_active_bionic( bio_sleep_shutdown ) ) {
         // Cold or heat may wake you up.
         // Player will sleep through cold or heat if fatigued enough.
         for( const bodypart_id &bp : u.get_all_body_parts() ) {
@@ -1227,8 +1240,7 @@ static void eff_fun_sleep( Character &u, effect &it )
         }
     }
 
-    // A bit of a hack: check if we are about to wake up for any reason, including regular
-    // timing out of sleep
+    // Check if we are about to wake up for any reason, including regular timing out of sleep.
     if( it.get_duration() <= 1_turns || woke_up ) {
         u.wake_up();
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -671,9 +671,9 @@ void sounds::process_sound_markers( Character *you )
             if( you->has_trait( trait_HEAVYSLEEPER ) ) {
                 sound_insensitivity += 10;
             } else if( you->has_trait( trait_HEAVYSLEEPER2 ) || you->has_trait( trait_HIBERNATE ) ) {
-                sound_insensitivity += 25;
+                sound_insensitivity += 15;
             } else if( you->has_trait( trait_LIGHTSLEEPER ) ) {
-                sound_insensitivity -= 5;
+                sound_insensitivity -= 10;
             }
             if( you->get_fatigue() > fatigue_levels::DEAD_TIRED ) {
                 sound_insensitivity += 10;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -184,6 +184,8 @@ static const ter_str_id ter_t_underbrush_harvested_winter( "t_underbrush_harvest
 
 static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
 static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
+static const trait_id trait_HIBERNATE( "HIBERNATE" );
+static const trait_id trait_LIGHTSLEEPER( "LIGHTSLEEPER" );
 
 struct monster_sound_event {
     int volume;
@@ -584,7 +586,6 @@ static bool describe_sound( sounds::sound_t category, bool from_player_position 
 void sounds::process_sound_markers( Character *you )
 {
     const map &here = get_map();
-
     bool is_deaf = you->is_deaf();
     const float volume_multiplier = you->hearing_ability();
     const int weather_vol = get_weather().weather_id->sound_attn;
@@ -610,7 +611,6 @@ void sounds::process_sound_markers( Character *you )
         // Deafening is based on the felt volume, as a player may be too deaf to
         // hear the deafening sound but still suffer additional hearing loss.
         const bool is_sound_deafening = rng( felt_volume / 2, felt_volume ) >= 150;
-
         // Deaf players hear no sound, but still are at risk of additional hearing loss.
         if( is_deaf ) {
             if( is_sound_deafening && !you->is_immune_effect( effect_deaf ) ) {
@@ -634,7 +634,12 @@ void sounds::process_sound_markers( Character *you )
                 continue;
             }
         }
-
+        if( is_deaf ) {
+            if( you->is_avatar() ) {
+                sounds_since_last_turn.clear();
+            }
+            return;
+        }
         // The heard volume of a sound is the player heard volume, regardless of true volume level.
         const int heard_volume = static_cast<int>( std::round( ( ( raw_volume - weather_vol ) *
                                  volume_multiplier ) - distance_to_sound ) );
@@ -651,7 +656,6 @@ void sounds::process_sound_markers( Character *you )
         if( you->controlling_vehicle ) {
             vehicle *veh = veh_pointer_or_null( here.veh_at( you->pos_abs() ) );
             const int noise = veh ? static_cast<int>( veh->vehicle_noise ) : 0;
-
             you->volume = std::max( you->volume, noise );
         }
 
@@ -659,13 +663,24 @@ void sounds::process_sound_markers( Character *you )
         bool slept_through = you->has_effect( effect_slept_through_alarm );
         // See if we need to wake someone up.
         if( you->in_sleep_state() ) {
-            if( ( ( !( you->has_trait( trait_HEAVYSLEEPER ) ||
-                       you->has_trait( trait_HEAVYSLEEPER2 ) ) && dice( 2, 15 ) < heard_volume ) ||
-                  ( you->has_trait( trait_HEAVYSLEEPER ) && dice( 3, 15 ) < heard_volume ) ||
-                  ( you->has_trait( trait_HEAVYSLEEPER2 ) && dice( 6, 15 ) < heard_volume ) ) &&
-                !you->has_effect( effect_narcosis ) &&
-                !you->has_bionic( bio_sleep_shutdown ) ) {
-                // Not kidding about sleep-through-firefight.
+            // Bail immediately if we're insensate.
+            if( you->has_effect( effect_narcosis ) && you->has_active_bionic( bio_sleep_shutdown ) ) {
+                continue;
+            }
+            int sound_insensitivity = 0;
+            if( you->has_trait( trait_HEAVYSLEEPER ) ) {
+                sound_insensitivity += 10;
+            } else if( you->has_trait( trait_HEAVYSLEEPER2 ) || you->has_trait( trait_HIBERNATE ) ) {
+                sound_insensitivity += 25;
+            } else if( you->has_trait( trait_LIGHTSLEEPER ) ) {
+                sound_insensitivity -= 5;
+            }
+            if( you->get_fatigue() > fatigue_levels::DEAD_TIRED ) {
+                sound_insensitivity += 10;
+            } else if( you->get_fatigue() > fatigue_levels::TIRED ) {
+                sound_insensitivity += 5;
+            }
+            if( rng( 0, 30 + sound_insensitivity ) < heard_volume ) {
                 you->wake_up();
                 you->add_msg_if_player( m_warning, _( "Something is making noise." ) );
             } else {
@@ -753,31 +768,25 @@ void sounds::process_sound_markers( Character *you )
         }
 
         int err_offset;
-        if( ( heard_volume + distance_to_sound ) / distance_to_sound < 2 ) {
-            err_offset = rng( 0, 3 );
-        } else if( ( heard_volume + distance_to_sound ) / distance_to_sound < 3 ) {
-            err_offset = rng( 0, 2 );
-        } else {
-            err_offset = rng( 0, 1 );
-        }
-
         // Echolocation has to be fairly precise or it's worse than useless.
         // However, it is never perfect.
         if( sound.category == sound_t::sensory ) {
-            if( ( heard_volume + distance_to_sound ) / distance_to_sound < 2 ) {
+            if( heard_volume < distance_to_sound ) {
                 err_offset = rng( 0, 3 );
-            } else if( ( heard_volume + distance_to_sound ) / distance_to_sound < 3 ) {
+            } else if( heard_volume < distance_to_sound * 2 ) {
                 err_offset = rng( 0, 2 );
+            } else if( one_in( 3 ) ) {
+                err_offset = rng( 0, 1 );
             } else {
-                if( one_in( 3 ) ) {
-                    err_offset = rng( 0, 1 );
-                } else {
-                    err_offset = 0;
-                }
+                err_offset = 0;
             }
+        } else {
+            int offset_max = heard_volume < distance_to_sound ? 3 :
+                            heard_volume < distance_to_sound * 2 ? 2 : 1;
+            err_offset = rng( 0, offset_max );
         }
 
-        // If Z-coordinate is different, draw even when you can see the source
+        // If Z-coordinate is different, draw even when you can see the source.
         const bool diff_z = pos.z() != you->posz();
 
         // Enumerate the valid points the player *cannot* see.
@@ -785,7 +794,7 @@ void sounds::process_sound_markers( Character *you )
         // Also show sensory sounds like SONAR even if we can see the point.
         std::vector<tripoint_bub_ms> unseen_points;
         for( const tripoint_bub_ms &newp : here.points_in_radius( pos, err_offset ) ) {
-            if( diff_z || sound.category == sound_t::sensory || !you->sees( here,  newp ) ) {
+            if( diff_z || sound.category == sound_t::sensory || !you->sees( here, newp ) ) {
                 unseen_points.emplace_back( newp );
             }
         }


### PR DESCRIPTION
#### Summary
Add Light Sleeper trait and optimize hearing

#### Purpose of change

#### Describe the solution
- Added the Light Sleeper trait, which makes sound, light, and pain more likely to awaken you.
- Optimized sound code when awake and asleep by skipping a bunch of unnecessary checks while deaf and tidying up repeated rng calls.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
