### PR TITLE
Creatures can react to reach attacks from unseen sources

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -532,7 +532,7 @@ class Creature : public viewer
         // Creatures temporarily detect unseen creatures when bumping into them.
         bool stumble_invis( const Creature &attacker, bool stumblemsg = true );
         // Use stumble_invis's system to try and find creatures throwing stuff at us from hiding.
-        bool react_to_ranged( const Creature &player );
+        bool react_to_ranged( const Creature &attacker );
         // Attack an empty location
         bool attack_air( const tripoint_bub_ms &p );
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4653,7 +4653,7 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
             if( critter->in_species( species_ROBOT ) ) {
                 critter->add_effect( effect_blind, rng( 5_seconds, 10_seconds ) );
             } else {
-                critter->add_effect( effect_blind, rng( 3_seconds, 6_seconds ) );
+                critter->add_effect( effect_blind, rng( 4_seconds, 8_seconds ) );
             }
         }
         viewer &player_view = get_player_view();

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1055,6 +1055,9 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         dealt_projectile_attack dp = dealt_projectile_attack();
         t.as_character()->on_hit( &here, this, bodypart_str_id::NULL_ID().id(), 0.0f, &dp );
     }
+    if( reach_attacking ) {
+        t.react_to_ranged( *this );
+    }
     if( drop_weapon && !cur_weap.is_null() && !cur_weap.has_flag( flag_INTEGRATED ) ) {
         map &here = get_map();
         item your_weapon = remove_weapon();


### PR DESCRIPTION
#### Summary
Creatures can react to reach attacks from unseen sources

#### Purpose of change
Add react_to_ranged to reach attacks, so they work the same as thrown items for telling victims where they're being attacked from.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
