### PR TITLE
fix densities for peanut butter and jam

### DIFF
--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -331,7 +331,7 @@
     "price_postapoc": "75 cent",
     "material": [ "fruit" ],
     "sealed": true,
-    "volume": "250 ml",
+    "volume": "125 ml",
     "phase": "liquid",
     "charges": 8,
     "fun": 10,

--- a/data/json/items/comestibles/nuts.json
+++ b/data/json/items/comestibles/nuts.json
@@ -575,7 +575,7 @@
     "price": "1 USD 95 cent",
     "price_postapoc": "10 USD",
     "//": "Two tablespoons per charge.",
-    "weight": "50 g",
+    "weight": "32 g",
     "volume": "250 ml",
     "comestible_type": "DRINK",
     "container": "jar_glass_sealed",


### PR DESCRIPTION
#### Summary
Balance "Fix densities of peanut butter and fruit jam"

#### Purpose of change

PB was way too dense in terms of g/mL, and had far too few calories/gram. Jam was way too bulky.

#### Describe the solution

Backport part of https://github.com/CleverRaven/Cataclysm-DDA/pull/81782

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
