### PR TITLE
Extract missing JSON translation fields

### DIFF
--- a/lang/string_extractor/parsers/bionic.py
+++ b/lang/string_extractor/parsers/bionic.py
@@ -11,3 +11,8 @@ def parse_bionic(json, origin):
     if "description" in json:
         write_text(json["description"], origin, c_format=False,
                    comment="Description of bionic \"{}\"".format(name))
+
+    if "cant_remove_reason" in json:
+        write_text(json["cant_remove_reason"], origin,
+                   comment="Reason bionic \"{}\" cannot be removed"
+                   .format(name))

--- a/lang/string_extractor/parsers/effect_type.py
+++ b/lang/string_extractor/parsers/effect_type.py
@@ -96,3 +96,8 @@ def parse_effect_type(json, origin):
                    context="memorial_female",
                    comment="Female memorial remove log of effect type \"{}\""
                    .format(effect_name))
+
+    if "blood_analysis_description" in json:
+        write_text(json["blood_analysis_description"], origin,
+                   comment="Blood analysis description of effect type \"{}\""
+                   .format(effect_name))

--- a/lang/string_extractor/parsers/field_type.py
+++ b/lang/string_extractor/parsers/field_type.py
@@ -11,6 +11,10 @@ def parse_field_type(json, origin):
         else:
             id_or_name = json["id"]
         field_names.append(id_or_name)
+        if "radiation_hurt_message" in fd:
+            write_text(fd["radiation_hurt_message"], origin,
+                       comment="Radiation damage message of field {}"
+                       .format(id_or_name))
         for eff in fd.get("effects", []):
             if "message" in eff:
                 write_text(eff["message"], origin,

--- a/lang/string_extractor/parsers/material.py
+++ b/lang/string_extractor/parsers/material.py
@@ -14,6 +14,10 @@ def parse_material(json, origin):
         write_text(json["cut_dmg_verb"], origin,
                    comment="Cut damage verb of material {}".format(name))
 
+    if "acid_dmg_verb" in json:
+        write_text(json["acid_dmg_verb"], origin,
+                   comment="acid damage verb of material {}".format(name))
+
     if "dmg_adj" in json:
         for i in range(4):
             write_text(json["dmg_adj"][i], origin,

--- a/lang/string_extractor/parsers/recipe.py
+++ b/lang/string_extractor/parsers/recipe.py
@@ -42,6 +42,12 @@ def parse_recipe(json, origin):
         write_text(json["blueprint_name"], origin,
                    comment="Blueprint name of recipe crafting \"{}\""
                    .format(result_hint(json)))
+    if json.get("steps"):
+        for i, step in enumerate(json["steps"], start=1):
+            if "unattend_message" in step:
+                write_text(step["unattend_message"], origin,
+                           comment="Unattended message for recipe step {}"
+                           .format(i))
     if "result_eocs" in json:
         for eoc in json["result_eocs"]:
             if type(eoc) is dict:


### PR DESCRIPTION
#### Summary
Bugfixes "Extract missing translatable strings from JSON"

#### Purpose of change
While working on the Russian .po file and checking the translation in-game, I noticed that some strings remained in English. These strings come from JSON data but were not picked up by the translation extractor.

#### Describe the solution
Added extraction for the following JSON fields:

- blood_analysis_description
- acid_dmg_verb
- cant_remove_reason
- radiation_hurt_message
- unattend_message in recipe steps

#### Describe alternatives you've considered
None
#### Testing
Ran `lang/update_pot.sh` locally. The updated extractor produced 74 new translation entries and removed none.

#### Additional context
Translation files are not included because I am still checking for other strings that may be missing from the extraction process.
This is a large project, and I am still getting familiar with some parts of its translation system.
Sorry if I missed any project conventions or if something needs to be adjusted.