### PR TITLE
Localize messages

### DIFF
--- a/lang/string_extractor/parsers/fault.py
+++ b/lang/string_extractor/parsers/fault.py
@@ -10,3 +10,6 @@ def parse_fault(json, origin):
     if "item_prefix" in json:
         write_text(json["item_prefix"], origin,
                    comment="Prefix for item's name \"{}\"".format(name))
+    if "item_suffix" in json:
+        write_text(json["item_suffix"], origin,
+                   comment="Suffix for item's name \"{}\"".format(name))

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3925,7 +3925,7 @@ void game::display_faction_epilogues()
                                                point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
                                                       std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
                 };
-                scrollable_text( new_win, elem.second.name,
+                scrollable_text( new_win, _( elem.second.name ),
                                  std::accumulate( epilogue.begin() + 1, epilogue.end(), epilogue.front(),
                 []( std::string lhs, const std::string & rhs ) -> std::string {
                     return std::move( lhs ) + "\n" + rhs;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -9218,7 +9218,7 @@ mapgen_update_func add_mapgen_update_func( const JsonObject &jo, bool &defer )
 }
 
 static const std::string missing_update_operation =
-    "missing update operation (not vehicle/appliance)";
+    translate_marker( "missing update operation (not vehicle/appliance)" );
 
 ret_val<void> run_mapgen_update_func(
     const update_mapgen_id &update_mapgen_id, const tripoint_abs_omt &omt_pos,

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -161,7 +161,7 @@ static const std::string omt_evac_center_18 = "evac_center_18";
 static const std::string omt_ranch_camp_63 = "ranch_camp_63";
 
 static const std::string return_ally_question_string =
-    "\n\nDo you wish to bring your allies back into your party?";
+    translate_marker( "\n\nDo you wish to bring your allies back into your party?" );
 
 //  Legacy faction camp mission strings used to translate tasks in progress when upgrading.
 static const std::string camp_upgrade_npc_string = "_faction_upgrade_camp";

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6475,22 +6475,22 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
             point_abs_om new_om_addr = random_entry( nearest_candidates );
             overmap_buffer.create_custom_overmap( new_om_addr, custom_overmap_specials );
         } else {
-            std::string msg =
-                "The following specials could not be placed, some missions may fail to initialize: ";
+            std::string unplaced_specials;
             int n = 0;
             for( auto iter = custom_overmap_specials.begin(); iter != custom_overmap_specials.end(); ) {
                 if( iter->instances_placed < iter->special_details->get_constraints().occurrences.min ) {
-                    msg.append( iter->special_details->id.c_str() ).append( ", " );
+                    unplaced_specials.append( iter->special_details->id.c_str() ).append( ", " );
                     n++;
                 }
                 ++iter;
             }
             if( n > 0 ) {
-                msg = msg.substr( 0, msg.length() - 2 );
+                unplaced_specials = unplaced_specials.substr( 0, unplaced_specials.length() - 2 );
             } else {
-                msg = msg.append( "<unknown>" );
+                unplaced_specials = _( "<unknown>" );
             }
-            add_msg( _( msg ) );
+            add_msg( _( "The following specials could not be placed, "
+                        "some missions may fail to initialize: %s" ), unplaced_specials );
         }
     }
     // Then fill in non-mandatory specials.

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1199,8 +1199,8 @@ static void draw_om_sidebar( ui_adaptor &ui,
 
     wattron( wbar, c_magenta );
     mvwprintw( wbar, point( 1, ++lines ), _( "Use movement keys to pan." ) );
-    mvwprintw( wbar, point( 1, ++lines ), _( string_format( "Press %s to preview route.",
-               inp_ctxt.get_desc( "CHOOSE_DESTINATION" ) ) ) );
+    mvwprintw( wbar, point( 1, ++lines ), string_format( pgettext( "overmap route preview",
+               "Press %s to preview route." ), inp_ctxt.get_desc( "CHOOSE_DESTINATION" ) ) );
     mvwprintw( wbar, point( 1, ++lines ), _( "Press again to confirm." ) );
     lines += 2;
     wattroff( wbar, c_magenta );


### PR DESCRIPTION
#### Summary
Continues the ongoing localization work..

#### Purpose of change
Some strings were not available for translation.

#### Describe the solution
Each commit fixes one localization problem:

- The companion return prompt is now extracted where it is defined instead of relying on a duplicate elsewhere.
- The full warning about unplaced overmap specials can now be translated without including the generated list.
- The missing mapgen update error is now included in the translation catalog.
- The overmap route hint is translated before the current key is inserted.
- Fault suffixes such as `snapped` and `no handle` are now extracted from JSON.
- Faction names, including `Your Followers`, are now translated in epilogue titles.

#### Testing
- Compiled the affected C++ files with `-Werror`
- Ran the full POT generation pipeline, including JSON extraction and catalog validation.

