### PR TITLE
Field dressing doesn't pulp zombies

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1497,6 +1497,15 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                                          random_entry( here.points_in_radius( you->pos_bub(),
                                                        std::max( 1, ( corpse->size - 1 ) ) ) ) );
             }
+            // Prevent organ farming.
+            if( corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
+                one_in( corpse->size * 3 ) ) {
+                add_msg_if_player_sees( you->pos_bub(),
+                                        _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );
+                here.add_splatter( type_gib, you->pos_bub(), corpse->size + 0 );
+                corpse_item.set_damage( 4000 );
+                corpse_item.set_flag( flag_PULPED );
+            }
             if( !act->targets.empty() ) {
                 act->targets.pop_back();
             }
@@ -1520,6 +1529,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                 add_msg_if_player_sees( you->pos_bub(),
                                         _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );
                 here.add_splatter( type_gib, you->pos_bub(), corpse->size + 0 );
+                corpse_item.set_damage( 4000 );
                 corpse_item.set_flag( flag_PULPED );
             }
             if( !act->targets.empty() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8719,8 +8719,7 @@ bool item::pulpable() const
 {
     return is_corpse() && ( corpse->has_flag( mon_flag_REVIVES ) || has_var( "zombie_form" ) ) &&
            damage() < max_damage() &&
-           !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
-              has_flag( flag_QUARTERED ) ||
+           !( has_flag( flag_QUARTERED ) ||
               has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) );
 }
 
@@ -8728,8 +8727,7 @@ bool item::can_revive() const
 {
     return is_corpse() && ( corpse->has_flag( mon_flag_REVIVES ) || has_var( "zombie_form" ) ) &&
            damage() < max_damage() &&
-           !( has_flag( flag_FIELD_DRESS ) || has_flag( flag_FIELD_DRESS_FAILED ) ||
-              has_flag( flag_QUARTERED ) ||
+           !( has_flag( flag_QUARTERED ) ||
               has_flag( flag_SKINNED ) || has_flag( flag_PULPED ) ||
               ( has_flag( flag_FROZEN ) && !corpse->has_flag( mon_flag_DORMANT ) ) );
 }


### PR DESCRIPTION
#### Summary
Field dressing doesn't pulp zombies

#### Purpose of change
This didn't make sense re: lore and was also dumb

#### Describe the solution
Field dressing has the same chance to accidentally pulp a zombie as bleeding, but it's only a chance, meaning it's almost always going to be a really bad idea to try to pulp zombies this way, kcal-wise.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
