### PR TITLE
remove large adjustable wrench

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -896,7 +896,6 @@
       { "item": "frame", "prob": 20, "damage": [ -1, 5 ] },
       [ "basket", 25 ],
       { "item": "wrench", "prob": 10, "damage": [ -1, 5 ] },
-      [ "wrench_large", 5 ],
       { "item": "shovel", "prob": 10, "damage": [ -1, 5 ] },
       { "item": "claw_bar", "prob": 5, "damage": [ -1, 5 ] },
       { "item": "crowbar", "prob": 15, "damage": [ -1, 5 ] },

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1486,8 +1486,8 @@
       [ "jack", 60 ],
       [ "jack_small", 60 ],
       [ "jack_makeshift", 30 ],
-      [ "wrench", 50 ],
-      [ "wrench_large", 20 ],
+      [ "wrench", 30 ],
+      [ "lug_wrench", 50 ],
       [ "socket_wrench_set", 40 ],
       [ "gloves_work", 30 ],
       [ "glasses_safety", 20 ]

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -161,7 +161,6 @@
       [ "pliers_locking", 40 ],
       [ "big_pliers", 5 ],
       [ "wrench", 75 ],
-      [ "wrench_large", 20 ],
       [ "socket_wrench_set", 20 ],
       [ "funnel", 50 ],
       [ "metal_file", 40 ],
@@ -291,7 +290,6 @@
     "items": [
       { "group": "tools_common_small", "prob": 90 },
       [ "wrench", 190 ],
-      [ "wrench_large", 20 ],
       [ "big_pliers", 10 ],
       [ "claw_bar", 4 ],
       [ "crowbar", 10 ],
@@ -966,8 +964,7 @@
       [ "wrench_small", 35 ],
       [ "hammer", 20 ],
       [ "multitool", 20 ],
-      [ "pliers_locking", 15 ],
-      [ "wrench_large", 5 ]
+      [ "pliers_locking", 15 ]
     ]
   },
   {

--- a/data/json/itemgroups/vehicles_fuel_related.json
+++ b/data/json/itemgroups/vehicles_fuel_related.json
@@ -77,7 +77,6 @@
             "distribution": [
               { "item": "wrench" },
               { "item": "wrench_small", "count": [ 1, 2 ] },
-              { "item": "wrench_large" },
               { "item": "socket_wrench_set" }
             ],
             "prob": 30

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1407,26 +1407,6 @@
     "melee_damage": { "bash": 10 }
   },
   {
-    "id": "wrench_large",
-    "type": "ITEM",
-    "subtypes": [ "TOOL" ],
-    "name": { "str": "large adjustable wrench", "str_pl": "large adjustable wrenches" },
-    "description": "An unusually large adjustable crescent wrench, with a long handle and jaws that widen over two inches.  This could easily turn most bolts, and should even work on wheel lug nuts.",
-    "//": "WESTWARD 31D018 from Walmart, 18-inch length, 2-3/8-inch jaws, 4.23 lb, assume 8g/ml steel density with some margin for mechanism and other empty space.",
-    "looks_like": "wrench",
-    "weight": "1900 g",
-    "volume": "250 ml",
-    "longest_side": "46 cm",
-    "price": "12 USD",
-    "price_postapoc": "1 USD",
-    "material": [ "steel" ],
-    "symbol": ";",
-    "color": "light_gray",
-    "qualities": [ [ "WRENCH", 2 ], [ "WHEEL_FAST", 1 ] ],
-    "flags": [ "BELT_CLIP" ],
-    "melee_damage": { "bash": 12 }
-  },
-  {
     "id": "makeshift_hose",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -868,7 +868,7 @@
     "subtype": "collection",
     "id": "mon_feral_sailor_death_drops",
     "entries": [
-      { "item": "wrench_large", "prob": 100, "damage": [ -1, 5 ] },
+      { "item": "wrench", "prob": 100, "damage": [ -1, 5 ] },
       { "group": "mon_zombie_sailor_death_drops", "prob": 100 }
     ]
   },

--- a/data/json/monsterdrops/zombie_survivor.json
+++ b/data/json/monsterdrops/zombie_survivor.json
@@ -134,7 +134,6 @@
       [ "claw_bar", 5 ],
       [ "hammer", 5 ],
       [ "hammer_sledge_engineer", 5 ],
-      [ "wrench_large", 5 ],
       [ "cudgel", 5 ],
       [ "nailboard", 25 ],
       [ "makeshift_crowbar", 35 ],

--- a/data/json/npcs/NC_MOTORHEAD.json
+++ b/data/json/npcs/NC_MOTORHEAD.json
@@ -98,7 +98,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "lug_wrench", "prob": 25 },
-      { "item": "wrench_large", "prob": 25 },
+      { "item": "wrench", "prob": 25 },
       { "item": "staff_pipe", "prob": 15 },
       { "item": "pipe", "prob": 15 }
     ]

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -4227,5 +4227,10 @@
     "type": "MIGRATION",
     "id": "plaguedoctor_robe",
     "replace": "cassock"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "wrench_large",
+    "replace": "wrench"
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1343,7 +1343,7 @@
           { "group": "charged_two_way_radio" },
           { "item": "tank_top" },
           { "item": "pants_army" },
-          { "item": "wrench_large" },
+          { "item": "wrench" },
           { "item": "screwdriver" },
           { "item": "hacksaw" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2075,7 +2075,7 @@
     "name": "adjustable wrenches",
     "description": "Recipes related to creating adjustable wrenches.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "wrench", "wrench_large", "wrench_small" ]
+    "nested_category_data": [ "wrench", "wrench_small" ]
   },
   {
     "id": "nested_funnels",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -571,24 +571,6 @@
   {
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
-    "result": "wrench_large",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
-    "difficulty": 6,
-    "time": "7 h",
-    "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 8 ], [ "steel_standard", 2 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
-    ],
-    "qualities": [ { "id": "GRIND", "level": 2 } ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
     "result": "lug_wrench",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",

--- a/data/json/requirements/vehicle.json
+++ b/data/json/requirements/vehicle.json
@@ -3,7 +3,7 @@
     "id": "vehicle_fasten",
     "type": "requirement",
     "//": "Compatible with legacy flag TOOL_WRENCH or when installing wheels",
-    "tools": [ [ [ "lug_wrench", -1 ], [ "wrench_large", -1 ], [ "cordless_impact_wrench", 100 ] ] ]
+    "tools": [ [ [ "lug_wrench", -1 ], [ "cordless_impact_wrench", 100 ] ] ]
   },
   {
     "id": "vehicle_wrench_1",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -5591,14 +5591,6 @@
     "components": [ [ [ "copper", 49 ] ] ]
   },
   {
-    "result": "wrench_large",
-    "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
-    "time": "15 m",
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
-    "components": [ [ [ "steel_chunk", 1 ] ], [ [ "steel_fragment", 3 ] ] ]
-  },
-  {
     "result": "wheel_rim_bicycle",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",


### PR DESCRIPTION
#### Summary
remove large adjustable wrench

#### Purpose of change
This item only existed to make it easier to remove tires. That's not how tires work. You need a huge pain in the ass tool irl.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
