### PR TITLE
Fix a bunch of terrain/monster interactions

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5584,7 +5584,7 @@ static void stop_grab( Character &who )
     if( avatar *a = dynamic_cast<avatar *>( &who ) ) {
         a->grab( object_type::NONE );
     } else {
-        debugmsg( "who in grabbing is not an avatar??" );
+        debugmsg( "A non-player character is grabbing somehow." );
     }
 }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -598,7 +598,7 @@ static void auto_features_warn()
     }
 }
 
-// Establish or release a grab on a vehicle
+// Establish or release a grab on a vehicle, furniture, or creature.
 static void grab()
 {
     avatar &you = get_avatar();
@@ -645,6 +645,15 @@ static void grab()
         }
     }
     if( creatures.creature_at( grabp ) && !creatures.creature_at( grabp )->is_hallucination() ) {
+        Creature *target = creatures.creature_at( grabp );
+        if( ( you.is_underwater() && !target->is_underwater() ) ||
+            ( !you.is_underwater() && target->is_underwater() ) ) {
+            if( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, you.pos_bub() ) ||
+                here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, grabp ) ) {
+                add_msg( _( "You can't grab through the floor." ) );
+                return;
+            }
+        }
         if( you.is_armed() ) {
             add_msg( _( "You'll need your hands free for grappling." ) );
             return;
@@ -658,8 +667,7 @@ static void grab()
             you.add_msg_if_player( ( "You're too exhausted to wrestle anything." ) );
             return;
         }
-        if( creatures.creature_at( grabp )->is_monster() &&
-            creatures.creature_at( grabp )->as_monster()->has_flag( mon_flag_GRAB_IMMUNE ) ) {
+        if( target->is_monster() && target->as_monster()->has_flag( mon_flag_GRAB_IMMUNE ) ) {
             add_msg( _( "You can't grab %s." ), creatures.creature_at( grabp )->disp_name() );
             return;
         }
@@ -676,18 +684,19 @@ static void grab()
 
         bool tolerate = false;
         // Friends will tolerate grabs, enemies are already mad. Neutral NPCs will not tolerate grabs unless they are helpless.
-        if( creatures.creature_at( grabp )->is_npc() ) {
-            tolerate = creatures.creature_at( grabp )->as_npc()->is_player_ally() ||
-                       creatures.creature_at( grabp )->as_npc()->is_enemy() ||
-                       creatures.creature_at( grabp )->as_npc()->has_effect( effect_narcosis ) ||
-                       !creatures.creature_at( grabp )->as_npc()->enough_working_legs();
+        if( target->is_npc() ) {
+            npc *target_npc = target->as_npc();
+            tolerate = target_npc->is_player_ally() ||
+                       target_npc->is_enemy() ||
+                       target_npc->has_effect( effect_narcosis ) ||
+                       !target_npc->enough_working_legs();
             // You can grab your pets.
-        } else if( creatures.creature_at( grabp )->is_monster() ) {
-            tolerate = creatures.creature_at( grabp )->as_monster()->is_pet();
+        } else if( target->is_monster() ) {
+            tolerate = target->as_monster()->is_pet();
         }
 
-        if( creatures.creature_at( grabp )->is_npc() && !tolerate ) {
-            if( !query_yn( _( "Really attack %s?" ), creatures.creature_at( grabp )->disp_name() ) ) {
+        if( target->is_npc() && !tolerate ) {
+            if( !query_yn( _( "Really attack %s?" ), target->disp_name() ) ) {
                 return;
             }
         }
@@ -696,8 +705,8 @@ static void grab()
         item weap =  null_item_reference();
         you.mod_moves( -100 - you.attack_speed( weap ) / weary_mult );
         you.as_character()->burn_energy_arms( -120 );
-        if( creatures.creature_at( grabp )->is_monster() ) {
-            monster *z = creatures.creature_at( grabp )->as_monster();
+        if( target->is_monster() ) {
+            monster *z = target->as_monster();
             // TODO: Force this to use unarmed skill for one-handed or multilimb grabs. Will need to
             // write an optional member into hit_roll to name a weapon skill.
             // TODO TWO: Grabbing with whip-type weapons? Definitely no one should tolerate that.
@@ -716,7 +725,7 @@ static void grab()
                     accuracy_penalty = -8.0f;
                 }
             }
-            int hitspread = creatures.creature_at( grabp )->deal_melee_attack( you.as_character(),
+            int hitspread = target->deal_melee_attack( you.as_character(),
                             you.as_character()->hit_roll() + accuracy_penalty );
             if( hitspread < 0 && !tolerate ) {
                 add_msg( m_warning, _( "You reach for %s, but fail to make contact!" ), z->disp_name() );
@@ -730,9 +739,9 @@ static void grab()
             you.add_effect( effect_grabbing, 1_days, true, 1 );
             you.grab_1.set( victimptr, grab_strength );
         } else {
-            Character *guy = creatures.creature_at( grabp )->as_character();
+            Character *guy = target->as_character();
             if( guy->is_npc() && !tolerate ) {
-                int hitspread = creatures.creature_at( grabp )->deal_melee_attack( you.as_character(),
+                int hitspread = target->deal_melee_attack( you.as_character(),
                                 you.as_character()->hit_roll() );
                 if( hitspread < 0 ) {
                     add_msg( m_warning, _( "You reach for %s, but fail to make contact!" ), guy->disp_name() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2694,7 +2694,6 @@ bool map::is_open_air( const tripoint_bub_ms &p ) const
 }
 
 // Move cost: 3D
-
 int map::move_cost( const tripoint_bub_ms &p, const bool ignore_fields ) const
 {
     // To save all of the bound checks and submaps fetching, we extract it
@@ -2707,9 +2706,7 @@ int map::move_cost( const tripoint_bub_ms &p, const bool ignore_fields ) const
     if( current_submap == nullptr ) {
         return 0;
     }
-
     field static nofield;
-
     const furn_t &furniture = current_submap->get_furn( l ).obj();
     const ter_t &terrain = current_submap->get_ter( l ).obj();
     const field &field = current_submap->get_field( l );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -335,10 +335,14 @@ bool mon_spellcasting_actor::call( monster &mon ) const
 
     if( !spell_data.self && !allow_no_target ) {
         Creature *tgt_creature = get_creature_tracker().creature_at( target_pos );
+        map &here = get_map();
+        // Prevent monsters from attacking through terrain if they are submerged under it & target isn't.
         if( tgt_creature && mon.is_underwater() && !tgt_creature->is_underwater() &&
-            get_map().has_flag_ter_or_furn( ter_furn_flag::TFLAG_SWIM_UNDER, mon.pos_bub() ) ) {
+            ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, mon.pos_bub() ) ||
+              here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, tgt_creature->pos_bub() ) ) ) {
             return false;
         }
+
     }
 
     // Bail out if the target is out of range.
@@ -505,7 +509,14 @@ Creature *melee_actor::find_target( monster &z ) const
                                trig_dist_precise(
                                    z.pos_bub(), target->pos_bub() ) ) ) <= range;
         }
-
+        // Prevent attacking through terrain if the target isn't underwater.
+        if( in_range ) {
+            if( z.is_underwater() && !target->is_underwater() &&
+                ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, z.pos_bub() ) ||
+                  here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, target->pos_bub() ) ) ) {
+                in_range = false;
+            }
+        }
         if( !in_range ||
             !z.sees( here, *target ) ||
             !here.clear_path( z.pos_bub( here ), target->pos_bub( here ),
@@ -793,8 +804,10 @@ bool melee_actor::call( monster &z ) const
         return false;
     }
 
+    // Prevent attacking through terrain if the target isn't underwater.
     if( z.is_underwater() && !target->is_underwater() &&
-        here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SWIM_UNDER, z.pos_bub() ) ) {
+        ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, z.pos_bub() ) ||
+          here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, target->pos_bub() ) ) ) {
         return false;
     }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1591,30 +1591,32 @@ int monster::calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t )
         // Swimming monsters move very fast in water, like fish and sharks.
     } else if( swims() ) {
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) && is_underwater() ) ) {
             movecost += 25;
         } else {
             movecost += 50 * here.move_cost( f );
             snow_penalty += 1;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, t ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) ) {
+            ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) &&
+            ( is_underwater() || here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ) ) ) {
             movecost += 25;
         } else {
             movecost += 50 * here.move_cost( t );
             snow_penalty += 1;
         }
     } else if( can_submerge() ) {
-        // No-breathe monsters have to walk underwater slowly.
+        // No-breathe monsters that can't swim have to walk underwater slowly.
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) && is_underwater() ) ) {
             movecost += 250;
         } else {
             movecost += 50 * here.move_cost( f );
             snow_penalty += 1;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, t ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) ) {
+            ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) &&
+            ( is_underwater() || here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ) ) ) {
             movecost += 250;
         } else {
             movecost += 50 * here.move_cost( t );
@@ -1643,14 +1645,12 @@ int monster::calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t )
     if( snow_penalty > 0 ) {
         // Snow depth movement penalty (outdoor, unroofed tiles only)
         if( here.is_outside( pos_bub() ) && !here.is_roofed( pos_bub() ) ) {
-            add_msg( _( "%s is in snow" ), name() );
             const double snow_mm = get_weather().get_snow_depth_mm( pos_abs_omt() );
             if( snow_mm >= 100 ) {
                 int penalty = snow_mm >= 500 ? 100 : ( snow_mm >= 250 ? 50 : 20 );
                 if( snow_penalty == 1 ) {
                     penalty /= 2;
                 }
-                add_msg( _( "%1s is in snow and gets penalty %2s" ), name(), penalty );
                 movecost += penalty;
             }
         }
@@ -1916,7 +1916,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     map &here = get_map();
     const tripoint_bub_ms pos = pos_bub( here );
 
-    const bool on_ground = !digging() && !flies();
+    const bool not_flying_or_digging = !digging() && !flies();
 
     const bool z_move = p.z() != pos.z();
     const bool going_up = p.z() > pos.z();
@@ -1999,17 +1999,21 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     // the "underwater" member is always out-of-sync for monsters.
     bool was_water = is_likely_underwater( here );
     bool will_be_water =
-        on_ground && (
-            // AQUATIC monsters always swim under the vehicles, while other swimming monsters are forced to surface.
-            has_flag( mon_flag_AQUATIC ) || ( can_submerge() && !here.veh_at( destination ) ) ||
-            // If the destination terrain has SWIM_UNDER, swimmers should remain submerged there.
-            ( swims() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) )
-        ) && ( here.is_divable( destination ) ||
-               here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) ||
-               // AQUATIC creatures stay submerged in any swimmable terrain (including shallow water).
-               ( has_flag( mon_flag_AQUATIC ) &&
-                 here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, destination ) ) );
-
+        not_flying_or_digging && (
+            // AQUATIC monsters always swim under vehicles, while other swimming monsters are forced to surface.
+            has_flag( mon_flag_AQUATIC ) ||
+            ( can_submerge() && !here.veh_at( destination ) ) ||
+            ( swims() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) &&
+              ( was_water || here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos ) ) )
+        ) && (
+            here.is_divable( destination ) ||
+            // If the destination terrain has SWIM_UNDER, swimmers should remain submerged when they move there.
+            ( swims() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) &&
+              ( was_water || here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos ) ) ) ||
+            // AQUATIC creatures stay submerged in any swimmable terrain (including shallow water).
+            ( has_flag( mon_flag_AQUATIC ) &&
+              here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, destination ) )
+        );
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         // Birds and other flying creatures flying over the deep water terrain.
         Character &player_character = get_player_character();
@@ -2060,20 +2064,21 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
     }
 
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, destination ) &&
-        on_ground && !here.has_vehicle_floor( destination ) ) {
+        not_flying_or_digging && !here.has_vehicle_floor( destination ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
 
-    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, destination ) && on_ground ) {
+    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, destination ) &&
+        not_flying_or_digging ) {
         add_effect( effect_no_sight, 1_turns, true );
     } else if( has_effect( effect_no_sight ) ) {
         remove_effect( effect_no_sight );
     }
 
     if( !here.has_vehicle_floor( destination ) ) {
-        if( type->size != creature_size::tiny && on_ground ) {
+        if( type->size != creature_size::tiny && not_flying_or_digging ) {
             const int sharp_damage = rng( 1, 10 );
             const int rough_damage = rng( 1, 2 );
             if( here.has_flag( ter_furn_flag::TFLAG_SHARP, pos ) && !one_in( 4 ) &&

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1584,64 +1584,77 @@ int monster::calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t )
     map &here = get_map();
     const int source_cost = here.move_cost( f );
     const int dest_cost = here.move_cost( t );
-    // Digging and flying monsters ignore terrain cost
+    int snow_penalty = 0;
+    // Digging and flying monsters ignore terrain cost.
     if( flies() || ( digging() && here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, t ) ) ) {
         movecost = 100;
-        // Swimming monsters move super fast in water
+        // Swimming monsters move very fast in water, like fish and sharks.
     } else if( swims() ) {
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ||
             here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
             movecost += 25;
         } else {
             movecost += 50 * here.move_cost( f );
+            snow_penalty += 1;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, t ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) ) {
             movecost += 25;
         } else {
             movecost += 50 * here.move_cost( t );
+            snow_penalty += 1;
         }
     } else if( can_submerge() ) {
-        // No-breathe monsters have to walk underwater slowly
+        // No-breathe monsters have to walk underwater slowly.
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, f ) ||
             here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
             movecost += 250;
         } else {
             movecost += 50 * here.move_cost( f );
+            snow_penalty += 1;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, t ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, t ) ) {
             movecost += 250;
         } else {
             movecost += 50 * here.move_cost( t );
+            snow_penalty += 1;
         }
         movecost /= 2;
     } else if( climbs() ) {
         if( here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, f ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            here.has_flag( ter_furn_flag::TFLAG_LADDER, f ) ) {
             movecost += 150;
         } else {
             movecost += 50 * here.move_cost( f );
+            snow_penalty += 1;
         }
         if( here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, t ) ||
-            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, f ) ) {
+            here.has_flag( ter_furn_flag::TFLAG_LADDER, t ) ) {
             movecost += 150;
         } else {
             movecost += 50 * here.move_cost( t );
+            snow_penalty += 1;
         }
         movecost /= 2;
     } else {
         movecost = ( ( 50 * source_cost ) + ( 50 * dest_cost ) ) / 2.0;
+    }
+    if( snow_penalty > 0 ) {
         // Snow depth movement penalty (outdoor, unroofed tiles only)
         if( here.is_outside( pos_bub() ) && !here.is_roofed( pos_bub() ) ) {
+            add_msg( _( "%s is in snow" ), name() );
             const double snow_mm = get_weather().get_snow_depth_mm( pos_abs_omt() );
             if( snow_mm >= 100 ) {
-                const int penalty = snow_mm >= 500 ? 100 : ( snow_mm >= 250 ? 50 : 20 );
+                int penalty = snow_mm >= 500 ? 100 : ( snow_mm >= 250 ? 50 : 20 );
+                if( snow_penalty == 1 ) {
+                    penalty /= 2;
+                }
+                add_msg( _( "%1s is in snow and gets penalty %2s" ), name(), penalty );
                 movecost += penalty;
             }
         }
     }
-
     return movecost;
 }
 
@@ -2528,7 +2541,8 @@ void monster::shove_vehicle( const tripoint_bub_ms &remote_destination,
                             if( vpi.has_flag( "INITIAL_PART" ) ) {
                                 add_msg_if_player_sees( nearby_destination, m_bad, _( "The %s falls over!" ), veh.name );
                             } else {
-                                add_msg_if_player_sees( nearby_destination, m_bad, _( "The %1$s's %2$s is disconnected!" ), veh.name,
+                                add_msg_if_player_sees( nearby_destination, m_bad, _( "The %1$s's %2$s is disconnected!" ),
+                                                        veh.name,
                                                         vp.part().name() );
                             }
                             if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -424,7 +424,7 @@ class vpart_info
 
         /** Volume of a foldable part when folded */
         std::optional<units::volume> folded_volume = std::nullopt;
-        
+
         /** Cargo location volume */
         units::volume size = 0_ml;
 


### PR DESCRIPTION
#### Summary
Fix a bunch of terrain/monster interactions

#### Purpose of change
A recent update to climbing stuff accidentally screwed up monster speed in snow. On closer inspection: monster SWIM_UNDER stuff was wholly fucked.

#### Describe the solution
- It should now be impossible to attack or be attacked by monsters which are under bridges, docks, ice etc. when you are not also down there.
- Monsters are now much better at appropriately tracking movecost.
- Monsters who can climb no longer ignore snow penalties when not climbing.
- Monsters should be unable to dive under ice etc unless they're already swimming.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
