### PR TITLE
Fix depressions above underground stuff

### DIFF
--- a/data/json/mapgen/map_extras/field_clutter.json
+++ b/data/json/mapgen/map_extras/field_clutter.json
@@ -62,7 +62,7 @@
             [ "null", 6 ]
           ],
           "x": 0,
-          "y": 0
+          "y": 0, "neighbors": { "below": [ "solid_earth" ] }
         }
       ]
     }
@@ -82,7 +82,7 @@
             [ "mudpuddle_5x5", 1 ]
           ],
           "x": 0,
-          "y": 0
+          "y": 0, "neighbors": { "below": [ "solid_earth" ] }
         }
       ]
     }


### PR DESCRIPTION
#### Summary
Fix depressions above underground stuff

#### Purpose of change
Depressions in field_clutter were breaking into sewers and labs. This is easily avoidable, I think, by putting "below": [ "solid_earth" ].

#### Describe the solution
Try it.

#### Describe alternatives you've considered

#### Testing
Loads and runs, and depressions spawn normally. I can't check beyond that easily so I guess if someone spots another instance of this, then we'll come back to it, otherwise we're good.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
