### PR TITLE
Fix sfx for using talking doll, shouting, etc

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -785,7 +785,6 @@ std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint_bub
 
 std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint_bub_ms & )
 {
-    p->add_msg_if_player( _( "You take some anticonvulsant medication." ) );
     /** @EFFECT_STR reduces duration of anticonvulsant medication */
     time_duration duration = 8_hours - p->str_cur * rng( 0_turns, 10_minutes );
     if( p->has_trait( trait_TOLERANCE ) ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -612,9 +612,9 @@ void sounds::process_sound_markers( Character *you )
         // Deafening is based on the felt volume, as a player may be too deaf to
         // hear the deafening sound but still suffer additional hearing loss.
         const bool is_sound_deafening = rng( felt_volume / 2, felt_volume ) >= 150;
-        // Deaf players hear no sound, but still are at risk of additional hearing loss.
-        if( is_deaf ) {
-            if( is_sound_deafening && !you->is_immune_effect( effect_deaf ) ) {
+        // Deaf characters hear no sound, but still are at risk of additional hearing loss.
+        if( is_sound_deafening && !you->is_immune_effect( effect_deaf ) ) {
+            if( is_deaf ) {
                 you->add_effect( effect_deaf, std::min( 4_minutes,
                                                         time_duration::from_turns( felt_volume - 130 ) / 8 ) );
                 if( !you->has_flag( json_flag_PAIN_IMMUNE ) ) {
@@ -623,16 +623,12 @@ void sounds::process_sound_markers( Character *you )
                         you->mod_pain( rng( 0, 2 ) );
                     }
                 }
-            }
-            continue;
-        }
-
-        if( is_sound_deafening && !you->is_immune_effect( effect_deaf ) ) {
-            const time_duration deafness_duration = time_duration::from_turns( felt_volume - 130 ) / 4;
-            you->add_effect( effect_deaf, deafness_duration );
-            if( you->is_deaf() && !is_deaf ) {
-                is_deaf = true;
-                continue;
+            } else {
+                const time_duration deafness_duration = time_duration::from_turns( felt_volume - 130 ) / 4;
+                you->add_effect( effect_deaf, deafness_duration );
+                if( you->is_deaf() && !is_deaf ) {
+                    is_deaf = true;
+                }
             }
         }
         if( is_deaf ) {
@@ -648,11 +644,11 @@ void sounds::process_sound_markers( Character *you )
         if( distance_to_sound < 1 && heard_volume > 0 ) {
             // Min here because good hearing doesn't overestimate sounds, but bad will underestimate.
             you->volume = std::min( you->volume, heard_volume );
-            continue;
         }
         if( heard_volume < 1 ) {
             continue;
         }
+
         // Noises from vehicle player is in.
         if( you->controlling_vehicle ) {
             vehicle *veh = veh_pointer_or_null( here.veh_at( you->pos_abs() ) );


### PR DESCRIPTION
#### Summary
Fix sfx for using talking doll, shouting, etc

#### Purpose of change
An early continue was skipping out of actually playing the sound.

#### Describe the solution
Fix, and tidy up the code some more besides.

#### Describe alternatives you've considered

#### Testing
Debug says the sound is playing. I look in my sound folder and see no sfx. Maybe it's not in the sound pack? Oh well.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
