### PR TITLE
Update ammo_pouch.json, quiver description

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -372,7 +372,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "quiver" },
-    "description": "A leather quiver worn at the waist that can hold twelve arrows or fifteen bolts.",
+    "description": "A leather quiver worn at the waist that can hold twelve arrows or sixteen bolts.",
     "weight": "260 g",
     "volume": "500 ml",
     "price": "65 USD",


### PR DESCRIPTION
#### Summary
Corrected the "quiver" description from "fifteen bolts" to "sixteen bolts"

#### Purpose of change
Misleading description states that the quiver can hold fifteen bolts where it can actually hold sixteen bolts.

#### Describe the solution
Alter the description.

#### Describe alternatives you've considered
Alter the number of bolts held down to fifteen to match the description.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
