### PR TITLE
Fix pulp stamina cost to cost instead of recover stamina

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9159,7 +9159,7 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
                 }
 
                 // Mix of Isaac Clarke stomps and swinging your weapon.
-                you.burn_energy_all( -you.get_standard_stamina_cost() );
+                you.burn_energy_all( you.get_base_melee_stamina_cost() );
 
                 you.recoil = MAX_RECOIL;
 


### PR DESCRIPTION
#### Summary

Fixes the stamina cost for pulping having an extra negative, and being zero for an unarmed character.

#### Purpose of change

For pulping, burn_energy_all is called on the negative of get_standard_stamina_cost.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/085cf17301c81ad8c4cd30671a47057af1c9de2d/src/activity_actor.cpp#L9162


For comparison, smashing calls burn_energy_arms with a negative number, without an additional negative on the returned value of get_standard_stamina_cost.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/085cf17301c81ad8c4cd30671a47057af1c9de2d/src/handle_action.cpp#L1125-L1126


Note that in get_standard_stamina_cost, the returned value includes a * -1.0, making it negative.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/085cf17301c81ad8c4cd30671a47057af1c9de2d/src/character.cpp#L3521-L3522


In PR #1325, it was commented that "Smashing now uses the standard stamina cost for making a melee attack with whatever you're using", so pulping was probably supposed to cost stamina.


Btw the stamina cost for melee attacks also has a min of 75. From what I can tell, without this the stamina cost for an unarmed character is 0.

https://github.com/Cataclysm-TLG/Cataclysm-TLG/blob/085cf17301c81ad8c4cd30671a47057af1c9de2d/src/melee.cpp#L1066-L1069

#### Describe the solution

I switched it to you.burn_energy_all( you.get_base_melee_stamina_cost() );

There's no more extra negative, so now stamina is spent on pulping, like it's spent with melee attacks or smashing. I also switched from get_standard_stamina_cost to get_base_melee_stamina_cost, which is just get_standard_stamina_cost but with a min cost of 75 so that unarmed isn't free stamina-wise.

#### Describe alternatives you've considered

I wondered about if this would affect the balance, but it seems just like with smashing there's a popup before stamina gets low enough to slow/debuff the player, with an option to continue after a break, so it's just a matter of the player needing to take some breaks between pulping, which is small in comparison to the time it take for the weariness to recover. And the intent as expressed in the refactoring PR was that the stamina cost would be the same as with melee attacks.

#### Testing

Kill zombies and pulp their corpses. Verify that pulping costs stamina, and if it gets low enough the game prompts the player if they want to stop or continue after a break.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
