### PR TITLE
Fix hallucination drops and reach friendly fire

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1130,7 +1130,7 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost,
             !x_in_y( ( target_size * target_size + 1 ) * skill,
                      ( inter->get_size() * inter->get_size() + 1 ) * 10 ) ) {
             // Even if we miss here, low roll means weapon is pushed away or something like that.
-            if( inter->has_effect( effect_pet ) || ( inter->is_monster() && ( inter->attitude_to( *this ) == Attitude::FRIENDLY || ( inter->attitude_to( *this ) == Attitude::NEUTRAL && critter->attitude_to( *this ) != Attitude::NEUTRAL ) ) ) || ( inter->is_npc() &&
+            if( inter->has_effect( effect_pet ) || ( inter->is_monster() && ( inter->attitude_to( *this ) == Attitude::FRIENDLY || ( inter->attitude_to( *this ) == Attitude::NEUTRAL && ( critter->is_monster() && critter->attitude_to( *this ) != Attitude::NEUTRAL ) ) ) ) || ( inter->is_npc() &&
                     !inter->as_npc()->is_enemy() && !inter->as_npc()->guaranteed_hostile() ) ) {
                 if( query_yn( _( "Your attack may cause accidental injury, continue?" ) ) ) {
                     critter = inter;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1129,9 +1129,9 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost,
         if( inter != nullptr &&
             !x_in_y( ( target_size * target_size + 1 ) * skill,
                      ( inter->get_size() * inter->get_size() + 1 ) * 10 ) ) {
-            // Even if we miss here, low roll means weapon is pushed away or something like that
-            if( inter->has_effect( effect_pet ) || ( inter->is_npc() &&
-                    inter->as_npc()->is_friendly( get_player_character() ) ) ) {
+            // Even if we miss here, low roll means weapon is pushed away or something like that.
+            if( inter->has_effect( effect_pet ) || ( inter->is_monster() && ( inter->attitude_to( *this ) == Attitude::FRIENDLY || ( inter->attitude_to( *this ) == Attitude::NEUTRAL && critter->attitude_to( *this ) != Attitude::NEUTRAL ) ) ) || ( inter->is_npc() &&
+                    !inter->as_npc()->is_enemy() && !inter->as_npc()->guaranteed_hostile() ) ) {
                 if( query_yn( _( "Your attack may cause accidental injury, continue?" ) ) ) {
                     critter = inter;
                     break;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1587,11 +1587,16 @@ void npc::stow_item( item &it )
             add_msg_if_npc( m_info, _( "<npcname> puts away the %s." ), ret->tname() );
         }
         mod_moves( -item_handling_cost( it ) );
-    } else { // No room for weapon, so we drop it
+    } else { // No room for weapon, so we drop it.
         if( avatar_sees ) {
             add_msg_if_npc( m_info, _( "<npcname> drops the %s." ), it.tname() );
         }
-        here.add_item_or_charges( pos_bub( here ), remove_item( it ) );
+        if( !is_hallucination() ) {
+            // We're a hallucination, so get rid of the item without actually placing anything on the ground.
+            remove_item( it );
+        } else {
+            here.add_item_or_charges( pos_bub( here ), remove_item( it ) );
+        }
     }
 }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3776,7 +3776,7 @@ void npc::worker_downtime()
 void npc::move_pause()
 
 {
-    // make sure we're using the best weapon
+    // Make sure we're using the best weapon.
     if( calendar::once_every( 1_hours ) ) {
         deactivate_bionic_by_id( bio_sleep_shutdown );
         for( const bionic_id &bio_id : health_cbms ) {
@@ -4533,7 +4533,7 @@ item *npc::evaluate_best_weapon() const
 
 bool npc::wield_better_weapon()
 {
-    // These are also assigned here so npc::evaluate_best_weapon() can be called by itself
+    // These are also assigned here so npc::evaluate_best_weapon() can be called by itself.
     bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );
     bool use_silent = is_player_ally() && rules.has_flag( ally_rule::use_silent );
 
@@ -4553,7 +4553,7 @@ bool npc::wield_better_weapon()
     add_msg_debug( debugmode::DF_NPC, "Wielding %s at value %.1f", better_weapon->type->get_id().str(),
                    evaluate_weapon( *better_weapon, can_use_gun, use_silent ) );
 
-    // Always returns true, but future proof
+    // Always returns true, but future proof.
     bool wield_success = wield( *better_weapon );
     if( !wield_success ) {
         debugmsg( "NPC failed to wield better weapon %s", better_weapon->tname() );


### PR DESCRIPTION
#### Summary
Fix hallucination drops and reach friendly fire

#### Purpose of change
- A player noted a hallucinated NPC drop their crossbow to switch to melee. The crossbow remained after the NPC was gone.
- Someone accidentally stabbed an innocent squirrel with a pike. This was really funny, but it also highlighted a weakness in the friendly fire warning in reach attack code. While exploring that, I found more.

#### Describe the solution
- Hallucinated NPCs just delete their weapons when they want to drop them. You're still told that they dropped it, but no weapon appears on the ground.
- Previously, reach attacks only warned about interposing creatures if they were your followers or your pets. Now they warn if the monster is a pet, if it's friendly, or if it's neutral and the monster you're targeting is not neutral. Against NPCs, you will get a warning any time you might hit an NPC which is not hostile or guaranteed hostile.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
