### PR TITLE
Buff tool battery for vehicle work

### DIFF
--- a/data/json/items/battery.json
+++ b/data/json/items/battery.json
@@ -102,8 +102,8 @@
     "longest_side": "113 mm",
     "price": "22 USD",
     "price_postapoc": "35 cent",
-    "capacity": 97,
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 97 } } ]
+    "capacity": 110,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 110 } } ]
   },
   {
     "id": "heavy_plus_battery_cell",


### PR DESCRIPTION
#### Summary
Buff tool battery for vehicle work

#### Purpose of change
Tool batteries got nerfed to match their real-world counterparts, but it made them very slightly too weak to install fuel tanks in vehicles. Currently, you need to have the full amount of charge needed before beginning a vehicle part installation job, so this needed fixing.

#### Describe the solution
Added 13 capacity to tool batteries, bringing them from 97 kJ to 110. This should be enough for any installation.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
