### PR TITLE
Remove weird ecology requirements

### DIFF
--- a/data/json/construction/furniture_tools.json
+++ b/data/json/construction/furniture_tools.json
@@ -166,7 +166,7 @@
     "id": "constr_compost_empty",
     "group": "build_compost_tank",
     "category": "FURN",
-    "required_skills": [ [ "fabrication", 5 ], [ "mechanics", 2 ], [ "survival", 4 ] ],
+    "required_skills": [ [ "fabrication", 5 ], [ "mechanics", 2 ], [ "survival", 3 ] ],
     "time": "2880 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SAW_M", "level": 1 } ], [ { "id": "SMOOTH", "level": 1 } ] ],
     "using": [ [ "welding_standard", 10 ] ],

--- a/data/json/construction/manufactured.json
+++ b/data/json/construction/manufactured.json
@@ -60,7 +60,7 @@
     "id": "constr_covered_well",
     "group": "build_water_well",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 4 ], [ "survival", 4 ] ],
+    "required_skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
     "time": "480 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
     "components": [
@@ -101,7 +101,7 @@
     "id": "constr_rootcellar",
     "group": "build_root_cellar",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "survival", 4 ], [ "cooking", 4 ] ],
+    "required_skills": [ [ "survival", 3 ], [ "cooking", 3 ] ],
     "time": "130 m",
     "qualities": [ [ { "id": "DIG", "level": 2 } ], [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [
@@ -143,7 +143,7 @@
     "id": "constr_wooden_well",
     "group": "build_water_well",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 4 ], [ "survival", 4 ] ],
+    "required_skills": [ [ "fabrication", 4 ], [ "survival", 3 ] ],
     "time": "120 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [

--- a/data/json/construction/roofs.json
+++ b/data/json/construction/roofs.json
@@ -130,7 +130,7 @@
     "id": "constr_thatched_roof",
     "group": "build_thatched_roof",
     "category": "CONSTRUCT",
-    "required_skills": [ [ "fabrication", 3 ], [ "survival", 7 ] ],
+    "required_skills": [ [ "fabrication", 3 ] ],
     "time": "300 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [


### PR DESCRIPTION
#### Summary
Remove weird ecology requirements

#### Purpose of change
Thatched roofs for some reason required ecology 7 to craft. ?????

#### Describe the solution
- Thatched roofs no longer require ecology 7 to construct.
- Lowered the ecology requirement to construct wells and root cellars.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
