### PR TITLE
Partially fix ledge climbing down

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13705,21 +13705,32 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
 
     map &here = get_map();
     Character &you = get_player_character();
-    // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
+    // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free.
     if( !you.move_effects( false, examp ) ) {
-        // move_effects determined we could not move, waste all moves
+        // Move_effects determined we could not move, waste all moves.
         you.set_moves( 0 );
         return;
     }
 
     if( !here.valid_move( you.pos_bub(), examp, false, true ) ) {
-        // Can't move horizontally to the ledge
+        // Can't move horizontally to the ledge.
         return;
     }
 
     // Scan the height of the drop and what's in the way.
     const climbing_aid::fall_scan fall( examp );
-
+    const item_location weapon = you.get_wielded_item();
+    if( weapon && weapon->is_two_handed( you ) ) {
+        if( query_yn(
+                _( "You can't climb because you have to wield a %s with both hands.\n\nPut it away?" ),
+                weapon->tname() ) ) {
+            if( !you.unwield() ) {
+                return;
+            }
+        } else {
+            return;
+        }
+    }
     int estimated_climb_cost = you.climbing_cost( tripoint_bub_ms( fall.pos_bottom() ), examp );
     const float fall_mod = you.fall_damage_mod();
     add_msg_debug( debugmode::DF_IEXAMINE, "Climb cost %d", estimated_climb_cost );
@@ -13744,7 +13755,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
         damage_estimate *= std::pow( fall_mod, 30.f / damage_estimate );
     }
 
-    // Rough messaging about safety.  "seems safe" can leave a 1-2% chance unlike "perfectly safe".
+    // Rough messaging about safety. "Seems safe" can leave a 1-2% chance unlike "perfectly safe".
     bool seems_perfectly_safe = slip_chance < -5 && aid.down.max_height >= fall.height;
     if( seems_perfectly_safe ) {
         query = _( "It <color_green>seems perfectly safe</color> to climb down like this." );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5357,10 +5357,6 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
             }
             break;
         }
-        /*case ledge_climb_down: {
-            g->climb_down( examp );
-            break;
-        }*/
         case ledge_peek_down: {
             // Peek
             tripoint_bub_ms where = examp;
@@ -5386,27 +5382,6 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
             here.furn( just_below ).obj().examine( you, just_below );
             break;
         }
-        /*case ledge_cling_down: {
-            // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
-            if( !you.move_effects( false ) ) {
-                you.mod_moves( -to_moves<int>( 1_seconds ) );
-                return;
-            }
-
-            if( !here.valid_move( you.pos(), examp, false, true ) ) {
-                // Covered with something
-                return;
-            } else {
-                you.setpos( examp );
-                g->vertical_move( -1, false );
-                if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, you.pos() ) ) {
-                    you.set_underwater( true );
-                    g->water_affect_items( you );
-                    you.add_msg_if_player( _( "You crawl down and dive underwater." ) );
-                }
-            }
-            break;
-        }*/
         case ledge_glide: {
             // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
             if( !you.move_effects( false, examp ) ) {
@@ -5450,7 +5425,7 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
         case ledge_fall_down: {
             if( query_yn( _( "Climbing might be safer.  Really fall from the ledge?" ) ) ) {
                 you.mod_moves( -to_moves<int>( 1_seconds ) );
-                // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free
+                // If player is grabbed, trapped, or somehow otherwise movement-impeded, first try to break free.
                 if( !you.move_effects( false, examp ) ) {
                     return;
                 }


### PR DESCRIPTION
#### Summary
Partially fix ledge climbing down

#### Purpose of change
When I fixed climbing in #2970 I didn't realize that ledge() was running its own check that wasn't compatible. 

#### Describe the solution
Now, we check for a bulky item before running the climb cost check there at all and back out if it's impossible.

#### Describe alternatives you've considered
Remaining problem: climbing_aids all include climbing down as a part of their action. They shouldn't. Anchoring a grappling hook or dragline or placing a ladder below should just end the action and you can decide to climb after. This is only really a problem with the ladder right now, but ladders can just be placed on the open air and they'll fall safely down to where they need to be so you can get down them.

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
