### PR TITLE
duffelbag size fixes

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -16,7 +16,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "38 L",
+        "max_contains_volume": "66 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "60 cm",
         "magazine_well": "7500 ml",

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2582,37 +2582,6 @@
     "armor": [ { "encumbrance": [ 0, 0 ], "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {
-    "id": "long_duffelbag",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "name": { "str": "longarm bag" },
-    "description": "A long duffel bag.  Provides storage for long arms and rifles.  Quite cumbersome.",
-    "weight": "1203 g",
-    "volume": "12 L",
-    "price": "180 USD",
-    "price_postapoc": "8 USD",
-    "material": [ "canvas" ],
-    "symbol": "[",
-    "looks_like": "rucksack",
-    "color": "green",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "30 L",
-        "max_contains_weight": "80 kg",
-        "max_item_length": "150 cm",
-        "magazine_well": "10 L",
-        "moves": 300
-      }
-    ],
-    "warmth": 8,
-    "material_thickness": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
-    "armor": [
-      { "encumbrance": [ 8, 42 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
-    ]
-  },
-  {
     "id": "rifle_case_soft",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/json/obsoletion_and_migration/migration_items.json
+++ b/data/json/obsoletion_and_migration/migration_items.json
@@ -4230,5 +4230,10 @@
     "type": "MIGRATION",
     "id": "folded_trashcan_large",
     "replace": "roller_bin"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "long_duffelbag",
+    "replace": "duffelbag"
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2287,20 +2287,6 @@
     "components": [ [ [ "strap_large", 2, "LIST" ] ] ]
   },
   {
-    "result": "long_duffelbag",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_STORAGE",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "10 h",
-    "autolearn": true,
-    "reversible": true,
-    "using": [ [ "tailoring_canvas_sheet", 32 ], [ "fastener_large", 2 ], [ "waterproofing_plastic_sheets", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
-  },
-  {
     "result": "rifle_case_soft",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
#### Summary
Content "Fix survivor duffel bag, delete 'longarm bag'"

#### Purpose of change

A `duffelbag`'s size was corrected to be larger than 35L in #1796 but the crafted item, the survivor duffel bag, wasn't updated.

The craftable-only "longarm bag" item does not exist in the real world. The term "longarm bag" did not exist until a dubious PR for DDA invented it for the `long_duffelbag`.

#### Describe the solution

Set survivor duffel to 10% larger than the baseline duffelbag.

Delete recipe and replace every `long_duffelbag` with a `duffelbag`.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Item was obsoleted in DDA in https://github.com/CleverRaven/Cataclysm-DDA/pull/81883

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
