### PR TITLE
Delete spilled liquids and fix (old)

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -831,11 +831,6 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
         return ret_val<edible_rating>::make_failure( _( "That doesn't look edible in its current form." ) );
     }
 
-    if( food.has_own_flag( flag_DIRTY ) ) {
-        return ret_val<edible_rating>::make_failure(
-                   _( "This is full of dirt after being on the ground." ) );
-    }
-
     const bool eat_verb  = food.has_flag( flag_USE_EAT_VERB );
     const bool edible    = eat_verb ||  comest->comesttype == comesttype_FOOD;
     const bool drinkable = !eat_verb && comest->comesttype == comesttype_DRINK;

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -94,7 +94,6 @@ const flag_id flag_DECAYS_IN_AIR( "DECAYS_IN_AIR" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );
-const flag_id flag_DIRTY( "DIRTY" );
 const flag_id flag_DISABLE_SIGHTS( "DISABLE_SIGHTS" );
 const flag_id flag_DROP_ACTION_ONLY_IF_LIQUID( "DROP_ACTION_ONLY_IF_LIQUID" );
 const flag_id flag_DURABLE_MELEE( "DURABLE_MELEE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -102,7 +102,6 @@ extern const flag_id flag_DECAYS_IN_AIR;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;
-extern const flag_id flag_DIRTY;
 extern const flag_id flag_DISABLE_SIGHTS;
 extern const flag_id flag_DROP_ACTION_ONLY_IF_LIQUID;
 extern const flag_id flag_DURABLE_MELEE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1589,17 +1589,10 @@ bool _stacks_rot( item const &lhs, item const &rhs, bool combine_liquid )
            lhs.rotten() == rhs.rotten();
 }
 
-bool _stacks_mushy_dirty( item const &lhs, item const &rhs )
-{
-    return lhs.has_flag( flag_MUSHY ) == rhs.has_flag( flag_MUSHY ) &&
-           lhs.has_own_flag( flag_DIRTY ) == rhs.has_own_flag( flag_DIRTY );
-}
-
 bool _stacks_food_status( item const &lhs, item const &rhs )
 {
     return ( lhs.is_fresh() == rhs.is_fresh() || lhs.is_going_bad() == rhs.is_going_bad() ||
-             lhs.rotten() == rhs.rotten() ) &&
-           _stacks_mushy_dirty( lhs, rhs );
+             lhs.rotten() == rhs.rotten() );
 }
 
 bool _stacks_food_traits( item const &lhs, item const &rhs )
@@ -1782,7 +1775,7 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     if( this_goes_bad && that_goes_bad ) {
         if( same_type ) {
             bits.set( tname::segments::FOOD_STATUS,
-                      _stacks_rot( *this, rhs, combine_liquid ) && _stacks_mushy_dirty( *this, rhs ) );
+                      _stacks_rot( *this, rhs, combine_liquid ) );
 
         } else {
             bits.set( tname::segments::FOOD_STATUS, _stacks_food_status( *this, rhs ) );
@@ -6196,7 +6189,7 @@ nc_color item::color_in_inventory( const Character *const ch ) const
     } else if( is_armor() && player_character.has_trait( trait_WOOLALLERGY ) &&
                ( made_of( material_wool ) || has_own_flag( flag_wooled ) ) ) {
         ret = c_red;
-    } else if( is_filthy() || has_own_flag( flag_DIRTY ) ) {
+    } else if( is_filthy() ) {
         ret = c_brown;
     } else if( is_relic() && !has_flag( flag_MUNDANE ) ) {
         ret = c_pink;
@@ -15777,15 +15770,13 @@ bool item::on_drop( const tripoint_bub_ms &pos )
 
 bool item::on_drop( const tripoint_bub_ms &pos, map &m )
 {
-    // dropping liquids, even currently frozen ones, on the ground makes them
-    // dirty
-    if( made_of_from_type( phase_id::LIQUID ) && !m.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, pos ) &&
-        !has_own_flag( flag_DIRTY ) ) {
-        set_flag( flag_DIRTY );
+    // Spilled liquids aren't recoverable, so just remove them from the game.
+    // TODO: Maybe place a field here for certain kinds of liquid (blood, fuel).
+    if( made_of_from_type( phase_id::LIQUID ) &&
+        !m.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, pos ) ) {
+        return true;
     }
-
     avatar &player_character = get_avatar();
-
     return type->drop_action && type->drop_action.call( &player_character, *this, &m, pos );
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1184,9 +1184,12 @@ class item : public visitable
             return goes_bad() && get_relative_rot() < 0.1;
         }
 
-        /** an item is about to become rotten when shelf life has nearly elapsed */
+        /** An item is about to become rotten when shelf life has nearly elapsed. */
         bool is_going_bad() const {
-            return goes_bad() && get_shelf_life() - rot < 12_hours;
+            if( !goes_bad() ) {
+                return false;
+            }
+            return get_relative_rot() >= 0.5 && get_shelf_life() - rot < 12_hours;
         }
 
         /** returns true if item is now rotten after all shelf life has elapsed */

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2173,8 +2173,8 @@ void item_pocket::leak( map &here, Character *carrier, const tripoint_bub_ms &po
                 here.add_item_or_charges( pos, *iter );
                 if( carrier != nullptr ) {
                     carrier->invalidate_weight_carried_cache();
-                    carrier->add_msg_if_player( _( "Liquid leaked out from the %s and dripped onto the ground!" ),
-                                                this->get_name() );
+                    carrier->add_msg_if_player( _( "%S leaks from the %s." ),
+                                                iter->tname(), this->get_name() );
                 }
             }
             iter = contents.erase( iter );

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -376,9 +376,7 @@ std::string food_status( item const &it, unsigned int /* quantity */,
 {
     std::string tagtext;
     if( it.goes_bad() || it.is_food() ) {
-        if( it.has_own_flag( flag_DIRTY ) ) {
-            tagtext += _( " (dirty)" );
-        } else if( it.rotten() ) {
+        if( it.rotten() ) {
             tagtext += _( " (rotten)" );
         } else if( it.has_flag( flag_MUSHY ) ) {
             tagtext += _( " (mushy)" );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6137,7 +6137,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
 
     std::optional<std::pair<item *, tripoint_bub_ms>> first_added;
     int copies_to_add_here = how_many_copies_fit( pos );
-    // force is used by mapgen to place items in SEALED spots intentionally.
+    // Force is used by mapgen to place items in SEALED spots intentionally.
     if( ( ( !has_flag( ter_furn_flag::TFLAG_NOITEM, pos ) &&
             ( !has_flag( ter_furn_flag::TFLAG_SEALED, pos ) || force ) ) ||
           ( has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, pos ) && obj.made_of( phase_id::LIQUID ) ) ) &&


### PR DESCRIPTION
#### Summary
Delete spilled liquids and fix (old)

#### Purpose of change
Spilled liquids and the dirty flag were pointless. You couldn't do anything with them, they just sat there making you think you could. Worse, there were no mechanics for liquids evaporating or soaking into the ground, so they'd just sit there forever.

(old) was showing up on things like fresh fish fillets because it was only checking for whether the food would spoil in 12 hours or less at room temperature, making people think something was wrong.

#### Describe the solution
- Spilled liquids are now simply deleted. They never had any purpose, so now they're gone.
- Food does not say (old) unless it has both less than 12 hours to go and is more than 50% below its maximum freshness.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
