### PR TITLE
remove obsolete alien grass reference

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -112,7 +112,6 @@ static const ter_str_id ter_t_door_locked_interior( "t_door_locked_interior" );
 static const ter_str_id ter_t_door_locked_peep( "t_door_locked_peep" );
 static const ter_str_id ter_t_fault( "t_fault" );
 static const ter_str_id ter_t_grass( "t_grass" );
-static const ter_str_id ter_t_grass_alien( "t_grass_alien" );
 static const ter_str_id ter_t_grass_dead( "t_grass_dead" );
 static const ter_str_id ter_t_grass_golf( "t_grass_golf" );
 static const ter_str_id ter_t_grass_white( "t_grass_white" );
@@ -940,9 +939,6 @@ bool avatar_action::eat_here( avatar &you )
             return false;
         } else if( ter_underfoot == ter_t_grass_white ) {
             add_msg( _( "This grass is tainted with paint and thus inedible." ) );
-            return false;
-        } else if( ter_underfoot == ter_t_grass_alien ) {
-            add_msg( _( "This grass is razor sharp and would probably shred your mouth." ) );
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
Category "Brief description"
Grazer throws a warning when trying to eat grass because it looks for alien grass

#### Purpose of change
Fix grazer mutation

#### Describe the solution
Removed alien grass id references because portal storms don't exist

#### Describe alternatives you've considered
None

#### Testing
Activated grazer, ate grass

#### Additional context

https://github.com/user-attachments/assets/4333666f-5229-4179-86a7-b0173db4839f



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
