### PR TITLE
Make it easier for the refugee center to spawn

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2452,8 +2452,8 @@
     "connections": [ { "point": [ 7, 15, 0 ], "terrain": "road", "connection": "local_road", "from": [ 7, 14, 0 ] } ],
     "locations": [ "wilderness" ],
     "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, -1 ],
-    "occurrences": [ 75, 100 ],
+    "city_sizes": [ -1, 8 ],
+    "occurrences": [ 90, 100 ],
     "priority": 1,
     "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },


### PR DESCRIPTION
#### Summary
Make it easier for the refugee center to spawn

#### Purpose of change

#### Describe the solution
The refugee center's spawn conditions are now more permissive, with no minimum nearby city size, and a maximum of 8, instead of a min of 3 and no max. It now has a 90% chance of being placed per overmap instead of a 75%. So it's not always right nearby, but it should just about always be within one overmap.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
