### PR TITLE
No leaping in water

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -76,7 +76,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -112,7 +114,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -145,7 +149,8 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -178,7 +183,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -211,7 +218,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -244,7 +253,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [
@@ -309,7 +320,9 @@
         { "not": { "u_has_effect": "electrocuted" } },
         { "not": { "u_has_effect": "grabbed" } },
         { "not": { "u_has_move_mode": "prone" } },
-        { "not": { "u_has_flag": "CANNOT_MOVE" } }
+        { "not": { "u_has_flag": "CANNOT_MOVE" } },
+        { "not": "u_is_on_liquid" },
+        { "not": "u_is_underwater" }
       ]
     },
     "effect": [


### PR DESCRIPTION
#### Summary
No leaping in water

#### Purpose of change

#### Describe the solution
- Being in or under water blocks all forms of leap except batrachian's crushing leap, which is usable in water but not under it.
- Bull charge cannot be used in or under water.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
