### PR TITLE
Quick fixes

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -412,7 +412,7 @@
     "calories": 1190,
     "fun": -10,
     "parasites": 32,
-    "vitamins": [ [ "meat_allergen", 1 ], [ "junkfood_allergen", 1 ] ],
+    "vitamins": [ [ "meat_allergen", 1 ], [ "junk_allergen", 1 ] ],
     "flags": [ "SMOKABLE", "RAW", "PREDATOR_FUN" ],
     "use_action": [ "PETFOOD" ],
     "smoking_result": "meat_smoked",
@@ -435,7 +435,7 @@
     "spoils_in": "14 days",
     "parasites": 30,
     "fun": -15,
-    "vitamins": [ [ "junkfood_allergen", 1 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "junk_allergen", 1 ], [ "meat_allergen", 1 ] ],
     "flags": [ "SMOKABLE", "RAW" ],
     "smoking_result": "bacon_uncut"
   },
@@ -456,7 +456,7 @@
     "spoils_in": "42 days",
     "fun": 6,
     "quench": -9,
-    "vitamins": [ [ "junkfood_allergen", 1 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "junk_allergen", 1 ], [ "meat_allergen", 1 ] ],
     "flags": [ "EATEN_HOT", "SMOKED" ]
   },
   {
@@ -801,7 +801,7 @@
     "parasites": 0,
     "calories": 1190,
     "fun": 2,
-    "vitamins": [ [ "junkfood_allergen", 1 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "junk_allergen", 1 ], [ "meat_allergen", 1 ] ],
     "flags": [ "EATEN_HOT" ]
   },
   {

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -198,7 +198,7 @@
     "price_postapoc": "4 USD",
     "material": [ "flesh" ],
     "flags": [ "EATEN_HOT", "SMOKED" ],
-    "vitamins": [ [ "junkfood_allergen", 1 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "junk_allergen", 1 ], [ "meat_allergen", 1 ] ],
     "quench": -3,
     "fun": 5
   },

--- a/data/json/recipes/practice/ranged.json
+++ b/data/json/recipes/practice/ranged.json
@@ -28,8 +28,7 @@
         "metal_RPG_die",
         "RPG_die",
         "rock",
-        "sharp_rock",
-        "bearing"
+        "sharp_rock"
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Quick fixes

#### Purpose of change
Fixed a "junkfood_allergen" error as well as one relating to the removed bearing recipe.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
