### PR TITLE
Improve ecology learning from fishing and woodcutting

### DIFF
--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -31,7 +31,7 @@
 10 - Legendary.  (If you are not literaly Miyamoto Musashi, then you are pretty sure you could take him in a duel.)
 
 # Experience required for skill levels:
-The formula is level² * 100. Characters who gain xp pass that xp through factors like focus and enchantment-based learning modifiers. These numbers aren't shown to the player, they see skill rank progress as a percentage.
+The formula is level² * 100. Characters who gain xp pass that xp through factors like focus and enchantment-based learning modifiers. These numbers aren't shown to the player, they see skill rank progress as a percentage. Numbers below assume no traits and 100 focus, and indicate the value as passed by practice().
 
 1          100
 2          400

--- a/doc/GAME_BALANCE.md
+++ b/doc/GAME_BALANCE.md
@@ -30,6 +30,19 @@
 9 - Phenom.  (If the world hadn't ended, your contributions to the field of medicine could have been considered invaluable for decades to come.)<br><br>
 10 - Legendary.  (If you are not literaly Miyamoto Musashi, then you are pretty sure you could take him in a duel.)
 
+# Experience required for skill levels:
+The formula is level² * 100. Characters who gain xp pass that xp through factors like focus and enchantment-based learning modifiers. These numbers aren't shown to the player, they see skill rank progress as a percentage.
+
+1          100
+2          400
+3          900
+4        1,600
+5        2,500
+6        3,600
+7        4,900
+8        6,400
+9        8,100
+10      10,000
 
 # Monster melee skill scaling:
 Minimum skill: 0 (no melee potential; turret, fungal wall)

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3815,6 +3815,7 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
                     GROUP_FISH, true );
         const mtype_id fish_mon = random_entry_ref( fish_group );
         caught_corpse( who, here, fish_mon.obj() );
+        who.practice( skill_survival, 10, 5 );
     } else {
         monster *chosen_fish = random_entry( fishables );
         chosen_fish->fish_population -= 1;
@@ -3826,6 +3827,7 @@ static void rod_fish( Character &who, const std::vector<monster *> &fishables )
                 caught_corpse( who, here, *( chosen_fish->type ) );
             }
         }
+        who.practice( skill_survival, 10, 5 );
     }
 }
 
@@ -3879,8 +3881,8 @@ void fish_activity_actor::do_turn( player_activity &, Character &who )
         who.add_msg_if_player( m_good, _( "You feel a tug on your line!" ) );
         rod_fish( who, fishables );
     }
-    if( calendar::once_every( 60_minutes ) ) {
-        who.practice( skill_survival, rng( 1, 3 ) );
+    if( calendar::once_every( 10_minutes ) ) {
+        who.practice( skill_survival, 10, 5 );
     }
 }
 
@@ -7527,6 +7529,7 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
             who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
     }
+    who.practice( skill_survival, 5, 4 );
     here.ter_set( pos, ter_t_dirt );
     who.add_msg_if_player( m_good, _( "You finish chopping wood." ) );
 
@@ -7681,7 +7684,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
             }
         }
     }
-    who.practice( skill_survival, 3, 3 );
+    who.practice( skill_survival, 20, 4 );
     here.cut_down_tree( pos, direction.xy() );
 
     who.add_msg_if_player( m_good, _( "You finish chopping down a tree." ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3185,7 +3185,7 @@ bool Character::practice( const skill_id &id, int amount, int cap, bool suppress
     }
 
     if( amount > 0 &&
-        static_cast<int>( get_skill_level( id ) ) > cap ) { //blunt grinding cap implementation for crafting
+        static_cast<int>( get_skill_level( id ) ) > cap ) {
         amount = 0;
         if( !suppress_warning ) {
             handle_skill_warning( id, false );


### PR DESCRIPTION
#### Summary
Improve ecology learning from fishing and woodcutting.

#### Purpose of change
These things didn't teach enough.

#### Describe the solution
- Chopping down trees teaches significantly more now. It's not the ideal way to learn, but it's noticeable.
- Chopping trunks into logs teaches a bit.
- Fishing now teaches significantly better. You learn a bit every 10 minutes no matter what, and a bit more whenever you catch anything.

#### Describe alternatives you've considered

#### Testing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: The Last Generation is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
