### PR TITLE
A number of minor json fixes

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1924,6 +1924,7 @@
     "addiction_type": "cannabis",
     "material": [ "vegetable" ],
     "flags": [ "NO_INGEST", "NO_TEMP" ],
+    "vitamins": [ [ "cannabis", 7 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You smoke some weed.",

--- a/data/json/items/comestibles/wheat.json
+++ b/data/json/items/comestibles/wheat.json
@@ -614,7 +614,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "FOOD",
     "name": { "str": "sponge cake" },
-    "description": "Plain, fluffy cake for the proletariat.",
+    "description": "Plain, fluffy cake.",
     "container": "box_small",
     "weight": "68 g",
     "volume": "187 ml",
@@ -635,7 +635,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "FOOD",
     "name": { "str": "space cake" },
-    "description": "This cake's destiny is to take you on a gnarly trip.",
+    "description": "This cake's destiny is to take you on a gnarly trip.  There is cake, and you will be baked.",
     "container": "box_small",
     "weight": "68 g",
     "volume": "187 ml",
@@ -647,7 +647,7 @@
     "calories": 278,
     "fun": 18,
     "spoils_in": "17 days",
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 5 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ], [ "cannabis", 10 ] ],
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 5 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ], [ "cannabis", 14 ] ],
     "flags": [ "EATEN_HOT" ]
   },
   {
@@ -680,7 +680,7 @@
     "calories": 278,
     "fun": 18,
     "spoils_in": "17 days",
-    "vitamins": [ [ "calcium", 2 ], [ "iron", 5 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ], [ "cannabis", 10 ] ],
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 5 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ], [ "cannabis", 14 ] ],
     "flags": [ "EATEN_HOT" ]
   }
 ]

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -300,7 +300,7 @@
     "price": "20 USD",
     "price_postapoc": "2 USD 50 cent",
     "qualities": [ [ "HAMMER", 1 ], [ "COOK", 1 ] ],
-    "weapon_category": [ "HOOKING_WEAPONS" ],
+    "weapon_category": [ "HOOKING_WEAPONRY" ],
     "melee_damage": { "bash": 3, "stab": 6 }
   },
   {

--- a/data/json/npcs/necc/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/necc/members/NPC_Maria_Serrano.json
@@ -199,16 +199,6 @@
         ],
         "topic": "TALK_GODCO_Maria_Tailor_Start"
       },
-      {
-        "text": "I'll have a gambeson.",
-        "condition": { "u_has_items": { "item": "icon", "count": 15 } },
-        "effect": [
-          { "npc_add_var": "general_trade_u_want_gambeson", "value": "yes" },
-          { "math": [ "n_timer_trade_knitting = time('now')" ] },
-          { "u_sell_item": "icon", "count": 15 }
-        ],
-        "topic": "TALK_GODCO_Maria_Tailor_Start"
-      },
       { "text": "What can you sew?", "topic": "TALK_GODCO_Maria_Tailor_What" },
       { "text": "How long does it take you to make these?", "topic": "TALK_GODCO_Maria_Tailor_Time" },
       { "text": "What's the price?", "topic": "TALK_GODCO_Maria_Tailor_Price" },
@@ -311,21 +301,6 @@
         ],
         "topic": "TALK_GODCO_Maria_Tailor_Done"
       },
-      {
-        "text": "I ordered a gambeson.",
-        "condition": {
-          "and": [
-            { "npc_has_var": "general_trade_u_want_gambeson", "value": "yes" },
-            { "math": [ "time_since(n_timer_trade_knitting)", ">=", "time('4 d')" ] }
-          ]
-        },
-        "effect": [
-          { "npc_lose_var": "general_trade_u_want_gambeson" },
-          { "npc_lose_var": "timer_trade_knitting" },
-          { "u_spawn_item": "gambeson" }
-        ],
-        "topic": "TALK_GODCO_Maria_Tailor_Done"
-      },
       { "text": "Nevermind.  Let's talk about something else.", "topic": "TALK_GODCO_Maria_2" },
       { "text": "Nevermind, I have to leave.", "topic": "TALK_DONE" }
     ]
@@ -333,7 +308,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Maria_Tailor_What",
-    "dynamic_line": "I sure can!  For now, I can make t-shirts, pants, dresses, longcoats, backpacks, jackets, and a gambeson; if that's your thing.",
+    "dynamic_line": "I sure can!  For now, I can make t-shirts, pants, dresses, longcoats, backpacks, and jackets.",
     "responses": [
       { "text": "Let's get to it.", "topic": "TALK_GODCO_Maria_Tailor_Something" },
       { "text": "How long does it take you to make these?", "topic": "TALK_GODCO_Maria_Tailor_Time" },
@@ -345,7 +320,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Maria_Tailor_Price",
-    "dynamic_line": "T-shirts, pants, jackets, and dresses are four icons.  Longcoats and backpacks are six icons.  A gambeson is fifteen.",
+    "dynamic_line": "T-shirts, pants, jackets, and dresses are four icons.  Longcoats and backpacks are six icons.",
     "responses": [
       { "text": "Let's get to it.", "topic": "TALK_GODCO_Maria_Tailor_Something" },
       { "text": "How long does it take you to make these?", "topic": "TALK_GODCO_Maria_Tailor_Time" },
@@ -356,7 +331,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Maria_Tailor_Time",
-    "dynamic_line": "T-shirts, pants, jackets, and dresses take me two days.  Longcoats and backpacks take four days, while a gambeson takes six days.",
+    "dynamic_line": "T-shirts, pants, jackets, and dresses take me two days.  Longcoats and backpacks take four days.",
     "responses": [
       { "text": "Let's get to it.", "topic": "TALK_GODCO_Maria_Tailor_Something" },
       { "text": "What's the price?", "topic": "TALK_GODCO_Maria_Tailor_Price" },

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -1319,7 +1319,8 @@
     "name": { "str": "Quarterstaff Proficiency (Familiar)" },
     "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
     "default_time_multiplier": 1.5,
-    "default_skill_penalty": 0.2
+    "default_skill_penalty": 0.2,
+    "can_learn": false
   },
   {
     "type": "proficiency",
@@ -1328,8 +1329,9 @@
     "name": { "str": "Quarterstaff Proficiency (Pro)" },
     "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
     "default_time_multiplier": 1.5,
-    "default_skill_penalty": 0.2
-  }
+    "default_skill_penalty": 0.2,
+    "can_learn": false
+  },
   {
     "type": "proficiency",
     "id": "prof_quarterstaves_master",
@@ -1337,6 +1339,7 @@
     "name": { "str": "Quarterstaff Proficiency (Master)" },
     "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
     "default_time_multiplier": 1.5,
-    "default_skill_penalty": 0.2
+    "default_skill_penalty": 0.2,
+    "can_learn": false
   }
 ]

--- a/data/json/obsoletion_and_migration/obsoletion.json
+++ b/data/json/obsoletion_and_migration/obsoletion.json
@@ -1311,5 +1311,32 @@
     "valid": false,
     "purifiable": false,
     "player_display": false
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_quarterstaves_familiar",
+    "category": "prof_combat",
+    "name": { "str": "Quarterstaff Proficiency (Familiar)" },
+    "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
+    "default_time_multiplier": 1.5,
+    "default_skill_penalty": 0.2
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_quarterstaves_pro",
+    "category": "prof_combat",
+    "name": { "str": "Quarterstaff Proficiency (Pro)" },
+    "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
+    "default_time_multiplier": 1.5,
+    "default_skill_penalty": 0.2
+  }
+  {
+    "type": "proficiency",
+    "id": "prof_quarterstaves_master",
+    "category": "prof_combat",
+    "name": { "str": "Quarterstaff Proficiency (Master)" },
+    "description": "Obsoleted proficiency.  This has been replaced with staff proficiency and exists here only to prevent error messages.",
+    "default_time_multiplier": 1.5,
+    "default_skill_penalty": 0.2
   }
 ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -3884,7 +3884,7 @@
       [ [ "any_butter_or_oil", 4, "LIST" ] ],
       [ [ "sugar_standard", 1, "LIST" ] ],
       [ [ "eggs_any_shape", 1, "LIST" ] ],
-      [ [ "weed", 5 ] ]
+      [ [ "weed", 8 ] ]
     ],
     "charges": 4
   },
@@ -3921,7 +3921,7 @@
       [ [ "sugar_standard", 1, "LIST" ] ],
       [ [ "chocolate", 1 ] ],
       [ [ "eggs_any_shape", 1, "LIST" ] ],
-      [ [ "weed", 5 ] ]
+      [ [ "weed", 8 ] ]
     ],
     "charges": 4
   },


### PR DESCRIPTION
#### Summary
A number of minor json fixes

#### Purpose of change
- Removed a deprecated option from Maria's dialogue.
- Fixed wead brownies.
- Fixed grip hook's weapon category ID.
- Obsoleted the old quarterstaves proficiencies to prevent error messages from popping up. These will still show on your character if you had them, but provide no benefit. If you want to keep your proficiencies, simply debug the equivalent level of staff proficiency onto your character.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
