### PR TITLE
Fix fallback techs when using melee styles

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1578,6 +1578,7 @@ void Character::roll_damage( const damage_type_id &dt, bool crit, damage_instanc
         di.add_damage( dt, other_dam, arpen, armor_mult, other_mul );
     }
 }
+
 std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_technique(
     Creature const &t, const item_location &weap, bool crit,
     bool dodge_counter, bool block_counter, const std::vector<matec_id> &blacklist ) const
@@ -1633,6 +1634,7 @@ std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id> Character::pick_tech
                                               sub_bodypart_str_id::NULL_ID() ) );
     }
 }
+
 std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
         Character::evaluate_technique( const matec_id &tec_id, Creature const &t, const item_location &weap,
                                        std::vector<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>> &fallbacks,
@@ -1754,9 +1756,11 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
             add_msg_debug( debugmode::DF_MELEE,
                            "Negative tech weighting failed roll, attack %s discarded", tec_id->name );
         } else {
-            // Fallback techs should always fire in place of tec_none if possible, even if they failed their roll.
-            if( tec_id->is_valid_character( *this ) ) {
-                // We still need a valid vector to make a fallback attack.
+            // Fallback techs should be available when unarmed, even if the selected
+            // style normally requires a weapon. They should not override an invalid weapon.
+            const bool unarmed = !is_armed();
+            const bool valid_character = tec_id->is_valid_character( *this );
+            if( unarmed || valid_character ) {
                 std::optional<std::pair<attack_vector_id, sub_bodypart_str_id>> vector;
                 vector = martial_arts_data->choose_attack_vector( *this, tec_id );
                 if( vector ) {
@@ -1764,7 +1768,7 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
                     add_msg_debug( debugmode::DF_MELEE, "Adding fallback tech %s to the tech list", tec_id->name );
                 } else {
                     add_msg_debug( debugmode::DF_MELEE, "No valid attack vector found, fallback attack %s discarded",
-                                   tec_id->name );
+                                tec_id->name );
                 }
             }
         }


### PR DESCRIPTION
#### Summary
Fix fallback techs when using melee styles

#### Purpose of change
Melee-only styles such as Niten-Ichi Ryu use tec_none when the character is wielding an invalid weapon. This is correct and intended, but they were also using tec_none when the character was unarmed, rather than the character's unarmed fallback attacks, which was causing them to not use attack vectors or gain experience.

#### Describe the solution
Fix the check so that characters will kick and punch if they're set to a weapon style but have no weapon.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
