### PR TITLE
Fix reading morale

### DIFF
--- a/data/json/mapgen/airport/s_airport_private.json
+++ b/data/json/mapgen/airport/s_airport_private.json
@@ -70,11 +70,7 @@
         "4": "t_region_groundcover_urban"
       },
       "furniture": {
-        "4": [
-          [ "f_generator_broken", 25 ],
-          [ "f_diesel_generator", 5 ],
-          [ "f_gasoline_generator", 5 ]
-        ],
+        "4": [ [ "f_generator_broken", 25 ], [ "f_diesel_generator", 5 ], [ "f_gasoline_generator", 5 ] ],
         "q": "f_dumpster",
         "e": "f_machinery_light",
         "f": "f_locker",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1806,7 +1806,7 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
         who.burn_energy_all( -1 );
     }
 
-    // do not spam the message log
+    // Do not spam the message log.
     if( calendar::once_every( 5_minutes ) ) {
         add_msg_debug( debugmode::DF_ACT_READ, "%s reading time = %s",
                        who.name, to_string_writable( time_duration::from_moves( act.moves_left ) ) );
@@ -1932,7 +1932,7 @@ bool read_activity_actor::player_read( avatar &you )
         const int book_fun = learner->book_fun_for( *book, *learner );
         if( book_fun != 0 ) {
             learner->add_morale( morale_book,
-                                 book_fun, book_fun * 10,
+                                 book_fun, book_fun,
                                  2_hours, 1_hours, true,
                                  book->type );
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -775,7 +775,7 @@ void avatar::identify( const item &item )
     if( reading->intel != 0 ) {
         add_msg( m_info, _( "Requires intelligence of %d to easily read." ), reading->intel );
     }
-    //It feels wrong to use a pointer to *this, but I can't find any other player pointers in this method.
+
     if( book_fun_for( book, *this ) != 0 ) {
         add_msg( m_info, _( "Reading this book affects your morale by %d." ), book_fun_for( book, *this ) );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12482,18 +12482,13 @@ int Character::book_fun_for( const item &book, const Character &p ) const
         return 0;
     }
 
-    // Don't you like serving humans?!
-    if( ( p.has_trait( trait_CANNIBAL ) || p.has_trait( trait_PSYCHOPATH ) ||
-          p.has_trait( trait_SAPIOVORE ) ) &&
-        book.typeId() == itype_cookbook_human ) {
-        fun_bonus = std::abs( fun_bonus );
-    } else if( p.has_trait( trait_SPIRITUAL ) && book.has_flag( flag_INSPIRATIONAL ) ) {
-        fun_bonus = std::abs( fun_bonus * 3 );
-    }
-
-    if( has_trait( trait_LOVES_BOOKS ) ) {
-        fun_bonus = std::max( fun_bonus + 2, static_cast<int>( std::round( fun_bonus * 1.2 ) ) );
-    } else if( has_trait( trait_HATES_BOOKS ) ) {
+    if( p.has_trait( trait_LOVES_BOOKS ) || ( p.has_trait( trait_SPIRITUAL ) && book.has_flag( flag_INSPIRATIONAL ) ) ) {
+        if( book.type->book->fun < 0 ) {
+            fun_bonus = 0;
+        } else {
+            fun_bonus = std::max( fun_bonus + 2, static_cast<int>( std::round( fun_bonus * 1.2 ) ) );
+        }
+    } else if( p.has_trait( trait_HATES_BOOKS ) ) {
         if( book.type->book->fun > 0 ) {
             fun_bonus = std::min( fun_bonus - 2, fun_bonus / 2 );
         } else {


### PR DESCRIPTION
#### Summary
Fix reading morale

#### Purpose of change
Reading morale was able to stack up to 10 times a book's enjoyability. If you had bookworm, that was already 1.2x so you'd be able to skim something a few times and get 12 times its intended morale boost.

#### Describe the solution
Fixed. Spiritual+religious books are also fixed, and now just work the same as bookworm. Removed some dead code.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
