### PR TITLE
Improve climb code

### DIFF
--- a/data/json/climbing.json
+++ b/data/json/climbing.json
@@ -115,7 +115,7 @@
   {
     "type": "climbing_aid",
     "id": "furn_LADDER",
-    "//": "currently applies to placeable stepladders, not constructed stair-like ladders",
+    "//": "currently applies to placeable ladders, not constructed fixed ladders",
     "copy-from": "generic_stepladder",
     "down": {
       "menu_text": "Climb down %s here.",

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -389,6 +389,6 @@
     "symbol": "#",
     "color": [ "light_green", "green", "yellow_yellow", "brown" ],
     "move_cost": 8,
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "CLIMBABLE", "SINGLE_SUPPORT", "DRAW_BELOW" ]
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "UNSTABLE", "CLIMBABLE", "SINGLE_SUPPORT", "DRAW_BELOW", "NOITEM" ]
   }
 ]

--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -72,7 +72,6 @@
   },
   {
     "type": "ITEM",
-    "subtypes": [ "MILLING" ],
     "id": "antler_piece",
     "symbol": "%",
     "color": "white",
@@ -84,9 +83,7 @@
     "weight": "140 g",
     "volume": "80 ml",
     "longest_side": "4 cm",
-    "to_hit": -2,
-    "into": "meal_bone",
-    "recipe": "meal_bone_mill_1_1"
+    "to_hit": -2
   },
   {
     "type": "ITEM",

--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -82,7 +82,7 @@
     "techniques": [ "WBLOCK_1" ],
     "weight": "2500 g",
     "volume": "4000 ml",
-    "longest_side": "305 cm",
+    "longest_side": "435 cm",
     "flags": [ "POLEARM", "SPEAR", "REACH_ATTACK", "REACH3", "NONCONDUCTIVE", "ALWAYS_TWOHAND", "SPAWN_ACTIVE" ],
     "weapon_category": [ "STAFFS" ],
     "to_hit": { "grip": "none", "length": "long", "surface": "any", "balance": "clumsy" },
@@ -91,7 +91,7 @@
     "countdown_interval": "4 hours",
     "revert_to": "long_pole",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 18 }
+    "melee_damage": { "bash": 16 }
   },
   {
     "type": "ITEM",
@@ -104,14 +104,14 @@
     "techniques": [ "WBLOCK_1" ],
     "weight": "2500 g",
     "volume": "4000 ml",
-    "longest_side": "305 cm",
+    "longest_side": "435 cm",
     "flags": [ "POLEARM", "SPEAR", "REACH_ATTACK", "REACH3", "NONCONDUCTIVE", "ALWAYS_TWOHAND", "DURABLE_MELEE" ],
     "weapon_category": [ "STAFFS" ],
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "clumsy" },
     "price": "40 USD",
     "price_postapoc": "50 cent",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 18 }
+    "melee_damage": { "bash": 16 }
   },
   {
     "type": "ITEM",

--- a/data/json/mapgen_palettes/common_parameters.json
+++ b/data/json/mapgen_palettes/common_parameters.json
@@ -81,7 +81,9 @@
       },
       "exterior_highrise_wall_type": {
         "type": "ter_str_id",
-        "default": { "distribution": [ [ "t_strconc_wall", 1 ], [ "t_strconc_wall_w", 3 ], [ "t_strconc_wall_gray", 1 ], [ "t_brick_wall", 6 ] ] }
+        "default": {
+          "distribution": [ [ "t_strconc_wall", 1 ], [ "t_strconc_wall_w", 3 ], [ "t_strconc_wall_gray", 1 ], [ "t_brick_wall", 6 ] ]
+        }
       }
     },
     "terrain": {

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -29,10 +29,11 @@
     "scents_tracked": [ "sc_human", "sc_fetid" ],
     "harvest": "zombie_humanoid_mushroom",
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "10 s" } ],
-    "special_attacks": [ 
+    "special_attacks": [
       { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 6 } ],
+      { "id": "scratch_humanoid", "cooldown": 6 }
+    ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
     "flags": [ "SEES", "SMELLS", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
@@ -109,9 +110,11 @@
     "vision_night": 3,
     "harvest": "zombie_humanoid_mushroom",
     "emit_fields": [ { "emit_id": "emit_fungal_haze_plume", "delay": "3 s" } ],
-    "special_attacks": [ { "id": "grab", "cooldown": 8 },
+    "special_attacks": [
+      { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 6 } ],
+      { "id": "scratch_humanoid", "cooldown": 6 }
+    ],
     "death_drops": { "subtype": "collection", "groups": [ [ "default_zombie_death_drops", 100 ], [ "explode_zed_fungal", 100 ] ] },
     "death_function": { "corpse_type": "NO_CORPSE", "effect": { "id": "death_fungus", "hit_self": true } },
     "flags": [ "SEES", "STUMBLES", "WARM", "BASHES", "GROUP_BASH", "POISON", "HARDTOSHOOT", "NO_BREATHE", "PUSH_MON", "FILTHY" ],
@@ -200,10 +203,12 @@
     "vision_night": 5,
     "harvest": "big_mr_bones",
     "grab_strength": 44,
-    "special_attacks": [ { "id": "smash", "throw_strength": 54 },
-        { "id": "grab", "cooldown": 8 },
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 54 },
+      { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 6 } ],
+      { "id": "scratch_humanoid", "cooldown": 6 }
+    ],
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "12 s" } ],
     "death_drops": { "subtype": "collection", "groups": [ [ "mon_zombie_hulk_death_drops", 100 ], [ "explode_zed_fungal_bone", 100 ] ] },
     "death_function": { "corpse_type": "NO_CORPSE", "effect": { "id": "death_fungus", "hit_self": true } },
@@ -241,9 +246,11 @@
     "vision_night": 5,
     "harvest": "zombie_humanoid_mushroom",
     "grab_strength": 10,
-    "special_attacks": [ { "id": "grab", "cooldown": 8 },
+    "special_attacks": [
+      { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 6 } ],
+      { "id": "scratch_humanoid", "cooldown": 6 }
+    ],
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "18 s" } ],
     "scents_tracked": [ "sc_fetid", "sc_human" ],
     "death_drops": {
@@ -292,7 +299,8 @@
         "spell_data": { "id": "spore_spray", "min_level": 1 },
         "monster_message": "The %s spews a cloud of spores!",
         "cooldown": 40
-      },        { "id": "grab", "cooldown": 8 },
+      },
+      { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
       { "id": "scratch_humanoid", "cooldown": 6 }
     ],
@@ -462,7 +470,8 @@
     "special_attacks": [
       { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 12 } ],
+      { "id": "scratch_humanoid", "cooldown": 12 }
+    ],
     "death_drops": "default_zombie_death_drops",
     "scents_tracked": [ "sc_fetid", "sc_human" ],
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "4 s" } ],
@@ -544,7 +553,11 @@
     "harvest": "zombie_humanoid_mushroom",
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "10 s" } ],
     "grab_strength": 15,
-    "special_attacks": [ { "id": "grab" }, { "id": "bite_humanoid", "attack_upper": false, "cooldown": 5 }, { "id": "scratch_humanoid", "attack_upper": false } ],
+    "special_attacks": [
+      { "id": "grab" },
+      { "id": "bite_humanoid", "attack_upper": false, "cooldown": 5 },
+      { "id": "scratch_humanoid", "attack_upper": false }
+    ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
     "flags": [
@@ -592,7 +605,8 @@
     "special_attacks": [
       { "id": "grab", "cooldown": 8 },
       { "id": "bite_humanoid", "cooldown": 8 },
-      { "id": "scratch_humanoid", "cooldown": 6 } ],
+      { "id": "scratch_humanoid", "cooldown": 6 }
+    ],
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
     "emit_fields": [ { "emit_id": "emit_fungal_leak", "delay": "3 s" } ],

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -361,7 +361,6 @@ std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
         const item &it = items.front();
         const int dropcount = items.size() * it.count();
         const std::string it_name = it.tname( dropcount );
-
         switch( reason ) {
             case item_drop_reason::deliberate:
                 if( can_move_there ) {
@@ -459,7 +458,6 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
                                const std::list<item> &items )
 {
     map &here = get_map();
-
     put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( here ) );
 }
 
@@ -472,7 +470,17 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
         try_to_put_into_vehicle( you, reason, items, *vp );
         return;
     }
-    drop_on_map( you, reason, items, here, where );
+    if( !here->can_put_items_ter_furn( where ) ) {
+        for( const tripoint_bub_ms &pos : here->points_in_radius( where, 1 ) ) {
+            if( here->can_put_items_ter_furn( pos ) ) {
+                drop_on_map( you, reason, items, here, pos );
+                return;
+            }
+            debugmsg( _( "A dropped item was lost because there was no valid tile to contain it." ) );
+        }
+    } else {
+        drop_on_map( you, reason, items, here, where );
+    }
 }
 
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13928,7 +13928,16 @@ int Character::climbing_cost( const tripoint_bub_ms &from, const tripoint_bub_ms
 {
     map &here = get_map();
     if( !here.valid_move( from, to, false, true ) ) {
-        return 0;
+        bool can_climb = false;
+        for( const tripoint_bub_ms &pt : points_in_radius( from, 1 ) ) {
+            if( here.has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, pt ) ) {
+                can_climb = true;
+                break;
+            }
+        }
+        if( !can_climb ) {
+            return 0;
+        }
     }
 
     const int diff = here.climb_difficulty( from, *this );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -810,7 +810,6 @@ bool Character::dispose_item( item_location &&obj, const std::string &prompt )
     menu.text = prompt.empty() ? string_format( _( "Dispose of %s" ), obj->tname() ) : prompt;
     std::vector<dispose_option> opts;
 
-
     const bool bucket = obj->will_spill() && !obj->is_container_empty();
 
     opts.emplace_back( dispose_option{

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -61,7 +61,6 @@ static const ter_str_id ter_t_tree_deadpine( "t_tree_deadpine" );
 static const ter_str_id ter_t_tree_deadpine_warped( "t_tree_deadpine_warped" );
 static const ter_str_id ter_t_tree_fungal( "t_tree_fungal" );
 static const ter_str_id ter_t_tree_fungal_young( "t_tree_fungal_young" );
-static const ter_str_id ter_t_tree_marloss( "t_tree_marloss" );
 static const ter_str_id ter_t_tree_very_dead( "t_tree_very_dead" );
 static const ter_str_id ter_t_tree_young( "t_tree_young" );
 
@@ -210,7 +209,7 @@ void fungal_effects::spread_fungus_one_tile( const tripoint_bub_ms &p, const int
                    t == ter_t_tree_deadpine_warped || t == ter_t_tree_very_dead ) {
             here.ter_set( p, ter_t_tree_fungal );
             converted = true;
-        } else if( t != ter_t_tree_marloss && t != ter_t_tree_fungal &&
+        } else if( t != ter_t_marloss_tree && t != ter_t_tree_fungal &&
                    here.has_flag( ter_furn_flag::TFLAG_TREE, p ) ) {
             const int chance = rng( 1, 100 - fungus_neighbors );
             if( chance < 2 ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11775,15 +11775,9 @@ void game::vertical_move( int movez, bool force, bool peeking )
     int move_cost = 100;
     tripoint_bub_ms stairs( pos.xy(), pos.z() + movez );
     bool wall_cling = u.has_flag( json_flag_WALL_CLING );
-    bool adjacent_climb = false;
     if( !force && movez == 1 && !here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos ) &&
         !u.is_underwater() ) {
         // Climbing
-        for( const tripoint_bub_ms &p : here.points_in_radius( pos, 1 ) ) {
-            if( here.has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, p ) ) {
-                adjacent_climb = true;
-            }
-        }
         if( here.has_floor_or_support( stairs ) ) {
             tripoint_bub_ms dest_phase = pos;
             dest_phase.z() += 1;
@@ -11796,34 +11790,8 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
         }
 
-        if( u.get_working_arm_count() < 1 && !here.has_flag( ter_furn_flag::TFLAG_LADDER, pos ) ) {
-            add_msg( m_info, _( "You can't climb because your arms are too damaged or encumbered." ) );
-            return;
-        }
-
         const int cost = u.climbing_cost( pos, stairs );
         add_msg_debug( debugmode::DF_GAME, "Climb cost %d", cost );
-        const bool can_climb_here = cost > 0 ||
-                                    u.has_flag( json_flag_CLIMB_NO_LADDER ) || wall_cling;
-        if( !can_climb_here && !adjacent_climb ) {
-            add_msg( m_info, _( "You can't climb here - you need walls and/or furniture to brace against." ) );
-            return;
-        }
-
-        const item_location weapon = u.get_wielded_item();
-        if( !here.has_flag( ter_furn_flag::TFLAG_LADDER, pos ) && weapon &&
-            weapon->is_two_handed( u ) ) {
-            if( query_yn(
-                    _( "You can't climb because you have to wield a %s with both hands.\n\nPut it away?" ),
-                    weapon->tname() ) ) {
-                if( !u.unwield() ) {
-                    return;
-                }
-            } else {
-                return;
-            }
-        }
-
         std::vector<tripoint_bub_ms> pts;
         for( const tripoint_bub_ms &pt : here.points_in_radius( stairs, 1 ) ) {
             if( here.passable_through( pt ) &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11790,8 +11790,13 @@ void game::vertical_move( int movez, bool force, bool peeking )
             }
         }
 
-        const int cost = u.climbing_cost( pos, stairs );
-        add_msg_debug( debugmode::DF_GAME, "Climb cost %d", cost );
+        int cost = u.climbing_cost( pos, stairs );
+        add_msg_debug( debugmode::DF_GAME, "Climb cost: %d", cost );
+
+        if( cost == 0 ) {
+            return;
+        }
+
         std::vector<tripoint_bub_ms> pts;
         for( const tripoint_bub_ms &pt : here.points_in_radius( stairs, 1 ) ) {
             if( here.passable_through( pt ) &&

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2955,7 +2955,8 @@ int map::climb_difficulty( const tripoint_bub_ms &p, const Creature &you ) const
     }
 
     for( const tripoint_bub_ms &pt : points_in_radius( p, 1 ) ) {
-        if( impassable_ter_furn( pt ) ) {
+        bool climb_adjacent = has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, pt );
+        if( impassable_ter_furn( pt ) && !climb_adjacent ) {
             // TODO: Non-hardcoded climbability
             best_difficulty = std::min( best_difficulty, 10 );
             blocks_movement++;
@@ -2964,7 +2965,7 @@ int map::climb_difficulty( const tripoint_bub_ms &p, const Creature &you ) const
             // TODO: Some definitely shouldn't be.
             best_difficulty = std::min( best_difficulty, 7 );
             // Climb a tree.
-        } else if( has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, p ) ) {
+        } else if( climb_adjacent ) {
             best_difficulty = std::min( best_difficulty, 5 );
         }
         if( best_difficulty > 1 && ( has_flag( ter_furn_flag::TFLAG_CLIMBABLE, pt ) ||

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2921,17 +2921,36 @@ int map::climb_difficulty( const tripoint_bub_ms &p, const Creature &you ) const
         debugmsg( "climb_difficulty on out of bounds point: %d, %d, %d", p.x(), p.y(), p.z() );
         return INT_MAX;
     }
-
     int best_difficulty = INT_MAX;
     int blocks_movement = 0;
-    // TODO: Weight checks for ladders.
-    if( has_flag( ter_furn_flag::TFLAG_LADDER, p ) ) {
-        // Really easy, but you have to stand on the tile
-        return 1;
-    } else if( has_flag( ter_furn_flag::TFLAG_RAMP, p ) ||
-               has_flag( ter_furn_flag::TFLAG_RAMP_UP, p ) ||
-               has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, p ) ) {
-        // We're on something stair-like, so halfway there already
+    if( !you.is_monster() ) {
+        const Character &guy = *you.as_character();
+        item_location wielding = guy.get_wielded_item();
+        bool item_twohand = wielding && wielding->is_two_handed( guy );
+        if( wielding && item_twohand ) {
+            if( guy.is_avatar() ) {
+                if( query_yn(
+                        _( "You can't climb because you have to wield a %s with both hands.\n\nPut it away?" ),
+                        wielding->tname() ) ) {
+                    if( !get_avatar().unwield() ) {
+                        return INT_MAX;
+                    }
+                } else {
+                    return INT_MAX;
+                }
+            } else {
+                return INT_MAX;
+            }
+        }
+        bool armor_restricts_hands = guy.worn_with_flag( flag_RESTRICT_HANDS );
+        bool missing_arms = !guy.has_two_arms_lifting();
+        if( armor_restricts_hands || missing_arms ) {
+            you.add_msg_if_player( _( "You need the use of at least one hand to climb." ) );
+            return INT_MAX;
+        }
+    }
+    if( has_flag( ter_furn_flag::TFLAG_RAMP_UP_LOW, p ) ) {
+        // We're on something stair-like, so halfway there already.
         best_difficulty = 7;
     }
 
@@ -2944,42 +2963,51 @@ int map::climb_difficulty( const tripoint_bub_ms &p, const Creature &you ) const
             // Vehicle tiles are quite good for climbing.
             // TODO: Some definitely shouldn't be.
             best_difficulty = std::min( best_difficulty, 7 );
+            // Climb a tree.
+        } else if( has_flag( ter_furn_flag::TFLAG_CLIMB_ADJACENT, p ) ) {
+            best_difficulty = std::min( best_difficulty, 5 );
         }
-        if( best_difficulty > 5 && ( has_flag( ter_furn_flag::TFLAG_CLIMBABLE, pt ) ) ) {
+        if( best_difficulty > 1 && ( has_flag( ter_furn_flag::TFLAG_CLIMBABLE, pt ) ||
+                                     has_flag( ter_furn_flag::TFLAG_LADDER, pt ) ) ) {
             map &here = get_map();
             bool furn_supports_weight = true;
             bool ter_supports_weight = true;
             if( !veh_at( pt ) ) {
                 // Specifically check for climbable furniture so that we don't get irrelevant messages about nonclimbable furniture.
+                bool ladder_furn = false;
                 if( here.has_furn( pt ) ) {
                     const furn_id &climbing_furniture = furn( pt );
-                    // I don't think we need this null guard, but it can hardly hurt.
-                    if( climbing_furniture != furn_str_id::NULL_ID() ) {
-                        if( climbing_furniture.obj().bash &&
-                            ( climbing_furniture.obj().has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ||
-                              climbing_furniture.obj().has_flag( ter_furn_flag::TFLAG_LADDER ) ) ) {
-                            if( you.get_weight() / 10000_gram > here.furn( pt ).obj().bash->str_min ) {
-                                you.add_msg_if_player( _( "The %s can't support your weight." ), here.furn( pt ).obj().name() );
-                                furn_supports_weight = false;
-                            }
+                    ladder_furn = climbing_furniture &&
+                                  climbing_furniture.obj().has_flag( ter_furn_flag::TFLAG_LADDER );
+                    if( climbing_furniture.obj().bash &&
+                        ( climbing_furniture.obj().has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ||
+                          ladder_furn ) ) {
+                        if( you.get_weight() / 10000_gram > here.furn( pt ).obj().bash->str_min ) {
+                            you.add_msg_if_player( _( "The %s can't support your weight." ), here.furn( pt ).obj().name() );
+                            furn_supports_weight = false;
                         }
                     }
                 }
                 ter_t climbing_terrain = here.ter( pt ).obj();
-                if( climbing_terrain.bash && ( ( climbing_terrain.has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ||
-                                                 climbing_terrain.has_flag( ter_furn_flag::TFLAG_LADDER ) ) &&
+                bool ladder_ter = climbing_terrain.has_flag( ter_furn_flag::TFLAG_LADDER );
+                if( climbing_terrain.bash && ( ( ladder_ter ||
+                                                 ( climbing_terrain.has_flag( ter_furn_flag::TFLAG_CLIMBABLE ) ) ) &&
                                                you.get_weight() / 10000_gram > here.ter( pt ).obj().bash->str_min ) ) {
                     you.add_msg_if_player( _( "The %s can't support your weight." ), here.ter( pt ).obj().name() );
                     ter_supports_weight = false;
                 }
                 if( furn_supports_weight && ter_supports_weight ) {
-                    best_difficulty = 5;
+                    if( ( ladder_furn && furn_supports_weight ) || ( ladder_ter && ter_supports_weight ) ) {
+                        best_difficulty = 1;
+                    } else {
+                        best_difficulty = 5;
+                    }
                 }
             }
         }
     }
 
-    // TODO: Make this more sensible - check opposite sides, not just movement blocker count
+    // TODO: Make this more sensible - check opposite sides, not just movement blocker count.
     return std::max( 0, best_difficulty - blocks_movement );
 }
 

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -588,7 +588,7 @@ void field_processor_spread_gas( const tripoint_bub_ms &p, field_entry &cur, fie
 }
 
 static void field_processor_fd_spores( const tripoint_bub_ms &p, field_entry &cur,
-        field_proc_data &/*pd*/ )
+                                       field_proc_data &/*pd*/ )
 {
     // if( cur_fd_type_id == fd_spores ) {
     // There's already RNG in the function we call here, so a simple interval works fine here.


### PR DESCRIPTION
#### Summary
Improve climb code

#### Purpose of change
- Trees and ladders were not running basically any checks for climbing up them.
- There was some old bad code and some duplicated stuff.

#### Describe the solution
- Climbing up trees is now a proper climb check. You can fail. It's kind of difficult to get up there.
- You can't climb basically anything with your hands full.
- You can no longer place items on treetops.
- If you are prompted to drop an item in a NOITEM tile and do so, the item will attempt to fall into an adjacent tile instead of silently vanishing. If it can't do that, you will see an error message about it.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
