### PR TITLE
Buff acid resistance of some materials

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2006,7 +2006,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 3, "cut": 5, "acid": 15, "heat": 8, "bullet": 6 }
+    "resist": { "bash": 3, "cut": 5, "acid": 18, "heat": 8, "bullet": 6 }
   },
   {
     "type": "material",
@@ -2026,7 +2026,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "//": "Should have 15 acid, 5 cut, 8 fire, and no listed stab, but it's internal, so...",
+    "//": "Should have 18 acid, 5 cut, 8 fire, and no listed stab, but it's internal, so...",
     "resist": { "bash": 3, "cut": 1, "stab": 2, "acid": 0, "heat": 0, "bullet": 6 }
   },
   {
@@ -2049,7 +2049,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 1.25, "cut": 4, "acid": 8, "heat": 3, "bullet": 2 },
+    "resist": { "bash": 1.25, "cut": 4, "acid": 6, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2349,7 +2349,7 @@
       { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
       { "fuel": 0.15, "smoke": 5, "burn": 0.5 }
     ],
-    "resist": { "bash": 0.8, "cut": 1, "acid": 9, "heat": 2, "bullet": 2 },
+    "resist": { "bash": 0.8, "cut": 1, "acid": 18, "heat": 2, "bullet": 2 },
     "repair_difficulty": 2
   },
   {
@@ -2384,7 +2384,7 @@
       { "fuel": 0.05, "smoke": 2, "burn": 0.03 },
       { "fuel": 0.15, "smoke": 5, "burn": 0.5 }
     ],
-    "resist": { "bash": 0.3, "cut": 0.15, "acid": 9, "heat": 1, "bullet": 0 },
+    "resist": { "bash": 0.3, "cut": 0.15, "acid": 14, "heat": 1, "bullet": 0 },
     "repair_difficulty": 0
   },
   {
@@ -2399,7 +2399,7 @@
       { "fuel": 2, "smoke": 1, "burn": 0.04 },
       { "fuel": 3, "smoke": 1, "burn": 0.06 }
     ],
-    "resist": { "bash": 1.0, "cut": 0.4, "acid": 6, "heat": 2, "bullet": 1 },
+    "resist": { "bash": 1.0, "cut": 0.4, "acid": 10, "heat": 2, "bullet": 1 },
     "repair_difficulty": 1
   },
   {
@@ -2422,7 +2422,7 @@
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
-    "resist": { "bash": 0, "cut": 0, "acid": 2, "heat": 3, "bullet": 0 },
+    "resist": { "bash": 0, "cut": 0, "acid": 5, "heat": 3, "bullet": 0 },
     "repair_difficulty": 4
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -1430,7 +1430,7 @@
       { "fuel": 0.2, "smoke": 10, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 1.2, "cut": 2, "acid": 8, "heat": 2.2, "bullet": 2 },
+    "resist": { "bash": 1.2, "cut": 2, "acid": 12, "heat": 2.2, "bullet": 2 },
     "repair_difficulty": 3
   },
   {
@@ -1639,7 +1639,7 @@
       { "fuel": 0.4, "smoke": 1, "burn": 0.003 },
       { "fuel": 1, "smoke": 2, "burn": 0.008 }
     ],
-    "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
+    "resist": { "bash": 2, "cut": 1, "acid": 10, "heat": 0, "bullet": 0 }
   },
   {
     "type": "material",
@@ -1661,7 +1661,7 @@
       { "fuel": 300, "smoke": 0, "burn": 2 },
       { "fuel": 450, "smoke": 0, "burn": 3 }
     ],
-    "resist": { "bash": 0, "cut": 0, "acid": 0, "heat": 0, "bullet": 0 }
+    "resist": { "bash": 2, "cut": 1, "acid": 12, "heat": 0, "bullet": 0 }
   },
   {
     "type": "material",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -317,7 +317,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "bronze_fragment", 0.5 ] ],
-    "resist": { "bash": 3.5, "cut": 4.5, "acid": 1, "heat": 2, "bullet": 2 },
+    "resist": { "bash": 3.5, "cut": 4.5, "acid": 2, "heat": 2, "bullet": 2 },
     "repair_difficulty": 4
   },
   {
@@ -352,7 +352,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 2 },
+    "resist": { "bash": 6, "cut": 6, "acid": 9, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
   },
   {
@@ -393,14 +393,14 @@
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
     "acid_dmg_verb": "corroded",
-    "resist": { "bash": 0.4, "cut": 0.6, "acid": 10, "heat": 10, "bullet": 2 }
+    "resist": { "bash": 0.4, "cut": 0.6, "acid": 18, "heat": 10, "bullet": 2 }
   },
   {
     "type": "material",
     "id": "damaged_ceramic",
     "name": "Compromised Ceramic",
     "copy-from": "ceramic",
-    "resist": { "bash": 0.2, "cut": 0.5, "acid": 10, "heat": 10, "bullet": 0.8 }
+    "resist": { "bash": 0.2, "cut": 0.5, "acid": 16, "heat": 10, "bullet": 0.8 }
   },
   {
     "type": "material",
@@ -507,7 +507,7 @@
     "cut_dmg_verb": "cut",
     "acid_dmg_verb": "burned",
     "burn_products": [ [ "ceramic_shard", 0.5 ] ],
-    "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
+    "resist": { "bash": 2, "cut": 3, "acid": 10, "heat": 3, "bullet": 2 }
   },
   {
     "type": "material",
@@ -521,8 +521,8 @@
     "dmg_adj": [ "chipped", "scratched", "cracked", "shattered" ],
     "bash_dmg_verb": "cracked",
     "cut_dmg_verb": "cut",
-    "acid_dmg_verb": "burned",
-    "resist": { "bash": 2, "cut": 3, "acid": 6, "heat": 3, "bullet": 2 }
+    "acid_dmg_verb": "etched",
+    "resist": { "bash": 2, "cut": 3, "acid": 15, "heat": 3, "bullet": 2 }
   },
   {
     "type": "material",
@@ -540,7 +540,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "burned",
     "burn_products": [ [ "copper", 0.5 ] ],
-    "resist": { "bash": 2, "cut": 3, "acid": 0, "heat": 3, "bullet": 2 },
+    "resist": { "bash": 2, "cut": 3, "acid": 13, "heat": 3, "bullet": 2 },
     "repair_difficulty": 3
   },
   {
@@ -1235,7 +1235,7 @@
       { "fuel": 0.35, "smoke": 5, "burn": 0.004, "volume_per_turn": "1 L" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 1, "bullet": 1 }
+    "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 0, "bullet": 1 }
   },
   {
     "type": "material",
@@ -1922,7 +1922,7 @@
       { "fuel": 1, "smoke": 3, "burn": 0.2 },
       { "fuel": 1, "smoke": 4, "burn": 0.3 }
     ],
-    "resist": { "bash": 5, "cut": 1, "acid": 10, "heat": 2, "bullet": 1 },
+    "resist": { "bash": 5, "cut": 1, "acid": 20, "heat": 2, "bullet": 1 },
     "repair_difficulty": 3
   },
   {
@@ -1947,7 +1947,7 @@
       { "fuel": 1, "smoke": 3, "burn": 0.2 },
       { "fuel": 1, "smoke": 4, "burn": 0.3 }
     ],
-    "resist": { "bash": 3, "cut": 1, "acid": 10, "heat": 3, "bullet": 1 },
+    "resist": { "bash": 3, "cut": 1, "acid": 20, "heat": 3, "bullet": 1 },
     "repair_difficulty": 3
   },
   {
@@ -1973,7 +1973,7 @@
       { "fuel": 1, "smoke": 3, "burn": 0.2 },
       { "fuel": 1, "smoke": 4, "burn": 0.3 }
     ],
-    "resist": { "bash": 1, "cut": 1, "acid": 7, "heat": 1, "bullet": 1 },
+    "resist": { "bash": 1, "cut": 1, "acid": 18, "heat": 1, "bullet": 1 },
     "repair_difficulty": 3
   },
   {
@@ -2006,7 +2006,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 3, "cut": 5, "acid": 10, "heat": 8, "bullet": 6 }
+    "resist": { "bash": 3, "cut": 5, "acid": 15, "heat": 8, "bullet": 6 }
   },
   {
     "type": "material",
@@ -2026,7 +2026,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "//": "Should have 8 acid, 5 cut, 8 fire, and no listed stab, but it's internal, so...",
+    "//": "Should have 15 acid, 5 cut, 8 fire, and no listed stab, but it's internal, so...",
     "resist": { "bash": 3, "cut": 1, "stab": 2, "acid": 0, "heat": 0, "bullet": 6 }
   },
   {
@@ -2049,7 +2049,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 1.25, "cut": 4, "acid": 6, "heat": 3, "bullet": 2 },
+    "resist": { "bash": 1.25, "cut": 4, "acid": 8, "heat": 3, "bullet": 2 },
     "repair_difficulty": 2
   },
   {
@@ -2072,7 +2072,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 1.75, "cut": 7.5, "acid": 7, "heat": 3, "bullet": 4 },
+    "resist": { "bash": 1.75, "cut": 7.5, "acid": 10, "heat": 3, "bullet": 4 },
     "repair_difficulty": 2
   },
   {
@@ -2091,7 +2091,7 @@
     "cut_dmg_verb": "scratched",
     "acid_dmg_verb": "corroded",
     "burn_products": [ [ "scrap", 0.5 ] ],
-    "resist": { "bash": 6, "cut": 6, "acid": 7, "heat": 3, "bullet": 5.8 },
+    "resist": { "bash": 6, "cut": 6, "acid": 12, "heat": 3, "bullet": 5.8 },
     "repair_difficulty": 4
   },
   {
@@ -2324,23 +2324,6 @@
     "acid_dmg_verb": "corroded",
     "resist": { "bash": 6, "cut": 6, "acid": 5, "heat": 3, "bullet": 5 },
     "repair_difficulty": 7
-  },
-  {
-    "type": "material",
-    "id": "carbide",
-    "//": "Based on tungsten carbide",
-    "density": 16.0,
-    "name": "Layered Carbide",
-    "breathability": "SECOND_SKIN",
-    "specific_heat_liquid": 0.82,
-    "specific_heat_solid": 0.45,
-    "latent_heat": 273,
-    "chip_resist": 12,
-    "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
-    "bash_dmg_verb": "dented",
-    "cut_dmg_verb": "scratched",
-    "acid_dmg_verb": "corroded",
-    "resist": { "bash": 6, "cut": 6, "acid": 30, "heat": 30, "bullet": 5 }
   },
   {
     "type": "material",
@@ -3118,7 +3101,7 @@
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "wind_resist": 100,
-    "resist": { "bash": 0.5, "cut": 0.1, "bullet": 0.1, "acid": 0, "heat": 0 }
+    "resist": { "bash": 0.5, "cut": 0.1, "bullet": 0.1, "acid": 0, "heat": 2 }
   },
   {
     "type": "material",

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -228,8 +228,8 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // We copy the damage unit here since it will be mutated by mitigate_damage()
     damage_unit pre_mitigation = du;
 
-    // reduce the damage
-    // -1 is passed as roll so that each material is rolled individually
+    // Reduce the damage
+    // -1 is passed as roll so that each material is rolled individually.
     armor.mitigate_damage( du, sbp, -1 );
 
     // check if the armor was damaged

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9491,7 +9491,7 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
         if( shield_hp > 0 ) {
             return armor_status::UNDAMAGED;
         } else {
-            //Shields deliberately ignore the enchantment multiplier, as the health mechanic wouldn't make sense otherwise.
+            // Shields deliberately ignore the enchantment multiplier, as the health mechanic wouldn't make sense otherwise.
             mod_damage( itype::damage_scale * 6 );
             return armor_status::DESTROYED;
         }


### PR DESCRIPTION
#### Summary
Buff acid resistance of some materials

#### Purpose of change
Acid was way too damaging to certain materials it should be nearly or entirely unable to harm. We want to reduce the runaway damage values on the acid spells, but first let's crank up the resistances for a few mateirals that ought to be better at it.
- Steel: Steel and iron aren't great at this, and we're assuming a highly volatile mix of compounds here. Still, they shouldn't be bad either, so they get a bit of a buff.
- Copper: Copper is pretty good at this. Bronze ain't.
- Rubber, vinyl, soft rubber: These ought to be basically immune. This isn't yet the case, but the chance has gone WAY down.
- Treated leather: These are treated specifically for acid resistance.
- Feathers get 2 bonus fire damage resistance, too. This only matters for the feathers mutation. Feathers are not fireproof AT ALL, but putting some air between you and the flame is a good thing.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
