### PR TITLE
Monsters are immune to the character-specific fungal infection effect

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -104,6 +104,7 @@ static const efftype_id effect_emp( "emp" );
 static const efftype_id effect_fake_common_cold( "fake_common_cold" );
 static const efftype_id effect_fake_flu( "fake_flu" );
 static const efftype_id effect_fallout( "fallout" );
+static const efftype_id effect_fungus( "fungus" );
 static const efftype_id effect_grabbing( "grabbing" );
 static const efftype_id effect_has_bag( "has_bag" );
 static const efftype_id effect_heavysnare( "heavysnare" );
@@ -1943,8 +1944,8 @@ bool monster::is_elec_immune() const
 
 bool monster::is_immune_effect( const efftype_id &effect ) const
 {
-    // Currently monsters aren't affected by radiation.
-    if( effect == effect_bite || effect == effect_infected || effect == effect_fallout ) {
+    // Currently monsters aren't affected by radiation. Fungal effects are handled with the fungal_poison effect.
+    if( effect == effect_bite || effect == effect_infected || effect == effect_fallout || effect == effect_fungus ) {
         return true;
     }
 


### PR DESCRIPTION
#### Summary
Monsters are immune to the character-specific fungal infection effect

#### Purpose of change
Monsters handle this another way.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
