### PR TITLE
Peek drop

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2578,6 +2578,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Drop items while peeking",
+    "category": "LOOK",
+    "id": "peek_drop",
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -968,7 +968,8 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
     }
 }
 
-void avatar_action::peek_drop( const drop_locations &what, const std::optional<tripoint_bub_ms> &peek_pos )
+void avatar_action::peek_drop( const drop_locations &what,
+                               const std::optional<tripoint_bub_ms> &peek_pos )
 {
     if( peek_pos ) {
         Character &player = get_player_character();

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -968,6 +968,14 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
     }
 }
 
+void avatar_action::peek_drop( const drop_locations &what, const std::optional<tripoint_bub_ms> &peek_pos )
+{
+    if( peek_pos ) {
+        Character &player = get_player_character();
+        player.drop( what, *peek_pos, false, true );
+    }
+}
+
 void avatar_action::plthrow( avatar &you, item_location loc,
                              const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -7,6 +7,7 @@
 
 #include "activity_type.h"
 #include "coordinates.h"
+#include "item_location.h"
 #include "point.h"
 
 class Character;
@@ -63,6 +64,10 @@ void fire_ranged_bionic( avatar &you, const item &fake_gun );
  * @return true if attempt to fire was successful (aim then cancel is also considered success)
  */
 bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
+
+// Called when dropping an item while peeking.
+void peek_drop( const drop_locations &what,
+              const std::optional<tripoint_bub_ms> &peek_pos = std::nullopt );
 
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -67,7 +67,7 @@ bool fire_turret_manual( avatar &you, map &m, turret_data &turret );
 
 // Called when dropping an item while peeking.
 void peek_drop( const drop_locations &what,
-              const std::optional<tripoint_bub_ms> &peek_pos = std::nullopt );
+                const std::optional<tripoint_bub_ms> &peek_pos = std::nullopt );
 
 // Throw an item  't'
 void plthrow( avatar &you, item_location loc,

--- a/src/character.h
+++ b/src/character.h
@@ -2511,8 +2511,8 @@ class Character : public Creature, public visitable
         /** Returns all items that must be taken off before taking off this item */
         std::list<item *> get_dependent_worn_items( const item &it );
         /** Drops an item to the specified location */
-        void drop( item_location loc, const tripoint_bub_ms &where );
-        virtual void drop( const drop_locations &what, const tripoint_bub_ms &target, bool stash = false );
+        void drop( item_location loc, const tripoint_bub_ms &where, bool peeking = false );
+        virtual void drop( const drop_locations &what, const tripoint_bub_ms &target, bool stash = false, bool peeking = false );
         /** Assigns character activity to pick up items from the given drop_locations.
          *  Requires sufficient storage; items cannot be wielded or worn from this activity.
          */

--- a/src/character.h
+++ b/src/character.h
@@ -2512,7 +2512,8 @@ class Character : public Creature, public visitable
         std::list<item *> get_dependent_worn_items( const item &it );
         /** Drops an item to the specified location */
         void drop( item_location loc, const tripoint_bub_ms &where, bool peeking = false );
-        virtual void drop( const drop_locations &what, const tripoint_bub_ms &target, bool stash = false, bool peeking = false );
+        virtual void drop( const drop_locations &what, const tripoint_bub_ms &target, bool stash = false,
+                           bool peeking = false );
         /** Assigns character activity to pick up items from the given drop_locations.
          *  Requires sufficient storage; items cannot be wielded or worn from this activity.
          */

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -655,7 +655,8 @@ void Character::drop( const drop_locations &what, const tripoint_bub_ms &target,
     }
     invalidate_leak_level_cache();
     const std::optional<vpart_reference> vp = here.veh_at( target ).cargo();
-    if( ( !peeking && square_dist( pos_bub(), target ) > 1 ) || square_dist( pos_bub(), target ) > 2 || !( stash || here.can_put_items( target ) )
+    if( ( !peeking && square_dist( pos_bub(), target ) > 1 ) || square_dist( pos_bub(), target ) > 2 ||
+        !( stash || here.can_put_items( target ) )
         || ( vp.has_value() && vp->part().is_cleaner_on() ) ) {
         add_msg_player_or_npc( m_info, _( "You can't place items here!" ),
                                _( "<npcname> can't place items here!" ) );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -639,14 +639,14 @@ int Character::get_item_position( const item *it ) const
     return inv->position_by_item( it );
 }
 
-void Character::drop( item_location loc, const tripoint_bub_ms &where )
+void Character::drop( item_location loc, const tripoint_bub_ms &where, bool peeking )
 {
-    drop( { std::make_pair( loc, loc->count() ) }, where );
+    drop( { std::make_pair( loc, loc->count() ) }, where, peeking );
     invalidate_inventory_validity_cache();
 }
 
 void Character::drop( const drop_locations &what, const tripoint_bub_ms &target,
-                      bool stash )
+                      bool stash, bool peeking )
 {
     map &here = get_map();
 
@@ -655,7 +655,7 @@ void Character::drop( const drop_locations &what, const tripoint_bub_ms &target,
     }
     invalidate_leak_level_cache();
     const std::optional<vpart_reference> vp = here.veh_at( target ).cargo();
-    if( rl_dist( pos_bub(), target ) > 1 || !( stash || here.can_put_items( target ) )
+    if( ( !peeking && square_dist( pos_bub(), target ) > 1 ) || square_dist( pos_bub(), target ) > 2 || !( stash || here.can_put_items( target ) )
         || ( vp.has_value() && vp->part().is_cleaner_on() ) ) {
         add_msg_player_or_npc( m_info, _( "You can't place items here!" ),
                                _( "<npcname> can't place items here!" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2412,6 +2412,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     u.takeoff( locThisItem.obtain( u ) );
                     break;
                 case 'd':
+                
                     u.drop( locThisItem, u.pos_bub() );
                     break;
                 case 'U':
@@ -6582,8 +6583,8 @@ void game::pickup( const tripoint_bub_ms &p )
     u.pick_up( game_menus::inv::pickup( p ) );
 }
 
-//Shift player by one tile, look_around(), then restore previous position.
-//represents carefully peeking around a corner, hence the large move cost.
+// Shift player by one tile, look_around(), then restore previous position.
+// represents carefully peeking around a corner, hence the large move cost.
 void game::peek()
 {
     map &here = get_map();
@@ -6641,6 +6642,9 @@ void game::peek( const tripoint_bub_ms &p )
     if( result.peek_action && *result.peek_action == PA_BLIND_THROW ) {
         item_location loc;
         avatar_action::plthrow( u, loc, p );
+    }
+    if( result.peek_action && *result.peek_action == PA_PEEK_DROP ) {
+        avatar_action::peek_drop( game_menus::inv::multidrop( u ), p );
     }
     here.invalidate_map_cache( p.z() );
     here.invalidate_visibility_cache();
@@ -7311,6 +7315,7 @@ look_around_result game::look_around(
     ctxt.register_action( "EXTENDED_DESCRIPTION" );
     ctxt.register_action( "SELECT" );
     if( peeking ) {
+        ctxt.register_action( "peek_drop" );
         ctxt.register_action( "throw_blind" );
     }
     if( !select_zone ) {
@@ -7563,6 +7568,8 @@ look_around_result game::look_around(
             ly = ly + vec->y();
             center.x() = center.x() + vec->x();
             center.y() = center.y() + vec->y();
+        } else if( action == "peek_drop" ) {
+            result.peek_action = PA_PEEK_DROP;
         } else if( action == "throw_blind" ) {
             result.peek_action = PA_BLIND_THROW;
         } else if( action == "zoom_in" ) {
@@ -7575,7 +7582,7 @@ look_around_result game::look_around(
             mark_main_ui_adaptor_resize();
         }
     } while( action != "QUIT" && action != "CONFIRM" && action != "SELECT" && action != "TRAVEL_TO" &&
-             action != "throw_blind" );
+             action != "peek_drop" && action != "throw_blind" );
 
     if( center.z() != old_levz ) {
         here.invalidate_map_cache( old_levz );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2412,7 +2412,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     u.takeoff( locThisItem.obtain( u ) );
                     break;
                 case 'd':
-                
+
                     u.drop( locThisItem, u.pos_bub() );
                     break;
                 case 'U':

--- a/src/game.h
+++ b/src/game.h
@@ -112,8 +112,8 @@ using item_filter = std::function<bool ( const item & )>;
 using item_location_filter = std::function<bool ( const item_location & )>;
 
 enum peek_act : int {
-    PA_BLIND_THROW
-    // obvious future additional value is PA_BLIND_FIRE
+    PA_BLIND_THROW,
+    PA_PEEK_DROP
 };
 
 struct look_around_result {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1638,9 +1638,9 @@ bool npc::wield( item_location loc, bool remove_old )
 }
 
 void npc::drop( const drop_locations &what, const tripoint_bub_ms &target,
-                bool stash )
+                bool stash, bool peeking )
 {
-    Character::drop( what, target, stash );
+    Character::drop( what, target, stash, peeking );
     // TODO: Remove the hack. Its here because npcs didn't process activities, but they do now
     // so is this necessary?
     activity.do_turn( *this );

--- a/src/npc.h
+++ b/src/npc.h
@@ -961,7 +961,7 @@ class npc : public Character
         bool wield( item &it );
         bool wield( item_location loc, bool remove_old = true );
         void drop( const drop_locations &what, const tripoint_bub_ms &target,
-                   bool stash ) override;
+                   bool stash, bool peeking = false ) override;
         bool adjust_worn();
         bool has_healing_item( healing_options try_to_fix );
         healing_options patient_assessment( const Character &c );


### PR DESCRIPTION
#### Summary
Peek drop

#### Purpose of change
#2970 made it impossible to get solar arrays safely off of roofs. You can deconstruct a solar panel or use a long rope to carry the array down, but that requires a bit of prep. Since it's only one story, you should just be able to drop items down gently.

#### Describe the solution
Examine the ledge, hit "peek down", press d. You will be prompted to drop items. Just like when peek-throwing it will look like you're back up on the roof (and you are) but the items will be gently placed on the tile below that you peeked to.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
