### PR TITLE
make retrieve software quest not delete your devices

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -361,7 +361,17 @@
     "type": "mission_definition",
     "name": { "str": "Retrieve Software" },
     "description": "Retrieve the software in their computer marked on your map.",
-    "goal": "MGOAL_FIND_ANY_ITEM",
+    "goal": "MGOAL_CONDITION",
+    "goal_condition": {
+      "and": [ {
+        "or": [ 
+          { "and": [ { "u_has_software": { "item": "software_hacking", "device": "usb_drive" } }, { "npc_has_class": "NC_HACKER" } ] },
+          { "and": [ { "u_has_software": { "item": "software_medical", "device": "usb_drive" } }, { "npc_has_class": "NC_DOCTOR" } ] },
+          { "and": [ { "u_has_software": { "item": "software_math", "device": "usb_drive" } }, { "npc_has_class": "NC_SCIENTIST" } ] },
+          { "and": [ { "u_has_software": { "item": "software_useless", "device": "usb_drive" } }, { "not": { "or": [ { "npc_has_class": "NC_HACKER" }, { "npc_has_class": "NC_DOCTOR" }, { "npc_has_class": "NC_SCIENTIST" } ] } } ] }
+        ]
+      } ]
+    },
     "difficulty": 2,
     "value": 80000,
     "place": "near_town",


### PR DESCRIPTION
#### Summary
The retrieve software quest which requires you to go to a random city house and download a misc software from the npc's computer to a usb drive they give you. But it also has the option to download it to your phone. I downloaded it to both the usb drive and my phone. Upon delievering the quest the npc deleted both the usb drive and my phone from existance.

#### Purpose of change
Make the quest only require you to have the software, no need to delete them from your inventory

#### Describe the solution
Based on https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2950/changes#diff-62da5787e36e5333bcec0d365da01db4921d86fc3cebdb0be176d3947c02eb51R386
Change the goal to a condition where you show the quest giver a software based on their class, according to `place_npc_software` https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/526fafd6aec73279c9ff125ce1b3ae9baf98bbb6/src/mission_start.cpp#L150

#### Describe alternatives you've considered
Instead of using `u_has_software`, use `u_has_items` or `u_has_item`. But for some reason, the quest was not recognizing those items on my inventory to mark as complete. It only worked when i used `u_has_software`. Additionally, `u_has_software` requires a device upon which the item is stored, without this definition the game refused to load with the error `missing required field "device" in object:  { "item": "software_hacking" } `

#### Testing
As shown in the video below: Spawned an NPC with the NC_DOCTOR class and a random npc without a special class. Gave them each a Retrieve Software mission. The quest is only considered complete when their desired software is on inventory.

#### Additional context

https://github.com/user-attachments/assets/b65f8d24-87fc-497e-ba3e-675093a617fb



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
