### PR TITLE
Fix innawood firemaking

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -84,16 +84,10 @@
     "activity_level": "BRISK_EXERCISE",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
+    "skill_used": "survival",
     "difficulty": 4,
-    "time": "2 h",
+    "time": "1 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_basic", 1 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
-    ],
     "components": [ [ [ "steel_fragment", 1 ] ], [ [ "flint", 1 ] ] ]
   },
   {

--- a/data/mods/innawood/recipes/tools/tools_primitive.json
+++ b/data/mods/innawood/recipes/tools/tools_primitive.json
@@ -19,5 +19,35 @@
       [ [ "material_gravel", 1000 ] ],
       [ [ "cotton_patch", 4 ], [ "wire_mesh", 4 ], [ "fibercloth_patch", 4 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fire_drill",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "skills_required": [ "survival", 3 ],
+    "time": "5 m",
+    "autolearn": true,
+    "using": [ [ "cordage_short", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 } ],
+    "components": [ [ [ "stick", 1 ] ], [ [ "splinter", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fire_drill_large",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "skills_required": [ "survival", 2 ],
+    "time": "30 m",
+    "autolearn": true,
+    "using": [ [ "cordage_short", 1 ] ],
+    "qualities": [ { "id": "CUT", "level": 1 }, [ { "id": "DRILL_ROCK", "level": 1 }, { "id": "DRILL", "level": 1 } ] ],
+    "components": [ [ [ "stick", 1 ] ], [ [ "rock", 1 ], [ "ceramic_shard", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Fix innawood firemaking

#### Purpose of change
Firemaking tools require ecology 4 in mainline, but Innawood requires that you have access to fire ASAP. There's not a way to progress or even survive without it.

#### Describe the solution
- The large fire drill now requires only 2 ecology in Innawood, the regular one requires 3. It has not changed in main.
- Flint and steel no longer requires any tools in main or Innawood, since all you need for flint and steel is flint and steel.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
