### PR TITLE
Fix throwing rounding mismatch

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -427,7 +427,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         }
         // Range can be 0.
         size_t traj_len = t_copy.size();
-        while( traj_len > 0 && trig_dist_precise( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
+        while( traj_len > 0 && trig_dist( source, t_copy[traj_len - 1] ) > proj_arg.range ) {
             --traj_len;
         }
 


### PR DESCRIPTION
#### Summary
Fix throwing rounding mismatch

#### Purpose of change
fixes #2972 

#### Describe the solution
See linked issue.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
