### PR TITLE
223 guns have grip slots

### DIFF
--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -477,7 +477,8 @@
       [ "mechanism", 2 ],
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
-      [ "stock", 1 ]
+      [ "stock", 1 ],
+      [ "grip", 1 ]
     ],
     "flags": [ "FIRE_TWOHAND" ],
     "melee_damage": { "bash": 12 }
@@ -519,7 +520,8 @@
       [ "mechanism", 2 ],
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
-      [ "stock", 1 ]
+      [ "stock", 1 ],
+      [ "grip", 1 ]
     ],
     "flags": [ "FIRE_TWOHAND" ],
     "melee_damage": { "bash": 12 }
@@ -578,7 +580,8 @@
       [ "rail mount", 2 ],
       [ "sights mount", 1 ],
       [ "stock mount", 1 ],
-      [ "underbarrel mount", 1 ]
+      [ "underbarrel mount", 1 ],
+      [ "grip", 1 ]
     ],
     "//": "This weapon has an extremely high rate of fire, due to the open bolt design. This is based on a cyclic rate of fire of 1150 RPM, which is close to 19 rounds per second. 6 rounds is comparable to to other weapons with similar rates, such as the MAC-11.",
     "modes": [ [ "DEFAULT", "auto", 6 ] ],
@@ -706,7 +709,8 @@
       [ "stock accessory", 1 ],
       [ "sights mount", 1 ],
       [ "rail mount", 1 ],
-      [ "stock", 1 ]
+      [ "stock", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [
       {
@@ -747,7 +751,8 @@
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
       [ "stock mount", 1 ],
-      [ "underbarrel mount", 1 ]
+      [ "underbarrel mount", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [
       {
@@ -809,7 +814,8 @@
       [ "sights mount", 1 ],
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
-      [ "stock mount", 1 ]
+      [ "stock mount", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "augmag_30rd", "augmag_10rd", "augmag_42rd", "augmag_100rd" ] }
@@ -847,7 +853,8 @@
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
       [ "stock mount", 1 ],
-      [ "underbarrel mount", 1 ]
+      [ "underbarrel mount", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "zpap85mag" ] } ],
     "melee_damage": { "bash": 12 }
@@ -988,7 +995,8 @@
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
       [ "stock mount", 1 ],
-      [ "underbarrel", 1 ]
+      [ "underbarrel", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [
       {
@@ -1046,7 +1054,8 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "stock accessory", 2 ],
-      [ "stock", 1 ]
+      [ "stock", 1 ],
+      [ "grip", 1 ]
     ],
     "flags": [ "FIRE_TWOHAND", "EASY_CLEAN" ],
     "melee_damage": { "bash": 10 }
@@ -1084,7 +1093,8 @@
       [ "sights", 1 ],
       [ "sling", 1 ],
       [ "stock accessory", 1 ],
-      [ "underbarrel", 1 ]
+      [ "underbarrel", 1 ],
+      [ "grip", 1 ]
     ],
     "pocket_data": [
       {


### PR DESCRIPTION
#### Summary
223 guns have grip slots

#### Purpose of change
Most 223 guns didn't have grip slots. These items are commonly given ergonomic grips irl.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
