### PR TITLE
nausea fixes

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1493,13 +1493,14 @@ void Character::modify_morale( item &food, const int nutr )
         if( strength_adjusted > 10 ) {
             nausea_chance -= ( std::min( get_str(), strength_adjusted ) / 2 );
         }
-    }
-    if( nausea_chance > 0 && x_in_y( std::min( 100, nausea_chance ), 100 ) ) {
-        nausea_chance = static_cast<int>( nausea_chance * rng_float( 1.25, 0.5 ) );
-        // 15 minutes is the max duration, and the effect's intensity automatically scales with duration.
-        add_effect( effect_nausea, ( 1 / ( std::min( 100, nausea_chance ) * .15 ) ) * 15_minutes );
-        add_msg_player_or_npc( _( "You're not sure you're going to be able to keep that down." ),
-                               _( "<npcname> looks about ready to puke." ) );
+        if( nausea_chance > 0 && x_in_y( std::min( 100, nausea_chance ), 100 ) ) {
+            const double nausea_severity = nausea_chance * rng_float( 1.25, 0.5 );
+            // 15 minutes is the max duration, and the effect's intensity automatically scales with duration.
+            // Max duration is reached when nausea_severity is 1/0.15=6.667.
+            add_effect( effect_nausea, std::min( 100.0, nausea_severity ) * 0.15 * 15_minutes );
+            add_msg_player_or_npc( _( "You're not sure you're going to be able to keep that down." ),
+                                   _( "<npcname> looks about ready to puke." ) );
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary

Fix the nausea chance >5 threshold, fix duration to be proportional to nausea chance instead of inversely proportional, and remove premature truncation of the random nausea duration.

#### Purpose of change

I noticed a couple of things when looking at the nausea code for the strength stat stuff.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/9b142a435a05b07473b71e4c351d8d99533d4b80/src/consumption.cpp#L1487-L1503

1. Strength decreases nausea chance, but only if nausea chance is > 5, which meant that in some circumstances a more unfun food can have a lower nausea chance than a less unfun food. I was confused on what the > 5 check was for until I found #1413, which implied that a slightly unfun food should not have a chance of causing nausea, which was currently not true as the part of the code causing nausea chance was outside of the > 5 condition.
2. I noticed with the duration that the term regarding nausea chance was in the denominator, implying that a lower nausea chance results in increased duration and intensity of nausea. This seems unintended if the intent is that low unfun foods are not as risky in terms of nausea.
3. While working on the duration fix I noticed that nausea chance is multiplied by a random float between 0.5 to 1.25, and then cast to an int. This would cause truncation. So, for an example that assumes the other duration fix, if the random range was from 2.5 to 1 then the duration would only be 1 * 0.15 * 15 * 60 = 135 seconds or 2 * 0.15 * 15 * 60 = 270 seconds, but wouldn't be any value of seconds between 135 and 20. Which wouldn't necessarily be noticeable for large ranges, but if nausea chance pre-rng is 1 there could be post-rng values under 1, which would be truncated to 0, which might mean the effect doesn't get applied properly.

As commented in the alternatives section, I also noticed that the effect of strength on nausea jumps suddenly from 10 to 11 due to the > 10 condition, but did not change that due to not being sure about the preferred solution.

#### Describe the solution

1. I moved the conditional with the >0 and the x in y chance, that added the nausea effect, to inside the nausea chance > 5 conditional, so nausea is not inflicted when nausea chance is 5 or less. So for a normal character with no applicable traits or effects increasing nausea chance, eating normal but slightly unfun foods does not inflict nausea.
2. I changed the duration from 1 / ( std::min( 100, nausea_chance ) to std::min( 100, nausea_chance). So when nausea chance occurs, nausea from eating raw mutant meat is likely to be more intense or last longer than nausea from eating butter.
3. The code for calculating nausea duration now uses doubles rather than ints which should avoid premature int truncation.

#### Describe alternatives you've considered

It seemed to me that the intent was that foods past a certain amount of unfunness would have a chance to cause nausea, based on what was said in #1413 and on other references to a -5/-6 threshold. It's possible that the intent was changed from a hard gate to low unfun foods just being less severe to the point that the consequences of eating them were tolerable, in which case the 5 nausea chance threshold could just be changed to only gate the picky eater effect, and maybe chanced to > 0 if the intent is that picky eaters can get more nauseous for any foods they don't like.

I think the effect of strength on nausea chance probably shouldn't jump from 0 to -5 when going from strength 10 to 11, but I wasn't sure if the effect of strength on nausea chance at 10 strength should be 0 or -5, so I left that alone.

The nausea duration involved multiplying the nausea chance, or its reciprocal by 0.15, then multiplying it by the 15 minutes duration. 7 * 0.15 * 15 minutes = 15.75 minutes, so the duration reached the max at about -6 or -7 fun. There's a min 100, which would imply that the max input would be on a range of 0 to 100. But if the 0.15 was changed to a 0.01 such that 100 nausea chance represented maximum nausea, then a -10 or -20 fun food would have a relatively light effect, which definitely seemed wrong. So I left it as is.

#### Testing

Eat unfun or otherwise nauseous foods and verify that the above applies. Note that nausea chance 6 is still causes pretty high nausea so you might want a strength 11 character and eat a bunch of dehydrated garlic cloves or such, since -6 fun is enough to cause nausea but the nausea chance would be reduced by 5 down to 1 when calculating severity, causing less severe nausea than when eating raw tainted human meat.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
