### PR TITLE
Fix blood/organ farming prevention

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -234,6 +234,7 @@ static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_social( "social" );
 static const skill_id skill_survival( "survival" );
 
+static const species_id species_ABERRATION( "ABERRATION" );
 static const species_id species_FERAL( "FERAL" );
 static const species_id species_HUMAN( "HUMAN" );
 static const species_id species_ZOMBIE( "ZOMBIE" );
@@ -1498,7 +1499,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                                                        std::max( 1, ( corpse->size - 1 ) ) ) ) );
             }
             // Prevent organ farming.
-            if( corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
+            if( ( corpse->in_species( species_ZOMBIE ) || corpse->in_species( species_ABERRATION ) ) && corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
                 one_in( corpse->size * 3 ) ) {
                 add_msg_if_player_sees( you->pos_bub(),
                                         _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );
@@ -1524,7 +1525,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
                          translation() ).translated() );
             corpse_item.set_flag( flag_BLED );
             // Prevent blood farming.
-            if( corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
+            if( ( corpse->in_species( species_ZOMBIE ) || corpse->in_species( species_ABERRATION ) ) && corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
                 one_in( corpse->size * 3 ) ) {
                 add_msg_if_player_sees( you->pos_bub(),
                                         _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1500,7 +1500,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
             }
             // Prevent organ farming.
             if( ( corpse->in_species( species_ZOMBIE ) || corpse->in_species( species_ABERRATION ) ) && corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
-                one_in( corpse->size * 3 ) ) {
+                one_in( corpse->size * 2 ) ) {
                 add_msg_if_player_sees( you->pos_bub(),
                                         _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );
                 here.add_splatter( type_gib, you->pos_bub(), corpse->size + 0 );
@@ -1526,7 +1526,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
             corpse_item.set_flag( flag_BLED );
             // Prevent blood farming.
             if( ( corpse->in_species( species_ZOMBIE ) || corpse->in_species( species_ABERRATION ) ) && corpse->has_flag( mon_flag_REVIVES ) && !corpse_item.has_flag( flag_PULPED ) &&
-                one_in( corpse->size * 3 ) ) {
+                one_in( corpse->size * 2 ) ) {
                 add_msg_if_player_sees( you->pos_bub(),
                                         _( "The corpse spasms one final time and bursts apart in a shower of gore." ) );
                 here.add_splatter( type_gib, you->pos_bub(), corpse->size + 0 );


### PR DESCRIPTION
#### Summary
Fix blood/organ farming prevention

#### Purpose of change
#3042 added a thing we've had in place for bleeding for a while: revivable corpses will sometimes pulp themselves when being bled, as a means to prevent players from endlessly farming them for resources. I realized that this was also being applied to regular animals. Obviously we don't want regular animals occasionally exploding when players are trying to do normal things to process them for meat.

#### Describe the solution
The chance to pulp when field dressing or bleeding a corpse now only applies to corpses that are in species zombie or aberration. You will never pulp a regular deer or other similar creature this way, so it's safe to process them however you normally would.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
