### PR TITLE
Fix nausea chance strength impact

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1490,9 +1490,9 @@ void Character::modify_morale( item &food, const int nutr )
         }
         int strength_adjusted = enchantment_cache->modify_value( enchant_vals::mod::STRENGTH_NATURAL,
                                 get_str_base() );
-        if( strength_adjusted > 10 ) {
-            nausea_chance -= ( std::min( get_str(), strength_adjusted ) / 2 );
-        }
+        // Nausea chance is not reduced at strength 9.
+        // Nausea chance reduction ranges from 1 to 10 for strength 10 through 19.
+        nausea_chance -= std::clamp( std::min( get_str(), strength_adjusted ) - 9, 0, 10 );
         if( nausea_chance > 0 && x_in_y( std::min( 100, nausea_chance ), 100 ) ) {
             const double nausea_severity = nausea_chance * rng_float( 1.25, 0.5 );
             // 15 minutes is the max duration, and the effect's intensity automatically scales with duration.


### PR DESCRIPTION
#### Summary
Fixing nausea chance strength reduction to be 0-10 for strength 10-19.

#### Purpose of change
Previously, at strength 10, nausea chance was not reduced, and at strength 11, it was. And it was reduced by about strength/2=5.

This fix attempt to implement the comment at https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/2990#issuecomment-5403228688

#### Describe the solution
Now, at strength 9, nausea chance is still not reduced, at strength 10 it's reduced by 1, and each additional point in strength reduces nausea chance by an additional point, up to reducing nausea chance by 10 at strength 19.

#### Describe alternatives you've considered
Capping at strength 20 instead? There are other possibilities for the range, like starting at 11 instead of 10, or having strength below 9 increase nausea chance for nausea-inducing food. This is just attempting to implement the behavior as described in the comment.

#### Testing
Test that a strength 10 character does not have significantly less nausea chance/duration than a strength 9 character, and that a strength 20 character is decently less likely to get nausea or gets not as severe nausea.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
