### PR TITLE
Build: demote GCC 16 -Wsfinae-incomplete to warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,12 @@ if (NOT MSVC)
     else()
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-unknown-warning")
     endif()
+    # GCC 16 -Wsfinae-incomplete: SFINAE on incomplete forward-declared types
+    # (e.g. std::reference_wrapper<vehicle>) is link-compatible across TUs.
+    check_cxx_compiler_flag(-Wsfinae-incomplete HAVE_SFINAE_INCOMPLETE)
+    if (HAVE_SFINAE_INCOMPLETE)
+        set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-error=sfinae-incomplete")
+    endif ()
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")
     endif ()

--- a/Makefile
+++ b/Makefile
@@ -340,6 +340,14 @@ else
     CXX = $(CROSS)$(OS_COMPILER)
     LD  = $(CROSS)$(OS_LINKER)
   endif
+  CXX_WARNINGS += -Wno-unknown-warning
+  WARNINGS += -Wno-unknown-warning
+  # GCC 16 -Wsfinae-incomplete: SFINAE on incomplete forward-declared types
+  # (e.g. std::reference_wrapper<vehicle>) is link-compatible across TUs.
+  GCC_MAJOR := $(shell $(CROSS)$(OS_COMPILER) -dumpversion 2>/dev/null | cut -d. -f1)
+  ifeq ($(shell expr $(GCC_MAJOR) \>= 16 2>/dev/null), 1)
+    CXX_WARNINGS += -Wno-error=sfinae-incomplete
+  endif
 endif
 
 STRIP = $(CROSS)strip
@@ -551,7 +559,7 @@ ifeq ($(NATIVE), osx)
   DEFINES += -DMACOSX
   CXXFLAGS += -mmacosx-version-min=10.15
   LDFLAGS += -mmacosx-version-min=10.15 -framework CoreFoundation -Wl,-headerpad_max_install_names
-  LDFLAGS += -liconv 
+  LDFLAGS += -liconv
   ifeq ($(UNIVERSAL_BINARY), 1)
     CXXFLAGS += -arch x86_64 -arch arm64
     LDFLAGS += -arch x86_64 -arch arm64


### PR DESCRIPTION
#### Summary
Build "Demote GCC 16 -Wsfinae-incomplete to warning"

#### Purpose of change
GCC 16 fails to build Cataclysm due to its new `sfinae-incomplete` warning being treated as an error.

> New `-Wsfinae-incomplete` diagnostic fires on forward-declared types used in SFINAE traits (e.g. `std::reference_wrapper<vehicle>`), which is all over the codebase.

#### Describe the solution
> Add `-Wno-error=sfinae-incomplete` on GCC >= 16. Still surfaces as a warning, just not fatal. Both Makefile and CMakeLists.txt.

#### Describe alternatives you've considered
> Actually fixing the includes. There are a lot. And then to deal with IWYU...

#### Testing
> N/A, build-only.

#### Additional context
Backport of https://github.com/CleverRaven/Cataclysm-DDA/pull/86841 (plus a trailing whitespace fix).