### PR TITLE
Fix some profession names

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4561,7 +4561,7 @@
   {
     "type": "profession",
     "id": "skaterkid",
-    "name": { "male": "Skater Boy (Rollerblades)", "female": "Skater Girl (Rollerblades)" },
+    "name": { "male": "Roller Boy", "female": "Roller Girl" },
     "description": "You love to skate!  You've probably spent more time on a pair of blades than off.  Things have gotten pretty bad, but at least the cops aren't telling you where you can't roll.",
     "npc_background": "BG_survival_story_TEENAGER_TOUGH",
     "points": 1,
@@ -4593,7 +4593,7 @@
   {
     "type": "profession",
     "id": "skaterkid_board",
-    "name": { "male": "Skater Boy (Skateboard)", "female": "Skater Girl (Skateboard)" },
+    "name": { "male": "Skater Boy", "female": "Skater Girl" },
     "description": "You love to skate!  You've probably spent more time on a skateboard than off.  Things have gotten pretty bad, but at least the cops aren't telling you where you can't roll.",
     "npc_background": "BG_survival_story_TEENAGER_TOUGH",
     "points": 1,
@@ -4626,14 +4626,14 @@
   {
     "type": "profession",
     "id": "jdelinquent",
-    "name": "Juvenile Delinquent",
+    "name": "Delinquent",
     "description": "You never cared for grown-ups telling you what to do, so you ended up spending quite a few days in the principal's office.  Now, not needing grown-ups to tell you what to do is the only reason you're alive.  Man, you really should've played hooky today.",
     "npc_background": "BG_survival_story_TEENAGER_TOUGH",
-    "points": 0,
+    "points": 2,
     "proficiencies": [ "prof_unarmed_familiar" ],
     "skills": [
       { "level": 1, "name": "gun" },
-      { "level": 1, "name": "archery" },
+      { "level": 1, "name": "throw" },
       { "level": 1, "name": "melee" },
       { "level": 1, "name": "unarmed" },
       { "level": 1, "name": "dodge" }


### PR DESCRIPTION
#### Summary
Fix some profession names

#### Purpose of change
Skater boy/girl (rollerblades) and skater boy/girl (skateboard) looked dumb. Now it's roller boy/girl and skater boy/girl

#### Describe the solution
Fix that. Change juvenile delinquent to delinquent. Change their archery skill to throwing, make that profession cost a point.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
