### PR TITLE
Re-add rock throw to psycho killer and frenzied worker

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -155,6 +155,30 @@
     "description": "The Cataclysm began as an outbreak of what then seemed like violent insanity, but there must be something more to it, as these lost souls freely walk among the undead without being attacked.  This one has got their hands on a kitchen knife, and they look eager to put it to use.",
     "copy-from": "mon_feral_human_pipe",
     "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_human_thrown_rock",
+        "ammo_type": "rock",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 3 ] ],
+        "fake_str": 8,
+        "condition": {
+          "and": [
+            { "test_eoc": "is_disarmed" },
+            { "not": { "u_has_effect": "maimed_arm" } },
+            { "not": { "u_has_flag": "grab" } },
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } },
+            { "not": { "u_has_flag": "webbed" } },
+            { "not": { "u_has_flag": "downed" } }
+          ]
+        },
+        "require_targeting_player": false,
+        "ranges": [ [ 2, 5, "DEFAULT" ] ],
+        "description": "The psycho killer throws a rock!"
+      },
       { "id": "feral_weapon_knife_chef" },
       { "id": "feral_unarmed" },
       { "id": "feral_bite" },
@@ -228,6 +252,30 @@
     "description": "This person must have been some sort of technician before the Cataclysm.  Now, they're reduced to a mad thing, still wearing the remains of a work uniform and clutching a hammer that is now nothing more than a weapon.",
     "copy-from": "mon_feral_human_pipe",
     "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_human_thrown_rock",
+        "ammo_type": "rock",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 3 ] ],
+        "fake_str": 8,
+        "condition": {
+          "and": [
+            { "test_eoc": "is_disarmed" },
+            { "not": { "u_has_effect": "maimed_arm" } },
+            { "not": { "u_has_flag": "grab" } },
+            { "not": { "u_has_flag": "grab_filter" } },
+            { "not": { "u_has_effect": "blind" } },
+            { "not": { "u_has_flag": "webbed" } },
+            { "not": { "u_has_flag": "downed" } }
+          ]
+        },
+        "require_targeting_player": false,
+        "ranges": [ [ 2, 5, "DEFAULT" ] ],
+        "description": "The frenzied worker throws a rock!"
+      },
       { "id": "feral_weapon_hammer" },
       { "id": "feral_unarmed" },
       { "id": "feral_bite" },


### PR DESCRIPTION
#### Summary

Let the pyscho killer and the worker/technician ferals throw rocks again (assuming it wasn't intended to take rock throwing away from those).

Feel free to disregard or close if that change was intended.

#### Purpose of change

I noticed in a playthrough that ferals weren't throwing any rocks at me. After some more investigation I found that some types of ferals do still through rocks, it's just that the ones name psycho killer and frenzied worker didn't, and I just happened to run into several of the psycho killer monster in a row.

Seems it was removed from those in #2924.

#### Describe the solution

I basically copied the rock throwing weapon from the monsters that still had it, back to mon_feral_human_knife and mon_feral_human_tool, who they were removed from.

#### Describe alternatives you've considered

I thought about if it would make sense for some ferals to have or not have rock throwing, but I was uncertain so I just stuck to creating a PR that adds it back to the ones it was removed from in #2924 just in case the removal was unintended.

#### Testing

Spawn in psycho killers and frenzied technicians, and verify that they throw rocks when in the correct range.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
