### PR TITLE
Fix dragging so higher strength decreases pain

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11214,7 +11214,7 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
 
         ///\EFFECT_STR determines ability to drag furniture
     } else if( str_req > str &&
-               one_in( std::max( 20 - str_req - str, 2 ) ) ) {
+               one_in( std::max( 20 - ( str_req - str ), 2 ) ) ) {
         add_msg( m_bad, _( "You strain yourself trying to move the heavy %s!" ),
                  furntype.name() );
         u.mod_pain( 1 ); // Hurt ourselves.


### PR DESCRIPTION
#### Summary
Fix pain and failure from dragging slightly heavy furniture so strength decreases rather than increases failure.

#### Purpose of change

When I was looking into how dragging heavy furniture worked, I noticed higher strength, when strength is still below the required strength, increased the chance of pain and failure from dragging heavy furniture, which is associated with the "You strain yourself..." message.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/f08aa269ab23b4f06d82460d0eac9429478d2335/src/game.cpp#L11216-L11220

It seemed to me that the intent was probably that the greater the difference between strength and the required strength, the more likely it is to suffer from pain and fail.

For comparison, a similar formula is used to calculate the chance of dragging stuff taking extra time, with the only difference being str_req - str is in parenthesis there, so negative effects are more common as the difference between required strength and strength increases, so a higher strength decreases rather than increases the chances.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/f08aa269ab23b4f06d82460d0eac9429478d2335/src/game.cpp#L11104-L11106

#### Describe the solution

Putting str_req - str in parenthesis, so the odds of pain and failure are 20-the difference between required strength and strength, rather than 20-required strength-str.

Note that there seems to be a separate 1 in 3 chance of failure, so the chance of failing to move slightly too heavy furniture is closer to 1/3 than 1/20, which is still lower than before where it would have been like 2/3 for furniture that requires 1 more strength than the player has, and they are still unable to move furniture that's significantly too heavy.

#### Describe alternatives you've considered

I feel like it's clear that the current code (higher strength increasing pain) is probably wrong, and that the correct state is clear especially since elsewhere did have the str_req - str in parenthesis.

#### Testing

A character requires 9 strength to grab and pull an empty locker. So at 8 strength, 20-(str_req - str)=20-1=19 i.e. 1 in 19, whereas the old formula was 20-str_req-str=20-9-8=3. So after the change the "You strain yourself trying to move the heavy ..." message would pop up significantly less.

Note that the difficulty of grabbing and dragging is affected by stuff being inside the furniture, and also I'm pretty sure that appliances are different and use different code (i.e. an oven spawned in a house is furniture, a disconnected oven placed by the construction menu is an appliance).

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
