### PR TITLE
Localize additional NPC and gameplay messages

### DIFF
--- a/lang/string_extractor/parsers/npc.py
+++ b/lang/string_extractor/parsers/npc.py
@@ -88,6 +88,9 @@ def parse_npc(json, origin):
     if "name_suffix" in json:
         write_text(json["name_suffix"], origin,
                    comment=["Name suffix of {} NPC".format(gender), comment])
+    if "temp_suffix" in json:
+        write_text(json["temp_suffix"], origin,
+                   comment=["Temporary profession of {} NPC".format(gender), comment])
     for snip in chatbin_snippets:
         if snip in json:
             write_text(json[snip], origin,

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1022,12 +1022,12 @@ void avatar_action::plthrow( avatar &you, item_location loc,
             }
             if( range <= 1 || you.get_stamina_max() < ( -1 * stamina_mod ) ||
                 their_size - your_size > you.get_arm_str() / 10 ) {
-                you.add_msg_if_player( ( "You can't muster the strength to throw %s." ),
+                you.add_msg_if_player( _( "You can't muster the strength to throw %s." ),
                                        you.grab_1.victim->disp_name() );
                 return;
             }
             if( ( you.get_stamina() ) < ( stamina_mod ) ) {
-                you.add_msg_if_player( ( "You're too exhausted to throw %s." ), you.grab_1.victim->disp_name() );
+                you.add_msg_if_player( _( "You're too exhausted to throw %s." ), you.grab_1.victim->disp_name() );
                 return;
             }
             if( ( you.grab_1.victim->has_effect_with_flag( json_flag_GRAB_FILTER ) &&

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3130,14 +3130,11 @@ void game::bury_screen() const
     const int days = to_days<int>( survived );
 
     if( days > 0 ) {
-        // NOLINTNEXTLINE(cata-translate-string-literal)
-        sTemp = string_format( "%dd %dh %dm", days, hours, minutes );
+        sTemp = string_format( pgettext( "time duration", "%dd %dh %dm" ), days, hours, minutes );
     } else if( hours > 0 ) {
-        // NOLINTNEXTLINE(cata-translate-string-literal)
-        sTemp = string_format( "%dh %dm", hours, minutes );
+        sTemp = string_format( pgettext( "time duration", "%dh %dm" ), hours, minutes );
     } else {
-        // NOLINTNEXTLINE(cata-translate-string-literal)
-        sTemp = string_format( "%dm", minutes );
+        sTemp = string_format( pgettext( "time duration", "%dm" ), minutes );
     }
 
     center_print( w_rip, iInfoLine++, c_white, sTemp );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -664,7 +664,7 @@ static void grab()
         }
         // TODO: Dynamically calculate stamina cost.
         if( you.get_stamina() < 400 ) {
-            you.add_msg_if_player( ( "You're too exhausted to wrestle anything." ) );
+            you.add_msg_if_player( _( "You're too exhausted to wrestle anything." ) );
             return;
         }
         if( target->is_monster() && target->as_monster()->has_flag( mon_flag_GRAB_IMMUNE ) ) {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -547,8 +547,8 @@ void veh_app_interact::toggle_hide_wiring( map &here )
     vehicle_part &vp = veh->part( part_idx );
     const bool should_hide = !vp.hidden;
     vp.hidden = should_hide;
-    if( query_yn( string_format( "Also %s all the wiring on this floor?",
-                                 should_hide ? "hide" : "unhide" ) ) ) {
+    if( query_yn( should_hide ? _( "Also hide all the wiring on this floor?" ) :
+                  _( "Also unhide all the wiring on this floor?" ) ) ) {
         for( const tripoint_bub_ms &target : here.points_on_zlevel() ) {
             if( auto target_vpart_position = here.veh_at( target ) ) {
                 if( auto target_vpart_reference = target_vpart_position.part_with_feature( flag_WIRING, false ) ) {
@@ -614,7 +614,7 @@ void veh_app_interact::populate_app_actions( map &here )
         app_actions.emplace_back( [&here, this]() {
             toggle_hide_wiring( here );
         } );
-        imenu.addentry( -1, true, 0, string_format( _( "%s wiring" ), vp->hidden ? "Unhide" : "Hide" ) );
+        imenu.addentry( -1, true, 0, vp->hidden ? _( "Unhide wiring" ) : _( "Hide wiring" ) );
     }
 #endif
 


### PR DESCRIPTION
## Summary

Continues the ongoing localization work by covering several messages that were not yet available for translation.

## Purpose of change

While checking the Russian translation in-game, I found another strings that were not reaching the normal gettext workflow:

- temporary NPC profession suffixes;
- the survival duration shown on the death screen;
- failure messages when grabbing or throwing a creature;
- appliance wiring prompts and menu labels.

## Describe the solution

- Added JSON extractor support for the NPC `temp_suffix` field. This covers temporary professions such as `Beggar` and `Prisoner`.
- Made the compact death-screen duration formats translatable:
  - `%dd %dh %dm`
  - `%dh %dm`
  - `%dm`
- Wrapped these grapple and throw messages in `_()`:
  - `You can't muster the strength to throw %s.`
  - `You're too exhausted to throw %s.`
  - `You're too exhausted to wrestle anything.`
- Localized the appliance wiring visibility action:
  - `Also hide all the wiring on this floor?`
  - `Also unhide all the wiring on this floor?`
  - `Hide wiring`
  - `Unhide wiring`

Using complete messages instead of translating `hide` and `unhide` separately lets translators use a natural word order in their language.

## Describe alternatives you've considered

None

## Testing

- Ran the gettext extraction validation.
  - `temp_suffix` adds direct extractor coverage; the current `Beggar` and `Prisoner` entries already existed through `npc_class.name`.
  - RIP duration formats add 3 new gettext entries.
  - Grapple and throw messages add 3 new gettext entries.
  - Appliance wiring adds 4 full gettext entries and replaces the old `%s wiring` composite entry.
- Compiled the modified C++ translation units with the project Makefile and `-Werror`