### PR TITLE
Update wind messaging and fix wetness

### DIFF
--- a/data/json/itemgroups/Labs/lab_security.json
+++ b/data/json/itemgroups/Labs/lab_security.json
@@ -4,9 +4,7 @@
     "type": "item_group",
     "//": "This group spawns power banks with a random amount of power.",
     "subtype": "distribution",
-    "entries": [
-      { "item": "UPS_off", "prob": 100, "charges": [ 0, 600 ] }
-    ]
+    "entries": [ { "item": "UPS_off", "prob": 100, "charges": [ 0, 600 ] } ]
   },
   {
     "id": "SUS_rivtech_loot",

--- a/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/harvest_cbm.json
@@ -37,23 +37,14 @@
         "prob": 20
       },
       {
-        "collection": [
-          { "item": "bio_armor_torso", "prob": 30 },
-          { "item": "bio_armor_head", "prob": 20 }
-        ],
+        "collection": [ { "item": "bio_armor_torso", "prob": 30 }, { "item": "bio_armor_head", "prob": 20 } ],
         "prob": 20
       },
       {
-        "collection": [
-          { "item": "bio_armor_torso", "prob": 60 },
-          { "item": "bio_armor_head", "prob": 30 }
-        ],
+        "collection": [ { "item": "bio_armor_torso", "prob": 60 }, { "item": "bio_armor_head", "prob": 30 } ],
         "prob": 20
       },
-      {
-        "collection": [ { "item": "bio_weight", "prob": 50 } ],
-        "prob": 60
-      },
+      { "collection": [ { "item": "bio_weight", "prob": 50 } ], "prob": 60 },
       { "item": "bio_armor_head", "prob": 30 },
       { "item": "bio_armor_torso", "prob": 20 },
       { "item": "bio_weight", "prob": 35 }

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -2683,7 +2683,9 @@
       "RAINPROOF",
       "POCKETS",
       "COLLAR",
-      "SPAWN_ACTIVE", "NO_UNLOAD", "NO_RELOAD"
+      "SPAWN_ACTIVE",
+      "NO_UNLOAD",
+      "NO_RELOAD"
     ],
     "power_draw": "1 kW",
     "revert_to": "optical_cloak",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -969,13 +969,9 @@
     "symbol": ";",
     "color": "light_gray",
     "tool_ammo": [ "battery" ],
-    "use_action": [
-      { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
-    ],
+    "use_action": [ { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "ELECTRONIC", "IS_UPS" ],
-    "pocket_data": [
-      { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 600 } }
-    ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 600 } } ],
     "melee_damage": { "bash": 2 }
   },
   {

--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -30,11 +30,7 @@
         "You play a bluegrass tune on your banjo.",
         "You play a quick ditty on your banjo."
       ],
-      "npc_descriptions":[
-        "play a little tune on the banjo.",
-        "play a bluegrass tune on the banjo.",
-        "play a quick ditty on the banjo."
-      ]
+      "npc_descriptions": [ "play a little tune on the banjo.", "play a bluegrass tune on the banjo.", "play a quick ditty on the banjo." ]
     },
     "melee_damage": { "bash": 4 }
   },
@@ -67,11 +63,7 @@
         "You play a warbling trill on your flute.",
         "You play a beautiful piece on your flute."
       ],
-      "npc_descriptions":[
-        "play a little tune on the flute.",
-        "play a warbling trill on the flute.",
-        "play a beautiful piece on the flute."
-      ]
+      "npc_descriptions": [ "play a little tune on the flute.", "play a warbling trill on the flute.", "play a beautiful piece on the flute." ]
     },
     "melee_damage": { "bash": 2 }
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4101,45 +4101,21 @@
     ],
     "enchantments": [
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "crouch" },
-            { "not": "u_can_drop_weapon" },
-            { "u_has_trait": "WINGS_BAT" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "u_has_trait": "WINGS_BAT" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.7 }, { "value": "FOOTSTEP_NOISE", "multiply": 0 } ],
         "ench_effects": [ { "effect": "quadruped_full", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "run" },
-            { "not": "u_can_drop_weapon" },
-            { "u_has_trait": "WINGS_BAT" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" }, { "u_has_trait": "WINGS_BAT" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.2 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.6 } ],
         "ench_effects": [ { "effect": "quadruped_full", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "crouch" },
-            { "not": "u_can_drop_weapon" },
-            { "u_has_trait": "WINGS_BAT" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "u_has_trait": "WINGS_BAT" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "run" },
-            { "not": "u_can_drop_weapon" },
-            { "u_has_trait": "WINGS_BAT" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" }, { "u_has_trait": "WINGS_BAT" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
       {
@@ -7140,11 +7116,7 @@
       [
         {
           "condition": {
-            "and": [
-              { "u_has_move_mode": "crouch" },
-              { "not": "u_can_drop_weapon" },
-              { "not": { "u_has_flag": "QUADRUPED_RUN" } }
-            ]
+            "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "not": { "u_has_flag": "QUADRUPED_RUN" } } ]
           },
           "msg_on": { "text": "Your paws make it easier to crawl on all fours." }
         }
@@ -7934,59 +7906,29 @@
     "enchantments": [
       { "condition": "ALWAYS", "values": [ { "value": "WEIGHT", "multiply": 0.12 } ] },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "crouch" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.85 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.5 } ],
         "ench_effects": [ { "effect": "quadruped_full", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "run" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" } ] },
         "values": [ { "value": "MOVE_COST", "multiply": -0.3 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.5 } ],
         "ench_effects": [ { "effect": "quadruped_full", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "crouch" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "run" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" } ] },
         "ench_effects": [ { "effect": "natural_stance", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "crouch" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" } ] },
         "ench_effects": [ { "effect": "wall_crawl", "intensity": 1 } ]
       },
       {
-        "condition": {
-          "and": [
-            { "u_has_move_mode": "run" },
-            { "not": "u_can_drop_weapon" }
-          ]
-        },
+        "condition": { "and": [ { "u_has_move_mode": "run" }, { "not": "u_can_drop_weapon" } ] },
         "ench_effects": [ { "effect": "wall_crawl", "intensity": 1 } ]
       },
       {
@@ -9201,11 +9143,7 @@
         }
       ]
     ],
-    "enchantments": [
-      "ench_quadruped_movement_bipedal",
-      "ench_quadruped_movement_full_crouch",
-      "ench_quadruped_movement_full_run"
-    ]
+    "enchantments": [ "ench_quadruped_movement_bipedal", "ench_quadruped_movement_full_crouch", "ench_quadruped_movement_full_run" ]
   },
   {
     "type": "mutation",
@@ -9236,11 +9174,7 @@
       [
         {
           "condition": {
-            "and": [
-              { "u_has_move_mode": "crouch" },
-              { "not": "u_can_drop_weapon" },
-              { "not": { "u_has_flag": "QUADRUPED_RUN" } }
-            ]
+            "and": [ { "u_has_move_mode": "crouch" }, { "not": "u_can_drop_weapon" }, { "not": { "u_has_flag": "QUADRUPED_RUN" } } ]
           },
           "msg_on": { "text": "Your paws make it easier to crawl on all fours." }
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -14092,16 +14092,18 @@ void Character::water_immersion()
     if( underwater || here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub() ) ||
         here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) ||
         here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, pos_bub() ) ) {
+        // Levitation means we're leaping or being knocked around.
+        // That keeps us out of the water unless WATER_CUBE is true, because that
+        // means our whole Z-level is underwater and levitation doesn't matter.
         if( !in_vehicle && !here.has_flag_furn( "BRIDGE", pos_bub() ) &&
-            ( !has_effect_with_flag( json_flag_LEVITATION ) && !underwater ) ) {
+            ( !has_effect_with_flag( json_flag_LEVITATION ) &&
+              !here.has_flag( ter_furn_flag::TFLAG_WATER_CUBE, pos_bub() ) ) ) {
             int drench_amount = 0;
             body_part_set drenched_parts;
             if( underwater || is_prone() ) {
-                // TODO: gain "swimming" proficiency but not "athletics" skill.
                 drench_amount = 100;
                 drenched_parts = get_drenching_body_parts();
             } else if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos_bub() ) ) {
-                // TODO: gain "swimming" proficiency but not "athletics" skill.
                 // Same as above, except no head/eyes/mouth.
                 drench_amount = 100;
                 drenched_parts = get_drenching_body_parts( false );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -109,21 +109,24 @@ static const morale_type morale_pyromania_nofire( "morale_pyromania_nofire" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
 
-static const trait_id trait_CHITIN_FUR( "CHITIN_FUR" );
-static const trait_id trait_CHITIN_FUR2( "CHITIN_FUR2" );
-static const trait_id trait_CHITIN_FUR3( "CHITIN_FUR3" );
+static const trait_id trait_CHITIN( "CHITIN" );
 static const trait_id trait_DEBUG_LS( "DEBUG_LS" );
 static const trait_id trait_DEBUG_NOTEMP( "DEBUG_NOTEMP" );
+static const trait_id trait_FEATHERS( "FEATHERS" );
 static const trait_id trait_FELINE_FUR( "FELINE_FUR" );
 static const trait_id trait_FUR( "FUR" );
 static const trait_id trait_INFRESIST( "INFRESIST" );
 static const trait_id trait_INFIMMUNE( "INFIMMUNE" );
-static const trait_id trait_LIGHTFUR( "LIGHTFUR" );
 static const trait_id trait_LUPINE_FUR( "LUPINE_FUR" );
+static const trait_id trait_LUPINE_FUR_SUMMER( "LUPINE_FUR_SUMMER" );
 static const trait_id trait_M_DEPENDENT( "M_DEPENDENT" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
+static const trait_id trait_SCALES( "SCALES" );
 static const trait_id trait_SLIMY( "SLIMY" );
+static const trait_id trait_THICK_SCALES( "THICK_SCALES" );
 static const trait_id trait_URSINE_FUR( "URSINE_FUR" );
+static const trait_id trait_URSINE_FUR_SUMMER( "URSINE_FUR_SUMMER" );
+static const trait_id trait_VISCOUS( "VISCOUS" );
 
 static const vitamin_id vitamin_blood( "blood" );
 static const vitamin_id vitamin_calcium( "calcium" );
@@ -135,29 +138,32 @@ void Character::update_body_wetness( const w_point &weather )
     // Average number of turns to go from completely soaked to fully dry
     // assuming average temperature and humidity
     constexpr time_duration average_drying = 30_minutes;
+    float trait_mult = 1.0f;
 
-    // Fur/slime retains moisture
-    float trait_mult = 1.0;
-    if( has_trait( trait_LIGHTFUR ) || has_trait( trait_FUR ) || has_trait( trait_FELINE_FUR ) ||
-        has_trait( trait_LUPINE_FUR ) || has_trait( trait_CHITIN_FUR ) || has_trait( trait_CHITIN_FUR2 ) ||
-        has_trait( trait_CHITIN_FUR3 ) ) {
-        trait_mult = 2.0;
-    }
-    if( has_trait( trait_URSINE_FUR ) || has_trait( trait_SLIMY ) ) {
-        trait_mult = 4.0;
+    // Some fur retains water.
+    if( has_trait( trait_FUR ) || has_trait( trait_FELINE_FUR ) ||
+        has_trait( trait_LUPINE_FUR_SUMMER ) || has_trait( trait_URSINE_FUR_SUMMER ) ) {
+        trait_mult = 2.0f;
+    // Winter coats are better at shedding water.
+    } else if( has_trait( trait_LUPINE_FUR ) || has_trait( trait_URSINE_FUR )  ) {
+        trait_mult = 1.33f;
+    // Slimy characters stay wet much longer.
+    } else if( has_trait( trait_SLIMY ) || has_trait( trait_VISCOUS ) ) {
+        trait_mult = 4.0f;
+    // Scales, feathers, and chitin shed water easily.
+    } else if( has_trait( trait_SCALES ) || has_trait( trait_THICK_SCALES ) || has_trait( trait_CHITIN ) || has_trait( trait_FEATHERS ) ) {
+        trait_mult = 0.5f;
     }
 
-    // Weather slows down drying
+    // Weather slows down drying.
     float weather_mult = 1.0;
     weather_mult += ( ( weather.humidity - 66.0f ) - ( units::to_fahrenheit(
                           weather.temperature ) - 65.0f ) ) / 100.0f;
     weather_mult = std::max( 0.1f, weather_mult );
-
     for( const bodypart_id &bp : get_all_body_parts() ) {
-
         const units::temperature temp_conv = get_part_temp_conv( bp );
         const int drench_cap = get_part_drench_capacity( bp );
-        // do sweat related tests assuming not underwater
+        // Do sweat related tests, assuming we're not underwater.
         if( !is_underwater() ) {
             const int wetness = get_part_wetness( bp );
             if( wetness == 0 ) {

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -915,7 +915,7 @@ void Character::update_bodytemp()
             }
         }
 
-        // Warn the player about windchill, but only on cold bodyparts
+        // Warn the player about windchill, but only on cold bodyparts.
         const units::temperature conv_temp = get_part_temp_conv( bp );
         if( conv_temp <= BODYTEMP_COLD && windchill < units::from_kelvin_delta( -30 ) &&
             now - record.last_wind_extreme > cooldown_danger ) {
@@ -925,7 +925,7 @@ void Character::update_bodytemp()
         } else if( conv_temp <= BODYTEMP_COLD && windchill < units::from_fahrenheit_delta( -20 ) &&
                    now - record.last_wind_strong > cooldown_danger ) {
             add_msg( m_bad,
-                     _( "The strong wind is chilling your unprotected %s." ),
+                     _( "The strong wind is chilling your %s." ),
                      body_part_name( bp ) );
             record.last_wind_strong = now;
         } else if( conv_temp <= BODYTEMP_COLD && windchill < units::from_fahrenheit_delta( -10 ) &&

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -143,15 +143,16 @@ void Character::update_body_wetness( const w_point &weather )
     // Some fur retains water.
     if( has_trait( trait_FUR ) || has_trait( trait_FELINE_FUR ) ||
         has_trait( trait_LUPINE_FUR_SUMMER ) || has_trait( trait_URSINE_FUR_SUMMER ) ) {
-        trait_mult = 2.0f;
-    // Winter coats are better at shedding water.
-    } else if( has_trait( trait_LUPINE_FUR ) || has_trait( trait_URSINE_FUR )  ) {
-        trait_mult = 1.33f;
-    // Slimy characters stay wet much longer.
+        trait_mult = 1.5f;
+        // Winter coats are better at shedding water.
+    } else if( has_trait( trait_LUPINE_FUR ) || has_trait( trait_URSINE_FUR ) ) {
+        trait_mult = 1.25f;
+        // Slimy characters stay wet much longer.
     } else if( has_trait( trait_SLIMY ) || has_trait( trait_VISCOUS ) ) {
-        trait_mult = 4.0f;
-    // Scales, feathers, and chitin shed water easily.
-    } else if( has_trait( trait_SCALES ) || has_trait( trait_THICK_SCALES ) || has_trait( trait_CHITIN ) || has_trait( trait_FEATHERS ) ) {
+        trait_mult = 3.0f;
+        // Scales, feathers, and chitin shed water easily.
+    } else if( has_trait( trait_SCALES ) || has_trait( trait_THICK_SCALES ) ||
+               has_trait( trait_CHITIN ) || has_trait( trait_FEATHERS ) ) {
         trait_mult = 0.5f;
     }
 


### PR DESCRIPTION
#### Summary
Update wind messaging and fix wetness

#### Purpose of change

#### Describe the solution
- Improved some messaging regarding windchill.
- Wetness when swimming wasn't properly applying to the head due to a bad check. Now it does.
- Traits were affecting drying rates, but the code was outdated and pretty lame. Now, when air drying:
- Fur, feline fur, summer coat, and scruffy fur dry 50% slower.
- Lupine fur and ursine fur dry 25% slower, as these are winter coats designed to shed water.
- Slimy and Viscous characters dry 200% slower.
- Scales, chitin, thick scales, and feathers will cause a character to dry 50% faster.

Characters lose heat when air drying. The rate of drying does not affect how much heat is lost per tick, but it does mean that characters that stay wet for longer will cool themselves longer, and vice versa. Thus, summer coat and scruffy fur can help a character keep cool in the summer: Jump in the water, swim around till you're soaked, then hop out and you'll be cooler than normal for longer than a human.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
