### PR TITLE
Fix grappled creature death crashes

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3059,6 +3059,7 @@ void monster::die( map *here, Creature *nkiller )
         const tripoint_range<tripoint_bub_ms> &surrounding = here->points_in_radius( pos_bub(), 1, 0 );
         Creature *grabber = nullptr;
         for( const effect &grab : get_effects_with_flag( json_flag_GRAB ) ) {
+            const efftype_id grab_id = grab.get_id();
             // Is our grabber around?
             for( const tripoint_bub_ms loc : surrounding ) {
                 Character *guy = creatures.creature_at<Character>( loc );
@@ -3070,14 +3071,14 @@ void monster::die( map *here, Creature *nkiller )
                 }
             }
             if( grabber == nullptr ) {
-                remove_effect( grab.get_id() );
+                remove_effect( grab_id );
                 add_msg_debug( debugmode::DF_MONSTER, "Orphan grab found and removed from dead monster" );
                 continue;
             }
             if( grabber && !grabber->is_monster() ) {
                 grabber->as_character()->release_grapple();
             }
-            remove_effect( grab.get_id() );
+            remove_effect( grab_id );
         }
     }
     if( has_effect_with_flag( json_flag_GRAB_FILTER ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3163,6 +3163,7 @@ void npc::die( map *here, Creature *nkiller )
         const tripoint_range<tripoint_bub_ms> &surrounding = here.points_in_radius( pos_bub(), 1, 0 );
         Creature *grabber = nullptr;
         for( const effect &grab : get_effects_with_flag( json_flag_GRAB ) ) {
+            const efftype_id grab_id = grab.get_id();
             // Is our grabber around?
             for( const tripoint_bub_ms loc : surrounding ) {
                 Creature *someone = creatures.creature_at( loc );
@@ -3173,14 +3174,14 @@ void npc::die( map *here, Creature *nkiller )
                 }
             }
             if( grabber == nullptr ) {
-                remove_effect( grab.get_id() );
+                remove_effect( grab_id );
                 add_msg_debug( debugmode::DF_MATTACK, "Orphan grab found and removed from dead NPC" );
                 continue;
             }
             if( grabber && !grabber->is_monster() ) {
                 grabber->as_character()->release_grapple();
             }
-            remove_effect( grab.get_id() );
+            remove_effect( grab_id );
         }
     }
     release_grapple();


### PR DESCRIPTION
#### Summary
Bugfix "Fix grappled creature death crashes"

#### Purpose of change

Two macOS crash reports show the same invalid access while a grappled creature dies:

```text
Creature::has_effect
Creature::remove_effect
Creature::remove_effect
npc::die / monster::die
```

`get_effects_with_flag()` returns references to effects. The death handlers kept one of those references across `release_grapple()`, which can remove the referenced grab effect. Reading `grab.get_id()` afterward could therefore use a dangling reference and crash.

#### Describe the solution

Copy the grab effect ID before calling `release_grapple()`, then use the stable copy for effect removal. Apply the same fix to both NPC and monster death handling.

#### Describe alternatives you have considered

Changing `get_effects_with_flag()` to return effect copies would affect every caller and perform broader copying. Restricting the lifetime fix to the two confirmed crash paths keeps this bugfix focused.

#### Testing

- Compiled `npc.cpp` and `monster.cpp` with the macOS release, tiles, and sound configuration and warnings treated as errors.
- Ran `git diff --check`.
- Audited the NPC and monster grapple cleanup paths to ensure neither reads the effect reference after `release_grapple()`.

#### Additional context

Sanitized crash details:

```text
Exception: EXC_BAD_ACCESS at 0x000000000000000c
Faulting thread: main thread

Crash 1: Creature::has_effect -> Creature::remove_effect -> npc::die
Crash 2: Creature::has_effect -> Creature::remove_effect -> monster::die
```