### PR TITLE
Rebalance mapgen wall parameters

### DIFF
--- a/data/json/mapgen_palettes/common_parameters.json
+++ b/data/json/mapgen_palettes/common_parameters.json
@@ -20,7 +20,8 @@
             [ "t_wall_cyan", 1 ],
             [ "t_wall_black", 3 ],
             [ "t_wall_orange", 3 ],
-            [ "t_brick_wall", 2 ]
+            [ "t_wall_wood", 2 ],
+            [ "t_brick_wall", 1 ]
           ]
         }
       },
@@ -28,18 +29,15 @@
         "type": "ter_str_id",
         "default": {
           "distribution": [
-            [ "t_brick_wall", 4 ],
-            [ "t_wall_wood", 2 ],
-            [ "t_wall_w", 4 ],
-            [ "t_wall_gray", 2 ],
+            [ "t_brick_wall", 6 ],
+            [ "t_wall_wood", 4 ],
+            [ "t_wall_w", 12 ],
+            [ "t_wall_gray", 6 ],
             [ "t_concrete_wall", 2 ],
-            [ "t_concrete_wall_w", 4 ],
+            [ "t_concrete_wall_w", 2 ],
             [ "t_concrete_wall_gray", 2 ],
-            [ "t_strconc_wall", 1 ],
-            [ "t_strconc_wall_w", 2 ],
-            [ "t_strconc_wall_gray", 1 ],
             [ "t_sconc_wall", 1 ],
-            [ "t_sconc_wall_w", 2 ],
+            [ "t_sconc_wall_w", 1 ],
             [ "t_sconc_wall_gray", 1 ]
           ]
         }
@@ -60,25 +58,30 @@
         "type": "ter_str_id",
         "default": {
           "distribution": [
-            [ "t_strconc_wall", 1 ],
-            [ "t_strconc_wall_b", 1 ],
-            [ "t_strconc_wall_g", 1 ],
-            [ "t_strconc_wall_r", 1 ],
-            [ "t_strconc_wall_w", 10 ],
-            [ "t_strconc_wall_p", 1 ],
-            [ "t_strconc_wall_P", 1 ],
-            [ "t_strconc_wall_y", 1 ],
-            [ "t_strconc_wall_orange", 1 ],
-            [ "t_strconc_wall_gray", 2 ],
-            [ "t_strconc_wall_brown", 1 ],
-            [ "t_strconc_wall_cyan", 1 ],
-            [ "t_strconc_wall_black", 1 ]
+            [ "t_wall_b", 1 ],
+            [ "t_wall_g", 1 ],
+            [ "t_wall_p", 1 ],
+            [ "t_wall_P", 1 ],
+            [ "t_wall_r", 1 ],
+            [ "t_wall_w", 15 ],
+            [ "t_wall_y", 4 ],
+            [ "t_wall_gray", 5 ],
+            [ "t_wall_brown", 1 ],
+            [ "t_wall_cyan", 1 ],
+            [ "t_wall_black", 1 ],
+            [ "t_wall_orange", 1 ],
+            [ "t_concrete_wall", 3 ],
+            [ "t_concrete_wall_w", 3 ],
+            [ "t_concrete_wall_gray", 3 ],
+            [ "t_sconc_wall", 2 ],
+            [ "t_sconc_wall_w", 2 ],
+            [ "t_sconc_wall_gray", 2 ]
           ]
         }
       },
       "exterior_highrise_wall_type": {
         "type": "ter_str_id",
-        "default": { "distribution": [ [ "t_strconc_wall", 1 ], [ "t_strconc_wall_w", 3 ], [ "t_strconc_wall_gray", 1 ] ] }
+        "default": { "distribution": [ [ "t_strconc_wall", 1 ], [ "t_strconc_wall_w", 3 ], [ "t_strconc_wall_gray", 1 ], [ "t_brick_wall", 6 ] ] }
       }
     },
     "terrain": {
@@ -95,10 +98,10 @@
         "type": "ter_str_id",
         "default": {
           "distribution": [
-            [ "t_splitrail_fence", 3 ],
-            [ "t_chainfence", 2 ],
-            [ "t_fence", 2 ],
-            [ "t_privacy_fence", 1 ],
+            [ "t_splitrail_fence", 2 ],
+            [ "t_chainfence", 5 ],
+            [ "t_fence", 5 ],
+            [ "t_privacy_fence", 5 ],
             [ "t_drystone_wall_half", 1 ]
           ]
         }


### PR DESCRIPTION
#### Summary
Rebalance mapgen wall parameters

#### Purpose of change
We ported these from DDA, but the probabilities are way off. I am finding that half the town is made of concrete, and all highrise buildings are made of reinforced concrete, with none being made of brick ever, and their interiors are also made of reinforced concrete. I have been in a lot of highrise buildings and they just as often have drywall inside, even if they're concrete outside!

#### Describe the solution
- Houses are never made of reinforced concrete. They are only rarely made of regular concrete.
- House interiors can be wood. It's not common but NE has a lot of old houses.
- Houses and their inteirors are now most often going to be ordianary walls (stucco, drywall, wood frame, etc).
- Highrises can be brick on the outside, sometimes.
- Highrise interiors are never reinforced concrete. Sometimes they are regular concrete, but most often they're more lightweight materials.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
