### PR TITLE
Localize messages

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6830,13 +6830,13 @@ void play_with_pet_activity_actor::finish( player_activity &act, Character &who 
     if( !who.has_trait( trait_PSYCHOPATH ) && !who.has_trait( trait_NUMB ) ) {
         who.add_morale( morale_play_with_pet, 10, 10, 5_hours, 25_minutes );
         if( !playstr.empty() ) {
-            who.add_msg_if_player( m_good, playstr, pet_name );
+            who.add_msg_if_player( m_good, _( playstr ), pet_name );
         }
         who.add_msg_if_player( m_good, _( "Playing with your %s has lifted your spirits a bit." ),
                                pet_name );
     } else {
         if( !playstr.empty() ) {
-            who.add_msg_if_player( m_good, playstr, pet_name );
+            who.add_msg_if_player( m_good, _( playstr ), pet_name );
         }
         who.add_msg_if_player( _( "Your %s seems to enjoy the interaction, but you feel nothing." ),
                                pet_name );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -4536,7 +4536,7 @@ void npc::do_npc_craft( const std::optional<tripoint_bub_ms> &loc, const recipe_
         craft( loc, goto_recipe );
     } else {
         uilist menu;
-        menu.text = "Craft what?";
+        menu.text = _( "Craft what?" );
         menu.addentry( 0, true, MENU_AUTOASSIGN, _( "Craft new item" ) );
         menu.addentry( 1, true, MENU_AUTOASSIGN, _( "Work on craft" ) );
         menu.query();
@@ -4548,10 +4548,10 @@ void npc::do_npc_craft( const std::optional<tripoint_bub_ms> &loc, const recipe_
             uilist item_selection;
             do {
                 item_selection.init();
-                item_selection.text = "Craft what?";
+                item_selection.text = _( "Craft what?" );
                 item_selection.selected = selected;
-                item_selection.addentry( 0, true, MENU_AUTOASSIGN, "Start crafting" );
-                item_selection.addentry( 1, true, MENU_AUTOASSIGN, "Select all" );
+                item_selection.addentry( 0, true, MENU_AUTOASSIGN, _( "Start crafting" ) );
+                item_selection.addentry( 1, true, MENU_AUTOASSIGN, _( "Select all" ) );
                 int index = 2;
 
                 for( item_location &itm : craft_item_list ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2894,9 +2894,11 @@ void inventory_selector::draw_footer( const catacurses::window &w ) const
             wprintz( w, c_light_gray, " >" );
         }
 
+        const std::string view_mode = _uimode == uimode::hierarchy ?
+                                      pgettext( "inventory view mode", "hierarchy" ) :
+                                      pgettext( "inventory view mode", "categories" );
         right_print( w, getmaxy( w ) - border, border + 1, c_light_gray,
-                     string_format( "< [%s] %s >", ctxt.get_desc( "VIEW_CATEGORY_MODE" ),
-                                    io::enum_to_string( _uimode ) ) );
+                     string_format( "< [%s] %s >", ctxt.get_desc( "VIEW_CATEGORY_MODE" ), view_mode ) );
         const auto footer = get_footer( mode );
         if( !footer.first.empty() ) {
             const int string_width = utf8_width( footer.first );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3655,18 +3655,21 @@ bool item::armor_full_protection_info( std::vector<iteminfo> &info,
                 insert_separation_line( info );
             }
 
-            std::string coverage = "<bold>Protection for</bold>:";
+            std::vector<std::string> covered_names;
             if( !covered_subparts.empty() ) {
                 // Only show subparts explicitly listed in the item json.
                 for( const sub_bodypart_id sbp : covered_subparts ) {
-                    coverage += string_format( " The <info>%s</info>.", sbp->name );
+                    covered_names.emplace_back( string_format( "<info>%s</info>", sbp->name ) );
                 }
             } else {
                 // Show body parts only if no subparts were defined.
                 for( const bodypart_id bp : covered_main ) {
-                    coverage += string_format( " The <info>%s</info>.", bp->name );
+                    covered_names.emplace_back( string_format( "<info>%s</info>", bp->name ) );
                 }
             }
+            const std::string coverage = string_format( _( "<bold>Protection for</bold>: %s." ),
+                                         enumerate_as_string( covered_names,
+                                                 enumeration_conjunction::none ) );
             info.emplace_back( "ARMOR", coverage );
             // Pick a representative subpart to populate armor data.
             sub_bodypart_id rep;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7199,7 +7199,7 @@ std::optional<int> iuse::sextant( Character *p, item *, const tripoint_bub_ms &p
     if( debug_mode ) {
         // Debug mode always shows all sun angles
         const float azimuth = to_degrees( sun_position.first );
-        p->add_msg_if_player( m_neutral, "Sun altitude %.1f°, azimuth %.1f°", altitude, azimuth );
+        p->add_msg_if_player( m_neutral, _( "Sun altitude %.1f°, azimuth %.1f°" ), altitude, azimuth );
     } else if( g->is_sheltered( pos ) ) {
         p->add_msg_if_player( m_neutral, _( "You can't see the Sun from here." ) );
     } else if( altitude > 0 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1535,7 +1535,7 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms 
         if( petfood.feed.empty() ) {
             p->add_msg_if_player( m_good, _( "The %1$s is your pet now!" ), mon->get_name() );
         } else {
-            p->add_msg_if_player( m_good, petfood.feed, mon->get_name() );
+            p->add_msg_if_player( m_good, _( petfood.feed ), mon->get_name() );
         }
 
         mon->friendly = -1;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -653,7 +653,8 @@ static void damage_targets( const spell &sp, Creature &caster,
             const float dodge_training = sp.dodge_training( caster );
             if( cr->dodge_check( spell_accuracy, dodge_training ) ) {
                 if( !cr->is_monster() ) {
-                    cr->add_msg_player_or_npc( "You dodge out of the way!", "%s dodges out of the way!" );
+                    cr->add_msg_player_or_npc( _( "You dodge out of the way!" ),
+                                               _( "<npcname> dodges out of the way!" ) );
                 } else {
                     if( !cr->has_effect( effect_invisibility ) ) {
                         add_msg_if_player_sees( cr->pos_bub(), m_bad, _( "%1$s dodges out of the way!" ),

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -375,7 +375,7 @@ void vehicle::print_fuel_indicators( map &here, const catacurses::window &win, c
     // check if the current index is less than the max size minus 12 or 5, to indicate that there's more
     if( start_index < static_cast<int>( fuels.size() ) - ( isHorizontal ? 12 : 5 ) ) {
         mvwprintz( win, p + point( 0, yofs ), c_light_green, ">" );
-        wprintz( win, c_light_gray, " for more" );
+        wprintz( win, c_light_gray, _( " for more" ) );
     }
 }
 


### PR DESCRIPTION
#### Summary
Continues the ongoing localization work..I hope this doesn’t look annoying, haha.

Localizes messages shown when casting dodgeable spells, assigning NPC crafting,
viewing extra vehicle fuel types, and using a sextant in debug mode.
Fixed armor protection summaries, pet interactions and feeding, and inventory view mode labels.

#### Purpose of change
These messages were not available for translation.

#### Describe the solution
- Localize spell dodge messages.
- Localize NPC crafting menu text.
- Localize the `for more` fuel indicator text.
- Localize sextant coordinate messages for debug mode.
- Localize the complete armor protection summary, keeping body-part enumeration as a formatted argument.
- Localize configurable pet-play and pet-food messages at their display sites.
- Localize inventory view mode labels.

#### Testing
Files in commits compiled  with the project Makefile and `-Werror`.