### PR TITLE
Shouter/howler/etc now display more helpful messaging.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7781,17 +7781,35 @@ void Character::shout( std::string msg, bool order )
     // Mutations make shouting louder or quieter, they also define the default message.
     if( has_trait( trait_SHOUT3 ) ) {
         if( msg.empty() ) {
-            msg = is_avatar() ? _( "yourself let out a piercing howl!" ) : _( "a piercing howl!" );
+            if( is_avatar() ) {
+                msg = _( "yourself let out a piercing howl!" );
+            } else if( get_player_character().sees( get_map(), *this ) ) {
+                msg = string_format( _( "%s let out a piercing howl!" ), disp_name( false, true ) );
+            } else {
+                msg = _( "a piercing howl!" );
+            }
             shout = "howl";
         }
     } else if( has_trait( trait_SHOUT2 ) ) {
         if( msg.empty() ) {
-            msg = is_avatar() ? _( "yourself scream loudly!" ) : _( "a loud scream!" );
+            if( is_avatar() ) {
+                msg = _( "yourself scream loudly!" );
+            } else if( get_player_character().sees( get_map(), *this ) ) {
+                msg = string_format( _( "%s scream loudly!" ), disp_name( false, true ) );
+            } else {
+                msg = _( "a loud scream!" );
+            }
             shout = "scream";
         }
     } else if( has_trait( trait_SCREECH ) ) {
         if( msg.empty() ) {
-            msg = is_avatar() ? _( "yourself screech loudly!" ) : _( "a loud screech!" );
+            if( is_avatar() ) {
+                msg = _( "yourself screech loudly!" );
+            } else if( get_player_character().sees( get_map(), *this ) ) {
+                msg = string_format( _( "%s screech loudly!" ), disp_name( false, true ) );
+            } else {
+                msg = _( "a loud screech!" );
+            }
             shout = "screech";
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7826,10 +7826,26 @@ void Character::shout( std::string msg, bool order )
     }
     if( noise <= 2 ) {
         add_msg_if_player( m_warning, _( "Your %s is barely audible!" ), shout );
-        msg = is_avatar() ? _( "your faint voice." ) : _( "an indistinct voice." );
+        if( msg.empty() ) {
+            if( is_avatar() ) {
+                msg = _( "your own faint voice." );
+            } else if( get_player_character().sees( get_map(), *this ) ) {
+                msg = string_format( _( "%s indistinct voice." ), disp_name( true, true ) );
+            } else {
+                msg = _( "an indistinct voice." );
+            }
+        }
     }
     if( msg.empty() ) {
-        msg = is_avatar() ? _( "yourself shout loudly!" ) : _( "a loud shout!" );
+        if( msg.empty() ) {
+            if( is_avatar() ) {
+                msg = _( "yourself shout loudly!" );
+            } else if( get_player_character().sees( get_map(), *this ) ) {
+                msg = string_format( _( "%s shout loudly!" ), disp_name( false, true ) );
+            } else {
+                msg = _( "a loud shout!" );
+            }
+        }
     }
     sounds::sound( pos_bub(), noise, order ? sounds::sound_t::order : sounds::sound_t::alert, msg,
                    false,

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -530,7 +530,7 @@ void sounds::process_sounds()
     recent_sounds.clear();
 }
 
-// skip some sounds to avoid message spam
+// Skip some sounds to avoid message spam.
 static bool describe_sound( sounds::sound_t category, bool from_player_position )
 {
     if( from_player_position ) {
@@ -568,7 +568,7 @@ static bool describe_sound( sounds::sound_t category, bool from_player_position 
             case sounds::sound_t::activity:
                 return one_in( 50 );
             case sounds::sound_t::destructive_activity:
-                return one_in( 20 );
+                return one_in( 10 );
             case sounds::sound_t::speech:
             case sounds::sound_t::electronic_speech:
             case sounds::sound_t::alarm:

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -580,12 +580,15 @@ void suffer::while_awake( Character &you )
     }
 
     if( you.has_trait( trait_SHOUT1 ) && one_turn_in( 6_hours ) ) {
+        you.add_msg_if_player( _( "You shout loudly!" ) );
         you.shout();
     }
     if( you.has_trait( trait_SHOUT2 ) && one_turn_in( 4_hours ) ) {
+        you.add_msg_if_player( _( "You scream loudly!" ) );
         you.shout();
     }
     if( you.has_trait( trait_SHOUT3 ) && one_turn_in( 3_hours ) ) {
+        you.add_msg_if_player( _( "You let out a piercing howl!" ) );
         you.shout();
     }
     if( you.has_trait( trait_M_SPORES ) && one_turn_in( 4_hours ) ) {


### PR DESCRIPTION
#### Summary
Shouter/howler/etc now display more helpful messaging.

#### Purpose of change
These mutations weren't giving any feedback. Shouting manually prints a special message, we just need to duplicate that here.

#### Describe the solution
- Print a message in suffer() when the character shouts/howls/screams automatically.
- If you see and hear an NPC shouting/howling/etc, it actually tells you who's making the noise instead of just vaguely mentioning that a howl came from over there.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
