### PR TITLE
Chafing and Pupating

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2890,14 +2890,15 @@
     "immune_bp_flags": [ "BIONIC_LIMB" ],
     "base_mods": { "speed_mod": [ -4 ], "pain_min": [ 1 ], "pain_chance": [ 2 ], "pain_max_val": [ 15 ] },
     "limb_score_mods": [
-      { "limb_score": "manip", "modifier": -0.05 },
-      { "limb_score": "grip", "modifier": -0.05 },
-      { "limb_score": "block", "modifier": -0.05 },
-      { "limb_score": "lift", "modifier": -0.05 },
-      { "limb_score": "move_speed", "modifier": -0.05 },
-      { "limb_score": "balance", "modifier": -0.05 },
-      { "limb_score": "swimming", "modifier": -0.05 },
-      { "limb_score": "crawl", "modifier": -0.05 }
+      { "limb_score": "manip", "modifier": 0.8 },
+      { "limb_score": "grip", "modifier": 0.8 },
+      { "limb_score": "block", "modifier": 0.8 },
+      { "limb_score": "lift", "modifier": 0.8 },
+      { "limb_score": "move_speed", "modifier": 0.8 },
+      { "limb_score": "balance", "modifier": 0.8 },
+      { "limb_score": "swimming", "modifier": 0.8 },
+      { "limb_score": "crawl", "modifier": 0.8 },
+      { "limb_score": "reaction", "modifier": 0.8 }
     ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD_LOCAL" ]
   },
@@ -2955,8 +2956,8 @@
     "max_intensity": 2,
     "scaling_mods": { "speed_mod": [ -5 ] },
     "limb_score_mods": [
-      { "limb_score": "manip", "modifier": 0 },
-      { "limb_score": "grip", "modifier": 0 },
+      { "limb_score": "manip", "modifier": 0.5, "scaling": -0.25 },
+      { "limb_score": "grip", "modifier": 0.5, "scaling": -0.25 },
       { "limb_score": "block", "modifier": 0.5, "scaling": -0.25 },
       { "limb_score": "lift", "modifier": 0.5, "scaling": -0.25 },
       { "limb_score": "move_speed", "modifier": 0.75, "scaling": -0.25 },

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2883,8 +2883,8 @@
   {
     "type": "effect_type",
     "id": "chafing",
-    "name": [ "Uncomfortable" ],
-    "desc": [ "Your %s is uncomfortable.  Wearing something soft under your hard armor would help." ],
+    "name": [ "Chafing" ],
+    "desc": [ "Rigid equipment worn over your %s is causing discomfort.  Wearing something soft underneath it would help." ],
     "max_intensity": 1,
     "part_descs": true,
     "immune_bp_flags": [ "BIONIC_LIMB" ],

--- a/data/json/monsters/zed-pupating.json
+++ b/data/json/monsters/zed-pupating.json
@@ -32,18 +32,52 @@
           "monster_message": "The pupating zombie crawler bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
       ]
-    }
+    },
+    "delete": { "upgrades": { "half_life": 4, "into": "mon_zombie_crawler_pupa" } }
   },
   {
     "id": "mon_zombie_pupa_decoy",
     "type": "MONSTER",
     "name": { "str": "pupating zombie" },
     "description": "This human corpse is wrapped in sticky black fibers that cover everything from the neck down.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.",
-    "copy-from": "mon_zombie_fat",
+    "default_faction": "zombie",
+    "bodytype": "blob",
+    "species": [ "ZOMBIE", "HUMAN" ],
+    "volume": "75000 ml",
+    "weight": "74000 g",
+    "hp": 95,
+    "speed": 55,
+    "material": [ "flesh" ],
+    "symbol": "Z",
+    "color": "green",
+    "aggression": 100,
+    "morale": 100,
+    "melee_dice": 2,
+    "melee_dice_sides": 4,
+    "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
+    "weakpoint_sets": [ "wps_humanoid_body", "wps_humanoid_head_small" ],
+    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
+    "vision_night": 3,
+    "death_drops": "default_zombie_death_drops",
+    "burn_into": "mon_zombie_scorched",
+    "fungalize_into": "mon_zombie_fat_fungus",
+    "flags": [
+      "SEES",
+      "HEARS",
+      "STUMBLES",
+      "WARM",
+      "GRABS",
+      "BASHES",
+      "GROUP_BASH",
+      "POISON",
+      "NO_BREATHE",
+      "REVIVES",
+      "PUSH_MON",
+      "FILTHY",
+      "GEN_DORMANT"
+    ],
     "harvest": "zombie_pupating",
     "decay": "zombie_decay",
-    "bodytype": "blob",
-    "delete": { "categories": [ "CLASSIC" ] },
     "bleed_rate": 50,
     "special_attacks": [ { "type": "bite", "cooldown": 3 } ],
     "upgrades": { "half_life": 4, "into": "mon_zombie_pupa" },
@@ -69,7 +103,8 @@
           "monster_message": "The pupating zombie bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
       ]
-    }
+    },
+    "delete": { "upgrades": { "half_life": 4, "into": "mon_zombie_pupa" } }
   },
   {
     "id": "mon_brute_pupa_decoy",
@@ -101,8 +136,10 @@
           "cooldown": 50,
           "monster_message": "The pupating brute bursts, and gore-smeared winged beasts climb out of the corpse!"
         }
-      ]
-    }
+      ],
+      "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF" ]
+    },
+    "delete": { "upgrades": { "half_life": 168, "into_group": "GROUP_BRUTE_PUPA" } }
   },
   {
     "id": "mon_hulk_pupa_decoy",
@@ -230,9 +267,8 @@
     "type": "MONSTER",
     "name": { "str": "shady pupating zombie" },
     "description": "An uncanny shadow envelops this creature.  You can make out the outline of what once may have been a human being, but its edges bulge rhythmically in places that are not anatomically possible for humans.",
-    "copy-from": "mon_zombie_fat",
+    "copy-from": "mon_zombie_pupa_decoy",
     "bodytype": "blob",
-    "delete": { "categories": [ "CLASSIC" ] },
     "special_attacks": [ { "type": "bite", "cooldown": 3 } ],
     "regenerates": 5,
     "bleed_rate": 0,
@@ -259,7 +295,9 @@
           "cooldown": 50,
           "monster_message": "The pupating zombie bursts, and shadowy winged beasts climb out of the corpse!"
         }
-      ]
-    }
+      ],
+      "flags": [ "SMALLSLUDGETRAIL", "SLUDGEPROOF", "NIGHT_INVISIBILITY" ]
+    },
+    "delete": { "upgrades": { "half_life": 4, "into": "mon_zombie_pupa_shady" } }
   }
 ]


### PR DESCRIPTION
#### Summary
Chafing and Pupating

#### Purpose of change

#### Describe the solution
- The Uncomfortable effect has been renamed to Chafing and given a clearer description.
- The Chafing effect no longer sets all your limb scores to zero. Instead, it reduces them all by 20% per part, in addition to the speed penalty and pain it causes.
- Pupating zombies were using a rat's nest of copy-froms and this was causing a lot of them to break. Things has been cleaned up somewhat.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
