### PR TITLE
More meat fixes

### DIFF
--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -167,7 +167,6 @@
     "name": { "str": "cooked scrap of fish", "str_pl": "cooked scraps of fish" },
     "parasites": 0,
     "spoils_in": "1 day",
-    "flags": [ "NUTRIENT_OVERRIDE" ],
     "calories": 26,
     "weight": "15 g",
     "volume": "25 ml"
@@ -325,6 +324,7 @@
     "copy-from": "human_flesh",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
     "name": { "str_sp": "cooked human flesh" },
     "description": "A cooked portion of human flesh.",
     "material": [ "hflesh" ],
@@ -499,7 +499,6 @@
     "spoils_in": "1 day",
     "calories": 40,
     "fun": -10,
-    "cooks_like": "meat_cooked",
     "vitamins": [ [ "iron", 1 ], [ "meat_allergen", 1 ] ],
     "flags": [ "RAW", "PREDATOR_FUN" ],
     "use_action": [ "PETFOOD" ],
@@ -507,18 +506,22 @@
   },
   {
     "id": "meat_scrap_cooked",
-    "copy-from": "flesh",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
+    "material": [ "flesh" ],
+    "symbol": "%",
+    "color": "red",
     "weight": "21 g",
     "volume": "22 ml",
     "spoils_in": "1 day",
-    "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
     "name": { "str": "cooked scrap of meat", "str_pl": "cooked scraps of meat" },
     "description": "A small morsel of meat, cooked until safe to eat.",
     "price": "75 cent",
     "price_postapoc": "10 cent",
     "parasites": 0,
     "calories": 40,
+    "fun": 0,
     "vitamins": [ [ "iron", 1 ], [ "meat_allergen", 1 ] ],
     "flags": [ "EATEN_HOT" ]
   },
@@ -530,7 +533,7 @@
     "looks_like": "meat_scrap",
     "name": { "str": "scrap of human flesh", "str_pl": "scraps of human flesh" },
     "description": "A tiny scrap of raw human flesh.",
-    "vitamins": [ [ "calcium", 0 ], [ "iron", 1 ], [ "human_flesh_vitamin", 1 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "iron", 1 ], [ "human_flesh_vitamin", 1 ], [ "meat_allergen", 1 ] ],
     "material": [ "hflesh" ]
   },
   {
@@ -677,7 +680,7 @@
     "color": "red",
     "comestible_type": "DRINK",
     "looks_like": "hblood",
-    "calories": 210,
+    "calories": 190,
     "fun": -15,
     "symbol": "~",
     "charges": 1,
@@ -689,15 +692,14 @@
   {
     "id": "mutant_human_cooked",
     "copy-from": "mutant_human_flesh",
-    "calories": 402,
+    "calories": 201,
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "cooked cretin" },
+    "name": { "str_sp": "cooked foul human flesh" },
     "description": "Cooked meat from a heavily mutated humanoid.  Now that the worst bits have been picked out, it's probably digestible, if not very appetizing.",
-    "proportional": { "price": 1.5 },
     "parasites": 0,
     "fun": 0,
-    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "BAD_TASTE" ]
+    "flags": [ "EATEN_HOT", "BAD_TASTE" ]
   },
   {
     "type": "ITEM",
@@ -1504,7 +1506,7 @@
     "material": [ "flesh" ],
     "volume": "250 ml",
     "fun": -10,
-    "flags": [ "TRADER_AVOID", "SMOKABLE", "NUTRIENT_OVERRIDE", "RAW" ],
+    "flags": [ "TRADER_AVOID", "SMOKABLE", "RAW" ],
     "smoking_result": "dry_meat_tainted",
     "vitamins": [ [ "meat_allergen", 1 ] ]
   },
@@ -1528,7 +1530,7 @@
     "material": [ "hflesh" ],
     "volume": "250 ml",
     "fun": -10,
-    "flags": [ "TRADER_AVOID", "SMOKABLE", "NUTRIENT_OVERRIDE", "RAW" ],
+    "flags": [ "TRADER_AVOID", "SMOKABLE", "RAW" ],
     "smoking_result": "dry_meat_tainted",
     "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
   },
@@ -1553,7 +1555,7 @@
     "spoils_in": "2 days",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "flags": [ "TRADER_AVOID", "NUTRIENT_OVERRIDE", "NO_REPAIR" ]
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "type": "ITEM",
@@ -1576,7 +1578,7 @@
     "spoils_in": "2 days",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "flags": [ "TRADER_AVOID", "NUTRIENT_OVERRIDE", "NO_REPAIR" ]
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
   },
   {
     "id": "blood_tainted",
@@ -1922,7 +1924,7 @@
     "material": [ "migo_flesh" ],
     "volume": "250 ml",
     "fun": -30,
-    "flags": [ "TRADER_AVOID", "NUTRIENT_OVERRIDE" ]
+    "flags": [ "TRADER_AVOID" ]
   },
   {
     "id": "blood_mi-go",

--- a/data/json/items/comestibles/meat_dishes.json
+++ b/data/json/items/comestibles/meat_dishes.json
@@ -1483,8 +1483,8 @@
     "id": "dry_meat",
     "name": { "str_sp": "dehydrated meat" },
     "conditional_names": [
-      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "%s, human" } },
-      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "%s, mutant" } }
+      { "type": "VITAMIN", "condition": "human_flesh_vitamin", "name": { "str_sp": "dehydrated human flesh" } },
+      { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "dehydrated foul meat" } }
     ],
     "copy-from": "meat_cooked",
     "weight": "85 g",

--- a/data/json/mapgen/nested/aux_nested.json
+++ b/data/json/mapgen/nested/aux_nested.json
@@ -545,13 +545,10 @@
       "place_vehicles": [ { "vehicle": "luggage_large", "x": 0, "y": 0, "chance": 80, "status": 0 } ]
     }
   },
-    {
+  {
     "type": "mapgen",
     "nested_mapgen_id": "luggage_1x1",
-    "object": {
-      "mapgensize": [ 1, 1 ],
-      "place_vehicles": [ { "vehicle": "luggage", "x": 0, "y": 0, "chance": 80, "status": 0 } ]
-    }
+    "object": { "mapgensize": [ 1, 1 ], "place_vehicles": [ { "vehicle": "luggage", "x": 0, "y": 0, "chance": 80, "status": 0 } ] }
   },
   {
     "type": "mapgen",


### PR DESCRIPTION
#### Summary
More meat fixes

#### Purpose of change
There are still lots of issues with meat, but we can keep chipping away.

#### Describe the solution
Remove more copy-froms and cooks_likes

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
