### PR TITLE
add hunter's enchantment to pack hunter

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5159,7 +5159,8 @@
     "prereqs2": [ "PRED3" ],
     "threshreq": [ "THRESH_LUPINE" ],
     "category": [ "LUPINE" ],
-    "flags": [ "PRED3" ]
+    "flags": [ "PRED3" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "COMBAT_CATCHUP", "multiply": 2.0 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Pack Hunter was missing the combat exp multiplier described in its description. Compared to the Hunter and Predator mutations, it offered nothing other than the PRED3 flag, which only affects eating raw meat and killing guilt monsters, but loses the combat exp multiplier.

#### Purpose of change
Add the missing enchantment to Pack Hunter

#### Describe the solution
Add the same enchantment Hunter has to Pack Hunter. Which is canine mutants keep the combat multiplier, but don't suffer -1 Intelligence.

#### Describe alternatives you've considered
Maybe Pack Hunter should have a 1.5 multiplier? Up to you to decide the numbers.

#### Testing
Spawned as a naked, 0 skill 8 stats character, punched a debug monster 10 times, melee went to 0(16%), unarmed went to 0(29%).
Same scenario, new character, fully mutated canine with debug menu, removed fangs, tail and nails. Switched Pack Hunter for Hunter. Melee went to 0(20%) and unarmed went to 0(33%).
Third test, same as second test, but didn't switch Pack Hunter for Hunter. Melee went to the same as first scenario 0(16%) and 0(29%).

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
