### PR TITLE
Localize messages

### DIFF
--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -32,6 +32,14 @@ def parse_generic(json, origin):
         write_text(json["description"], origin, c_format=False,
                    comment=comment + ["Description of \"{}\"".format(name)])
 
+    port_comment = "Electronic port type of item \"{}\"".format(name)
+    if "e_port" in json:
+        write_text(json["e_port"], origin, context="electronic port type",
+                   comment=port_comment, c_format=False)
+    for port in json.get("e_ports_banned", []):
+        write_text(port, origin, context="electronic port type",
+                   comment=port_comment, c_format=False)
+
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)
     if "tick_action" in json:

--- a/lang/string_extractor/parsers/json_flag.py
+++ b/lang/string_extractor/parsers/json_flag.py
@@ -2,6 +2,9 @@ from ..write_text import write_text
 
 
 def parse_json_flag(json, origin):
+    if "name" in json:
+        write_text(json["name"], origin, c_format=False,
+                   comment="Name of JSON flag \"{}\"".format(json["id"]))
     if "info" in json:
         write_text(json["info"], origin, c_format=False, comment=[
             "Please leave anything in <angle brackets> unchanged.",

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4692,15 +4692,19 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
         info.emplace_back( "DESCRIPTION", feedback );
     }
 
-    std::string &eport = type->tool->e_port;
+    const std::string &eport = type->tool->e_port;
     if( !eport.empty() ) {
+        const std::string eport_name = pgettext( "electronic port type", eport.c_str() );
         std::string compat;
-        compat += _( "* This device has electronic port type: " + colorize( eport, c_light_green ) );
-        std::vector<std::string> &eport_banned = type->tool->e_ports_banned;
+        compat += string_format( pgettext( "electronic port information",
+                                           "* This device has electronic port type: %s" ),
+                                 colorize( eport_name, c_light_green ) );
+        const std::vector<std::string> &eport_banned = type->tool->e_ports_banned;
         if( !eport_banned.empty() ) {
             compat += _( "\n* This device does not support transfer to e-port types: " );
-            for( std::string &s : eport_banned ) {
-                compat += colorize( _( s ), c_yellow );
+            for( const std::string &port : eport_banned ) {
+                const std::string port_name = pgettext( "electronic port type", port.c_str() );
+                compat += colorize( port_name, c_yellow );
             }
         }
         info.emplace_back( "DESCRIPTION", compat );

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -17,6 +17,7 @@
 #include "input_context.h"
 #include "input_enums.h"
 #include "output.h"
+#include "translations.h"
 #include "ui_manager.h"
 #include "weather.h"
 
@@ -322,11 +323,11 @@ static void draw_medical_titlebar( const catacurses::window &window, Character &
         right_print( window, 1, right_indent, c_white, desc );
     }
 
-    const std::string TITLE_STR = "Medical";
+    const std::string title = pgettext( "medical menu title", "Medical" );
 
     // Window Title
-    if( WIDTH - details_width - utf8_width( TITLE_STR ) > WIDTH / 2 ) {
-        center_print( window, 0, c_blue, _( TITLE_STR ) );
+    if( WIDTH - details_width - utf8_width( title ) > WIDTH / 2 ) {
+        center_print( window, 0, c_blue, title );
     }
 }
 


### PR DESCRIPTION
#### Summary
Continues the ongoing localization work..
I’m not fully confident about these changes, so I’d really appreciate a thorough review. 
My background is in a different technology stack..But I hope the approaches are clear enough.

#### Purpose of change
Some strings were not available for translation.

#### Describe the solution
- Translate the Medical menu title.
- Translate the complete electronic-port message.
- Extract values from `e_port` and `e_ports_banned` with one
  `electronic port type` context, then translate them at display time.
- Translate port names only when displaying them; keep the IDs used by game logic unchanged.
- Extract JSON flag display names for translation.

#### Testing
- Compiled with -Werror flag.
- Ran the `lang/update_pot.sh` (locally) pipeline for JSON flag names.