### PR TITLE
Update misc.json, remove looks_like from sleeping_bag_roll

### DIFF
--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -122,7 +122,7 @@
     "copy-from": "sleeping_bag",
     "name": { "str": "rolled sleeping bag" },
     "description": "A large sleeping bag that covers you head to toe, with a strap for carrying it on your back when not in use.  This one is medium weight.  Activate it to unroll it so you can use it for warmth.",
-    "looks_like": "sleeping_bag",
+    "looks_like": "",
     "material_thickness": 4,
     "flags": [ "OVERSIZE", "BELTED" ],
     "use_action": { "menu_text": "Unroll", "type": "transform", "target": "sleeping_bag", "msg": "You unroll the sleeping bag." },


### PR DESCRIPTION
#### Summary
Changed the looks_like of the sleeping_bag_roll to "" in order to make the rolled sleeping bag have no worn sprite as opposed to using the same full body sprite that the unrolled sleeping bag uses.

#### Purpose of change
The full body blanket sprite which the sleeping bag uses when worn seems inappropriate for the rolled sleeping bag as it's strapped to the back.

#### Describe the solution
sleeping_bag_roll now uses '"looks_like": ""'

#### Describe alternatives you've considered
Either find or draw an appropriate sprite to replace it with, likely unnecessary since the back of the character is not very visible.


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
