### PR TITLE
fix typo in appearance_hair_styles.json: "medum" -> "medium"

### DIFF
--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1287,7 +1287,7 @@
     "variants": [
       {
         "id": "black",
-        "name": { "str": "Hair: black, medum curls" },
+        "name": { "str": "Hair: black, medium curls" },
         "description": "Your face is framed by black curls.",
         "weight": 20
       },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes typo introduced in recent hair changes

#### Describe the solution
Corrects "medum" to "medium"


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
