### PR TITLE
delete extra copy of trash_junkyard itemgroup

### DIFF
--- a/data/json/itemgroups/trash_and_debris.json
+++ b/data/json/itemgroups/trash_and_debris.json
@@ -303,26 +303,6 @@
     ]
   },
   {
-    "type": "item_group",
-    "id": "trash_junkyard",
-    "items": [
-      { "item": "glass_shard", "prob": 30, "charges": [ 1, 60 ] },
-      [ "scrap", 50 ],
-      [ "steel_chunk", 30 ],
-      [ "steel_fragment", 30 ],
-      [ "frame", 20 ],
-      [ "rigid_plastic_sheet", 2 ],
-      [ "chain", 10 ],
-      [ "spring", 10 ],
-      [ "hdframe", 10 ],
-      [ "hose", 10 ],
-      [ "wheel_mount_medium", 10 ],
-      [ "alternator_car", 10 ],
-      [ "alternator_truck", 5 ],
-      [ "alternator_motorbike", 2 ]
-    ]
-  },
-  {
     "id": "collapsed_building_rubble",
     "type": "item_group",
     "subtype": "collection",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

When the file `SUS/trash.json` was manually added to make the backport of d6f58f1a24415c035dbbcbe91b54380621459205 work in #1468, it included the `trash_junkyard` itemgroup from DDA.

But that itemgroup was deleted in DDA from this older file in https://github.com/CleverRaven/Cataclysm-DDA/pull/79855 and moved into the new file in https://github.com/CleverRaven/Cataclysm-DDA/pull/79848.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/f4bbd87aa5f0408214b00a91fa519738de347dee/data/json/itemgroups/SUS/trash.json#L122-L123

TLG includes the new file, but never backported the deletion, so it now has 2 itemgroups with the same name in different files.

#### Describe the solution

Delete the older copy.

#### Describe alternatives you've considered

Delete the newer copy? (Edit: done in 7d2bb903127f0886d072939ad11d068087a0c5f1)

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

It's unclear why 2 itemgroups with the same name didn't trigger any kind of error.

<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
