### PR TITLE
Fix weird fungalization

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -19,11 +19,11 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "bleed_rate": 0,
     "weakpoint_sets": [ "wps_fungaloid_structure" ],
-    "emit_fields": [ { "emit_id": "emit_fungal_haze_plume", "delay": "5 s" } ],
+    "emit_fields": [ { "emit_id": "emit_fungal_haze_plume", "delay": "4 s" } ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_fungaloid_basic", "prof_wp_fungaloid_advanced" ],
     "luminance": 40,
     "harvest": "exempt",
-    "special_attacks": [ { "type": "spell", "id": "spore_cloud", "spell_data": { "id": "spore_cloud", "min_level": 2 }, "cooldown": 10 } ],
+    "special_attacks": [ { "type": "spell", "id": "spore_cloud", "spell_data": { "id": "spore_cloud", "min_level": 2 }, "cooldown": 8 } ],
     "regenerates": 2,
     "death_function": { "corpse_type": "NO_CORPSE", "effect": { "id": "death_fungus", "hit_self": true } },
     "flags": [ "HEARS", "GOODHEARING", "NOHEAD", "POISON", "IMMOBILE", "NO_BREATHE" ],
@@ -167,8 +167,8 @@
     "luminance": 200,
     "emit_fields": [ { "emit_id": "emit_fungal_haze_plume", "delay": "3 s" } ],
     "special_attacks": [
-      [ "FUNGUS_BIG_BLOSSOM", 40 ],
-      { "type": "spell", "id": "spore_cloud", "spell_data": { "id": "spore_cloud", "min_level": 3 }, "cooldown": 10 }
+      [ "FUNGUS_BIG_BLOSSOM", 30 ],
+      { "type": "spell", "id": "spore_cloud", "spell_data": { "id": "spore_cloud", "min_level": 3 }, "cooldown": 6 }
     ],
     "weakpoint_sets": [ "wps_fungaloid_structure" ],
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_fungaloid_basic", "prof_wp_fungaloid_advanced" ],

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -206,7 +206,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint_bub_ms &p, const int
                 here.ter_set( p, ter_t_tree_fungal_young );
                 converted = true;
             }
-        } else if( t == ter_t_tree_dead || ter_t_tree_dead_warped || t == ter_t_tree_deadpine ||
+        } else if( t == ter_t_tree_dead || t == ter_t_tree_dead_warped || t == ter_t_tree_deadpine ||
                    t == ter_t_tree_deadpine_warped || t == ter_t_tree_very_dead ) {
             here.ter_set( p, ter_t_tree_fungal );
             converted = true;

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -222,7 +222,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint_bub_ms &p, const int
                     add_msg_if_player_sees( p, m_warning, _( "The tree bulges and sags, becoming a fungal blossom!" ) );
                 }
                 converted = true;
-            } else if( chance < 9 ) {
+            } else if( chance < 11 ) {
                 here.ter_set( p, ter_t_tree_fungal );
                 converted = true;
             }


### PR DESCRIPTION
#### Summary
Fix weird fungalization

#### Purpose of change
A malformed if statement was accidentally breaking the fungalize code in a subtle way that could transform ineligible terrain into fungal trees.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
