### PR TITLE
remove trash from mall filing cabinet

### DIFF
--- a/data/json/mapgen/mall/mall_second_floor.json
+++ b/data/json/mapgen/mall/mall_second_floor.json
@@ -58,7 +58,7 @@
         ],
         "K": [ { "item": "vending_food_items", "chance": 20 }, { "item": "vending_drink_items", "chance": 20 } ],
         "Y": { "item": "trash", "chance": 100, "repeat": [ 1, 2 ] },
-        "S": { "item": "trash", "chance": 30, "repeat": [ 4, 6 ] },
+        "S": { "item": "SUS_office_filing_cabinet", "chance": 30 },
         "R": { "item": "magazines", "chance": 30, "repeat": [ 1, 2 ] },
         "z": [
           { "item": "hatstore_accessories", "chance": 40, "repeat": [ 1, 2 ] },


### PR DESCRIPTION
#### Summary
Content "Remove inexplicable trash from one filing cabinet in the mall"

#### Purpose of change

The contents of filing cabinets in the mall all made sense, except for this one.

#### Describe the solution

Adapt https://github.com/CleverRaven/Cataclysm-DDA/pull/81449

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
