### PR TITLE
Fix sided item behavior for nonstandard limbs, fix sheaths

### DIFF
--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -156,11 +156,32 @@
     "flags": [ "BELTED", "VARSIZE", "OVERSIZE", "WATER_FRIENDLY", "NONCONDUCTIVE" ],
     "armor": [
       {
+        "coverage": 15,
         "covers": [ "leg_l", "leg_r" ],
-        "coverage": 50,
         "encumbrance": 4,
         "volume_encumber_modifier": 0.25,
         "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
+      },
+      {
+        "coverage": 8,
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.25,
+        "covers": [ "gastropod_foot" ],
+        "specifically_covers": [ "gastropod_foot_upper" ]
+      },
+      {
+        "encumbrance": 4,
+        "coverage": 4,
+        "volume_encumber_modifier": 0.25,
+        "covers": [ "cephalopod_arm_2", "cephalopod_arm_5" ],
+        "specifically_covers": [ "cephalopod_arm_2_base", "cephalopod_arm_5_base" ]
+      },
+      {
+        "encumbrance": 4,
+        "coverage": 4,
+        "volume_encumber_modifier": 0.25,
+        "covers": [ "crab_leg_1", "crab_leg_3" ],
+        "specifically_covers": [ "crab_leg_1_merus", "crab_leg_3_merus" ]
       }
     ]
   },
@@ -200,6 +221,20 @@
         "encumbrance": 4,
         "volume_encumber_modifier": 0.3,
         "specifically_covers": [ "leg_upper_r", "leg_upper_l" ]
+      },
+      {
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.3,
+        "coverage": 15,
+        "covers": [ "cephalopod_arm_2", "cephalopod_arm_5" ],
+        "specifically_covers": [ "cephalopod_arm_2_base", "cephalopod_arm_5_base" ]
+      },
+      {
+        "encumbrance": 4,
+        "volume_encumber_modifier": 0.3,
+        "coverage": 15,
+        "covers": [ "crab_leg_1", "crab_leg_3" ],
+        "specifically_covers": [ "crab_leg_1_merus", "crab_leg_3_merus" ]
       }
     ]
   },
@@ -636,6 +671,18 @@
         "coverage": 3,
         "covers": [ "gastropod_foot" ],
         "specifically_covers": [ "gastropod_foot_upper" ]
+      },
+      {
+        "encumbrance": [ 1, 2 ],
+        "coverage": 4,
+        "covers": [ "cephalopod_arm_2", "cephalopod_arm_5" ],
+        "specifically_covers": [ "cephalopod_arm_2_base", "cephalopod_arm_5_base" ]
+      },
+      {
+        "encumbrance": [ 1, 2 ],
+        "coverage": 4,
+        "covers": [ "crab_leg_1", "crab_leg_3" ],
+        "specifically_covers": [ "crab_leg_1_merus", "crab_leg_3_merus" ]
       }
     ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -6426,14 +6426,13 @@
   {
     "type": "mutation",
     "id": "PALE",
-    "name": { "str": "Pale Skin" },
+    "name": { "str": "Pallid" },
     "points": 0,
     "visibility": 3,
     "ugliness": 1,
-    "description": "Your skin is rather pale.",
+    "description": "Your skin appears unnaturally pale.",
     "changes_to": [ "ALBINO" ],
-    "category": [ "LUPINE", "TROGLOBITE", "MOUSE", "RABBIT", "BEAST" ],
-    "types": [ "skin_tone" ]
+    "category": [ "LUPINE", "TROGLOBITE", "MOUSE", "RABBIT", "BEAST" ]
   },
   {
     "type": "mutation",

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -398,7 +398,7 @@ std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, cons
         guy.add_msg_if_npc( _( "<npcname> puts on their %s." ), to_wear.tname() );
     }
 
-    // skip this for unsorted items in debug mode
+    // Skip this for unsorted items in debug mode.
     if( do_sort_items ) {
         new_item_it->on_wear( guy );
 
@@ -1392,9 +1392,7 @@ static ret_val<void> rigid_test(
 
 ret_val<void> outfit::check_rigid_conflicts( const item &clothing, side s ) const
 {
-
     std::unordered_set<sub_bodypart_id> to_test;
-
     // if not overridden get the actual side of the item
     if( s == side::num_sides ) {
         s = clothing.get_side();
@@ -1436,14 +1434,11 @@ ret_val<void> outfit::check_rigid_conflicts( const item &clothing ) const
     if( !clothing.is_sided() ) {
         return check_rigid_conflicts( clothing, side::BOTH );
     }
-
     ret_val<void> ls = check_rigid_conflicts( clothing, side::LEFT );
     ret_val<void> rs = check_rigid_conflicts( clothing, side::RIGHT );
-
     if( !ls.success() && !rs.success() ) {
         return ls;
     }
-
     return ret_val<void>::make_success();
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1138,33 +1138,6 @@ body_part_set item::get_covered_body_parts( const side s, const Character *you )
     return res;
 }
 
-namespace
-{
-
-const std::array<bodypart_str_id, 4> &left_side_parts()
-{
-    static const std::array<bodypart_str_id, 4> result{ {
-            body_part_arm_l,
-            body_part_hand_l,
-            body_part_leg_l,
-            body_part_foot_l
-        } };
-    return result;
-}
-
-const std::array<bodypart_str_id, 4> &right_side_parts()
-{
-    static const std::array<bodypart_str_id, 4> result{ {
-            body_part_arm_r,
-            body_part_hand_r,
-            body_part_leg_r,
-            body_part_foot_r
-        } };
-    return result;
-}
-
-} // namespace
-
 static void iterate_helper_sbp_masked( const item *i, const side s,
                                        const std::function<void( const sub_bodypart_str_id & )> &cb,
                                        const body_part_set *mask = nullptr );
@@ -1177,7 +1150,6 @@ static void iterate_helper_sbp_masked( const item *i, const side s,
     if( armor == nullptr ) {
         return;
     }
-
     for( const armor_portion_data &data : armor->sub_data ) {
         if( !data.sub_coverage.empty() ) {
             for( const sub_bodypart_str_id &sbp : data.sub_coverage ) {
@@ -1193,8 +1165,6 @@ static void iterate_helper_sbp_masked( const item *i, const side s,
         }
     }
 }
-
-
 
 static void iterate_helper_masked( const item *i, const side s,
                                    const std::function<void( const bodypart_str_id & )> &cb,
@@ -1227,13 +1197,11 @@ static void iterate_helper_masked( const item *i, const side s,
     if( armor == nullptr ) {
         return;
     }
-    const auto &opposite_side_parts = s == side::LEFT ? right_side_parts() : left_side_parts();
     for( const armor_portion_data &data : armor->data ) {
         if( data.covers.has_value() ) {
             for( const bodypart_str_id &bpid : data.covers.value() ) {
                 if( s != side::BOTH && s != side::num_sides ) {
-                    if( std::find( opposite_side_parts.begin(), opposite_side_parts.end(),
-                                   bpid ) != opposite_side_parts.end() ) {
+                    if( bpid->part_side != s && bpid->part_side != side::BOTH ) {
                         continue;
                     }
                 }


### PR DESCRIPTION
#### Summary
Fix sided item behavior for nonstandard limbs, fix sheaths

#### Purpose of change
A bunch of sheaths weren't usable by characters with nonstandard legs. Additionally, sided items were being worn on both sides for nonstandard limbs like crab legs. This turned out to be because despite having json data available, the game was still using old hardcoded stuff.

#### Describe the solution
Sided items now are properly worn on just 1 side of your cephalopod arms or what have you. If you have a monolimb like a gastropod foot, sidedness doesn't matter and the item is just worn on it generally.

Gastropods can't wear garter sheaths because those are specifically a thing for your thigh, but it's assumed the others can just be worn on a longer strap, so that's all been fixed.

The 6-knife sheath for throwing knives now has less encumbrance and coverage.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
